### PR TITLE
Performance audit: React hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ A package may only import from scopes listed above it (e.g. `suite` can depend o
 - [Common Issues](skills/common-issues/SKILL.md) – Known issues and their solutions
 - [Components](skills/components/SKILL.md) – React component file structure and patterns
 - [Common Tasks](skills/common-tasks/SKILL.md) – Dependency management, package creation, and troubleshooting
-- [Defensive Programming](skills/defensive-programming/SKILL.md) – Exhaustive checks, safe defaults, and non-mutating array methods
+- [Data Fetching](skills/data-fetching/SKILL.md) – TanStack Query: useQuery over effect-driven fetching, query keys, shared query hooks
+- [Defensive Programming](skills/defensive-programming/SKILL.md) – Exhaustive checks, safe defaults, absent values, network features, EVM address comparison, and non-mutating array methods
 - [Dependency Injection](skills/dependency-injection/SKILL.md) – DI pattern for service definitions, factories, and composition roots
 - [Development Commands](skills/development-commands/SKILL.md) – Running apps, linting, testing, and building
 - [Git and Commit Guidelines](skills/git-and-commit-guidelines/SKILL.md) – Conventional Commits format and best practices

--- a/code-review-threads/README.md
+++ b/code-review-threads/README.md
@@ -1,0 +1,234 @@
+# Code-review threads — `@cermakjiri` as reviewer
+
+Every inline code-review comment `@cermakjiri` left on **other people's** pull requests in `trezor/trezor-suite` between **2026-05-11** and **2026-08-11**, grouped into *review-thread-groups* and sorted by the topic each thread discusses.
+
+## What a review-thread-group is
+
+One entity per review thread the reviewer participated in. Each contains:
+
+- the **PR** it lives on (number, title, author, state),
+- the **file and line** the thread is anchored to,
+- the **diff hunk** — the code actually under discussion,
+- a **link to the discussion thread** on GitHub,
+- a **permalink to that exact line of code** at the PR head commit,
+- the **full conversation** — the reviewer’s comments and every reply.
+
+## Numbers
+
+| | |
+| --- | --- |
+| Review-thread-groups | **86** |
+| Reviewer comments inside them | **98** |
+| Distinct PRs | **31** |
+| Distinct PR authors | **13** |
+| Window | 2026-05-11 → 2026-08-11 |
+| First / last comment | 2026-05-12 / 2026-08-10 |
+| Topics | 14 |
+
+## Topics
+
+| # | Topic | Groups | |
+| --- | --- | --- | --- |
+| 01 | **[Acknowledgements & cross-references](by-topic/01-acknowledgements-and-pointers.md)** | 14 | Approvals, thanks, "nice catch" notes, and pointers to another thread — no actionable request. Kept for completeness. |
+| 11 | **[TypeScript type safety](by-topic/11-typescript-type-safety.md)** | 12 | Type predicates, `satisfies`, narrowing account types via `AccountWithNetworkType`, avoiding casts, fixing types instead of working around them. |
+| 14 | **[Readability & simplification](by-topic/14-readability-and-simplification.md)** | 11 | Extracting named helpers/variables, early returns over nesting, dropping redundant branches, naming, and reusing existing utils. |
+| 03 | **[Data fetching — prefer TanStack Query](by-topic/03-data-fetching-tanstack-query.md)** | 7 | Replacing imperative effect/thunk-driven fetching with `useQuery`/`useMutation`, exposing `queryOptions` on shared hooks, and picking the narrowest query hook. |
+| 05 | **[Performance & memoization](by-topic/05-performance-and-memoization.md)** | 7 | Redundant or missing `useMemo`, stable references that stop breaking memoization, and running independent async work concurrently. |
+| 09 | **[Component structure & file layout](by-topic/09-component-structure-and-files.md)** | 7 | One React component per file, extracting sub-components, hooks in their own file next to the component, and package/folder structure (tree-like vs. linear). |
+| 10 | **[Nullability & sentinel values](by-topic/10-nullability-and-sentinel-values.md)** | 6 | Avoiding `''`/`0` sentinel fallbacks, preferring explicit `undefined`, and narrowing null/undefined upstream so components get asserted types. |
+| 12 | **[Code placement, package boundaries & reuse](by-topic/12-code-placement-and-reuse.md)** | 6 | Moving shared logic to `suite-common` so `suite-native` can reuse it, avoiding circular deps via nested exports, and where selectors/abstractions belong. |
+| 07 | **[Error handling & developer experience](by-topic/07-error-handling-and-devx.md)** | 4 | Unhandled thunk rejections crashing components, validation that returns `null` instead of throwing, silently skipping instead of failing loudly. |
+| 02 | **[CI, tooling & guardrails](by-topic/02-ci-tooling-and-guardrails.md)** | 3 | GitHub Actions workflow configuration and lint rules that prevent whole classes of regressions. |
+| 06 | **[Runtime validation & parsing](by-topic/06-runtime-validation-and-parsing.md)** | 3 | Zod schemas for parsing `unknown` data instead of casting, and questioning validation constraints in low-level converters. |
+| 08 | **[Single source of truth](by-topic/08-single-source-of-truth.md)** | 3 | Deriving behaviour from network config features and from the Earn yield worker API rather than duplicating constants in the client. |
+| 04 | **[React hooks & effects](by-topic/04-react-hooks-and-effects.md)** | 2 | Refs vs. state, effect dependencies and stale closures (`useFreshRef` / `useCurrentRef`). |
+| 13 | **[Comments & documentation](by-topic/13-comments-and-docs.md)** | 1 | Code comments that do not explain the whole rule they document. |
+| 99 | [Review summary comments](by-topic/99-review-summary-comments.md) | 13 | Top-level review bodies — no file/line anchor. |
+
+### Distribution
+
+```
+Acknowledgements & cross-references             14  ██████████████
+TypeScript type safety                          12  ████████████
+Readability & simplification                    11  ███████████
+Data fetching — prefer TanStack Query            7  ███████
+Performance & memoization                        7  ███████
+Component structure & file layout                7  ███████
+Nullability & sentinel values                    6  ██████
+Code placement, package boundaries & reuse       6  ██████
+Error handling & developer experience            4  ████
+CI, tooling & guardrails                         3  ███
+Runtime validation & parsing                     3  ███
+Single source of truth                           3  ███
+React hooks & effects                            2  ██
+Comments & documentation                         1  █
+```
+
+## Index by pull request
+
+| PR | Author | State | Groups | Title |
+| --- | --- | --- | --- | --- |
+| [#31076](https://github.com/trezor/trezor-suite/pull/31076) | `@izmy` | merged | 1 | fix(suite-native): polish standalone wrap/unwrap UI |
+| [#31071](https://github.com/trezor/trezor-suite/pull/31071) | `@TomasBoda` | merged | 1 | fix(suite-native): communicate weth vault as eth |
+| [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `@TomasBoda` | merged | 8 | Mobile - Asset Detail Screen Revamp |
+| [#30910](https://github.com/trezor/trezor-suite/pull/30910) | `@53gur0` | merged | 4 | fix(suite-desktop): double-check nonces origination |
+| [#30797](https://github.com/trezor/trezor-suite/pull/30797) | `@53gur0` | merged | 1 | feat(suite-desktop): ensure auto-tracked wrapped native assets |
+| [#30791](https://github.com/trezor/trezor-suite/pull/30791) | `@TomasBoda` | merged | 1 | Earn Yield - Add Rewards Tooltips |
+| [#30255](https://github.com/trezor/trezor-suite/pull/30255) | `@53gur0` | merged | 1 | feat(suite-native): label wrap/unwrap transactions |
+| [#30154](https://github.com/trezor/trezor-suite/pull/30154) | `@vojtatranta` | open | 4 | WIP: 28878 playwright perf tracking |
+| [#30091](https://github.com/trezor/trezor-suite/pull/30091) | `@MiroslavProchazka` | open | 2 | fix(workflows): adjust aws session duration for icon workflow |
+| [#30028](https://github.com/trezor/trezor-suite/pull/30028) | `@tomasklim` | merged | 2 | Cardano staking updates |
+| [#29947](https://github.com/trezor/trezor-suite/pull/29947) | `@peter-sanderson` | merged | 1 | fix(earn): reduce Yield.xyz declaration size |
+| [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `@53gur0` | open | 7 | feat(suite-native): evm cancel  |
+| [#29445](https://github.com/trezor/trezor-suite/pull/29445) | `@tomasklim` | merged | 2 | fix(suite): keep account graph data visible while refetching |
+| [#29054](https://github.com/trezor/trezor-suite/pull/29054) | `@53gur0` | merged | 6 | perf(suite-desktop): tanstack query improvements |
+| [#29031](https://github.com/trezor/trezor-suite/pull/29031) | `@TomasBoda` | merged | 3 | Tron - Earn dashboard + Staking limits |
+| [#28948](https://github.com/trezor/trezor-suite/pull/28948) | `@53gur0` | merged | 3 | fix(suite-native): display aggregated amounts on tx list item |
+| [#28908](https://github.com/trezor/trezor-suite/pull/28908) | `@matusbalascak` | merged | 1 | feat(suite): implement tron staking dashboard |
+| [#28816](https://github.com/trezor/trezor-suite/pull/28816) | `@53gur0` | merged | 4 | feat(wallet-core): improve nonce discovery for EVM |
+| [#28797](https://github.com/trezor/trezor-suite/pull/28797) | `@mroz22` | closed | 1 | chore(validators): remove dead validator types |
+| [#28761](https://github.com/trezor/trezor-suite/pull/28761) | `@OriginalEveres` | merged | 1 | refactor(suite): extract shared debug utilities |
+| [#28414](https://github.com/trezor/trezor-suite/pull/28414) | `@marekrjpolak` | merged | 1 | Eth conversion utils |
+| [#28374](https://github.com/trezor/trezor-suite/pull/28374) | `@matusbalascak` | merged | 1 | feat(suite): add Tron staking page basics |
+| [#28234](https://github.com/trezor/trezor-suite/pull/28234) | `@matusbalascak` | merged | 2 | feat(suite): add transaction data editor to tron send form |
+| [#27901](https://github.com/trezor/trezor-suite/pull/27901) | `@matusbalascak` | merged | 4 | Yield speed up transaction support |
+| [#27829](https://github.com/trezor/trezor-suite/pull/27829) | `@unknown` | unknown | 1 | (PR no longer accessible — deleted or hidden) |
+| [#27725](https://github.com/trezor/trezor-suite/pull/27725) | `@izmy` | merged | 2 | fix(suite): handle Solana tx timeout in review modal |
+| [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `@BrantalikP` | merged | 12 | feat(suite-native): yield deposit |
+| [#27716](https://github.com/trezor/trezor-suite/pull/27716) | `@matusbalascak` | merged | 1 | Yield issues |
+| [#27621](https://github.com/trezor/trezor-suite/pull/27621) | `@BrantalikP` | merged | 1 | fix(suite-native): fee selector balance error |
+| [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `@matusbalascak` | merged | 6 | Self-composed `withdraw` / `redeem` calldata for stablecoin yield |
+| [#27584](https://github.com/trezor/trezor-suite/pull/27584) | `@izmy` | merged | 1 | Control Earn actions through message-system feature flags |
+
+## Index by PR author
+
+| Author | Groups |
+| --- | --- |
+| `@53gur0` | 26 |
+| `@matusbalascak` | 15 |
+| `@BrantalikP` | 13 |
+| `@TomasBoda` | 13 |
+| `@izmy` | 4 |
+| `@vojtatranta` | 4 |
+| `@tomasklim` | 4 |
+| `@MiroslavProchazka` | 2 |
+| `@unknown` | 1 |
+| `@marekrjpolak` | 1 |
+| `@OriginalEveres` | 1 |
+| `@mroz22` | 1 |
+| `@peter-sanderson` | 1 |
+
+## Full group → topic map
+
+| Group | PR | File:line | Topic |
+| --- | --- | --- | --- |
+| G01 | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:119` | TypeScript type safety |
+| G02 | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:118` | TypeScript type safety |
+| G03 | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts:170` | Nullability & sentinel values |
+| G04 | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:205` | Acknowledgements & cross-references |
+| G05 | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts:111` | Performance & memoization |
+| G06 | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts:87` | Acknowledgements & cross-references |
+| G07 | [#27584](https://github.com/trezor/trezor-suite/pull/27584) | `packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx:44` | Single source of truth |
+| G08 | [#27621](https://github.com/trezor/trezor-suite/pull/27621) | `suite-native/module-earn/src/hooks/useComposeEarnFees.ts:164` | Data fetching — prefer TanStack Query |
+| G09 | [#27716](https://github.com/trezor/trezor-suite/pull/27716) | `suite-common/suite-constants/src/evm.ts:18` | Single source of truth |
+| G10 | [#27725](https://github.com/trezor/trezor-suite/pull/27725) | `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx:49` | React hooks & effects |
+| G11 | [#27725](https://github.com/trezor/trezor-suite/pull/27725) | `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx:74` | Error handling & developer experience |
+| G12 | [#27901](https://github.com/trezor/trezor-suite/pull/27901) | `packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx:96` | Readability & simplification |
+| G13 | [#27901](https://github.com/trezor/trezor-suite/pull/27901) | `suite-common/calldata/src/calldata.ts:56` | Acknowledgements & cross-references |
+| G14 | [#27901](https://github.com/trezor/trezor-suite/pull/27901) | `suite-common/wallet-core/src/accounts/accountsThunks.ts:166` | Readability & simplification |
+| G15 | [#27901](https://github.com/trezor/trezor-suite/pull/27901) | `suite-common/wallet-utils/src/ethUtils.ts:91` | Acknowledgements & cross-references |
+| G16 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts:7` | Code placement, package boundaries & reuse |
+| G17 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx:24` | Acknowledgements & cross-references |
+| G18 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts:220` | Error handling & developer experience |
+| G19 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-common/wallet-core/src/index.ts:65` | Code placement, package boundaries & reuse |
+| G20 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-native/tx-simulation/package.json:28` | Component structure & file layout |
+| G21 | [#27829](https://github.com/trezor/trezor-suite/pull/27829) | `suite-common/earn-staking-api/src/staking/hooks/useEthereumValidatorsQueue.ts:19` | Data fetching — prefer TanStack Query |
+| G22 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx:129` | React hooks & effects |
+| G23 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-native/module-earn/src/components/YieldPendingTransactionModalConstants.ts:9` | Component structure & file layout |
+| G24 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts:49` | TypeScript type safety |
+| G25 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts:27` | TypeScript type safety |
+| G26 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-native/module-earn/src/hooks/useYieldDepositReview.ts:34` | Readability & simplification |
+| G27 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts:40` | Code placement, package boundaries & reuse |
+| G28 | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `suite-native/module-earn/src/screens/YieldDepositReviewScreen.tsx:162` | Component structure & file layout |
+| G29 | [#28234](https://github.com/trezor/trezor-suite/pull/28234) | `suite-common/wallet-core/src/send/tron/buildContract.ts:9` | Readability & simplification |
+| G30 | [#28234](https://github.com/trezor/trezor-suite/pull/28234) | `suite-common/wallet-core/src/send/sendFormThunks.ts:84` | Acknowledgements & cross-references |
+| G31 | [#28374](https://github.com/trezor/trezor-suite/pull/28374) | `packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx:28` | Code placement, package boundaries & reuse |
+| G32 | [#28414](https://github.com/trezor/trezor-suite/pull/28414) | `suite-common/wallet-utils/src/ethConverter.ts:33` | Runtime validation & parsing |
+| G33 | [#28761](https://github.com/trezor/trezor-suite/pull/28761) | `suite/settings/src/settingsSelectors.ts:30` | Code placement, package boundaries & reuse |
+| G34 | [#28797](https://github.com/trezor/trezor-suite/pull/28797) | `suite-common/validators/src/types.ts:1` | TypeScript type safety |
+| G35 | [#28908](https://github.com/trezor/trezor-suite/pull/28908) | `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx:15` | TypeScript type safety |
+| G36 | [#28948](https://github.com/trezor/trezor-suite/pull/28948) | `suite-native/transactions/src/components/TransactionTarget.tsx:125` | Performance & memoization |
+| G37 | [#28948](https://github.com/trezor/trezor-suite/pull/28948) | `suite-native/transactions/src/components/TransactionTarget.tsx:119` | Readability & simplification |
+| G38 | [#28948](https://github.com/trezor/trezor-suite/pull/28948) | `suite-native/transactions/src/components/TransactionListItem.tsx:134` | Performance & memoization |
+| G39 | [#28816](https://github.com/trezor/trezor-suite/pull/28816) | `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:68` | Acknowledgements & cross-references |
+| G40 | [#28816](https://github.com/trezor/trezor-suite/pull/28816) | `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:439` | TypeScript type safety |
+| G41 | [#28816](https://github.com/trezor/trezor-suite/pull/28816) | `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:82` | Runtime validation & parsing |
+| G42 | [#28816](https://github.com/trezor/trezor-suite/pull/28816) | `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:75` | TypeScript type safety |
+| G43 | [#29054](https://github.com/trezor/trezor-suite/pull/29054) | `suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts:73` | CI, tooling & guardrails |
+| G44 | [#29054](https://github.com/trezor/trezor-suite/pull/29054) | `packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx:63` | Performance & memoization |
+| G45 | [#29054](https://github.com/trezor/trezor-suite/pull/29054) | `suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts:22` | Acknowledgements & cross-references |
+| G46 | [#29054](https://github.com/trezor/trezor-suite/pull/29054) | `suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts:239` | Acknowledgements & cross-references |
+| G47 | [#29054](https://github.com/trezor/trezor-suite/pull/29054) | `suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts:47` | Acknowledgements & cross-references |
+| G48 | [#29054](https://github.com/trezor/trezor-suite/pull/29054) | `suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts:32` | Acknowledgements & cross-references |
+| G49 | [#29031](https://github.com/trezor/trezor-suite/pull/29031) | `packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts:52` | Single source of truth |
+| G50 | [#29031](https://github.com/trezor/trezor-suite/pull/29031) | `packages/suite/src/hooks/earn/useStakingYield.ts:46` | Performance & memoization |
+| G51 | [#29031](https://github.com/trezor/trezor-suite/pull/29031) | `packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx:386` | Readability & simplification |
+| G52 | [#30091](https://github.com/trezor/trezor-suite/pull/30091) | `.github/workflows/release-suite-coin-icons.yml:46` | CI, tooling & guardrails |
+| G53 | [#30091](https://github.com/trezor/trezor-suite/pull/30091) | `.github/workflows/release-suite-coin-icons.yml:46` | CI, tooling & guardrails |
+| G54 | [#29947](https://github.com/trezor/trezor-suite/pull/29947) | `suite-common/earn-stablecoin-api/src/services/yieldxyz.ts:50` | Code placement, package boundaries & reuse |
+| G55 | [#30255](https://github.com/trezor/trezor-suite/pull/30255) | `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx:134` | Component structure & file layout |
+| G56 | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts:66` | Data fetching — prefer TanStack Query |
+| G57 | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts:100` | TypeScript type safety |
+| G58 | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `suite-common/wallet-core/src/send/useEvmNonceInfo.ts:95` | Data fetching — prefer TanStack Query |
+| G59 | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `suite-native/module-transactions/src/hooks/useCancelEvmTransaction.ts:67` | Runtime validation & parsing |
+| G60 | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `suite-native/module-transactions/src/hooks/useDeviceGuardedSign.ts:74` | Data fetching — prefer TanStack Query |
+| G61 | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `suite-native/module-transactions/src/components/CancelEvmTransactionButton.tsx:46` | Component structure & file layout |
+| G62 | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `suite-native/module-transactions/src/redux.d.ts:11` | TypeScript type safety |
+| G63 | [#30154](https://github.com/trezor/trezor-suite/pull/30154) | `packages/suite/src/support/suite/Main.tsx:39` | Component structure & file layout |
+| G64 | [#30154](https://github.com/trezor/trezor-suite/pull/30154) | `suite/e2e/performance/perfMeasure.ts:53` | Error handling & developer experience |
+| G65 | [#30154](https://github.com/trezor/trezor-suite/pull/30154) | `packages/perf-e2e/src/instrumentation.ts:69` | Error handling & developer experience |
+| G66 | [#30154](https://github.com/trezor/trezor-suite/pull/30154) | `packages/perf-e2e/src/instrumentation.ts:91` | Acknowledgements & cross-references |
+| G67 | [#30791](https://github.com/trezor/trezor-suite/pull/30791) | `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts:85` | Performance & memoization |
+| G68 | [#30028](https://github.com/trezor/trezor-suite/pull/30028) | `suite-common/wallet-utils/src/cardanoStakingUtils.ts:111` | Readability & simplification |
+| G69 | [#30028](https://github.com/trezor/trezor-suite/pull/30028) | `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts:421` | Readability & simplification |
+| G70 | [#30797](https://github.com/trezor/trezor-suite/pull/30797) | `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts:93` | Comments & documentation |
+| G71 | [#29445](https://github.com/trezor/trezor-suite/pull/29445) | `packages/suite/src/actions/wallet/graphActions.ts:105` | Acknowledgements & cross-references |
+| G72 | [#29445](https://github.com/trezor/trezor-suite/pull/29445) | `packages/suite/src/actions/wallet/graphActions.ts:171` | Data fetching — prefer TanStack Query |
+| G73 | [#30910](https://github.com/trezor/trezor-suite/pull/30910) | `suite-common/wallet-utils/src/transactionUtils.ts:182` | Readability & simplification |
+| G74 | [#30910](https://github.com/trezor/trezor-suite/pull/30910) | `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx:90` | Performance & memoization |
+| G75 | [#30910](https://github.com/trezor/trezor-suite/pull/30910) | `suite-common/wallet-utils/src/transactionUtils.ts:80` | Readability & simplification |
+| G76 | [#30910](https://github.com/trezor/trezor-suite/pull/30910) | `suite-common/wallet-utils/src/transactionUtils.ts:93` | TypeScript type safety |
+| G77 | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `suite-native/module-earn/src/hooks/useYieldBadge.tsx:41` | Nullability & sentinel values |
+| G78 | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `suite-native/module-earn/src/hooks/useYieldBadge.tsx:45` | Nullability & sentinel values |
+| G79 | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:30` | Readability & simplification |
+| G80 | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:103` | Component structure & file layout |
+| G81 | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:113` | Nullability & sentinel values |
+| G82 | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:122` | Nullability & sentinel values |
+| G83 | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `suite-native/module-earn/src/components/YieldBadge.tsx:52` | Data fetching — prefer TanStack Query |
+| G84 | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:52` | Nullability & sentinel values |
+| G85 | [#31076](https://github.com/trezor/trezor-suite/pull/31076) | `suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx:166` | Acknowledgements & cross-references |
+| G86 | [#31071](https://github.com/trezor/trezor-suite/pull/31071) | `suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx:262` | TypeScript type safety |
+
+## Scope & method
+
+- **Window** comments created between **2026-05-11** and **2026-08-11**.
+- **Reviewer only.** PRs `@cermakjiri` authored are excluded — comments there are author replies, not review. That removed 33 comment(s) across 19 own PR(s).
+- **Collection** a repo-wide REST sweep of `/pulls/comments?since=…` unioned with `gh search prs --reviewed-by` and `--commenter`, then every `reviewThreads` node fetched over GraphQL (paginated), keeping threads with at least one reviewer comment in the window.
+- **Reconciliation** the REST sweep saw 94 reviewer comment(s) in the window. 94 are in this report; 0 could not be attached to a reachable PR. 4 further comment(s) appear here that REST cannot see (unsubmitted PENDING reviews).
+- **Topics** 86 group(s) classified from `scripts/review-threads/overrides.json`, 0 by keyword heuristic, 0 unclassified.
+
+### Caveats
+
+- **Unsubmitted drafts.** 4 group(s) (G63, G64, G65, G66) belong to PENDING reviews that were never submitted — nobody else can see them. Worth submitting or discarding.
+- **Inaccessible PRs.** 1 group(s) (G21) sit on PRs the API will not return, so PR title, author, and replies are unrecoverable. The comment body and diff hunk survived.
+- Groups marked *outdated* are anchored to a diff that has since changed, so the "line of code" permalink points at the original diff position and may no longer match.
+- Reactions-only participation (👍 on someone else's comment without writing one) is not captured — GitHub does not surface it as a comment.
+- Topic assignment is keyword-heuristic unless pinned in `overrides.json`. Treat auto-tagged groups as a first pass.
+
+## Regenerate
+
+```bash
+node scripts/review-threads/collect.mjs --since 2026-05-11 --until 2026-08-11
+```
+
+_Generated 2026-08-11 from the GitHub API (REST + GraphQL)._

--- a/code-review-threads/SKILLS-PROPOSAL.md
+++ b/code-review-threads/SKILLS-PROPOSAL.md
@@ -1,0 +1,816 @@
+# Review threads → skills: proposal
+
+Digest of [`code-review-threads/`](README.md) — 86 harvested review-thread-groups from 31 PRs — into
+candidate coding-standard rules, each routed to an existing `skills/` file or to a proposed new one.
+
+Method: one agent per topic extracted candidate rules, a second agent independently re-checked every
+coverage claim and citation, a synthesiser deduped across topics, and every load-bearing citation below
+was then verified by hand against the working tree.
+
+## Routing summary
+
+| #   | Rule                                                                             | Groups | Destination                             |
+| --- | -------------------------------------------------------------------------------- | ------ | --------------------------------------- |
+| 1   | Keep an absent value `undefined` — don't substitute `''` or `'0'`                | 3      | skills/defensive-programming/SKILL.md   |
+| 2   | Fetch with `useQuery`, not an effect that dispatches and mirrors state           | 4      | **NEW** skills/data-fetching/SKILL.md   |
+| 3   | Replace an `as` cast with `satisfies`, a guard, a parse, or a better type        | 4      | skills/typescript/SKILL.md              |
+| 4   | Take `AccountWithNetworkType<T>`, not `Account`, and narrow once upstream        | 2      | skills/typescript/SKILL.md              |
+| 5   | Compare EVM addresses with `areEvmAddressesEqual`, not ad-hoc `.toLowerCase()`   | 2      | skills/defensive-programming/SKILL.md   |
+| 6   | Only call `.unwrap()` where you handle the rejection                             | 1      | skills/redux/SKILL.md                   |
+| 7   | Fail with a named error instead of returning a bare `null`                       | 2      | skills/defensive-programming/SKILL.md   |
+| 8   | Extract logic both apps need into suite-common instead of duplicating it per app | 2      | skills/packages/SKILL.md                |
+| 9   | Export one React component per file, and give an extracted hook its own file     | 3      | skills/components/SKILL.md              |
+| 10  | Decide per-network behaviour from network `features`, not a symbol list          | 1      | skills/defensive-programming/SKILL.md   |
+| 11  | Give a name to logic the reader has to decode                                    | 5      | skills/comments/SKILL.md                |
+| 12  | Let callers pass `queryOptions` into a shared query hook, never overwrite them   | 1      | **NEW** skills/data-fetching/SKILL.md   |
+| 13  | Type test fixtures with `satisfies`, not `as unknown as`                         | 2      | skills/tests/SKILL.md                   |
+| 14  | Call the narrowest query hook for what you render                                | 1      | **NEW** skills/data-fetching/SKILL.md   |
+| 15  | Pick the ref hook by when `.current` is read                                     | 1      | skills/performance-react-hooks/SKILL.md |
+
+## Proposed new skill
+
+### `skills/data-fetching/` — 3 rules
+
+```yaml
+name: data-fetching
+description: TanStack Query conventions: fetching with useQuery instead of an effect that dispatches a thunk, when useMutation is the right tool, query keys, and how a shared query hook exposes options. Use when a screen needs to load data, when writing or reviewing a hook in suite-common that wraps useQuery, or when you find yourself mirroring loading/error state into useState.
+```
+
+- ## Fetch with `useQuery`, not an effect that dispatches and mirrors state
+- ## Let callers pass `queryOptions` into a shared query hook, never overwrite them
+- ## Call the narrowest query hook for what you render
+
+**Why not an existing file:** Grep over skills/ finds zero mentions of TanStack Query, `useQuery`, `useMutation` or `queryKey`. The two candidate existing homes both distort the rules: skills/redux is about the effect+thunk+slice pattern these rules steer away from (its :216 lifecycle-actions bullet would end up arguing against its own subject), and skills/performance-react-hooks covers fetch-in-effect only from the dependency-stability angle (:81 "the request count is unbounded"), prescribing a narrower dependency array rather than replacing the effect. The query layer is a distinct domain with its own vocabulary (query identity, `enabled`, `select`, key factories) and its own already-mechanized parts. Three rules is in line with existing small skills (packages, import-export and publish-config each have two headings). The skill must open by naming the lint boundary: `@tanstack/eslint-plugin-query` `flat/recommended-strict` is on for every file using the Query API (packages/eslint/src/reactQueryConfig.mjs:10), so query-key exhaustive-deps, rest-destructuring and mutation property order must not be restated in prose.
+
+## Rules
+
+### 1. Keep an absent value `undefined` — don't substitute `''` or `'0'`
+
+- **Destination** `skills/defensive-programming/SKILL.md` (existing-add)
+- **Backing** 3 review-thread-group(s) — Nullability & sentinel values (G03, G77, G78)
+- **Confidence** high
+
+When a value is genuinely missing, pass `undefined` (or `null` where that is the domain type) and let the consumer decide what to render; do not fill the hole with `''` or `'0'`. If the absence makes the surrounding computation meaningless, guard on it and let the type narrow — `if (!token?.symbol) return [];` — instead of manufacturing a value that satisfies the compiler. Boundary: a controlled form input's `value` and string concatenation legitimately need `?? ''`; there `''` is the real empty state, not a stand-in for absence.
+
+**Why it matters.** `''` and `'0'` are indistinguishable from real data, so the absence stops being visible: a `?? ''` symbol reaches a vault lookup as a legitimate key and silently matches nothing, a `?? '0'` balance renders as a confident zero where the UI should show a placeholder, and every downstream reader has to re-guess whether the empty value meant "absent" or "empty". The type-checker cannot help, because the sentinel is a valid inhabitant of the declared type.
+
+**Existing coverage.** skills/defensive-programming/SKILL.md:10 — "Whenever possible, cover all cases. If a new case is added in the future, TypeScript should force the developer to set behavior for it." The heading above it sounds like coverage, but all three sub-sections (:12 explicit return types, exhaustive switch, type-mapping) are about exhausting union _cases_; nothing in skills/ says anything about substituting a placeholder for a missing value.
+
+```tsx
+// bad - the pre-fix shape from #30994: '' is not a symbol, yet it reaches the vault lookup as data
+const heldToken = {
+    address: token.contract,
+    symbol: token.symbol ?? '',
+    decimals: token.decimals,
+};
+
+// good - useYieldBadge.tsx:41 - the lookup is meaningless without a symbol, so guard and narrow
+if (!networkSymbol || !token?.symbol) return [];
+
+const heldToken = {
+    address: token.contract,
+    symbol: token.symbol,
+    decimals: token.decimals,
+};
+```
+
+**Evidence**
+
+- G03 https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224430555 — "isn't better to pass undefined than empty strings so a react component could decide if it should display some placeholder"
+- G77 https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749106530 and G78 …#discussion_r3749107437 — same note, different PR/author; both landed
+- VERIFIED live violation: packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts:217 — `const inputTokenSymbol = isSharesInput ? (receiptToken?.symbol ?? '') : (token?.symbol ?? '');` (also :204 `return token?.balance ?? '';`)
+- VERIFIED accepted fix: suite-native/module-earn/src/hooks/useYieldBadge.tsx:41 `if (!networkSymbol || !token?.symbol) return [];`, then :45 `symbol: token.symbol,`
+- VERIFIED dead sentinel: suite-native/module-accounts-management/src/components/YourPositionCard.tsx:77 `vaultId={yieldBadge.vaultId ?? ''}` on a value the hook types as non-optional `vaultId: string` (useYieldBadge.tsx:21)
+- VERIFIED scale/boundary: 245 occurrences of `?? ''` across packages/suite/src, suite-common and suite-native, many legitimate — so this is prose, not lint
+
+### 2. Fetch with `useQuery`, not an effect that dispatches and mirrors state
+
+- **Destination** `NEW skills/data-fetching/SKILL.md` (new-skill)
+- **Backing** 4 review-thread-group(s) — Data fetching — prefer TanStack Query (rule 1: G08, G60, G72, G56); Data fetching — prefer TanStack Query (rule 2 `useMutation` only when user-triggered: G56, G08 — same groups, merged)
+- **Confidence** high
+
+Data a screen needs as soon as its inputs exist belongs in a `useQuery` keyed by those inputs, not in a `useEffect` that dispatches a thunk and mirrors loading/error/race state into `useState`. Query identity gives request de-duplication, discarding of superseded responses and an `AbortSignal` for free. The corollary: `useMutation` is for imperative, user-triggered writes — if you find yourself calling `mutate()` from a `useEffect`, the case is declarative, so move it to `useQuery` and turn the effect's guard clause into `enabled`. Add the key to the factories in `suite-common/react-query/src/constants/queryKeys.ts`; never inline `queryKey: []`.
+
+**Why it matters.** The effect version needs a request-id guard to drop stale responses and a manual loading flag: miss the guard and a superseded fee estimate overwrites the current one, miss the flag and the spinner never clears. A mutation fired from an effect is worse — it has no cache identity, so nothing de-duplicates it and nothing aborts the superseded call, while the effect's dependency on the whole `account` object re-fires it after every blockchain update.
+
+**Existing coverage.** skills/redux/SKILL.md:216 — "For async thunks, try to make use of the lifecycle actions whenever it makes sense. For example, when you have an async thunk that fetches something and saves in state." — the closest existing text, and it points the opposite way; putting this rule there would make the redux skill argue against its own subject. Grep confirms zero mentions of TanStack Query, `useQuery`, `useMutation` or `queryKey` anywhere in skills/.
+
+```tsx
+// bad - useEthereumCancelTxCompose.ts:115 - a mutation nothing user-triggered ever calls, fired
+// from an effect whose deps include the whole `account` object
+const {
+    mutate,
+    data,
+    isPending: isComposing,
+} = useMutation({
+    mutationFn: () => dispatch(composeEthereumCancelTransactionThunk({ account, tx })).unwrap(),
+});
+
+useEffect(() => {
+    if (account.networkType !== 'ethereum' || !feeInfo) return;
+
+    mutate();
+}, [account, tx, feeInfo, mutate]);
+
+// good - the preconditions become `enabled`, and the effect disappears with them
+const { data, isPending: isComposing } = useQuery({
+    queryKey: desktopQueryKeys.ethereumCancelTx(account.key, tx.txid),
+    queryFn: () => dispatch(composeEthereumCancelTransactionThunk({ account, tx })).unwrap(),
+    enabled: account.networkType === 'ethereum' && Boolean(feeInfo),
+});
+```
+
+**Evidence**
+
+- G08 https://github.com/trezor/trezor-suite/pull/27621#discussion_r3233333111 (@BrantalikP — useMutation/useQuery instead of effect + isComposing state)
+- G60 https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682381623 (@53gur0 — "this looks like job for useQuery")
+- G56 https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682308103 (@53gur0 — "Why not using useQuery if it's more declarative than imperative use-case?")
+- G72 https://github.com/trezor/trezor-suite/pull/29445#discussion_r3712475266 (@tomasklim — graph fetching thunk "could be fairly easily replaced with tanstack query")
+- VERIFIED live hand-rolled shape: suite-native/module-earn/src/hooks/useComposeEarnFees.ts:93 (`useState` loading flag), :96 (`requestIdRef`), :193-196 (the effect that bumps the id and fires the compose)
+- VERIFIED live mutate()-from-effect: packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts:55 (`useMutation`), :115-120 (`useEffect` calling `mutate()` with deps `[account, tx, feeInfo, mutate]`)
+- VERIFIED good precedents: suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.ts:26-40 (`useQuery` wrapping `dispatch(thunk()).unwrap()` with `enabled: missingRateTickers.length > 0`, keyed via `commonQueryKeys.missingRateTickers`) — note it carries an `@tanstack/query/exhaustive-deps` disable at :25 for the stable `dispatch`, so cite it for the shape, not as disable-free; packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.ts (the G72 fetch, now a query keyed by `desktopQueryKeys.accountGraphUpdate`)
+- VERIFIED central key factories: suite-common/react-query/src/constants/queryKeys.ts:3 `commonQueryKeys`, :31 `desktopQueryKeys`, both `satisfies Record<string, AllowedQueryKey>`
+- VERIFIED lint boundary: packages/eslint/src/reactQueryConfig.mjs:10 enables `flat/recommended-strict`, so exhaustive-deps/rest-destructuring/mutation property order are already mechanized and must not be restated in prose
+
+### 3. Replace an `as` cast with `satisfies`, a guard, a parse, or a better type
+
+- **Destination** `skills/typescript/SKILL.md` (existing-add)
+- **Backing** 4 review-thread-group(s) — TypeScript type safety (G57, G86, G76); Runtime validation & parsing (G41, G59 — folded in as the schema clause only; see disputes)
+- **Confidence** high
+
+An `as` cast is an unchecked claim, so it is the wrong tool at the places it is most tempting. Constructing a value: use `satisfies` — it checks the shape without erasing what the compiler knows. Narrowing a string you did not construct: use the existing guard (`isNetworkSymbol` from `@suite-common/wallet-config`) where there is a fallback to fall back to, or the sanctioned `asNetworkSymbol` wrapper at a parse boundary where the string comes from outside and there is no alternative. An object payload from outside the type system: parse it (`safeParse` on a schema in `@suite-common/schemas`, as `parseEvmFeeHex` does; HTTP responses already get this from `createHttpClient`'s per-endpoint `schema`). If none of those fit because the type is wrong, change the type rather than casting around it.
+
+**Why it matters.** The cast silences the compiler exactly where the shape is decided, so a later field rename, or a value that was never a `NetworkSymbol`, compiles fine and fails at runtime — `TokenIcon` renders nothing, or a `networks[symbol]` lookup returns `undefined` far from the cast that caused it. `satisfies`, a guard and a parse all keep the same code compiling only while it is still true.
+
+**Existing coverage.** skills/typescript/SKILL.md:22 — "Use `unknown` for situations where a function _doesn't know_ the incoming type and not when it _doesn't care_ about the type. With better type safety, `unknown` can help us catch possible errors early on." The file already has two sections about not silencing the compiler (`@ts-expect-error` vs `@ts-ignore` at :8, `unknown` vs `any` at :20) and offers a hand-written type guard at :26-34; `as` is the third way and is absent.
+
+```ts
+// bad - useEthereumCancelTxCompose.ts:105 - the cast is the only reason this literal type-checks,
+// so a renamed field on PrecomposedTransactionFinalCancelRbf keeps compiling here
+return {
+    composedCancelTx: {
+        ...normalLevel,
+        rbfType: 'cancel',
+        prevTxid: tx.txid,
+    } as PrecomposedTransactionFinalCancelRbf,
+    cancelFormState: formState,
+};
+
+// good - `satisfies` checks the same shape without erasing it; if it does not compile, the type is
+// wrong and that is the thing to fix - not something to assert past
+const composedCancelTx = {
+    ...normalLevel,
+    rbfType: 'cancel',
+    prevTxid: tx.txid,
+} satisfies PrecomposedTransactionFinalCancelRbf;
+```
+
+**Evidence**
+
+- G57 https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682317823 — "The casting doesn't feel right here. Can we rather use `satisfies` or add new type?"
+- G86 https://github.com/trezor/trezor-suite/pull/31071#discussion_r3750108169 — guard instead of `as NetworkSymbol` (author: "done")
+- G76 https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721463180 — the fix-the-type variant: "wouldn't be better to fix the `sent` type or introduce new one"
+- G41 https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452739137 — "What about using some Zod schema for parsing of the unknown data instead of the casting?"
+- VERIFIED live object-literal cast (the G57 shape, still unfixed): packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts:105-110 — `{ ...normalLevel, rbfType: 'cancel', prevTxid: tx.txid } as PrecomposedTransactionFinalCancelRbf`
+- VERIFIED the guard: suite-common/wallet-config/src/utils.ts:117 `isNetworkSymbol`; idiomatic use at suite-native/atoms/src/Badge.tsx:82-84
+- VERIFIED the third tool the digest missed: suite-common/wallet-config/src/types.ts:8 `export const asNetworkSymbol = (symbol: string): NetworkSymbol => symbol as NetworkSymbol;` — 310 matching lines in `*/src/*` against 69 for `isNetworkSymbol`, so a rule naming only `isNetworkSymbol` would misfire
+- VERIFIED the real parse boundary: suite-common/schemas/src/evm/fees/index.ts:37-41 `parseEvmFeeHex` (`safeParse` → `data | null`) and suite-common/http-client/src/httpClient.ts:46-58 (per-endpoint `schema` required)
+- VERIFIED gap: `satisfies` appears nowhere in skills/ (only unrelated prose at skills/redux/SKILL.md:222) despite ~500 uses in src
+
+### 4. Take `AccountWithNetworkType<T>`, not `Account`, and narrow once upstream
+
+- **Destination** `skills/typescript/SKILL.md` (existing-add)
+- **Backing** 2 review-thread-group(s) — TypeScript type safety (G40, G35)
+- **Confidence** high
+
+When code only makes sense for one network type, type its input as `AccountWithNetworkType<'tron'>` (from `@suite-common/wallet-types`) instead of `Account` or the hand-rolled `Account & { networkType: 'tron' }`. Do the "is this the right account?" check once at the boundary that produces the account, so nothing downstream needs a guard for a case that cannot happen. Cross-reference skills/defensive-programming/SKILL.md: the point of the narrower type is that the impossible branches get deleted, not defensively handled.
+
+**Why it matters.** Passing the wide `Account` pushes the network check into every consumer: `getTronResources` returns `undefined` for every non-tron account, so `TronResourcesCard` reads every field through `?? 0` and an all-zero card is indistinguishable from a real one. With the narrowed type the redundant `getTronResources` call and its `misc?.` chain disappear, and on the ethereum variant `misc.nonce: string` becomes non-optional outright.
+
+**Existing coverage.** skills/typescript/SKILL.md:38 "## Prefer direct type assignment to indirect" with the rationale at :56 — "Direct assignment may add an import, but it prevents the need to refactor if the `NetworkSymbol` detaches from `Account`…". Same instinct (name the precise type) but it is about importing a type rather than reaching through `Account['symbol']`; nothing in the file covers extracting a discriminated-union member.
+
+```tsx
+// bad - TronResourcesCard.tsx:17 - any Account gets in, so the card re-derives the network check
+// and every read needs a fallback that hides an all-zero card
+interface TronResourcesCardProps {
+    account: Account;
+}
+
+const resources = getTronResources(account); // undefined for every non-tron account
+const energyAvailable = resources?.availableEnergy ?? 0;
+
+// good - the network check happens once upstream; the redundant call and chain are gone
+interface TronResourcesCardProps {
+    account: AccountWithNetworkType<'tron'>;
+}
+
+const energyAvailable = account.misc.tronResources?.availableEnergy ?? 0;
+```
+
+**Evidence**
+
+- G40 https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452406666 (author applied it)
+- G35 https://github.com/trezor/trezor-suite/pull/28908#discussion_r3440966584 (different author, same note)
+- VERIFIED suite-common/wallet-types/src/account.ts:111-112 — `export type AccountWithNetworkType<NetworkType extends AccountNetworkSpecific['networkType']> = Extract<Account, { networkType: NetworkType }>`
+- VERIFIED live violation (thread unresolved): packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx:17-19 — `interface TronResourcesCardProps { account: Account; }`
+- VERIFIED suite-common/wallet-utils/src/tronStakingUtils.ts:49-50 — returns `undefined` unless `networkType === 'tron'`
+- VERIFIED 3 remaining hand-rolled intersections vs 23 files consuming `AccountWithNetworkType`: TransactionReviewEthereumNotes.tsx:19, composeYieldWithdrawTransaction.ts:21, suite-native/staking/src/stakeFormEthereumNativeTypes.ts:6
+
+### 5. Compare EVM addresses with `areEvmAddressesEqual`, not ad-hoc `.toLowerCase()`
+
+- **Destination** `skills/defensive-programming/SKILL.md` (existing-add)
+- **Backing** 2 review-thread-group(s) — Readability & simplification (G12, G75)
+- **Confidence** high
+
+EVM addresses reach Suite in mixed EIP-55 casing, so any equality check has to be checksum-agnostic. Use `areEvmAddressesEqual` from `@suite-common/address` instead of lowercasing at the call site, and normalize once at the parse boundary when a value is stored or passed on (two already-normalized values may then compare with plain `===`). Two boundaries: it is EVM-only (it returns `false` for bech32/base58 addresses), and it pulls viem in, so a consumer reachable from `build-connect` may keep a documented hand-rolled comparison.
+
+**Why it matters.** A `.toLowerCase()` missing on one side compiles, type-checks and silently answers "not ours": in `isSignedByDescriptor` that mis-attributes a transaction's signer and feeds wrong EVM nonce arithmetic; in the trading approve flow it would compare against the wrong spender. Nothing fails loudly — the wrong boolean just propagates. `areEvmAddressesEqual` handles both sides and missing/invalid input, so there is nothing left to remember.
+
+**Existing coverage.** skills/defensive-programming/SKILL.md:65 — "`[...items].sort()` and `items.slice().sort()` are workarounds for `sort` mutating in place, and they only work if you remember the copy. `toSorted`, `toReversed`, `toSpliced` and `with` return a new array, so forgetting is not an option — and forgetting matters here…" — the same argument one domain over (the shared API removes a step you can forget, and the failure surfaces far from the cause), which is why this belongs next to it. Nothing in skills/ mentions address comparison.
+
+```ts
+// bad - transactionUtils.ts:76 - drop the .toLowerCase() on either side and this silently answers
+// "not our transaction" for any EIP-55 mixed-case address; the intent needs a comment to survive
+const isSignedByDescriptor = (details: AccountTransaction['details'], descriptor: string) =>
+    !!details?.vin?.some(
+        vin =>
+            vin.isAccountOwned ||
+            vin.addresses?.some(address => address.toLowerCase() === descriptor.toLowerCase()),
+    );
+
+// good - checksum-agnostic and null-safe in one call, and the name states the intent
+const isSignedByDescriptor = (details: AccountTransaction['details'], descriptor: string) =>
+    !!details?.vin?.some(
+        vin =>
+            vin.isAccountOwned ||
+            vin.addresses?.some(address => areEvmAddressesEqual(address, descriptor)),
+    );
+```
+
+**Evidence**
+
+- G12 https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279119442 (plus the follow-up comment r3279122220 — "Or use some general method for formatting the address based on network?")
+- G75 https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721438603 — "what about using `areEvmAddressesEqual`?"
+- VERIFIED suite-common/address/src/evmChecksumUtils.ts:10-18 — `areEvmAddressesEqual = (a?: string | null, b?: string | null): boolean` over viem `isAddress` + `isAddressEqual`, with the null-safety documented in its own comment
+- VERIFIED still ad-hoc in develop: suite-common/wallet-utils/src/transactionUtils.ts:76-81 (`address.toLowerCase() === descriptor.toLowerCase()`, guarded by `vin.isAccountOwned ||`), and suite-common/wallet-utils/package.json already declares `@suite-common/address`
+- VERIFIED normalize-at-the-boundary half: suite-common/calldata/src/validation/evm/address.ts:39 `normalize: (input: string) => input.toLowerCase() as EvmAddress`
+- VERIFIED documented exception: networks/ethereum/network-ethereum/src/constants/wrappedNativeToken.ts:43-52 (viem would break the build-connect bundle)
+- VERIFIED not mechanizable: 30 `x.toLowerCase() === y.toLowerCase()` sites repo-wide, ~9 of them non-address (browser name, token symbol, fw revision), so a lint selector cannot decide it; ~21 are a separate migration
+
+### 6. Only call `.unwrap()` where you handle the rejection
+
+- **Destination** `skills/redux/SKILL.md` (existing-add)
+- **Backing** 1 review-thread-group(s) — Error handling & developer experience (G11)
+- **Confidence** high
+
+`dispatch(thunk())` resolves with the rejected action; adding `.unwrap()` re-throws it instead. Every `.unwrap()` must therefore sit inside a `try/catch`, inside a `useMutation` `mutationFn`, or be returned to a caller that does one of those. If you do not need the resolved value, drop `.unwrap()` and read the lifecycle state from Redux. A `catch {}` may be empty only with a comment naming the thunk that owns the error state.
+
+**Why it matters.** An unhandled rejection from an `onClick` gives the user a button that does nothing, skips every statement after the `.unwrap()` — in the review modal that is the draft removal and the `goto` that leaves the flow — and surfaces as a context-free unhandled-rejection in Sentry instead of the error state the thunk already wrote to the store.
+
+**Existing coverage.** skills/redux/SKILL.md:216 — "For async thunks, try to make use of the lifecycle actions whenever it makes sense… If fetching was not successful, you can explicitly modify the slice state in a relevant way" — covers the thunk-author side only; `.unwrap()` appears nowhere in skills/ (grep: zero hits).
+
+```tsx
+// bad - useTradingSellTradeActions.ts:103 - reached from onClick; nothing catches the rejected thunk,
+// so the button silently does nothing and everything after the await is skipped
+const addBankAccount = async () => {
+    if (!selectedQuote) return;
+
+    await dispatch(requestSellTradeThunk({ quote: selectedQuote })).unwrap();
+};
+
+// good - useMutation owns the rejection, and `mutation.error` is what renders it
+const addBankAccountMutation = useMutation({
+    mutationFn: (quote: SellQuote) => dispatch(requestSellTradeThunk({ quote })).unwrap(),
+});
+```
+
+**Evidence**
+
+- G11 https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241245158 — "now the thunk's promise can be rejected, causing the component to crash, let's please add `try/catch` / `useMutation`"
+- VERIFIED the fixed shape: packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx:85-101 — `.unwrap()` at :93 inside `try`, with the empty `catch` commented at :100 ("Error state is handled by signAndPushSendFormTransactionThunk.")
+- VERIFIED live violation reached from a click handler: packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts:103-107 (`await dispatch(requestSellTradeThunk(...)).unwrap();` with no try/catch), wired at packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSellBankAccount.tsx:62 `onClick={addBankAccount}`
+- VERIFIED the mutation variant: packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx:117-125
+- VERIFIED `createThunk` is RTK `createAsyncThunk` (suite-common/redux-utils/src/createThunk.ts:51), so the `.unwrap()` re-throw semantics hold; ~50 non-test `.unwrap()` call sites in packages/suite
+
+### 7. Fail with a named error instead of returning a bare `null`
+
+- **Destination** `skills/defensive-programming/SKILL.md` (existing-add)
+- **Backing** 2 review-thread-group(s) — Error handling & developer experience (G18, G64)
+- **Confidence** high
+
+When a helper cannot produce a valid result, surface which precondition failed: a typed `Result`/discriminated variant the caller branches on for expected failures, or a `throw` whose message names the missing field for an invariant the caller cannot act on. A bare `null` return — and its harness twin, logging "skipping" and returning — is neither, and collapses several distinct failures into one indistinguishable value. Name the missing field (`fee`, `gasLimit`), never its value: these strings reach Sentry and toasts.
+
+**Why it matters.** On the signing path a bare `null` leaves the caller able to render only "something went wrong"; nothing in the store, the log or Sentry says whether the fee data, the payload or the gas parameters were missing, so the reason has to be re-derived by bisecting the helper by hand. Because `createThunk` serializes a thrown error down to `{name, message, stack}`, the message string is the entire diagnostic that survives into the slice and the UI.
+
+**Existing coverage.** skills/defensive-programming/SKILL.md:77 — "Unless failures are unpredictable, pass errors via `return` and do not `throw`. Throwing exceptions is not type-safe. There is a `Result` type that shall be used." This half-covers it and is why it belongs here: the sentence reads as a blanket ban on `throw`, which is exactly the reasoning that produced the `null`-returning helpers in #27718.
+
+```ts
+// bad - the pre-fix shape from #27718 - one `null` for a missing fee and for an unparsable payload
+const getStablecoinYieldTransactionWithSelectedFee = (
+    parsedTransaction: StablecoinYieldParsedTransactionForSigning,
+    selectedFee?: EvmSelectedFee | null,
+): StablecoinYieldParsedTransactionForSigning | null => {
+    const parsedSelectedFee = parseEvmFeeHex(selectedFee);
+
+    if (!parsedSelectedFee) return null;
+
+    return { ...parsedTransaction, ...flattenEvmFees(parsedSelectedFee) };
+};
+
+// good - stablecoinYieldSigningUtils.ts:64 - the message names the missing field, so the slice,
+// the toast and Sentry all say why; the return type loses `| null` with it
+if (!parsedSelectedFee) {
+    throw new Error('Fee information is missing for the transaction.');
+}
+```
+
+**Evidence**
+
+- G18 https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287452170 — "instead of throwing errors it returns null … from DevX it'll be much harder to deduce what's wrong"; author agreed and reverted to explicit errors
+- G64 https://github.com/trezor/trezor-suite/pull/30154#discussion_r3702600838 — the same note in harness form ("why skipping it … this should throw an error instead"). NOTE: this is an unpublished pending draft; the URL 404s and the file is not in the tree, so cite it as prose context only, never as a link or file:line
+- VERIFIED the landed good shape: suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts:64 `throw new Error('Fee information is missing for the transaction.');`, :101 `'Yield transaction gas parameters are missing.'`, :201 `'Unsupported yield transaction payload.'` — and the return types at :56/:197 carry no `| null`
+- VERIFIED `Result` exists as the alternative: packages/type-utils/src/result.ts
+- VERIFIED the outbound sink that makes the field/value distinction load-bearing: packages/suite/src/utils/suite/sentry.ts `Sentry.captureException(error)`
+
+### 8. Extract logic both apps need into suite-common instead of duplicating it per app
+
+- **Destination** `skills/packages/SKILL.md` (existing-add)
+- **Backing** 2 review-thread-group(s) — Code placement, package boundaries & reuse (G27, G31)
+- **Confidence** high
+
+When the same derivation or hook body appears in the web/desktop app and in `suite-native`, move the platform-agnostic core into the shared layer — into the `@suite-common/*` hook that already returns the raw data, or into a `@suite-common/*` util — and leave only the platform glue (navigation, native components, desktop analytics) in each app. If a hook cannot be shared wholesale, extract the pure parts rather than copying the whole file; if nothing platform-agnostic is left, keep the duplicate and say so in a comment.
+
+**Why it matters.** Copies drift silently. `getPollIntervalMs` was extracted to `suite-common/wallet-utils/src/pollingUtils.ts:5`, but `packages/suite` kept two local re-implementations, so the block-time-to-poll ratio now lives in three places: change the shared one and mobile plus suite's wrap/unwrap flows move while suite's Tron-stake and yield pending-tx screens silently keep the old value.
+
+**Existing coverage.** skills/packages/SKILL.md:15 — "| @suite-common | /suite-common | code shared between @suite and @suite native | @trezor |" — the scope table declares what suite-common is _for_ but never says what to do when you notice the same logic in both apps; grep finds nothing about duplication anywhere in skills/ (nearest is skills/project-structure/SKILL.md:11, also declarative only).
+
+```tsx
+// bad - the pre-review shape from #28374 - each app re-derives the same value from raw query data
+const { data } = useTronStakingStats();
+const maxApr = data?.length ? Math.max(...data.map(({ apr }) => apr)) : null;
+
+// good - useTronStakingStats.ts:17 - the shared hook derives it once, both apps just read it
+export function useTronStakingStats(queryOptions?: Partial<UseQueryOptions<TrxStats>>) {
+    const stats = useQuery({ staleTime: 5 * 60 * 1000, ...queryOptions, queryKey, queryFn });
+
+    const maxApr = stats.data?.length ? Math.max(...stats.data.map(({ apr }) => apr)) : null;
+    const formattedMaxApr = maxApr ? Number(maxApr.toFixed(2)) : null;
+
+    return { stats, maxApr, formattedMaxApr };
+}
+```
+
+**Evidence**
+
+- G27 https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302426845 (author pushed back: "there is some platform specific code that made it harder" — which is why the rule is about extracting the core, not moving whole hooks)
+- G31 https://github.com/trezor/trezor-suite/pull/28374#discussion_r3361541527 (landed as commit 8aeffe08cc)
+- VERIFIED the landed shape: suite-common/earn-staking-api/src/staking/hooks/useTronStakingStats.ts:17-20 derives `maxApr`/`formattedMaxApr` and returns them; consumed by packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx:33 and suite-native/module-earn/src/components/EarnAccountCard.tsx:87
+- VERIFIED the three live copies of `getPollIntervalMs`: suite-common/wallet-utils/src/pollingUtils.ts:5 (shared, also used by suite-common/wallet-core/src/stablecoin-yield/hooks/useWrappedNativePendingTx.ts:74 and suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts:20), vs local re-implementations at packages/suite/src/components/earn/staking/tron/hooks/useTronStakePendingTransactionTracking.ts:20 and packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts:35
+- VERIFIED the boundary is already lint-enforced in one direction: `local-rules/no-suite-imports-in-suite-common` (packages/eslint/src/localRulesConfig.mjs)
+
+### 9. Export one React component per file, and give an extracted hook its own file
+
+- **Destination** `skills/components/SKILL.md` (existing-add)
+- **Backing** 3 review-thread-group(s) — Component structure & file layout (G28, G61, G80)
+- **Confidence** high
+
+A file exports exactly one React component. A helper component that only this file uses still gets its own file next to it (not a shared `parts.tsx`), and a hook extracted from a component goes into `hooks/<useHookName>.ts(x)` named after the hook. The countable half of this is mechanizable — see the ESLint follow-up — so the prose carries only what a linter cannot decide: where the extracted unit goes.
+
+**Why it matters.** The reviewer raised it on three PRs by three different authors; each time the second component or the inline hook was the part that later needed reuse or refactoring, and it was not reachable by filename or renderable in a test on its own.
+
+**Existing coverage.** skills/components/SKILL.md:8-16 — "## 🟠 File structure / 1. ↕️ Imports … 7. 🍱 Component" — the list orders sections _within_ one file and never says a file holds exactly one component; nothing in the file mentions a `hooks/` directory or hook file naming.
+
+```tsx
+// bad - #29622 - two components in one file; the fee row is not findable by filename and cannot be
+// reused or rendered in a test on its own
+const CancelTransactionFeeRow = ({ title, fee, symbol }: CancelTransactionFeeRowProps) => (
+    <TransactionDetailRow title={title}>{/* ... */}</TransactionDetailRow>
+);
+
+export const CancelEvmTransactionButton = ({ accountKey, transaction }: Props) => (
+    <CancelTransactionFeeRow title={feeTitle} fee={fee} symbol={transaction.symbol} />
+);
+
+// good - one component per file, and the hook in hooks/ named after itself
+// components/CancelEvmTransactionButton.tsx
+import { CancelTransactionFeeRow } from './CancelTransactionFeeRow';
+import { useCancelEvmTransaction } from '../hooks/useCancelEvmTransaction';
+
+export const CancelEvmTransactionButton = ({ accountKey, transaction }: Props) => {
+    const { fee, cancel } = useCancelEvmTransaction({ accountKey, transaction });
+
+    return <CancelTransactionFeeRow fee={fee} symbol={transaction.symbol} onPress={cancel} />;
+};
+```
+
+**Evidence**
+
+- G28 https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302449312 — "One component per file please to make it easily readable" (reviewer later accepted a follow-up: "I still think it'd be better to divide it … but I don't push it")
+- G61 https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682393196 — "Let's please have single react component per file (easier to find the component, easier to refactor…)" — restated firmly two months later
+- G80 https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749138330 — "Let's put it to new file with the name of the hook."
+- VERIFIED the applied G80 fix: suite-native/module-accounts-management/src/hooks/useYourPositionCardYieldBadge.tsx:13 (`.tsx`, because it returns JSX-bearing values), imported by ../components/YourPositionCard.tsx
+- VERIFIED nothing enforces it today: `grep -rn no-multi-comp packages/eslint/src eslint-local-rules` → 0 hits; packages/eslint/src/reactConfig.mjs:16-25 lists the enabled `react/*` rules and it is absent
+- NOT VERIFIABLE IN REPO: G61's file (CancelEvmTransactionButton.tsx) — PR #29622 is still open, so cite the discussion URL only
+
+### 10. Decide per-network behaviour from network `features`, not a symbol list
+
+- **Destination** `skills/defensive-programming/SKILL.md` (existing-add)
+- **Backing** 1 review-thread-group(s) — Single source of truth (G49)
+- **Confidence** medium
+
+Whether a coin supports a capability is declared in the `networks` config (`features: NetworkFeature[]`), so read it through `hasNetworkFeatures(account, [...])` (the default — it honours per-`accountType` overrides), `getNetworkFeatures(symbol)` for a symbol-level check, or a list derived from the config (`STAKING_SYMBOLS`, `isStakingSymbol`) when you need the whole set. Do not compare `account.symbol` against literals. A constant deliberately pinned to an external contract — e.g. the EVM spender labels copied from firmware so the approve flow cannot drift out of clear-signing — is the exception, and must carry a comment saying why.
+
+**Why it matters.** Adding a network sets its `features` in one place, but every hardcoded `symbol === '…' || …` chain has to be found and edited by hand. Miss one and the capability silently disappears for that coin in that view — no type error, no failing test, just a coin that never shows up. The existing exhaustiveness guidance cannot help: a boolean chain type-checks perfectly while being incomplete.
+
+**Existing coverage.** skills/defensive-programming/SKILL.md:10 — "Whenever possible, cover all cases. If a new case is added in the future, TypeScript should force the developer to set behavior for it." Same failure mode, but every technique under it is compiler-enforcement, which cannot fire on a symbol chain — hence a sibling section rather than an edit.
+
+```tsx
+// bad - useStakingTableData.ts:47 - a second list of staking coins that nothing keeps in sync with
+// the network config; adding a fifth staking network silently skips this view
+const stakingAccounts = accounts.filter(
+    account =>
+        account.symbol === 'eth' ||
+        account.symbol === 'sol' ||
+        account.symbol === 'ada' ||
+        account.symbol === 'trx',
+);
+
+// good - the predicate is derived from `features: ['staking']`, so a new network is included for free
+const stakingAccounts = accounts.filter(account => isStakingSymbol(account.symbol));
+```
+
+**Evidence**
+
+- G49 https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467403327 — author agreed ("I definitely agree… I can look at it and create follow-up PRs") and the follow-ups have not landed
+- VERIFIED live violation, and the only non-test one of its shape in the repo: packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts:47-52 — a four-way `account.symbol === 'eth' || 'sol' || 'ada' || 'trx'` filter
+- VERIFIED the same filter done right in the other app: suite-native/module-earn/src/hooks/useStakingListData.ts:36 `accounts.filter(acc => isStakingSymbol(acc.symbol))`
+- VERIFIED the config and the derived APIs: suite-common/wallet-config/src/types.ts:99 `features: NetworkFeature[]`; suite-common/wallet-config/src/networksConfig.ts:810/:814 (`StakingNetworkSymbol`, `STAKING_SYMBOLS` derived from `features.includes('staking')`); suite-common/wallet-utils/src/stakingUtils.ts:86 `isStakingSymbol`; suite-common/wallet-utils/src/accountUtils.ts:1045 `hasNetworkFeatures` (which reads `accountTypes[accountType]?.features ?? network.features`); suite-common/wallet-config/src/utils.ts:111 `getNetworkFeatures`
+- VERIFIED the firmware-pinned exception that is actually in the tree: suite-common/suite-constants/src/evm.ts `EVM_SPENDER_LABELS` ("Flattened copy of KNOWN_ADDRESSES from the firmware") — note `KNOWN_VAULTS`, which the digest cited, no longer exists
+
+### 11. Give a name to logic the reader has to decode
+
+- **Destination** `skills/comments/SKILL.md` (existing-add)
+- **Backing** 5 review-thread-group(s) — Readability & simplification (G69, G73, G51); Component structure & file layout (G55, G63 — the render-body JSX variant of the same rule)
+- **Confidence** medium
+
+When a block needs a comment paragraph before it makes sense, or a component body assembles a `ReactNode` into a `let` through an `if / else if / else` chain, extract it into a named function or component and let early returns replace the nesting; when the same compound condition appears in two places, hoist it into a named `const`. The name is what the next reader reads instead of re-deriving the logic, and the long comment then hangs on the extracted unit rather than on a line only someone already inside the block will see. Do not extract a single-use one-liner — the trigger is concrete: a multi-line comment, or the same compound condition twice.
+
+**Why it matters.** Four review threads stalled here, one of them with the reviewer saying they had to reconstruct the block before they could judge it — which is exactly what a reader with less context will fail to do. A duplicated compound condition additionally drifts: `EarnStakingAccountRow` had to keep two copies of the same two-status check in sync, so adding a third status would have changed one branch and not the other.
+
+**Existing coverage.** skills/comments/SKILL.md:10 — "The best comment is usually no comment. A clear name says more than a line explaining an unclear one, so reach for a comment only when the code genuinely can't speak for itself." Its example is a variable rename (`b` → `accountBalance`), so it does not tell a reader to extract a commented block, hoist a repeated condition, or move a JSX branch chain out of a render body. Note the file's "Comment the why, not the what" section currently blesses transactionUtils.ts:175-182 as a model why-comment, so the new section is the sharpening that says where such a comment belongs.
+
+```tsx
+// bad - the pre-fix shape from #30255 - three layouts assembled into a `let` before the screen
+// renders anything; the reader unwinds the chain to find the actual output
+let transactionTitle: ReactNode;
+if (isUnstakeTransaction) {
+    transactionTitle = <UnstakeTransactionDetailTitle unstakeAmount={unstakeAmount} />;
+} else if (wrapKind) {
+    transactionTitle = <WrapTransactionName transaction={transaction} kind={wrapKind} />;
+} else {
+    transactionTitle = <TransactionName transaction={transaction} isPending={isPending} />;
+}
+
+// good - TransactionDetailTitle.tsx:21 - each case returns and is forgotten; the screen renders
+// <TransactionDetailTitle /> and the name says what it is
+export const TransactionDetailTitle = ({ transaction, isPending, tokenTransfer }: Props) => {
+    const unstakeAmount = getUnstakeTxAmount(transaction);
+    const wrapKind = getNativeWrapTxKind(transaction);
+
+    if (unstakeAmount !== undefined) {
+        return <UnstakeTransactionDetailTitle unstakeAmount={unstakeAmount} />;
+    }
+
+    if (wrapKind) {
+        return <WrapTransactionName transaction={transaction} kind={wrapKind} />;
+    }
+
+    return <TransactionName transaction={transaction} isPending={isPending} />;
+};
+```
+
+**Evidence**
+
+- G69 https://github.com/trezor/trezor-suite/pull/30028#discussion_r3711981075 — "It took me a while to digest this piece, I'd move it to `getPoolDelegation` with early `return` avoiding nesting." (applied)
+- G73 https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721407524 — "what about wrapping it to new fn so it's easily digestible (for other readers) by the fn name and if needed then the long comment?" (not applied; naming point unrebutted)
+- G51 https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467480205 — "there's same condition for this and the case above, what about putting it into some var?" (applied as `apyAvailable`)
+- G55 https://github.com/trezor/trezor-suite/pull/30255#discussion_r3682093502 — "To maintain the render method readability, I'd suggest move this to new component and doing early returns" (applied by the PR author)
+- G63 (#30154) — same note on new instrumentation in Main.tsx; an unpublished pending draft, so not citable and not counted as independent corroboration
+- VERIFIED applied fixes: suite-native/module-transactions/src/components/TransactionDetailTitle.tsx:21-52 (early returns at :29 and :39, fallthrough at :49), rendered from screens/TransactionDetailScreen.tsx; packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts:313-320 (`getPoolDelegation` with `if (stakeType !== 'stake') return undefined;`); packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx:297-299 (`apyAvailable`, reused at :325 and :424)
+- VERIFIED the un-extracted case still in develop: suite-common/wallet-utils/src/transactionUtils.ts:175-182 — a 6-line comment followed by an inline `while` loop
+- VERIFIED gap: the contribution guide's own readability example, skills/skills-and-code-style-contribution/rule-template.md:60 "Return early instead of nesting the happy path", has no home in any SKILL.md
+
+### 12. Let callers pass `queryOptions` into a shared query hook, never overwrite them
+
+- **Destination** `NEW skills/data-fetching/SKILL.md` (new-skill)
+- **Backing** 1 review-thread-group(s) — Data fetching — prefer TanStack Query (G21)
+- **Confidence** medium
+
+A query hook in `suite-common` is consumed by both apps, whose needs differ per screen (`enabled`, `staleTime`, `select`). Accept a caller options object as the second parameter, type it as `Omit<UseQueryOptions<…>, 'queryKey'>` so no caller can break the query identity, spread it before `queryKey`/`queryFn`, and express the hook's own condition as a destructuring default (`{ enabled = Boolean(account), ...rest }`) rather than assigning after the spread. A hook local to `packages/suite` or a `module-*` package has one consumer and needs no options parameter.
+
+**Why it matters.** Assigning `enabled` after `...queryOptions` silently discards what the caller asked for, so a screen that disabled the query still fires it for an account it is not showing; dropping the parameter entirely forces the second consumer to fork the hook.
+
+**Existing coverage.** skills/components/SKILL.md:67 "## Prop drilling and identifiers" and skills/packages/SKILL.md:19 "## Packages size" are the nearest structural rules, and neither mentions hooks or query options; nothing in skills/ states how a shared hook exposes configuration.
+
+```tsx
+// bad - useSolanaRewardsTotal.ts:11 - the caller's `enabled` is spread in, then overwritten
+export function useSolanaRewardsTotal(account: Account, queryOptions?: RewardsQueryOptions) {
+    return useQuery({
+        ...queryOptions,
+        enabled: account.symbol === 'sol',
+        queryKey: commonQueryKeys.solanaRewardsTotal(account.descriptor),
+        queryFn: () => getSolanaRewardsTotal({ routeParams: { address: account.descriptor } }),
+    });
+}
+
+// good - useEthereumValidatorsQueue.ts:13 - the hook's condition is only the caller's default, and
+// `queryKey` is omitted from the options so no caller can break the query identity
+export function useEthereumValidatorsQueue(
+    { account, timestamp }: UseEthereumValidatorsQueueProps,
+    {
+        enabled = Boolean(account),
+        ...restQueryOptions
+    }: Omit<UseQueryOptions<EthValidatorsQueue>, 'queryKey'> = {},
+) {
+    return useQuery({
+        staleTime: 60 * 1000, // 1 minute
+        ...restQueryOptions,
+        enabled,
+        queryKey: commonQueryKeys.validatorsQueue(account?.key, timestamp),
+        queryFn: () => getEthereumValidatorsQueue({ params: { timestamp } }),
+    });
+}
+```
+
+**Evidence**
+
+- G21 https://github.com/trezor/trezor-suite/pull/27829#discussion_r3288598035 — "This is general hook and the usage might vary in suite and suite-native" (PR no longer accessible on GitHub)
+- VERIFIED the reviewer's shape is what shipped: suite-common/earn-staking-api/src/staking/hooks/useEthereumValidatorsQueue.ts:13-27 — `enabled = Boolean(account)` destructuring default at :16, `Omit<UseQueryOptions<…>, 'queryKey'>` at :18-21, spread before `queryKey` at :23-27
+- VERIFIED live silent-drop defect: suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsTotal.ts:11-14 spreads `...queryOptions` then hard-codes `enabled: account.symbol === 'sol'`, so a caller's `enabled: false` is ignored
+- VERIFIED third instance: suite-common/earn-staking-api/src/staking/hooks/useTronStakingStats.ts:8 (`queryOptions?: Partial<UseQueryOptions<…>>`, spread before queryKey)
+- VERIFIED the type is re-exported for this purpose: suite-common/react-query/src/index.ts
+
+### 13. Type test fixtures with `satisfies`, not `as unknown as`
+
+- **Destination** `skills/tests/SKILL.md` (existing-add)
+- **Backing** 2 review-thread-group(s) — TypeScript type safety (G24, G25)
+- **Confidence** medium
+
+Already stated in the tests skill, but it needs three sharpenings: name the replacement (`satisfies`, and `satisfies Omit<T, 'field'>[]` / `satisfies Pick<T, …>` for a deliberately partial fixture), say `as unknown as` explicitly since that is the form actually in the tree, and carve out the legitimate exceptions — a cast on a branded primitive (`'eth-account-key' as AccountKey`), and `} satisfies T as unknown as T` for a fixture that is structurally complete but nominally incompatible.
+
+**Why it matters.** `as unknown as` disables checking for every field inside, so renaming or retyping a field in `Account`/`TokenInfo` leaves the fixture compiling and the test asserting on a shape production no longer produces — the failure surfaces later as a mysterious assertion, not a type error at the fixture.
+
+**Existing coverage.** skills/tests/SKILL.md:85-87 — "All fixtures and mocks shall be typed and declaratively defined; using `as` to cast an incomplete object is only a last resort. This may add boilerplate, but it ensures type changes surface as type errors instead of hard-to-fix failing tests." It gives the principle and the consequence but no API to reach for, says `as` rather than `as unknown as`, and carves out no exception.
+
+```ts
+// bad - useSubscribeForSolanaBlockUpdates.test.ts:19 - the double cast turns off checking for every
+// field inside, so a renamed Account field keeps compiling here
+const solanaAccount = {
+    key: 'sol-account-1',
+    symbol: 'sol',
+    networkType: 'solana',
+} as unknown as Account;
+
+// good - the complete parts stay checked; only the outer shape remains a last-resort cast
+const tokens = [{ contract, symbol: 'USDC', decimals: 6, balance: '25' }] satisfies Omit<
+    TokenInfo,
+    'standard'
+>[];
+```
+
+**Evidence**
+
+- G24 https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302343773 — "at least partial type validation might be a good idea via `satisfies`"
+- G25 https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302376413 — suggested `] satisfies Omit<TokenInfo, 'standard'>[],` (applied; useResolvedYieldFlowData.test.ts now carries exactly that, so it is the _good_ example, not the bad one)
+- VERIFIED live offender to use as the bad example: suite-native/transaction-management/src/hooks/useSubscribeForSolanaBlockUpdates.test.ts:19-24 — `{ key: 'sol-account-1', symbol: 'sol', networkType: 'solana' } as unknown as Account`
+- VERIFIED the suggestion compiles: packages/blockchain-link-types/src/common.ts:313-328 — `TokenInfo` requires only `standard`, `contract`, `decimals`
+- VERIFIED the exception is unavoidable: suite-common/wallet-types/src/account.ts:134 — `AccountKey` is a branded template literal
+- VERIFIED scale: 145 test/mock/fixture files vs 23 source files contain `as unknown as` across packages/suite/src, suite-common and suite-native
+
+### 14. Call the narrowest query hook for what you render
+
+- **Destination** `NEW skills/data-fetching/SKILL.md` (new-skill)
+- **Backing** 1 review-thread-group(s) — Data fetching — prefer TanStack Query (G83)
+- **Confidence** medium
+
+When a hook exists for the single record a component renders, do not call the list hook and filter client-side. Narrow the shape with the query's `select`, not with a wider fetch. The list hook is right when the screen genuinely renders the list; the rule is about a per-item component (or a per-item hook) reaching for it.
+
+**Why it matters.** The wide call sits in code that runs once per row, and every consumer shares the one list cache key, so any invalidation refetches all `YIELD_OPPORTUNITIES_DEFAULT_LIMIT` (100) records for all of them; the narrow hook scopes both the request and the invalidation to the vault actually on screen.
+
+**Existing coverage.** skills/performance-react-hooks/SKILL.md:71 — "Narrower than the containing object, never wider than the closure: `accountKey`, not `account`" — the same instinct one layer down (dependency arrays), which is why the network-level version does not belong in that file.
+
+```tsx
+// bad - #30994 - one badge per token row, each pulling the whole 100-vault list for one APY
+const { data: yieldOpportunities } = useAllYieldOpportunities();
+const vault = yieldOpportunities?.find(opportunity => opportunity.id === vaultId);
+
+// good - YieldBadge.tsx:52 - one request per vault, cached under its own key
+const { data: vault } = useYieldOpportunity(vaultId);
+```
+
+**Evidence**
+
+- G83 https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749155737 — "Let's use useYieldOpportunity instead of useAllYieldOpportunities" (@TomasBoda: "done")
+- VERIFIED adopted: suite-native/module-earn/src/components/YieldBadge.tsx:5 imports `useYieldOpportunity` and :52 calls `useYieldOpportunity(vaultId)`
+- VERIFIED the defect still recurs one level up: suite-native/module-accounts-management/src/hooks/useYourPositionCardYieldBadge.tsx:18 still calls `useAllYieldOpportunities()` from a per-item hook
+- VERIFIED the wide hook's page size: suite-common/earn-stablecoin-api/src/config/index.ts:1 `YIELD_OPPORTUNITIES_DEFAULT_LIMIT = 100`; the narrow hook with its `select` parameter is suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts
+- VERIFIED separate cache keys: suite-common/react-query/src/constants/queryKeys.ts:15 `yieldOpportunity` vs :16 `yieldOpportunitiesList`
+
+### 15. Pick the ref hook by when `.current` is read
+
+- **Destination** `skills/performance-react-hooks/SKILL.md` (existing-add)
+- **Backing** 1 review-thread-group(s) — React hooks & effects (G10)
+- **Confidence** medium
+
+Already stated, but buried and unexemplified. Choose by the moment the value is read: `useFreshRef` assigns during render, so `.current` is the newest value and it is the only correct choice when the ref is read in render or inside a `useMemo`; `useCurrentRef` assigns in an effect keyed on the value. Neither holds the _previous_ value — and `useCurrentRef` does not either inside a later effect, because its own effect is declared first and has already run. For a transition test ("was set, is now cleared") use a plain `useRef`, read it at the top of the effect and assign it on the last line.
+
+**Why it matters.** Reaching for either helper when previous-value semantics are needed makes the transition condition `prevRef.current && !value` permanently false, so the effect's branch never runs — a silent no-op with no lint error and no crash. In `TransactionReviewModalBody` that branch is what clears `isSending` after a failed push; if it never fires, the expired-tx "Try again" button stays blocked and the user is stuck in the review modal.
+
+**Existing coverage.** skills/performance-react-hooks/SKILL.md:127-131 — "`useFreshRef` assigns during render, so `.current` is always the newest value; it is the only correct choice when the ref is read in render or inside a `useMemo`. `useCurrentRef` assigns in an effect, so during render `.current` still holds the last committed value. Neither tracks the previous value — for that, assign a plain `useRef` at the end of the effect."
+
+```tsx
+// bad - the reviewer's suggestion on #27725 - `useFreshRef` assigns during render, so `.current` is
+// already the new `serializedTx` when the effect runs and the transition is never detected
+// (`useCurrentRef` fails the same way: its own effect is declared first and has already assigned)
+const serializedTxRef = useFreshRef(serializedTx);
+
+useEffect(() => {
+    if (serializedTxRef.current && !serializedTx && isSending) {
+        setIsSending(false);
+    }
+}, [isSending, serializedTx, serializedTxRef]);
+
+// good - TransactionReviewModalBody.tsx:59 - a plain ref, read first and assigned last, is the only
+// shape that holds the previous value
+const prevSerializedTxRef = useRef(serializedTx);
+
+useEffect(() => {
+    if (prevSerializedTxRef.current && !serializedTx && isSending) {
+        setIsSending(false);
+    }
+
+    prevSerializedTxRef.current = serializedTx;
+}, [isSending, serializedTx]);
+```
+
+**Evidence**
+
+- G10 https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241224796 — the reviewer suggested `useFreshRef`, then `useCurrentRef`; both were wrong for this call site and the author's plain `useRef` was correct, which is why the rule is a selection criterion and not "prefer the helper"
+- VERIFIED packages/react-utils/src/hooks/useFreshRef.ts:14-15 (assigns during render) vs packages/react-utils/src/hooks/useCurrentRef.ts:16-18 (assigns inside `useEffect(…, [value])`)
+- VERIFIED the shipped previous-value pattern: packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx:59 (`useRef(serializedTx)`), read at :67, reassigned at :70 as the last statement of the effect, with the blocked-button rationale commented at :63-65
+- VERIFIED the distinction is live, not theoretical: 33 `useCurrentRef(` call sites in packages/suite (e.g. useYieldFlow.ts:149, useAllowanceModal.ts:94-97)
+- VERIFIED current placement: skills/performance-react-hooks/SKILL.md:127-131, inside `## Never add a new eslint-disable for exhaustive-deps` (:118) and wedged mid-paragraph between suppression advice and dependency-stability advice
+
+## Edits to existing files
+
+### `skills/defensive-programming/SKILL.md`
+
+_add four sections and disambiguate one existing heading_
+
+Add: (1) "Do not substitute a placeholder for a missing value" (rank 1) — and rename the existing "## Do not fall back to default" to "## Do not fall back to a default case", or the two read as duplicates in the table of contents; (2) "Compare EVM addresses with areEvmAddressesEqual" (rank 5), placed right after "Prefer the non-mutating array methods" whose argument it reuses; (3) "Fail with a named error instead of returning a bare null" (rank 7) as a `###` nested INSIDE "## Do not use exceptions" (:75), not a sibling — the two are in direct tension and a sibling heading reads as a contradiction; while there, add the missing consequence to :77 and state that the ban on `throw` does not license `| null` return types (a bare null is not a Result — packages/type-utils/src/result.ts); (4) "Decide per-network behaviour from network features" (rank 10) as a sibling after the exhaustiveness section. NOTE: three of these four are domain-specific (addresses, networks, signing) while the file's existing rules are all language-level, so widen the frontmatter description accordingly — as written ("...or when sorting, reversing or splicing an array") none of its triggers fire for a reader about to write `?? ''` or `symbol === 'eth' ||`.
+
+### `skills/typescript/SKILL.md`
+
+_add two sections_
+
+Add "Replace an `as` cast with `satisfies`, a guard, a parse, or a better type" (rank 3) directly after "## Prefer `unknown` to `any`" (:20), so the hand-written type guard at :26-34 and its scaled-up forms (guard / asNetworkSymbol / zod schema) sit together; and "Take AccountWithNetworkType<T>, not Account" (rank 4) after "## Prefer direct type assignment to indirect" (:38). Keep the second one's example in `interface` form to match the real TronResourcesCard.tsx:17 (the file's own last section prefers types to interfaces, so convert it in the good half rather than silently rewriting the quoted bad half).
+
+### `skills/comments/SKILL.md`
+
+_add one section_
+
+Add "Give a name to logic the reader has to decode" (rank 11) after "## Prefer self-documenting code", covering all three vehicles: extract a commented block into a named function with guard clauses, hoist a twice-used compound condition into a named const, and move a render-body `let` + if/else-if JSX chain into its own component with early returns. Reconcile it with "## Comment the why, not the what", which currently reads as blessing the un-extracted transactionUtils.ts:175-182 case.
+
+### `skills/components/SKILL.md`
+
+_add one section, sharpen one, add one cross-reference_
+
+Add "Export one React component per file, and give an extracted hook its own file" (rank 9), stating only what lint cannot decide: the extracted component gets its own file (not a shared parts.tsx) and the hook goes to hooks/<useHookName>.ts(x). Add a one-line cross-reference from "## Component structure" step 7 (Render) to the new comments/ section for the JSX-branch-chain case, and to skills/performance-react-hooks/SKILL.md:31 which already names a child component as a destination for render-body work. Sharpen "## Prop drilling and identifiers" (:69) only to the extent of noting that passing the identifier does not mean the child owns the null branch — see disputes; I am not adding the full nullability-upstream rule.
+
+### `skills/redux/SKILL.md`
+
+_add one subsection_
+
+Add "Only call `.unwrap()` where you handle the rejection" (rank 6) as a `###` inside the existing "## Thunks" section, after the bullet list ending at :217 and before "### State and dependency contracts" (:219) — a new `## ` heading would terminate the Thunks section rather than extend it. State the empty-catch convention (a comment naming the thunk that owns the error state, as at TransactionReviewModal.tsx:100) and correct the reviewer's own framing: an unhandled async rejection is NOT caught by the error boundary (packages/suite/src/support/suite/ErrorBoundary.tsx wraps react-error-boundary, render/lifecycle only), so do not write "the component crashes".
+
+### `skills/tests/SKILL.md`
+
+_sharpen existing text at :85-87_
+
+Rewrite the fixture-typing sentence to name `satisfies` (and `satisfies Omit<T, 'field'>[]` / `Pick<T, …>` for partial fixtures), to say `as unknown as` explicitly since that is the form in the tree, and to carve out the two legitimate exceptions (branded primitives like `as AccountKey`; `} satisfies T as unknown as T` where a fixture is structurally complete but nominally incompatible). Use suite-native/transaction-management/src/hooks/useSubscribeForSolanaBlockUpdates.test.ts:19-24 as the bad example — NOT useResolvedYieldFlowData.test.ts, which already carries the applied fix.
+
+### `skills/performance-react-hooks/SKILL.md`
+
+_promote and exemplify existing text at :127-131_
+
+Move the three ref-hook sentences out of "## Never add a new eslint-disable for exhaustive-deps" into their own heading ("## Pick the ref hook by when .current is read") next to "## Keep hook dependencies referentially stable" (:45); add the verified bad/good pair from TransactionReviewModalBody.tsx:59-71; add the consequence (a silently dead effect branch, no error); and add the mechanism the current text omits — `useCurrentRef` fails inside a later effect not because of render timing but because its own effect is declared first and has already assigned, which is what took three review round-trips to establish.
+
+### `skills/packages/SKILL.md`
+
+_add one section and widen frontmatter_
+
+Add "Extract logic both apps need into suite-common instead of duplicating it per app" (rank 8) after the scope table, with the platform-glue boundary stated explicitly (only the part free of platform APIs moves; if nothing platform-agnostic is left, keep the duplicate and say so). Widen the frontmatter description, which currently triggers only on "creating new packages or resolving cyclic dependencies" — a reader noticing the same derivation in both apps is doing neither. skills/project-structure ("Use when navigating the codebase or deciding where to place new code") is the closer trigger match today, so cross-link from there.
+
+### `packages/eslint/src/reactQueryConfig.mjs`
+
+_config follow-up, not a skill change_
+
+`@tanstack/query/no-rest-destructuring` (which catches `{ ...queryResult }`, the whole of harvest group G43) is only `warn` upstream, so it currently depends on `--max-warnings 0`; pin it to `error`. Separately, the plugin's import detector only recognises `@tanstack/*-query` sources, and repo code imports `useQuery` from the `@suite-common/react-query` re-export, so detection falls back to the type-checked path which local runs disable via `disableTypeChecked` — the whole plugin is effectively inert locally for wrapper imports and a developer only learns in CI.
+
+### `packages/eslint/src/reactConfig.mjs`
+
+_config follow-up, not a skill change_
+
+Enable `react/no-multi-comp` (its `ignoreStateless` option already defaults to false, so the bare rule suffices) to mechanize the countable half of the one-component-per-file rule. Expect a large existing-code backlog — land it as `warn` first or scope it to suite-native. Also consider `@typescript-eslint/consistent-type-assertions` with `objectLiteralTypeAssertions: 'never'`, which mechanizes both the object-literal half of the `as`-cast rule (e.g. useEthereumCancelTxCompose.ts:105) and most of the 145 fixture files using `as unknown as` — land it as one config change, not two.
+
+## Deliberately not turned into rules
+
+- **Resolve `null`/`undefined` above the component, not inside it (nullability G81+G82)**  
+  Fails the recurrence bar — two threads, but one PR and one author — and the consequence is structural, not correctness. It would also require rewriting two existing rules that currently point the other way (components/SKILL.md:69 prescribes exactly the accountKey-in, select-in-child shape the reviewer rejected, and basic-syntax/SKILL.md:139-143 presents `if (!value) return null` inside the component as the good shape), which is a lot of churn for one conversation. The verified residue — useYourPositionCardYieldBadge.tsx:7-11 still takes `account?: Account | null` and re-widens with `?? undefined` at :20, leaving a dead `if (!symbol) return null;` at YourPositionCard.tsx:48, a pointless `account?.formattedBalance` at :52 and a dead `account &&` at :73 — is a code cleanup, not a standard.
+
+- **Import a package's section entry point, never a flattened root barrel (code-placement G16)**  
+  The pattern has a sample size of one and its sibling in the same allowlist contradicts it: `@suite-common/earn-stablecoin-api` is registered in `packagesWithSectionEntryPoints` (packages/eslint/src/localRulesConfig.mjs:44) yet I verified it DOES have a root src/index.ts re-exporting services, config, verification, five hooks and context, with 72 root imports and zero deep imports. Only `@suite-common/earn-stablecoin` actually has no root barrel. Writing "never a flattened root barrel" would ship a rule the repo visibly contradicts; the cited cyclic-dependency rationale is also unsourced (the commit that created the pattern, d78e143701, gives no reason). Needs a team decision first.
+
+- **Parse untrusted data with a Zod schema instead of casting, as a standalone section (runtime-validation G41+G59)**  
+  The evidence does not support the rule as stated — see disputes. I verified `EvmGasParamsGweiSchema` has exactly two references in src (its own declaration at suite-common/schemas/src/evm/fees/index.ts:26 and the `z.infer` at :32) and is never `safeParse`d, so the commit cited as proof (ddc68e61f1) introduced no runtime validation at all; the value it cast was already fully typed, not `unknown`. Kept only as one clause of the `as`-cast rule (rank 3), citing the two honest boundary examples: `parseEvmFeeHex` and http-client's per-endpoint `schema`.
+
+- **Don't spread a TanStack Query result into a new object (CI/tooling G43)**  
+  Generalizable and high-consequence, but already decided by a linter: `@tanstack/query/no-rest-destructuring` ships in `flat/recommended-strict`, enabled at packages/eslint/src/reactQueryConfig.mjs:10. Repo convention (skills/skills-and-code-style-contribution/rule-template.md:8-11) sends anything a linter can decide to the ESLint config. Carried forward as a config follow-up instead.
+
+- **Prefer the non-mutating array methods to copy-then-mutate (readability G68)**  
+  Fully covered already. skills/defensive-programming/SKILL.md:63-73 names the replacement APIs, the consequence and why nothing catches it, and I confirmed the G68 site was fixed (suite-common/wallet-utils/src/cardanoStakingUtils.ts:111 now reads `pools.toSorted(...)`). The review note predates the written section by a week, so it is not evidence the rule is being ignored. No change needed.
+
+- **Represent a multi-state flow as one status field, not a fistful of booleans (readability G26)**  
+  One thread, one PR, no cited bug, and half-covered by skills/naming/SKILL.md:22 ("perhaps it would be better to pick another data type, like an `enum`"). Worth promoting only if more instances turn up in a later harvest.
+
+- **Delete a `switch` whose every case returns the same value (readability G37); prefer `.filter` over `if/else` inside `.map` (G14); share a type between two adjacent builders (G29); use design-system primitives instead of copy-pasted `prepareNativeStyle` (G79)**  
+  All one-off NITs on single PRs with no stated failure mode, and G79's comment was itself a joke, so no standard was asserted. G37 is the one item here a lint selector could decide (a SwitchStatement whose cases have identical bodies) — if anyone wants it, it belongs in packages/eslint, not prose.
+
+- **Derive a type predicate from the lookup table instead of re-listing its keys (typescript G01+G02)**  
+  Crisp and with a real drift consequence, but one PR, one author, and the blast radius is a missing UI label rather than correctness. The "let the compiler force coverage" idea is already the theme of skills/defensive-programming/SKILL.md:10-61. The reviewer's own first suggestion (`Object.keys(...).includes(...)`) does not narrow at all, which is a further reason not to canonize the thread.
+
+- **Ambient-declaration plumbing: `export {}` vs a .d.ts rename (G34); the `declare module 'redux'` Dispatch augmentation (G62); a non-empty tuple type instead of `@ts-expect-error` for noUncheckedIndexedAccess (G42)**  
+  None reached an agreed answer. G34 ends on a question, G62 got no reply, and G42 explicitly failed to land — the author tried the real fix (`[FeeLevel, ...FeeLevel[]]`), found it too invasive and rolled back. A reply that reverts the change is evidence against a rule.
+
+- **Improve `createHttpClient` instead of annotating every endpoint's return type (G54); move wallet-core thunks that don't depend on wallet-core into the domain package (G19); debug-settings selector placement (G33); tree-like folder structure for suite-native (G23); mirror the common/evm sub-package split in tx-simulation (G20)**  
+  All prescribe refactors nobody executed. The per-endpoint annotations are still in suite-common/earn-stablecoin-api/src/services/yieldxyz.ts, the thunks are still exported from suite-common/wallet-core/src/index.ts, and G23 was explicitly refused by the author on behalf of the mobile team while the flat layout remains the majority. G19's argument is already made at skills/packages/SKILL.md:31. Writing these up would document intentions, and in G23's case would put the guide in conflict with most of the code — per skills/skills-and-code-style-contribution/SKILL.md that belongs in a `proposal`-labelled issue first.
+
+- **Fetch constants from the yield worker instead of hardcoding them (G09); don't reference a constant another PR is deleting (G07); justify each validation constraint in a low-level converter (G32)**  
+  G09's outcome was the opposite of the note — the hardcoded copy was deliberately retained so the approve flow cannot drift out of clear-signing, and that outcome survives as the exception clause of the network-features rule (rank 10), now anchored to `EVM_SPENDER_LABELS`, since the `KNOWN_VAULTS` the digest cited no longer exists in the tree. G07 is PR sequencing, and the API it suggested was not even the one adopted. G32 is an unresolved design debate that names no replacement.
+
+- **Keep the assumed-role AWS session short and assume it after the long work (CI G52+G53); enable instrumentation logging behind a --debug flag (G65)**  
+  G52/G53 are the same line of the same workflow in one PR, the signal reviewer argued FOR the longer duration, and the thread resolved structurally via a different PR — plus no skill covers GitHub Actions authoring and one discussion cannot justify inventing one. G65 is a feature suggestion on an open PR, never submitted, and the swallowing it objects to is already annotated in the code.
+
+- **Narrow with the query's `select` as a rule of its own (G58)**  
+  The reviewer's own comment is self-deflating ("NIT (ignore if you will)… I guess there's no advantage compare to this solution"), names no consequence, and the thread is outdated with no reply. Survives as one clause inside the narrowest-hook rule.
+
+## Where the audit overrode the first pass
+
+### Whether "parse untrusted data with a Zod schema instead of casting" is a standalone rule
+
+- **First pass** Keep it as a new `## ` section in skills/typescript/SKILL.md, confidence medium, on the strength of G41 plus commit ddc68e61f1 "the note was acted on".
+- **Audit** verdictHolds: false — the cast was on an already-typed parameter, not `unknown`; the commit added no runtime validation; a reader following the rule would add a `safeParse` the real fix does not contain. Recommends rewriting into two narrower rules (don't write a guard that narrows to a closed object literal; derive a shared named type via z.infer).
+- **Resolution** Sided with the audit on the facts, but rejected both of its replacement rules and folded the surviving idea into the `as`-cast rule (rank 3) as one clause of a four-option replacement menu.
+- **Basis** I verified the audit's decisive point myself: `grep -rn EvmGasParamsGweiSchema` over src returns exactly two hits — the declaration at suite-common/schemas/src/evm/fees/index.ts:26 and the `z.infer` at :32 — so nothing ever parses with it. The audit's two proposed replacements each rest on one thread and one author and clear neither the recurrence nor the consequence bar, so promoting them would just relocate the weakness. But schema-parsing at a genuine boundary IS supported by the repo (parseEvmFeeHex's safeParse, createHttpClient's mandatory per-endpoint schema), and G59's reviewer offered `?.` as an equally acceptable alternative, so it belongs as one option among several rather than as its own directive.
+
+### Which existing skill hosts "give a name to logic the reader has to decode"
+
+- **First pass** skills/basic-syntax/SKILL.md, nearest text being :28 "Try to use empty lines as a tool for structuring the code even better."
+- **Audit** skills/comments/SKILL.md — the rule's own trigger ("an inline block needs a comment paragraph") is a comment-placement judgement, and comments/SKILL.md:10 states the actual principle; basic-syntax is syntax and layout.
+- **Resolution** Followed the audit (comments/), and additionally merged the separate component-structure rule "Extract a branching JSX block into its own component with early returns" into it rather than keeping two sections.
+- **Basis** I read both files: basic-syntax:28 is about blank lines between statement groups, and the file's other sections are brace style, parameter wrapping and JSX truthiness — extraction is none of those. comments/SKILL.md:10 is the real principle, and hosting it there also forces the reconciliation the audit spotted: "Comment the why, not the what" currently reads as blessing the un-extracted transactionUtils.ts:175-182 case. The merge is mine, not either input's: the JSX rule lost half its evidence in audit (G63 is an unpublished draft whose URL 404s, and the corroborating commit 38983ebd46 turns out to be authored by the PR author complying, not by a third party), so on its own it is one instance of readability advice — but it is the same underlying move as G69/G73/G51, so it survives as a scenario inside one section with a cross-reference from components/.
+
+### Destination kind for the test-fixture rule
+
+- **First pass** existing-covered (skills/tests/SKILL.md:85), i.e. no change needed — while its own notes simultaneously listed three gaps to fix.
+- **Audit** existing-covered + needs sharpening: the sentence gives the principle and the consequence but names no replacement API, says `as` where the tree has `as unknown as`, and carves out no exception.
+- **Resolution** existing-add (a sharpening edit to :85-87), and swapped the codeExample per the audit.
+- **Basis** The digest's own notes contradict its field, and the audit is right that a reader following the current text cannot tell that `satisfies Omit<TokenInfo, 'standard'>[]` is the move. The example swap is load-bearing: the digest labelled useResolvedYieldFlowData.test.ts as the offender, but the audit found it already carries the applied fix — publishing it as "bad" would ship a stale citation on day one. I used the live offender instead (useSubscribeForSolanaBlockUpdates.test.ts:19-24, which I read and verified).
+
+### Which API replaces an ad-hoc `as NetworkSymbol` cast
+
+- **First pass** The `isNetworkSymbol` type guard, described as "already the repo idiom".
+- **Audit** False as stated — suite-common/wallet-config/src/types.ts also exports `asNetworkSymbol`, a sanctioned wrapper for exactly this conversion, called ~298 times against 63 `isNetworkSymbol` references; the prose must split guard-vs-wrapper or it misfires on most remaining sites.
+- **Resolution** Adopted the audit's three-way split (guard where there is a fallback, `asNetworkSymbol` at a parse boundary, `satisfies` when constructing) and added the zod/parse case as a fourth.
+- **Basis** I verified both halves myself: types.ts:8 (not :7 as first reported) is `export const asNetworkSymbol = (symbol: string): NetworkSymbol => symbol as NetworkSymbol;`, with 310 matching lines in src against 69 for `isNetworkSymbol`. A rule that names only the guard would be ignored or disabled at the majority of sites, which is exactly how a skill entry dies.
+
+### The stated consequence of an unhandled `.unwrap()` rejection
+
+- **First pass** "the error boundary unmounts the subtree, so a device rejection blanks the review modal mid-flow" (echoing the reviewer's "causing the component to crash").
+- **Audit** The mechanism is wrong — react-error-boundary catches render/lifecycle errors only, not a promise rejection from an async onClick. Real consequences: a button that silently does nothing, every statement after the await skipped, and a context-free unhandled rejection in Sentry.
+- **Resolution** Rewrote the why-clause to the audit's version, keeping the rule and its destination.
+- **Basis** The audit's reasoning is sound on how error boundaries work, and the concrete cost it identifies is checkable in the cited file: TransactionReviewModal.tsx:95-97 removes the send-form draft and navigates away after the `.unwrap()`. Hand-check correction to both agents: the file now wraps that in `try { … } catch {}` at :99-100 with the comment “Error state is handled by signAndPushSendFormTransactionThunk”, so G11's note was acted on — this site is the _good_ example now, not a live defect, and the section must not present it as one. Shipping the crash claim would get the rule discounted by the first reader who tests it.
+
+### Whether `getPollIntervalMs` drift affects only mobile
+
+- **First pass** "a one-place change silently applies to mobile only".
+- **Audit** Wrong — the shared util also reaches packages/suite through suite-common/wallet-core/src/stablecoin-yield/hooks/useWrappedNativePendingTx.ts, consumed by suite's wrap/unwrap flows.
+- **Resolution** Adopted the audit's phrasing.
+- **Basis** I ran the grep: the shared `pollingUtils.ts:5` is imported by useWrappedNativePendingTx.ts:74, suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts:20 and useNavigateAfterPushedTransaction.ts:89, while packages/suite keeps two local re-implementations (useTronStakePendingTransactionTracking.ts:20, useYieldPendingTransactionTracking.ts:35). So the split is per-screen inside suite, not per-app, which is a sharper argument for the rule than the digest's.
+
+### Whether the areEvmAddressesEqual example can be quoted as-is
+
+- **First pass** A bad/good pair at transactionUtils.ts:80 showing only the `.toLowerCase()` comparison.
+- **Audit** The snippet is doctored — it drops the `vin.isAccountOwned ||` short-circuit and the 3-line comment at :73-75 that already documents the case-insensitivity; swapping it as shown would change behaviour.
+- **Resolution** Kept the rule at rank 5 but rewrote the example to include `isAccountOwned ||`, and made the point that the helper replaces the comment rather than the guard.
+- **Basis** I read :70-95 and the audit is exactly right: the deliberate comment is there, so the honest argument is not "nobody thought about casing here" but "the intent needs a paragraph to survive, and the helper's name carries it instead". I also flagged the audit's further finding for whoever writes the section: suite-common/calldata/src/validation/evm/address.ts normalizes at :39 yet still compares ad-hoc at :18/:29, so the section must say what to do after normalization or that file reads as a counter-example.

--- a/code-review-threads/by-topic/02-ci-tooling-and-guardrails.md
+++ b/code-review-threads/by-topic/02-ci-tooling-and-guardrails.md
@@ -1,0 +1,127 @@
+# CI, tooling & guardrails
+
+GitHub Actions workflow configuration and lint rules that prevent whole classes of regressions.
+
+**3 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `aws-session-duration` ×2, `github-actions` ×2, `eslint-rule`, `follow-up-issue`, `hotfix`, `proxy-regression`, `root-cause`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G43](#g43--suite-commonearn-stablecoin-apisrchooksmerkl-rewardsusegetmerklrewardsts73) | [#29054](https://github.com/trezor/trezor-suite/pull/29054) | `useGetMerklRewards.ts:73` | eslint-rule, proxy-regression, follow-up-issue |
+| [G52](#g52--githubworkflowsrelease-suite-coin-iconsyml46) | [#30091](https://github.com/trezor/trezor-suite/pull/30091) | `release-suite-coin-icons.yml:46` | github-actions, aws-session-duration, hotfix |
+| [G53](#g53--githubworkflowsrelease-suite-coin-iconsyml46) | [#30091](https://github.com/trezor/trezor-suite/pull/30091) | `release-suite-coin-icons.yml:46` | github-actions, aws-session-duration, root-cause |
+
+---
+
+### G43 — `suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts:73`
+
+- **PR** [#29054 — perf(suite-desktop): tanstack query improvements](https://github.com/trezor/trezor-suite/pull/29054) · author `@53gur0` · merged
+- **My first comment** 2026-06-24
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466747822
+- **Line of code** https://github.com/trezor/trezor-suite/blob/2f97fd998cb3ebe9281946bf7288815092649074/suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts#L73
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved
+- **Tags** `eslint-rule`, `proxy-regression`, `follow-up-issue`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -70,7 +70,12 @@ export function useGetMerklRewards<Address extends string>(
+     }, [queryClient, queryEntriesRef, chainsRewardsRef]);
+ 
+     return {
+-        ...queryResult,
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-24
+
+> We should (in another PR) try to introduce some Eslint rule to warn us about that. ✍️ 🤔 
+> I didn't realize it's gonna break the proxy, even though it's now very much obvious.
+
+**@53gur0** · 2026-06-25
+
+> https://github.com/trezor/trezor-suite/issues/29097
+
+---
+
+### G52 — `.github/workflows/release-suite-coin-icons.yml:46`
+
+- **PR** [#30091 — fix(workflows): adjust aws session duration for icon workflow](https://github.com/trezor/trezor-suite/pull/30091) · author `@MiroslavProchazka` · open
+- **My first comment** 2026-07-20
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30091#discussion_r3613679568
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d63a7b82cbe07139744abc9d4c2f52b01fe13906/.github/workflows/release-suite-coin-icons.yml#L46
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `github-actions`, `aws-session-duration`, `hotfix`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -43,6 +43,7 @@ jobs:
+         with:
+           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production_icons
+           aws-region: ${{ env.AWS_REGION }}
++          role-duration-seconds: 14400 # 4 hours
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-20
+
+> It seems like a good hotfix. I'd just increase it to 5h as some successful runs took more than 4h.
+>
+> https://github.com/trezor/trezor-suite/actions/workflows/release-suite-coin-icons.yml?query=is%3Asuccess
+
+---
+
+### G53 — `.github/workflows/release-suite-coin-icons.yml:46`
+
+- **PR** [#30091 — fix(workflows): adjust aws session duration for icon workflow](https://github.com/trezor/trezor-suite/pull/30091) · author `@MiroslavProchazka` · open
+- **My first comment** 2026-07-20
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30091#discussion_r3613713586
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d63a7b82cbe07139744abc9d4c2f52b01fe13906/.github/workflows/release-suite-coin-icons.yml#L46
+- **Thread** 4 comment(s), 2 mine
+- **Status** unresolved
+- **Tags** `github-actions`, `aws-session-duration`, `root-cause`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -43,6 +43,7 @@ jobs:
+         with:
+           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production_icons
+           aws-region: ${{ env.AWS_REGION }}
++          role-duration-seconds: 14400 # 4 hours
+```
+
+</details>
+
+**Conversation**
+
+**@vdovhanych** · 2026-07-20
+
+> This is very long, and I don't want to have secrets available for this long.
+
+**🟦 @cermakjiri (me)** · 2026-07-20
+
+> The default is 1h, so is 4x longer really too long? The script might run over 4h (which itself the core issue) https://github.com/trezor/trezor-suite/actions/workflows/release-suite-coin-icons.yml?query=is%3Asuccess.
+
+**@vdovhanych** · 2026-07-20
+
+> Yes even 1 hour which is default is too long in my opinion. It should be asy to rework it so it runs stores the images and then in actions it authenticates and syncs those stored images
+
+**🟦 @cermakjiri (me)** · 2026-07-21
+
+> This should become hopefully irrelevant once this is going to be merged. 🙏   https://github.com/trezor/trezor-suite/pull/30108
+
+---

--- a/code-review-threads/by-topic/03-data-fetching-tanstack-query.md
+++ b/code-review-threads/by-topic/03-data-fetching-tanstack-query.md
@@ -1,0 +1,583 @@
+# Data fetching — prefer TanStack Query
+
+Replacing imperative effect/thunk-driven fetching with `useQuery`/`useMutation`, exposing `queryOptions` on shared hooks, and picking the narrowest query hook.
+
+**7 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `less-code` ×2, `use-query` ×2, `declarative`, `narrower-query-hook`, `nit`, `over-fetching`, `query-options`, `replace-thunk`, `shared-hook`, `suite-vs-native`, `tech-debt`, `use-mutation`, `use-query-select`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G08](#g08--suite-nativemodule-earnsrchooksusecomposeearnfeests164) | [#27621](https://github.com/trezor/trezor-suite/pull/27621) | `useComposeEarnFees.ts:164` | use-mutation, less-code |
+| [G21](#g21--suite-commonearn-staking-apisrcstakinghooksuseethereumvalidatorsqueuets19) | [#27829](https://github.com/trezor/trezor-suite/pull/27829) | `useEthereumValidatorsQueue.ts:19` | query-options, shared-hook, suite-vs-native |
+| [G72](#g72--packagessuitesrcactionswalletgraphactionsts171) | [#29445](https://github.com/trezor/trezor-suite/pull/29445) | `graphActions.ts:171` | replace-thunk, tech-debt |
+| [G56](#g56--packagessuitesrchookswalletuseethereumcanceltxcomposets66) | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `useEthereumCancelTxCompose.ts:66` | use-query, declarative, less-code |
+| [G58](#g58--suite-commonwallet-coresrcsenduseevmnonceinfots95) | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `useEvmNonceInfo.ts:95` | use-query-select, nit |
+| [G60](#g60--suite-nativemodule-transactionssrchooksusedeviceguardedsignts74) | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `useDeviceGuardedSign.ts:74` | use-query |
+| [G83](#g83--suite-nativemodule-earnsrccomponentsyieldbadgetsx52) | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `YieldBadge.tsx:52` | narrower-query-hook, over-fetching |
+
+---
+
+### G08 — `suite-native/module-earn/src/hooks/useComposeEarnFees.ts:164`
+
+- **PR** [#27621 — fix(suite-native): fee selector balance error](https://github.com/trezor/trezor-suite/pull/27621) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-13
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27621#discussion_r3233333111
+- **Line of code** https://github.com/trezor/trezor-suite/blob/6d670a9a95edff04d3fa15914e87f56373da4571/suite-native/module-earn/src/hooks/useComposeEarnFees.ts#L164
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `use-mutation`, `less-code`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -91,43 +96,77 @@ export const useComposeEarnFees = ({
+     const feeInfo = useSelector((state: FeesRootState) =>
+         selectConvertedNetworkFeeInfo(state, account?.symbol),
+     );
++    const areFeesLoading = useSelector((state: FeesRootState) =>
++        selectAreFeesLoading(state, account?.symbol),
++    );
++    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
++    const selectedFee = formDraft?.selectedFee;
++    const selectedFeeLevel = selectedFee ? feeLevels[selectedFee] : undefined;
++    const fee = isFinalPrecomposedTransaction(selectedFeeLevel) ? selectedFeeLevel.fee : null;
++    const { isFeeUnavailable } = getFeeAvailability({
++        fee,
++        feeLevels,
++        selectedFee,
++        isLoading: areFeesLoading || isComposingFeeLevels,
++    });
+ 
+     const composeFeeLevels = useCallback(async () => {
+-        if (!formState || !account || !feeInfo) return;
+-
+-        const { selectedFee, feePerUnit, feeLimit, maxFeePerGas, maxPriorityFeePerGas } =
+-            formDraftRef.current ?? {};
+-
+-        const mergedFormState = {
+-            ...formState,
+-            selectedFee: selectedFee ?? formState.selectedFee,
+-            feePerUnit: feePerUnit ?? formState.feePerUnit,
+-            feeLimit: feeLimit ?? formState.feeLimit,
+-            maxFeePerGas: maxFeePerGas ?? formState.maxFeePerGas,
+-            maxPriorityFeePerGas: maxPriorityFeePerGas ?? formState.maxPriorityFeePerGas,
+-        };
+-
+-        const response = await dispatch(
+-            composeSendFormTransactionFeeLevelsThunk({
+-                formState: mergedFormState,
+-                composeContext: { account, feeInfo, network: getNetwork(account.symbol) },
+-            }),
+-        );
+-        if (!isFulfilled(response)) return;
+-
+-        dispatch(transactionManagementActions.storeFeeLevels({ feeLevels: response.payload }));
+-
+-        const normalLevel = response.payload.normal;
+-        if (!mergedFormState.feePerUnit && isFinalPrecomposedTransaction(normalLevel)) {
+-            mergedFormState.feePerUnit = normalLevel.feePerByte;
++        if (!formState || !account || !feeInfo) {
++            setIsComposingFeeLevels(false);
++
++            return;
+         }
+ 
+-        saveDraft(mergedFormState);
++        setIsComposingFeeLevels(true);
++
++        try {
++            const {
++                selectedFee: draftSelectedFee,
++                feePerUnit,
++                feeLimit,
++                maxFeePerGas,
++                maxPriorityFeePerGas,
++            } = formDraftRef.current ?? {};
++
++            const mergedFormState = {
++                ...formState,
++                selectedFee: draftSelectedFee ?? formState.selectedFee,
++                feePerUnit: feePerUnit ?? formState.feePerUnit,
++                feeLimit: feeLimit ?? formState.feeLimit,
++                maxFeePerGas: maxFeePerGas ?? formState.maxFeePerGas,
++                maxPriorityFeePerGas: maxPriorityFeePerGas ?? formState.maxPriorityFeePerGas,
++            };
++
++            const response = await dispatch(
++                composeSendFormTransactionFeeLevelsThunk({
++                    formState: mergedFormState,
++                    composeContext: { account, feeInfo, network: getNetwork(account.symbol) },
++                }),
++            );
++            if (!isFulfilled(response)) return;
++
++            dispatch(transactionManagementActions.storeFeeLevels({ feeLevels: response.payload }));
++
++            const normalLevel = response.payload.normal;
++            if (!mergedFormState.feePerUnit && isFinalPrecomposedTransaction(normalLevel)) {
++                mergedFormState.feePerUnit = normalLevel.feePerByte;
++            }
++
++            saveDraft(mergedFormState);
++        } finally {
++            setIsComposingFeeLevels(false);
++        }
+     }, [dispatch, formState, account, feeInfo, saveDraft]);
+ 
+     useEffect(() => {
++        setIsComposingFeeLevels(!!formState && !!account && !!feeInfo);
+         debounce(composeFeeLevels);
+-    }, [debounce, composeFeeLevels]);
++    }, [account, debounce, composeFeeLevels, feeInfo, formState]);
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-13
+
+> suggestion for the proper fix: it looks like good job for `useMutation` / `useQuery` (it'd be cleaner & requiring less code)
+
+---
+
+### G21 — `suite-common/earn-staking-api/src/staking/hooks/useEthereumValidatorsQueue.ts:19`
+
+- **PR** [#27829 — (PR no longer accessible — deleted or hidden)](https://github.com/trezor/trezor-suite/pull/27829) · author `@unknown` · unknown
+- **My first comment** 2026-05-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27829#discussion_r3288598035
+- **Thread** 1 comment(s), 1 mine
+- **Status** **⚠️ PR no longer accessible on GitHub**
+- **Tags** `query-options`, `shared-hook`, `suite-vs-native`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -1,23 +1,23 @@
+-import { type ResponseError, type ResponseValidationError } from '@suite-common/http-client';
+-import { type UseQueryOptions, commonQueryKeys, useQuery } from '@suite-common/react-query';
++import { commonQueryKeys, useQuery } from '@suite-common/react-query';
+ import { type Account } from '@suite-common/wallet-types';
+ 
+-import { type EthValidatorsQueue } from '../../api/types';
+ import { getEthereumValidatorsQueue } from '../services';
+ 
+ interface UseEthereumValidatorsQueueProps {
+-    account: Account;
++    account: Account | null;
+     timestamp?: number;
++    enabled?: boolean;
+ }
+ 
+-export function useEthereumValidatorsQueue(
+-    { account, timestamp }: UseEthereumValidatorsQueueProps,
+-    queryOptions?: UseQueryOptions<EthValidatorsQueue, ResponseError | ResponseValidationError>,
+-) {
++export function useEthereumValidatorsQueue({
++    account,
++    timestamp,
++    enabled,
++}: UseEthereumValidatorsQueueProps) {
+     return useQuery({
+         staleTime: 60 * 1000, // 1 minute
+-        ...queryOptions,
+-        queryKey: commonQueryKeys.validatorsQueue(account.key, timestamp),
++        enabled: !!account && (enabled ?? true),
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-22
+
+> Sure, checking for `null` account and enabling it only when it's defined makes sense. But why have you removed the `queryOptions`? This is general hook and the usage might vary in `suite` and `suite-native`. 
+>
+> It'd be better to this like this:
+> ```ts
+> import { type ResponseError, type ResponseValidationError } from '@suite-common/http-client';
+> import { type UseQueryOptions, commonQueryKeys, useQuery } from '@suite-common/react-query';
+> import { type Account } from '@suite-common/wallet-types';
+>
+> import { type EthValidatorsQueue } from '../../api/types';
+> import { getEthereumValidatorsQueue } from '../services';
+>
+> interface UseEthereumValidatorsQueueProps {
+>     account: Account | null;
+>     timestamp?: number;
+> }
+>
+> export function useEthereumValidatorsQueue(
+>     { account, timestamp }: UseEthereumValidatorsQueueProps,
+>     {
+>         enabled = Boolean(account),
+>         ...restQueryOptions
+>     }: Omit<
+>         UseQueryOptions<EthValidatorsQueue, ResponseError | ResponseValidationError>,
+>         'queryKey'
+>     > = {},
+> ) {
+>     return useQuery({
+>         staleTime: 60 * 1000, // 1 minute
+>         ...restQueryOptions,
+>         queryKey: commonQueryKeys.validatorsQueue(account?.key, timestamp),
+>         queryFn: () =>
+>             getEthereumValidatorsQueue({
+>                 params: { timestamp },
+>             }),
+>     });
+> }
+> ```
+> of course and edit the query key: `validatorsQueue: (accountKey: string | undefined, timestamp?: number) => [`
+
+---
+
+### G72 — `packages/suite/src/actions/wallet/graphActions.ts:171`
+
+- **PR** [#29445 — fix(suite): keep account graph data visible while refetching](https://github.com/trezor/trezor-suite/pull/29445) · author `@tomasklim` · merged
+- **My first comment** 2026-08-04
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29445#discussion_r3712475266
+- **Line of code** https://github.com/trezor/trezor-suite/blob/372eb0020be72615a95bf328f8a3526846e1b807/packages/suite/src/actions/wallet/graphActions.ts#L171
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `replace-thunk`, `tech-debt`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -127,7 +166,6 @@ export const fetchAccountGraphData =
+                         descriptor: account.descriptor,
+                         symbol: account.symbol,
+                     },
+-                    data: [],
+                     isLoading: false,
+                     error: true,
+                 },
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-04
+
+> I really don't like this thunk, it could be fairly easily replaced with tanstack query. But that's for another time, I know.
+
+---
+
+### G56 — `packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts:66`
+
+- **PR** [#29622 — feat(suite-native): evm cancel ](https://github.com/trezor/trezor-suite/pull/29622) · author `@53gur0` · open
+- **My first comment** 2026-07-30
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682308103
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts#L66
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `use-query`, `declarative`, `less-code`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -53,62 +51,17 @@ export const useEthereumCancelTxCompose = ({ account, tx }: UseEthereumCancelTxC
+         error: mutationError,
+         isPending: isComposing,
+     } = useMutation({
+-        mutationFn: async (): Promise<{
+-            composedCancelTx: PrecomposedTransactionFinalCancelRbf;
+-            cancelFormState: FormState;
+-        }> => {
+-            if (!feeInfo || tx.rbfParams?.type !== 'ethereum') {
+-                throw new Error('Missing fee info or invalid RBF params for Ethereum cancellation');
++        mutationFn: async (): Promise<ComposedEthereumCancelTransaction> => {
++            if (account.networkType !== 'ethereum') {
++                throw new Error('Ethereum cancellation is only available for EVM accounts');
+             }
+ 
+-            const { rbfParams } = tx;
+-            const network = getNetwork(account.symbol);
+-
+-            const formState: FormState = {
+-                outputs: [
+-                    {
+-                        type: 'payment',
+-                        address: account.descriptor,
+-                        amount: '0',
+-                        fiat: '',
+-                        currency: { value: '', label: '' },
+-                        token: null,
+-                    },
+-                ],
+-                selectedFee: 'normal',
+-                feePerUnit: '',
+-                feeLimit: '',
+-                options: ['broadcast'],
+-                isCoinControlEnabled: false,
+-                hasCoinControlBeenOpened: false,
+-                selectedUtxos: [],
+-                rbfParams,
+-            };
+-
+-            const feeLevels = await dispatch(
+-                composeSendFormTransactionFeeLevelsThunk({
+-                    formState,
+-                    composeContext: {
+-                        account,
+-                        network,
+-                        feeInfo: getEthereumRbfFeeInfo(feeInfo, rbfParams),
+-                    },
+-                }),
+-            ).unwrap();
+-
+-            const normalLevel = feeLevels.normal;
+-            if (!normalLevel || normalLevel.type === 'error' || normalLevel.type === 'nonfinal') {
+-                throw new Error('Unable to compose a valid cancellation fee level.');
++            const result = await dispatch(composeEthereumCancelTransactionThunk({ account, tx }));
++            if (isRejected(result)) {
++                throw result.payload ?? new Error('Unknown error');
+             }
+ 
+-            return {
+-                composedCancelTx: {
+-                    ...normalLevel,
+-                    rbfType: 'cancel',
+-                    prevTxid: tx.txid,
+-                } as PrecomposedTransactionFinalCancelRbf,
+-                cancelFormState: formState,
+-            };
++            return result.payload;
+         },
+     });
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-30
+
+> Why not using useQuery if it's more declarative than imperative use-case? It would result in shorter code a little:
+>
+> ```ts
+>     const { ... } = useQuery({
+>         enabled: account.networkType === 'ethereum' && !!feeInfo && tx.rbfParams?.type === 'ethereum',
+>         queryKey: [],
+>         queryFn: async () => {
+>             const result = await dispatch(composeEthereumCancelTransactionThunk({ account, tx }));
+>
+>             if (isRejected(result)) {
+>                 throw result.payload ?? new Error('Unknown error');
+>             }
+>
+>             return result.payload;
+>         }
+>     })
+> ```
+
+---
+
+### G58 — `suite-common/wallet-core/src/send/useEvmNonceInfo.ts:95`
+
+- **PR** [#29622 — feat(suite-native): evm cancel ](https://github.com/trezor/trezor-suite/pull/29622) · author `@53gur0` · open
+- **My first comment** 2026-07-30
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682340518
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-common/wallet-core/src/send/useEvmNonceInfo.ts#L95 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `use-query-select`, `nit`
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-30
+
+> NIT (ignore if you will): This might be part of the useQuery as `select` method. Anyway I guess there's no advantage compare to this solution.
+
+---
+
+### G60 — `suite-native/module-transactions/src/hooks/useDeviceGuardedSign.ts:74`
+
+- **PR** [#29622 — feat(suite-native): evm cancel ](https://github.com/trezor/trezor-suite/pull/29622) · author `@53gur0` · open
+- **My first comment** 2026-07-30
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682381623
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-native/module-transactions/src/hooks/useDeviceGuardedSign.ts#L74
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `use-query`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,88 @@
++import { useCallback, useRef, useState } from 'react';
++import { useSelector } from 'react-redux';
++
++import { useFocusEffect, useNavigation } from '@react-navigation/native';
++
++import {
++    type DeviceRootState,
++    selectDeviceButtonRequestsCodes,
++    selectIsDeviceConnectedAndAuthorized,
++} from '@suite-common/device';
++import {
++    AuthorizeDeviceStackRoutes,
++    type NavigateParameters,
++    type RootStackParamList,
++    RootStackRoutes,
++    type StackToStackCompositeNavigationProps,
++    type TransactionDetailStackParamList,
++    type TransactionDetailStackRoutes,
++} from '@suite-native/navigation';
++
++type NavigationProp = StackToStackCompositeNavigationProps<
++    TransactionDetailStackParamList,
++    TransactionDetailStackRoutes.TransactionDetail,
++    RootStackParamList
++>;
++
++type UseDeviceGuardedSignParams = {
++    // The signing action to run once the device is connected and authorized.
++    sign: () => Promise<void>;
++    // Where the connection guard returns the user if they abort connecting the device.
++    cancelNavigationTarget: NavigateParameters<RootStackParamList>;
++};
++
++/**
++ * Runs a signing action behind the native device-connection guard: `requestSign` routes through the
++ * DeviceConnectionGuard screen (which connects/unlocks the device if needed, or returns immediately
++ * when it's already authorized), and `sign` runs once this screen regains focus with an authorized
++ * device. Exposes `isSigning` and `isWaitingForDevice` (the device is showing a button request) for
++ * the caller's UI. Mirrors the pattern the send/stellar flows use inline.
++ */
++export const useDeviceGuardedSign = ({
++    sign,
++    cancelNavigationTarget,
++}: UseDeviceGuardedSignParams) => {
++    const navigation = useNavigation<NavigationProp>();
++    const isDeviceConnectedAndAuthorized = useSelector((state: DeviceRootState) =>
++        selectIsDeviceConnectedAndAuthorized(state),
++    );
++    const buttonRequestCodes = useSelector((state: DeviceRootState) =>
++        selectDeviceButtonRequestsCodes(state),
++    );
++
++    const [isSigning, setIsSigning] = useState(false);
++    const pendingSignRef = useRef(false);
++    const isWaitingForDevice = isSigning && buttonRequestCodes.length > 0;
++
++    const runSign = useCallback(async () => {
++        setIsSigning(true);
++        try {
++            await sign();
++        } finally {
++            setIsSigning(false);
++        }
++    }, [sign]);
++
++    // When the screen regains focus after the device-connection guard, execute the pending sign.
++    useFocusEffect(
++        useCallback(() => {
++            if (pendingSignRef.current && isDeviceConnectedAndAuthorized) {
++                pendingSignRef.current = false;
++                runSign();
++            }
++        }, [isDeviceConnectedAndAuthorized, runSign]),
++    );
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-30
+
+> this looks like job for `useQuery`
+
+---
+
+### G83 — `suite-native/module-earn/src/components/YieldBadge.tsx:52`
+
+- **PR** [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749155737
+- **Line of code** https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-earn/src/components/YieldBadge.tsx#L52 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `narrower-query-hook`, `over-fetching`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,92 @@
++import { Pressable } from 'react-native';
++
++import { useNavigation } from '@react-navigation/native';
++
++import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
++import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
++import { type Account, type TokenAddress, toTokenAddress } from '@suite-common/wallet-types';
++import { Badge, type BadgeProps } from '@suite-native/atoms';
++import { Translation, type TxKeyPath } from '@suite-native/intl';
++import {
++    AppTabsRoutes,
++    EarnStackRoutes,
++    type RootStackParamList,
++    RootStackRoutes,
++    type StackNavigationProps,
++} from '@suite-native/navigation';
++
++type YieldBadgeVariant = 'inactive' | 'active' | 'promo';
++
++type YieldBadgeVariantConfig = {
++    translationId: TxKeyPath;
++    intent?: BadgeProps['intent'];
++};
++
++const variantConfigMap: Record<YieldBadgeVariant, YieldBadgeVariantConfig> = {
++    inactive: {
++        translationId: 'moduleAccountManagement.accountDetailContentScreen.yieldBadge.upToRate',
++        intent: 'brand',
++    },
++    active: {
++        translationId: 'moduleAccountManagement.accountDetailContentScreen.yieldBadge.yieldRate',
++        intent: 'brand',
++    },
++    promo: {
++        translationId: 'moduleAccountManagement.accountDetailContentScreen.yieldBadge.promoRate',
++        intent: 'brand',
++    },
++};
++
++interface YieldBadgeProps {
++    apy: number;
++    variant: YieldBadgeVariant;
++    account: Account;
++    vaultId: string;
++    tokenContract?: TokenAddress;
++}
++
++type NavigationProps = StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>;
++
++export const YieldBadge = ({ apy, variant, account, vaultId, tokenContract }: YieldBadgeProps) => {
++    const navigation = useNavigation<NavigationProps>();
++    const { data: yieldOpportunities } = useAllYieldOpportunities();
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> Let's use `useYieldOpportunity` instead of `useAllYieldOpportunities`
+
+**@TomasBoda** · 2026-08-10
+
+> done
+
+---

--- a/code-review-threads/by-topic/04-react-hooks-and-effects.md
+++ b/code-review-threads/by-topic/04-react-hooks-and-effects.md
@@ -1,0 +1,225 @@
+# React hooks & effects
+
+Refs vs. state, effect dependencies and stale closures (`useFreshRef` / `useCurrentRef`).
+
+**2 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `stale-closure`, `use-effect-deps`, `use-fresh-ref`, `use-ref`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G22](#g22--suite-nativemodule-earnsrccomponentsyieldpendingtransactionmodaltsx129) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `YieldPendingTransactionModal.tsx:129` | use-ref |
+| [G10](#g10--packagessuitesrccomponentssuitemodalsreduxmodaltransactionreviewmodaltransactionreviewmodalbodytsx49) | [#27725](https://github.com/trezor/trezor-suite/pull/27725) | `TransactionReviewModalBody.tsx:49` | use-effect-deps, stale-closure, use-fresh-ref |
+
+---
+
+### G22 — `suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx:129`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-26
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302177192
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx#L129
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved
+- **Tags** `use-ref`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,307 @@
++import { type ReactNode, useCallback, useMemo } from 'react';
++import { StyleSheet, View } from 'react-native';
++import {
++    Extrapolation,
++    interpolate,
++    useAnimatedStyle,
++    useSharedValue,
++} from 'react-native-reanimated';
++
++import { type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
++import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
++
++import { useFormatters } from '@suite-common/formatters';
++import { type NetworkSymbol } from '@suite-common/wallet-config';
++import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
++import {
++    Badge,
++    BottomSheetModal,
++    type BottomSheetModalRef,
++    Box,
++    Button,
++    Card,
++    CircularSpinner,
++    HStack,
++    Text,
++    VStack,
++} from '@suite-native/atoms';
++import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
++import { CryptoIcon, Icon, NetworkIcon } from '@suite-native/icons';
++import { Translation } from '@suite-native/intl';
++import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
++
++import { YieldPendingTransactionModalBackdrop } from './YieldPendingTransactionModalBackdrop';
++import { modalSnap } from './YieldPendingTransactionModalConstants';
++import { YieldPendingTransactionModalHeader } from './YieldPendingTransactionModalHeader';
++import { YieldPendingTransactionModalRow } from './YieldPendingTransactionModalRow';
++
++type YieldPendingTransactionModalProps = {
++    accountLabel: string;
++    accountSymbol: NetworkSymbol;
++    amount?: ReactNode;
++    amountLabel?: ReactNode;
++    amountTokenContract?: TokenAddress;
++    amountTokenSymbol?: TokenSymbol;
++    fee?: string;
++    isExploreDisabled?: boolean;
++    onExplorePress: () => void;
++    pendingLabel?: ReactNode;
++    ref: BottomSheetModalRef;
++    submittedAt: Date;
++    title: ReactNode;
++    vaultName?: string;
++    vaultTokenContract?: TokenAddress;
++};
++
++const VAULT_NAME_MAX_WIDTH = 150;
++
++const pendingIconStyle = prepareNativeStyle(utils => ({
++    width: 56,
++    height: 56,
++    borderRadius: utils.borders.radii.round,
++    alignItems: 'center',
++    justifyContent: 'center',
++    backgroundColor: utils.colors.surfaceFillRaised,
++    ...utils.boxShadows.small,
++}));
++
++const constrainedValueStyle = prepareNativeStyle(() => ({
++    maxWidth: VAULT_NAME_MAX_WIDTH,
++    minWidth: 0,
++    flexShrink: 1,
++}));
++
++const constrainedValueTextStyle = prepareNativeStyle(() => ({
++    minWidth: 0,
++    flexShrink: 1,
++}));
++
++const getBottomSheet = (ref: BottomSheetModalRef): BottomSheetModalMethods | null => {
++    if (typeof ref === 'object' && ref !== null && 'current' in ref) {
++        return ref.current;
++    }
++
++    return null;
++};
++
++export const YieldPendingTransactionModalContainer = ({ children }: { children?: ReactNode }) => (
++    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
++        {children}
++    </View>
++);
++
++export const YieldPendingTransactionModal = ({
++    accountLabel,
++    accountSymbol,
++    amount,
++    amountLabel,
++    amountTokenContract,
++    amountTokenSymbol,
++    fee,
++    isExploreDisabled,
++    onExplorePress,
++    pendingLabel = <Translation id="moduleTrading.tradingConfirmationScreen.pending" />,
++    ref,
++    submittedAt,
++    title,
++    vaultName,
++    vaultTokenContract,
++}: YieldPendingTransactionModalProps) => {
++    const { applyStyle } = useNativeStyles();
++    const { DateFormatter, TimeFormatter } = useFormatters();
++    const animatedIndex = useSharedValue<number>(modalSnap.expandedIndex);
++    const snapPoints = useMemo(() => [modalSnap.collapsedHeight, modalSnap.expandedHeight], []);
++    const caretAnimatedStyle = useAnimatedStyle(() => {
++        const rotation = interpolate(
++            animatedIndex.value,
++            [modalSnap.collapsedIndex, modalSnap.expandedIndex],
++            [180, 0],
++            Extrapolation.CLAMP,
++        );
++
++        return {
++            transform: [{ rotateZ: `${rotation}deg` }],
++        };
++    });
++
++    const handleToggleSheet = useCallback(() => {
++        const isExpanded = animatedIndex.value >= modalSnap.indexMidpoint;
++        const bottomSheet = getBottomSheet(ref);
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> Shouldn't be this rather done via `useRef` hook?
+
+**@BrantalikP** · 2026-05-26
+
+> nono, this serves simply as ref check if you look into the getBottomSheet, I need access to the ref from the parent to have control over the modal
+
+---
+
+### G10 — `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx:49`
+
+- **PR** [#27725 — fix(suite): handle Solana tx timeout in review modal](https://github.com/trezor/trezor-suite/pull/27725) · author `@izmy` · merged
+- **My first comment** 2026-05-14
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241224796
+- **Line of code** https://github.com/trezor/trezor-suite/blob/c2c0a043af623204c4116c8fddb4fabe5a9d28d6/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx#L49
+- **Thread** 4 comment(s), 2 mine
+- **Status** resolved
+- **Tags** `use-effect-deps`, `stale-closure`, `use-fresh-ref`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -39,14 +40,26 @@ export const TransactionReviewModalBody = ({
+     isRbfConfirmedError,
+ }: TransactionReviewModalBodyProps) => {
+     const analytics = useAnalytics();
++    const dispatch = useDispatch();
+     const account = useSelector(selectAccountIncludingChosenInTrading);
+     const device = useSelector(selectSelectedDevice);
+     const [isSending, setIsSending] = useState(false);
+-    const { precomposedTx } = txInfoState;
+-    const [hasTxExpired, setHasTxExpired] = useState(false);
++    const { precomposedTx, serializedTx } = txInfoState;
++    const [hasTxReviewExpired, setHasTxReviewExpired] = useState(false);
++    const prevSerializedTxRef = useRef(serializedTx);
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-14
+
+> I think the intent here prevent triggering useEffect on `serializedTx` change but having fresh `serializedTx` value in the useEffect, right? If so, use `useFreshRef` 🙏
+
+**@izmy** · 2026-05-14
+
+> `useFreshRef` would not work here because this ref intentionally stores the previous `serializedTx` value. The effect needs to detect the transition from signed tx present to signed tx cleared, not read the latest value.
+
+**🟦 @cermakjiri (me)** · 2026-05-14
+
+> this only stores the value on mount, if you want prev., the `useCurrentRef` is the solution (I can see now, the naming is misleading 😄)
+
+**@izmy** · 2026-05-14
+
+> `useCurrentRef` updates before this effect runs. Here we need to read the previous `serializedTx` first and only then update the ref, so the manual update at the end of the effect is intentional.
+
+---

--- a/code-review-threads/by-topic/06-runtime-validation-and-parsing.md
+++ b/code-review-threads/by-topic/06-runtime-validation-and-parsing.md
@@ -1,0 +1,244 @@
+# Runtime validation & parsing
+
+Zod schemas for parsing `unknown` data instead of casting, and questioning validation constraints in low-level converters.
+
+**3 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `zod` ×2, `avoid-cast`, `bigint-hex`, `edge-cases`, `input-constraints`, `optional-chaining`, `unknown-data`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G32](#g32--suite-commonwallet-utilssrcethconverterts33) | [#28414](https://github.com/trezor/trezor-suite/pull/28414) | `ethConverter.ts:33` | input-constraints, edge-cases, bigint-hex |
+| [G41](#g41--suite-commonwallet-coresrcsendsendformethereumthunksts82) | [#28816](https://github.com/trezor/trezor-suite/pull/28816) | `sendFormEthereumThunks.ts:82` | zod, avoid-cast, unknown-data |
+| [G59](#g59--suite-nativemodule-transactionssrchooksusecancelevmtransactionts67) | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `useCancelEvmTransaction.ts:67` | zod, optional-chaining |
+
+---
+
+### G32 — `suite-common/wallet-utils/src/ethConverter.ts:33`
+
+- **PR** [#28414 — Eth conversion utils](https://github.com/trezor/trezor-suite/pull/28414) · author `@marekrjpolak` · merged
+- **My first comment** 2026-06-15
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28414#discussion_r3411500893
+- **Line of code** https://github.com/trezor/trezor-suite/blob/f1bc0880bc762d80234ead125311c8a867fdb6ab/suite-common/wallet-utils/src/ethConverter.ts#L33
+- **Thread** 4 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `input-constraints`, `edge-cases`, `bigint-hex`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,94 @@
++import type {
++    DecimalString,
++    Ether,
++    Gwei,
++    HexString,
++    IntegerString,
++    Wei,
++} from '@suite-common/wallet-types';
++import { BigNumber } from '@trezor/utils';
++
++interface EthValue {
++    toWei(format: 'hex'): Wei & HexString;
++    toWei(format: 'bignumber'): Wei & BigNumber;
++    toWei(format?: 'string'): Wei & IntegerString;
++    toGwei(format: 'bignumber'): Gwei & BigNumber;
++    toGwei(format?: 'string'): Gwei & DecimalString;
++    toEther(format: 'bignumber'): Ether & BigNumber;
++    toEther(format?: 'string'): Ether & DecimalString;
++}
++
++const GWEI_DECIMALS = 9;
++const ETHER_DECIMALS = 18;
++
++const error = (value: unknown, reason: string) =>
++    new Error(`Value '${value}' is invalid (${reason})`);
++
++const toHex = (value: BigNumber): HexString => `0x${value.toString(16)}`;
++
++const toBN = (value: string | bigint, shift = 0) => {
++    const bn = new BigNumber(value);
++
++    if (bn.isNaN()) throw error(value, 'not a number');
++    if (bn.isNegative()) throw error(value, 'negative');
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-15
+
+> Why can't it be negative?
+
+**@marekrjpolak** · 2026-06-15
+
+> Because I said so? :melting_face:  Actually it's a good question. I just thought that negative value in hex would be something like `-0xabcd` and given that we often do things like `slice(2)`, it would've been broken anyway. The same applies to decimal numbers like `0xab.cd`.
+>
+> By the way the old `web3-utils` does this:
+> ```
+> console.log(fromWei('-1234', 'gwei')); // prints 0.0000-1234
+> ```
+>
+> Do we expect negative ether/gwei/wei amounts somewhere?
+
+**@53gur0** · 2026-06-15
+
+> yes, like displaying a tx fee
+
+**@marekrjpolak** · 2026-06-15
+
+> But the fee is not really negative, or is it? You mean this? 
+> <img width="280" height="104" alt="image" src="https://github.com/user-attachments/assets/e2482162-fb20-483d-ad57-6822ef4169e9" />
+>
+> The thing is that these utils are more low-level and I don't want to end up with negative hexes and stuff like that.
+
+---
+
+### G41 — `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:82`
+
+- **PR** [#28816 — feat(wallet-core): improve nonce discovery for EVM](https://github.com/trezor/trezor-suite/pull/28816) · author `@53gur0` · merged
+- **My first comment** 2026-06-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452739137
+- **Line of code** https://github.com/trezor/trezor-suite/blob/2bb3fd21988b7db91be9d2fb8428da5de1bdbece/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts#L82 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `zod`, `avoid-cast`, `unknown-data`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -52,6 +57,71 @@ import {
+ import { selectAddressDisplayType } from '../settings/walletSettingsReducer';
+ import { selectTransactions } from '../transactions/transactionsSelectors';
+ 
++/**
++ * Returns fee info with levels bumped above the original transaction's gas price,
++ * so that the replacement transaction will be accepted by the mempool.
++ *
++ * Expects `feeInfo` with levels already in Gwei (i.e. from selectConvertedNetworkFeeInfo).
++ * `originalGasParams` must also be in Gwei.
++ */
++export const getEthereumRbfFeeInfo = (
++    feeInfo: FeeInfo,
++    originalGasParams: { gasPrice?: string; maxFeePerGas?: string; maxPriorityFeePerGas?: string },
++): FeeInfo => {
++    // feeInfo.levels are already in Gwei — do NOT call getConvertedOrDefaultFeeInfo here,
++    // that would double-convert and produce near-zero values.
++    const { levels } = feeInfo;
++    // @ts-expect-error: indexing with noUncheckedIndexedAccess
++    const firstLevel: (typeof levels)[number] = levels[0];
++    if (!firstLevel) return feeInfo;
++
++    if (isEip1559(originalGasParams) && isEip1559(firstLevel)) {
++        const currentMaxFee = new BigNumber(originalGasParams.maxFeePerGas);
++        // Cast back to access maxPriorityFeePerGas — isEip1559 narrows to { maxFeePerGas: string } only
++        const currentMaxPriorityFee = new BigNumber(
++            (originalGasParams as { maxPriorityFeePerGas?: string }).maxPriorityFeePerGas || '0',
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-22
+
+> What about using some Zod schema for parsing of the unknown data instead of the casting? There's already something related to that here `suite-common/schemas/src/evm/fees/index.ts` but it's been done only for hex strings yet.
+
+---
+
+### G59 — `suite-native/module-transactions/src/hooks/useCancelEvmTransaction.ts:67`
+
+- **PR** [#29622 — feat(suite-native): evm cancel ](https://github.com/trezor/trezor-suite/pull/29622) · author `@53gur0` · open
+- **My first comment** 2026-07-30
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682364238
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-native/module-transactions/src/hooks/useCancelEvmTransaction.ts#L67
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `zod`, `optional-chaining`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,221 @@
++import { useCallback, useMemo } from 'react';
++import { useDispatch, useSelector } from 'react-redux';
++
++import { useNavigation } from '@react-navigation/native';
++import { isFulfilled, isRejected } from '@reduxjs/toolkit';
++
++import { useMutation } from '@suite-common/react-query';
++import {
++    type AccountsRootState,
++    type PushTransactionError,
++    type SignTransactionError,
++    type SignTransactionTimeoutError,
++    type TransactionsRootState,
++    composeEthereumCancelTransactionThunk,
++    selectAccountByKey,
++    selectIsTransactionPending,
++    useEvmNonceInfo,
++} from '@suite-common/wallet-core';
++import {
++    type AccountKey,
++    type WalletAccountTransaction,
++    type WalletAccountTransactionWithRequiredRbfParams,
++} from '@suite-common/wallet-types';
++import {
++    getNetworkAccountFeatures,
++    getPendingEvmNonceStatus,
++    isTransactionBumpable,
++    isTransactionCancellable,
++} from '@suite-common/wallet-utils';
++import { useTranslate } from '@suite-native/intl';
++import {
++    type NavigateParameters,
++    type RootStackParamList,
++    RootStackRoutes,
++    type StackToStackCompositeNavigationProps,
++    type TransactionDetailStackParamList,
++    TransactionDetailStackRoutes,
++} from '@suite-native/navigation';
++import { signAndPushEvmCancelTransactionThunk } from '@suite-native/send';
++import { useToast } from '@suite-native/toasts';
++
++import { useDeviceGuardedSign } from './useDeviceGuardedSign';
++
++type NavigationProp = StackToStackCompositeNavigationProps<
++    TransactionDetailStackParamList,
++    TransactionDetailStackRoutes.TransactionDetail,
++    RootStackParamList
++>;
++
++const hasEthereumRbfParams = (
++    tx: WalletAccountTransaction,
++): tx is WalletAccountTransactionWithRequiredRbfParams => tx.rbfParams?.type === 'ethereum';
++
++// Mirrors the reject value of signAndPushEvmCancelTransactionThunk.
++type CancelFailure =
++    | SignTransactionError
++    | SignTransactionTimeoutError
++    | PushTransactionError
++    | undefined;
++
++// Extracts a human-readable failure reason: push failures carry the node's message in `metadata`
++// (e.g. "nonce too low", "could not replace existing tx"), while signing failures/timeouts expose
++// it directly on `message`.
++const getCancelFailureReason = (error: CancelFailure): string | undefined => {
++    if (!error) return undefined;
++
++    if ('metadata' in error) return error.metadata.error.message;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-30
+
+> I dunno, I'd either use Zod schema for parsing or use `.?` operator as it can be undefined
+
+---

--- a/code-review-threads/by-topic/07-error-handling-and-devx.md
+++ b/code-review-threads/by-topic/07-error-handling-and-devx.md
@@ -1,0 +1,503 @@
+# Error handling & developer experience
+
+Unhandled thunk rejections crashing components, validation that returns `null` instead of throwing, silently skipping instead of failing loudly.
+
+**4 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `breaking-change`, `component-crash`, `debug-flag`, `devx`, `e2e`, `fail-loudly`, `logging`, `observability`, `skip-vs-throw`, `throw-vs-null`, `unhandled-rejection`, `use-mutation`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G18](#g18--suite-commonearn-stablecoinsrcsigningstablecoinyieldsigningutilsts220) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `stablecoinYieldSigningUtils.ts:220` | throw-vs-null, breaking-change, devx |
+| [G11](#g11--packagessuitesrccomponentssuitemodalsreduxmodaltransactionreviewmodaltransactionreviewmodaltsx74) | [#27725](https://github.com/trezor/trezor-suite/pull/27725) | `TransactionReviewModal.tsx:74` | unhandled-rejection, component-crash, use-mutation |
+| [G64](#g64--suitee2eperformanceperfmeasurets53) | [#30154](https://github.com/trezor/trezor-suite/pull/30154) | `perfMeasure.ts:53` | fail-loudly, skip-vs-throw, e2e |
+| [G65](#g65--packagesperf-e2esrcinstrumentationts69) | [#30154](https://github.com/trezor/trezor-suite/pull/30154) | `instrumentation.ts:69` | logging, debug-flag, observability |
+
+---
+
+### G18 — `suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts:220`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287452170
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts#L220
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved
+- **Tags** `throw-vs-null`, `breaking-change`, `devx`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,221 @@
++import { parseUnsignedEvmTransactionForSigning } from '@suite-common/earn-stablecoin-api';
++import { flattenEvmFees, parseEvmFeeHex } from '@suite-common/schemas/src/evm';
++import { type NetworkSymbol } from '@suite-common/wallet-config';
++import {
++    type EvmSelectedFee,
++    type FormState,
++    type PrecomposedTransactionFinal,
++    type YieldFormMetadata,
++} from '@suite-common/wallet-types';
++import {
++    asAmountUnit,
++    evmHexToBigNumber,
++    evmHexWeiToGwei,
++    getContractAddressForNetworkSymbol,
++    unitsToSubunits,
++} from '@suite-common/wallet-utils';
++import { type EthereumSignTransaction, type TokenInfo } from '@trezor/connect-common';
++import { BigNumber } from '@trezor/utils';
++
++export type StablecoinYieldParsedTransactionForSigning = NonNullable<
++    ReturnType<typeof parseUnsignedEvmTransactionForSigning>
++>;
++
++type BuildStablecoinYieldReviewTokenParams = {
++    token: {
++        contractAddress?: string | null;
++        decimals: number;
++        symbol: string;
++    };
++    symbol: NetworkSymbol;
++};
++
++type BuildStablecoinYieldReviewStateParams = BuildStablecoinYieldReviewTokenParams & {
++    amount: string;
++    flowType: YieldFormMetadata['type'];
++    tx: StablecoinYieldParsedTransactionForSigning;
++    vaultName: string;
++};
++
++type BuildStablecoinYieldReviewStateResult = {
++    formState: FormState;
++    precomposedTransaction: PrecomposedTransactionFinal;
++};
++
++type BuildStablecoinYieldTransactionReviewParams = Omit<
++    BuildStablecoinYieldReviewStateParams,
++    'tx'
++> & {
++    selectedFee?: EvmSelectedFee | null;
++    unsignedTransaction: string;
++};
++
++type BuildStablecoinYieldTransactionReviewResult = BuildStablecoinYieldReviewStateResult & {
++    transactionForSigning: EthereumSignTransaction['transaction'];
++};
++
++const getStablecoinYieldTransactionWithSelectedFee = (
++    parsedTransaction: StablecoinYieldParsedTransactionForSigning,
++    selectedFee?: EvmSelectedFee | null,
++): StablecoinYieldParsedTransactionForSigning | null => {
++    if (!selectedFee) {
++        return parsedTransaction;
++    }
++
++    const parsedSelectedFee = parseEvmFeeHex(selectedFee);
++
++    if (!parsedSelectedFee) {
++        return null;
++    }
++
++    return {
++        ...parsedTransaction,
++        ...flattenEvmFees(parsedSelectedFee),
++    };
++};
++
++export const getStablecoinYieldTransactionForSigning = (
++    parsedTransaction: StablecoinYieldParsedTransactionForSigning,
++): EthereumSignTransaction['transaction'] => {
++    const commonTransactionFields = {
++        to: parsedTransaction.to,
++        value: parsedTransaction.value ?? '0x0',
++        gasLimit: parsedTransaction.gasLimit,
++        nonce: parsedTransaction.nonce,
++        data: parsedTransaction.data,
++        chainId: parsedTransaction.chainId,
++    };
++
++    if (parsedTransaction.maxFeePerGas && parsedTransaction.maxPriorityFeePerGas) {
++        return {
++            ...commonTransactionFields,
++            maxFeePerGas: parsedTransaction.maxFeePerGas,
++            maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,
++        };
++    }
++
++    if (parsedTransaction.gasPrice) {
++        return {
++            ...commonTransactionFields,
++            gasPrice: parsedTransaction.gasPrice,
++            txType: parsedTransaction.type,
++        };
++    }
++
++    throw new Error('Yield transaction gas parameters are missing.');
++};
++
++const buildStablecoinYieldReviewToken = ({
++    token,
++    symbol,
++}: BuildStablecoinYieldReviewTokenParams): TokenInfo | undefined => {
++    if (!token.contractAddress) {
++        return undefined;
++    }
++
++    return {
++        standard: 'ERC20',
++        contract: getContractAddressForNetworkSymbol(symbol, token.contractAddress),
++        symbol: token.symbol,
++        decimals: token.decimals,
++        name: token.symbol,
++    };
++};
++
++export const buildStablecoinYieldReviewState = ({
++    tx,
++    amount,
++    token,
++    symbol,
++    flowType,
++    vaultName,
++}: BuildStablecoinYieldReviewStateParams): BuildStablecoinYieldReviewStateResult => {
++    const gasPriceHex = tx.maxFeePerGas ?? tx.gasPrice ?? ('0x0' as `0x${string}`);
++    const gasLimit = evmHexToBigNumber(tx.gasLimit);
++    const gasPrice = evmHexToBigNumber(gasPriceHex);
++    const feePerUnit = evmHexWeiToGwei(gasPriceHex);
++    const fee = gasLimit.multipliedBy(gasPrice);
++    const reviewToken = buildStablecoinYieldReviewToken({ token, symbol });
++    const amountSubunits = unitsToSubunits({
++        value: asAmountUnit(new BigNumber(amount)),
++        decimals: token.decimals,
++    });
++
++    const eip1559ReviewFields: Partial<
++        Pick<PrecomposedTransactionFinal, 'maxFeePerGas' | 'maxPriorityFeePerGas'>
++    > =
++        tx.maxFeePerGas && tx.maxPriorityFeePerGas
++            ? {
++                  maxFeePerGas: evmHexWeiToGwei(tx.maxFeePerGas),
++                  maxPriorityFeePerGas: evmHexWeiToGwei(tx.maxPriorityFeePerGas),
++              }
++            : {};
++
++    const formState: FormState = {
++        outputs: [
++            {
++                type: 'payment',
++                address: tx.to,
++                amount,
++                fiat: '',
++                currency: { value: '', label: '' },
++                token: reviewToken?.contract ?? null,
++                dataHex: tx.data,
++            },
++        ],
++        selectedFee: 'custom',
++        feePerUnit,
++        feeLimit: gasLimit.toFixed(0),
++        ...eip1559ReviewFields,
++        options: ['broadcast', 'transactionData'],
++        transactionData: tx.data,
++        isCoinControlEnabled: false,
++        hasCoinControlBeenOpened: false,
++        selectedUtxos: [],
++        yieldMetadata: { type: flowType, vaultName },
++    };
++
++    const precomposedTransaction: PrecomposedTransactionFinal = {
++        type: 'final',
++        fee: fee.toFixed(0),
++        feePerByte: feePerUnit,
++        feeLimit: gasLimit.toFixed(0),
++        totalSpent: reviewToken ? amountSubunits.toFixed(0) : amountSubunits.plus(fee).toFixed(0),
++        bytes: 0,
++        inputs: [],
++        outputs: [
++            {
++                address: tx.to,
++                amount: amountSubunits.toFixed(0),
++            },
++        ],
++        outputsPermutation: [0],
++        ...(reviewToken ? { token: reviewToken, isTokenKnown: true } : {}),
++        ...eip1559ReviewFields,
++    };
++
++    return { formState, precomposedTransaction };
++};
++
++export const buildStablecoinYieldTransactionReview = ({
++    unsignedTransaction,
++    selectedFee,
++    ...reviewStateParams
++}: BuildStablecoinYieldTransactionReviewParams): BuildStablecoinYieldTransactionReviewResult | null => {
++    const parsedTransaction = parseUnsignedEvmTransactionForSigning(unsignedTransaction);
++
++    if (!parsedTransaction) {
++        return null;
++    }
++
++    const tx = getStablecoinYieldTransactionWithSelectedFee(parsedTransaction, selectedFee);
++
++    if (!tx) {
++        return null;
++    }
++
++    return {
++        ...buildStablecoinYieldReviewState({ ...reviewStateParams, tx }),
++        transactionForSigning: getStablecoinYieldTransactionForSigning(tx),
++    };
++};
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-22
+
+> Great that you moved it to common 👍 One thing worries me though there's breaking change how the validation works now: i.e. instead of throwing errors it returns null.  
+> At least from DevX it'll be much harder to deduce what's wrong or am I missing something? 🤔
+
+**@BrantalikP** · 2026-05-25
+
+> Each platform handles the error in its own way, but you’re right that returning `null` was probably too implicit. For example, it would be harder to notice that the error is related to the `fee data`. I’ve brought the explicit errors back. Thanks for pointing this out
+
+---
+
+### G11 — `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx:74`
+
+- **PR** [#27725 — fix(suite): handle Solana tx timeout in review modal](https://github.com/trezor/trezor-suite/pull/27725) · author `@izmy` · merged
+- **My first comment** 2026-05-14
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241245158
+- **Line of code** https://github.com/trezor/trezor-suite/blob/c2c0a043af623204c4116c8fddb4fabe5a9d28d6/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx#L74 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `unhandled-rejection`, `component-crash`, `use-mutation`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -60,16 +64,19 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
+         }
+     };
+ 
+-    const handleSendTx = async () => {
+-        await dispatch(
++    const handleSignAndPushSendTx = async () => {
++        const result = await dispatch(
+             signAndPushSendFormTransactionThunk({
+                 formState: send.precomposedForm!,
+                 precomposedTransaction: send.precomposedTx!,
+                 selectedAccount: selectedAccount.account,
+             }),
+-        );
++        ).unwrap();
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-14
+
+> now the thunk's promise can be rejected, causing the component to crash, let's please add `try/catch` / `useMutation` 🙏
+
+**@izmy** · 2026-05-14
+
+> done
+
+---
+
+### G64 — `suite/e2e/performance/perfMeasure.ts:53`
+
+- **PR** [#30154 — WIP: 28878 playwright perf tracking](https://github.com/trezor/trezor-suite/pull/30154) · author `@vojtatranta` · open
+- **My first comment** 2026-08-03
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30154#discussion_r3702600838
+- **Line of code** https://github.com/trezor/trezor-suite/blob/3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef/suite/e2e/performance/perfMeasure.ts#L53
+- **Thread** 1 comment(s), 1 mine
+- **Status** **⚠️ PENDING — review never submitted, draft visible only to you** · unresolved
+- **Tags** `fail-loudly`, `skip-vs-throw`, `e2e`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,149 @@
++import { CDPSession, Page, TestInfo } from '@playwright/test';
++import { appendFileSync, writeFileSync } from 'fs';
++import path from 'path';
++
++import {
++    PerfMetrics,
++    buildJsonReport,
++    compareScenario,
++    formatHumanReport,
++    getScenarioBaseline,
++    loadBaselinesSync,
++    readPerfMetrics,
++    startPerfMeasurement,
++} from '@trezor/perf-e2e';
++
++export const BASELINES_PATH = path.join(__dirname, 'baselines.json');
++
++// Gitignored, accumulates across runs. `perf:update` promotes medians from it into the baselines, so
++// accepting new numbers never requires a dedicated re-run.
++export const SAMPLES_PATH = path.join(__dirname, '.perf-samples.jsonl');
++
++// Lets the long-task observer flush and trailing renders settle before metrics are read.
++const SETTLE_MS = 400;
++
++// Chrome trace categories that make a rerender/long-task investigation possible.
++const TRACE_CATEGORIES = [
++    'devtools.timeline',
++    'disabled-by-default-devtools.timeline',
++    'v8.execute',
++    'disabled-by-default-v8.cpu_profiler',
++    'blink.user_timing',
++    'loading',
++    'toplevel',
++];
++
++/**
++ * Measures a single interaction and enforces the performance baseline.
++ *
++ * Instrumentation is installed globally at app load (see `electronSetup`), so no reload is needed
++ * here. On a target where it was not installed, the interaction still runs and measurement is
++ * skipped.
++ */
++export const measurePerformance = async (
++    page: Page,
++    testInfo: TestInfo,
++    scenario: string,
++    interaction: () => Promise<void>,
++): Promise<PerfMetrics | null> => {
++    const installed = await page.evaluate(
++        () =>
++            typeof (window as unknown as { __trezorPerf__?: unknown }).__trezorPerf__ !==
++            'undefined',
++    );
++    if (!installed) {
++        // eslint-disable-next-line no-console
++        console.log(
++            `[perf] instrumentation not installed (non-web target?) — skipping "${scenario}"`,
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-03
+
+> It's for desktop too. I think this should throw an error instead (i.e. if a dev attempts to measure a test there's missing `__trezorPerf__`, why skipping it, right?)
+
+---
+
+### G65 — `packages/perf-e2e/src/instrumentation.ts:69`
+
+- **PR** [#30154 — WIP: 28878 playwright perf tracking](https://github.com/trezor/trezor-suite/pull/30154) · author `@vojtatranta` · open
+- **My first comment** 2026-08-03
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30154#discussion_r3703857163
+- **Line of code** https://github.com/trezor/trezor-suite/blob/3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef/packages/perf-e2e/src/instrumentation.ts#L69
+- **Thread** 1 comment(s), 1 mine
+- **Status** **⚠️ PENDING — review never submitted, draft visible only to you** · unresolved
+- **Tags** `logging`, `debug-flag`, `observability`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,197 @@
++import { type PerfMetrics } from './types';
++
++/**
++ * Browser-side instrumentation.
++ *
++ * The functions below are executed inside the page, not in Node. They are handed verbatim to
++ * Playwright (`page.addInitScript` / `page.evaluate`), which serializes their source, so they MUST
++ * be fully self-contained: no imports, no closures over module state, only browser globals.
++ *
++ * `installPerfInstrumentation` must run at document start (before react-dom loads) so the React
++ * commit hook is installed before React probes `__REACT_DEVTOOLS_GLOBAL_HOOK__`.
++ */
++
++export const PERF_GLOBAL_KEY = '__trezorPerf__';
++
++type PerfController = {
++    start: () => void;
++    stop: () => PerfMetrics;
++    /** Fed by the app's <Profiler> onRender (see suite Main). Accumulates render duration. */
++    recordRender: (actualDuration: number) => void;
++};
++
++/**
++ * Idempotent.
++ *
++ * - React commit count: hooks `__REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberRoot` (works on any
++ *   build). Render *duration* comes from a real React <Profiler> in the app calling `recordRender`;
++ *   that only produces non-zero values when the app is built with React's profiling build
++ *   (`PERF_PROFILER` webpack alias), which the e2e desktop build enables.
++ * - Long tasks / TBT: a `longtask` PerformanceObserver buffers every entry; the window is applied
++ *   at `stop()` time so entries delivered late (observer callbacks are async) are not lost.
++ */
++export function installPerfInstrumentation(): void {
++    // Only instrument the top-level app frame. This init script runs in every frame (including the
++    // cross-origin Trezor Connect iframe/popup that handles device communication), and we must never
++    // touch those — measure only the main app. Comparing window references is same-origin-safe.
++    if (typeof window === 'undefined' || window.top !== window.self) {
++        return;
++    }
++
++    const w = window as unknown as Record<string, unknown>;
++    if (w.__trezorPerf__) {
++        return;
++    }
++
++    const state = {
++        enabled: false,
++        startTime: 0,
++        endTime: 0,
++        commitCount: 0,
++        renderDurationMs: 0,
++        // Whether the app's <Profiler> reported at least one render this window. Stays false when the
++        // app is not built with React's profiling build — then render duration is unavailable (null),
++        // not 0, so it is never mistaken for an improvement.
++        renderRecorded: false,
++        longTasks: [] as Array<{ start: number; duration: number }>,
++    };
++
++    const onCommit = (): void => {
++        if (!state.enabled) {
++            return;
++        }
++        state.commitCount += 1;
++    };
++
++    const hookKey = '__REACT_DEVTOOLS_GLOBAL_HOOK__';
++    const existingHook = w[hookKey] as
++        | { onCommitFiberRoot?: (...args: unknown[]) => unknown }
++        | undefined;
++
++    if (existingHook) {
++        // Real DevTools hook already present (e.g. extension): wrap the existing callback.
++        const previous = existingHook.onCommitFiberRoot;
++        existingHook.onCommitFiberRoot = (...args: unknown[]) => {
++            try {
++                onCommit();
++            } catch {
++                // ignore instrumentation errors, never break the app
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-03
+
+> it might not a break the app but could signal something's off regarding the perf. measurement. What about enabling the logging when adding `--debug` flag?
+
+---

--- a/code-review-threads/by-topic/08-single-source-of-truth.md
+++ b/code-review-threads/by-topic/08-single-source-of-truth.md
@@ -1,0 +1,159 @@
+# Single source of truth
+
+Deriving behaviour from network config features and from the Earn yield worker API rather than duplicating constants in the client.
+
+**3 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `earn-worker-api` ×2, `hardcoded-constants`, `network-config-features`, `staking`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G07](#g07--packagessuitesrccomponentsearndashboardyieldearnyieldaccountopportunitytsx44) | [#27584](https://github.com/trezor/trezor-suite/pull/27584) | `EarnYieldAccountOpportunity.tsx:44` | earn-worker-api |
+| [G09](#g09--suite-commonsuite-constantssrcevmts18) | [#27716](https://github.com/trezor/trezor-suite/pull/27716) | `evm.ts:18` | earn-worker-api, hardcoded-constants |
+| [G49](#g49--packagessuitesrccomponentsearndashboardstakinghooksusestakingtabledatats52) | [#29031](https://github.com/trezor/trezor-suite/pull/29031) | `useStakingTableData.ts:52` | network-config-features, staking |
+
+---
+
+### G07 — `packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx:44`
+
+- **PR** [#27584 — Control Earn actions through message-system feature flags](https://github.com/trezor/trezor-suite/pull/27584) · author `@izmy` · merged
+- **My first comment** 2026-05-12
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27584#discussion_r3226868495
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d80db0d9dd30dcdff39e3356cf862e0dfdadb3a2/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx#L44 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 3 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `earn-worker-api`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -39,6 +41,9 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
+     const [isFirmwareModalOpen, setIsFirmwareModalOpen] = useState(false);
+     const selectedDevice = useSelector(selectSelectedDevice);
+     const isFirmwareOutdated = !isStablecoinYieldSupported(selectedDevice);
++    const vaultContractAddress = EVM_VAULT_ADDRESSES[opportunity.vault.id];
+```
+
+</details>
+
+**Conversation**
+
+**@matusbalascak** · 2026-05-12
+
+> [This](https://github.com/trezor/trezor-suite/pull/27497) PR removed the `EVM_VAULT_ADDRESSES`, so just FYI, this will have to change
+
+**🟦 @cermakjiri (me)** · 2026-05-12
+
+> There's going to be a new endpoint:
+>
+> ```ts
+>     const { address: vaultAddress } = await getYieldVault({
+>         routeParams: {
+>             networkSymbol: account.symbol,
+>             vaultId: vault.id,
+>         },
+>     });
+> ```
+>
+> https://github.com/trezor/trezor-suite/pull/27497/changes#diff-a3b8ddad088598b73f8c4910ec5a6e9748405a090dc807317b2d8e1ff2c55993R45-R48
+>
+> The worker should be deployed sometime today. 🙏
+
+**@izmy** · 2026-05-12
+
+> I ended up using the address from the output token instead.
+
+---
+
+### G09 — `suite-common/suite-constants/src/evm.ts:18`
+
+- **PR** [#27716 — Yield issues](https://github.com/trezor/trezor-suite/pull/27716) · author `@matusbalascak` · merged
+- **My first comment** 2026-05-14
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27716#discussion_r3239510765
+- **Line of code** https://github.com/trezor/trezor-suite/blob/ed136b658b979ccd43f691bbd6661c7e53b5a37c/suite-common/suite-constants/src/evm.ts#L18
+- **Thread** 4 comment(s), 2 mine
+- **Status** unresolved
+- **Tags** `earn-worker-api`, `hardcoded-constants`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -8,4 +8,13 @@ export const EVM_SPENDER_LABELS: Record<string, string> = {
+     '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae': 'LiFi Diamond',
+ };
+ 
++/**
++ * Exact copy of KNOWN_VAULTS from the firmware
++ * (trezor/trezor-firmware/blob/main/core/src/apps/ethereum/yielding_vaults.py),
++ */
++export const KNOWN_VAULTS: Record<string, string> = {
++    '0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829': 'Trezor Steakhouse USDT Prime Vault',
++    '0xde6c23e561f3e55846207ec45a91b777e0f7c889': 'Trezor Steakhouse USDC Prime Vault',
++};
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-14
+
+> I though there were a consensus making the Earn yield worker source of the truth in this matter. 🤔 Has it changed? cc @tomasklim
+
+**🟦 @cermakjiri (me)** · 2026-05-14
+
+> If it's about the label, I can extend the res. of `https://earn.trezor.io/yield/vaults/v1`
+
+**@matusbalascak** · 2026-05-14
+
+> IMO, the Earn API response may change over time, which could cause the approve flow to get out of sync with the firmware. This way, we ensure these vaults are always clear-signed.
+
+**@tomasklim** · 2026-05-14
+
+> Let's sync on/after standup. 
+>
+> In fw it is now hardcoded, in the future it will be dynamic. I am fine with this right now, the only issue I see now is to check if fw has `Vault` translatable. But that's extra edge case
+
+---
+
+### G49 — `packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts:52`
+
+- **PR** [#29031 — Tron - Earn dashboard + Staking limits](https://github.com/trezor/trezor-suite/pull/29031) · author `@TomasBoda` · merged
+- **My first comment** 2026-06-24
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467403327
+- **Line of code** https://github.com/trezor/trezor-suite/blob/30b4edc6e5f92ac9b4ee75d6982d15bf59c66322/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts#L52
+- **Thread** 2 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `network-config-features`, `staking`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -44,7 +45,11 @@ export const useStakingTableData = (): UseStakingTableDataResult => {
+     const accounts = useSelector(selectVisibleDeviceAccounts);
+ 
+     const stakingAccounts = accounts.filter(
+-        account => account.symbol === 'eth' || account.symbol === 'sol' || account.symbol === 'ada',
++        account =>
++            account.symbol === 'eth' ||
++            account.symbol === 'sol' ||
++            account.symbol === 'ada' ||
++            account.symbol === 'trx',
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-24
+
+> I'm not sure why we haven't done up to this point but what about using network config `getNetwork(account.symbol).features.includes('staking')` so we move the source of truth there?
+
+**@TomasBoda** · 2026-06-25
+
+> I definitely agree, but there were some reasons it was designed like this at the beginning, I believe due to fiat rates fetching. I can look at it and create follow-up PRs
+
+---

--- a/code-review-threads/by-topic/09-component-structure-and-files.md
+++ b/code-review-threads/by-topic/09-component-structure-and-files.md
@@ -1,0 +1,712 @@
+# Component structure & file layout
+
+One React component per file, extracting sub-components, hooks in their own file next to the component, and package/folder structure (tree-like vs. linear).
+
+**7 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `extract-component` ×2, `one-component-per-file` ×2, `conventions`, `early-return`, `evm-vs-common`, `extensibility`, `folder-structure`, `hook-own-file`, `package-structure`, `render-profiler`, `render-readability`, `scaling`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G20](#g20--suite-nativetx-simulationpackagejson28) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `package.json:28` | package-structure, evm-vs-common, extensibility |
+| [G23](#g23--suite-nativemodule-earnsrccomponentsyieldpendingtransactionmodalconstantsts9) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `YieldPendingTransactionModalConstants.ts:9` | folder-structure, conventions, scaling |
+| [G28](#g28--suite-nativemodule-earnsrcscreensyielddepositreviewscreentsx162) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `YieldDepositReviewScreen.tsx:162` | one-component-per-file |
+| [G61](#g61--suite-nativemodule-transactionssrccomponentscancelevmtransactionbuttontsx46) | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `CancelEvmTransactionButton.tsx:46` | one-component-per-file |
+| [G63](#g63--packagessuitesrcsupportsuitemaintsx39) | [#30154](https://github.com/trezor/trezor-suite/pull/30154) | `Main.tsx:39` | extract-component, render-profiler |
+| [G55](#g55--suite-nativemodule-transactionssrcscreenstransactiondetailscreentsx134) | [#30255](https://github.com/trezor/trezor-suite/pull/30255) | `TransactionDetailScreen.tsx:134` | extract-component, early-return, render-readability |
+| [G80](#g80--suite-nativemodule-accounts-managementsrccomponentsyourpositioncardtsx103) | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `YourPositionCard.tsx:103` | hook-own-file |
+
+---
+
+### G20 — `suite-native/tx-simulation/package.json:28`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287627901
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/tx-simulation/package.json#L28
+- **Thread** 2 comment(s), 2 mine
+- **Status** resolved
+- **Tags** `package-structure`, `evm-vs-common`, `extensibility`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,29 @@
++{
++    "name": "@suite-native/tx-simulation",
++    "version": "1.0.0",
++    "private": true,
++    "license": "See LICENSE.md in repo root",
++    "sideEffects": false,
++    "main": "src/index",
++    "scripts": {
++        "depcheck": "yarn g:depcheck",
++        "type-check": "yarn g:tsc --build",
++        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
++    },
++    "dependencies": {
++        "@suite-common/formatters": "workspace:*",
++        "@suite-common/tx-simulation": "workspace:*",
++        "@suite-common/wallet-config": "workspace:*",
++        "@suite-common/wallet-types": "workspace:*",
++        "@suite-common/wallet-utils": "workspace:*",
++        "@suite-native/atoms": "workspace:*",
++        "@suite-native/clipboard": "workspace:*",
++        "@suite-native/icons": "workspace:*",
++        "@suite-native/intl": "workspace:*",
++        "@trezor/utils": "workspace:*",
++        "react": "19.2.4",
++        "react-native": "0.83.2",
++        "react-native-reanimated": "~4.2.1",
++        "web3-utils": "^4.3.3"
++    }
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-22
+
+> Nice! 🎉
+
+**🟦 @cermakjiri (me)** · 2026-05-22
+
+> One thing though: could you please follow similar structure as in other tx-simulation packages so it's going to be easy to extend them in future for other non-evm networks too? E.g.:
+> ```ts
+> tx-simulation/src 
+>    /common
+>        /components
+>        /hooks
+>    /evm
+>        /components   
+>        /hooks
+> ```
+>
+> Anyway it could be done in some follow up 🙏
+
+---
+
+### G23 — `suite-native/module-earn/src/components/YieldPendingTransactionModalConstants.ts:9`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-26
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302274382
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/components/YieldPendingTransactionModalConstants.ts#L9
+- **Thread** 3 comment(s), 2 mine
+- **Status** unresolved
+- **Tags** `folder-structure`, `conventions`, `scaling`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,9 @@
++export const modalSnap = {
++    collapsedIndex: 0,
++    expandedIndex: 1,
++    collapsedHeight: 148,
++    expandedHeight: 592,
++    indexMidpoint: 0.5,
++    collapsedBackdropOpacity: 0,
++    expandedBackdropOpacity: 0.5,
++} as const;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> This is out of scope this PR, anyway I believe it'd be good to at least open up the discussion on the topic:
+>
+> I've just noticed that suite-native packages are following some really strict linear file structure. However, the issue with that it breaks implicit relationships between components apposed to tree-like file structure.
+>
+> Linear:
+> ```
+> some-pkg/src/
+>     /components
+>          SomeScreen.tsx
+>          SomeFooter.tsx
+>          SomeFooterButton.tsx
+>          ...
+>   /hooks
+>         useSomeFooter.tsx
+>         useSomeXYZ.tsx
+>         ...
+> ```
+>
+> Tree-like:
+> ```
+> some-pkg/src/
+>     /components
+>          /SomeScreen
+>                   /hooks
+>                        useSomeXYZ.tsx # hook for the `SomeScreen`.tsx
+>                  /constants
+>                  /{other-architectual-primitives}
+>                  /SomeFooter
+>                         /hooks
+>                              useSomeFooter.tsx # hook only for the relevant   footer
+>                         SomeFooterButton.tsx
+>                   SomeScreen.tsx
+> ```
+>
+> - The relationship between components is implicit by the structure. If something is shared across more of them, it can be just move respective level up. 
+> - It scales: It can effectively decrease browsing complexity to O(logn) making much better for bigger file structure to orient to.
+
+**@BrantalikP** · 2026-05-26
+
+> This is my setup everywhere except at Trezor. Could not agree more.
+>
+> Although I would love to do it right away, I still do not think it is a good idea to introduce new patterns into an existing codebase when the current approach is followed by the majority.
+>
+> This should be decided by other devs as well. I tried to convince other mobile devs in the past, unfortunately without success.
+>
+> If you plan any initiative to introduce this pattern, I would be more than happy to support it.
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> Glad to hear that! 
+>
+> I kind of agree that it's better to have unified approaches across teams in the same codebase, however if I should always wait for everything to be accepted by our Suite Council, I'm afraid there'd be not much of progress. Maybe the borderline might be defined on team-level / package-level (something like that), when there's a need to introduce a new pattern / coding practice like this. 
+>
+> Anyway, thank you for your feedback on that. I hope we will make this work soon. 🚀
+
+---
+
+### G28 — `suite-native/module-earn/src/screens/YieldDepositReviewScreen.tsx:162`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-26
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302449312
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/screens/YieldDepositReviewScreen.tsx#L162
+- **Thread** 3 comment(s), 2 mine
+- **Status** resolved
+- **Tags** `one-component-per-file`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,164 @@
++import { useEffect, useMemo } from 'react';
++import { useSelector } from 'react-redux';
++
++import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
++
++import {
++    type StablecoinYieldRootState,
++    type YieldFlowResolvedData,
++    selectStablecoinYieldSessionByFlowKey,
++} from '@suite-common/wallet-core';
++import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
++import { Text, VStack } from '@suite-native/atoms';
++import {
++    ConfirmOnTrezorWrapper,
++    useConfirmOnTrezorController,
++} from '@suite-native/confirm-on-trezor';
++import { Translation } from '@suite-native/intl';
++import {
++    ScreenHeader,
++    type StackNavigationProps,
++    type YieldStackParamList,
++    YieldStackRoutes,
++} from '@suite-native/navigation';
++
++import { EarnReviewSubmittedCard } from '../components/EarnReviewSubmittedCard';
++import { YieldReviewList } from '../components/YieldReviewList';
++import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
++import { useYieldDepositReview } from '../hooks/useYieldDepositReview';
++import { buildYieldDepositFeePreview } from '../yieldDepositFeeUtils';
++
++type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldDepositReview>;
++type NavigationProps = StackNavigationProps<
++    YieldStackParamList,
++    YieldStackRoutes.YieldDepositReview
++>;
++
++type DepositReviewContentProps = {
++    feePreview: PrecomposedTransactionFinal;
++    flowData: YieldFlowResolvedData;
++    flowKey: string;
++    review: {
++        amount: string;
++        receiptAmount: string;
++    };
++    tokenSymbol: string;
++};
++
++const DepositReviewContent = ({
++    feePreview,
++    flowData,
++    flowKey,
++    review,
++    tokenSymbol,
++}: DepositReviewContentProps) => {
++    const { confirmOnTrezorRef, revealConfirmOnTrezorSheet, closeSheet } =
++        useConfirmOnTrezorController();
++    const {
++        handleSubmitDepositReview,
++        handleDepositSubmitted,
++        isSendingDeposit,
++        isSigningDeposit,
++        isSubmitDisabled,
++        isDepositSigned,
++    } = useYieldDepositReview({
++        flowData,
++        flowKey,
++    });
++
++    useEffect(() => {
++        if (isSigningDeposit) {
++            revealConfirmOnTrezorSheet();
++        } else {
++            closeSheet();
++        }
++    }, [closeSheet, isSigningDeposit, revealConfirmOnTrezorSheet]);
++
++    return (
++        <ConfirmOnTrezorWrapper
++            isManualControlEnabled
++            controlRef={confirmOnTrezorRef}
++            closeActionType="back"
++            defaultHeader={
++                <ScreenHeader
++                    closeActionType="back"
++                    customContent={
++                        <Text variant="body-md-strong">
++                            <Translation id="earn.yieldDepositReviewScreen.title" />
++                        </Text>
++                    }
++                />
++            }
++        >
++            <VStack flex={1} justifyContent="space-between">
++                <YieldReviewList
++                    accountKey={flowData.account.key}
++                    amount={review.amount}
++                    fee={feePreview.fee}
++                    isFooterVisible={!isSigningDeposit && !isDepositSigned}
++                    isSubmitDisabled={isSubmitDisabled}
++                    isSubmitLoading={isSigningDeposit}
++                    onSubmit={handleSubmitDepositReview}
++                    receiveAmount={review.receiptAmount}
++                    receiveTokenSymbol={flowData.receiptToken.symbol}
++                    tokenSymbol={tokenSymbol}
++                    variant="deposit"
++                />
++                {isDepositSigned && (
++                    <EarnReviewSubmittedCard
++                        buttonTranslationId="earn.yieldDepositReviewScreen.submitButton"
++                        isButtonLoading={isSendingDeposit}
++                        messageTranslationId="earn.yieldDepositReviewScreen.successMessage"
++                        onButtonPress={handleDepositSubmitted}
++                    />
++                )}
++            </VStack>
++        </ConfirmOnTrezorWrapper>
++    );
++};
++
++export const YieldDepositReviewScreen = () => {
++    const route = useRoute<RouteProps>();
++    const navigation = useNavigation<NavigationProps>();
++    const { flowData, flowKey, tokenSymbol, resolutionStatus } = useResolvedYieldFlowData(
++        route.params,
++    );
++    const session = useSelector((state: StablecoinYieldRootState) =>
++        selectStablecoinYieldSessionByFlowKey(state, 'deposit', flowKey),
++    );
++    const review = session?.action.review;
++    const feePreview = useMemo(
++        () => (review ? buildYieldDepositFeePreview(review.unsignedTransaction) : null),
++        [review],
++    );
++
++    useEffect(() => {
++        if (resolutionStatus !== 'resolved') {
++            return;
++        }
++
++        if (session?.step === 'complete') {
++            navigation.replace(YieldStackRoutes.YieldDepositComplete, route.params);
++
++            return;
++        }
++
++        if (!review || session?.step !== 'action') {
++            navigation.navigate(YieldStackRoutes.YieldDeposit, route.params);
++        }
++    }, [navigation, resolutionStatus, review, route.params, session?.step]);
++
++    if (resolutionStatus !== 'resolved' || !review || !feePreview) {
++        return null;
++    }
++
++    return (
++        <DepositReviewContent
++            feePreview={feePreview}
++            flowData={flowData}
++            flowKey={flowKey}
++            review={review}
++            tokenSymbol={tokenSymbol}
++        />
++    );
++};
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> One component per file please to make it easily readable 🙏
+
+**@BrantalikP** · 2026-05-26
+
+> https://github.com/trezor/trezor-suite/pull/27718#discussion_r3298064343 answered here already. WDYT?
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> TBH I still think it'd be better to divide it (better readability, so less bugs; easier composibility; potential easier refactoring in the future) but I don't push it. Also, it might be subject of some follow-up.
+
+---
+
+### G61 — `suite-native/module-transactions/src/components/CancelEvmTransactionButton.tsx:46`
+
+- **PR** [#29622 — feat(suite-native): evm cancel ](https://github.com/trezor/trezor-suite/pull/29622) · author `@53gur0` · open
+- **My first comment** 2026-07-30
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682393196
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-native/module-transactions/src/components/CancelEvmTransactionButton.tsx#L46
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `one-component-per-file`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,147 @@
++import { type AccountKey, type WalletAccountTransaction } from '@suite-common/wallet-types';
++import {
++    BottomSheetModal,
++    Box,
++    Button,
++    Text,
++    VStack,
++    useBottomSheetModal,
++} from '@suite-native/atoms';
++import { ConfirmOnTrezorAnimation } from '@suite-native/confirm-on-trezor';
++import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
++import { Translation, useTranslate } from '@suite-native/intl';
++
++import { TransactionDetailRow } from './TransactionDetailRow';
++import { useCancelEvmTransaction } from '../hooks/useCancelEvmTransaction';
++
++type CancelEvmTransactionButtonProps = {
++    accountKey: AccountKey;
++    transaction: WalletAccountTransaction;
++};
++
++type CancelTransactionFeeRowProps = {
++    title: string;
++    fee: string;
++    symbol: WalletAccountTransaction['symbol'];
++};
++
++const CancelTransactionFeeRow = ({ title, fee, symbol }: CancelTransactionFeeRowProps) => (
++    <TransactionDetailRow title={title}>
++        <Box alignItems="flex-end">
++            <CryptoAmountFormatter
++                value={fee}
++                symbol={symbol}
++                variant="body-sm"
++                color="contentPrimary"
++                isBalance={false}
++            />
++            <CryptoToFiatAmountFormatter
++                value={fee}
++                symbol={symbol}
++                variant="body-sm"
++                color="contentSecondary"
++            />
++        </Box>
++    </TransactionDetailRow>
++);
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-30
+
+> Let's please have single react component per file (easier to find the component, easier to refactor the component, easier to read this file) 🙏
+
+---
+
+### G63 — `packages/suite/src/support/suite/Main.tsx:39`
+
+- **PR** [#30154 — WIP: 28878 playwright perf tracking](https://github.com/trezor/trezor-suite/pull/30154) · author `@vojtatranta` · open
+- **My first comment** 2026-08-03
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30154#discussion_r3702586003
+- **Line of code** https://github.com/trezor/trezor-suite/blob/3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef/packages/suite/src/support/suite/Main.tsx#L39 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 1 comment(s), 1 mine
+- **Status** **⚠️ PENDING — review never submitted, draft visible only to you** · unresolved · outdated
+- **Tags** `extract-component`, `render-profiler`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -17,6 +18,25 @@ import { ResponsiveContextProvider } from 'src/support/suite/ResponsiveContext';
+ import { RouterHandler } from './RouterHandler';
+ import { useConnectPopupModals } from './useConnectPopupModals';
+ 
++// DefinePlugin constant, true only for the e2e perf build. Everywhere else it is `false`, so the
++// <Profiler> branch below and these helpers are dead-code-eliminated from production bundles.
++const PERF_PROFILER_BUILD = process.env.PERF_PROFILER as unknown as boolean;
++
++// The perf-e2e instrumentation exposes __trezorPerf__ before the app loads; onRender no-ops when the
++// global is absent.
++const getPerfController = () =>
++    typeof window !== 'undefined'
++        ? (
++              window as unknown as {
++                  __trezorPerf__?: { recordRender?: (actualDuration: number) => void };
++              }
++          ).__trezorPerf__
++        : undefined;
++
++const onPerfRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {
++    getPerfController()?.recordRender?.(actualDuration);
++};
++
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-03
+
+> Let's move everything new here to `RenderProfiler` component
+
+---
+
+### G55 — `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx:134`
+
+- **PR** [#30255 — feat(suite-native): label wrap/unwrap transactions](https://github.com/trezor/trezor-suite/pull/30255) · author `@53gur0` · merged
+- **My first comment** 2026-07-30
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30255#discussion_r3682093502
+- **Line of code** https://github.com/trezor/trezor-suite/blob/0c78e8b7cf19237b2c1f77c4c7d95378e9f29285/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx#L134 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `extract-component`, `early-return`, `render-readability`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -84,43 +87,60 @@ export const TransactionDetailScreen = ({
+ 
+     const allOutputs = account !== null ? createTargets({ transaction, account }) : [];
+ 
++    // WETH wrap/unwrap and unstake render their own amount-bearing title directly, bypassing the
++    // generic "<type> transaction" header template (which would append " transaction" to the label).
++    let transactionTitle: ReactNode;
++    if (isUnstakeTransaction) {
++        transactionTitle = (
++            <UnstakeTransactionDetailTitle
++                unstakeAmount={unstakeAmount}
++                symbol={transaction.symbol}
++                variant="body-md-strong"
++            />
++        );
++    } else if (wrapKind) {
++        transactionTitle = (
++            <WrapTransactionName
++                transaction={transaction}
++                kind={wrapKind}
++                variant="body-md-strong"
++            />
++        );
++    } else {
++        transactionTitle = (
++            <>
++                <TokenIcon
++                    symbol={transaction.symbol}
++                    contractAddress={tokenTransfer?.contract}
++                    showNetworkIcon
++                />
++                <Text variant="body-md-strong">
++                    <Translation
++                        id="transactions.detail.header"
++                        values={{
++                            transactionType: () => (
++                                <TransactionName
++                                    key={transaction.txid}
++                                    transaction={transaction}
++                                    isPending={isPending}
++                                    variant="body-md-strong"
++                                />
++                            ),
++                        }}
++                    />
++                </Text>
++            </>
++        );
++    }
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-30
+
+> To maintain the render method readability, I'd suggest move this to new component and doing early returns
+
+**@tomasklim** · 2026-08-03
+
+> Extracted into a new `TransactionDetailTitle` component with early returns 👍
+
+---
+
+### G80 — `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:103`
+
+- **PR** [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749138330
+- **Line of code** https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L103 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `hook-own-file`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,218 @@
++import { useSelector } from 'react-redux';
++
++import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
++import {
++    type NetworkSymbol,
++    getDisplaySymbol,
++    getNetworkDisplaySymbolName,
++} from '@suite-common/wallet-config';
++import {
++    type AccountsRootState,
++    selectAccountByKey,
++    selectAccountNetworkSymbol,
++} from '@suite-common/wallet-core';
++import {
++    type Account,
++    type AccountKey,
++    type TokenAddress,
++    type TokenInfoBranded,
++    type TokenSymbol,
++} from '@suite-common/wallet-types';
++import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';
++import { Box, Card, HStack, Text } from '@suite-native/atoms';
++import {
++    CryptoAmountFormatter,
++    CryptoToFiatAmountFormatter,
++    TokenAmountFormatter,
++    TokenToFiatAmountFormatter,
++} from '@suite-native/formatters';
++import { TokenIcon } from '@suite-native/icons';
++import {
++    YieldBadge,
++    useNativeYieldVault,
++    useStakingRate,
++    useYieldBadge,
++} from '@suite-native/module-earn';
++import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
++import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
++
++const cardStyle = prepareNativeStyle(utils => ({
++    flexDirection: 'row',
++    justifyContent: 'space-between',
++    alignItem: 'center',
++    marginHorizontal: utils.spacings.sp16,
++    padding: utils.spacings.sp16,
++    backgroundColor: utils.colors.surfaceFillRaised,
++    borderRadius: utils.borders.radii.r16,
++}));
++
++const cardContentStyle = prepareNativeStyle(_ => ({
++    flexShrink: 1,
++    justifyContent: 'flex-start',
++    alignItems: 'flex-start',
++}));
++
++interface UseYourPositionCardYieldBadgeProps {
++    account?: Account | null;
++    token?: TokenInfoBranded | null;
++    symbol?: NetworkSymbol | null;
++}
++
++const useYourPositionCardYieldBadge = ({
++    account,
++    token,
++    symbol,
++}: UseYourPositionCardYieldBadgeProps) => {
++    const { data: yieldOpportunities } = useAllYieldOpportunities();
++
++    const nativeYieldVault = useNativeYieldVault({ account: account ?? undefined });
++
++    const { rate: stakingRate } = useStakingRate({
++        symbol: account?.symbol,
++        accountKey: account?.key,
++    });
++
++    const promoYieldBadge =
++        !token && nativeYieldVault?.bestVault
++            ? {
++                  apy:
++                      stakingRate !== null && isApyAvailable(stakingRate)
++                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)
++                          : nativeYieldVault.bestVault.apy,
++                  vaultId: nativeYieldVault.bestVault.id,
++              }
++            : null;
++
++    const yieldBadge = useYieldBadge({
++        networkSymbol: symbol ?? undefined,
++        token: token ?? undefined,
++        accountTokens: account?.tokens,
++        type: token && isErc4626(token) ? 'defi' : 'default',
++        yieldOpportunities,
++    });
++
++    const usedYieldBadge = promoYieldBadge ?? yieldBadge;
++
++    const usedYieldBadgeVariant = (() => {
++        if (promoYieldBadge) return 'promo' as const;
++
++        return yieldBadge?.hasVaultPosition ? ('active' as const) : ('inactive' as const);
++    })();
++
++    return { yieldBadge: usedYieldBadge, yieldBadgeVariant: usedYieldBadgeVariant };
++};
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> Let's put it to new file with the name of the hook. 🙏
+
+**@TomasBoda** · 2026-08-10
+
+> done
+
+---

--- a/code-review-threads/by-topic/10-nullability-and-sentinel-values.md
+++ b/code-review-threads/by-topic/10-nullability-and-sentinel-values.md
@@ -1,0 +1,682 @@
+# Nullability & sentinel values
+
+Avoiding `''`/`0` sentinel fallbacks, preferring explicit `undefined`, and narrowing null/undefined upstream so components get asserted types.
+
+**6 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `empty-string-sentinel` ×3, `component-props` ×2, `narrow-upstream` ×2, `suggestion` ×2, `api-design`, `balance-formatting`, `fallback-chain`, `question`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G03](#g03--packagessuitesrccomponentsearnyieldhooksuseyieldflowts170) | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `useYieldFlow.ts:170` | empty-string-sentinel, api-design |
+| [G77](#g77--suite-nativemodule-earnsrchooksuseyieldbadgetsx41) | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `useYieldBadge.tsx:41` | empty-string-sentinel, suggestion |
+| [G78](#g78--suite-nativemodule-earnsrchooksuseyieldbadgetsx45) | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `useYieldBadge.tsx:45` | empty-string-sentinel, suggestion |
+| [G81](#g81--suite-nativemodule-accounts-managementsrccomponentsyourpositioncardtsx113) | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `YourPositionCard.tsx:113` | narrow-upstream, component-props |
+| [G82](#g82--suite-nativemodule-accounts-managementsrccomponentsyourpositioncardtsx122) | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `YourPositionCard.tsx:122` | narrow-upstream, component-props |
+| [G84](#g84--suite-nativemodule-accounts-managementsrccomponentsyourpositioncardtsx52) | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `YourPositionCard.tsx:52` | fallback-chain, balance-formatting, question |
+
+---
+
+### G03 — `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts:170`
+
+- **PR** [#27590 — Self-composed `withdraw` / `redeem` calldata for stablecoin yield](https://github.com/trezor/trezor-suite/pull/27590) · author `@matusbalascak` · merged
+- **My first comment** 2026-05-12
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224430555
+- **Line of code** https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts#L170
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `empty-string-sentinel`, `api-design`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -139,7 +151,23 @@ export const useYieldFlow = ({
+ 
+     const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
+ 
+-    const maxAmount = flowType === 'deposit' ? (token?.balance ?? '') : suppliedAmount;
++    const withdrawInputUnit = methods.watch('withdrawInputUnit');
++    const isSharesInput = flowType === 'withdraw' && withdrawInputUnit === 'shares';
++    const canToggleWithdrawUnit = flowType === 'withdraw' && !!token && !!receiptToken;
++
++    const getWithdrawMaxAmount = () => {
++        if (isSharesInput) {
++            return suppliedSharesAmount;
++        }
++
++        return suppliedAmount;
++    };
++    const maxAmount = flowType === 'deposit' ? (token?.balance ?? '') : getWithdrawMaxAmount();
++
++    const inputTokenSymbol = isSharesInput ? (receiptToken?.symbol ?? '') : (token?.symbol ?? '');
++    const otherUnitTokenSymbol = isSharesInput
++        ? (token?.symbol ?? '')
++        : (receiptToken?.symbol ?? '');
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-12
+
+> isn't better to pass undefined than empty strings so a react component could decide if it should display some placeholder for example?
+
+---
+
+### G77 — `suite-native/module-earn/src/hooks/useYieldBadge.tsx:41`
+
+- **PR** [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749106530
+- **Line of code** https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-earn/src/hooks/useYieldBadge.tsx#L41 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `empty-string-sentinel`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,102 @@
++import { useMemo } from 'react';
++import { useSelector } from 'react-redux';
++
++import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
++import { type MessageSystemRootState } from '@suite-common/message-system';
++import { type EnhancedTokenInfo } from '@suite-common/token-definitions';
++import { type NetworkSymbol } from '@suite-common/wallet-config';
++import {
++    getYieldVaultForOutputToken,
++    getYieldVaultsForInputToken,
++    hasYieldVaultPosition,
++} from '@suite-common/wallet-core';
++import { getApyPercent } from '@suite-common/wallet-utils';
++import { type TokenInfo } from '@trezor/blockchain-link-types';
++import { exhaustive } from '@trezor/type-utils';
++
++import { selectBestEnabledYieldVault } from '../selectors';
++
++interface YieldBadgeData {
++    apy: number;
++    vaultId: string;
++    hasVaultPosition: boolean;
++}
++
++interface UseYieldBadgeProps {
++    networkSymbol?: NetworkSymbol;
++    token?: EnhancedTokenInfo;
++    accountTokens: TokenInfo[] | undefined;
++    type: 'default' | 'defi';
++    yieldOpportunities?: YieldDtoV2[];
++}
++
++export const useYieldBadge = ({
++    networkSymbol,
++    token,
++    accountTokens,
++    type,
++    yieldOpportunities,
++}: UseYieldBadgeProps): YieldBadgeData | null => {
++    const matchedVaults = useMemo(() => {
++        if (!networkSymbol || !token) return [];
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> Is there real use case with undefined token.symbol and setting `''` seems like way to potential bug / unnecessary checks down stream. Therefore:
+> ```suggestion
+>         if (!networkSymbol || !token || !token.symbol) return [];
+> ```
+
+**@TomasBoda** · 2026-08-10
+
+> done
+
+---
+
+### G78 — `suite-native/module-earn/src/hooks/useYieldBadge.tsx:45`
+
+- **PR** [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749107437
+- **Line of code** https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-earn/src/hooks/useYieldBadge.tsx#L45 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `empty-string-sentinel`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,102 @@
++import { useMemo } from 'react';
++import { useSelector } from 'react-redux';
++
++import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
++import { type MessageSystemRootState } from '@suite-common/message-system';
++import { type EnhancedTokenInfo } from '@suite-common/token-definitions';
++import { type NetworkSymbol } from '@suite-common/wallet-config';
++import {
++    getYieldVaultForOutputToken,
++    getYieldVaultsForInputToken,
++    hasYieldVaultPosition,
++} from '@suite-common/wallet-core';
++import { getApyPercent } from '@suite-common/wallet-utils';
++import { type TokenInfo } from '@trezor/blockchain-link-types';
++import { exhaustive } from '@trezor/type-utils';
++
++import { selectBestEnabledYieldVault } from '../selectors';
++
++interface YieldBadgeData {
++    apy: number;
++    vaultId: string;
++    hasVaultPosition: boolean;
++}
++
++interface UseYieldBadgeProps {
++    networkSymbol?: NetworkSymbol;
++    token?: EnhancedTokenInfo;
++    accountTokens: TokenInfo[] | undefined;
++    type: 'default' | 'defi';
++    yieldOpportunities?: YieldDtoV2[];
++}
++
++export const useYieldBadge = ({
++    networkSymbol,
++    token,
++    accountTokens,
++    type,
++    yieldOpportunities,
++}: UseYieldBadgeProps): YieldBadgeData | null => {
++    const matchedVaults = useMemo(() => {
++        if (!networkSymbol || !token) return [];
++
++        const heldToken = {
++            address: token.contract,
++            symbol: token.symbol ?? '',
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> ```suggestion
+>             symbol: token.symbol,
+> ```
+
+**@TomasBoda** · 2026-08-10
+
+> done
+
+---
+
+### G81 — `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:113`
+
+- **PR** [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749145328
+- **Line of code** https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L113 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `narrow-upstream`, `component-props`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,218 @@
++import { useSelector } from 'react-redux';
++
++import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
++import {
++    type NetworkSymbol,
++    getDisplaySymbol,
++    getNetworkDisplaySymbolName,
++} from '@suite-common/wallet-config';
++import {
++    type AccountsRootState,
++    selectAccountByKey,
++    selectAccountNetworkSymbol,
++} from '@suite-common/wallet-core';
++import {
++    type Account,
++    type AccountKey,
++    type TokenAddress,
++    type TokenInfoBranded,
++    type TokenSymbol,
++} from '@suite-common/wallet-types';
++import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';
++import { Box, Card, HStack, Text } from '@suite-native/atoms';
++import {
++    CryptoAmountFormatter,
++    CryptoToFiatAmountFormatter,
++    TokenAmountFormatter,
++    TokenToFiatAmountFormatter,
++} from '@suite-native/formatters';
++import { TokenIcon } from '@suite-native/icons';
++import {
++    YieldBadge,
++    useNativeYieldVault,
++    useStakingRate,
++    useYieldBadge,
++} from '@suite-native/module-earn';
++import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
++import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
++
++const cardStyle = prepareNativeStyle(utils => ({
++    flexDirection: 'row',
++    justifyContent: 'space-between',
++    alignItem: 'center',
++    marginHorizontal: utils.spacings.sp16,
++    padding: utils.spacings.sp16,
++    backgroundColor: utils.colors.surfaceFillRaised,
++    borderRadius: utils.borders.radii.r16,
++}));
++
++const cardContentStyle = prepareNativeStyle(_ => ({
++    flexShrink: 1,
++    justifyContent: 'flex-start',
++    alignItems: 'flex-start',
++}));
++
++interface UseYourPositionCardYieldBadgeProps {
++    account?: Account | null;
++    token?: TokenInfoBranded | null;
++    symbol?: NetworkSymbol | null;
++}
++
++const useYourPositionCardYieldBadge = ({
++    account,
++    token,
++    symbol,
++}: UseYourPositionCardYieldBadgeProps) => {
++    const { data: yieldOpportunities } = useAllYieldOpportunities();
++
++    const nativeYieldVault = useNativeYieldVault({ account: account ?? undefined });
++
++    const { rate: stakingRate } = useStakingRate({
++        symbol: account?.symbol,
++        accountKey: account?.key,
++    });
++
++    const promoYieldBadge =
++        !token && nativeYieldVault?.bestVault
++            ? {
++                  apy:
++                      stakingRate !== null && isApyAvailable(stakingRate)
++                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)
++                          : nativeYieldVault.bestVault.apy,
++                  vaultId: nativeYieldVault.bestVault.id,
++              }
++            : null;
++
++    const yieldBadge = useYieldBadge({
++        networkSymbol: symbol ?? undefined,
++        token: token ?? undefined,
++        accountTokens: account?.tokens,
++        type: token && isErc4626(token) ? 'defi' : 'default',
++        yieldOpportunities,
++    });
++
++    const usedYieldBadge = promoYieldBadge ?? yieldBadge;
++
++    const usedYieldBadgeVariant = (() => {
++        if (promoYieldBadge) return 'promo' as const;
++
++        return yieldBadge?.hasVaultPosition ? ('active' as const) : ('inactive' as const);
++    })();
++
++    return { yieldBadge: usedYieldBadge, yieldBadgeVariant: usedYieldBadgeVariant };
++};
++
++interface YourPositionCardProps {
++    accountKey: AccountKey;
++    tokenContract?: TokenAddress;
++}
++
++export const YourPositionCard = ({ accountKey, tokenContract }: YourPositionCardProps) => {
++    const { applyStyle } = useNativeStyles();
++
++    const account = useSelector((state: AccountsRootState) =>
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> This selection should be done outside this component so the types here can assert only `account` and doesn't have to always check for undefined/null cases 🙏
+
+**@TomasBoda** · 2026-08-10
+
+> done, also for `token`
+
+---
+
+### G82 — `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:122`
+
+- **PR** [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749150115
+- **Line of code** https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L122 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `narrow-upstream`, `component-props`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,218 @@
++import { useSelector } from 'react-redux';
++
++import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
++import {
++    type NetworkSymbol,
++    getDisplaySymbol,
++    getNetworkDisplaySymbolName,
++} from '@suite-common/wallet-config';
++import {
++    type AccountsRootState,
++    selectAccountByKey,
++    selectAccountNetworkSymbol,
++} from '@suite-common/wallet-core';
++import {
++    type Account,
++    type AccountKey,
++    type TokenAddress,
++    type TokenInfoBranded,
++    type TokenSymbol,
++} from '@suite-common/wallet-types';
++import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';
++import { Box, Card, HStack, Text } from '@suite-native/atoms';
++import {
++    CryptoAmountFormatter,
++    CryptoToFiatAmountFormatter,
++    TokenAmountFormatter,
++    TokenToFiatAmountFormatter,
++} from '@suite-native/formatters';
++import { TokenIcon } from '@suite-native/icons';
++import {
++    YieldBadge,
++    useNativeYieldVault,
++    useStakingRate,
++    useYieldBadge,
++} from '@suite-native/module-earn';
++import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
++import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
++
++const cardStyle = prepareNativeStyle(utils => ({
++    flexDirection: 'row',
++    justifyContent: 'space-between',
++    alignItem: 'center',
++    marginHorizontal: utils.spacings.sp16,
++    padding: utils.spacings.sp16,
++    backgroundColor: utils.colors.surfaceFillRaised,
++    borderRadius: utils.borders.radii.r16,
++}));
++
++const cardContentStyle = prepareNativeStyle(_ => ({
++    flexShrink: 1,
++    justifyContent: 'flex-start',
++    alignItems: 'flex-start',
++}));
++
++interface UseYourPositionCardYieldBadgeProps {
++    account?: Account | null;
++    token?: TokenInfoBranded | null;
++    symbol?: NetworkSymbol | null;
++}
++
++const useYourPositionCardYieldBadge = ({
++    account,
++    token,
++    symbol,
++}: UseYourPositionCardYieldBadgeProps) => {
++    const { data: yieldOpportunities } = useAllYieldOpportunities();
++
++    const nativeYieldVault = useNativeYieldVault({ account: account ?? undefined });
++
++    const { rate: stakingRate } = useStakingRate({
++        symbol: account?.symbol,
++        accountKey: account?.key,
++    });
++
++    const promoYieldBadge =
++        !token && nativeYieldVault?.bestVault
++            ? {
++                  apy:
++                      stakingRate !== null && isApyAvailable(stakingRate)
++                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)
++                          : nativeYieldVault.bestVault.apy,
++                  vaultId: nativeYieldVault.bestVault.id,
++              }
++            : null;
++
++    const yieldBadge = useYieldBadge({
++        networkSymbol: symbol ?? undefined,
++        token: token ?? undefined,
++        accountTokens: account?.tokens,
++        type: token && isErc4626(token) ? 'defi' : 'default',
++        yieldOpportunities,
++    });
++
++    const usedYieldBadge = promoYieldBadge ?? yieldBadge;
++
++    const usedYieldBadgeVariant = (() => {
++        if (promoYieldBadge) return 'promo' as const;
++
++        return yieldBadge?.hasVaultPosition ? ('active' as const) : ('inactive' as const);
++    })();
++
++    return { yieldBadge: usedYieldBadge, yieldBadgeVariant: usedYieldBadgeVariant };
++};
++
++interface YourPositionCardProps {
++    accountKey: AccountKey;
++    tokenContract?: TokenAddress;
++}
++
++export const YourPositionCard = ({ accountKey, tokenContract }: YourPositionCardProps) => {
++    const { applyStyle } = useNativeStyles();
++
++    const account = useSelector((state: AccountsRootState) =>
++        selectAccountByKey(state, accountKey),
++    );
++
++    const symbol = useSelector((state: AccountsRootState) =>
++        selectAccountNetworkSymbol(state, accountKey),
++    );
++    const token = useSelector((state: TokensRootState) =>
++        selectAccountTokenInfo(state, accountKey, tokenContract),
++    );
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> Might be the case for `symbol` and `token` too 🙏 
+> https://github.com/trezor/trezor-suite/pull/30994/changes#r3749145328
+
+**@TomasBoda** · 2026-08-10
+
+> done
+
+---
+
+### G84 — `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:52`
+
+- **PR** [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749218834
+- **Line of code** https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L52
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved
+- **Tags** `fallback-chain`, `balance-formatting`, `question`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,218 @@
++import { useSelector } from 'react-redux';
++
++import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
++import {
++    type NetworkSymbol,
++    getDisplaySymbol,
++    getNetworkDisplaySymbolName,
++} from '@suite-common/wallet-config';
++import {
++    type AccountsRootState,
++    selectAccountByKey,
++    selectAccountNetworkSymbol,
++} from '@suite-common/wallet-core';
++import {
++    type Account,
++    type AccountKey,
++    type TokenAddress,
++    type TokenInfoBranded,
++    type TokenSymbol,
++} from '@suite-common/wallet-types';
++import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';
++import { Box, Card, HStack, Text } from '@suite-native/atoms';
++import {
++    CryptoAmountFormatter,
++    CryptoToFiatAmountFormatter,
++    TokenAmountFormatter,
++    TokenToFiatAmountFormatter,
++} from '@suite-native/formatters';
++import { TokenIcon } from '@suite-native/icons';
++import {
++    YieldBadge,
++    useNativeYieldVault,
++    useStakingRate,
++    useYieldBadge,
++} from '@suite-native/module-earn';
++import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
++import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
++
++const cardStyle = prepareNativeStyle(utils => ({
++    flexDirection: 'row',
++    justifyContent: 'space-between',
++    alignItem: 'center',
++    marginHorizontal: utils.spacings.sp16,
++    padding: utils.spacings.sp16,
++    backgroundColor: utils.colors.surfaceFillRaised,
++    borderRadius: utils.borders.radii.r16,
++}));
++
++const cardContentStyle = prepareNativeStyle(_ => ({
++    flexShrink: 1,
++    justifyContent: 'flex-start',
++    alignItems: 'flex-start',
++}));
++
++interface UseYourPositionCardYieldBadgeProps {
++    account?: Account | null;
++    token?: TokenInfoBranded | null;
++    symbol?: NetworkSymbol | null;
++}
++
++const useYourPositionCardYieldBadge = ({
++    account,
++    token,
++    symbol,
++}: UseYourPositionCardYieldBadgeProps) => {
++    const { data: yieldOpportunities } = useAllYieldOpportunities();
++
++    const nativeYieldVault = useNativeYieldVault({ account: account ?? undefined });
++
++    const { rate: stakingRate } = useStakingRate({
++        symbol: account?.symbol,
++        accountKey: account?.key,
++    });
++
++    const promoYieldBadge =
++        !token && nativeYieldVault?.bestVault
++            ? {
++                  apy:
++                      stakingRate !== null && isApyAvailable(stakingRate)
++                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)
++                          : nativeYieldVault.bestVault.apy,
++                  vaultId: nativeYieldVault.bestVault.id,
++              }
++            : null;
++
++    const yieldBadge = useYieldBadge({
++        networkSymbol: symbol ?? undefined,
++        token: token ?? undefined,
++        accountTokens: account?.tokens,
++        type: token && isErc4626(token) ? 'defi' : 'default',
++        yieldOpportunities,
++    });
++
++    const usedYieldBadge = promoYieldBadge ?? yieldBadge;
++
++    const usedYieldBadgeVariant = (() => {
++        if (promoYieldBadge) return 'promo' as const;
++
++        return yieldBadge?.hasVaultPosition ? ('active' as const) : ('inactive' as const);
++    })();
++
++    return { yieldBadge: usedYieldBadge, yieldBadgeVariant: usedYieldBadgeVariant };
++};
++
++interface YourPositionCardProps {
++    accountKey: AccountKey;
++    tokenContract?: TokenAddress;
++}
++
++export const YourPositionCard = ({ accountKey, tokenContract }: YourPositionCardProps) => {
++    const { applyStyle } = useNativeStyles();
++
++    const account = useSelector((state: AccountsRootState) =>
++        selectAccountByKey(state, accountKey),
++    );
++
++    const symbol = useSelector((state: AccountsRootState) =>
++        selectAccountNetworkSymbol(state, accountKey),
++    );
++    const token = useSelector((state: TokensRootState) =>
++        selectAccountTokenInfo(state, accountKey, tokenContract),
++    );
++
++    const { yieldBadge, yieldBadgeVariant } = useYourPositionCardYieldBadge({
++        account,
++        token,
++        symbol,
++    });
++
++    if (!symbol) return null;
++
++    const tokenSymbol = token?.symbol ?? getDisplaySymbol(symbol);
++    const tokenName = token?.name ?? getNetworkDisplaySymbolName(symbol);
++    const balance = token?.balance ?? account?.formattedBalance ?? '0';
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> are we sure it can handle `formattedBalance` balance too?
+
+**@TomasBoda** · 2026-08-10
+
+> yes, it works. also on other places in the repo
+
+---

--- a/code-review-threads/by-topic/11-typescript-type-safety.md
+++ b/code-review-threads/by-topic/11-typescript-type-safety.md
@@ -1,0 +1,767 @@
+# TypeScript type safety
+
+Type predicates, `satisfies`, narrowing account types via `AccountWithNetworkType`, avoiding casts, fixing types instead of working around them.
+
+**12 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `suggestion` ×7, `satisfies` ×3, `account-with-network-type` ×2, `d-ts` ×2, `test-fixtures` ×2, `type-guard` ×2, `ambient-types`, `avoid-cast`, `explicit-annotation`, `fix-the-type`, `is-network-symbol`, `module-augmentation`, `narrow-upstream`, `question`, `redux-augmentation`, `tx-type-modelling`, `type-predicate`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G01](#g01--packagessuitesrccomponentssuitemodalsreduxmodaltransactionreviewmodaltransactionreviewoutputlisttransactionreviewoutputtsx119) | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `TransactionReviewOutput.tsx:119` | type-guard, suggestion |
+| [G02](#g02--packagessuitesrccomponentssuitemodalsreduxmodaltransactionreviewmodaltransactionreviewoutputlisttransactionreviewoutputtsx118) | [#27590](https://github.com/trezor/trezor-suite/pull/27590) | `TransactionReviewOutput.tsx:118` | type-predicate, suggestion |
+| [G24](#g24--suite-nativemodule-earnsrchooks__tests__useresolvedyieldflowdatatestts49) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `useResolvedYieldFlowData.test.ts:49` | satisfies, test-fixtures |
+| [G25](#g25--suite-nativemodule-earnsrchooks__tests__useresolvedyieldflowdatatestts27) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `useResolvedYieldFlowData.test.ts:27` | satisfies, test-fixtures, suggestion |
+| [G34](#g34--suite-commonvalidatorssrctypests1) | [#28797](https://github.com/trezor/trezor-suite/pull/28797) | `types.ts:1` | ambient-types, d-ts, module-augmentation |
+| [G40](#g40--suite-commonwallet-coresrcsendsendformethereumthunksts439) | [#28816](https://github.com/trezor/trezor-suite/pull/28816) | `sendFormEthereumThunks.ts:439` | account-with-network-type, suggestion |
+| [G42](#g42--suite-commonwallet-coresrcsendsendformethereumthunksts75) | [#28816](https://github.com/trezor/trezor-suite/pull/28816) | `sendFormEthereumThunks.ts:75` | explicit-annotation, suggestion |
+| [G35](#g35--packagessuitesrcviewswalletstakingcomponentstronstakingdashboardtronresourcescardtronresourcescardtsx15) | [#28908](https://github.com/trezor/trezor-suite/pull/28908) | `TronResourcesCard.tsx:15` | account-with-network-type, narrow-upstream, suggestion |
+| [G57](#g57--suite-commonwallet-coresrcsendcomposecanceltransactioncomposeethereumcanceltransactionthunkts100) | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `composeEthereumCancelTransactionThunk.ts:100` | avoid-cast, satisfies |
+| [G62](#g62--suite-nativemodule-transactionssrcreduxdts11) | [#29622](https://github.com/trezor/trezor-suite/pull/29622) | `redux.d.ts:11` | d-ts, redux-augmentation, question |
+| [G76](#g76--suite-commonwallet-utilssrctransactionutilsts93) | [#30910](https://github.com/trezor/trezor-suite/pull/30910) | `transactionUtils.ts:93` | fix-the-type, tx-type-modelling |
+| [G86](#g86--suite-nativemodule-accounts-managementsrccomponentsstablecoinyieldtokenoverviewtsx262) | [#31071](https://github.com/trezor/trezor-suite/pull/31071) | `StablecoinYieldTokenOverview.tsx:262` | type-guard, is-network-symbol, suggestion |
+
+---
+
+### G01 — `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:119`
+
+- **PR** [#27590 — Self-composed `withdraw` / `redeem` calldata for stablecoin yield](https://github.com/trezor/trezor-suite/pull/27590) · author `@matusbalascak` · merged
+- **My first comment** 2026-05-12
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224403668
+- **Line of code** https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx#L119
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `type-guard`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -92,6 +92,32 @@ const approvalStrings: Record<EvmApprovalPurpose, Record<'value' | 'label', Tran
+     },
+ };
+ 
++const yieldStrings: Record<
++    Extract<EvmTransactionPurpose, 'deposit' | 'withdraw' | 'redeem'>,
++    Record<'value' | 'label' | 'amount', TranslationKey>
++> = {
++    deposit: {
++        value: 'TR_EARN_YIELD_REVIEW_SUPPLY_DESCRIPTION',
++        label: 'TR_EARN_YIELD_REVIEW_SUPPLY_TITLE',
++        amount: 'TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT',
++    },
++    withdraw: {
++        value: 'TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION',
++        label: 'TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE',
++        amount: 'TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT',
++    },
++    redeem: {
++        value: 'TR_EARN_YIELD_REVIEW_REDEEM_DESCRIPTION',
++        label: 'TR_EARN_YIELD_REVIEW_REDEEM_TITLE',
++        amount: 'TR_EARN_YIELD_REVIEW_REDEEM_AMOUNT',
++    },
++};
++
++const isYieldAction = (
++    evmTxType: EvmTransactionPurpose | undefined,
++): evmTxType is 'deposit' | 'withdraw' | 'redeem' =>
++    evmTxType === 'deposit' || evmTxType === 'withdraw' || evmTxType === 'redeem';
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-12
+
+> ```suggestion
+>     Object.keys(yieldStrings).includes(evmTxType)
+> ```
+
+---
+
+### G02 — `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:118`
+
+- **PR** [#27590 — Self-composed `withdraw` / `redeem` calldata for stablecoin yield](https://github.com/trezor/trezor-suite/pull/27590) · author `@matusbalascak` · merged
+- **My first comment** 2026-05-12
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224406990
+- **Line of code** https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx#L118
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `type-predicate`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -92,6 +92,32 @@ const approvalStrings: Record<EvmApprovalPurpose, Record<'value' | 'label', Tran
+     },
+ };
+ 
++const yieldStrings: Record<
++    Extract<EvmTransactionPurpose, 'deposit' | 'withdraw' | 'redeem'>,
++    Record<'value' | 'label' | 'amount', TranslationKey>
++> = {
++    deposit: {
++        value: 'TR_EARN_YIELD_REVIEW_SUPPLY_DESCRIPTION',
++        label: 'TR_EARN_YIELD_REVIEW_SUPPLY_TITLE',
++        amount: 'TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT',
++    },
++    withdraw: {
++        value: 'TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION',
++        label: 'TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE',
++        amount: 'TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT',
++    },
++    redeem: {
++        value: 'TR_EARN_YIELD_REVIEW_REDEEM_DESCRIPTION',
++        label: 'TR_EARN_YIELD_REVIEW_REDEEM_TITLE',
++        amount: 'TR_EARN_YIELD_REVIEW_REDEEM_AMOUNT',
++    },
++};
++
++const isYieldAction = (
++    evmTxType: EvmTransactionPurpose | undefined,
++): evmTxType is 'deposit' | 'withdraw' | 'redeem' =>
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-12
+
+> ```suggestion
+> ): evmTxType is keyof typeof yieldStrings  =>
+> ```
+
+---
+
+### G24 — `suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts:49`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-26
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302343773
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts#L49 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 3 comment(s), 2 mine
+- **Status** resolved · outdated
+- **Tags** `satisfies`, `test-fixtures`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,102 @@
++import { type YieldDto } from '@suite-common/earn-stablecoin-api';
++import { type Account, type AccountKey } from '@suite-common/wallet-types';
++
++import { resolveYieldFlowData } from '../useResolvedYieldFlowData';
++
++const accountKey = 'eth-account-key' as AccountKey;
++const underlyingTokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
++const receiptTokenAddress = '0xde6c23e561f3e55846207ec45a91b777e0f7c889';
++const yieldId = 'ethereum-usdc-steakusdc';
++
++const account = {
++    key: accountKey,
++    symbol: 'eth',
++    tokens: [
++        {
++            contract: underlyingTokenAddress,
++            symbol: 'USDC',
++            decimals: 6,
++            balance: '25',
++        },
++        {
++            contract: receiptTokenAddress,
++            symbol: 'trSHUSDCp',
++            decimals: 18,
++            balance: '1.5',
++        },
++    ],
++} as unknown as Account;
++
++const vault = {
++    id: yieldId,
++    network: 'ethereum',
++    providerId: 'morpho',
++    metadata: { name: 'Steakhouse USDC Prime' },
++    token: {
++        address: underlyingTokenAddress,
++        symbol: 'USDC',
++        decimals: 6,
++        coinGeckoId: 'usd-coin',
++    },
++    outputToken: {
++        address: receiptTokenAddress,
++        symbol: 'trSHUSDCp',
++        name: 'Trezor Steakhouse USDC Prime',
++        decimals: 18,
++        coinGeckoId: 'usd-coin',
++    },
++    rewardRate: { total: 0.05 },
++} as unknown as YieldDto;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> I understand the `vault` should have the type, however at least partial type validation might be a good idea via `satisfies`.
+
+**@BrantalikP** · 2026-05-26
+
+> partial would not work for the hook, I completed the mock instead https://github.com/trezor/trezor-suite/pull/27718/changes/25a82a123cb603cf14c3f6db7e4cc1a5187b3eab
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> nice 💪
+
+---
+
+### G25 — `suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts:27`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-26
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302376413
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts#L27 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `satisfies`, `test-fixtures`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,102 @@
++import { type YieldDto } from '@suite-common/earn-stablecoin-api';
++import { type Account, type AccountKey } from '@suite-common/wallet-types';
++
++import { resolveYieldFlowData } from '../useResolvedYieldFlowData';
++
++const accountKey = 'eth-account-key' as AccountKey;
++const underlyingTokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
++const receiptTokenAddress = '0xde6c23e561f3e55846207ec45a91b777e0f7c889';
++const yieldId = 'ethereum-usdc-steakusdc';
++
++const account = {
++    key: accountKey,
++    symbol: 'eth',
++    tokens: [
++        {
++            contract: underlyingTokenAddress,
++            symbol: 'USDC',
++            decimals: 6,
++            balance: '25',
++        },
++        {
++            contract: receiptTokenAddress,
++            symbol: 'trSHUSDCp',
++            decimals: 18,
++            balance: '1.5',
++        },
++    ],
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> e.g.:
+> ```suggestion
+>     ] satisfies Omit<TokenInfo, 'standard'>[],
+> ```
+
+**@BrantalikP** · 2026-05-26
+
+> https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302376413
+
+---
+
+### G34 — `suite-common/validators/src/types.ts:1`
+
+- **PR** [#28797 — chore(validators): remove dead validator types](https://github.com/trezor/trezor-suite/pull/28797) · author `@mroz22` · closed
+- **My first comment** 2026-06-18
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28797#discussion_r3434859843
+- **Line of code** https://github.com/trezor/trezor-suite/blob/e036bd91faaf6704ba8192bf6060ba16195cac9b/suite-common/validators/src/types.ts#L1
+- **Thread** 3 comment(s), 2 mine
+- **Status** unresolved
+- **Tags** `ambient-types`, `d-ts`, `module-augmentation`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -1,11 +1,8 @@
+-import { type AnySchema } from 'yup';
++export {};
+```
+
+</details>
+
+**Conversation**
+
+**@peter-sanderson** · 2026-06-17
+
+> sus
+
+**🟦 @cermakjiri (me)** · 2026-06-18
+
+> it's this or `import './types';` in `validators/src/index.ts` 🤷‍♂️
+
+**🟦 @cermakjiri (me)** · 2026-06-18
+
+> no, now it can actually be just `validators.d.ts` that should be picked by ts without import, right?
+
+---
+
+### G40 — `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:439`
+
+- **PR** [#28816 — feat(wallet-core): improve nonce discovery for EVM](https://github.com/trezor/trezor-suite/pull/28816) · author `@53gur0` · merged
+- **My first comment** 2026-06-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452406666
+- **Line of code** https://github.com/trezor/trezor-suite/blob/2bb3fd21988b7db91be9d2fb8428da5de1bdbece/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts#L439 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `account-with-network-type`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -350,39 +420,80 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
+     },
+ );
+ 
+-export const ethereumGetCurrentNonceThunk = createThunk<
+-    { nonce: string },
+-    { selectedAccount: Account & { networkType: 'ethereum' }; rbfParams?: RbfTransactionParams }
+->(
+-    `${SEND_MODULE_PREFIX}/ethereumGetCurrentNonceThunk`,
+-    ({ selectedAccount, rbfParams }, { getState }) => {
+-        // Ethereum account `misc.nonce` is not updated before pending tx is mined
+-        // Calculate `pendingNonce`: greatest value in pending tx + 1
+-        // This may lead to unexpected/unwanted behavior
+-        // whenever pending tx gets rejected all following txs (with higher nonce) will be rejected as well
+-        const transactions = selectTransactions(getState());
+-        const pendingTxs = (transactions[selectedAccount.key] || [])
+-            .filter(isPending)
+-            .filter(isSentTransaction);
+-        const pendingNonce = pendingTxs.reduce((value, tx) => {
+-            if (!tx.ethereumSpecific) return value;
++/**
++ * Resolves the nonce to use for the next Ethereum transaction.
++ *
++ * For RBF (cancel / speed-up) the original tx's nonce is reused. Otherwise:
++ *  - `confirmedNonce` = the account's current nonce from the backend (account.misc.nonce), or the
++ *    mined-only nonce from blockbook when `fetchConfirmedNonce` is true (trezor/blockbook#1562).
++ *  - `nonce` (signing default) = `confirmedNonce` advanced past any *contiguous* outgoing pending
++ *    txs. Gapped pending txs (e.g. a stuck tx far above the confirmed nonce) are ignored, so the
++ *    suggestion fills the gap instead of queueing behind an unmineable tx.
++ */
++export const resolveEthereumNonce = async ({
++    selectedAccount,
++    rbfParams,
++    accountTransactions,
++    fetchConfirmedNonce,
++}: {
++    selectedAccount: Account & { networkType: 'ethereum' };
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-22
+
+> NIT: 
+> ```suggestion
+>     selectedAccount: AccountWithNetworkType<'ethereum'>
+> ```
+
+**@53gur0** · 2026-06-25
+
+> fixup! 682b51f2f89b
+
+---
+
+### G42 — `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:75`
+
+- **PR** [#28816 — feat(wallet-core): improve nonce discovery for EVM](https://github.com/trezor/trezor-suite/pull/28816) · author `@53gur0` · merged
+- **My first comment** 2026-06-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452740309
+- **Line of code** https://github.com/trezor/trezor-suite/blob/2bb3fd21988b7db91be9d2fb8428da5de1bdbece/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts#L75 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 3 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `explicit-annotation`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -52,6 +57,71 @@ import {
+ import { selectAddressDisplayType } from '../settings/walletSettingsReducer';
+ import { selectTransactions } from '../transactions/transactionsSelectors';
+ 
++/**
++ * Returns fee info with levels bumped above the original transaction's gas price,
++ * so that the replacement transaction will be accepted by the mempool.
++ *
++ * Expects `feeInfo` with levels already in Gwei (i.e. from selectConvertedNetworkFeeInfo).
++ * `originalGasParams` must also be in Gwei.
++ */
++export const getEthereumRbfFeeInfo = (
++    feeInfo: FeeInfo,
++    originalGasParams: { gasPrice?: string; maxFeePerGas?: string; maxPriorityFeePerGas?: string },
++): FeeInfo => {
++    // feeInfo.levels are already in Gwei — do NOT call getConvertedOrDefaultFeeInfo here,
++    // that would double-convert and produce near-zero values.
++    const { levels } = feeInfo;
++    // @ts-expect-error: indexing with noUncheckedIndexedAccess
++    const firstLevel: (typeof levels)[number] = levels[0];
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-22
+
+> ```suggestion
+>     const firstLevel: FeeLevel = levels[0];
+> ```
+
+**@53gur0** · 2026-06-29
+
+> a32a3c185ec8
+>
+> also fixed type for the feeLevel to have at least one element 
+> ```
+> levels: [FeeLevel, ...FeeLevel[]];
+> ```
+
+**@53gur0** · 2026-06-29
+
+> Unfortunately it's too many changes it seems. Would be great to address this issue separately. Had to rollback the type to possibly empty array
+
+---
+
+### G35 — `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx:15`
+
+- **PR** [#28908 — feat(suite): implement tron staking dashboard](https://github.com/trezor/trezor-suite/pull/28908) · author `@matusbalascak` · merged
+- **My first comment** 2026-06-19
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28908#discussion_r3440966584
+- **Line of code** https://github.com/trezor/trezor-suite/blob/6110524d4bdcfe7c05c242cf1e60e55fe8336db2/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx#L15
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `account-with-network-type`, `narrow-upstream`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,85 @@
++import { useState } from 'react';
++
++import { Translation } from '@suite/intl';
++import { goto } from '@suite/router';
++import { type Account, type TronResourceType } from '@suite-common/wallet-types';
++import { getTronResources } from '@suite-common/wallet-utils';
++import { Button, Card, Column, Icon, Row, Text } from '@trezor/components';
++
++import { useDispatch } from 'src/hooks/suite';
++
++import { TronResourceModal } from '../TronResourceModal';
++import { TronResourceRow } from './TronResourceRow';
++
++interface TronResourcesCardProps {
++    account: Account;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-19
+
+> It might be useful to go with `AccountWithNetworkType<'tron'>` for stricter types and less conditions. 
+> ```suggestion
+>     account: AccountWithNetworkType<'tron'>;
+> ```
+> and do the "is it correct account check" only once somewhere upstream
+
+---
+
+### G57 — `suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts:100`
+
+- **PR** [#29622 — feat(suite-native): evm cancel ](https://github.com/trezor/trezor-suite/pull/29622) · author `@53gur0` · open
+- **My first comment** 2026-07-30
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682317823
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts#L100
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `avoid-cast`, `satisfies`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,104 @@
++import { isRejected } from '@reduxjs/toolkit';
++
++import { createThunk } from '@suite-common/redux-utils';
++import { getNetwork } from '@suite-common/wallet-config';
++import {
++    type AccountWithNetworkType,
++    type FormState,
++    type PrecomposedTransactionFinalCancelRbf,
++    type WalletAccountTransactionWithRequiredRbfParams,
++} from '@suite-common/wallet-types';
++
++import { selectConvertedNetworkFeeInfo } from '../../fees/feesReducer';
++import { SEND_MODULE_PREFIX } from '../sendFormConstants';
++import { getEthereumRbfFeeInfo } from '../sendFormEthereumThunks';
++import { composeSendFormTransactionFeeLevelsThunk } from '../sendFormThunks';
++import { type ComposeFeeLevelsError } from '../sendFormTypes';
++
++export type ComposeEthereumCancelTransactionThunkParams = {
++    account: AccountWithNetworkType<'ethereum'>;
++    tx: WalletAccountTransactionWithRequiredRbfParams;
++};
++
++export type ComposedEthereumCancelTransaction = {
++    composedCancelTx: PrecomposedTransactionFinalCancelRbf;
++    cancelFormState: FormState;
++};
++
++/**
++ * Composes an EVM cancel transaction: a 0-value transfer to the account's own address reusing the
++ * original tx's nonce (via `rbfParams`, applied at signing time) with a fee bumped above the
++ * original gas params so the mempool accepts the replacement.
++ */
++export const composeEthereumCancelTransactionThunk = createThunk<
++    ComposedEthereumCancelTransaction,
++    ComposeEthereumCancelTransactionThunkParams,
++    { rejectValue: ComposeFeeLevelsError }
++>(
++    `${SEND_MODULE_PREFIX}/composeEthereumCancelTransactionThunk`,
++    async ({ account, tx }, { dispatch, getState, rejectWithValue }) => {
++        const feeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);
++        const { rbfParams } = tx;
++
++        if (!feeInfo || rbfParams.type !== 'ethereum') {
++            return rejectWithValue({
++                error: 'fee-levels-compose-failed',
++                message: 'Missing fee info or invalid RBF params for Ethereum cancellation.',
++            });
++        }
++
++        const cancelFormState: FormState = {
++            outputs: [
++                {
++                    type: 'payment',
++                    address: account.descriptor,
++                    amount: '0',
++                    fiat: '',
++                    currency: { value: '', label: '' },
++                    token: null,
++                },
++            ],
++            selectedFee: 'normal',
++            feePerUnit: '',
++            feeLimit: '',
++            options: ['broadcast'],
++            isCoinControlEnabled: false,
++            hasCoinControlBeenOpened: false,
++            selectedUtxos: [],
++            rbfParams,
++        };
++
++        const response = await dispatch(
++            composeSendFormTransactionFeeLevelsThunk({
++                formState: cancelFormState,
++                composeContext: {
++                    account,
++                    network: getNetwork(account.symbol),
++                    feeInfo: getEthereumRbfFeeInfo(feeInfo, rbfParams),
++                },
++            }),
++        );
++
++        if (isRejected(response)) {
++            return rejectWithValue(response.payload ?? { error: 'fee-levels-compose-failed' });
++        }
++
++        const normalLevel = response.payload.normal;
++        if (!normalLevel || normalLevel.type === 'error' || normalLevel.type === 'nonfinal') {
++            return rejectWithValue({
++                error: 'fee-levels-compose-failed',
++                message: 'Unable to compose a valid cancellation fee level.',
++            });
++        }
++
++        return {
++            // The ethereum compose path never yields the Cardano-specific final shape.
++            composedCancelTx: {
++                ...normalLevel,
++                rbfType: 'cancel',
++                prevTxid: tx.txid,
++            } as PrecomposedTransactionFinalCancelRbf,
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-30
+
+> The casting doesn't feel right here. Can we rather use `satisfies` or add new type?
+
+---
+
+### G62 — `suite-native/module-transactions/src/redux.d.ts:11`
+
+- **PR** [#29622 — feat(suite-native): evm cancel ](https://github.com/trezor/trezor-suite/pull/29622) · author `@53gur0` · open
+- **My first comment** 2026-07-30
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682514942
+- **Line of code** https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-native/module-transactions/src/redux.d.ts#L11
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `d-ts`, `redux-augmentation`, `question`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,11 @@
++import { type AsyncThunkAction, type ThunkAction } from '@reduxjs/toolkit';
++
++declare module 'redux' {
++    export interface Dispatch<A extends Action = AnyAction> {
++        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
++
++        <ReturnType = any, State = any, ExtraThunkArg = any>(
++            thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, A>,
++        ): ReturnType;
++    }
++}
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-30
+
+> is this really required? 👀
+
+---
+
+### G76 — `suite-common/wallet-utils/src/transactionUtils.ts:93`
+
+- **PR** [#30910 — fix(suite-desktop): double-check nonces origination](https://github.com/trezor/trezor-suite/pull/30910) · author `@53gur0` · merged
+- **My first comment** 2026-08-05
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721463180
+- **Line of code** https://github.com/trezor/trezor-suite/blob/12d9c3c83e0083f174dc67d285823596bbfba921/suite-common/wallet-utils/src/transactionUtils.ts#L93
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `fix-the-type`, `tx-type-modelling`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -70,11 +70,28 @@ export const isPending = (tx: WalletAccountTransaction | AccountTransaction) =>
+     return !!tx && (!tx.blockHeight || tx.blockHeight < 0);
+ };
+ 
+-// Also matches 'contract': a contract-deployment tx is signed and broadcast from the account's own
+-// address and consumes an EVM nonce exactly like a plain send, so it must count toward the same
+-// nonce pool (see getEvmNonceInfo) even though blockbook classifies it under a distinct type.
+-export const isSentTransaction = (tx: WalletAccountTransaction | AccountTransaction) =>
+-    ['sent', 'self', 'contract'].includes(tx.type);
++// isAccountOwned is set by enhanceVinVout at transform time; the descriptor comparison is the
++// fallback for records where it is absent, and is case-insensitive because EVM addresses reach us in
++// mixed EIP-55 casing (cf. isOutgoing in blockchain-link-utils).
++const isSignedByDescriptor = (details: AccountTransaction['details'], descriptor: string) =>
++    !!details?.vin?.some(
++        vin =>
++            vin.isAccountOwned ||
++            vin.addresses?.some(address => address.toLowerCase() === descriptor.toLowerCase()),
++    );
++
++/**
++ * Whether the account itself signed (and paid for) the transaction.
++ *
++ * Deliberately not `tx.type`, which is a display label: it reads 'sent' for any transaction moving
++ * value out of the account — including one signed by a stranger, since an ERC-20 Transfer log or a
++ * transferFrom(account, …) call may name any `from` — and 'failed' for the account's own reverted
++ * sends. EVM nonce arithmetic needs authorship instead: a foreign transaction carries the *signer's*
++ * nonce, which says nothing about this account, while an own failed or contract-deployment
++ * transaction consumes a nonce exactly like a plain send.
++ */
++export const isSignedByAccount = (tx: Pick<WalletAccountTransaction, 'details' | 'descriptor'>) =>
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-05
+
+> If I understand it correctly, the `sent` type is basically useless / broken because of: 
+>
+> > call may name any `from` — and 'failed' for the account's own reverted sends
+>
+> so wouldn't be better to fix the `sent` type or introduce new one... something in this direction?
+
+---
+
+### G86 — `suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx:262`
+
+- **PR** [#31071 — fix(suite-native): communicate weth vault as eth](https://github.com/trezor/trezor-suite/pull/31071) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/31071#discussion_r3750108169
+- **Line of code** https://github.com/trezor/trezor-suite/blob/a9f17868ba66f7bbd488e71aa765c728422c1ae9/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx#L262 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 4 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `type-guard`, `is-network-symbol`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -256,14 +257,22 @@ export const StablecoinYieldTokenOverview = ({
+                         {depositedPosition && (
+                             <HStack alignItems="center" spacing="sp8">
+                                 <TokenIcon
+-                                    symbol={depositedPosition.symbol}
++                                    symbol={
++                                        wrappedNativeSymbol !== null
++                                            ? (wrappedNativeSymbol as NetworkSymbol)
+```
+
+</details>
+
+**Conversation**
+
+**@izmy** · 2026-08-10
+
+> `toTokenSymbol(wrappedNativeSymbol)`
+
+**@TomasBoda** · 2026-08-10
+
+> doesn't work here. the `symbol` prop expects a `NetworkSymbol`
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> what about `wrappedNativeSymbol && isNetworkSymbol(wrappedNativeSymbol) ? ... : ...`?
+
+**@TomasBoda** · 2026-08-11
+
+> done
+
+---

--- a/code-review-threads/by-topic/12-code-placement-and-reuse.md
+++ b/code-review-threads/by-topic/12-code-placement-and-reuse.md
@@ -1,0 +1,345 @@
+# Code placement, package boundaries & reuse
+
+Moving shared logic to `suite-common` so `suite-native` can reuse it, avoiding circular deps via nested exports, and where selectors/abstractions belong.
+
+**6 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `api-design`, `barrel-exports`, `circular-deps`, `consistency`, `debug-settings`, `duplication`, `encapsulation`, `hook-extraction`, `http-client`, `native-reuse`, `package-boundaries`, `selector-placement`, `suite-common`, `type-declaration-size`, `wallet-core`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G16](#g16--packagessuitesrcactionswalletstablecoin-yieldclaimmerklerewardsthunkts7) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `claimMerkleRewardsThunk.ts:7` | circular-deps, barrel-exports, encapsulation |
+| [G19](#g19--suite-commonwallet-coresrcindexts65) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `index.ts:65` | package-boundaries, wallet-core |
+| [G27](#g27--suite-nativemodule-earnsrchooksuseyieldpendingtransactiontrackingts40) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `useYieldPendingTransactionTracking.ts:40` | duplication, suite-common |
+| [G31](#g31--packagessuitesrccomponentsearnmodalsearninanutshelltronstakeinanutshellmodaltsx28) | [#28374](https://github.com/trezor/trezor-suite/pull/28374) | `TronStakeInANutshellModal.tsx:28` | native-reuse, hook-extraction |
+| [G33](#g33--suitesettingssrcsettingsselectorsts30) | [#28761](https://github.com/trezor/trezor-suite/pull/28761) | `settingsSelectors.ts:30` | selector-placement, consistency, debug-settings |
+| [G54](#g54--suite-commonearn-stablecoin-apisrcservicesyieldxyzts50) | [#29947](https://github.com/trezor/trezor-suite/pull/29947) | `yieldxyz.ts:50` | http-client, type-declaration-size, api-design |
+
+---
+
+### G16 — `packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts:7`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287392749
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts#L7 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 3 comment(s), 2 mine
+- **Status** resolved · outdated
+- **Tags** `circular-deps`, `barrel-exports`, `encapsulation`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -4,7 +4,7 @@ import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+ import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
+ import { Calldata, asEvmAddress } from '@suite-common/calldata';
+ import { selectSelectedDevice } from '@suite-common/device';
+-import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-22
+
+> This was intentional because putting all exports into single file leads to cir. dep. Nested exports effectively mitigate that. At the same time some encapsulation is good (at section/category level) so the package can expose only certain components. 
+>
+> I know, it was only discussed here https://satoshilabs.slack.com/archives/G019WLX2P7B/p1776270754685949 but could be please stay by this? I think we are all quite happy that there're finally no (ecma-script module) cir. dep. 😀
+
+**@BrantalikP** · 2026-05-25
+
+> I had eslint issue on mobile, adding it to localRules helped. Thanks! https://github.com/trezor/trezor-suite/pull/27718/changes/d374bb0dfeb989927db160d282ed1435f0963770
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> Awesome 🙌
+
+---
+
+### G19 — `suite-common/wallet-core/src/index.ts:65`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287618775
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-common/wallet-core/src/index.ts#L65
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved
+- **Tags** `package-boundaries`, `wallet-core`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -62,6 +62,7 @@ export * from './stake/stakeThunks';
+ export * from './stablecoin-yield/stablecoinYieldReducer';
+ export * from './stablecoin-yield/stablecoinYieldSelectors';
+ export * from './stablecoin-yield/stablecoinYieldApprovalThunks';
++export * from './stablecoin-yield/stablecoinYieldDepositThunks';
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-22
+
+> Disclaimer: I know it was already here so just genuinely asking 😃 could it be moved in theory to `@suite-common/earn-stablecoin`? Because I don't see dependency on the wallet-core what so ever.
+
+**@BrantalikP** · 2026-05-25
+
+> agree, let's conduct it in separate PR please.
+
+---
+
+### G27 — `suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts:40`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-26
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302426845
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts#L40
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved
+- **Tags** `duplication`, `suite-common`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,140 @@
++import { useEffect } from 'react';
++import { useDispatch, useSelector } from 'react-redux';
++
++import {
++    type AccountsRootState,
++    type FeesRootState,
++    type TransactionsRootState,
++    type YieldFlowType,
++    type YieldPendingTransactionState,
++    fetchAndUpdateAccountThunk,
++    selectConvertedNetworkFeeInfo,
++    selectTransactionByAccountKeyAndTxid,
++    stablecoinYieldActions,
++} from '@suite-common/wallet-core';
++import { type Account } from '@suite-common/wallet-types';
++import { isPending } from '@suite-common/wallet-utils';
++
++const DEFAULT_PENDING_TX_POLL_INTERVAL_MS = 3_000;
++const MIN_PENDING_TX_POLL_INTERVAL_MS = 2_000;
++const BLOCK_TIME_TO_POLL_INTERVAL_RATIO = 2;
++
++type YieldPendingTrackingRootState = TransactionsRootState & AccountsRootState & FeesRootState;
++
++type UseYieldPendingTransactionTrackingParams = {
++    account: Account | null;
++    flowKey: string | null;
++    flowType: YieldFlowType;
++    isScreenFocused?: boolean;
++    onApprovalConfirmed?: () => void;
++    pendingTransaction: YieldPendingTransactionState | undefined;
++};
++
++const getPollIntervalMs = (blockTime: number | undefined): number => {
++    if (!blockTime) return DEFAULT_PENDING_TX_POLL_INTERVAL_MS;
++
++    return Math.max(
++        (blockTime / BLOCK_TIME_TO_POLL_INTERVAL_RATIO) * 1000,
++        MIN_PENDING_TX_POLL_INTERVAL_MS,
++    );
++};
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> It looks like the same fn as in `@trezor/suite`, what about putting it to suite-common?
+
+**@BrantalikP** · 2026-05-26
+
+> I think I tried, but there is some platform specific code that made it harder to do or make it more complicated that it should if we do it, let me revalidate it. 💪
+
+---
+
+### G31 — `packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx:28`
+
+- **PR** [#28374 — feat(suite): add Tron staking page basics](https://github.com/trezor/trezor-suite/pull/28374) · author `@matusbalascak` · merged
+- **My first comment** 2026-06-05
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28374#discussion_r3361541527
+- **Line of code** https://github.com/trezor/trezor-suite/blob/f7cf6d5d9aa4c0fb2b3faa9ae762736b06bb160a/packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx#L28
+- **Thread** 2 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `native-reuse`, `hook-extraction`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,116 @@
++import { Translation } from '@suite/intl';
++import { useTronStakingStats } from '@suite-common/earn-staking-api';
++import { type EarnModalAction } from '@suite-common/suite-types/src/staking';
++import { BulletList, Divider } from '@trezor/components';
++
++import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
++
++import { EarnInANutshellHighlights } from './components/EarnInANutshellHighlights';
++import { EarnInANutshellModalLayout } from './components/EarnInANutshellModalLayout';
++import {
++    type EarnInANutshellProcess,
++    EarnInANutshellProcesses,
++} from './components/EarnInANutshellProcesses';
++import { EarnInfoRow } from './components/EarnInfoRow';
++
++const TRON_UNSTAKING_PERIOD_DAYS = 14;
++
++interface TronStakeInANutshellModalProps {
++    onCancel: () => void;
++    actionType?: EarnModalAction;
++}
++
++export const TronStakeInANutshellModal = ({
++    onCancel,
++    actionType = 'close',
++}: TronStakeInANutshellModalProps) => {
++    const { data } = useTronStakingStats();
++    const apy = data?.length ? Math.max(...data.map(({ apr }) => apr)) : null;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-05
+
+> What about putting this `maxApy` to `useTronStakingStats` so suite-native can re-use it?
+
+**@matusbalascak** · 2026-06-05
+
+> Good point, I'll implement it in the following PRs
+
+---
+
+### G33 — `suite/settings/src/settingsSelectors.ts:30`
+
+- **PR** [#28761 — refactor(suite): extract shared debug utilities](https://github.com/trezor/trezor-suite/pull/28761) · author `@OriginalEveres` · merged
+- **My first comment** 2026-06-16
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28761#discussion_r3418674994
+- **Line of code** https://github.com/trezor/trezor-suite/blob/ab30c91089162d17697092aa39e8ef7810ae3181/suite/settings/src/settingsSelectors.ts#L29-L30 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `selector-placement`, `consistency`, `debug-settings`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -16,20 +14,6 @@ export const selectTorOnionLinks = (state: SuiteSettingsRootState) =>
+     state.suiteSettings.torOnionLinks;
+ export const selectIsCoinjoinReceiveWarningHidden = (state: SuiteSettingsRootState) =>
+     state.suiteSettings.isCoinjoinReceiveWarningHidden;
+-export const selectIsDebugModeActive = (state: SuiteSettingsRootState) =>
+-    state.suiteSettings.debug.showDebugMenu;
+-export const selectIsUnlockedBootloaderAllowed = (state: SuiteSettingsRootState) =>
+-    state.suiteSettings.debug.isUnlockedBootloaderAllowed;
+-export const selectDebugTransports = (state: SuiteSettingsRootState) =>
+-    state.suiteSettings.debug.transports;
+-export const selectShowConnectLogs = (state: SuiteSettingsRootState) =>
+-    state.suiteSettings.debug.showConnectLogs;
+-export const selectInvityServerEnvironment = (state: SuiteSettingsRootState) =>
+-    state.suiteSettings.debug.invityServerEnvironment;
+-export const selectEarnYieldWorkerBaseUrl = (state: SuiteSettingsRootState) =>
+-    state.suiteSettings.debug.earnYieldWorkerBaseUrl ?? defaultEarnYieldWorkerBaseUrl;
+```
+
+</details>
+
+**Conversation**
+
+**@OriginalEveres** · 2026-06-15
+
+> @tomasklim is this really a good place for this? I would maybe put it into the earn package instead of debug, it seems that its correctly placed in `suite-native` like that.
+>
+> WDYT?
+
+**🟦 @cermakjiri (me)** · 2026-06-16
+
+> But then, shouldn't be done same for other debug options too?
+
+---
+
+### G54 — `suite-common/earn-stablecoin-api/src/services/yieldxyz.ts:50`
+
+- **PR** [#29947 — fix(earn): reduce Yield.xyz declaration size](https://github.com/trezor/trezor-suite/pull/29947) · author `@peter-sanderson` · merged
+- **My first comment** 2026-07-23
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29947#discussion_r3636383687
+- **Line of code** https://github.com/trezor/trezor-suite/blob/8001e4e43467feddfd58ee9cd047b29fae2e051f/suite-common/earn-stablecoin-api/src/services/yieldxyz.ts#L50
+- **Thread** 2 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `http-client`, `type-declaration-size`, `api-design`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -13,12 +21,30 @@ export const yieldXyzApi = createHttpClient({
+     headers: { 'X-Suite-Version': getSuiteVersion() },
+ });
+ 
+-export const getYields = yieldXyzApi('/yields', {
+-    method: 'GET',
+-    schema: YieldsResponseV2,
+-});
++type YieldXyzRequestOptions = {
++    signal?: AbortSignal;
++};
+ 
+-export const getYield = yieldXyzApi('/yields/:vaultId', {
+-    method: 'GET',
+-    schema: YieldResponseV2,
+-});
++type GetYieldsOptions = YieldXyzRequestOptions & {
++    params?: z.input<typeof GetYieldsV2QueryParams>;
++};
++
++type GetYieldOptions = YieldXyzRequestOptions & {
++    routeParams: { vaultId: string };
++};
++
++/** Prevents declaration emit from expanding the inferred Yield.xyz list schema. */
++export const getYields: (options?: GetYieldsOptions) => Promise<YieldsResponseV2Output> =
++    yieldXyzApi('/yields', {
++        method: 'GET',
++        schema: YieldsResponseV2,
++    });
++
++/** Prevents declaration emit from expanding the inferred Yield.xyz detail schema. */
++export const getYield: (options: GetYieldOptions) => Promise<YieldResponseV2Output> = yieldXyzApi(
++    '/yields/:vaultId',
++    {
++        method: 'GET',
++        schema: YieldResponseV2,
++    },
++);
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-07-23
+
+> I can see the type decl. size improvement. However, it seems, we are going to need doing this for each service / endpoint. What about rather improving the `createHttpClient` itself?
+>
+> I've drafted it as kind of a `0.0.1` version to iterate it later on as we gather more usage experience, thus it's easier to design a better interface for it. I can think of extending it with schemas for search params / URL params (e.g. `/users/:userId`), request body. 
+>
+> Do you have some design interface idea for reducing the type decl. size?
+
+**@peter-sanderson** · 2026-07-23
+
+> I yolo drafted the protoype here: https://github.com/trezor/trezor-suite/pull/30220
+
+---

--- a/code-review-threads/by-topic/13-comments-and-docs.md
+++ b/code-review-threads/by-topic/13-comments-and-docs.md
@@ -1,0 +1,50 @@
+# Comments & documentation
+
+Code comments that do not explain the whole rule they document.
+
+**1 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `incomplete-comment`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G70](#g70--packagessuitesrcactionswalletwrapnativetokenthunksts93) | [#30797](https://github.com/trezor/trezor-suite/pull/30797) | `wrapNativeTokenThunks.ts:93` | incomplete-comment |
+
+---
+
+### G70 — `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts:93`
+
+- **PR** [#30797 — feat(suite-desktop): ensure auto-tracked wrapped native assets](https://github.com/trezor/trezor-suite/pull/30797) · author `@53gur0` · merged
+- **My first comment** 2026-08-04
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30797#discussion_r3712209811
+- **Line of code** https://github.com/trezor/trezor-suite/blob/f0c0c9ae1224757da8738a3abbc08f5d343c0706/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts#L93 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `incomplete-comment`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -85,27 +87,36 @@ export const submitWrapNativeTokenThunk = createThunk(
+                 return undefined;
+             }
+ 
++            // Start tracking the wrapped native token so it shows up in the interface without the
++            // user having to manually paste its contract address. Once it's part of account.tokens
++            // it also survives account refreshes (see fetchAccountTokens). Dedupe so re-wrapping an
++            // already-tracked token doesn't create a duplicate entry.
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-04
+
+> This comment misses some parts. Maybe adding one-line sentence comment could do it:
+> ```
+> // Make sure re-wrapping doesn't create a duplicate
+> ```
+
+---

--- a/code-review-threads/by-topic/14-readability-and-simplification.md
+++ b/code-review-threads/by-topic/14-readability-and-simplification.md
@@ -1,0 +1,572 @@
+# Readability & simplification
+
+Extracting named helpers/variables, early returns over nesting, dropping redundant branches, naming, and reusing existing utils.
+
+**11 review-thread-group(s)** · [← back to index](../README.md)
+
+Tags: `duplication` ×2, `extract-fn` ×2, `address-comparison`, `address-normalization`, `copy-paste`, `correctness-question`, `dead-branch`, `design-system`, `early-return`, `extract-condition`, `helper-fn`, `naming`, `nesting`, `no-mutation`, `nonce-logic`, `prefer-filter-over-if-else`, `reuse-existing-util`, `shared-type`, `status-enum`, `styling`, `suggestion`, `to-sorted`
+
+| # | PR | File | Tags |
+| --- | --- | --- | --- |
+| [G26](#g26--suite-nativemodule-earnsrchooksuseyielddepositreviewts34) | [#27718](https://github.com/trezor/trezor-suite/pull/27718) | `useYieldDepositReview.ts:34` | naming, status-enum |
+| [G12](#g12--packagessuitesrcviewswallettradingcommontradingformtradingapprovemodaltsx96) | [#27901](https://github.com/trezor/trezor-suite/pull/27901) | `TradingApproveModal.tsx:96` | address-normalization, helper-fn |
+| [G14](#g14--suite-commonwallet-coresrcaccountsaccountsthunksts166) | [#27901](https://github.com/trezor/trezor-suite/pull/27901) | `accountsThunks.ts:166` | prefer-filter-over-if-else |
+| [G29](#g29--suite-commonwallet-coresrcsendtronbuildcontractts9) | [#28234](https://github.com/trezor/trezor-suite/pull/28234) | `buildContract.ts:9` | shared-type, duplication |
+| [G37](#g37--suite-nativetransactionssrccomponentstransactiontargettsx119) | [#28948](https://github.com/trezor/trezor-suite/pull/28948) | `TransactionTarget.tsx:119` | dead-branch, suggestion |
+| [G51](#g51--packagessuitesrccomponentsearndashboardstakingearnstakingaccountrowtsx386) | [#29031](https://github.com/trezor/trezor-suite/pull/29031) | `EarnStakingAccountRow.tsx:386` | extract-condition, duplication |
+| [G68](#g68--suite-commonwallet-utilssrccardanostakingutilsts111) | [#30028](https://github.com/trezor/trezor-suite/pull/30028) | `cardanoStakingUtils.ts:111` | to-sorted, no-mutation |
+| [G69](#g69--packagessuitesrcactionswalletstakestakeformcardanoactionsts421) | [#30028](https://github.com/trezor/trezor-suite/pull/30028) | `stakeFormCardanoActions.ts:421` | extract-fn, early-return, nesting |
+| [G73](#g73--suite-commonwallet-utilssrctransactionutilsts182) | [#30910](https://github.com/trezor/trezor-suite/pull/30910) | `transactionUtils.ts:182` | extract-fn, nonce-logic, correctness-question |
+| [G75](#g75--suite-commonwallet-utilssrctransactionutilsts80) | [#30910](https://github.com/trezor/trezor-suite/pull/30910) | `transactionUtils.ts:80` | reuse-existing-util, address-comparison |
+| [G79](#g79--suite-nativemodule-accounts-managementsrccomponentsyourpositioncardtsx30) | [#30994](https://github.com/trezor/trezor-suite/pull/30994) | `YourPositionCard.tsx:30` | styling, copy-paste, design-system |
+
+---
+
+### G26 — `suite-native/module-earn/src/hooks/useYieldDepositReview.ts:34`
+
+- **PR** [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · author `@BrantalikP` · merged
+- **My first comment** 2026-05-26
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302415688
+- **Line of code** https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/hooks/useYieldDepositReview.ts#L34 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `naming`, `status-enum`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,155 @@
++import { useCallback, useState } from 'react';
++import { useDispatch, useSelector } from 'react-redux';
++
++import { useNavigation } from '@react-navigation/native';
++import { isRejected } from '@reduxjs/toolkit';
++
++import {
++    type StablecoinYieldRootState,
++    type YieldFlowResolvedData,
++    selectStablecoinYieldTxReview,
++} from '@suite-common/wallet-core';
++import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
++import type {
++    StackNavigationProps,
++    YieldStackParamList,
++    YieldStackRoutes,
++} from '@suite-native/navigation';
++
++import { USER_CANCELLED_ERROR_CODES } from '../constants';
++import { pushYieldActionReviewThunk, signYieldActionReviewThunk } from '../yieldTransactionThunks';
++import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
++
++type UseYieldDepositReviewParams = {
++    flowData: YieldFlowResolvedData;
++    flowKey: string;
++};
++
++type UseYieldDepositReviewResult = {
++    handleSubmitDepositReview: () => Promise<void>;
++    handleDepositSubmitted: () => Promise<void>;
++    isSendingDeposit: boolean;
++    isSigningDeposit: boolean;
++    isSubmitDisabled: boolean;
++    isDepositSigned: boolean;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-26
+
+> `depositStatus` might be more suitable for so many states
+
+**@BrantalikP** · 2026-05-26
+
+>  https://github.com/trezor/trezor-suite/pull/27718/changes/0743fc3a03ac49eb3c3283cca51f78db6f9f21c1
+
+---
+
+### G12 — `packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx:96`
+
+- **PR** [#27901 — Yield speed up transaction support](https://github.com/trezor/trezor-suite/pull/27901) · author `@matusbalascak` · merged
+- **My first comment** 2026-05-21
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279119442
+- **Line of code** https://github.com/trezor/trezor-suite/blob/776fa680167b24f58af7090350ed97bbd77587f2/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx#L96 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 2 mine
+- **Status** unresolved · outdated
+- **Tags** `address-normalization`, `helper-fn`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -92,8 +92,8 @@ export const TradingApproveModal = ({ amount, cryptoId }: TradingApproveModalPro
+         const exchange = selectedQuote?.exchange;
+         const provider = exchange ? providersInfo?.[exchange] : null;
+ 
+-        const approvalData = getEvmApprovalTxData(selectedQuote?.dexTx?.data);
+-        const spender = approvalData?.spender ?? null;
++        const approvalData = Calldata.evm.erc20.approve.decode(selectedQuote?.dexTx?.data);
++        const spender = approvalData?.spender.toLowerCase() ?? null;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-21
+
+> Would it make sense to return the `spender` from `decode` as `approvalData?.spender.toLowerCase() ?? null`?
+
+**🟦 @cermakjiri (me)** · 2026-05-21
+
+> Or use some general method for formatting the address based on network?
+
+---
+
+### G14 — `suite-common/wallet-core/src/accounts/accountsThunks.ts:166`
+
+- **PR** [#27901 — Yield speed up transaction support](https://github.com/trezor/trezor-suite/pull/27901) · author `@matusbalascak` · merged
+- **My first comment** 2026-05-21
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279157068
+- **Line of code** https://github.com/trezor/trezor-suite/blob/776fa680167b24f58af7090350ed97bbd77587f2/suite-common/wallet-core/src/accounts/accountsThunks.ts#L166
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `prefer-filter-over-if-else`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -159,9 +159,24 @@ export const fetchAndUpdateAccountThunk = createThunk(
+                 dispatch(transactionsActions.removeTransaction({ account, txs: analyze.remove }));
+             }
+             if (analyze.add.length > 0) {
++                // Blockbook returns empty tokens for pending contract calls. Copy them
++                // from our fake tx (identified by `deadline`) so RBF on this pending tx still
++                // has token + amount.
++                const enrichedAdd = analyze.add.map(freshTx => {
++                    if ((freshTx.tokens?.length ?? 0) > 0) return freshTx;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-05-21
+
+> NIT 🤏: `.filter` > `if/else`
+
+---
+
+### G29 — `suite-common/wallet-core/src/send/tron/buildContract.ts:9`
+
+- **PR** [#28234 — feat(suite): add transaction data editor to tron send form](https://github.com/trezor/trezor-suite/pull/28234) · author `@matusbalascak` · merged
+- **My first comment** 2026-06-01
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28234#discussion_r3334490148
+- **Line of code** https://github.com/trezor/trezor-suite/blob/14f1ff0af72ac9b357b3b085fede1021ddaab031/suite-common/wallet-core/src/send/tron/buildContract.ts#L9 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 1 comment(s), 1 mine
+- **Status** resolved · outdated
+- **Tags** `shared-type`, `duplication`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,39 @@
++export const buildTriggerContract = ({
++    ownerHex,
++    recipientHex,
++    data,
++}: {
++    ownerHex: string;
++    recipientHex: string;
++    data: string;
++}) =>
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-01
+
+> nit: put it to shared interface / type with `buildTransferContract`?
+
+---
+
+### G37 — `suite-native/transactions/src/components/TransactionTarget.tsx:119`
+
+- **PR** [#28948 — fix(suite-native): display aggregated amounts on tx list item](https://github.com/trezor/trezor-suite/pull/28948) · author `@53gur0` · merged
+- **My first comment** 2026-06-22
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452277831
+- **Line of code** https://github.com/trezor/trezor-suite/blob/c8494882fbe89e3e5478598c155ac54dd43dd25a/suite-native/transactions/src/components/TransactionTarget.tsx#L119 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `dead-branch`, `suggestion`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -116,14 +116,14 @@ export const TransactionTarget = ({
+         if (isSolanaUnstakeTx) return null;
+         switch (type) {
+             case 'target':
+-                return transaction.amount;
++                return payload.amount;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-22
+
+> All cases return the same value, so:
+> ```suggestion
+> ```
+
+**@53gur0** · 2026-06-22
+
+> fixup! fb26ac6cfe55e183a65697034cc8aa6bc5219871
+
+---
+
+### G51 — `packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx:386`
+
+- **PR** [#29031 — Tron - Earn dashboard + Staking limits](https://github.com/trezor/trezor-suite/pull/29031) · author `@TomasBoda` · merged
+- **My first comment** 2026-06-24
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467480205
+- **Line of code** https://github.com/trezor/trezor-suite/blob/30b4edc6e5f92ac9b4ee75d6982d15bf59c66322/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx#L386 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 2 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `extract-condition`, `duplication`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -338,7 +382,8 @@ export const EarnStakingAccountRow = ({
+             </Table.Cell>
+ 
+             <Table.Cell>
+-                {stakingStatus === 'staking-outdated-provider' ? (
++                {stakingStatus === 'staking-outdated-provider' ||
++                stakingStatus === 'staking-remaining-votes' ? (
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-06-24
+
+> there's same condition for this and the case above, what about putting it into some var?
+> ```ts
+> const apyAvailable = stakingStatus !== 'staking-outdated-provider' && stakingStatus !== 'staking-remaining-votes'
+> ```
+
+**@TomasBoda** · 2026-06-26
+
+> done
+
+---
+
+### G68 — `suite-common/wallet-utils/src/cardanoStakingUtils.ts:111`
+
+- **PR** [#30028 — Cardano staking updates](https://github.com/trezor/trezor-suite/pull/30028) · author `@tomasklim` · merged
+- **My first comment** 2026-08-04
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30028#discussion_r3711920509
+- **Line of code** https://github.com/trezor/trezor-suite/blob/7e62dbfeaae420a6bb64042264b12dccdd3ba28d/suite-common/wallet-utils/src/cardanoStakingUtils.ts#L111 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `to-sorted`, `no-mutation`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -92,27 +91,30 @@ export const poolBech32ToHex = (poolId: string): string => {
+     return Buffer.from(bytes).toString('hex');
+ };
+ 
+-export const selectBestCardanoPool = (pools?: AdaPools['pools']) => {
+-    if (!pools || pools.length === 0) return CARDANO_EVERSTAKE_STAKING_POOL;
+-
+-    // find the one within the threshold
+-    const bestPool = pools.find(pool => pool.saturation < CARDANO_POOL_SATURATION_SAFE_THRESHOLD);
+-
+-    if (bestPool) {
++export const selectBestCardanoPool = (pools?: AdaPools['pools'], currentPoolId?: string | null) => {
++    // An account already delegated to an Everstake pool must never be moved to another
++    // pool, no matter which UI flow composes the delegation.
++    if (
++        currentPoolId &&
++        (EVERSTAKE_POOLS.includes(currentPoolId) || pools?.some(pool => pool.id === currentPoolId))
++    ) {
+         return {
+-            hex: poolBech32ToHex(bestPool.id),
+-            bech32: bestPool.id,
++            hex: poolBech32ToHex(currentPoolId),
++            bech32: currentPoolId,
+         };
+     }
+ 
+-    // pick the last one (lowest saturation)
+-    const fallbackIndex = pools.length - 1;
+-    // @ts-expect-error: indexing with noUncheckedIndexedAccess
+-    const fallback: (typeof pools)[number] = pools[fallbackIndex];
++    if (!pools || pools.length === 0) return CARDANO_EVERSTAKE_STAKING_POOL;
++
++    // Sort client-side instead of relying on the API ordering contract; new stakes
++    // always go to the least saturated pool.
++    const [bestPool] = [...pools].sort((a, b) => a.saturation - b.saturation);
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-04
+
+> nit: `pools.toSorted`
+
+---
+
+### G69 — `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts:421`
+
+- **PR** [#30028 — Cardano staking updates](https://github.com/trezor/trezor-suite/pull/30028) · author `@tomasklim` · merged
+- **My first comment** 2026-08-04
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30028#discussion_r3711981075
+- **Line of code** https://github.com/trezor/trezor-suite/blob/7e62dbfeaae420a6bb64042264b12dccdd3ba28d/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts#L421 _(thread is outdated — line refers to the original diff, may have moved)_
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved · outdated
+- **Tags** `extract-fn`, `early-return`, `nesting`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -395,5 +402,23 @@ export const signTransaction =
+             return signedTx;
+         }
+ 
+-        return signedTx.payload.serializedTx;
++        // Report the pool from the certificate that was actually signed, not a later
++        // recomputation — a divergence from the account pool must stay observable.
++        const fromPool = getCardanoAccountPoolId(account);
++        const poolDelegation: StakingCardanoPoolDelegationPayload | undefined =
++            formValues.stakeType === 'stake'
++                ? {
++                      fromPool: fromPool ? (EVERSTAKE_POOL_NAMES[fromPool] ?? fromPool) : undefined,
++                      toPool: EVERSTAKE_POOL_NAMES[selectedPool.bech32] ?? selectedPool.bech32,
++                      toPoolSaturation: cardanoPools.find(pool => pool.id === selectedPool.bech32)
++                          ?.saturation,
++                      poolsDataAvailable: cardanoPools.length > 0,
++                      isEverstakeToEverstake:
++                          fromPool !== null &&
++                          fromPool !== selectedPool.bech32 &&
++                          isCardanoStakedWithEverstake(account, cardanoPools),
++                  }
++                : undefined;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-04
+
+> NIT (readability): It took me a while to digest this piece, I'd move it to `getPoolDelegation` with early `return` avoiding nesting.
+
+---
+
+### G73 — `suite-common/wallet-utils/src/transactionUtils.ts:182`
+
+- **PR** [#30910 — fix(suite-desktop): double-check nonces origination](https://github.com/trezor/trezor-suite/pull/30910) · author `@53gur0` · merged
+- **My first comment** 2026-08-05
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721407524
+- **Line of code** https://github.com/trezor/trezor-suite/blob/12d9c3c83e0083f174dc67d285823596bbfba921/suite-common/wallet-utils/src/transactionUtils.ts#L182
+- **Thread** 3 comment(s), 2 mine
+- **Status** unresolved
+- **Tags** `extract-fn`, `nonce-logic`, `correctness-question`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -157,10 +174,12 @@ export const getEvmNonceInfo = (
+ 
+     // accountNonce (e.g. account.misc.nonce) can lag behind the local tx list if it hasn't been
+     // refreshed since a confirmed tx was locally picked up. A locally confirmed nonce proves a
+-    // higher true nonce exists, so it's a floor accountNonce can't be below. When no confirmed
+-    // nonce is locally known this is 0, so it never lowers accountNonce.
+-    const maxLocalConfirmedNonce = confirmedNonces.size > 0 ? Math.max(...confirmedNonces) + 1 : 0;
+-    const effectiveAccountNonce = Math.max(accountNonce, maxLocalConfirmedNonce);
++    // higher true nonce exists, so it's a floor accountNonce can't be below. The floor walks up
++    // contiguously rather than jumping to max(confirmedNonces): an isolated outlier (a corrupted
++    // record, or a nonce that never belonged to this account) is then never reached — see
++    // getEvmNonceInfoFromConfirmedNonce for the same reasoning.
++    let effectiveAccountNonce = accountNonce;
++    while (confirmedNonces.has(effectiveAccountNonce)) effectiveAccountNonce += 1;
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-05
+
+> So is it really ok not to take the highest one, right?
+>
+> I know it's minor but what about wrapping it to new fn so it's easily digestible (for other readers) by the fn name and if needed then the long comment?
+> ```ts
+> /**
+>    ...
+> */
+> function getNextAvailableEvmNonce(confirmedNonces: Set<string>, accountNonce: string) {
+>   let effectiveAccountNonce = accountNonce;
+>
+>    while (confirmedNonces.has(effectiveAccountNonce)) effectiveAccountNonce += 1
+>
+>   return effectiveAccountNonce  
+> }
+
+**@53gur0** · 2026-08-05
+
+> the issue was that list of pending nonces also contained transactions and nonces that were not created by the user
+
+**🟦 @cermakjiri (me)** · 2026-08-05
+
+> okay
+
+---
+
+### G75 — `suite-common/wallet-utils/src/transactionUtils.ts:80`
+
+- **PR** [#30910 — fix(suite-desktop): double-check nonces origination](https://github.com/trezor/trezor-suite/pull/30910) · author `@53gur0` · merged
+- **My first comment** 2026-08-05
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721438603
+- **Line of code** https://github.com/trezor/trezor-suite/blob/12d9c3c83e0083f174dc67d285823596bbfba921/suite-common/wallet-utils/src/transactionUtils.ts#L80
+- **Thread** 1 comment(s), 1 mine
+- **Status** unresolved
+- **Tags** `reuse-existing-util`, `address-comparison`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -70,11 +70,28 @@ export const isPending = (tx: WalletAccountTransaction | AccountTransaction) =>
+     return !!tx && (!tx.blockHeight || tx.blockHeight < 0);
+ };
+ 
+-// Also matches 'contract': a contract-deployment tx is signed and broadcast from the account's own
+-// address and consumes an EVM nonce exactly like a plain send, so it must count toward the same
+-// nonce pool (see getEvmNonceInfo) even though blockbook classifies it under a distinct type.
+-export const isSentTransaction = (tx: WalletAccountTransaction | AccountTransaction) =>
+-    ['sent', 'self', 'contract'].includes(tx.type);
++// isAccountOwned is set by enhanceVinVout at transform time; the descriptor comparison is the
++// fallback for records where it is absent, and is case-insensitive because EVM addresses reach us in
++// mixed EIP-55 casing (cf. isOutgoing in blockchain-link-utils).
++const isSignedByDescriptor = (details: AccountTransaction['details'], descriptor: string) =>
++    !!details?.vin?.some(
++        vin =>
++            vin.isAccountOwned ||
++            vin.addresses?.some(address => address.toLowerCase() === descriptor.toLowerCase()),
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-05
+
+> what about using `areEvmAddressesEqual`?
+
+---
+
+### G79 — `suite-native/module-accounts-management/src/components/YourPositionCard.tsx:30`
+
+- **PR** [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · author `@TomasBoda` · merged
+- **My first comment** 2026-08-10
+- **Discussion thread** https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749129439
+- **Line of code** https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L30
+- **Thread** 2 comment(s), 1 mine
+- **Status** resolved
+- **Tags** `styling`, `copy-paste`, `design-system`
+
+<details>
+<summary>Code under discussion (diff hunk)</summary>
+
+```diff
+@@ -0,0 +1,218 @@
++import { useSelector } from 'react-redux';
++
++import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
++import {
++    type NetworkSymbol,
++    getDisplaySymbol,
++    getNetworkDisplaySymbolName,
++} from '@suite-common/wallet-config';
++import {
++    type AccountsRootState,
++    selectAccountByKey,
++    selectAccountNetworkSymbol,
++} from '@suite-common/wallet-core';
++import {
++    type Account,
++    type AccountKey,
++    type TokenAddress,
++    type TokenInfoBranded,
++    type TokenSymbol,
++} from '@suite-common/wallet-types';
++import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';
++import { Box, Card, HStack, Text } from '@suite-native/atoms';
++import {
++    CryptoAmountFormatter,
++    CryptoToFiatAmountFormatter,
++    TokenAmountFormatter,
++    TokenToFiatAmountFormatter,
++} from '@suite-native/formatters';
++import { TokenIcon } from '@suite-native/icons';
++import {
++    YieldBadge,
++    useNativeYieldVault,
++    useStakingRate,
++    useYieldBadge,
++} from '@suite-native/module-earn';
++import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
++import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
++
++const cardStyle = prepareNativeStyle(utils => ({
++    flexDirection: 'row',
++    justifyContent: 'space-between',
++    alignItem: 'center',
++    marginHorizontal: utils.spacings.sp16,
++    padding: utils.spacings.sp16,
++    backgroundColor: utils.colors.surfaceFillRaised,
++    borderRadius: utils.borders.radii.r16,
++}));
++
++const cardContentStyle = prepareNativeStyle(_ => ({
++    flexShrink: 1,
++    justifyContent: 'flex-start',
++    alignItems: 'flex-start',
++}));
+```
+
+</details>
+
+**Conversation**
+
+**🟦 @cermakjiri (me)** · 2026-08-10
+
+> I know if I'd do this in Suite desktop, Growth team will say something... but I assume it's more relaxed in suite-native 😄
+
+**@TomasBoda** · 2026-08-10
+
+> I think I copied this from the previous asset card 😬
+
+---

--- a/code-review-threads/by-topic/99-review-summary-comments.md
+++ b/code-review-threads/by-topic/99-review-summary-comments.md
@@ -1,0 +1,125 @@
+# Review summary comments (no code anchor)
+
+Top-level bodies of the reviews `@cermakjiri` submitted. These are not review-thread-groups —
+they have no file/line anchor — but they are part of the same review activity.
+
+**13 summary comment(s)** · [← back to index](../README.md)
+
+---
+
+### [#27621 — fix(suite-native): fee selector balance error](https://github.com/trezor/trezor-suite/pull/27621) · `@BrantalikP`
+
+- **Verdict** `APPROVED` · 2026-05-13
+- **Link** https://github.com/trezor/trezor-suite/pull/27621#pullrequestreview-4280552662
+
+> LGTM as hotfix, I didn't test it though.
+
+---
+
+### [#27763 — fix(suite): block yield tx broadcast when balance can't cover fee](https://github.com/trezor/trezor-suite/pull/27763) · `@matusbalascak`
+
+- **Verdict** `APPROVED` · 2026-05-14
+- **Link** https://github.com/trezor/trezor-suite/pull/27763#pullrequestreview-4290564707
+
+> LGTM 👍
+
+---
+
+### [#27718 — feat(suite-native): yield deposit](https://github.com/trezor/trezor-suite/pull/27718) · `@BrantalikP`
+
+- **Verdict** `COMMENTED` · 2026-05-22
+- **Link** https://github.com/trezor/trezor-suite/pull/27718#pullrequestreview-4344310603
+
+> I still need to go through many files (especially `suite-native` ones) so here's at least the 1st batch. 😃
+
+---
+
+### [#28234 — feat(suite): add transaction data editor to tron send form](https://github.com/trezor/trezor-suite/pull/28234) · `@matusbalascak`
+
+- **Verdict** `APPROVED` · 2026-06-01
+- **Link** https://github.com/trezor/trezor-suite/pull/28234#pullrequestreview-4401582356
+
+> I think we need some claude rule `if args.length > 2, then prefer object args over inline args`  😄
+
+---
+
+### [#28414 — Eth conversion utils](https://github.com/trezor/trezor-suite/pull/28414) · `@marekrjpolak`
+
+- **Verdict** `APPROVED` · 2026-06-15
+- **Link** https://github.com/trezor/trezor-suite/pull/28414#pullrequestreview-4495021396
+
+> It looks clean and we get rid off [the dependency](https://bundlephobia.com/package/web3-utils@4.3.3), it looks good by me. Nice improvement 👍
+
+---
+
+### [#28796 — chore(schemas): remove dead EVM general schema code](https://github.com/trezor/trezor-suite/pull/28796) · `@mroz22`
+
+- **Verdict** `APPROVED` · 2026-06-18
+- **Link** https://github.com/trezor/trezor-suite/pull/28796#pullrequestreview-4523761451
+
+> Nice, thanks
+
+---
+
+### [#28888 — Bump Wallet Deps 26.6](https://github.com/trezor/trezor-suite/pull/28888) · `@53gur0`
+
+- **Verdict** `APPROVED` · 2026-06-19
+- **Link** https://github.com/trezor/trezor-suite/pull/28888#pullrequestreview-4530889138
+
+> Apart the one type-check error, LGTM 👍
+
+---
+
+### [#28816 — feat(wallet-core): improve nonce discovery for EVM](https://github.com/trezor/trezor-suite/pull/28816) · `@53gur0`
+
+- **Verdict** `COMMENTED` · 2026-06-22
+- **Link** https://github.com/trezor/trezor-suite/pull/28816#pullrequestreview-4544273998
+
+> Some minors but otherwise LGTM. 👍  However another review by someone from Connect might be a good idea. 🙏
+
+---
+
+### [#29054 — perf(suite-desktop): tanstack query improvements](https://github.com/trezor/trezor-suite/pull/29054) · `@53gur0`
+
+- **Verdict** `APPROVED` · 2026-06-24
+- **Link** https://github.com/trezor/trezor-suite/pull/29054#pullrequestreview-4561767478
+
+> Just two minors. Otherwise very nice improvements (and fixes)  🚀  and I've learnt several new things today, thanks 😄
+
+---
+
+### [#30536 — feat(suite-desktop): restore warp/unwrap broadcast toast titles](https://github.com/trezor/trezor-suite/pull/30536) · `@53gur0`
+
+- **Verdict** `APPROVED` · 2026-07-30
+- **Link** https://github.com/trezor/trezor-suite/pull/30536#pullrequestreview-4818111495
+
+> LGTM
+
+---
+
+### [#30584 — feat(suite-desktop): don't allow to skip wrapping step if user has no WETH](https://github.com/trezor/trezor-suite/pull/30584) · `@53gur0`
+
+- **Verdict** `APPROVED` · 2026-07-30
+- **Link** https://github.com/trezor/trezor-suite/pull/30584#pullrequestreview-4818203406
+
+> LGTM
+
+---
+
+### [#30994 — Mobile - Asset Detail Screen Revamp](https://github.com/trezor/trezor-suite/pull/30994) · `@TomasBoda`
+
+- **Verdict** `APPROVED` · 2026-08-10
+- **Link** https://github.com/trezor/trezor-suite/pull/30994#pullrequestreview-4896680837
+
+> LGTM 🚀
+
+---
+
+### [#31076 — fix(suite-native): polish standalone wrap/unwrap UI](https://github.com/trezor/trezor-suite/pull/31076) · `@izmy`
+
+- **Verdict** `APPROVED` · 2026-08-10
+- **Link** https://github.com/trezor/trezor-suite/pull/31076#pullrequestreview-4897316667
+
+> LGTM 🚀
+
+---

--- a/code-review-threads/data/digest.md
+++ b/code-review-threads/data/digest.md
@@ -1,0 +1,822 @@
+### G01 | thread PRRT_kwDOCNxUSM6BUnjx | PR #27590 (@matusbalascak) Self-composed `withdraw` / `redeem` calldata for stablecoin yield
+FILE: packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:119
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  ```suggestion
+    Object.keys(yieldStrings).includes(evmTxType)
+```
+
+### G02 | thread PRRT_kwDOCNxUSM6BUoKa | PR #27590 (@matusbalascak) Self-composed `withdraw` / `redeem` calldata for stablecoin yield
+FILE: packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:118
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  ```suggestion
+): evmTxType is keyof typeof yieldStrings  =>
+```
+
+### G03 | thread PRRT_kwDOCNxUSM6BUsbo | PR #27590 (@matusbalascak) Self-composed `withdraw` / `redeem` calldata for stablecoin yield
+FILE: packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts:170
+TOPIC (current): nullability-and-sentinel-values [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  isn't better to pass undefined than empty strings so a react component could decide if it should display some placeholder for example?
+
+### G04 | thread PRRT_kwDOCNxUSM6BUvxw | PR #27590 (@matusbalascak) Self-composed `withdraw` / `redeem` calldata for stablecoin yield
+FILE: packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:205
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  👍
+
+### G05 | thread PRRT_kwDOCNxUSM6BVoxk | PR #27590 (@matusbalascak) Self-composed `withdraw` / `redeem` calldata for stablecoin yield
+FILE: packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts:111
+TOPIC (current): performance-and-memoization [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  NIT: It could run in concurrently:
+
+```ts
+    const nonceTask = dispatch(
+        ethereumGetCurrentNonceThunk({ selectedAccount: account }),
+    ).unwrap();
+
+    const estimatedFeeTask = TrezorConnect.blockchainEstimateFee({
+        coin: account.symbol,
+        identity: getAccountIdentity(account),
+        request: {
+            blocks: [2],
+            specific: {
+                from: account.descriptor,
+                to: vaultAddress,
+                data: builderResult.data,
+                value: '0x0',
+            },
+        },
+    });
+
+   const [{nonce}, estimatedFee] = await Promise.all([nonceTask, estimatedFeeTask] as const)
+```
+
+### G06 | thread PRRT_kwDOCNxUSM6BVo8_ | PR #27590 (@matusbalascak) Self-composed `withdraw` / `redeem` calldata for stablecoin yield
+FILE: packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts:87
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  👍
+
+### G07 | thread PRRT_kwDOCNxUSM6BYOnF | PR #27584 (@izmy) Control Earn actions through message-system feature flags
+FILE: packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx:44
+TOPIC (current): single-source-of-truth [override]
+COMMENTS: 3 (reviewer: 1)
+REVIEWER SAID:
+  There's going to be a new endpoint:
+
+```ts
+    const { address: vaultAddress } = await getYieldVault({
+        routeParams: {
+            networkSymbol: account.symbol,
+            vaultId: vault.id,
+        },
+    });
+```
+
+https://github.com/trezor/trezor-suite/pull/27497/changes#diff-a3b8ddad088598b73f8c4910ec5a6e9748405a090dc807317b2d8e1ff2c55993R45-R48
+
+The worker should be deployed sometime today. 🙏
+
+### G08 | thread PRRT_kwDOCNxUSM6Btmtm | PR #27621 (@BrantalikP) fix(suite-native): fee selector balance error
+FILE: suite-native/module-earn/src/hooks/useComposeEarnFees.ts:164
+TOPIC (current): data-fetching-tanstack-query [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  suggestion for the proper fix: it looks like good job for `useMutation` / `useQuery` (it'd be cleaner & requiring less code)
+
+### G09 | thread PRRT_kwDOCNxUSM6B-tIg | PR #27716 (@matusbalascak) Yield issues
+FILE: suite-common/suite-constants/src/evm.ts:18
+TOPIC (current): single-source-of-truth [override]
+COMMENTS: 4 (reviewer: 2)
+REVIEWER SAID:
+  I though there were a consensus making the Earn yield worker source of the truth in this matter. 🤔 Has it changed? cc @tomasklim
+  --- (next comment by reviewer) ---
+  If it's about the label, I can extend the res. of `https://earn.trezor.io/yield/vaults/v1`
+
+### G10 | thread PRRT_kwDOCNxUSM6CDjHz | PR #27725 (@izmy) fix(suite): handle Solana tx timeout in review modal
+FILE: packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx:49
+TOPIC (current): react-hooks-and-effects [override]
+COMMENTS: 4 (reviewer: 2)
+REVIEWER SAID:
+  I think the intent here prevent triggering useEffect on `serializedTx` change but having fresh `serializedTx` value in the useEffect, right? If so, use `useFreshRef` 🙏
+  --- (next comment by reviewer) ---
+  this only stores the value on mount, if you want prev., the `useCurrentRef` is the solution (I can see now, the naming is misleading 😄)
+
+### G11 | thread PRRT_kwDOCNxUSM6CDmn5 | PR #27725 (@izmy) fix(suite): handle Solana tx timeout in review modal
+FILE: packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx:74
+TOPIC (current): error-handling-and-devx [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  now the thunk's promise can be rejected, causing the component to crash, let's please add `try/catch` / `useMutation` 🙏
+
+### G12 | thread PRRT_kwDOCNxUSM6DtN5y | PR #27901 (@matusbalascak) Yield speed up transaction support
+FILE: packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx:96
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 2 (reviewer: 2)
+REVIEWER SAID:
+  Would it make sense to return the `spender` from `decode` as `approvalData?.spender.toLowerCase() ?? null`?
+  --- (next comment by reviewer) ---
+  Or use some general method for formatting the address based on network?
+
+### G13 | thread PRRT_kwDOCNxUSM6DtSw4 | PR #27901 (@matusbalascak) Yield speed up transaction support
+FILE: suite-common/calldata/src/calldata.ts:56
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  👍
+
+### G14 | thread PRRT_kwDOCNxUSM6DtUdu | PR #27901 (@matusbalascak) Yield speed up transaction support
+FILE: suite-common/wallet-core/src/accounts/accountsThunks.ts:166
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  NIT 🤏: `.filter` > `if/else`
+
+### G15 | thread PRRT_kwDOCNxUSM6DtaNF | PR #27901 (@matusbalascak) Yield speed up transaction support
+FILE: suite-common/wallet-utils/src/ethUtils.ts:91
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  nice cleanup 🎉
+
+### G16 | thread PRRT_kwDOCNxUSM6EENVt | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts:7
+TOPIC (current): code-placement-and-reuse [override]
+COMMENTS: 3 (reviewer: 2)
+REVIEWER SAID:
+  This was intentional because putting all exports into single file leads to cir. dep. Nested exports effectively mitigate that. At the same time some encapsulation is good (at section/category level) so the package can expose only certain components. 
+
+I know, it was only discussed here https://satoshilabs.slack.com/archives/G019WLX2P7B/p1776270754685949 but could be please stay by this? I think we are all quite happy that there're finally no (ecma-script module) cir. dep. 😀
+  --- (next comment by reviewer) ---
+  Awesome 🙌
+
+### G17 | thread PRRT_kwDOCNxUSM6EEQHH | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx:24
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  thanks 👍
+
+### G18 | thread PRRT_kwDOCNxUSM6EEXhV | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts:220
+TOPIC (current): error-handling-and-devx [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  Great that you moved it to common 👍 One thing worries me though there's breaking change how the validation works now: i.e. instead of throwing errors it returns null.  
+At least from DevX it'll be much harder to deduce what's wrong or am I missing something? 🤔
+
+### G19 | thread PRRT_kwDOCNxUSM6EE1NZ | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-common/wallet-core/src/index.ts:65
+TOPIC (current): code-placement-and-reuse [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  Disclaimer: I know it was already here so just genuinely asking 😃 could it be moved in theory to `@suite-common/earn-stablecoin`? Because I don't see dependency on the wallet-core what so ever.
+
+### G20 | thread PRRT_kwDOCNxUSM6EE24t | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-native/tx-simulation/package.json:28
+TOPIC (current): component-structure-and-files [override]
+COMMENTS: 2 (reviewer: 2)
+REVIEWER SAID:
+  Nice! 🎉
+  --- (next comment by reviewer) ---
+  One thing though: could you please follow similar structure as in other tx-simulation packages so it's going to be easy to extend them in future for other non-evm networks too? E.g.:
+```ts
+tx-simulation/src 
+   /common
+       /components
+       /hooks
+   /evm
+       /components   
+       /hooks
+```
+
+Anyway it could be done in some follow up 🙏
+
+### G21 | thread comment:3288598035 | PR #27829 (@unknown) (PR no longer accessible — deleted or hidden)
+FILE: suite-common/earn-staking-api/src/staking/hooks/useEthereumValidatorsQueue.ts:19
+TOPIC (current): data-fetching-tanstack-query [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  Sure, checking for `null` account and enabling it only when it's defined makes sense. But why have you removed the `queryOptions`? This is general hook and the usage might vary in `suite` and `suite-native`. 
+
+It'd be better to this like this:
+```ts
+import { type ResponseError, type ResponseValidationError } from '@suite-common/http-client';
+import { type UseQueryOptions, commonQueryKeys, useQuery } from '@suite-common/react-query';
+import { type Account } from '@suite-common/wallet-types';
+
+import { type EthValidatorsQueue } from '../../api/types';
+import { getEthereumValidatorsQueue } from '../services';
+
+interface UseEthereumValidatorsQueueProps {
+    account: Account | null;
+    timestamp?: number;
+}
+
+export function useEthereumValidatorsQueue(
+    { account, timestamp }: UseEthereumValidatorsQueueProps,
+    {
+        enabled = Boolean(account),
+        ...restQueryOptions
+    }: Omit<
+        UseQueryOptions<EthValidatorsQueue, ResponseError | ResponseValidationError>,
+        'queryKey'
+    > = {},
+) {
+    return useQuery({
+        staleTime: 60 * 1000, // 1 minute
+        ...restQueryOptions,
+        queryKey: commonQueryKeys.validatorsQueue(account?.key, timestamp),
+        queryFn: () =>
+            getEthereumValidatorsQueue({
+                params: { timestamp },
+            }),
+    });
+}
+```
+of course and edit the query key: `validatorsQueue: (accountKey: string | undefined, timestamp?: number) => [`
+
+### G22 | thread PRRT_kwDOCNxUSM6EuQjn | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx:129
+TOPIC (current): react-hooks-and-effects [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  Shouldn't be this rather done via `useRef` hook?
+
+### G23 | thread PRRT_kwDOCNxUSM6EuhYu | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-native/module-earn/src/components/YieldPendingTransactionModalConstants.ts:9
+TOPIC (current): component-structure-and-files [override]
+COMMENTS: 3 (reviewer: 2)
+REVIEWER SAID:
+  This is out of scope this PR, anyway I believe it'd be good to at least open up the discussion on the topic:
+
+I've just noticed that suite-native packages are following some really strict linear file structure. However, the issue with that it breaks implicit relationships between components apposed to tree-like file structure.
+
+Linear:
+```
+some-pkg/src/
+    /components
+         SomeScreen.tsx
+         SomeFooter.tsx
+         SomeFooterButton.tsx
+         ...
+  /hooks
+        useSomeFooter.tsx
+        useSomeXYZ.tsx
+        ...
+```
+
+Tree-like:
+```
+some-pkg/src/
+    /components
+         /SomeScreen
+                  /hooks
+                       useSomeXYZ.tsx # hook for the `SomeScreen`.tsx
+                 /constants
+                 /{other-architectual-primitives}
+                 /SomeFooter
+                        /hooks
+                             useSomeFooter.tsx # hook only for the relevant   footer
+                        SomeFooterButton.tsx
+                  SomeScreen.tsx
+```
+
+- The relationship between components is implicit by the structure. If something is shared across more of them, it can be just move respective level up. 
+- It scales: It can effectively decrease browsing complexity to O(logn) making much better for bigger file structure to orient to.
+  --- (next comment by reviewer) ---
+  Glad to hear that! 
+
+I kind of agree that it's better to have unified approaches across teams in the same codebase, however if I should always wait for everything to be accepted by our Suite Council, I'm afraid there'd be not much of progress. Maybe the borderline might be defined on team-level / package-level (something like that), when there's a need to introduce a new pattern / coding practice like this. 
+
+Anyway, thank you for your feedback on that. I hope we will make this work soon. 🚀
+
+### G24 | thread PRRT_kwDOCNxUSM6Eutly | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts:49
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 3 (reviewer: 2)
+REVIEWER SAID:
+  I understand the `vault` should have the type, however at least partial type validation might be a good idea via `satisfies`.
+  --- (next comment by reviewer) ---
+  nice 💪
+
+### G25 | thread PRRT_kwDOCNxUSM6Euzhb | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts:27
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  e.g.:
+```suggestion
+    ] satisfies Omit<TokenInfo, 'standard'>[],
+```
+
+### G26 | thread PRRT_kwDOCNxUSM6Eu6Ts | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-native/module-earn/src/hooks/useYieldDepositReview.ts:34
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  `depositStatus` might be more suitable for so many states
+
+### G27 | thread PRRT_kwDOCNxUSM6Eu8Pd | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts:40
+TOPIC (current): code-placement-and-reuse [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  It looks like the same fn as in `@trezor/suite`, what about putting it to suite-common?
+
+### G28 | thread PRRT_kwDOCNxUSM6EvADR | PR #27718 (@BrantalikP) feat(suite-native): yield deposit
+FILE: suite-native/module-earn/src/screens/YieldDepositReviewScreen.tsx:162
+TOPIC (current): component-structure-and-files [override]
+COMMENTS: 3 (reviewer: 2)
+REVIEWER SAID:
+  One component per file please to make it easily readable 🙏
+  --- (next comment by reviewer) ---
+  TBH I still think it'd be better to divide it (better readability, so less bugs; easier composibility; potential easier refactoring in the future) but I don't push it. Also, it might be subject of some follow-up.
+
+### G29 | thread PRRT_kwDOCNxUSM6GIZu2 | PR #28234 (@matusbalascak) feat(suite): add transaction data editor to tron send form
+FILE: suite-common/wallet-core/src/send/tron/buildContract.ts:9
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  nit: put it to shared interface / type with `buildTransferContract`?
+
+### G30 | thread PRRT_kwDOCNxUSM6GImBo | PR #28234 (@matusbalascak) feat(suite): add transaction data editor to tron send form
+FILE: suite-common/wallet-core/src/send/sendFormThunks.ts:84
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  I like the nesting per network 👍
+
+### G31 | thread PRRT_kwDOCNxUSM6HT_F2 | PR #28374 (@matusbalascak) feat(suite): add Tron staking page basics
+FILE: packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx:28
+TOPIC (current): code-placement-and-reuse [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  What about putting this `maxApy` to `useTronStakingStats` so suite-native can re-use it?
+
+### G32 | thread PRRT_kwDOCNxUSM6JfIUb | PR #28414 (@marekrjpolak) Eth conversion utils
+FILE: suite-common/wallet-utils/src/ethConverter.ts:33
+TOPIC (current): runtime-validation-and-parsing [override]
+COMMENTS: 4 (reviewer: 1)
+REVIEWER SAID:
+  Why can't it be negative?
+
+### G33 | thread PRRT_kwDOCNxUSM6Jsnb1 | PR #28761 (@OriginalEveres) refactor(suite): extract shared debug utilities
+FILE: suite/settings/src/settingsSelectors.ts:30
+TOPIC (current): code-placement-and-reuse [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  But then, shouldn't be done same for other debug options too?
+
+### G34 | thread PRRT_kwDOCNxUSM6KLrm- | PR #28797 (@mroz22) chore(validators): remove dead validator types
+FILE: suite-common/validators/src/types.ts:1
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 3 (reviewer: 2)
+REVIEWER SAID:
+  it's this or `import './types';` in `validators/src/index.ts` 🤷‍♂️
+  --- (next comment by reviewer) ---
+  no, now it can actually be just `validators.d.ts` that should be picked by ts without import, right?
+
+### G35 | thread PRRT_kwDOCNxUSM6KxA-t | PR #28908 (@matusbalascak) feat(suite): implement tron staking dashboard
+FILE: packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx:15
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  It might be useful to go with `AccountWithNetworkType<'tron'>` for stricter types and less conditions. 
+```suggestion
+    account: AccountWithNetworkType<'tron'>;
+```
+and do the "is it correct account check" only once somewhere upstream
+
+### G36 | thread PRRT_kwDOCNxUSM6LQoSc | PR #28948 (@53gur0) fix(suite-native): display aggregated amounts on tx list item
+FILE: suite-native/transactions/src/components/TransactionTarget.tsx:125
+TOPIC (current): performance-and-memoization [override]
+COMMENTS: 2 (reviewer: 2)
+REVIEWER SAID:
+  ```suggestion
+    }, [type, payload.amount, isSolanaUnstakeTx]);
+```
+  --- (next comment by reviewer) ---
+  These memo seem redundant, there's no complexity (`O(1)`), it could some `get____Amount` util. I just need to say but it's not your code, I know 😄
+
+### G37 | thread PRRT_kwDOCNxUSM6LQoco | PR #28948 (@53gur0) fix(suite-native): display aggregated amounts on tx list item
+FILE: suite-native/transactions/src/components/TransactionTarget.tsx:119
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  All cases return the same value, so:
+```suggestion
+```
+
+### G38 | thread PRRT_kwDOCNxUSM6LQqvp | PR #28948 (@53gur0) fix(suite-native): display aggregated amounts on tx list item
+FILE: suite-native/transactions/src/components/TransactionListItem.tsx:134
+TOPIC (current): performance-and-memoization [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  I'd suggest using memo for this, wdyt?
+
+### G39 | thread PRRT_kwDOCNxUSM6LQ-O5 | PR #28816 (@53gur0) feat(wallet-core): improve nonce discovery for EVM
+FILE: suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:68
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  nice to mention this 👍
+
+### G40 | thread PRRT_kwDOCNxUSM6LQ_3e | PR #28816 (@53gur0) feat(wallet-core): improve nonce discovery for EVM
+FILE: suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:439
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  NIT: 
+```suggestion
+    selectedAccount: AccountWithNetworkType<'ethereum'>
+```
+
+### G41 | thread PRRT_kwDOCNxUSM6LR8C5 | PR #28816 (@53gur0) feat(wallet-core): improve nonce discovery for EVM
+FILE: suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:82
+TOPIC (current): runtime-validation-and-parsing [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  What about using some Zod schema for parsing of the unknown data instead of the casting? There's already something related to that here `suite-common/schemas/src/evm/fees/index.ts` but it's been done only for hex strings yet.
+
+### G42 | thread PRRT_kwDOCNxUSM6LR8QV | PR #28816 (@53gur0) feat(wallet-core): improve nonce discovery for EVM
+FILE: suite-common/wallet-core/src/send/sendFormEthereumThunks.ts:75
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 3 (reviewer: 1)
+REVIEWER SAID:
+  ```suggestion
+    const firstLevel: FeeLevel = levels[0];
+```
+
+### G43 | thread PRRT_kwDOCNxUSM6L4rFn | PR #29054 (@53gur0) perf(suite-desktop): tanstack query improvements
+FILE: suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts:73
+TOPIC (current): ci-tooling-and-guardrails [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  We should (in another PR) try to introduce some Eslint rule to warn us about that. ✍️ 🤔 
+I didn't realize it's gonna break the proxy, even though it's now very much obvious.
+
+### G44 | thread PRRT_kwDOCNxUSM6L4rvu | PR #29054 (@53gur0) perf(suite-desktop): tanstack query improvements
+FILE: packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx:63
+TOPIC (current): performance-and-memoization [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  nit: what about using static array (i.e it has stable ref) so it doesn't break the useMemo?
+
+### G45 | thread PRRT_kwDOCNxUSM6L4tds | PR #29054 (@53gur0) perf(suite-desktop): tanstack query improvements
+FILE: suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts:22
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  hehe, how so I didn't notice that, thanks 😄
+
+### G46 | thread PRRT_kwDOCNxUSM6L4vls | PR #29054 (@53gur0) perf(suite-desktop): tanstack query improvements
+FILE: suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts:239
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  https://github.com/trezor/trezor-suite/pull/29054/changes#r3466751441 🙏
+
+### G47 | thread PRRT_kwDOCNxUSM6L4v29 | PR #29054 (@53gur0) perf(suite-desktop): tanstack query improvements
+FILE: suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts:47
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  ❤️
+
+### G48 | thread PRRT_kwDOCNxUSM6L4wXG | PR #29054 (@53gur0) perf(suite-desktop): tanstack query improvements
+FILE: suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts:32
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  nice 👍
+
+### G49 | thread PRRT_kwDOCNxUSM6L6fov | PR #29031 (@TomasBoda) Tron - Earn dashboard + Staking limits
+FILE: packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts:52
+TOPIC (current): single-source-of-truth [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  I'm not sure why we haven't done up to this point but what about using network config `getNetwork(account.symbol).features.includes('staking')` so we move the source of truth there?
+
+### G50 | thread PRRT_kwDOCNxUSM6L6pCr | PR #29031 (@TomasBoda) Tron - Earn dashboard + Staking limits
+FILE: packages/suite/src/hooks/earn/useStakingYield.ts:46
+TOPIC (current): performance-and-memoization [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  If nothing changes this should be really low O(n), right? My point is if it would make sense move to some `useStakingYieldApy` with `useMemo` or not.
+
+### G51 | thread PRRT_kwDOCNxUSM6L6tfc | PR #29031 (@TomasBoda) Tron - Earn dashboard + Staking limits
+FILE: packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx:386
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  there's same condition for this and the case above, what about putting it into some var?
+```ts
+const apyAvailable = stakingStatus !== 'staking-outdated-provider' && stakingStatus !== 'staking-remaining-votes'
+```
+
+### G52 | thread PRRT_kwDOCNxUSM6SN0xn | PR #30091 (@MiroslavProchazka) fix(workflows): adjust aws session duration for icon workflow
+FILE: .github/workflows/release-suite-coin-icons.yml:46
+TOPIC (current): ci-tooling-and-guardrails [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  It seems like a good hotfix. I'd just increase it to 5h as some successful runs took more than 4h.
+
+https://github.com/trezor/trezor-suite/actions/workflows/release-suite-coin-icons.yml?query=is%3Asuccess
+
+### G53 | thread PRRT_kwDOCNxUSM6SNxR0 | PR #30091 (@MiroslavProchazka) fix(workflows): adjust aws session duration for icon workflow
+FILE: .github/workflows/release-suite-coin-icons.yml:46
+TOPIC (current): ci-tooling-and-guardrails [override]
+COMMENTS: 4 (reviewer: 2)
+REVIEWER SAID:
+  The default is 1h, so is 4x longer really too long? The script might run over 4h (which itself the core issue) https://github.com/trezor/trezor-suite/actions/workflows/release-suite-coin-icons.yml?query=is%3Asuccess.
+  --- (next comment by reviewer) ---
+  This should become hopefully irrelevant once this is going to be merged. 🙏   https://github.com/trezor/trezor-suite/pull/30108
+
+### G54 | thread PRRT_kwDOCNxUSM6TLEtD | PR #29947 (@peter-sanderson) fix(earn): reduce Yield.xyz declaration size
+FILE: suite-common/earn-stablecoin-api/src/services/yieldxyz.ts:50
+TOPIC (current): code-placement-and-reuse [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  I can see the type decl. size improvement. However, it seems, we are going to need doing this for each service / endpoint. What about rather improving the `createHttpClient` itself?
+
+I've drafted it as kind of a `0.0.1` version to iterate it later on as we gather more usage experience, thus it's easier to design a better interface for it. I can think of extending it with schemas for search params / URL params (e.g. `/users/:userId`), request body. 
+
+Do you have some design interface idea for reducing the type decl. size?
+
+### G55 | thread PRRT_kwDOCNxUSM6VEtNU | PR #30255 (@53gur0) feat(suite-native): label wrap/unwrap transactions
+FILE: suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx:134
+TOPIC (current): component-structure-and-files [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  To maintain the render method readability, I'd suggest move this to new component and doing early returns
+
+### G56 | thread PRRT_kwDOCNxUSM6VFRu_ | PR #29622 (@53gur0) feat(suite-native): evm cancel 
+FILE: packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts:66
+TOPIC (current): data-fetching-tanstack-query [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  Why not using useQuery if it's more declarative than imperative use-case? It would result in shorter code a little:
+
+```ts
+    const { ... } = useQuery({
+        enabled: account.networkType === 'ethereum' && !!feeInfo && tx.rbfParams?.type === 'ethereum',
+        queryKey: [],
+        queryFn: async () => {
+            const result = await dispatch(composeEthereumCancelTransactionThunk({ account, tx }));
+
+            if (isRejected(result)) {
+                throw result.payload ?? new Error('Unknown error');
+            }
+
+            return result.payload;
+        }
+    })
+```
+
+### G57 | thread PRRT_kwDOCNxUSM6VFTbC | PR #29622 (@53gur0) feat(suite-native): evm cancel 
+FILE: suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts:100
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  The casting doesn't feel right here. Can we rather use `satisfies` or add new type?
+
+### G58 | thread PRRT_kwDOCNxUSM6VFXRL | PR #29622 (@53gur0) feat(suite-native): evm cancel 
+FILE: suite-common/wallet-core/src/send/useEvmNonceInfo.ts:95
+TOPIC (current): data-fetching-tanstack-query [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  NIT (ignore if you will): This might be part of the useQuery as `select` method. Anyway I guess there's no advantage compare to this solution.
+
+### G59 | thread PRRT_kwDOCNxUSM6VFbQ1 | PR #29622 (@53gur0) feat(suite-native): evm cancel 
+FILE: suite-native/module-transactions/src/hooks/useCancelEvmTransaction.ts:67
+TOPIC (current): runtime-validation-and-parsing [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  I dunno, I'd either use Zod schema for parsing or use `.?` operator as it can be undefined
+
+### G60 | thread PRRT_kwDOCNxUSM6VFeR0 | PR #29622 (@53gur0) feat(suite-native): evm cancel 
+FILE: suite-native/module-transactions/src/hooks/useDeviceGuardedSign.ts:74
+TOPIC (current): data-fetching-tanstack-query [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  this looks like job for `useQuery`
+
+### G61 | thread PRRT_kwDOCNxUSM6VFgQk | PR #29622 (@53gur0) feat(suite-native): evm cancel 
+FILE: suite-native/module-transactions/src/components/CancelEvmTransactionButton.tsx:46
+TOPIC (current): component-structure-and-files [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  Let's please have single react component per file (easier to find the component, easier to refactor the component, easier to read this file) 🙏
+
+### G62 | thread PRRT_kwDOCNxUSM6VF1ES | PR #29622 (@53gur0) feat(suite-native): evm cancel 
+FILE: suite-native/module-transactions/src/redux.d.ts:11
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  is this really required? 👀
+
+### G63 | thread PRRT_kwDOCNxUSM6V6ebt | PR #30154 (@vojtatranta) WIP: 28878 playwright perf tracking
+FILE: packages/suite/src/support/suite/Main.tsx:39
+TOPIC (current): component-structure-and-files [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  Let's move everything new here to `RenderProfiler` component
+
+### G64 | thread PRRT_kwDOCNxUSM6V6hAa | PR #30154 (@vojtatranta) WIP: 28878 playwright perf tracking
+FILE: suite/e2e/performance/perfMeasure.ts:53
+TOPIC (current): error-handling-and-devx [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  It's for desktop too. I think this should throw an error instead (i.e. if a dev attempts to measure a test there's missing `__trezorPerf__`, why skipping it, right?)
+
+### G65 | thread PRRT_kwDOCNxUSM6V942D | PR #30154 (@vojtatranta) WIP: 28878 playwright perf tracking
+FILE: packages/perf-e2e/src/instrumentation.ts:69
+TOPIC (current): error-handling-and-devx [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  it might not a break the app but could signal something's off regarding the perf. measurement. What about enabling the logging when adding `--debug` flag?
+
+### G66 | thread PRRT_kwDOCNxUSM6V95Qp | PR #30154 (@vojtatranta) WIP: 28878 playwright perf tracking
+FILE: packages/perf-e2e/src/instrumentation.ts:91
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  https://github.com/trezor/trezor-suite/pull/30154/changes#r3703857163
+
+### G67 | thread PRRT_kwDOCNxUSM6WR352 | PR #30791 (@TomasBoda) Earn Yield - Add Rewards Tooltips
+FILE: packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts:85
+TOPIC (current): performance-and-memoization [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  NIT (memory):  all useMemo hooks can be combined into single one, all of them have the same dep (`rewards.data.accountsRewards`)
+
+### G68 | thread PRRT_kwDOCNxUSM6WS_VP | PR #30028 (@tomasklim) Cardano staking updates
+FILE: suite-common/wallet-utils/src/cardanoStakingUtils.ts:111
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  nit: `pools.toSorted`
+
+### G69 | thread PRRT_kwDOCNxUSM6WTJXX | PR #30028 (@tomasklim) Cardano staking updates
+FILE: packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts:421
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  NIT (readability): It took me a while to digest this piece, I'd move it to `getPoolDelegation` with early `return` avoiding nesting.
+
+### G70 | thread PRRT_kwDOCNxUSM6WTvIt | PR #30797 (@53gur0) feat(suite-desktop): ensure auto-tracked wrapped native assets
+FILE: packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts:93
+TOPIC (current): comments-and-docs [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  This comment misses some parts. Maybe adding one-line sentence comment could do it:
+```
+// Make sure re-wrapping doesn't create a duplicate
+```
+
+### G71 | thread PRRT_kwDOCNxUSM6WUXFG | PR #29445 (@tomasklim) fix(suite): keep account graph data visible while refetching
+FILE: packages/suite/src/actions/wallet/graphActions.ts:105
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  ooff, so until now there wasn't any pagination. 😄 Nice improvement 👍
+
+### G72 | thread PRRT_kwDOCNxUSM6WUawu | PR #29445 (@tomasklim) fix(suite): keep account graph data visible while refetching
+FILE: packages/suite/src/actions/wallet/graphActions.ts:171
+TOPIC (current): data-fetching-tanstack-query [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  I really don't like this thunk, it could be fairly easily replaced with tanstack query. But that's for another time, I know.
+
+### G73 | thread PRRT_kwDOCNxUSM6Wrxn2 | PR #30910 (@53gur0) fix(suite-desktop): double-check nonces origination
+FILE: suite-common/wallet-utils/src/transactionUtils.ts:182
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 3 (reviewer: 2)
+REVIEWER SAID:
+  So is it really ok not to take the highest one, right?
+
+I know it's minor but what about wrapping it to new fn so it's easily digestible (for other readers) by the fn name and if needed then the long comment?
+```ts
+/**
+   ...
+*/
+function getNextAvailableEvmNonce(confirmedNonces: Set<string>, accountNonce: string) {
+  let effectiveAccountNonce = accountNonce;
+
+   while (confirmedNonces.has(effectiveAccountNonce)) effectiveAccountNonce += 1
+
+  return effectiveAccountNonce  
+}
+  --- (next comment by reviewer) ---
+  okay
+
+### G74 | thread PRRT_kwDOCNxUSM6Wr1b2 | PR #30910 (@53gur0) fix(suite-desktop): double-check nonces origination
+FILE: packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx:90
+TOPIC (current): performance-and-memoization [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  uff, no useMemo anywhere... anyway that's for another PR (I know it was here before, I just help myself not commenting it) 😄
+
+### G75 | thread PRRT_kwDOCNxUSM6Wr22C | PR #30910 (@53gur0) fix(suite-desktop): double-check nonces origination
+FILE: suite-common/wallet-utils/src/transactionUtils.ts:80
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  what about using `areEvmAddressesEqual`?
+
+### G76 | thread PRRT_kwDOCNxUSM6Wr665 | PR #30910 (@53gur0) fix(suite-desktop): double-check nonces origination
+FILE: suite-common/wallet-utils/src/transactionUtils.ts:93
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  If I understand it correctly, the `sent` type is basically useless / broken because of: 
+
+> call may name any `from` — and 'failed' for the account's own reverted sends
+
+so wouldn't be better to fix the `sent` type or introduce new one... something in this direction?
+
+### G77 | thread PRRT_kwDOCNxUSM6X2f7S | PR #30994 (@TomasBoda) Mobile - Asset Detail Screen Revamp
+FILE: suite-native/module-earn/src/hooks/useYieldBadge.tsx:41
+TOPIC (current): nullability-and-sentinel-values [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  Is there real use case with undefined token.symbol and setting `''` seems like way to potential bug / unnecessary checks down stream. Therefore:
+```suggestion
+        if (!networkSymbol || !token || !token.symbol) return [];
+```
+
+### G78 | thread PRRT_kwDOCNxUSM6X2gF2 | PR #30994 (@TomasBoda) Mobile - Asset Detail Screen Revamp
+FILE: suite-native/module-earn/src/hooks/useYieldBadge.tsx:45
+TOPIC (current): nullability-and-sentinel-values [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  ```suggestion
+            symbol: token.symbol,
+```
+
+### G79 | thread PRRT_kwDOCNxUSM6X2j-v | PR #30994 (@TomasBoda) Mobile - Asset Detail Screen Revamp
+FILE: suite-native/module-accounts-management/src/components/YourPositionCard.tsx:30
+TOPIC (current): readability-and-simplification [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  I know if I'd do this in Suite desktop, Growth team will say something... but I assume it's more relaxed in suite-native 😄
+
+### G80 | thread PRRT_kwDOCNxUSM6X2lnu | PR #30994 (@TomasBoda) Mobile - Asset Detail Screen Revamp
+FILE: suite-native/module-accounts-management/src/components/YourPositionCard.tsx:103
+TOPIC (current): component-structure-and-files [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  Let's put it to new file with the name of the hook. 🙏
+
+### G81 | thread PRRT_kwDOCNxUSM6X2m4p | PR #30994 (@TomasBoda) Mobile - Asset Detail Screen Revamp
+FILE: suite-native/module-accounts-management/src/components/YourPositionCard.tsx:113
+TOPIC (current): nullability-and-sentinel-values [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  This selection should be done outside this component so the types here can assert only `account` and doesn't have to always check for undefined/null cases 🙏
+
+### G82 | thread PRRT_kwDOCNxUSM6X2nwb | PR #30994 (@TomasBoda) Mobile - Asset Detail Screen Revamp
+FILE: suite-native/module-accounts-management/src/components/YourPositionCard.tsx:122
+TOPIC (current): nullability-and-sentinel-values [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  Might be the case for `symbol` and `token` too 🙏 
+https://github.com/trezor/trezor-suite/pull/30994/changes#r3749145328
+
+### G83 | thread PRRT_kwDOCNxUSM6X2oxc | PR #30994 (@TomasBoda) Mobile - Asset Detail Screen Revamp
+FILE: suite-native/module-earn/src/components/YieldBadge.tsx:52
+TOPIC (current): data-fetching-tanstack-query [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  Let's use `useYieldOpportunity` instead of `useAllYieldOpportunities`
+
+### G84 | thread PRRT_kwDOCNxUSM6X20J5 | PR #30994 (@TomasBoda) Mobile - Asset Detail Screen Revamp
+FILE: suite-native/module-accounts-management/src/components/YourPositionCard.tsx:52
+TOPIC (current): nullability-and-sentinel-values [override]
+COMMENTS: 2 (reviewer: 1)
+REVIEWER SAID:
+  are we sure it can handle `formattedBalance` balance too?
+
+### G85 | thread PRRT_kwDOCNxUSM6X4-oe | PR #31076 (@izmy) fix(suite-native): polish standalone wrap/unwrap UI
+FILE: suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx:166
+TOPIC (current): acknowledgements-and-pointers [override]
+COMMENTS: 1 (reviewer: 1)
+REVIEWER SAID:
+  nice 👍
+
+### G86 | thread PRRT_kwDOCNxUSM6X1LU- | PR #31071 (@TomasBoda) fix(suite-native): communicate weth vault as eth
+FILE: suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx:262
+TOPIC (current): typescript-type-safety [override]
+COMMENTS: 4 (reviewer: 1)
+REVIEWER SAID:
+  what about `wrappedNativeSymbol && isNetworkSymbol(wrappedNativeSymbol) ? ... : ...`?

--- a/code-review-threads/data/review-thread-groups.json
+++ b/code-review-threads/data/review-thread-groups.json
@@ -1,0 +1,4831 @@
+{
+  "meta": {
+    "repo": "trezor/trezor-suite",
+    "reviewer": "cermakjiri",
+    "since": "2026-05-11",
+    "until": "2026-08-11",
+    "includeOwn": false,
+    "generatedAt": "2026-08-11T07:47:53.260Z",
+    "groupCount": 86,
+    "prCount": 31,
+    "reconciliation": {
+      "sweepTotal": 94,
+      "sweepCovered": 94,
+      "sweepMissing": 0,
+      "extraBeyondSweep": 4
+    }
+  },
+  "topics": [
+    {
+      "slug": "acknowledgements-and-pointers",
+      "title": "Acknowledgements & cross-references",
+      "blurb": "Approvals, thanks, \"nice catch\" notes, and pointers to another thread — no actionable request. Kept for completeness.",
+      "count": 14
+    },
+    {
+      "slug": "ci-tooling-and-guardrails",
+      "title": "CI, tooling & guardrails",
+      "blurb": "GitHub Actions workflow configuration and lint rules that prevent whole classes of regressions.",
+      "count": 3
+    },
+    {
+      "slug": "data-fetching-tanstack-query",
+      "title": "Data fetching — prefer TanStack Query",
+      "blurb": "Replacing imperative effect/thunk-driven fetching with `useQuery`/`useMutation`, exposing `queryOptions` on shared hooks, and picking the narrowest query hook.",
+      "count": 7
+    },
+    {
+      "slug": "react-hooks-and-effects",
+      "title": "React hooks & effects",
+      "blurb": "Refs vs. state, effect dependencies and stale closures (`useFreshRef` / `useCurrentRef`).",
+      "count": 2
+    },
+    {
+      "slug": "performance-and-memoization",
+      "title": "Performance & memoization",
+      "blurb": "Redundant or missing `useMemo`, stable references that stop breaking memoization, and running independent async work concurrently.",
+      "count": 7
+    },
+    {
+      "slug": "runtime-validation-and-parsing",
+      "title": "Runtime validation & parsing",
+      "blurb": "Zod schemas for parsing `unknown` data instead of casting, and questioning validation constraints in low-level converters.",
+      "count": 3
+    },
+    {
+      "slug": "error-handling-and-devx",
+      "title": "Error handling & developer experience",
+      "blurb": "Unhandled thunk rejections crashing components, validation that returns `null` instead of throwing, silently skipping instead of failing loudly.",
+      "count": 4
+    },
+    {
+      "slug": "single-source-of-truth",
+      "title": "Single source of truth",
+      "blurb": "Deriving behaviour from network config features and from the Earn yield worker API rather than duplicating constants in the client.",
+      "count": 3
+    },
+    {
+      "slug": "component-structure-and-files",
+      "title": "Component structure & file layout",
+      "blurb": "One React component per file, extracting sub-components, hooks in their own file next to the component, and package/folder structure (tree-like vs. linear).",
+      "count": 7
+    },
+    {
+      "slug": "nullability-and-sentinel-values",
+      "title": "Nullability & sentinel values",
+      "blurb": "Avoiding `''`/`0` sentinel fallbacks, preferring explicit `undefined`, and narrowing null/undefined upstream so components get asserted types.",
+      "count": 6
+    },
+    {
+      "slug": "typescript-type-safety",
+      "title": "TypeScript type safety",
+      "blurb": "Type predicates, `satisfies`, narrowing account types via `AccountWithNetworkType`, avoiding casts, fixing types instead of working around them.",
+      "count": 12
+    },
+    {
+      "slug": "code-placement-and-reuse",
+      "title": "Code placement, package boundaries & reuse",
+      "blurb": "Moving shared logic to `suite-common` so `suite-native` can reuse it, avoiding circular deps via nested exports, and where selectors/abstractions belong.",
+      "count": 6
+    },
+    {
+      "slug": "comments-and-docs",
+      "title": "Comments & documentation",
+      "blurb": "Code comments that do not explain the whole rule they document.",
+      "count": 1
+    },
+    {
+      "slug": "readability-and-simplification",
+      "title": "Readability & simplification",
+      "blurb": "Extracting named helpers/variables, early returns over nesting, dropping redundant branches, naming, and reusing existing utils.",
+      "count": 11
+    },
+    {
+      "slug": "unclassified",
+      "title": "Unclassified",
+      "blurb": "The heuristics could not place these. Read them and pin a topic in `overrides.json`.",
+      "count": 0
+    }
+  ],
+  "groups": [
+    {
+      "gid": "G01",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "type-guard",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27590,
+        "title": "Self-composed `withdraw` / `redeem` calldata for stablecoin yield",
+        "url": "https://github.com/trezor/trezor-suite/pull/27590",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-11T19:18:38Z",
+        "headRefOid": "69f3aa4d239c4a14fb94986743a350a217bb50e3"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6BUnjx",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx",
+        "line": 119,
+        "originalLine": 119,
+        "startLine": 119,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-12T07:10:00Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224403668",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx#L119",
+      "diffHunk": "@@ -92,6 +92,32 @@ const approvalStrings: Record<EvmApprovalPurpose, Record<'value' | 'label', Tran\n     },\n };\n \n+const yieldStrings: Record<\n+    Extract<EvmTransactionPurpose, 'deposit' | 'withdraw' | 'redeem'>,\n+    Record<'value' | 'label' | 'amount', TranslationKey>\n+> = {\n+    deposit: {\n+        value: 'TR_EARN_YIELD_REVIEW_SUPPLY_DESCRIPTION',\n+        label: 'TR_EARN_YIELD_REVIEW_SUPPLY_TITLE',\n+        amount: 'TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT',\n+    },\n+    withdraw: {\n+        value: 'TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION',\n+        label: 'TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE',\n+        amount: 'TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT',\n+    },\n+    redeem: {\n+        value: 'TR_EARN_YIELD_REVIEW_REDEEM_DESCRIPTION',\n+        label: 'TR_EARN_YIELD_REVIEW_REDEEM_TITLE',\n+        amount: 'TR_EARN_YIELD_REVIEW_REDEEM_AMOUNT',\n+    },\n+};\n+\n+const isYieldAction = (\n+    evmTxType: EvmTransactionPurpose | undefined,\n+): evmTxType is 'deposit' | 'withdraw' | 'redeem' =>\n+    evmTxType === 'deposit' || evmTxType === 'withdraw' || evmTxType === 'redeem';",
+      "comments": [
+        {
+          "databaseId": 3224403668,
+          "author": "cermakjiri",
+          "body": "```suggestion\n    Object.keys(yieldStrings).includes(evmTxType)\n```",
+          "createdAt": "2026-05-12T07:10:00Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224403668",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G02",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "type-predicate",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27590,
+        "title": "Self-composed `withdraw` / `redeem` calldata for stablecoin yield",
+        "url": "https://github.com/trezor/trezor-suite/pull/27590",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-11T19:18:38Z",
+        "headRefOid": "69f3aa4d239c4a14fb94986743a350a217bb50e3"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6BUoKa",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx",
+        "line": 118,
+        "originalLine": 118,
+        "startLine": 118,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-12T07:10:36Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224406990",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx#L118",
+      "diffHunk": "@@ -92,6 +92,32 @@ const approvalStrings: Record<EvmApprovalPurpose, Record<'value' | 'label', Tran\n     },\n };\n \n+const yieldStrings: Record<\n+    Extract<EvmTransactionPurpose, 'deposit' | 'withdraw' | 'redeem'>,\n+    Record<'value' | 'label' | 'amount', TranslationKey>\n+> = {\n+    deposit: {\n+        value: 'TR_EARN_YIELD_REVIEW_SUPPLY_DESCRIPTION',\n+        label: 'TR_EARN_YIELD_REVIEW_SUPPLY_TITLE',\n+        amount: 'TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT',\n+    },\n+    withdraw: {\n+        value: 'TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION',\n+        label: 'TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE',\n+        amount: 'TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT',\n+    },\n+    redeem: {\n+        value: 'TR_EARN_YIELD_REVIEW_REDEEM_DESCRIPTION',\n+        label: 'TR_EARN_YIELD_REVIEW_REDEEM_TITLE',\n+        amount: 'TR_EARN_YIELD_REVIEW_REDEEM_AMOUNT',\n+    },\n+};\n+\n+const isYieldAction = (\n+    evmTxType: EvmTransactionPurpose | undefined,\n+): evmTxType is 'deposit' | 'withdraw' | 'redeem' =>",
+      "comments": [
+        {
+          "databaseId": 3224406990,
+          "author": "cermakjiri",
+          "body": "```suggestion\n): evmTxType is keyof typeof yieldStrings  =>\n```",
+          "createdAt": "2026-05-12T07:10:36Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224406990",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G03",
+      "topic": "nullability-and-sentinel-values",
+      "tags": [
+        "empty-string-sentinel",
+        "api-design"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27590,
+        "title": "Self-composed `withdraw` / `redeem` calldata for stablecoin yield",
+        "url": "https://github.com/trezor/trezor-suite/pull/27590",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-11T19:18:38Z",
+        "headRefOid": "69f3aa4d239c4a14fb94986743a350a217bb50e3"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6BUsbo",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts",
+        "line": 170,
+        "originalLine": 170,
+        "startLine": 170,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-12T07:14:40Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224430555",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts#L170",
+      "diffHunk": "@@ -139,7 +151,23 @@ export const useYieldFlow = ({\n \n     const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));\n \n-    const maxAmount = flowType === 'deposit' ? (token?.balance ?? '') : suppliedAmount;\n+    const withdrawInputUnit = methods.watch('withdrawInputUnit');\n+    const isSharesInput = flowType === 'withdraw' && withdrawInputUnit === 'shares';\n+    const canToggleWithdrawUnit = flowType === 'withdraw' && !!token && !!receiptToken;\n+\n+    const getWithdrawMaxAmount = () => {\n+        if (isSharesInput) {\n+            return suppliedSharesAmount;\n+        }\n+\n+        return suppliedAmount;\n+    };\n+    const maxAmount = flowType === 'deposit' ? (token?.balance ?? '') : getWithdrawMaxAmount();\n+\n+    const inputTokenSymbol = isSharesInput ? (receiptToken?.symbol ?? '') : (token?.symbol ?? '');\n+    const otherUnitTokenSymbol = isSharesInput\n+        ? (token?.symbol ?? '')\n+        : (receiptToken?.symbol ?? '');",
+      "comments": [
+        {
+          "databaseId": 3224430555,
+          "author": "cermakjiri",
+          "body": "isn't better to pass undefined than empty strings so a react component could decide if it should display some placeholder for example?",
+          "createdAt": "2026-05-12T07:14:40Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224430555",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G04",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27590,
+        "title": "Self-composed `withdraw` / `redeem` calldata for stablecoin yield",
+        "url": "https://github.com/trezor/trezor-suite/pull/27590",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-11T19:18:38Z",
+        "headRefOid": "69f3aa4d239c4a14fb94986743a350a217bb50e3"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6BUvxw",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx",
+        "line": 205,
+        "originalLine": 205,
+        "startLine": 205,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-12T07:16:40Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224448995",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx#L205",
+      "diffHunk": "@@ -176,13 +193,16 @@ const getOutputTitle = (\n                 return <Translation id=\"TR_EARN_YIELD_DEPOSIT_TO\" />;\n             }\n             if (evmTxType === 'withdraw') {\n+                return <Translation id=\"TR_EARN_YIELD_WITHDRAW_FROM\" />;\n+            }\n+            if (evmTxType === 'redeem') {\n                 return <Translation id=\"TR_EARN_YIELD_REDEEM_FROM\" />;\n             }\n \n             return <Translation id={translation ? translation.label : 'TR_RECIPIENT_ADDRESS'} />;\n \n         case 'amount':\n-            if (evmTxType === 'deposit' || evmTxType === 'withdraw') {\n+            if (isYieldAction(evmTxType)) {",
+      "comments": [
+        {
+          "databaseId": 3224448995,
+          "author": "cermakjiri",
+          "body": "👍 ",
+          "createdAt": "2026-05-12T07:16:40Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224448995",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G05",
+      "topic": "performance-and-memoization",
+      "tags": [
+        "concurrency",
+        "promise-all"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27590,
+        "title": "Self-composed `withdraw` / `redeem` calldata for stablecoin yield",
+        "url": "https://github.com/trezor/trezor-suite/pull/27590",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-11T19:18:38Z",
+        "headRefOid": "69f3aa4d239c4a14fb94986743a350a217bb50e3"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6BVoxk",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts",
+        "line": 111,
+        "originalLine": 111,
+        "startLine": 111,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-12T08:11:16Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224762208",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts#L111",
+      "diffHunk": "@@ -0,0 +1,159 @@\n+import { numberToHex, toWei } from 'web3-utils';\n+\n+import { Calldata, asEvmAddress } from '@suite-common/calldata';\n+import { EVM_VAULT_ADDRESSES } from '@suite-common/earn-stablecoin-api';\n+import { notificationsActions } from '@suite-common/toast-notifications';\n+import { getNetwork } from '@suite-common/wallet-config';\n+import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';\n+import {\n+    type YieldFlowResolvedData,\n+    type YieldWithdrawInputUnit,\n+    selectRawNetworkFeeInfo,\n+} from '@suite-common/wallet-core';\n+import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';\n+import { type Account } from '@suite-common/wallet-types';\n+import {\n+    asAmountUnit,\n+    getAccountIdentity,\n+    getConvertedOrDefaultFeeInfo,\n+    unitsToSubunits,\n+} from '@suite-common/wallet-utils';\n+import TrezorConnect from '@trezor/connect';\n+import { BigNumber } from '@trezor/utils';\n+\n+import type { AppState, Dispatch } from 'src/types/suite';\n+\n+export type ComposeYieldWithdrawTransactionParams = {\n+    account: Account & { networkType: 'ethereum' };\n+    flowData: YieldFlowResolvedData;\n+    amount: string;\n+    withdrawInputUnit: YieldWithdrawInputUnit;\n+    dispatch: Dispatch;\n+    getState: () => AppState;\n+};\n+\n+export const composeYieldWithdrawTransaction = async ({\n+    account,\n+    flowData,\n+    amount,\n+    withdrawInputUnit,\n+    dispatch,\n+    getState,\n+}: ComposeYieldWithdrawTransactionParams): Promise<string> => {\n+    const { vault, token, receiptToken } = flowData;\n+    const vaultAddress = EVM_VAULT_ADDRESSES[vault.id];\n+\n+    if (!vaultAddress) {\n+        throw new Error(`Vault ${vault.id} is not supported for self-composed withdraw.`);\n+    }\n+\n+    const network = getNetwork(account.symbol);\n+\n+    if (!network.chainId) {\n+        throw new Error(`Network ${account.symbol} is missing chainId.`);\n+    }\n+\n+    const vaultChainId = Number(vault.chainId);\n+    if (!Number.isInteger(vaultChainId) || vaultChainId !== network.chainId) {\n+        throw new Error(\n+            `Account network chainId ${network.chainId} does not match vault chainId ${vault.chainId}.`,\n+        );\n+    }\n+\n+    const isSharesInput = withdrawInputUnit === 'shares';\n+    const decimals = isSharesInput ? receiptToken.decimals : token.decimals;\n+    const ownerAddress = asEvmAddress(account.descriptor);\n+    const amountSubunits = unitsToSubunits({\n+        value: asAmountUnit(new BigNumber(amount)),\n+        decimals,\n+    });\n+\n+    const builderResult = isSharesInput\n+        ? Calldata.evm.erc4626.redeem(\n+              {\n+                  shares: amountSubunits,\n+                  receiver: account.descriptor,\n+                  owner: account.descriptor,\n+              },\n+              { sender: ownerAddress },\n+          )\n+        : Calldata.evm.erc4626.withdraw(\n+              {\n+                  assets: amountSubunits,\n+                  receiver: account.descriptor,\n+                  owner: account.descriptor,\n+              },\n+              { sender: ownerAddress },\n+          );\n+\n+    if (!builderResult.isValid || !builderResult.data) {\n+        const issues = builderResult.errors.map(issue => issue.code).join(', ');\n+\n+        throw new Error(`Failed to encode withdraw calldata${issues ? `: ${issues}` : '.'}`);\n+    }\n+\n+    const { nonce } = await dispatch(\n+        ethereumGetCurrentNonceThunk({ selectedAccount: account }),\n+    ).unwrap();\n+\n+    const estimatedFee = await TrezorConnect.blockchainEstimateFee({\n+        coin: account.symbol,\n+        identity: getAccountIdentity(account),\n+        request: {\n+            blocks: [2],\n+            specific: {\n+                from: account.descriptor,\n+                to: vaultAddress,\n+                data: builderResult.data,\n+                value: '0x0',\n+            },\n+        },\n+    });",
+      "comments": [
+        {
+          "databaseId": 3224762208,
+          "author": "cermakjiri",
+          "body": "NIT: It could run in concurrently:\n\n```ts\n    const nonceTask = dispatch(\n        ethereumGetCurrentNonceThunk({ selectedAccount: account }),\n    ).unwrap();\n\n    const estimatedFeeTask = TrezorConnect.blockchainEstimateFee({\n        coin: account.symbol,\n        identity: getAccountIdentity(account),\n        request: {\n            blocks: [2],\n            specific: {\n                from: account.descriptor,\n                to: vaultAddress,\n                data: builderResult.data,\n                value: '0x0',\n            },\n        },\n    });\n\n   const [{nonce}, estimatedFee] = await Promise.all([nonceTask, estimatedFeeTask] as const)\n```\n ",
+          "createdAt": "2026-05-12T08:11:16Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224762208",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G06",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27590,
+        "title": "Self-composed `withdraw` / `redeem` calldata for stablecoin yield",
+        "url": "https://github.com/trezor/trezor-suite/pull/27590",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-11T19:18:38Z",
+        "headRefOid": "69f3aa4d239c4a14fb94986743a350a217bb50e3"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6BVo8_",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts",
+        "line": 87,
+        "originalLine": 87,
+        "startLine": 87,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-12T08:11:25Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224763170",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/69f3aa4d239c4a14fb94986743a350a217bb50e3/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts#L87",
+      "diffHunk": "@@ -0,0 +1,159 @@\n+import { numberToHex, toWei } from 'web3-utils';\n+\n+import { Calldata, asEvmAddress } from '@suite-common/calldata';\n+import { EVM_VAULT_ADDRESSES } from '@suite-common/earn-stablecoin-api';\n+import { notificationsActions } from '@suite-common/toast-notifications';\n+import { getNetwork } from '@suite-common/wallet-config';\n+import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';\n+import {\n+    type YieldFlowResolvedData,\n+    type YieldWithdrawInputUnit,\n+    selectRawNetworkFeeInfo,\n+} from '@suite-common/wallet-core';\n+import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';\n+import { type Account } from '@suite-common/wallet-types';\n+import {\n+    asAmountUnit,\n+    getAccountIdentity,\n+    getConvertedOrDefaultFeeInfo,\n+    unitsToSubunits,\n+} from '@suite-common/wallet-utils';\n+import TrezorConnect from '@trezor/connect';\n+import { BigNumber } from '@trezor/utils';\n+\n+import type { AppState, Dispatch } from 'src/types/suite';\n+\n+export type ComposeYieldWithdrawTransactionParams = {\n+    account: Account & { networkType: 'ethereum' };\n+    flowData: YieldFlowResolvedData;\n+    amount: string;\n+    withdrawInputUnit: YieldWithdrawInputUnit;\n+    dispatch: Dispatch;\n+    getState: () => AppState;\n+};\n+\n+export const composeYieldWithdrawTransaction = async ({\n+    account,\n+    flowData,\n+    amount,\n+    withdrawInputUnit,\n+    dispatch,\n+    getState,\n+}: ComposeYieldWithdrawTransactionParams): Promise<string> => {\n+    const { vault, token, receiptToken } = flowData;\n+    const vaultAddress = EVM_VAULT_ADDRESSES[vault.id];\n+\n+    if (!vaultAddress) {\n+        throw new Error(`Vault ${vault.id} is not supported for self-composed withdraw.`);\n+    }\n+\n+    const network = getNetwork(account.symbol);\n+\n+    if (!network.chainId) {\n+        throw new Error(`Network ${account.symbol} is missing chainId.`);\n+    }\n+\n+    const vaultChainId = Number(vault.chainId);\n+    if (!Number.isInteger(vaultChainId) || vaultChainId !== network.chainId) {\n+        throw new Error(\n+            `Account network chainId ${network.chainId} does not match vault chainId ${vault.chainId}.`,\n+        );\n+    }\n+\n+    const isSharesInput = withdrawInputUnit === 'shares';\n+    const decimals = isSharesInput ? receiptToken.decimals : token.decimals;\n+    const ownerAddress = asEvmAddress(account.descriptor);\n+    const amountSubunits = unitsToSubunits({\n+        value: asAmountUnit(new BigNumber(amount)),\n+        decimals,\n+    });\n+\n+    const builderResult = isSharesInput\n+        ? Calldata.evm.erc4626.redeem(\n+              {\n+                  shares: amountSubunits,\n+                  receiver: account.descriptor,\n+                  owner: account.descriptor,\n+              },\n+              { sender: ownerAddress },\n+          )\n+        : Calldata.evm.erc4626.withdraw(\n+              {\n+                  assets: amountSubunits,\n+                  receiver: account.descriptor,\n+                  owner: account.descriptor,\n+              },\n+              { sender: ownerAddress },\n+          );",
+      "comments": [
+        {
+          "databaseId": 3224763170,
+          "author": "cermakjiri",
+          "body": "👍 ",
+          "createdAt": "2026-05-12T08:11:25Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27590#discussion_r3224763170",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G07",
+      "topic": "single-source-of-truth",
+      "tags": [
+        "earn-worker-api"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27584,
+        "title": "Control Earn actions through message-system feature flags",
+        "url": "https://github.com/trezor/trezor-suite/pull/27584",
+        "author": "izmy",
+        "state": "MERGED",
+        "createdAt": "2026-05-11T16:17:40Z",
+        "headRefOid": "d80db0d9dd30dcdff39e3356cf862e0dfdadb3a2"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6BYOnF",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx",
+        "line": null,
+        "originalLine": 44,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-12T13:43:19Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27584#discussion_r3226868495",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d80db0d9dd30dcdff39e3356cf862e0dfdadb3a2/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx#L44",
+      "diffHunk": "@@ -39,6 +41,9 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp\n     const [isFirmwareModalOpen, setIsFirmwareModalOpen] = useState(false);\n     const selectedDevice = useSelector(selectSelectedDevice);\n     const isFirmwareOutdated = !isStablecoinYieldSupported(selectedDevice);\n+    const vaultContractAddress = EVM_VAULT_ADDRESSES[opportunity.vault.id];",
+      "comments": [
+        {
+          "databaseId": 3225668719,
+          "author": "matusbalascak",
+          "body": "[This](https://github.com/trezor/trezor-suite/pull/27497) PR removed the `EVM_VAULT_ADDRESSES`, so just FYI, this will have to change",
+          "createdAt": "2026-05-12T10:35:03Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27584#discussion_r3225668719",
+          "isMine": false
+        },
+        {
+          "databaseId": 3226868495,
+          "author": "cermakjiri",
+          "body": "There's going to be a new endpoint:\r\n\r\n```ts\r\n    const { address: vaultAddress } = await getYieldVault({\r\n        routeParams: {\r\n            networkSymbol: account.symbol,\r\n            vaultId: vault.id,\r\n        },\r\n    });\r\n```\r\n\r\nhttps://github.com/trezor/trezor-suite/pull/27497/changes#diff-a3b8ddad088598b73f8c4910ec5a6e9748405a090dc807317b2d8e1ff2c55993R45-R48\r\n\r\nThe worker should be deployed sometime today. 🙏 ",
+          "createdAt": "2026-05-12T13:43:19Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27584#discussion_r3226868495",
+          "isMine": true
+        },
+        {
+          "databaseId": 3227133879,
+          "author": "izmy",
+          "body": "I ended up using the address from the output token instead.",
+          "createdAt": "2026-05-12T14:16:01Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27584#discussion_r3227133879",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G08",
+      "topic": "data-fetching-tanstack-query",
+      "tags": [
+        "use-mutation",
+        "less-code"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27621,
+        "title": "fix(suite-native): fee selector balance error",
+        "url": "https://github.com/trezor/trezor-suite/pull/27621",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-12T07:44:51Z",
+        "headRefOid": "6d670a9a95edff04d3fa15914e87f56373da4571"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Btmtm",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-native/module-earn/src/hooks/useComposeEarnFees.ts",
+        "line": 164,
+        "originalLine": 164,
+        "startLine": 164,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-13T10:17:13Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27621#discussion_r3233333111",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/6d670a9a95edff04d3fa15914e87f56373da4571/suite-native/module-earn/src/hooks/useComposeEarnFees.ts#L164",
+      "diffHunk": "@@ -91,43 +96,77 @@ export const useComposeEarnFees = ({\n     const feeInfo = useSelector((state: FeesRootState) =>\n         selectConvertedNetworkFeeInfo(state, account?.symbol),\n     );\n+    const areFeesLoading = useSelector((state: FeesRootState) =>\n+        selectAreFeesLoading(state, account?.symbol),\n+    );\n+    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));\n+    const selectedFee = formDraft?.selectedFee;\n+    const selectedFeeLevel = selectedFee ? feeLevels[selectedFee] : undefined;\n+    const fee = isFinalPrecomposedTransaction(selectedFeeLevel) ? selectedFeeLevel.fee : null;\n+    const { isFeeUnavailable } = getFeeAvailability({\n+        fee,\n+        feeLevels,\n+        selectedFee,\n+        isLoading: areFeesLoading || isComposingFeeLevels,\n+    });\n \n     const composeFeeLevels = useCallback(async () => {\n-        if (!formState || !account || !feeInfo) return;\n-\n-        const { selectedFee, feePerUnit, feeLimit, maxFeePerGas, maxPriorityFeePerGas } =\n-            formDraftRef.current ?? {};\n-\n-        const mergedFormState = {\n-            ...formState,\n-            selectedFee: selectedFee ?? formState.selectedFee,\n-            feePerUnit: feePerUnit ?? formState.feePerUnit,\n-            feeLimit: feeLimit ?? formState.feeLimit,\n-            maxFeePerGas: maxFeePerGas ?? formState.maxFeePerGas,\n-            maxPriorityFeePerGas: maxPriorityFeePerGas ?? formState.maxPriorityFeePerGas,\n-        };\n-\n-        const response = await dispatch(\n-            composeSendFormTransactionFeeLevelsThunk({\n-                formState: mergedFormState,\n-                composeContext: { account, feeInfo, network: getNetwork(account.symbol) },\n-            }),\n-        );\n-        if (!isFulfilled(response)) return;\n-\n-        dispatch(transactionManagementActions.storeFeeLevels({ feeLevels: response.payload }));\n-\n-        const normalLevel = response.payload.normal;\n-        if (!mergedFormState.feePerUnit && isFinalPrecomposedTransaction(normalLevel)) {\n-            mergedFormState.feePerUnit = normalLevel.feePerByte;\n+        if (!formState || !account || !feeInfo) {\n+            setIsComposingFeeLevels(false);\n+\n+            return;\n         }\n \n-        saveDraft(mergedFormState);\n+        setIsComposingFeeLevels(true);\n+\n+        try {\n+            const {\n+                selectedFee: draftSelectedFee,\n+                feePerUnit,\n+                feeLimit,\n+                maxFeePerGas,\n+                maxPriorityFeePerGas,\n+            } = formDraftRef.current ?? {};\n+\n+            const mergedFormState = {\n+                ...formState,\n+                selectedFee: draftSelectedFee ?? formState.selectedFee,\n+                feePerUnit: feePerUnit ?? formState.feePerUnit,\n+                feeLimit: feeLimit ?? formState.feeLimit,\n+                maxFeePerGas: maxFeePerGas ?? formState.maxFeePerGas,\n+                maxPriorityFeePerGas: maxPriorityFeePerGas ?? formState.maxPriorityFeePerGas,\n+            };\n+\n+            const response = await dispatch(\n+                composeSendFormTransactionFeeLevelsThunk({\n+                    formState: mergedFormState,\n+                    composeContext: { account, feeInfo, network: getNetwork(account.symbol) },\n+                }),\n+            );\n+            if (!isFulfilled(response)) return;\n+\n+            dispatch(transactionManagementActions.storeFeeLevels({ feeLevels: response.payload }));\n+\n+            const normalLevel = response.payload.normal;\n+            if (!mergedFormState.feePerUnit && isFinalPrecomposedTransaction(normalLevel)) {\n+                mergedFormState.feePerUnit = normalLevel.feePerByte;\n+            }\n+\n+            saveDraft(mergedFormState);\n+        } finally {\n+            setIsComposingFeeLevels(false);\n+        }\n     }, [dispatch, formState, account, feeInfo, saveDraft]);\n \n     useEffect(() => {\n+        setIsComposingFeeLevels(!!formState && !!account && !!feeInfo);\n         debounce(composeFeeLevels);\n-    }, [debounce, composeFeeLevels]);\n+    }, [account, debounce, composeFeeLevels, feeInfo, formState]);",
+      "comments": [
+        {
+          "databaseId": 3233333111,
+          "author": "cermakjiri",
+          "body": "suggestion for the proper fix: it looks like good job for `useMutation` / `useQuery` (it'd be cleaner & requiring less code)",
+          "createdAt": "2026-05-13T10:17:13Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27621#discussion_r3233333111",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G09",
+      "topic": "single-source-of-truth",
+      "tags": [
+        "earn-worker-api",
+        "hardcoded-constants"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27716,
+        "title": "Yield issues",
+        "url": "https://github.com/trezor/trezor-suite/pull/27716",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T15:22:28Z",
+        "headRefOid": "ed136b658b979ccd43f691bbd6661c7e53b5a37c"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6B-tIg",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/suite-constants/src/evm.ts",
+        "line": 18,
+        "originalLine": 18,
+        "startLine": 18,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-14T06:29:14Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27716#discussion_r3239510765",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/ed136b658b979ccd43f691bbd6661c7e53b5a37c/suite-common/suite-constants/src/evm.ts#L18",
+      "diffHunk": "@@ -8,4 +8,13 @@ export const EVM_SPENDER_LABELS: Record<string, string> = {\n     '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae': 'LiFi Diamond',\n };\n \n+/**\n+ * Exact copy of KNOWN_VAULTS from the firmware\n+ * (trezor/trezor-firmware/blob/main/core/src/apps/ethereum/yielding_vaults.py),\n+ */\n+export const KNOWN_VAULTS: Record<string, string> = {\n+    '0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829': 'Trezor Steakhouse USDT Prime Vault',\n+    '0xde6c23e561f3e55846207ec45a91b777e0f7c889': 'Trezor Steakhouse USDC Prime Vault',\n+};",
+      "comments": [
+        {
+          "databaseId": 3239510765,
+          "author": "cermakjiri",
+          "body": "I though there were a consensus making the Earn yield worker source of the truth in this matter. 🤔 Has it changed? cc @tomasklim ",
+          "createdAt": "2026-05-14T06:29:14Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27716#discussion_r3239510765",
+          "isMine": true
+        },
+        {
+          "databaseId": 3239521371,
+          "author": "cermakjiri",
+          "body": "If it's about the label, I can extend the res. of `https://earn.trezor.io/yield/vaults/v1`",
+          "createdAt": "2026-05-14T06:31:53Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27716#discussion_r3239521371",
+          "isMine": true
+        },
+        {
+          "databaseId": 3239570586,
+          "author": "matusbalascak",
+          "body": "IMO, the Earn API response may change over time, which could cause the approve flow to get out of sync with the firmware. This way, we ensure these vaults are always clear-signed.",
+          "createdAt": "2026-05-14T06:43:02Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27716#discussion_r3239570586",
+          "isMine": false
+        },
+        {
+          "databaseId": 3239593904,
+          "author": "tomasklim",
+          "body": "Let's sync on/after standup. \n\nIn fw it is now hardcoded, in the future it will be dynamic. I am fine with this right now, the only issue I see now is to check if fw has `Vault` translatable. But that's extra edge case\n",
+          "createdAt": "2026-05-14T06:47:47Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27716#discussion_r3239593904",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G10",
+      "topic": "react-hooks-and-effects",
+      "tags": [
+        "use-effect-deps",
+        "stale-closure",
+        "use-fresh-ref"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27725,
+        "title": "fix(suite): handle Solana tx timeout in review modal",
+        "url": "https://github.com/trezor/trezor-suite/pull/27725",
+        "author": "izmy",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T22:49:19Z",
+        "headRefOid": "c2c0a043af623204c4116c8fddb4fabe5a9d28d6"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6CDjHz",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx",
+        "line": 49,
+        "originalLine": 49,
+        "startLine": 49,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-14T12:11:47Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241224796",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/c2c0a043af623204c4116c8fddb4fabe5a9d28d6/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx#L49",
+      "diffHunk": "@@ -39,14 +40,26 @@ export const TransactionReviewModalBody = ({\n     isRbfConfirmedError,\n }: TransactionReviewModalBodyProps) => {\n     const analytics = useAnalytics();\n+    const dispatch = useDispatch();\n     const account = useSelector(selectAccountIncludingChosenInTrading);\n     const device = useSelector(selectSelectedDevice);\n     const [isSending, setIsSending] = useState(false);\n-    const { precomposedTx } = txInfoState;\n-    const [hasTxExpired, setHasTxExpired] = useState(false);\n+    const { precomposedTx, serializedTx } = txInfoState;\n+    const [hasTxReviewExpired, setHasTxReviewExpired] = useState(false);\n+    const prevSerializedTxRef = useRef(serializedTx);",
+      "comments": [
+        {
+          "databaseId": 3241224796,
+          "author": "cermakjiri",
+          "body": "I think the intent here prevent triggering useEffect on `serializedTx` change but having fresh `serializedTx` value in the useEffect, right? If so, use `useFreshRef` 🙏 ",
+          "createdAt": "2026-05-14T12:11:47Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241224796",
+          "isMine": true
+        },
+        {
+          "databaseId": 3241837495,
+          "author": "izmy",
+          "body": "`useFreshRef` would not work here because this ref intentionally stores the previous `serializedTx` value. The effect needs to detect the transition from signed tx present to signed tx cleared, not read the latest value.",
+          "createdAt": "2026-05-14T13:57:30Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241837495",
+          "isMine": false
+        },
+        {
+          "databaseId": 3241864410,
+          "author": "cermakjiri",
+          "body": "this only stores the value on mount, if you want prev., the `useCurrentRef` is the solution (I can see now, the naming is misleading 😄)",
+          "createdAt": "2026-05-14T14:01:54Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241864410",
+          "isMine": true
+        },
+        {
+          "databaseId": 3242042683,
+          "author": "izmy",
+          "body": "`useCurrentRef` updates before this effect runs. Here we need to read the previous `serializedTx` first and only then update the ref, so the manual update at the end of the effect is intentional.",
+          "createdAt": "2026-05-14T14:29:17Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27725#discussion_r3242042683",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G11",
+      "topic": "error-handling-and-devx",
+      "tags": [
+        "unhandled-rejection",
+        "component-crash",
+        "use-mutation"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27725,
+        "title": "fix(suite): handle Solana tx timeout in review modal",
+        "url": "https://github.com/trezor/trezor-suite/pull/27725",
+        "author": "izmy",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T22:49:19Z",
+        "headRefOid": "c2c0a043af623204c4116c8fddb4fabe5a9d28d6"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6CDmn5",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx",
+        "line": null,
+        "originalLine": 74,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-14T12:15:22Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241245158",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/c2c0a043af623204c4116c8fddb4fabe5a9d28d6/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx#L74",
+      "diffHunk": "@@ -60,16 +64,19 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa\n         }\n     };\n \n-    const handleSendTx = async () => {\n-        await dispatch(\n+    const handleSignAndPushSendTx = async () => {\n+        const result = await dispatch(\n             signAndPushSendFormTransactionThunk({\n                 formState: send.precomposedForm!,\n                 precomposedTransaction: send.precomposedTx!,\n                 selectedAccount: selectedAccount.account,\n             }),\n-        );\n+        ).unwrap();",
+      "comments": [
+        {
+          "databaseId": 3241245158,
+          "author": "cermakjiri",
+          "body": "now the thunk's promise can be rejected, causing the component to crash, let's please add `try/catch` / `useMutation` 🙏 ",
+          "createdAt": "2026-05-14T12:15:22Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241245158",
+          "isMine": true
+        },
+        {
+          "databaseId": 3241950134,
+          "author": "izmy",
+          "body": "done",
+          "createdAt": "2026-05-14T14:15:36Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27725#discussion_r3241950134",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G12",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "address-normalization",
+        "helper-fn"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27901,
+        "title": "Yield speed up transaction support",
+        "url": "https://github.com/trezor/trezor-suite/pull/27901",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-20T19:39:47Z",
+        "headRefOid": "776fa680167b24f58af7090350ed97bbd77587f2"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6DtN5y",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx",
+        "line": null,
+        "originalLine": 96,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-21T06:32:46Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279119442",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/776fa680167b24f58af7090350ed97bbd77587f2/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx#L96",
+      "diffHunk": "@@ -92,8 +92,8 @@ export const TradingApproveModal = ({ amount, cryptoId }: TradingApproveModalPro\n         const exchange = selectedQuote?.exchange;\n         const provider = exchange ? providersInfo?.[exchange] : null;\n \n-        const approvalData = getEvmApprovalTxData(selectedQuote?.dexTx?.data);\n-        const spender = approvalData?.spender ?? null;\n+        const approvalData = Calldata.evm.erc20.approve.decode(selectedQuote?.dexTx?.data);\n+        const spender = approvalData?.spender.toLowerCase() ?? null;",
+      "comments": [
+        {
+          "databaseId": 3279119442,
+          "author": "cermakjiri",
+          "body": "Would it make sense to return the `spender` from `decode` as `approvalData?.spender.toLowerCase() ?? null`?",
+          "createdAt": "2026-05-21T06:32:46Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279119442",
+          "isMine": true
+        },
+        {
+          "databaseId": 3279122220,
+          "author": "cermakjiri",
+          "body": "Or use some general method for formatting the address based on network?",
+          "createdAt": "2026-05-21T06:33:23Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279122220",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G13",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27901,
+        "title": "Yield speed up transaction support",
+        "url": "https://github.com/trezor/trezor-suite/pull/27901",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-20T19:39:47Z",
+        "headRefOid": "776fa680167b24f58af7090350ed97bbd77587f2"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6DtSw4",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/calldata/src/calldata.ts",
+        "line": 56,
+        "originalLine": 56,
+        "startLine": 56,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-21T06:39:04Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279147147",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/776fa680167b24f58af7090350ed97bbd77587f2/suite-common/calldata/src/calldata.ts#L56",
+      "diffHunk": "@@ -9,31 +9,48 @@ import { buildRedeem } from './builder/evm/redeem';\n import { buildTransfer } from './builder/evm/transfer';\n import { buildWithdraw } from './builder/evm/withdraw';\n import { buildTrc20Transfer } from './builder/tron/trc20/transfer';\n+import { EVM_ABI } from './constants/evm';\n+import { createEvmDecoder } from './decoder/evm';\n \n export const Calldata = {\n     evm: {\n         erc20: {\n-            allowance: buildAllowance,\n-            approve: buildApprove,\n-            transfer: buildTransfer,\n+            allowance: { encode: buildAllowance },\n+            approve: {\n+                encode: buildApprove,\n+                decode: createEvmDecoder(EVM_ABI.erc20.approve),\n+            },\n+            transfer: {\n+                encode: buildTransfer,\n+                decode: createEvmDecoder(EVM_ABI.erc20.transfer),\n+            },\n         },\n         erc4626: {\n-            deposit: buildDeposit,\n-            withdraw: buildWithdraw,\n-            redeem: buildRedeem,\n+            deposit: {\n+                encode: buildDeposit,\n+                decode: createEvmDecoder(EVM_ABI.erc4626.deposit),\n+            },\n+            withdraw: {\n+                encode: buildWithdraw,\n+                decode: createEvmDecoder(EVM_ABI.erc4626.withdraw),\n+            },\n+            redeem: {\n+                encode: buildRedeem,\n+                decode: createEvmDecoder(EVM_ABI.erc4626.redeem),\n+            },\n         },\n         distributor: {\n-            claim: buildClaim,\n+            claim: { encode: buildClaim },\n         },\n         everstake: {\n-            stake: buildStake,\n-            unstake: buildUnstake,\n-            claimWithdrawRequest: buildClaimWithdrawRequest,\n+            stake: { encode: buildStake },\n+            unstake: { encode: buildUnstake },\n+            claimWithdrawRequest: { encode: buildClaimWithdrawRequest },\n         },\n     },\n     tron: {\n         trc20: {\n-            transfer: buildTrc20Transfer,\n+            transfer: { encode: buildTrc20Transfer },\n         },\n     },\n } as const;",
+      "comments": [
+        {
+          "databaseId": 3279147147,
+          "author": "cermakjiri",
+          "body": "👍 ",
+          "createdAt": "2026-05-21T06:39:04Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279147147",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G14",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "prefer-filter-over-if-else"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27901,
+        "title": "Yield speed up transaction support",
+        "url": "https://github.com/trezor/trezor-suite/pull/27901",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-20T19:39:47Z",
+        "headRefOid": "776fa680167b24f58af7090350ed97bbd77587f2"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6DtUdu",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/wallet-core/src/accounts/accountsThunks.ts",
+        "line": 166,
+        "originalLine": 166,
+        "startLine": 166,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-21T06:40:55Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279157068",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/776fa680167b24f58af7090350ed97bbd77587f2/suite-common/wallet-core/src/accounts/accountsThunks.ts#L166",
+      "diffHunk": "@@ -159,9 +159,24 @@ export const fetchAndUpdateAccountThunk = createThunk(\n                 dispatch(transactionsActions.removeTransaction({ account, txs: analyze.remove }));\n             }\n             if (analyze.add.length > 0) {\n+                // Blockbook returns empty tokens for pending contract calls. Copy them\n+                // from our fake tx (identified by `deadline`) so RBF on this pending tx still\n+                // has token + amount.\n+                const enrichedAdd = analyze.add.map(freshTx => {\n+                    if ((freshTx.tokens?.length ?? 0) > 0) return freshTx;",
+      "comments": [
+        {
+          "databaseId": 3279157068,
+          "author": "cermakjiri",
+          "body": "NIT 🤏: `.filter` > `if/else` ",
+          "createdAt": "2026-05-21T06:40:55Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279157068",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G15",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval",
+        "cleanup"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27901,
+        "title": "Yield speed up transaction support",
+        "url": "https://github.com/trezor/trezor-suite/pull/27901",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-05-20T19:39:47Z",
+        "headRefOid": "776fa680167b24f58af7090350ed97bbd77587f2"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6DtaNF",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/wallet-utils/src/ethUtils.ts",
+        "line": 91,
+        "originalLine": 91,
+        "startLine": 91,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-21T06:48:01Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279189613",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/776fa680167b24f58af7090350ed97bbd77587f2/suite-common/wallet-utils/src/ethUtils.ts#L91",
+      "diffHunk": "@@ -143,24 +71,21 @@ interface BuildTransactionDataParams {\n     spender: string;\n }\n \n+// TODO: drop this wrapper and migrate callers to `Calldata.evm.erc20.approve.encode` directly.\n export const buildApprovalTransactionData = ({\n     amount: rawAmount,\n     spender: rawSpender,\n }: BuildTransactionDataParams): string => {\n-    if (!isAddressValid(rawSpender, 'base')) {\n-        throw new Error('Invalid spender address');\n-    }\n-\n-    const amount = new BigNumber(rawAmount);\n-    const spender = rawSpender.toLowerCase().replace(/^0x/, '').padStart(64, '0');\n+    const result = Calldata.evm.erc20.approve.encode({\n+        spender: rawSpender,\n+        amount: new BigNumber(rawAmount),\n+    });\n \n-    if (amount.isNaN() || !amount.isInteger() || amount.isNegative() || amount.gt(UINT256_MAX)) {\n-        throw new Error('Invalid amount');\n+    if (!result.isValid || !result.data) {\n+        throw new Error(result.errors[0]?.code ?? 'INVALID_APPROVAL_PARAMS');\n     }\n \n-    const amountHex = amount.toString(16).padStart(64, '0');\n-\n-    return `${ERC20_APPROVE_SELECTOR}${spender}${amountHex}`;\n+    return result.data;\n };\n \n interface GetAllowanceAmountParams {",
+      "comments": [
+        {
+          "databaseId": 3279189613,
+          "author": "cermakjiri",
+          "body": "nice cleanup 🎉 ",
+          "createdAt": "2026-05-21T06:48:01Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27901#discussion_r3279189613",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G16",
+      "topic": "code-placement-and-reuse",
+      "tags": [
+        "circular-deps",
+        "barrel-exports",
+        "encapsulation"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6EENVt",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts",
+        "line": 7,
+        "originalLine": 7,
+        "startLine": 7,
+        "originalStartLine": null,
+        "diffSide": "LEFT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-22T09:33:00Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287392749",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/packages/suite/src/actions/wallet/stablecoin-yield/claimMerkleRewardsThunk.ts#L7",
+      "diffHunk": "@@ -4,7 +4,7 @@ import { asTypedDesktopAnalytics, events } from '@suite/analytics';\n import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';\n import { Calldata, asEvmAddress } from '@suite-common/calldata';\n import { selectSelectedDevice } from '@suite-common/device';\n-import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';",
+      "comments": [
+        {
+          "databaseId": 3287392749,
+          "author": "cermakjiri",
+          "body": "This was intentional because putting all exports into single file leads to cir. dep. Nested exports effectively mitigate that. At the same time some encapsulation is good (at section/category level) so the package can expose only certain components. \n\nI know, it was only discussed here https://satoshilabs.slack.com/archives/G019WLX2P7B/p1776270754685949 but could be please stay by this? I think we are all quite happy that there're finally no (ecma-script module) cir. dep. 😀",
+          "createdAt": "2026-05-22T09:33:00Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287392749",
+          "isMine": true
+        },
+        {
+          "databaseId": 3298025528,
+          "author": "BrantalikP",
+          "body": "I had eslint issue on mobile, adding it to localRules helped. Thanks! https://github.com/trezor/trezor-suite/pull/27718/changes/d374bb0dfeb989927db160d282ed1435f0963770",
+          "createdAt": "2026-05-25T12:03:45Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3298025528",
+          "isMine": false
+        },
+        {
+          "databaseId": 3302139761,
+          "author": "cermakjiri",
+          "body": "Awesome 🙌 ",
+          "createdAt": "2026-05-26T07:56:34Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302139761",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G17",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6EEQHH",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx",
+        "line": 24,
+        "originalLine": 24,
+        "startLine": 24,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-22T09:35:21Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287408654",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx#L24",
+      "diffHunk": "@@ -20,7 +20,10 @@ export function EarnYieldTxSimulationModal({\n     decision,\n     closeModal,\n }: EarnYieldTxSimulationModalProps) {\n-    const parsedData = useMemo(() => composeStablecoinYieldTxSimulationAction(data), [data]);\n+    const parsedData = useMemo(\n+        () => composeStablecoinYieldTxSimulationAction(data, globalThis.location.origin),",
+      "comments": [
+        {
+          "databaseId": 3287408654,
+          "author": "cermakjiri",
+          "body": "thanks 👍 ",
+          "createdAt": "2026-05-22T09:35:21Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287408654",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G18",
+      "topic": "error-handling-and-devx",
+      "tags": [
+        "throw-vs-null",
+        "breaking-change",
+        "devx"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6EEXhV",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts",
+        "line": 220,
+        "originalLine": 221,
+        "startLine": 220,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-22T09:41:26Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287452170",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts#L220",
+      "diffHunk": "@@ -0,0 +1,221 @@\n+import { parseUnsignedEvmTransactionForSigning } from '@suite-common/earn-stablecoin-api';\n+import { flattenEvmFees, parseEvmFeeHex } from '@suite-common/schemas/src/evm';\n+import { type NetworkSymbol } from '@suite-common/wallet-config';\n+import {\n+    type EvmSelectedFee,\n+    type FormState,\n+    type PrecomposedTransactionFinal,\n+    type YieldFormMetadata,\n+} from '@suite-common/wallet-types';\n+import {\n+    asAmountUnit,\n+    evmHexToBigNumber,\n+    evmHexWeiToGwei,\n+    getContractAddressForNetworkSymbol,\n+    unitsToSubunits,\n+} from '@suite-common/wallet-utils';\n+import { type EthereumSignTransaction, type TokenInfo } from '@trezor/connect-common';\n+import { BigNumber } from '@trezor/utils';\n+\n+export type StablecoinYieldParsedTransactionForSigning = NonNullable<\n+    ReturnType<typeof parseUnsignedEvmTransactionForSigning>\n+>;\n+\n+type BuildStablecoinYieldReviewTokenParams = {\n+    token: {\n+        contractAddress?: string | null;\n+        decimals: number;\n+        symbol: string;\n+    };\n+    symbol: NetworkSymbol;\n+};\n+\n+type BuildStablecoinYieldReviewStateParams = BuildStablecoinYieldReviewTokenParams & {\n+    amount: string;\n+    flowType: YieldFormMetadata['type'];\n+    tx: StablecoinYieldParsedTransactionForSigning;\n+    vaultName: string;\n+};\n+\n+type BuildStablecoinYieldReviewStateResult = {\n+    formState: FormState;\n+    precomposedTransaction: PrecomposedTransactionFinal;\n+};\n+\n+type BuildStablecoinYieldTransactionReviewParams = Omit<\n+    BuildStablecoinYieldReviewStateParams,\n+    'tx'\n+> & {\n+    selectedFee?: EvmSelectedFee | null;\n+    unsignedTransaction: string;\n+};\n+\n+type BuildStablecoinYieldTransactionReviewResult = BuildStablecoinYieldReviewStateResult & {\n+    transactionForSigning: EthereumSignTransaction['transaction'];\n+};\n+\n+const getStablecoinYieldTransactionWithSelectedFee = (\n+    parsedTransaction: StablecoinYieldParsedTransactionForSigning,\n+    selectedFee?: EvmSelectedFee | null,\n+): StablecoinYieldParsedTransactionForSigning | null => {\n+    if (!selectedFee) {\n+        return parsedTransaction;\n+    }\n+\n+    const parsedSelectedFee = parseEvmFeeHex(selectedFee);\n+\n+    if (!parsedSelectedFee) {\n+        return null;\n+    }\n+\n+    return {\n+        ...parsedTransaction,\n+        ...flattenEvmFees(parsedSelectedFee),\n+    };\n+};\n+\n+export const getStablecoinYieldTransactionForSigning = (\n+    parsedTransaction: StablecoinYieldParsedTransactionForSigning,\n+): EthereumSignTransaction['transaction'] => {\n+    const commonTransactionFields = {\n+        to: parsedTransaction.to,\n+        value: parsedTransaction.value ?? '0x0',\n+        gasLimit: parsedTransaction.gasLimit,\n+        nonce: parsedTransaction.nonce,\n+        data: parsedTransaction.data,\n+        chainId: parsedTransaction.chainId,\n+    };\n+\n+    if (parsedTransaction.maxFeePerGas && parsedTransaction.maxPriorityFeePerGas) {\n+        return {\n+            ...commonTransactionFields,\n+            maxFeePerGas: parsedTransaction.maxFeePerGas,\n+            maxPriorityFeePerGas: parsedTransaction.maxPriorityFeePerGas,\n+        };\n+    }\n+\n+    if (parsedTransaction.gasPrice) {\n+        return {\n+            ...commonTransactionFields,\n+            gasPrice: parsedTransaction.gasPrice,\n+            txType: parsedTransaction.type,\n+        };\n+    }\n+\n+    throw new Error('Yield transaction gas parameters are missing.');\n+};\n+\n+const buildStablecoinYieldReviewToken = ({\n+    token,\n+    symbol,\n+}: BuildStablecoinYieldReviewTokenParams): TokenInfo | undefined => {\n+    if (!token.contractAddress) {\n+        return undefined;\n+    }\n+\n+    return {\n+        standard: 'ERC20',\n+        contract: getContractAddressForNetworkSymbol(symbol, token.contractAddress),\n+        symbol: token.symbol,\n+        decimals: token.decimals,\n+        name: token.symbol,\n+    };\n+};\n+\n+export const buildStablecoinYieldReviewState = ({\n+    tx,\n+    amount,\n+    token,\n+    symbol,\n+    flowType,\n+    vaultName,\n+}: BuildStablecoinYieldReviewStateParams): BuildStablecoinYieldReviewStateResult => {\n+    const gasPriceHex = tx.maxFeePerGas ?? tx.gasPrice ?? ('0x0' as `0x${string}`);\n+    const gasLimit = evmHexToBigNumber(tx.gasLimit);\n+    const gasPrice = evmHexToBigNumber(gasPriceHex);\n+    const feePerUnit = evmHexWeiToGwei(gasPriceHex);\n+    const fee = gasLimit.multipliedBy(gasPrice);\n+    const reviewToken = buildStablecoinYieldReviewToken({ token, symbol });\n+    const amountSubunits = unitsToSubunits({\n+        value: asAmountUnit(new BigNumber(amount)),\n+        decimals: token.decimals,\n+    });\n+\n+    const eip1559ReviewFields: Partial<\n+        Pick<PrecomposedTransactionFinal, 'maxFeePerGas' | 'maxPriorityFeePerGas'>\n+    > =\n+        tx.maxFeePerGas && tx.maxPriorityFeePerGas\n+            ? {\n+                  maxFeePerGas: evmHexWeiToGwei(tx.maxFeePerGas),\n+                  maxPriorityFeePerGas: evmHexWeiToGwei(tx.maxPriorityFeePerGas),\n+              }\n+            : {};\n+\n+    const formState: FormState = {\n+        outputs: [\n+            {\n+                type: 'payment',\n+                address: tx.to,\n+                amount,\n+                fiat: '',\n+                currency: { value: '', label: '' },\n+                token: reviewToken?.contract ?? null,\n+                dataHex: tx.data,\n+            },\n+        ],\n+        selectedFee: 'custom',\n+        feePerUnit,\n+        feeLimit: gasLimit.toFixed(0),\n+        ...eip1559ReviewFields,\n+        options: ['broadcast', 'transactionData'],\n+        transactionData: tx.data,\n+        isCoinControlEnabled: false,\n+        hasCoinControlBeenOpened: false,\n+        selectedUtxos: [],\n+        yieldMetadata: { type: flowType, vaultName },\n+    };\n+\n+    const precomposedTransaction: PrecomposedTransactionFinal = {\n+        type: 'final',\n+        fee: fee.toFixed(0),\n+        feePerByte: feePerUnit,\n+        feeLimit: gasLimit.toFixed(0),\n+        totalSpent: reviewToken ? amountSubunits.toFixed(0) : amountSubunits.plus(fee).toFixed(0),\n+        bytes: 0,\n+        inputs: [],\n+        outputs: [\n+            {\n+                address: tx.to,\n+                amount: amountSubunits.toFixed(0),\n+            },\n+        ],\n+        outputsPermutation: [0],\n+        ...(reviewToken ? { token: reviewToken, isTokenKnown: true } : {}),\n+        ...eip1559ReviewFields,\n+    };\n+\n+    return { formState, precomposedTransaction };\n+};\n+\n+export const buildStablecoinYieldTransactionReview = ({\n+    unsignedTransaction,\n+    selectedFee,\n+    ...reviewStateParams\n+}: BuildStablecoinYieldTransactionReviewParams): BuildStablecoinYieldTransactionReviewResult | null => {\n+    const parsedTransaction = parseUnsignedEvmTransactionForSigning(unsignedTransaction);\n+\n+    if (!parsedTransaction) {\n+        return null;\n+    }\n+\n+    const tx = getStablecoinYieldTransactionWithSelectedFee(parsedTransaction, selectedFee);\n+\n+    if (!tx) {\n+        return null;\n+    }\n+\n+    return {\n+        ...buildStablecoinYieldReviewState({ ...reviewStateParams, tx }),\n+        transactionForSigning: getStablecoinYieldTransactionForSigning(tx),\n+    };\n+};",
+      "comments": [
+        {
+          "databaseId": 3287452170,
+          "author": "cermakjiri",
+          "body": "Great that you moved it to common 👍 One thing worries me though there's breaking change how the validation works now: i.e. instead of throwing errors it returns null.  \nAt least from DevX it'll be much harder to deduce what's wrong or am I missing something? 🤔",
+          "createdAt": "2026-05-22T09:41:26Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287452170",
+          "isMine": true
+        },
+        {
+          "databaseId": 3298432520,
+          "author": "BrantalikP",
+          "body": "Each platform handles the error in its own way, but you’re right that returning `null` was probably too implicit. For example, it would be harder to notice that the error is related to the `fee data`. I’ve brought the explicit errors back. Thanks for pointing this out",
+          "createdAt": "2026-05-25T13:33:37Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3298432520",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G19",
+      "topic": "code-placement-and-reuse",
+      "tags": [
+        "package-boundaries",
+        "wallet-core"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6EE1NZ",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-common/wallet-core/src/index.ts",
+        "line": 65,
+        "originalLine": 65,
+        "startLine": 65,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-22T10:09:32Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287618775",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-common/wallet-core/src/index.ts#L65",
+      "diffHunk": "@@ -62,6 +62,7 @@ export * from './stake/stakeThunks';\n export * from './stablecoin-yield/stablecoinYieldReducer';\n export * from './stablecoin-yield/stablecoinYieldSelectors';\n export * from './stablecoin-yield/stablecoinYieldApprovalThunks';\n+export * from './stablecoin-yield/stablecoinYieldDepositThunks';",
+      "comments": [
+        {
+          "databaseId": 3287618775,
+          "author": "cermakjiri",
+          "body": "Disclaimer: I know it was already here so just genuinely asking 😃 could it be moved in theory to `@suite-common/earn-stablecoin`? Because I don't see dependency on the wallet-core what so ever. ",
+          "createdAt": "2026-05-22T10:09:32Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287618775",
+          "isMine": true
+        },
+        {
+          "databaseId": 3298512382,
+          "author": "BrantalikP",
+          "body": "agree, let's conduct it in separate PR please. ",
+          "createdAt": "2026-05-25T13:51:30Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3298512382",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G20",
+      "topic": "component-structure-and-files",
+      "tags": [
+        "package-structure",
+        "evm-vs-common",
+        "extensibility"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6EE24t",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-native/tx-simulation/package.json",
+        "line": 28,
+        "originalLine": 28,
+        "startLine": 28,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-22T10:11:23Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287627901",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/tx-simulation/package.json#L28",
+      "diffHunk": "@@ -0,0 +1,29 @@\n+{\n+    \"name\": \"@suite-native/tx-simulation\",\n+    \"version\": \"1.0.0\",\n+    \"private\": true,\n+    \"license\": \"See LICENSE.md in repo root\",\n+    \"sideEffects\": false,\n+    \"main\": \"src/index\",\n+    \"scripts\": {\n+        \"depcheck\": \"yarn g:depcheck\",\n+        \"type-check\": \"yarn g:tsc --build\",\n+        \"lint:js\": \"yarn g:eslint '**/*.{ts,tsx,js}'\"\n+    },\n+    \"dependencies\": {\n+        \"@suite-common/formatters\": \"workspace:*\",\n+        \"@suite-common/tx-simulation\": \"workspace:*\",\n+        \"@suite-common/wallet-config\": \"workspace:*\",\n+        \"@suite-common/wallet-types\": \"workspace:*\",\n+        \"@suite-common/wallet-utils\": \"workspace:*\",\n+        \"@suite-native/atoms\": \"workspace:*\",\n+        \"@suite-native/clipboard\": \"workspace:*\",\n+        \"@suite-native/icons\": \"workspace:*\",\n+        \"@suite-native/intl\": \"workspace:*\",\n+        \"@trezor/utils\": \"workspace:*\",\n+        \"react\": \"19.2.4\",\n+        \"react-native\": \"0.83.2\",\n+        \"react-native-reanimated\": \"~4.2.1\",\n+        \"web3-utils\": \"^4.3.3\"\n+    }",
+      "comments": [
+        {
+          "databaseId": 3287627901,
+          "author": "cermakjiri",
+          "body": "Nice! 🎉 ",
+          "createdAt": "2026-05-22T10:11:23Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287627901",
+          "isMine": true
+        },
+        {
+          "databaseId": 3287654236,
+          "author": "cermakjiri",
+          "body": "One thing though: could you please follow similar structure as in other tx-simulation packages so it's going to be easy to extend them in future for other non-evm networks too? E.g.:\n```ts\ntx-simulation/src \n   /common\n       /components\n       /hooks\n   /evm\n       /components   \n       /hooks\n```\n\nAnyway it could be done in some follow up 🙏 ",
+          "createdAt": "2026-05-22T10:16:38Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3287654236",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G21",
+      "topic": "data-fetching-tanstack-query",
+      "tags": [
+        "query-options",
+        "shared-hook",
+        "suite-vs-native"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": true,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27829,
+        "title": "(PR no longer accessible — deleted or hidden)",
+        "url": "https://github.com/trezor/trezor-suite/pull/27829",
+        "author": "unknown",
+        "state": "UNKNOWN",
+        "createdAt": null,
+        "headRefOid": null
+      },
+      "thread": {
+        "id": "comment:3288598035",
+        "isResolved": null,
+        "isOutdated": null,
+        "path": "suite-common/earn-staking-api/src/staking/hooks/useEthereumValidatorsQueue.ts",
+        "line": null,
+        "originalLine": 19,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-22T13:13:16Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27829#discussion_r3288598035",
+      "codeUrl": null,
+      "diffHunk": "@@ -1,23 +1,23 @@\n-import { type ResponseError, type ResponseValidationError } from '@suite-common/http-client';\n-import { type UseQueryOptions, commonQueryKeys, useQuery } from '@suite-common/react-query';\n+import { commonQueryKeys, useQuery } from '@suite-common/react-query';\n import { type Account } from '@suite-common/wallet-types';\n \n-import { type EthValidatorsQueue } from '../../api/types';\n import { getEthereumValidatorsQueue } from '../services';\n \n interface UseEthereumValidatorsQueueProps {\n-    account: Account;\n+    account: Account | null;\n     timestamp?: number;\n+    enabled?: boolean;\n }\n \n-export function useEthereumValidatorsQueue(\n-    { account, timestamp }: UseEthereumValidatorsQueueProps,\n-    queryOptions?: UseQueryOptions<EthValidatorsQueue, ResponseError | ResponseValidationError>,\n-) {\n+export function useEthereumValidatorsQueue({\n+    account,\n+    timestamp,\n+    enabled,\n+}: UseEthereumValidatorsQueueProps) {\n     return useQuery({\n         staleTime: 60 * 1000, // 1 minute\n-        ...queryOptions,\n-        queryKey: commonQueryKeys.validatorsQueue(account.key, timestamp),\n+        enabled: !!account && (enabled ?? true),",
+      "comments": [
+        {
+          "databaseId": 3288598035,
+          "author": "cermakjiri",
+          "body": "Sure, checking for `null` account and enabling it only when it's defined makes sense. But why have you removed the `queryOptions`? This is general hook and the usage might vary in `suite` and `suite-native`. \n\nIt'd be better to this like this:\n```ts\nimport { type ResponseError, type ResponseValidationError } from '@suite-common/http-client';\nimport { type UseQueryOptions, commonQueryKeys, useQuery } from '@suite-common/react-query';\nimport { type Account } from '@suite-common/wallet-types';\n\nimport { type EthValidatorsQueue } from '../../api/types';\nimport { getEthereumValidatorsQueue } from '../services';\n\ninterface UseEthereumValidatorsQueueProps {\n    account: Account | null;\n    timestamp?: number;\n}\n\nexport function useEthereumValidatorsQueue(\n    { account, timestamp }: UseEthereumValidatorsQueueProps,\n    {\n        enabled = Boolean(account),\n        ...restQueryOptions\n    }: Omit<\n        UseQueryOptions<EthValidatorsQueue, ResponseError | ResponseValidationError>,\n        'queryKey'\n    > = {},\n) {\n    return useQuery({\n        staleTime: 60 * 1000, // 1 minute\n        ...restQueryOptions,\n        queryKey: commonQueryKeys.validatorsQueue(account?.key, timestamp),\n        queryFn: () =>\n            getEthereumValidatorsQueue({\n                params: { timestamp },\n            }),\n    });\n}\n```\nof course and edit the query key: `validatorsQueue: (accountKey: string | undefined, timestamp?: number) => [` ",
+          "createdAt": "2026-05-22T13:13:16Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27829#discussion_r3288598035",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G22",
+      "topic": "react-hooks-and-effects",
+      "tags": [
+        "use-ref"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6EuQjn",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx",
+        "line": 129,
+        "originalLine": 129,
+        "startLine": 129,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-26T08:03:11Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302177192",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx#L129",
+      "diffHunk": "@@ -0,0 +1,307 @@\n+import { type ReactNode, useCallback, useMemo } from 'react';\n+import { StyleSheet, View } from 'react-native';\n+import {\n+    Extrapolation,\n+    interpolate,\n+    useAnimatedStyle,\n+    useSharedValue,\n+} from 'react-native-reanimated';\n+\n+import { type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';\n+import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';\n+\n+import { useFormatters } from '@suite-common/formatters';\n+import { type NetworkSymbol } from '@suite-common/wallet-config';\n+import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';\n+import {\n+    Badge,\n+    BottomSheetModal,\n+    type BottomSheetModalRef,\n+    Box,\n+    Button,\n+    Card,\n+    CircularSpinner,\n+    HStack,\n+    Text,\n+    VStack,\n+} from '@suite-native/atoms';\n+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';\n+import { CryptoIcon, Icon, NetworkIcon } from '@suite-native/icons';\n+import { Translation } from '@suite-native/intl';\n+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';\n+\n+import { YieldPendingTransactionModalBackdrop } from './YieldPendingTransactionModalBackdrop';\n+import { modalSnap } from './YieldPendingTransactionModalConstants';\n+import { YieldPendingTransactionModalHeader } from './YieldPendingTransactionModalHeader';\n+import { YieldPendingTransactionModalRow } from './YieldPendingTransactionModalRow';\n+\n+type YieldPendingTransactionModalProps = {\n+    accountLabel: string;\n+    accountSymbol: NetworkSymbol;\n+    amount?: ReactNode;\n+    amountLabel?: ReactNode;\n+    amountTokenContract?: TokenAddress;\n+    amountTokenSymbol?: TokenSymbol;\n+    fee?: string;\n+    isExploreDisabled?: boolean;\n+    onExplorePress: () => void;\n+    pendingLabel?: ReactNode;\n+    ref: BottomSheetModalRef;\n+    submittedAt: Date;\n+    title: ReactNode;\n+    vaultName?: string;\n+    vaultTokenContract?: TokenAddress;\n+};\n+\n+const VAULT_NAME_MAX_WIDTH = 150;\n+\n+const pendingIconStyle = prepareNativeStyle(utils => ({\n+    width: 56,\n+    height: 56,\n+    borderRadius: utils.borders.radii.round,\n+    alignItems: 'center',\n+    justifyContent: 'center',\n+    backgroundColor: utils.colors.surfaceFillRaised,\n+    ...utils.boxShadows.small,\n+}));\n+\n+const constrainedValueStyle = prepareNativeStyle(() => ({\n+    maxWidth: VAULT_NAME_MAX_WIDTH,\n+    minWidth: 0,\n+    flexShrink: 1,\n+}));\n+\n+const constrainedValueTextStyle = prepareNativeStyle(() => ({\n+    minWidth: 0,\n+    flexShrink: 1,\n+}));\n+\n+const getBottomSheet = (ref: BottomSheetModalRef): BottomSheetModalMethods | null => {\n+    if (typeof ref === 'object' && ref !== null && 'current' in ref) {\n+        return ref.current;\n+    }\n+\n+    return null;\n+};\n+\n+export const YieldPendingTransactionModalContainer = ({ children }: { children?: ReactNode }) => (\n+    <View pointerEvents=\"box-none\" style={StyleSheet.absoluteFill}>\n+        {children}\n+    </View>\n+);\n+\n+export const YieldPendingTransactionModal = ({\n+    accountLabel,\n+    accountSymbol,\n+    amount,\n+    amountLabel,\n+    amountTokenContract,\n+    amountTokenSymbol,\n+    fee,\n+    isExploreDisabled,\n+    onExplorePress,\n+    pendingLabel = <Translation id=\"moduleTrading.tradingConfirmationScreen.pending\" />,\n+    ref,\n+    submittedAt,\n+    title,\n+    vaultName,\n+    vaultTokenContract,\n+}: YieldPendingTransactionModalProps) => {\n+    const { applyStyle } = useNativeStyles();\n+    const { DateFormatter, TimeFormatter } = useFormatters();\n+    const animatedIndex = useSharedValue<number>(modalSnap.expandedIndex);\n+    const snapPoints = useMemo(() => [modalSnap.collapsedHeight, modalSnap.expandedHeight], []);\n+    const caretAnimatedStyle = useAnimatedStyle(() => {\n+        const rotation = interpolate(\n+            animatedIndex.value,\n+            [modalSnap.collapsedIndex, modalSnap.expandedIndex],\n+            [180, 0],\n+            Extrapolation.CLAMP,\n+        );\n+\n+        return {\n+            transform: [{ rotateZ: `${rotation}deg` }],\n+        };\n+    });\n+\n+    const handleToggleSheet = useCallback(() => {\n+        const isExpanded = animatedIndex.value >= modalSnap.indexMidpoint;\n+        const bottomSheet = getBottomSheet(ref);",
+      "comments": [
+        {
+          "databaseId": 3302177192,
+          "author": "cermakjiri",
+          "body": "Shouldn't be this rather done via `useRef` hook? ",
+          "createdAt": "2026-05-26T08:03:11Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302177192",
+          "isMine": true
+        },
+        {
+          "databaseId": 3303558512,
+          "author": "BrantalikP",
+          "body": "nono, this serves simply as ref check if you look into the getBottomSheet, I need access to the ref from the parent to have control over the modal",
+          "createdAt": "2026-05-26T12:14:51Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303558512",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G23",
+      "topic": "component-structure-and-files",
+      "tags": [
+        "folder-structure",
+        "conventions",
+        "scaling"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6EuhYu",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-native/module-earn/src/components/YieldPendingTransactionModalConstants.ts",
+        "line": 9,
+        "originalLine": 9,
+        "startLine": 9,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-26T08:18:30Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302274382",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/components/YieldPendingTransactionModalConstants.ts#L9",
+      "diffHunk": "@@ -0,0 +1,9 @@\n+export const modalSnap = {\n+    collapsedIndex: 0,\n+    expandedIndex: 1,\n+    collapsedHeight: 148,\n+    expandedHeight: 592,\n+    indexMidpoint: 0.5,\n+    collapsedBackdropOpacity: 0,\n+    expandedBackdropOpacity: 0.5,\n+} as const;",
+      "comments": [
+        {
+          "databaseId": 3302274382,
+          "author": "cermakjiri",
+          "body": "This is out of scope this PR, anyway I believe it'd be good to at least open up the discussion on the topic:\n\nI've just noticed that suite-native packages are following some really strict linear file structure. However, the issue with that it breaks implicit relationships between components apposed to tree-like file structure.\n\nLinear:\n```\nsome-pkg/src/\n    /components\n         SomeScreen.tsx\n         SomeFooter.tsx\n         SomeFooterButton.tsx\n         ...\n  /hooks\n        useSomeFooter.tsx\n        useSomeXYZ.tsx\n        ...\n```\n\nTree-like:\n```\nsome-pkg/src/\n    /components\n         /SomeScreen\n                  /hooks\n                       useSomeXYZ.tsx # hook for the `SomeScreen`.tsx\n                 /constants\n                 /{other-architectual-primitives}\n                 /SomeFooter\n                        /hooks\n                             useSomeFooter.tsx # hook only for the relevant   footer\n                        SomeFooterButton.tsx\n                  SomeScreen.tsx\n```\n\n- The relationship between components is implicit by the structure. If something is shared across more of them, it can be just move respective level up. \n- It scales: It can effectively decrease browsing complexity to O(logn) making much better for bigger file structure to orient to.\n",
+          "createdAt": "2026-05-26T08:18:30Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302274382",
+          "isMine": true
+        },
+        {
+          "databaseId": 3303369039,
+          "author": "BrantalikP",
+          "body": "This is my setup everywhere except at Trezor. Could not agree more.\r\n\r\nAlthough I would love to do it right away, I still do not think it is a good idea to introduce new patterns into an existing codebase when the current approach is followed by the majority.\r\n\r\nThis should be decided by other devs as well. I tried to convince other mobile devs in the past, unfortunately without success.\r\n\r\nIf you plan any initiative to introduce this pattern, I would be more than happy to support it.",
+          "createdAt": "2026-05-26T11:24:49Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303369039",
+          "isMine": false
+        },
+        {
+          "databaseId": 3303987425,
+          "author": "cermakjiri",
+          "body": "Glad to hear that! \r\n\r\nI kind of agree that it's better to have unified approaches across teams in the same codebase, however if I should always wait for everything to be accepted by our Suite Council, I'm afraid there'd be not much of progress. Maybe the borderline might be defined on team-level / package-level (something like that), when there's a need to introduce a new pattern / coding practice like this. \r\n\r\nAnyway, thank you for your feedback on that. I hope we will make this work soon. 🚀 ",
+          "createdAt": "2026-05-26T13:28:12Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303987425",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G24",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "satisfies",
+        "test-fixtures"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Eutly",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts",
+        "line": null,
+        "originalLine": 49,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-26T08:29:17Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302343773",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts#L49",
+      "diffHunk": "@@ -0,0 +1,102 @@\n+import { type YieldDto } from '@suite-common/earn-stablecoin-api';\n+import { type Account, type AccountKey } from '@suite-common/wallet-types';\n+\n+import { resolveYieldFlowData } from '../useResolvedYieldFlowData';\n+\n+const accountKey = 'eth-account-key' as AccountKey;\n+const underlyingTokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';\n+const receiptTokenAddress = '0xde6c23e561f3e55846207ec45a91b777e0f7c889';\n+const yieldId = 'ethereum-usdc-steakusdc';\n+\n+const account = {\n+    key: accountKey,\n+    symbol: 'eth',\n+    tokens: [\n+        {\n+            contract: underlyingTokenAddress,\n+            symbol: 'USDC',\n+            decimals: 6,\n+            balance: '25',\n+        },\n+        {\n+            contract: receiptTokenAddress,\n+            symbol: 'trSHUSDCp',\n+            decimals: 18,\n+            balance: '1.5',\n+        },\n+    ],\n+} as unknown as Account;\n+\n+const vault = {\n+    id: yieldId,\n+    network: 'ethereum',\n+    providerId: 'morpho',\n+    metadata: { name: 'Steakhouse USDC Prime' },\n+    token: {\n+        address: underlyingTokenAddress,\n+        symbol: 'USDC',\n+        decimals: 6,\n+        coinGeckoId: 'usd-coin',\n+    },\n+    outputToken: {\n+        address: receiptTokenAddress,\n+        symbol: 'trSHUSDCp',\n+        name: 'Trezor Steakhouse USDC Prime',\n+        decimals: 18,\n+        coinGeckoId: 'usd-coin',\n+    },\n+    rewardRate: { total: 0.05 },\n+} as unknown as YieldDto;",
+      "comments": [
+        {
+          "databaseId": 3302343773,
+          "author": "cermakjiri",
+          "body": "I understand the `vault` should have the type, however at least partial type validation might be a good idea via `satisfies`.",
+          "createdAt": "2026-05-26T08:29:17Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302343773",
+          "isMine": true
+        },
+        {
+          "databaseId": 3303885746,
+          "author": "BrantalikP",
+          "body": "partial would not work for the hook, I completed the mock instead https://github.com/trezor/trezor-suite/pull/27718/changes/25a82a123cb603cf14c3f6db7e4cc1a5187b3eab",
+          "createdAt": "2026-05-26T13:13:27Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303885746",
+          "isMine": false
+        },
+        {
+          "databaseId": 3303928506,
+          "author": "cermakjiri",
+          "body": "nice 💪 ",
+          "createdAt": "2026-05-26T13:19:37Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303928506",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G25",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "satisfies",
+        "test-fixtures",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Euzhb",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts",
+        "line": null,
+        "originalLine": 27,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-26T08:33:58Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302376413",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/hooks/__tests__/useResolvedYieldFlowData.test.ts#L27",
+      "diffHunk": "@@ -0,0 +1,102 @@\n+import { type YieldDto } from '@suite-common/earn-stablecoin-api';\n+import { type Account, type AccountKey } from '@suite-common/wallet-types';\n+\n+import { resolveYieldFlowData } from '../useResolvedYieldFlowData';\n+\n+const accountKey = 'eth-account-key' as AccountKey;\n+const underlyingTokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';\n+const receiptTokenAddress = '0xde6c23e561f3e55846207ec45a91b777e0f7c889';\n+const yieldId = 'ethereum-usdc-steakusdc';\n+\n+const account = {\n+    key: accountKey,\n+    symbol: 'eth',\n+    tokens: [\n+        {\n+            contract: underlyingTokenAddress,\n+            symbol: 'USDC',\n+            decimals: 6,\n+            balance: '25',\n+        },\n+        {\n+            contract: receiptTokenAddress,\n+            symbol: 'trSHUSDCp',\n+            decimals: 18,\n+            balance: '1.5',\n+        },\n+    ],",
+      "comments": [
+        {
+          "databaseId": 3302376413,
+          "author": "cermakjiri",
+          "body": "e.g.:\n```suggestion\n    ] satisfies Omit<TokenInfo, 'standard'>[],\n```",
+          "createdAt": "2026-05-26T08:33:58Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302376413",
+          "isMine": true
+        },
+        {
+          "databaseId": 3303920329,
+          "author": "BrantalikP",
+          "body": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302376413",
+          "createdAt": "2026-05-26T13:18:23Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303920329",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G26",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "naming",
+        "status-enum"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Eu6Ts",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-earn/src/hooks/useYieldDepositReview.ts",
+        "line": null,
+        "originalLine": 34,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-26T08:39:37Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302415688",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/hooks/useYieldDepositReview.ts#L34",
+      "diffHunk": "@@ -0,0 +1,155 @@\n+import { useCallback, useState } from 'react';\n+import { useDispatch, useSelector } from 'react-redux';\n+\n+import { useNavigation } from '@react-navigation/native';\n+import { isRejected } from '@reduxjs/toolkit';\n+\n+import {\n+    type StablecoinYieldRootState,\n+    type YieldFlowResolvedData,\n+    selectStablecoinYieldTxReview,\n+} from '@suite-common/wallet-core';\n+import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';\n+import type {\n+    StackNavigationProps,\n+    YieldStackParamList,\n+    YieldStackRoutes,\n+} from '@suite-native/navigation';\n+\n+import { USER_CANCELLED_ERROR_CODES } from '../constants';\n+import { pushYieldActionReviewThunk, signYieldActionReviewThunk } from '../yieldTransactionThunks';\n+import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';\n+\n+type UseYieldDepositReviewParams = {\n+    flowData: YieldFlowResolvedData;\n+    flowKey: string;\n+};\n+\n+type UseYieldDepositReviewResult = {\n+    handleSubmitDepositReview: () => Promise<void>;\n+    handleDepositSubmitted: () => Promise<void>;\n+    isSendingDeposit: boolean;\n+    isSigningDeposit: boolean;\n+    isSubmitDisabled: boolean;\n+    isDepositSigned: boolean;",
+      "comments": [
+        {
+          "databaseId": 3302415688,
+          "author": "cermakjiri",
+          "body": "`depositStatus` might be more suitable for so many states",
+          "createdAt": "2026-05-26T08:39:37Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302415688",
+          "isMine": true
+        },
+        {
+          "databaseId": 3303790498,
+          "author": "BrantalikP",
+          "body": " https://github.com/trezor/trezor-suite/pull/27718/changes/0743fc3a03ac49eb3c3283cca51f78db6f9f21c1",
+          "createdAt": "2026-05-26T12:58:57Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303790498",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G27",
+      "topic": "code-placement-and-reuse",
+      "tags": [
+        "duplication",
+        "suite-common"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Eu8Pd",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts",
+        "line": 40,
+        "originalLine": 40,
+        "startLine": 40,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-26T08:41:09Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302426845",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts#L40",
+      "diffHunk": "@@ -0,0 +1,140 @@\n+import { useEffect } from 'react';\n+import { useDispatch, useSelector } from 'react-redux';\n+\n+import {\n+    type AccountsRootState,\n+    type FeesRootState,\n+    type TransactionsRootState,\n+    type YieldFlowType,\n+    type YieldPendingTransactionState,\n+    fetchAndUpdateAccountThunk,\n+    selectConvertedNetworkFeeInfo,\n+    selectTransactionByAccountKeyAndTxid,\n+    stablecoinYieldActions,\n+} from '@suite-common/wallet-core';\n+import { type Account } from '@suite-common/wallet-types';\n+import { isPending } from '@suite-common/wallet-utils';\n+\n+const DEFAULT_PENDING_TX_POLL_INTERVAL_MS = 3_000;\n+const MIN_PENDING_TX_POLL_INTERVAL_MS = 2_000;\n+const BLOCK_TIME_TO_POLL_INTERVAL_RATIO = 2;\n+\n+type YieldPendingTrackingRootState = TransactionsRootState & AccountsRootState & FeesRootState;\n+\n+type UseYieldPendingTransactionTrackingParams = {\n+    account: Account | null;\n+    flowKey: string | null;\n+    flowType: YieldFlowType;\n+    isScreenFocused?: boolean;\n+    onApprovalConfirmed?: () => void;\n+    pendingTransaction: YieldPendingTransactionState | undefined;\n+};\n+\n+const getPollIntervalMs = (blockTime: number | undefined): number => {\n+    if (!blockTime) return DEFAULT_PENDING_TX_POLL_INTERVAL_MS;\n+\n+    return Math.max(\n+        (blockTime / BLOCK_TIME_TO_POLL_INTERVAL_RATIO) * 1000,\n+        MIN_PENDING_TX_POLL_INTERVAL_MS,\n+    );\n+};",
+      "comments": [
+        {
+          "databaseId": 3302426845,
+          "author": "cermakjiri",
+          "body": "It looks like the same fn as in `@trezor/suite`, what about putting it to suite-common?",
+          "createdAt": "2026-05-26T08:41:09Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302426845",
+          "isMine": true
+        },
+        {
+          "databaseId": 3303297105,
+          "author": "BrantalikP",
+          "body": "I think I tried, but there is some platform specific code that made it harder to do or make it more complicated that it should if we do it, let me revalidate it. 💪",
+          "createdAt": "2026-05-26T11:05:12Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303297105",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G28",
+      "topic": "component-structure-and-files",
+      "tags": [
+        "one-component-per-file"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP",
+        "state": "MERGED",
+        "createdAt": "2026-05-13T16:59:16Z",
+        "headRefOid": "49849a8b2a17ae6deeb8424b91a233ea3d219618"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6EvADR",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-native/module-earn/src/screens/YieldDepositReviewScreen.tsx",
+        "line": 162,
+        "originalLine": 164,
+        "startLine": 162,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-05-26T08:44:20Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302449312",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/49849a8b2a17ae6deeb8424b91a233ea3d219618/suite-native/module-earn/src/screens/YieldDepositReviewScreen.tsx#L162",
+      "diffHunk": "@@ -0,0 +1,164 @@\n+import { useEffect, useMemo } from 'react';\n+import { useSelector } from 'react-redux';\n+\n+import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';\n+\n+import {\n+    type StablecoinYieldRootState,\n+    type YieldFlowResolvedData,\n+    selectStablecoinYieldSessionByFlowKey,\n+} from '@suite-common/wallet-core';\n+import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';\n+import { Text, VStack } from '@suite-native/atoms';\n+import {\n+    ConfirmOnTrezorWrapper,\n+    useConfirmOnTrezorController,\n+} from '@suite-native/confirm-on-trezor';\n+import { Translation } from '@suite-native/intl';\n+import {\n+    ScreenHeader,\n+    type StackNavigationProps,\n+    type YieldStackParamList,\n+    YieldStackRoutes,\n+} from '@suite-native/navigation';\n+\n+import { EarnReviewSubmittedCard } from '../components/EarnReviewSubmittedCard';\n+import { YieldReviewList } from '../components/YieldReviewList';\n+import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';\n+import { useYieldDepositReview } from '../hooks/useYieldDepositReview';\n+import { buildYieldDepositFeePreview } from '../yieldDepositFeeUtils';\n+\n+type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldDepositReview>;\n+type NavigationProps = StackNavigationProps<\n+    YieldStackParamList,\n+    YieldStackRoutes.YieldDepositReview\n+>;\n+\n+type DepositReviewContentProps = {\n+    feePreview: PrecomposedTransactionFinal;\n+    flowData: YieldFlowResolvedData;\n+    flowKey: string;\n+    review: {\n+        amount: string;\n+        receiptAmount: string;\n+    };\n+    tokenSymbol: string;\n+};\n+\n+const DepositReviewContent = ({\n+    feePreview,\n+    flowData,\n+    flowKey,\n+    review,\n+    tokenSymbol,\n+}: DepositReviewContentProps) => {\n+    const { confirmOnTrezorRef, revealConfirmOnTrezorSheet, closeSheet } =\n+        useConfirmOnTrezorController();\n+    const {\n+        handleSubmitDepositReview,\n+        handleDepositSubmitted,\n+        isSendingDeposit,\n+        isSigningDeposit,\n+        isSubmitDisabled,\n+        isDepositSigned,\n+    } = useYieldDepositReview({\n+        flowData,\n+        flowKey,\n+    });\n+\n+    useEffect(() => {\n+        if (isSigningDeposit) {\n+            revealConfirmOnTrezorSheet();\n+        } else {\n+            closeSheet();\n+        }\n+    }, [closeSheet, isSigningDeposit, revealConfirmOnTrezorSheet]);\n+\n+    return (\n+        <ConfirmOnTrezorWrapper\n+            isManualControlEnabled\n+            controlRef={confirmOnTrezorRef}\n+            closeActionType=\"back\"\n+            defaultHeader={\n+                <ScreenHeader\n+                    closeActionType=\"back\"\n+                    customContent={\n+                        <Text variant=\"body-md-strong\">\n+                            <Translation id=\"earn.yieldDepositReviewScreen.title\" />\n+                        </Text>\n+                    }\n+                />\n+            }\n+        >\n+            <VStack flex={1} justifyContent=\"space-between\">\n+                <YieldReviewList\n+                    accountKey={flowData.account.key}\n+                    amount={review.amount}\n+                    fee={feePreview.fee}\n+                    isFooterVisible={!isSigningDeposit && !isDepositSigned}\n+                    isSubmitDisabled={isSubmitDisabled}\n+                    isSubmitLoading={isSigningDeposit}\n+                    onSubmit={handleSubmitDepositReview}\n+                    receiveAmount={review.receiptAmount}\n+                    receiveTokenSymbol={flowData.receiptToken.symbol}\n+                    tokenSymbol={tokenSymbol}\n+                    variant=\"deposit\"\n+                />\n+                {isDepositSigned && (\n+                    <EarnReviewSubmittedCard\n+                        buttonTranslationId=\"earn.yieldDepositReviewScreen.submitButton\"\n+                        isButtonLoading={isSendingDeposit}\n+                        messageTranslationId=\"earn.yieldDepositReviewScreen.successMessage\"\n+                        onButtonPress={handleDepositSubmitted}\n+                    />\n+                )}\n+            </VStack>\n+        </ConfirmOnTrezorWrapper>\n+    );\n+};\n+\n+export const YieldDepositReviewScreen = () => {\n+    const route = useRoute<RouteProps>();\n+    const navigation = useNavigation<NavigationProps>();\n+    const { flowData, flowKey, tokenSymbol, resolutionStatus } = useResolvedYieldFlowData(\n+        route.params,\n+    );\n+    const session = useSelector((state: StablecoinYieldRootState) =>\n+        selectStablecoinYieldSessionByFlowKey(state, 'deposit', flowKey),\n+    );\n+    const review = session?.action.review;\n+    const feePreview = useMemo(\n+        () => (review ? buildYieldDepositFeePreview(review.unsignedTransaction) : null),\n+        [review],\n+    );\n+\n+    useEffect(() => {\n+        if (resolutionStatus !== 'resolved') {\n+            return;\n+        }\n+\n+        if (session?.step === 'complete') {\n+            navigation.replace(YieldStackRoutes.YieldDepositComplete, route.params);\n+\n+            return;\n+        }\n+\n+        if (!review || session?.step !== 'action') {\n+            navigation.navigate(YieldStackRoutes.YieldDeposit, route.params);\n+        }\n+    }, [navigation, resolutionStatus, review, route.params, session?.step]);\n+\n+    if (resolutionStatus !== 'resolved' || !review || !feePreview) {\n+        return null;\n+    }\n+\n+    return (\n+        <DepositReviewContent\n+            feePreview={feePreview}\n+            flowData={flowData}\n+            flowKey={flowKey}\n+            review={review}\n+            tokenSymbol={tokenSymbol}\n+        />\n+    );\n+};",
+      "comments": [
+        {
+          "databaseId": 3302449312,
+          "author": "cermakjiri",
+          "body": "One component per file please to make it easily readable 🙏 ",
+          "createdAt": "2026-05-26T08:44:20Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3302449312",
+          "isMine": true
+        },
+        {
+          "databaseId": 3303301098,
+          "author": "BrantalikP",
+          "body": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3298064343 answered here already. WDYT?",
+          "createdAt": "2026-05-26T11:06:17Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3303301098",
+          "isMine": false
+        },
+        {
+          "databaseId": 3304005716,
+          "author": "cermakjiri",
+          "body": "TBH I still think it'd be better to divide it (better readability, so less bugs; easier composibility; potential easier refactoring in the future) but I don't push it. Also, it might be subject of some follow-up.",
+          "createdAt": "2026-05-26T13:30:40Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/27718#discussion_r3304005716",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G29",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "shared-type",
+        "duplication"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28234,
+        "title": "feat(suite): add transaction data editor to tron send form",
+        "url": "https://github.com/trezor/trezor-suite/pull/28234",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-06-01T12:15:25Z",
+        "headRefOid": "14f1ff0af72ac9b357b3b085fede1021ddaab031"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6GIZu2",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-common/wallet-core/src/send/tron/buildContract.ts",
+        "line": null,
+        "originalLine": 9,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-01T13:30:16Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28234#discussion_r3334490148",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/14f1ff0af72ac9b357b3b085fede1021ddaab031/suite-common/wallet-core/src/send/tron/buildContract.ts#L9",
+      "diffHunk": "@@ -0,0 +1,39 @@\n+export const buildTriggerContract = ({\n+    ownerHex,\n+    recipientHex,\n+    data,\n+}: {\n+    ownerHex: string;\n+    recipientHex: string;\n+    data: string;\n+}) =>",
+      "comments": [
+        {
+          "databaseId": 3334490148,
+          "author": "cermakjiri",
+          "body": "nit: put it to shared interface / type with `buildTransferContract`? ",
+          "createdAt": "2026-06-01T13:30:16Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28234#discussion_r3334490148",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G30",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval",
+        "per-network-nesting"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28234,
+        "title": "feat(suite): add transaction data editor to tron send form",
+        "url": "https://github.com/trezor/trezor-suite/pull/28234",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-06-01T12:15:25Z",
+        "headRefOid": "14f1ff0af72ac9b357b3b085fede1021ddaab031"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6GImBo",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-common/wallet-core/src/send/sendFormThunks.ts",
+        "line": 84,
+        "originalLine": 84,
+        "startLine": 84,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-01T13:40:42Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28234#discussion_r3334557137",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/14f1ff0af72ac9b357b3b085fede1021ddaab031/suite-common/wallet-core/src/send/sendFormThunks.ts#L84",
+      "diffHunk": "@@ -72,16 +72,16 @@ import {\n     composeSolanaTransactionFeeLevelsThunk,\n     signSolanaSendFormTransactionThunk,\n } from './sendFormSolanaThunks';\n-import {\n-    composeTronTransactionFeeLevelsThunk,\n-    signTronSendFormTransactionThunk,\n-} from './sendFormTronThunks';\n import {\n     type ComposeFeeLevelsError,\n     type PushTransactionError,\n     type SignTransactionError,\n     type SignTransactionTimeoutError,\n } from './sendFormTypes';\n+import {\n+    composeTronTransactionFeeLevelsThunk,\n+    signTronSendFormTransactionThunk,\n+} from './tron/sendFormTronThunks';",
+      "comments": [
+        {
+          "databaseId": 3334557137,
+          "author": "cermakjiri",
+          "body": "I like the nesting per network 👍 ",
+          "createdAt": "2026-06-01T13:40:42Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28234#discussion_r3334557137",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G31",
+      "topic": "code-placement-and-reuse",
+      "tags": [
+        "native-reuse",
+        "hook-extraction"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28374,
+        "title": "feat(suite): add Tron staking page basics",
+        "url": "https://github.com/trezor/trezor-suite/pull/28374",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-06-04T12:56:04Z",
+        "headRefOid": "f7cf6d5d9aa4c0fb2b3faa9ae762736b06bb160a"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6HT_F2",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx",
+        "line": 28,
+        "originalLine": 28,
+        "startLine": 28,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-05T08:53:29Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28374#discussion_r3361541527",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/f7cf6d5d9aa4c0fb2b3faa9ae762736b06bb160a/packages/suite/src/components/earn/modals/EarnInANutshell/TronStakeInANutshellModal.tsx#L28",
+      "diffHunk": "@@ -0,0 +1,116 @@\n+import { Translation } from '@suite/intl';\n+import { useTronStakingStats } from '@suite-common/earn-staking-api';\n+import { type EarnModalAction } from '@suite-common/suite-types/src/staking';\n+import { BulletList, Divider } from '@trezor/components';\n+\n+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';\n+\n+import { EarnInANutshellHighlights } from './components/EarnInANutshellHighlights';\n+import { EarnInANutshellModalLayout } from './components/EarnInANutshellModalLayout';\n+import {\n+    type EarnInANutshellProcess,\n+    EarnInANutshellProcesses,\n+} from './components/EarnInANutshellProcesses';\n+import { EarnInfoRow } from './components/EarnInfoRow';\n+\n+const TRON_UNSTAKING_PERIOD_DAYS = 14;\n+\n+interface TronStakeInANutshellModalProps {\n+    onCancel: () => void;\n+    actionType?: EarnModalAction;\n+}\n+\n+export const TronStakeInANutshellModal = ({\n+    onCancel,\n+    actionType = 'close',\n+}: TronStakeInANutshellModalProps) => {\n+    const { data } = useTronStakingStats();\n+    const apy = data?.length ? Math.max(...data.map(({ apr }) => apr)) : null;",
+      "comments": [
+        {
+          "databaseId": 3361541527,
+          "author": "cermakjiri",
+          "body": "What about putting this `maxApy` to `useTronStakingStats` so suite-native can re-use it?",
+          "createdAt": "2026-06-05T08:53:29Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28374#discussion_r3361541527",
+          "isMine": true
+        },
+        {
+          "databaseId": 3361748953,
+          "author": "matusbalascak",
+          "body": "Good point, I'll implement it in the following PRs",
+          "createdAt": "2026-06-05T09:32:54Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28374#discussion_r3361748953",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G32",
+      "topic": "runtime-validation-and-parsing",
+      "tags": [
+        "input-constraints",
+        "edge-cases",
+        "bigint-hex"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28414,
+        "title": "Eth conversion utils",
+        "url": "https://github.com/trezor/trezor-suite/pull/28414",
+        "author": "marekrjpolak",
+        "state": "MERGED",
+        "createdAt": "2026-06-05T12:32:46Z",
+        "headRefOid": "f1bc0880bc762d80234ead125311c8a867fdb6ab"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6JfIUb",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/wallet-utils/src/ethConverter.ts",
+        "line": 33,
+        "originalLine": 33,
+        "startLine": 33,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-15T06:48:19Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28414#discussion_r3411500893",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/f1bc0880bc762d80234ead125311c8a867fdb6ab/suite-common/wallet-utils/src/ethConverter.ts#L33",
+      "diffHunk": "@@ -0,0 +1,94 @@\n+import type {\n+    DecimalString,\n+    Ether,\n+    Gwei,\n+    HexString,\n+    IntegerString,\n+    Wei,\n+} from '@suite-common/wallet-types';\n+import { BigNumber } from '@trezor/utils';\n+\n+interface EthValue {\n+    toWei(format: 'hex'): Wei & HexString;\n+    toWei(format: 'bignumber'): Wei & BigNumber;\n+    toWei(format?: 'string'): Wei & IntegerString;\n+    toGwei(format: 'bignumber'): Gwei & BigNumber;\n+    toGwei(format?: 'string'): Gwei & DecimalString;\n+    toEther(format: 'bignumber'): Ether & BigNumber;\n+    toEther(format?: 'string'): Ether & DecimalString;\n+}\n+\n+const GWEI_DECIMALS = 9;\n+const ETHER_DECIMALS = 18;\n+\n+const error = (value: unknown, reason: string) =>\n+    new Error(`Value '${value}' is invalid (${reason})`);\n+\n+const toHex = (value: BigNumber): HexString => `0x${value.toString(16)}`;\n+\n+const toBN = (value: string | bigint, shift = 0) => {\n+    const bn = new BigNumber(value);\n+\n+    if (bn.isNaN()) throw error(value, 'not a number');\n+    if (bn.isNegative()) throw error(value, 'negative');",
+      "comments": [
+        {
+          "databaseId": 3411500893,
+          "author": "cermakjiri",
+          "body": "Why can't it be negative?",
+          "createdAt": "2026-06-15T06:48:19Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28414#discussion_r3411500893",
+          "isMine": true
+        },
+        {
+          "databaseId": 3411883772,
+          "author": "marekrjpolak",
+          "body": "Because I said so? :melting_face:  Actually it's a good question. I just thought that negative value in hex would be something like `-0xabcd` and given that we often do things like `slice(2)`, it would've been broken anyway. The same applies to decimal numbers like `0xab.cd`.\r\n\r\nBy the way the old `web3-utils` does this:\r\n```\r\nconsole.log(fromWei('-1234', 'gwei')); // prints 0.0000-1234\r\n```\r\n\r\nDo we expect negative ether/gwei/wei amounts somewhere?",
+          "createdAt": "2026-06-15T08:04:15Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28414#discussion_r3411883772",
+          "isMine": false
+        },
+        {
+          "databaseId": 3413036449,
+          "author": "53gur0",
+          "body": "yes, like displaying a tx fee ",
+          "createdAt": "2026-06-15T11:20:38Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28414#discussion_r3413036449",
+          "isMine": false
+        },
+        {
+          "databaseId": 3413163731,
+          "author": "marekrjpolak",
+          "body": "But the fee is not really negative, or is it? You mean this? \r\n<img width=\"280\" height=\"104\" alt=\"image\" src=\"https://github.com/user-attachments/assets/e2482162-fb20-483d-ad57-6822ef4169e9\" />\r\n\r\nThe thing is that these utils are more low-level and I don't want to end up with negative hexes and stuff like that. ",
+          "createdAt": "2026-06-15T11:41:39Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28414#discussion_r3413163731",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G33",
+      "topic": "code-placement-and-reuse",
+      "tags": [
+        "selector-placement",
+        "consistency",
+        "debug-settings"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28761,
+        "title": "refactor(suite): extract shared debug utilities",
+        "url": "https://github.com/trezor/trezor-suite/pull/28761",
+        "author": "OriginalEveres",
+        "state": "MERGED",
+        "createdAt": "2026-06-15T08:25:35Z",
+        "headRefOid": "ab30c91089162d17697092aa39e8ef7810ae3181"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Jsnb1",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite/settings/src/settingsSelectors.ts",
+        "line": 30,
+        "originalLine": 30,
+        "startLine": 29,
+        "originalStartLine": 29,
+        "diffSide": "LEFT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-16T06:50:52Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28761#discussion_r3418674994",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/ab30c91089162d17697092aa39e8ef7810ae3181/suite/settings/src/settingsSelectors.ts#L29-L30",
+      "diffHunk": "@@ -16,20 +14,6 @@ export const selectTorOnionLinks = (state: SuiteSettingsRootState) =>\n     state.suiteSettings.torOnionLinks;\n export const selectIsCoinjoinReceiveWarningHidden = (state: SuiteSettingsRootState) =>\n     state.suiteSettings.isCoinjoinReceiveWarningHidden;\n-export const selectIsDebugModeActive = (state: SuiteSettingsRootState) =>\n-    state.suiteSettings.debug.showDebugMenu;\n-export const selectIsUnlockedBootloaderAllowed = (state: SuiteSettingsRootState) =>\n-    state.suiteSettings.debug.isUnlockedBootloaderAllowed;\n-export const selectDebugTransports = (state: SuiteSettingsRootState) =>\n-    state.suiteSettings.debug.transports;\n-export const selectShowConnectLogs = (state: SuiteSettingsRootState) =>\n-    state.suiteSettings.debug.showConnectLogs;\n-export const selectInvityServerEnvironment = (state: SuiteSettingsRootState) =>\n-    state.suiteSettings.debug.invityServerEnvironment;\n-export const selectEarnYieldWorkerBaseUrl = (state: SuiteSettingsRootState) =>\n-    state.suiteSettings.debug.earnYieldWorkerBaseUrl ?? defaultEarnYieldWorkerBaseUrl;",
+      "comments": [
+        {
+          "databaseId": 3416294815,
+          "author": "OriginalEveres",
+          "body": "@tomasklim is this really a good place for this? I would maybe put it into the earn package instead of debug, it seems that its correctly placed in `suite-native` like that.\n\nWDYT?",
+          "createdAt": "2026-06-15T20:14:24Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28761#discussion_r3416294815",
+          "isMine": false
+        },
+        {
+          "databaseId": 3418674994,
+          "author": "cermakjiri",
+          "body": "But then, shouldn't be done same for other debug options too? ",
+          "createdAt": "2026-06-16T06:50:52Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28761#discussion_r3418674994",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G34",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "ambient-types",
+        "d-ts",
+        "module-augmentation"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28797,
+        "title": "chore(validators): remove dead validator types",
+        "url": "https://github.com/trezor/trezor-suite/pull/28797",
+        "author": "mroz22",
+        "state": "CLOSED",
+        "createdAt": "2026-06-15T16:21:34Z",
+        "headRefOid": "e036bd91faaf6704ba8192bf6060ba16195cac9b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6KLrm-",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/validators/src/types.ts",
+        "line": 1,
+        "originalLine": 1,
+        "startLine": 1,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-18T09:54:16Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28797#discussion_r3434859843",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/e036bd91faaf6704ba8192bf6060ba16195cac9b/suite-common/validators/src/types.ts#L1",
+      "diffHunk": "@@ -1,11 +1,8 @@\n-import { type AnySchema } from 'yup';\n+export {};",
+      "comments": [
+        {
+          "databaseId": 3427469613,
+          "author": "peter-sanderson",
+          "body": "sus",
+          "createdAt": "2026-06-17T10:41:50Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28797#discussion_r3427469613",
+          "isMine": false
+        },
+        {
+          "databaseId": 3434859843,
+          "author": "cermakjiri",
+          "body": "it's this or `import './types';` in `validators/src/index.ts` 🤷‍♂️ ",
+          "createdAt": "2026-06-18T09:54:16Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28797#discussion_r3434859843",
+          "isMine": true
+        },
+        {
+          "databaseId": 3434866740,
+          "author": "cermakjiri",
+          "body": "no, now it can actually be just `validators.d.ts` that should be picked by ts without import, right?",
+          "createdAt": "2026-06-18T09:55:19Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28797#discussion_r3434866740",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G35",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "account-with-network-type",
+        "narrow-upstream",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28908,
+        "title": "feat(suite): implement tron staking dashboard",
+        "url": "https://github.com/trezor/trezor-suite/pull/28908",
+        "author": "matusbalascak",
+        "state": "MERGED",
+        "createdAt": "2026-06-18T15:30:18Z",
+        "headRefOid": "6110524d4bdcfe7c05c242cf1e60e55fe8336db2"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6KxA-t",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx",
+        "line": 15,
+        "originalLine": 15,
+        "startLine": 15,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-19T07:33:27Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28908#discussion_r3440966584",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/6110524d4bdcfe7c05c242cf1e60e55fe8336db2/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx#L15",
+      "diffHunk": "@@ -0,0 +1,85 @@\n+import { useState } from 'react';\n+\n+import { Translation } from '@suite/intl';\n+import { goto } from '@suite/router';\n+import { type Account, type TronResourceType } from '@suite-common/wallet-types';\n+import { getTronResources } from '@suite-common/wallet-utils';\n+import { Button, Card, Column, Icon, Row, Text } from '@trezor/components';\n+\n+import { useDispatch } from 'src/hooks/suite';\n+\n+import { TronResourceModal } from '../TronResourceModal';\n+import { TronResourceRow } from './TronResourceRow';\n+\n+interface TronResourcesCardProps {\n+    account: Account;",
+      "comments": [
+        {
+          "databaseId": 3440966584,
+          "author": "cermakjiri",
+          "body": "It might be useful to go with `AccountWithNetworkType<'tron'>` for stricter types and less conditions. \n```suggestion\n    account: AccountWithNetworkType<'tron'>;\n```\nand do the \"is it correct account check\" only once somewhere upstream",
+          "createdAt": "2026-06-19T07:33:27Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28908#discussion_r3440966584",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G36",
+      "topic": "performance-and-memoization",
+      "tags": [
+        "redundant-memo",
+        "extract-util",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28948,
+        "title": "fix(suite-native): display aggregated amounts on tx list item",
+        "url": "https://github.com/trezor/trezor-suite/pull/28948",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-19T15:41:18Z",
+        "headRefOid": "c8494882fbe89e3e5478598c155ac54dd43dd25a"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6LQoSc",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-native/transactions/src/components/TransactionTarget.tsx",
+        "line": 125,
+        "originalLine": 126,
+        "startLine": 125,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-22T12:43:32Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452276969",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/c8494882fbe89e3e5478598c155ac54dd43dd25a/suite-native/transactions/src/components/TransactionTarget.tsx#L125",
+      "diffHunk": "@@ -116,14 +116,14 @@ export const TransactionTarget = ({\n         if (isSolanaUnstakeTx) return null;\n         switch (type) {\n             case 'target':\n-                return transaction.amount;\n+                return payload.amount;\n             case 'internal':\n             case 'token':\n                 return payload.amount;\n             default:\n                 return exhaustive(type);\n         }\n-    }, [type, payload, transaction, isSolanaUnstakeTx]);\n+    }, [type, payload, isSolanaUnstakeTx]);",
+      "comments": [
+        {
+          "databaseId": 3452276969,
+          "author": "cermakjiri",
+          "body": "```suggestion\n    }, [type, payload.amount, isSolanaUnstakeTx]);\n```",
+          "createdAt": "2026-06-22T12:43:32Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452276969",
+          "isMine": true
+        },
+        {
+          "databaseId": 3452305185,
+          "author": "cermakjiri",
+          "body": "These memo seem redundant, there's no complexity (`O(1)`), it could some `get____Amount` util. I just need to say but it's not your code, I know 😄 ",
+          "createdAt": "2026-06-22T12:47:56Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452305185",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G37",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "dead-branch",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28948,
+        "title": "fix(suite-native): display aggregated amounts on tx list item",
+        "url": "https://github.com/trezor/trezor-suite/pull/28948",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-19T15:41:18Z",
+        "headRefOid": "c8494882fbe89e3e5478598c155ac54dd43dd25a"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6LQoco",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite-native/transactions/src/components/TransactionTarget.tsx",
+        "line": null,
+        "originalLine": 119,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-22T12:43:39Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452277831",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/c8494882fbe89e3e5478598c155ac54dd43dd25a/suite-native/transactions/src/components/TransactionTarget.tsx#L119",
+      "diffHunk": "@@ -116,14 +116,14 @@ export const TransactionTarget = ({\n         if (isSolanaUnstakeTx) return null;\n         switch (type) {\n             case 'target':\n-                return transaction.amount;\n+                return payload.amount;",
+      "comments": [
+        {
+          "databaseId": 3452277831,
+          "author": "cermakjiri",
+          "body": "All cases return the same value, so:\n```suggestion\n```",
+          "createdAt": "2026-06-22T12:43:39Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452277831",
+          "isMine": true
+        },
+        {
+          "databaseId": 3452791565,
+          "author": "53gur0",
+          "body": "fixup! fb26ac6cfe55e183a65697034cc8aa6bc5219871",
+          "createdAt": "2026-06-22T14:00:43Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452791565",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G38",
+      "topic": "performance-and-memoization",
+      "tags": [
+        "missing-memo",
+        "react-native-list"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28948,
+        "title": "fix(suite-native): display aggregated amounts on tx list item",
+        "url": "https://github.com/trezor/trezor-suite/pull/28948",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-19T15:41:18Z",
+        "headRefOid": "c8494882fbe89e3e5478598c155ac54dd43dd25a"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6LQqvp",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite-native/transactions/src/components/TransactionListItem.tsx",
+        "line": null,
+        "originalLine": 134,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-22T12:45:43Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452290449",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/c8494882fbe89e3e5478598c155ac54dd43dd25a/suite-native/transactions/src/components/TransactionListItem.tsx#L134",
+      "diffHunk": "@@ -129,11 +129,32 @@ export const TransactionListItem = ({\n     const includedCoinsCount = transaction.tokens.length;\n \n     const firstToken = transaction.tokens[0];\n-    const isTokenOnlyTransaction = transaction.amount === '0' && firstToken !== undefined;\n \n-    const allOutputs = account !== null ? createTargets({ transaction, account }) : [];\n+    const allOutputs =\n+        account !== null ? groupTargetOutputs(createTargets({ transaction, account })) : [];",
+      "comments": [
+        {
+          "databaseId": 3452290449,
+          "author": "cermakjiri",
+          "body": "I'd suggest using memo for this, wdyt? ",
+          "createdAt": "2026-06-22T12:45:43Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452290449",
+          "isMine": true
+        },
+        {
+          "databaseId": 3452806321,
+          "author": "53gur0",
+          "body": "fixup! eac55426e4cf0af632817b81d1cb22c857cab3a4",
+          "createdAt": "2026-06-22T14:02:52Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28948#discussion_r3452806321",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G39",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval",
+        "code-comment"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28816,
+        "title": "feat(wallet-core): improve nonce discovery for EVM",
+        "url": "https://github.com/trezor/trezor-suite/pull/28816",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-16T11:30:07Z",
+        "headRefOid": "2bb3fd21988b7db91be9d2fb8428da5de1bdbece"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6LQ-O5",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/wallet-core/src/send/sendFormEthereumThunks.ts",
+        "line": 68,
+        "originalLine": 65,
+        "startLine": 68,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-22T13:02:16Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452397806",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2bb3fd21988b7db91be9d2fb8428da5de1bdbece/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts#L68",
+      "diffHunk": "@@ -52,6 +57,71 @@ import {\n import { selectAddressDisplayType } from '../settings/walletSettingsReducer';\n import { selectTransactions } from '../transactions/transactionsSelectors';\n \n+/**\n+ * Returns fee info with levels bumped above the original transaction's gas price,\n+ * so that the replacement transaction will be accepted by the mempool.\n+ *\n+ * Expects `feeInfo` with levels already in Gwei (i.e. from selectConvertedNetworkFeeInfo).\n+ * `originalGasParams` must also be in Gwei.",
+      "comments": [
+        {
+          "databaseId": 3452397806,
+          "author": "cermakjiri",
+          "body": "nice to mention this 👍 ",
+          "createdAt": "2026-06-22T13:02:16Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452397806",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G40",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "account-with-network-type",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28816,
+        "title": "feat(wallet-core): improve nonce discovery for EVM",
+        "url": "https://github.com/trezor/trezor-suite/pull/28816",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-16T11:30:07Z",
+        "headRefOid": "2bb3fd21988b7db91be9d2fb8428da5de1bdbece"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6LQ_3e",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite-common/wallet-core/src/send/sendFormEthereumThunks.ts",
+        "line": null,
+        "originalLine": 439,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-22T13:03:43Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452406666",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2bb3fd21988b7db91be9d2fb8428da5de1bdbece/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts#L439",
+      "diffHunk": "@@ -350,39 +420,80 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<\n     },\n );\n \n-export const ethereumGetCurrentNonceThunk = createThunk<\n-    { nonce: string },\n-    { selectedAccount: Account & { networkType: 'ethereum' }; rbfParams?: RbfTransactionParams }\n->(\n-    `${SEND_MODULE_PREFIX}/ethereumGetCurrentNonceThunk`,\n-    ({ selectedAccount, rbfParams }, { getState }) => {\n-        // Ethereum account `misc.nonce` is not updated before pending tx is mined\n-        // Calculate `pendingNonce`: greatest value in pending tx + 1\n-        // This may lead to unexpected/unwanted behavior\n-        // whenever pending tx gets rejected all following txs (with higher nonce) will be rejected as well\n-        const transactions = selectTransactions(getState());\n-        const pendingTxs = (transactions[selectedAccount.key] || [])\n-            .filter(isPending)\n-            .filter(isSentTransaction);\n-        const pendingNonce = pendingTxs.reduce((value, tx) => {\n-            if (!tx.ethereumSpecific) return value;\n+/**\n+ * Resolves the nonce to use for the next Ethereum transaction.\n+ *\n+ * For RBF (cancel / speed-up) the original tx's nonce is reused. Otherwise:\n+ *  - `confirmedNonce` = the account's current nonce from the backend (account.misc.nonce), or the\n+ *    mined-only nonce from blockbook when `fetchConfirmedNonce` is true (trezor/blockbook#1562).\n+ *  - `nonce` (signing default) = `confirmedNonce` advanced past any *contiguous* outgoing pending\n+ *    txs. Gapped pending txs (e.g. a stuck tx far above the confirmed nonce) are ignored, so the\n+ *    suggestion fills the gap instead of queueing behind an unmineable tx.\n+ */\n+export const resolveEthereumNonce = async ({\n+    selectedAccount,\n+    rbfParams,\n+    accountTransactions,\n+    fetchConfirmedNonce,\n+}: {\n+    selectedAccount: Account & { networkType: 'ethereum' };",
+      "comments": [
+        {
+          "databaseId": 3452406666,
+          "author": "cermakjiri",
+          "body": "NIT: \n```suggestion\n    selectedAccount: AccountWithNetworkType<'ethereum'>\n```",
+          "createdAt": "2026-06-22T13:03:43Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452406666",
+          "isMine": true
+        },
+        {
+          "databaseId": 3472912817,
+          "author": "53gur0",
+          "body": "fixup! 682b51f2f89b",
+          "createdAt": "2026-06-25T08:23:38Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3472912817",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G41",
+      "topic": "runtime-validation-and-parsing",
+      "tags": [
+        "zod",
+        "avoid-cast",
+        "unknown-data"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28816,
+        "title": "feat(wallet-core): improve nonce discovery for EVM",
+        "url": "https://github.com/trezor/trezor-suite/pull/28816",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-16T11:30:07Z",
+        "headRefOid": "2bb3fd21988b7db91be9d2fb8428da5de1bdbece"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6LR8C5",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite-common/wallet-core/src/send/sendFormEthereumThunks.ts",
+        "line": null,
+        "originalLine": 82,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-22T13:53:19Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452739137",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2bb3fd21988b7db91be9d2fb8428da5de1bdbece/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts#L82",
+      "diffHunk": "@@ -52,6 +57,71 @@ import {\n import { selectAddressDisplayType } from '../settings/walletSettingsReducer';\n import { selectTransactions } from '../transactions/transactionsSelectors';\n \n+/**\n+ * Returns fee info with levels bumped above the original transaction's gas price,\n+ * so that the replacement transaction will be accepted by the mempool.\n+ *\n+ * Expects `feeInfo` with levels already in Gwei (i.e. from selectConvertedNetworkFeeInfo).\n+ * `originalGasParams` must also be in Gwei.\n+ */\n+export const getEthereumRbfFeeInfo = (\n+    feeInfo: FeeInfo,\n+    originalGasParams: { gasPrice?: string; maxFeePerGas?: string; maxPriorityFeePerGas?: string },\n+): FeeInfo => {\n+    // feeInfo.levels are already in Gwei — do NOT call getConvertedOrDefaultFeeInfo here,\n+    // that would double-convert and produce near-zero values.\n+    const { levels } = feeInfo;\n+    // @ts-expect-error: indexing with noUncheckedIndexedAccess\n+    const firstLevel: (typeof levels)[number] = levels[0];\n+    if (!firstLevel) return feeInfo;\n+\n+    if (isEip1559(originalGasParams) && isEip1559(firstLevel)) {\n+        const currentMaxFee = new BigNumber(originalGasParams.maxFeePerGas);\n+        // Cast back to access maxPriorityFeePerGas — isEip1559 narrows to { maxFeePerGas: string } only\n+        const currentMaxPriorityFee = new BigNumber(\n+            (originalGasParams as { maxPriorityFeePerGas?: string }).maxPriorityFeePerGas || '0',",
+      "comments": [
+        {
+          "databaseId": 3452739137,
+          "author": "cermakjiri",
+          "body": "What about using some Zod schema for parsing of the unknown data instead of the casting? There's already something related to that here `suite-common/schemas/src/evm/fees/index.ts` but it's been done only for hex strings yet.",
+          "createdAt": "2026-06-22T13:53:19Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452739137",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G42",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "explicit-annotation",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 28816,
+        "title": "feat(wallet-core): improve nonce discovery for EVM",
+        "url": "https://github.com/trezor/trezor-suite/pull/28816",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-16T11:30:07Z",
+        "headRefOid": "2bb3fd21988b7db91be9d2fb8428da5de1bdbece"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6LR8QV",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite-common/wallet-core/src/send/sendFormEthereumThunks.ts",
+        "line": null,
+        "originalLine": 75,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-22T13:53:29Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452740309",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2bb3fd21988b7db91be9d2fb8428da5de1bdbece/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts#L75",
+      "diffHunk": "@@ -52,6 +57,71 @@ import {\n import { selectAddressDisplayType } from '../settings/walletSettingsReducer';\n import { selectTransactions } from '../transactions/transactionsSelectors';\n \n+/**\n+ * Returns fee info with levels bumped above the original transaction's gas price,\n+ * so that the replacement transaction will be accepted by the mempool.\n+ *\n+ * Expects `feeInfo` with levels already in Gwei (i.e. from selectConvertedNetworkFeeInfo).\n+ * `originalGasParams` must also be in Gwei.\n+ */\n+export const getEthereumRbfFeeInfo = (\n+    feeInfo: FeeInfo,\n+    originalGasParams: { gasPrice?: string; maxFeePerGas?: string; maxPriorityFeePerGas?: string },\n+): FeeInfo => {\n+    // feeInfo.levels are already in Gwei — do NOT call getConvertedOrDefaultFeeInfo here,\n+    // that would double-convert and produce near-zero values.\n+    const { levels } = feeInfo;\n+    // @ts-expect-error: indexing with noUncheckedIndexedAccess\n+    const firstLevel: (typeof levels)[number] = levels[0];",
+      "comments": [
+        {
+          "databaseId": 3452740309,
+          "author": "cermakjiri",
+          "body": "```suggestion\n    const firstLevel: FeeLevel = levels[0];\n```",
+          "createdAt": "2026-06-22T13:53:29Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3452740309",
+          "isMine": true
+        },
+        {
+          "databaseId": 3491061041,
+          "author": "53gur0",
+          "body": "a32a3c185ec8\n\nalso fixed type for the feeLevel to have at least one element \n```\nlevels: [FeeLevel, ...FeeLevel[]];\n```",
+          "createdAt": "2026-06-29T10:39:46Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3491061041",
+          "isMine": false
+        },
+        {
+          "databaseId": 3491204150,
+          "author": "53gur0",
+          "body": "Unfortunately it's too many changes it seems. Would be great to address this issue separately. Had to rollback the type to possibly empty array  ",
+          "createdAt": "2026-06-29T11:05:45Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/28816#discussion_r3491204150",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G43",
+      "topic": "ci-tooling-and-guardrails",
+      "tags": [
+        "eslint-rule",
+        "proxy-regression",
+        "follow-up-issue"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29054,
+        "title": "perf(suite-desktop): tanstack query improvements",
+        "url": "https://github.com/trezor/trezor-suite/pull/29054",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T18:25:34Z",
+        "headRefOid": "2f97fd998cb3ebe9281946bf7288815092649074"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L4rFn",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts",
+        "line": 73,
+        "originalLine": 73,
+        "startLine": 73,
+        "originalStartLine": null,
+        "diffSide": "LEFT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T11:35:30Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466747822",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2f97fd998cb3ebe9281946bf7288815092649074/suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts#L73",
+      "diffHunk": "@@ -70,7 +70,12 @@ export function useGetMerklRewards<Address extends string>(\n     }, [queryClient, queryEntriesRef, chainsRewardsRef]);\n \n     return {\n-        ...queryResult,",
+      "comments": [
+        {
+          "databaseId": 3466747822,
+          "author": "cermakjiri",
+          "body": "We should (in another PR) try to introduce some Eslint rule to warn us about that. ✍️ 🤔 \nI didn't realize it's gonna break the proxy, even though it's now very much obvious. ",
+          "createdAt": "2026-06-24T11:35:30Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466747822",
+          "isMine": true
+        },
+        {
+          "databaseId": 3472692660,
+          "author": "53gur0",
+          "body": "https://github.com/trezor/trezor-suite/issues/29097",
+          "createdAt": "2026-06-25T07:42:00Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3472692660",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G44",
+      "topic": "performance-and-memoization",
+      "tags": [
+        "stable-reference",
+        "breaks-use-memo"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29054,
+        "title": "perf(suite-desktop): tanstack query improvements",
+        "url": "https://github.com/trezor/trezor-suite/pull/29054",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T18:25:34Z",
+        "headRefOid": "2f97fd998cb3ebe9281946bf7288815092649074"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L4rvu",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx",
+        "line": null,
+        "originalLine": 63,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T11:36:10Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466751441",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2f97fd998cb3ebe9281946bf7288815092649074/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx#L63",
+      "diffHunk": "@@ -60,7 +60,7 @@ export const EarnYieldTable = () => {\n         isYieldActive,\n         hasAnyRewardsData,\n     } = useYieldTableData({\n-        availableVaults,\n+        availableVaults: availableVaults ?? [],",
+      "comments": [
+        {
+          "databaseId": 3466751441,
+          "author": "cermakjiri",
+          "body": "nit: what about using static array (i.e it has stable ref) so it doesn't break the useMemo?",
+          "createdAt": "2026-06-24T11:36:10Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466751441",
+          "isMine": true
+        },
+        {
+          "databaseId": 3472754522,
+          "author": "53gur0",
+          "body": "fixup! e5cd0e1f16d9",
+          "createdAt": "2026-06-25T07:53:45Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3472754522",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G45",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29054,
+        "title": "perf(suite-desktop): tanstack query improvements",
+        "url": "https://github.com/trezor/trezor-suite/pull/29054",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T18:25:34Z",
+        "headRefOid": "2f97fd998cb3ebe9281946bf7288815092649074"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L4tds",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts",
+        "line": 22,
+        "originalLine": 22,
+        "startLine": 22,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T11:37:50Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466760958",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2f97fd998cb3ebe9281946bf7288815092649074/suite-common/earn-stablecoin-api/src/hooks/useYieldOpportunity.ts#L22",
+      "diffHunk": "@@ -9,32 +7,18 @@ interface UseYieldOpportunityProps<T extends YieldDto[keyof YieldDto] | YieldDto\n     select?: (yieldOpportunity: YieldDto) => T;\n }\n \n-const defaultSelect = <T extends YieldDto[keyof YieldDto] | YieldDto = YieldDto>(\n-    yieldOpportunity: YieldDto,\n-): T => yieldOpportunity as T;\n-\n export function useYieldOpportunity<T extends YieldDto[keyof YieldDto] | YieldDto = YieldDto>(\n     vaultId: string | undefined,\n-    { select = defaultSelect }: UseYieldOpportunityProps<T> = {},\n+    { select }: UseYieldOpportunityProps<T> = {},\n ) {\n-    const queryResult = useQuery({\n+    return useQuery({\n         enabled: Boolean(vaultId),\n-        queryKey: commonQueryKeys.yieldOpportunities(vaultId),\n+        queryKey: commonQueryKeys.yieldOpportunity(vaultId),\n         queryFn: ({ signal }) =>\n             getYield({\n                 routeParams: { vaultId: vaultId! },\n                 signal,\n             }),\n+        select,",
+      "comments": [
+        {
+          "databaseId": 3466760958,
+          "author": "cermakjiri",
+          "body": "hehe, how so I didn't notice that, thanks 😄 ",
+          "createdAt": "2026-06-24T11:37:50Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466760958",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G46",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "cross-reference"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29054,
+        "title": "perf(suite-desktop): tanstack query improvements",
+        "url": "https://github.com/trezor/trezor-suite/pull/29054",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T18:25:34Z",
+        "headRefOid": "2f97fd998cb3ebe9281946bf7288815092649074"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L4vls",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts",
+        "line": null,
+        "originalLine": 239,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T11:40:01Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466772939",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2f97fd998cb3ebe9281946bf7288815092649074/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts#L239",
+      "diffHunk": "@@ -236,7 +236,7 @@ export const useResolvedYieldFlowData = ({\n                 account,\n                 tokenContract,\n                 yieldId,\n-                yieldOpportunities,\n+                yieldOpportunities: yieldOpportunities ?? [],",
+      "comments": [
+        {
+          "databaseId": 3466772939,
+          "author": "cermakjiri",
+          "body": "https://github.com/trezor/trezor-suite/pull/29054/changes#r3466751441 🙏 ",
+          "createdAt": "2026-06-24T11:40:01Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466772939",
+          "isMine": true
+        },
+        {
+          "databaseId": 3472753937,
+          "author": "53gur0",
+          "body": "fixup! e5cd0e1f16d9",
+          "createdAt": "2026-06-25T07:53:39Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3472753937",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G47",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29054,
+        "title": "perf(suite-desktop): tanstack query improvements",
+        "url": "https://github.com/trezor/trezor-suite/pull/29054",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T18:25:34Z",
+        "headRefOid": "2f97fd998cb3ebe9281946bf7288815092649074"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L4v29",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts",
+        "line": 47,
+        "originalLine": 47,
+        "startLine": 47,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T11:40:17Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466774406",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2f97fd998cb3ebe9281946bf7288815092649074/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts#L47",
+      "diffHunk": "@@ -49,7 +44,7 @@ export const useStablecoinYieldListData = () => {\n     const { data: yieldOpportunities, isLoading } = useAllYieldOpportunities();\n \n     const listData = useMemo(() => {\n-        if (isLoading) {\n+        if (isLoading || !yieldOpportunities) {",
+      "comments": [
+        {
+          "databaseId": 3466774406,
+          "author": "cermakjiri",
+          "body": "❤️ ",
+          "createdAt": "2026-06-24T11:40:17Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466774406",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G48",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29054,
+        "title": "perf(suite-desktop): tanstack query improvements",
+        "url": "https://github.com/trezor/trezor-suite/pull/29054",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T18:25:34Z",
+        "headRefOid": "2f97fd998cb3ebe9281946bf7288815092649074"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L4wXG",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts",
+        "line": 32,
+        "originalLine": 32,
+        "startLine": 32,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T11:40:47Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466777199",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2f97fd998cb3ebe9281946bf7288815092649074/suite-common/earn-stablecoin-api/src/hooks/useGetYieldOpportunities.ts#L32",
+      "diffHunk": "@@ -1,31 +1,34 @@\n-import { type GetYieldsSort, type YieldsResponse } from '@suite-common/earn-stablecoin-defs';\n-import { type MutationOptions, desktopMutationKeys, useMutation } from '@suite-common/react-query';\n+import { type GetYieldsSort } from '@suite-common/earn-stablecoin-defs';\n+import { commonQueryKeys, useInfiniteQuery } from '@suite-common/react-query';\n \n+import { YIELD_OPPORTUNITIES_DEFAULT_LIMIT, queriesStaleTime } from '../config';\n import { getYields } from '../services';\n \n-interface GetYieldOpportunitiesVariables {\n-    offset?: number;\n+export interface UseGetYieldOpportunitiesProps {\n     limit?: number;\n     sort?: GetYieldsSort;\n-}\n-\n-export interface UseGetYieldOpportunitiesProps {\n-    onSuccess?: MutationOptions<YieldsResponse, Error, GetYieldOpportunitiesVariables>['onSuccess'];\n-    onError?: MutationOptions<YieldsResponse, Error, GetYieldOpportunitiesVariables>['onError'];\n+    enabled?: boolean;\n }\n \n /**\n- * Paginated list of Yield opportunities\n+ * Paginated list of Yield opportunities — each `fetchNextPage()` loads the next offset.\n  */\n-export function useGetYieldOpportunities({ onError, onSuccess }: UseGetYieldOpportunitiesProps) {\n-    return useMutation<YieldsResponse, Error, GetYieldOpportunitiesVariables>({\n-        mutationKey: desktopMutationKeys.getYieldOpportunities,\n-        mutationFn: ({ offset = 0, limit = 20, sort = 'statusEnterDesc' }) =>\n-            getYields({\n-                params: { offset, limit, sort },\n-            }),\n-        onError,\n-        onSuccess: (data, variables, onMutateResult, context) =>\n-            onSuccess?.(data, variables, onMutateResult, context),\n+export function useGetYieldOpportunities({\n+    limit = YIELD_OPPORTUNITIES_DEFAULT_LIMIT,\n+    sort = 'statusEnterDesc',\n+    enabled = true,\n+}: UseGetYieldOpportunitiesProps = {}) {\n+    return useInfiniteQuery({\n+        queryKey: commonQueryKeys.yieldOpportunitiesPages({ limit, sort }),\n+        queryFn: ({ pageParam, signal }) =>\n+            getYields({ params: { offset: pageParam, limit, sort }, signal }),\n+        initialPageParam: 0,\n+        getNextPageParam: lastPage => {\n+            const nextOffset = lastPage.offset + (lastPage.items?.length ?? 0);\n+\n+            return nextOffset < lastPage.total ? nextOffset : undefined;\n+        },\n+        enabled,\n+        staleTime: queriesStaleTime.getYieldOpportunities,",
+      "comments": [
+        {
+          "databaseId": 3466777199,
+          "author": "cermakjiri",
+          "body": "nice 👍 ",
+          "createdAt": "2026-06-24T11:40:47Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466777199",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G49",
+      "topic": "single-source-of-truth",
+      "tags": [
+        "network-config-features",
+        "staking"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29031,
+        "title": "Tron - Earn dashboard + Staking limits",
+        "url": "https://github.com/trezor/trezor-suite/pull/29031",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T10:54:17Z",
+        "headRefOid": "30b4edc6e5f92ac9b4ee75d6982d15bf59c66322"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L6fov",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts",
+        "line": 52,
+        "originalLine": 52,
+        "startLine": 52,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T13:22:29Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467403327",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/30b4edc6e5f92ac9b4ee75d6982d15bf59c66322/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts#L52",
+      "diffHunk": "@@ -44,7 +45,11 @@ export const useStakingTableData = (): UseStakingTableDataResult => {\n     const accounts = useSelector(selectVisibleDeviceAccounts);\n \n     const stakingAccounts = accounts.filter(\n-        account => account.symbol === 'eth' || account.symbol === 'sol' || account.symbol === 'ada',\n+        account =>\n+            account.symbol === 'eth' ||\n+            account.symbol === 'sol' ||\n+            account.symbol === 'ada' ||\n+            account.symbol === 'trx',",
+      "comments": [
+        {
+          "databaseId": 3467403327,
+          "author": "cermakjiri",
+          "body": "I'm not sure why we haven't done up to this point but what about using network config `getNetwork(account.symbol).features.includes('staking')` so we move the source of truth there?",
+          "createdAt": "2026-06-24T13:22:29Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467403327",
+          "isMine": true
+        },
+        {
+          "databaseId": 3474092189,
+          "author": "TomasBoda",
+          "body": "I definitely agree, but there were some reasons it was designed like this at the beginning, I believe due to fiat rates fetching. I can look at it and create follow-up PRs",
+          "createdAt": "2026-06-25T11:44:07Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29031#discussion_r3474092189",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G50",
+      "topic": "performance-and-memoization",
+      "tags": [
+        "use-memo-question",
+        "complexity"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29031,
+        "title": "Tron - Earn dashboard + Staking limits",
+        "url": "https://github.com/trezor/trezor-suite/pull/29031",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T10:54:17Z",
+        "headRefOid": "30b4edc6e5f92ac9b4ee75d6982d15bf59c66322"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L6pCr",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/hooks/earn/useStakingYield.ts",
+        "line": 46,
+        "originalLine": 46,
+        "startLine": 46,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T13:30:22Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467455740",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/30b4edc6e5f92ac9b4ee75d6982d15bf59c66322/packages/suite/src/hooks/earn/useStakingYield.ts#L46",
+      "diffHunk": "@@ -0,0 +1,51 @@\n+import {\n+    formatTronApr,\n+    getTronVotedApr,\n+    useTronStakingStats,\n+} from '@suite-common/earn-staking-api';\n+import { type NetworkSymbol } from '@suite-common/wallet-config';\n+import { selectAccountByKey, selectPoolStatsApy } from '@suite-common/wallet-core';\n+import { type AccountKey } from '@suite-common/wallet-types';\n+import { getTronVotes } from '@suite-common/wallet-utils';\n+\n+import { useSelector } from '../suite';\n+\n+interface UseStakingYieldProps {\n+    symbol: NetworkSymbol;\n+    accountKey?: AccountKey;\n+}\n+\n+interface StakingYield {\n+    apy: number | null;\n+}\n+\n+export const useStakingYield = ({ symbol, accountKey }: UseStakingYieldProps): StakingYield => {\n+    const account = useSelector(state => selectAccountByKey(state, accountKey));\n+\n+    const apy = useSelector(state =>\n+        selectPoolStatsApy(state, { networkSymbol: symbol, account: account ?? undefined }),\n+    );\n+\n+    const { stats, maxApr } = useTronStakingStats({\n+        enabled: symbol === 'trx',\n+    });\n+\n+    if (symbol !== 'trx') {\n+        return { apy };\n+    }\n+\n+    if (!accountKey || !account) {\n+        return { apy: formatTronApr(maxApr) };\n+    }\n+\n+    const votes = getTronVotes(account);\n+\n+    const votedApr = getTronVotedApr(\n+        stats.data,\n+        votes.map(({ address }) => address),\n+    );",
+      "comments": [
+        {
+          "databaseId": 3467455740,
+          "author": "cermakjiri",
+          "body": "If nothing changes this should be really low O(n), right? My point is if it would make sense move to some `useStakingYieldApy` with `useMemo` or not.",
+          "createdAt": "2026-06-24T13:30:22Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467455740",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G51",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "extract-condition",
+        "duplication"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29031,
+        "title": "Tron - Earn dashboard + Staking limits",
+        "url": "https://github.com/trezor/trezor-suite/pull/29031",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-06-23T10:54:17Z",
+        "headRefOid": "30b4edc6e5f92ac9b4ee75d6982d15bf59c66322"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6L6tfc",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx",
+        "line": null,
+        "originalLine": 386,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-06-24T13:34:11Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467480205",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/30b4edc6e5f92ac9b4ee75d6982d15bf59c66322/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx#L386",
+      "diffHunk": "@@ -338,7 +382,8 @@ export const EarnStakingAccountRow = ({\n             </Table.Cell>\n \n             <Table.Cell>\n-                {stakingStatus === 'staking-outdated-provider' ? (\n+                {stakingStatus === 'staking-outdated-provider' ||\n+                stakingStatus === 'staking-remaining-votes' ? (",
+      "comments": [
+        {
+          "databaseId": 3467480205,
+          "author": "cermakjiri",
+          "body": "there's same condition for this and the case above, what about putting it into some var?\n```ts\nconst apyAvailable = stakingStatus !== 'staking-outdated-provider' && stakingStatus !== 'staking-remaining-votes'\n```\n",
+          "createdAt": "2026-06-24T13:34:11Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29031#discussion_r3467480205",
+          "isMine": true
+        },
+        {
+          "databaseId": 3479803239,
+          "author": "TomasBoda",
+          "body": "done",
+          "createdAt": "2026-06-26T07:23:16Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29031#discussion_r3479803239",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G52",
+      "topic": "ci-tooling-and-guardrails",
+      "tags": [
+        "github-actions",
+        "aws-session-duration",
+        "hotfix"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30091,
+        "title": "fix(workflows): adjust aws session duration for icon workflow",
+        "url": "https://github.com/trezor/trezor-suite/pull/30091",
+        "author": "MiroslavProchazka",
+        "state": "OPEN",
+        "createdAt": "2026-07-20T09:39:19Z",
+        "headRefOid": "d63a7b82cbe07139744abc9d4c2f52b01fe13906"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6SN0xn",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": ".github/workflows/release-suite-coin-icons.yml",
+        "line": 46,
+        "originalLine": 46,
+        "startLine": 46,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-20T10:46:33Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30091#discussion_r3613679568",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d63a7b82cbe07139744abc9d4c2f52b01fe13906/.github/workflows/release-suite-coin-icons.yml#L46",
+      "diffHunk": "@@ -43,6 +43,7 @@ jobs:\n         with:\n           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production_icons\n           aws-region: ${{ env.AWS_REGION }}\n+          role-duration-seconds: 14400 # 4 hours",
+      "comments": [
+        {
+          "databaseId": 3613679568,
+          "author": "cermakjiri",
+          "body": "It seems like a good hotfix. I'd just increase it to 5h as some successful runs took more than 4h.\n\nhttps://github.com/trezor/trezor-suite/actions/workflows/release-suite-coin-icons.yml?query=is%3Asuccess",
+          "createdAt": "2026-07-20T10:46:33Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30091#discussion_r3613679568",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G53",
+      "topic": "ci-tooling-and-guardrails",
+      "tags": [
+        "github-actions",
+        "aws-session-duration",
+        "root-cause"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30091,
+        "title": "fix(workflows): adjust aws session duration for icon workflow",
+        "url": "https://github.com/trezor/trezor-suite/pull/30091",
+        "author": "MiroslavProchazka",
+        "state": "OPEN",
+        "createdAt": "2026-07-20T09:39:19Z",
+        "headRefOid": "d63a7b82cbe07139744abc9d4c2f52b01fe13906"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6SNxR0",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": ".github/workflows/release-suite-coin-icons.yml",
+        "line": 46,
+        "originalLine": 46,
+        "startLine": 46,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-20T10:53:10Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30091#discussion_r3613713586",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d63a7b82cbe07139744abc9d4c2f52b01fe13906/.github/workflows/release-suite-coin-icons.yml#L46",
+      "diffHunk": "@@ -43,6 +43,7 @@ jobs:\n         with:\n           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production_icons\n           aws-region: ${{ env.AWS_REGION }}\n+          role-duration-seconds: 14400 # 4 hours",
+      "comments": [
+        {
+          "databaseId": 3613660097,
+          "author": "vdovhanych",
+          "body": "This is very long, and I don't want to have secrets available for this long.",
+          "createdAt": "2026-07-20T10:42:49Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30091#discussion_r3613660097",
+          "isMine": false
+        },
+        {
+          "databaseId": 3613713586,
+          "author": "cermakjiri",
+          "body": "The default is 1h, so is 4x longer really too long? The script might run over 4h (which itself the core issue) https://github.com/trezor/trezor-suite/actions/workflows/release-suite-coin-icons.yml?query=is%3Asuccess. ",
+          "createdAt": "2026-07-20T10:53:10Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30091#discussion_r3613713586",
+          "isMine": true
+        },
+        {
+          "databaseId": 3613821299,
+          "author": "vdovhanych",
+          "body": "Yes even 1 hour which is default is too long in my opinion. It should be asy to rework it so it runs stores the images and then in actions it authenticates and syncs those stored images",
+          "createdAt": "2026-07-20T11:12:45Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30091#discussion_r3613821299",
+          "isMine": false
+        },
+        {
+          "databaseId": 3620086284,
+          "author": "cermakjiri",
+          "body": "This should become hopefully irrelevant once this is going to be merged. 🙏   https://github.com/trezor/trezor-suite/pull/30108",
+          "createdAt": "2026-07-21T07:03:52Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30091#discussion_r3620086284",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G54",
+      "topic": "code-placement-and-reuse",
+      "tags": [
+        "http-client",
+        "type-declaration-size",
+        "api-design"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29947,
+        "title": "fix(earn): reduce Yield.xyz declaration size",
+        "url": "https://github.com/trezor/trezor-suite/pull/29947",
+        "author": "peter-sanderson",
+        "state": "MERGED",
+        "createdAt": "2026-07-16T20:23:41Z",
+        "headRefOid": "8001e4e43467feddfd58ee9cd047b29fae2e051f"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6TLEtD",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/earn-stablecoin-api/src/services/yieldxyz.ts",
+        "line": 50,
+        "originalLine": 50,
+        "startLine": 50,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-23T07:41:20Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29947#discussion_r3636383687",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/8001e4e43467feddfd58ee9cd047b29fae2e051f/suite-common/earn-stablecoin-api/src/services/yieldxyz.ts#L50",
+      "diffHunk": "@@ -13,12 +21,30 @@ export const yieldXyzApi = createHttpClient({\n     headers: { 'X-Suite-Version': getSuiteVersion() },\n });\n \n-export const getYields = yieldXyzApi('/yields', {\n-    method: 'GET',\n-    schema: YieldsResponseV2,\n-});\n+type YieldXyzRequestOptions = {\n+    signal?: AbortSignal;\n+};\n \n-export const getYield = yieldXyzApi('/yields/:vaultId', {\n-    method: 'GET',\n-    schema: YieldResponseV2,\n-});\n+type GetYieldsOptions = YieldXyzRequestOptions & {\n+    params?: z.input<typeof GetYieldsV2QueryParams>;\n+};\n+\n+type GetYieldOptions = YieldXyzRequestOptions & {\n+    routeParams: { vaultId: string };\n+};\n+\n+/** Prevents declaration emit from expanding the inferred Yield.xyz list schema. */\n+export const getYields: (options?: GetYieldsOptions) => Promise<YieldsResponseV2Output> =\n+    yieldXyzApi('/yields', {\n+        method: 'GET',\n+        schema: YieldsResponseV2,\n+    });\n+\n+/** Prevents declaration emit from expanding the inferred Yield.xyz detail schema. */\n+export const getYield: (options: GetYieldOptions) => Promise<YieldResponseV2Output> = yieldXyzApi(\n+    '/yields/:vaultId',\n+    {\n+        method: 'GET',\n+        schema: YieldResponseV2,\n+    },\n+);",
+      "comments": [
+        {
+          "databaseId": 3636383687,
+          "author": "cermakjiri",
+          "body": "I can see the type decl. size improvement. However, it seems, we are going to need doing this for each service / endpoint. What about rather improving the `createHttpClient` itself?\n\nI've drafted it as kind of a `0.0.1` version to iterate it later on as we gather more usage experience, thus it's easier to design a better interface for it. I can think of extending it with schemas for search params / URL params (e.g. `/users/:userId`), request body. \n\nDo you have some design interface idea for reducing the type decl. size?\n\n",
+          "createdAt": "2026-07-23T07:41:20Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29947#discussion_r3636383687",
+          "isMine": true
+        },
+        {
+          "databaseId": 3637436578,
+          "author": "peter-sanderson",
+          "body": "I yolo drafted the protoype here: https://github.com/trezor/trezor-suite/pull/30220",
+          "createdAt": "2026-07-23T10:37:30Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29947#discussion_r3637436578",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G55",
+      "topic": "component-structure-and-files",
+      "tags": [
+        "extract-component",
+        "early-return",
+        "render-readability"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30255,
+        "title": "feat(suite-native): label wrap/unwrap transactions",
+        "url": "https://github.com/trezor/trezor-suite/pull/30255",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-07-24T13:04:41Z",
+        "headRefOid": "0c78e8b7cf19237b2c1f77c4c7d95378e9f29285"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6VEtNU",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx",
+        "line": null,
+        "originalLine": 134,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-30T10:53:28Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30255#discussion_r3682093502",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/0c78e8b7cf19237b2c1f77c4c7d95378e9f29285/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx#L134",
+      "diffHunk": "@@ -84,43 +87,60 @@ export const TransactionDetailScreen = ({\n \n     const allOutputs = account !== null ? createTargets({ transaction, account }) : [];\n \n+    // WETH wrap/unwrap and unstake render their own amount-bearing title directly, bypassing the\n+    // generic \"<type> transaction\" header template (which would append \" transaction\" to the label).\n+    let transactionTitle: ReactNode;\n+    if (isUnstakeTransaction) {\n+        transactionTitle = (\n+            <UnstakeTransactionDetailTitle\n+                unstakeAmount={unstakeAmount}\n+                symbol={transaction.symbol}\n+                variant=\"body-md-strong\"\n+            />\n+        );\n+    } else if (wrapKind) {\n+        transactionTitle = (\n+            <WrapTransactionName\n+                transaction={transaction}\n+                kind={wrapKind}\n+                variant=\"body-md-strong\"\n+            />\n+        );\n+    } else {\n+        transactionTitle = (\n+            <>\n+                <TokenIcon\n+                    symbol={transaction.symbol}\n+                    contractAddress={tokenTransfer?.contract}\n+                    showNetworkIcon\n+                />\n+                <Text variant=\"body-md-strong\">\n+                    <Translation\n+                        id=\"transactions.detail.header\"\n+                        values={{\n+                            transactionType: () => (\n+                                <TransactionName\n+                                    key={transaction.txid}\n+                                    transaction={transaction}\n+                                    isPending={isPending}\n+                                    variant=\"body-md-strong\"\n+                                />\n+                            ),\n+                        }}\n+                    />\n+                </Text>\n+            </>\n+        );\n+    }",
+      "comments": [
+        {
+          "databaseId": 3682093502,
+          "author": "cermakjiri",
+          "body": "To maintain the render method readability, I'd suggest move this to new component and doing early returns ",
+          "createdAt": "2026-07-30T10:53:28Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30255#discussion_r3682093502",
+          "isMine": true
+        },
+        {
+          "databaseId": 3704888570,
+          "author": "tomasklim",
+          "body": "Extracted into a new `TransactionDetailTitle` component with early returns 👍",
+          "createdAt": "2026-08-03T14:36:11Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30255#discussion_r3704888570",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G56",
+      "topic": "data-fetching-tanstack-query",
+      "tags": [
+        "use-query",
+        "declarative",
+        "less-code"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29622,
+        "title": "feat(suite-native): evm cancel ",
+        "url": "https://github.com/trezor/trezor-suite/pull/29622",
+        "author": "53gur0",
+        "state": "OPEN",
+        "createdAt": "2026-07-09T12:11:06Z",
+        "headRefOid": "d7908c9bf897b8ce10011e7f9c02e81bba3612b5"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6VFRu_",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts",
+        "line": 66,
+        "originalLine": 66,
+        "startLine": 66,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-30T11:31:34Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682308103",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts#L66",
+      "diffHunk": "@@ -53,62 +51,17 @@ export const useEthereumCancelTxCompose = ({ account, tx }: UseEthereumCancelTxC\n         error: mutationError,\n         isPending: isComposing,\n     } = useMutation({\n-        mutationFn: async (): Promise<{\n-            composedCancelTx: PrecomposedTransactionFinalCancelRbf;\n-            cancelFormState: FormState;\n-        }> => {\n-            if (!feeInfo || tx.rbfParams?.type !== 'ethereum') {\n-                throw new Error('Missing fee info or invalid RBF params for Ethereum cancellation');\n+        mutationFn: async (): Promise<ComposedEthereumCancelTransaction> => {\n+            if (account.networkType !== 'ethereum') {\n+                throw new Error('Ethereum cancellation is only available for EVM accounts');\n             }\n \n-            const { rbfParams } = tx;\n-            const network = getNetwork(account.symbol);\n-\n-            const formState: FormState = {\n-                outputs: [\n-                    {\n-                        type: 'payment',\n-                        address: account.descriptor,\n-                        amount: '0',\n-                        fiat: '',\n-                        currency: { value: '', label: '' },\n-                        token: null,\n-                    },\n-                ],\n-                selectedFee: 'normal',\n-                feePerUnit: '',\n-                feeLimit: '',\n-                options: ['broadcast'],\n-                isCoinControlEnabled: false,\n-                hasCoinControlBeenOpened: false,\n-                selectedUtxos: [],\n-                rbfParams,\n-            };\n-\n-            const feeLevels = await dispatch(\n-                composeSendFormTransactionFeeLevelsThunk({\n-                    formState,\n-                    composeContext: {\n-                        account,\n-                        network,\n-                        feeInfo: getEthereumRbfFeeInfo(feeInfo, rbfParams),\n-                    },\n-                }),\n-            ).unwrap();\n-\n-            const normalLevel = feeLevels.normal;\n-            if (!normalLevel || normalLevel.type === 'error' || normalLevel.type === 'nonfinal') {\n-                throw new Error('Unable to compose a valid cancellation fee level.');\n+            const result = await dispatch(composeEthereumCancelTransactionThunk({ account, tx }));\n+            if (isRejected(result)) {\n+                throw result.payload ?? new Error('Unknown error');\n             }\n \n-            return {\n-                composedCancelTx: {\n-                    ...normalLevel,\n-                    rbfType: 'cancel',\n-                    prevTxid: tx.txid,\n-                } as PrecomposedTransactionFinalCancelRbf,\n-                cancelFormState: formState,\n-            };\n+            return result.payload;\n         },\n     });",
+      "comments": [
+        {
+          "databaseId": 3682308103,
+          "author": "cermakjiri",
+          "body": "Why not using useQuery if it's more declarative than imperative use-case? It would result in shorter code a little:\n\n```ts\n    const { ... } = useQuery({\n        enabled: account.networkType === 'ethereum' && !!feeInfo && tx.rbfParams?.type === 'ethereum',\n        queryKey: [],\n        queryFn: async () => {\n            const result = await dispatch(composeEthereumCancelTransactionThunk({ account, tx }));\n\n            if (isRejected(result)) {\n                throw result.payload ?? new Error('Unknown error');\n            }\n\n            return result.payload;\n        }\n    })\n```",
+          "createdAt": "2026-07-30T11:31:34Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682308103",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G57",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "avoid-cast",
+        "satisfies"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29622,
+        "title": "feat(suite-native): evm cancel ",
+        "url": "https://github.com/trezor/trezor-suite/pull/29622",
+        "author": "53gur0",
+        "state": "OPEN",
+        "createdAt": "2026-07-09T12:11:06Z",
+        "headRefOid": "d7908c9bf897b8ce10011e7f9c02e81bba3612b5"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6VFTbC",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts",
+        "line": 100,
+        "originalLine": 100,
+        "startLine": 100,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-30T11:33:25Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682317823",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts#L100",
+      "diffHunk": "@@ -0,0 +1,104 @@\n+import { isRejected } from '@reduxjs/toolkit';\n+\n+import { createThunk } from '@suite-common/redux-utils';\n+import { getNetwork } from '@suite-common/wallet-config';\n+import {\n+    type AccountWithNetworkType,\n+    type FormState,\n+    type PrecomposedTransactionFinalCancelRbf,\n+    type WalletAccountTransactionWithRequiredRbfParams,\n+} from '@suite-common/wallet-types';\n+\n+import { selectConvertedNetworkFeeInfo } from '../../fees/feesReducer';\n+import { SEND_MODULE_PREFIX } from '../sendFormConstants';\n+import { getEthereumRbfFeeInfo } from '../sendFormEthereumThunks';\n+import { composeSendFormTransactionFeeLevelsThunk } from '../sendFormThunks';\n+import { type ComposeFeeLevelsError } from '../sendFormTypes';\n+\n+export type ComposeEthereumCancelTransactionThunkParams = {\n+    account: AccountWithNetworkType<'ethereum'>;\n+    tx: WalletAccountTransactionWithRequiredRbfParams;\n+};\n+\n+export type ComposedEthereumCancelTransaction = {\n+    composedCancelTx: PrecomposedTransactionFinalCancelRbf;\n+    cancelFormState: FormState;\n+};\n+\n+/**\n+ * Composes an EVM cancel transaction: a 0-value transfer to the account's own address reusing the\n+ * original tx's nonce (via `rbfParams`, applied at signing time) with a fee bumped above the\n+ * original gas params so the mempool accepts the replacement.\n+ */\n+export const composeEthereumCancelTransactionThunk = createThunk<\n+    ComposedEthereumCancelTransaction,\n+    ComposeEthereumCancelTransactionThunkParams,\n+    { rejectValue: ComposeFeeLevelsError }\n+>(\n+    `${SEND_MODULE_PREFIX}/composeEthereumCancelTransactionThunk`,\n+    async ({ account, tx }, { dispatch, getState, rejectWithValue }) => {\n+        const feeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);\n+        const { rbfParams } = tx;\n+\n+        if (!feeInfo || rbfParams.type !== 'ethereum') {\n+            return rejectWithValue({\n+                error: 'fee-levels-compose-failed',\n+                message: 'Missing fee info or invalid RBF params for Ethereum cancellation.',\n+            });\n+        }\n+\n+        const cancelFormState: FormState = {\n+            outputs: [\n+                {\n+                    type: 'payment',\n+                    address: account.descriptor,\n+                    amount: '0',\n+                    fiat: '',\n+                    currency: { value: '', label: '' },\n+                    token: null,\n+                },\n+            ],\n+            selectedFee: 'normal',\n+            feePerUnit: '',\n+            feeLimit: '',\n+            options: ['broadcast'],\n+            isCoinControlEnabled: false,\n+            hasCoinControlBeenOpened: false,\n+            selectedUtxos: [],\n+            rbfParams,\n+        };\n+\n+        const response = await dispatch(\n+            composeSendFormTransactionFeeLevelsThunk({\n+                formState: cancelFormState,\n+                composeContext: {\n+                    account,\n+                    network: getNetwork(account.symbol),\n+                    feeInfo: getEthereumRbfFeeInfo(feeInfo, rbfParams),\n+                },\n+            }),\n+        );\n+\n+        if (isRejected(response)) {\n+            return rejectWithValue(response.payload ?? { error: 'fee-levels-compose-failed' });\n+        }\n+\n+        const normalLevel = response.payload.normal;\n+        if (!normalLevel || normalLevel.type === 'error' || normalLevel.type === 'nonfinal') {\n+            return rejectWithValue({\n+                error: 'fee-levels-compose-failed',\n+                message: 'Unable to compose a valid cancellation fee level.',\n+            });\n+        }\n+\n+        return {\n+            // The ethereum compose path never yields the Cardano-specific final shape.\n+            composedCancelTx: {\n+                ...normalLevel,\n+                rbfType: 'cancel',\n+                prevTxid: tx.txid,\n+            } as PrecomposedTransactionFinalCancelRbf,",
+      "comments": [
+        {
+          "databaseId": 3682317823,
+          "author": "cermakjiri",
+          "body": "The casting doesn't feel right here. Can we rather use `satisfies` or add new type?",
+          "createdAt": "2026-07-30T11:33:25Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682317823",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G58",
+      "topic": "data-fetching-tanstack-query",
+      "tags": [
+        "use-query-select",
+        "nit"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29622,
+        "title": "feat(suite-native): evm cancel ",
+        "url": "https://github.com/trezor/trezor-suite/pull/29622",
+        "author": "53gur0",
+        "state": "OPEN",
+        "createdAt": "2026-07-09T12:11:06Z",
+        "headRefOid": "d7908c9bf897b8ce10011e7f9c02e81bba3612b5"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6VFXRL",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite-common/wallet-core/src/send/useEvmNonceInfo.ts",
+        "line": 95,
+        "originalLine": 95,
+        "startLine": 95,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-30T11:37:36Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682340518",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-common/wallet-core/src/send/useEvmNonceInfo.ts#L95",
+      "diffHunk": "",
+      "comments": [
+        {
+          "databaseId": 3682340518,
+          "author": "cermakjiri",
+          "body": "NIT (ignore if you will): This might be part of the useQuery as `select` method. Anyway I guess there's no advantage compare to this solution.  ",
+          "createdAt": "2026-07-30T11:37:36Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682340518",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G59",
+      "topic": "runtime-validation-and-parsing",
+      "tags": [
+        "zod",
+        "optional-chaining"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29622,
+        "title": "feat(suite-native): evm cancel ",
+        "url": "https://github.com/trezor/trezor-suite/pull/29622",
+        "author": "53gur0",
+        "state": "OPEN",
+        "createdAt": "2026-07-09T12:11:06Z",
+        "headRefOid": "d7908c9bf897b8ce10011e7f9c02e81bba3612b5"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6VFbQ1",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-native/module-transactions/src/hooks/useCancelEvmTransaction.ts",
+        "line": 67,
+        "originalLine": 67,
+        "startLine": 67,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-30T11:41:53Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682364238",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-native/module-transactions/src/hooks/useCancelEvmTransaction.ts#L67",
+      "diffHunk": "@@ -0,0 +1,221 @@\n+import { useCallback, useMemo } from 'react';\n+import { useDispatch, useSelector } from 'react-redux';\n+\n+import { useNavigation } from '@react-navigation/native';\n+import { isFulfilled, isRejected } from '@reduxjs/toolkit';\n+\n+import { useMutation } from '@suite-common/react-query';\n+import {\n+    type AccountsRootState,\n+    type PushTransactionError,\n+    type SignTransactionError,\n+    type SignTransactionTimeoutError,\n+    type TransactionsRootState,\n+    composeEthereumCancelTransactionThunk,\n+    selectAccountByKey,\n+    selectIsTransactionPending,\n+    useEvmNonceInfo,\n+} from '@suite-common/wallet-core';\n+import {\n+    type AccountKey,\n+    type WalletAccountTransaction,\n+    type WalletAccountTransactionWithRequiredRbfParams,\n+} from '@suite-common/wallet-types';\n+import {\n+    getNetworkAccountFeatures,\n+    getPendingEvmNonceStatus,\n+    isTransactionBumpable,\n+    isTransactionCancellable,\n+} from '@suite-common/wallet-utils';\n+import { useTranslate } from '@suite-native/intl';\n+import {\n+    type NavigateParameters,\n+    type RootStackParamList,\n+    RootStackRoutes,\n+    type StackToStackCompositeNavigationProps,\n+    type TransactionDetailStackParamList,\n+    TransactionDetailStackRoutes,\n+} from '@suite-native/navigation';\n+import { signAndPushEvmCancelTransactionThunk } from '@suite-native/send';\n+import { useToast } from '@suite-native/toasts';\n+\n+import { useDeviceGuardedSign } from './useDeviceGuardedSign';\n+\n+type NavigationProp = StackToStackCompositeNavigationProps<\n+    TransactionDetailStackParamList,\n+    TransactionDetailStackRoutes.TransactionDetail,\n+    RootStackParamList\n+>;\n+\n+const hasEthereumRbfParams = (\n+    tx: WalletAccountTransaction,\n+): tx is WalletAccountTransactionWithRequiredRbfParams => tx.rbfParams?.type === 'ethereum';\n+\n+// Mirrors the reject value of signAndPushEvmCancelTransactionThunk.\n+type CancelFailure =\n+    | SignTransactionError\n+    | SignTransactionTimeoutError\n+    | PushTransactionError\n+    | undefined;\n+\n+// Extracts a human-readable failure reason: push failures carry the node's message in `metadata`\n+// (e.g. \"nonce too low\", \"could not replace existing tx\"), while signing failures/timeouts expose\n+// it directly on `message`.\n+const getCancelFailureReason = (error: CancelFailure): string | undefined => {\n+    if (!error) return undefined;\n+\n+    if ('metadata' in error) return error.metadata.error.message;",
+      "comments": [
+        {
+          "databaseId": 3682364238,
+          "author": "cermakjiri",
+          "body": "I dunno, I'd either use Zod schema for parsing or use `.?` operator as it can be undefined ",
+          "createdAt": "2026-07-30T11:41:53Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682364238",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G60",
+      "topic": "data-fetching-tanstack-query",
+      "tags": [
+        "use-query"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29622,
+        "title": "feat(suite-native): evm cancel ",
+        "url": "https://github.com/trezor/trezor-suite/pull/29622",
+        "author": "53gur0",
+        "state": "OPEN",
+        "createdAt": "2026-07-09T12:11:06Z",
+        "headRefOid": "d7908c9bf897b8ce10011e7f9c02e81bba3612b5"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6VFeR0",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-native/module-transactions/src/hooks/useDeviceGuardedSign.ts",
+        "line": 74,
+        "originalLine": 74,
+        "startLine": 74,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-30T11:45:02Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682381623",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-native/module-transactions/src/hooks/useDeviceGuardedSign.ts#L74",
+      "diffHunk": "@@ -0,0 +1,88 @@\n+import { useCallback, useRef, useState } from 'react';\n+import { useSelector } from 'react-redux';\n+\n+import { useFocusEffect, useNavigation } from '@react-navigation/native';\n+\n+import {\n+    type DeviceRootState,\n+    selectDeviceButtonRequestsCodes,\n+    selectIsDeviceConnectedAndAuthorized,\n+} from '@suite-common/device';\n+import {\n+    AuthorizeDeviceStackRoutes,\n+    type NavigateParameters,\n+    type RootStackParamList,\n+    RootStackRoutes,\n+    type StackToStackCompositeNavigationProps,\n+    type TransactionDetailStackParamList,\n+    type TransactionDetailStackRoutes,\n+} from '@suite-native/navigation';\n+\n+type NavigationProp = StackToStackCompositeNavigationProps<\n+    TransactionDetailStackParamList,\n+    TransactionDetailStackRoutes.TransactionDetail,\n+    RootStackParamList\n+>;\n+\n+type UseDeviceGuardedSignParams = {\n+    // The signing action to run once the device is connected and authorized.\n+    sign: () => Promise<void>;\n+    // Where the connection guard returns the user if they abort connecting the device.\n+    cancelNavigationTarget: NavigateParameters<RootStackParamList>;\n+};\n+\n+/**\n+ * Runs a signing action behind the native device-connection guard: `requestSign` routes through the\n+ * DeviceConnectionGuard screen (which connects/unlocks the device if needed, or returns immediately\n+ * when it's already authorized), and `sign` runs once this screen regains focus with an authorized\n+ * device. Exposes `isSigning` and `isWaitingForDevice` (the device is showing a button request) for\n+ * the caller's UI. Mirrors the pattern the send/stellar flows use inline.\n+ */\n+export const useDeviceGuardedSign = ({\n+    sign,\n+    cancelNavigationTarget,\n+}: UseDeviceGuardedSignParams) => {\n+    const navigation = useNavigation<NavigationProp>();\n+    const isDeviceConnectedAndAuthorized = useSelector((state: DeviceRootState) =>\n+        selectIsDeviceConnectedAndAuthorized(state),\n+    );\n+    const buttonRequestCodes = useSelector((state: DeviceRootState) =>\n+        selectDeviceButtonRequestsCodes(state),\n+    );\n+\n+    const [isSigning, setIsSigning] = useState(false);\n+    const pendingSignRef = useRef(false);\n+    const isWaitingForDevice = isSigning && buttonRequestCodes.length > 0;\n+\n+    const runSign = useCallback(async () => {\n+        setIsSigning(true);\n+        try {\n+            await sign();\n+        } finally {\n+            setIsSigning(false);\n+        }\n+    }, [sign]);\n+\n+    // When the screen regains focus after the device-connection guard, execute the pending sign.\n+    useFocusEffect(\n+        useCallback(() => {\n+            if (pendingSignRef.current && isDeviceConnectedAndAuthorized) {\n+                pendingSignRef.current = false;\n+                runSign();\n+            }\n+        }, [isDeviceConnectedAndAuthorized, runSign]),\n+    );",
+      "comments": [
+        {
+          "databaseId": 3682381623,
+          "author": "cermakjiri",
+          "body": "this looks like job for `useQuery`",
+          "createdAt": "2026-07-30T11:45:02Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682381623",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G61",
+      "topic": "component-structure-and-files",
+      "tags": [
+        "one-component-per-file"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29622,
+        "title": "feat(suite-native): evm cancel ",
+        "url": "https://github.com/trezor/trezor-suite/pull/29622",
+        "author": "53gur0",
+        "state": "OPEN",
+        "createdAt": "2026-07-09T12:11:06Z",
+        "headRefOid": "d7908c9bf897b8ce10011e7f9c02e81bba3612b5"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6VFgQk",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-native/module-transactions/src/components/CancelEvmTransactionButton.tsx",
+        "line": 46,
+        "originalLine": 46,
+        "startLine": 46,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-30T11:47:08Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682393196",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-native/module-transactions/src/components/CancelEvmTransactionButton.tsx#L46",
+      "diffHunk": "@@ -0,0 +1,147 @@\n+import { type AccountKey, type WalletAccountTransaction } from '@suite-common/wallet-types';\n+import {\n+    BottomSheetModal,\n+    Box,\n+    Button,\n+    Text,\n+    VStack,\n+    useBottomSheetModal,\n+} from '@suite-native/atoms';\n+import { ConfirmOnTrezorAnimation } from '@suite-native/confirm-on-trezor';\n+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';\n+import { Translation, useTranslate } from '@suite-native/intl';\n+\n+import { TransactionDetailRow } from './TransactionDetailRow';\n+import { useCancelEvmTransaction } from '../hooks/useCancelEvmTransaction';\n+\n+type CancelEvmTransactionButtonProps = {\n+    accountKey: AccountKey;\n+    transaction: WalletAccountTransaction;\n+};\n+\n+type CancelTransactionFeeRowProps = {\n+    title: string;\n+    fee: string;\n+    symbol: WalletAccountTransaction['symbol'];\n+};\n+\n+const CancelTransactionFeeRow = ({ title, fee, symbol }: CancelTransactionFeeRowProps) => (\n+    <TransactionDetailRow title={title}>\n+        <Box alignItems=\"flex-end\">\n+            <CryptoAmountFormatter\n+                value={fee}\n+                symbol={symbol}\n+                variant=\"body-sm\"\n+                color=\"contentPrimary\"\n+                isBalance={false}\n+            />\n+            <CryptoToFiatAmountFormatter\n+                value={fee}\n+                symbol={symbol}\n+                variant=\"body-sm\"\n+                color=\"contentSecondary\"\n+            />\n+        </Box>\n+    </TransactionDetailRow>\n+);",
+      "comments": [
+        {
+          "databaseId": 3682393196,
+          "author": "cermakjiri",
+          "body": "Let's please have single react component per file (easier to find the component, easier to refactor the component, easier to read this file) 🙏 ",
+          "createdAt": "2026-07-30T11:47:08Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682393196",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G62",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "d-ts",
+        "redux-augmentation",
+        "question"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29622,
+        "title": "feat(suite-native): evm cancel ",
+        "url": "https://github.com/trezor/trezor-suite/pull/29622",
+        "author": "53gur0",
+        "state": "OPEN",
+        "createdAt": "2026-07-09T12:11:06Z",
+        "headRefOid": "d7908c9bf897b8ce10011e7f9c02e81bba3612b5"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6VF1ES",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-native/module-transactions/src/redux.d.ts",
+        "line": 11,
+        "originalLine": 11,
+        "startLine": 11,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-07-30T12:07:45Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682514942",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/d7908c9bf897b8ce10011e7f9c02e81bba3612b5/suite-native/module-transactions/src/redux.d.ts#L11",
+      "diffHunk": "@@ -0,0 +1,11 @@\n+import { type AsyncThunkAction, type ThunkAction } from '@reduxjs/toolkit';\n+\n+declare module 'redux' {\n+    export interface Dispatch<A extends Action = AnyAction> {\n+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;\n+\n+        <ReturnType = any, State = any, ExtraThunkArg = any>(\n+            thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, A>,\n+        ): ReturnType;\n+    }\n+}",
+      "comments": [
+        {
+          "databaseId": 3682514942,
+          "author": "cermakjiri",
+          "body": "is this really required? 👀 ",
+          "createdAt": "2026-07-30T12:07:45Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29622#discussion_r3682514942",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G63",
+      "topic": "component-structure-and-files",
+      "tags": [
+        "extract-component",
+        "render-profiler"
+      ],
+      "classifiedBy": "override",
+      "pending": true,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30154,
+        "title": "WIP: 28878 playwright perf tracking",
+        "url": "https://github.com/trezor/trezor-suite/pull/30154",
+        "author": "vojtatranta",
+        "state": "OPEN",
+        "createdAt": "2026-07-21T12:47:53Z",
+        "headRefOid": "3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6V6ebt",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "packages/suite/src/support/suite/Main.tsx",
+        "line": null,
+        "originalLine": 39,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-03T09:01:49Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30154#discussion_r3702586003",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef/packages/suite/src/support/suite/Main.tsx#L39",
+      "diffHunk": "@@ -17,6 +18,25 @@ import { ResponsiveContextProvider } from 'src/support/suite/ResponsiveContext';\n import { RouterHandler } from './RouterHandler';\n import { useConnectPopupModals } from './useConnectPopupModals';\n \n+// DefinePlugin constant, true only for the e2e perf build. Everywhere else it is `false`, so the\n+// <Profiler> branch below and these helpers are dead-code-eliminated from production bundles.\n+const PERF_PROFILER_BUILD = process.env.PERF_PROFILER as unknown as boolean;\n+\n+// The perf-e2e instrumentation exposes __trezorPerf__ before the app loads; onRender no-ops when the\n+// global is absent.\n+const getPerfController = () =>\n+    typeof window !== 'undefined'\n+        ? (\n+              window as unknown as {\n+                  __trezorPerf__?: { recordRender?: (actualDuration: number) => void };\n+              }\n+          ).__trezorPerf__\n+        : undefined;\n+\n+const onPerfRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {\n+    getPerfController()?.recordRender?.(actualDuration);\n+};\n+",
+      "comments": [
+        {
+          "databaseId": 3702586003,
+          "author": "cermakjiri",
+          "body": "Let's move everything new here to `RenderProfiler` component",
+          "createdAt": "2026-08-03T09:01:49Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30154#discussion_r3702586003",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G64",
+      "topic": "error-handling-and-devx",
+      "tags": [
+        "fail-loudly",
+        "skip-vs-throw",
+        "e2e"
+      ],
+      "classifiedBy": "override",
+      "pending": true,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30154,
+        "title": "WIP: 28878 playwright perf tracking",
+        "url": "https://github.com/trezor/trezor-suite/pull/30154",
+        "author": "vojtatranta",
+        "state": "OPEN",
+        "createdAt": "2026-07-21T12:47:53Z",
+        "headRefOid": "3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6V6hAa",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite/e2e/performance/perfMeasure.ts",
+        "line": 53,
+        "originalLine": 57,
+        "startLine": 53,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-03T09:04:33Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30154#discussion_r3702600838",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef/suite/e2e/performance/perfMeasure.ts#L53",
+      "diffHunk": "@@ -0,0 +1,149 @@\n+import { CDPSession, Page, TestInfo } from '@playwright/test';\n+import { appendFileSync, writeFileSync } from 'fs';\n+import path from 'path';\n+\n+import {\n+    PerfMetrics,\n+    buildJsonReport,\n+    compareScenario,\n+    formatHumanReport,\n+    getScenarioBaseline,\n+    loadBaselinesSync,\n+    readPerfMetrics,\n+    startPerfMeasurement,\n+} from '@trezor/perf-e2e';\n+\n+export const BASELINES_PATH = path.join(__dirname, 'baselines.json');\n+\n+// Gitignored, accumulates across runs. `perf:update` promotes medians from it into the baselines, so\n+// accepting new numbers never requires a dedicated re-run.\n+export const SAMPLES_PATH = path.join(__dirname, '.perf-samples.jsonl');\n+\n+// Lets the long-task observer flush and trailing renders settle before metrics are read.\n+const SETTLE_MS = 400;\n+\n+// Chrome trace categories that make a rerender/long-task investigation possible.\n+const TRACE_CATEGORIES = [\n+    'devtools.timeline',\n+    'disabled-by-default-devtools.timeline',\n+    'v8.execute',\n+    'disabled-by-default-v8.cpu_profiler',\n+    'blink.user_timing',\n+    'loading',\n+    'toplevel',\n+];\n+\n+/**\n+ * Measures a single interaction and enforces the performance baseline.\n+ *\n+ * Instrumentation is installed globally at app load (see `electronSetup`), so no reload is needed\n+ * here. On a target where it was not installed, the interaction still runs and measurement is\n+ * skipped.\n+ */\n+export const measurePerformance = async (\n+    page: Page,\n+    testInfo: TestInfo,\n+    scenario: string,\n+    interaction: () => Promise<void>,\n+): Promise<PerfMetrics | null> => {\n+    const installed = await page.evaluate(\n+        () =>\n+            typeof (window as unknown as { __trezorPerf__?: unknown }).__trezorPerf__ !==\n+            'undefined',\n+    );\n+    if (!installed) {\n+        // eslint-disable-next-line no-console\n+        console.log(\n+            `[perf] instrumentation not installed (non-web target?) — skipping \"${scenario}\"`,",
+      "comments": [
+        {
+          "databaseId": 3702600838,
+          "author": "cermakjiri",
+          "body": "It's for desktop too. I think this should throw an error instead (i.e. if a dev attempts to measure a test there's missing `__trezorPerf__`, why skipping it, right?)",
+          "createdAt": "2026-08-03T09:04:33Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30154#discussion_r3702600838",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G65",
+      "topic": "error-handling-and-devx",
+      "tags": [
+        "logging",
+        "debug-flag",
+        "observability"
+      ],
+      "classifiedBy": "override",
+      "pending": true,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30154,
+        "title": "WIP: 28878 playwright perf tracking",
+        "url": "https://github.com/trezor/trezor-suite/pull/30154",
+        "author": "vojtatranta",
+        "state": "OPEN",
+        "createdAt": "2026-07-21T12:47:53Z",
+        "headRefOid": "3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6V942D",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/perf-e2e/src/instrumentation.ts",
+        "line": 69,
+        "originalLine": 78,
+        "startLine": 69,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-03T12:29:40Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30154#discussion_r3703857163",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef/packages/perf-e2e/src/instrumentation.ts#L69",
+      "diffHunk": "@@ -0,0 +1,197 @@\n+import { type PerfMetrics } from './types';\n+\n+/**\n+ * Browser-side instrumentation.\n+ *\n+ * The functions below are executed inside the page, not in Node. They are handed verbatim to\n+ * Playwright (`page.addInitScript` / `page.evaluate`), which serializes their source, so they MUST\n+ * be fully self-contained: no imports, no closures over module state, only browser globals.\n+ *\n+ * `installPerfInstrumentation` must run at document start (before react-dom loads) so the React\n+ * commit hook is installed before React probes `__REACT_DEVTOOLS_GLOBAL_HOOK__`.\n+ */\n+\n+export const PERF_GLOBAL_KEY = '__trezorPerf__';\n+\n+type PerfController = {\n+    start: () => void;\n+    stop: () => PerfMetrics;\n+    /** Fed by the app's <Profiler> onRender (see suite Main). Accumulates render duration. */\n+    recordRender: (actualDuration: number) => void;\n+};\n+\n+/**\n+ * Idempotent.\n+ *\n+ * - React commit count: hooks `__REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberRoot` (works on any\n+ *   build). Render *duration* comes from a real React <Profiler> in the app calling `recordRender`;\n+ *   that only produces non-zero values when the app is built with React's profiling build\n+ *   (`PERF_PROFILER` webpack alias), which the e2e desktop build enables.\n+ * - Long tasks / TBT: a `longtask` PerformanceObserver buffers every entry; the window is applied\n+ *   at `stop()` time so entries delivered late (observer callbacks are async) are not lost.\n+ */\n+export function installPerfInstrumentation(): void {\n+    // Only instrument the top-level app frame. This init script runs in every frame (including the\n+    // cross-origin Trezor Connect iframe/popup that handles device communication), and we must never\n+    // touch those — measure only the main app. Comparing window references is same-origin-safe.\n+    if (typeof window === 'undefined' || window.top !== window.self) {\n+        return;\n+    }\n+\n+    const w = window as unknown as Record<string, unknown>;\n+    if (w.__trezorPerf__) {\n+        return;\n+    }\n+\n+    const state = {\n+        enabled: false,\n+        startTime: 0,\n+        endTime: 0,\n+        commitCount: 0,\n+        renderDurationMs: 0,\n+        // Whether the app's <Profiler> reported at least one render this window. Stays false when the\n+        // app is not built with React's profiling build — then render duration is unavailable (null),\n+        // not 0, so it is never mistaken for an improvement.\n+        renderRecorded: false,\n+        longTasks: [] as Array<{ start: number; duration: number }>,\n+    };\n+\n+    const onCommit = (): void => {\n+        if (!state.enabled) {\n+            return;\n+        }\n+        state.commitCount += 1;\n+    };\n+\n+    const hookKey = '__REACT_DEVTOOLS_GLOBAL_HOOK__';\n+    const existingHook = w[hookKey] as\n+        | { onCommitFiberRoot?: (...args: unknown[]) => unknown }\n+        | undefined;\n+\n+    if (existingHook) {\n+        // Real DevTools hook already present (e.g. extension): wrap the existing callback.\n+        const previous = existingHook.onCommitFiberRoot;\n+        existingHook.onCommitFiberRoot = (...args: unknown[]) => {\n+            try {\n+                onCommit();\n+            } catch {\n+                // ignore instrumentation errors, never break the app",
+      "comments": [
+        {
+          "databaseId": 3703857163,
+          "author": "cermakjiri",
+          "body": "it might not a break the app but could signal something's off regarding the perf. measurement. What about enabling the logging when adding `--debug` flag?",
+          "createdAt": "2026-08-03T12:29:40Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30154#discussion_r3703857163",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G66",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "cross-reference"
+      ],
+      "classifiedBy": "override",
+      "pending": true,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30154,
+        "title": "WIP: 28878 playwright perf tracking",
+        "url": "https://github.com/trezor/trezor-suite/pull/30154",
+        "author": "vojtatranta",
+        "state": "OPEN",
+        "createdAt": "2026-07-21T12:47:53Z",
+        "headRefOid": "3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6V95Qp",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/perf-e2e/src/instrumentation.ts",
+        "line": 91,
+        "originalLine": 100,
+        "startLine": 91,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-03T12:30:03Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30154#discussion_r3703859601",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/3dc9f6035d8c44fd7082e6f689cd3d03f2a9baef/packages/perf-e2e/src/instrumentation.ts#L91",
+      "diffHunk": "@@ -0,0 +1,197 @@\n+import { type PerfMetrics } from './types';\n+\n+/**\n+ * Browser-side instrumentation.\n+ *\n+ * The functions below are executed inside the page, not in Node. They are handed verbatim to\n+ * Playwright (`page.addInitScript` / `page.evaluate`), which serializes their source, so they MUST\n+ * be fully self-contained: no imports, no closures over module state, only browser globals.\n+ *\n+ * `installPerfInstrumentation` must run at document start (before react-dom loads) so the React\n+ * commit hook is installed before React probes `__REACT_DEVTOOLS_GLOBAL_HOOK__`.\n+ */\n+\n+export const PERF_GLOBAL_KEY = '__trezorPerf__';\n+\n+type PerfController = {\n+    start: () => void;\n+    stop: () => PerfMetrics;\n+    /** Fed by the app's <Profiler> onRender (see suite Main). Accumulates render duration. */\n+    recordRender: (actualDuration: number) => void;\n+};\n+\n+/**\n+ * Idempotent.\n+ *\n+ * - React commit count: hooks `__REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberRoot` (works on any\n+ *   build). Render *duration* comes from a real React <Profiler> in the app calling `recordRender`;\n+ *   that only produces non-zero values when the app is built with React's profiling build\n+ *   (`PERF_PROFILER` webpack alias), which the e2e desktop build enables.\n+ * - Long tasks / TBT: a `longtask` PerformanceObserver buffers every entry; the window is applied\n+ *   at `stop()` time so entries delivered late (observer callbacks are async) are not lost.\n+ */\n+export function installPerfInstrumentation(): void {\n+    // Only instrument the top-level app frame. This init script runs in every frame (including the\n+    // cross-origin Trezor Connect iframe/popup that handles device communication), and we must never\n+    // touch those — measure only the main app. Comparing window references is same-origin-safe.\n+    if (typeof window === 'undefined' || window.top !== window.self) {\n+        return;\n+    }\n+\n+    const w = window as unknown as Record<string, unknown>;\n+    if (w.__trezorPerf__) {\n+        return;\n+    }\n+\n+    const state = {\n+        enabled: false,\n+        startTime: 0,\n+        endTime: 0,\n+        commitCount: 0,\n+        renderDurationMs: 0,\n+        // Whether the app's <Profiler> reported at least one render this window. Stays false when the\n+        // app is not built with React's profiling build — then render duration is unavailable (null),\n+        // not 0, so it is never mistaken for an improvement.\n+        renderRecorded: false,\n+        longTasks: [] as Array<{ start: number; duration: number }>,\n+    };\n+\n+    const onCommit = (): void => {\n+        if (!state.enabled) {\n+            return;\n+        }\n+        state.commitCount += 1;\n+    };\n+\n+    const hookKey = '__REACT_DEVTOOLS_GLOBAL_HOOK__';\n+    const existingHook = w[hookKey] as\n+        | { onCommitFiberRoot?: (...args: unknown[]) => unknown }\n+        | undefined;\n+\n+    if (existingHook) {\n+        // Real DevTools hook already present (e.g. extension): wrap the existing callback.\n+        const previous = existingHook.onCommitFiberRoot;\n+        existingHook.onCommitFiberRoot = (...args: unknown[]) => {\n+            try {\n+                onCommit();\n+            } catch {\n+                // ignore instrumentation errors, never break the app\n+            }\n+\n+            return typeof previous === 'function' ? previous.apply(existingHook, args) : undefined;\n+        };\n+    } else {\n+        let nextRendererId = 1;\n+        const renderers = new Map<number, unknown>();\n+        w[hookKey] = {\n+            renderers,\n+            supportsFiber: true,\n+            inject(renderer: unknown): number {\n+                const id = nextRendererId;\n+                nextRendererId += 1;\n+                renderers.set(id, renderer);\n+\n+                return id;\n+            },\n+            onCommitFiberRoot: () => {\n+                try {\n+                    onCommit();\n+                } catch {\n+                    // ignore",
+      "comments": [
+        {
+          "databaseId": 3703859601,
+          "author": "cermakjiri",
+          "body": "https://github.com/trezor/trezor-suite/pull/30154/changes#r3703857163",
+          "createdAt": "2026-08-03T12:30:03Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30154#discussion_r3703859601",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G67",
+      "topic": "performance-and-memoization",
+      "tags": [
+        "combine-use-memo",
+        "same-deps"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30791,
+        "title": "Earn Yield - Add Rewards Tooltips",
+        "url": "https://github.com/trezor/trezor-suite/pull/30791",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-04T09:53:31Z",
+        "headRefOid": "f3b38dbf735eb0709fab5b9ce61e8dea38c75eb8"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6WR352",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts",
+        "line": 85,
+        "originalLine": 85,
+        "startLine": 85,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-04T10:30:28Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30791#discussion_r3711500676",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/f3b38dbf735eb0709fab5b9ce61e8dea38c75eb8/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts#L85",
+      "diffHunk": "@@ -0,0 +1,88 @@\n+import { useMemo } from 'react';\n+\n+import {\n+    type AccountWithNetworkType,\n+    type BaseCurrencyAmount,\n+    asBaseCurrencyAmount,\n+} from '@suite-common/wallet-types';\n+import { type AmountUnit, asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';\n+import { BigNumber } from '@trezor/utils';\n+\n+import { type useMerklRewards } from 'src/components/earn/yield/claim/hooks';\n+\n+interface UseYieldClaimRewardsDataProps {\n+    rewards: ReturnType<typeof useMerklRewards>['merklRewardsQuery'];\n+}\n+\n+interface UseYieldClaimRewardsDataResult {\n+    accountRewards: AccountRewards;\n+    tokenRewards: TokenRewards;\n+}\n+\n+interface AccountReward {\n+    account: AccountWithNetworkType<'ethereum'>;\n+    fiat: BigNumber;\n+}\n+\n+export type AccountRewards = AccountReward[];\n+\n+interface TokenReward {\n+    symbol: string;\n+    crypto: AmountUnit;\n+    fiat: BaseCurrencyAmount;\n+}\n+\n+export type TokenRewards = TokenReward[];\n+\n+type TokenMap = {\n+    [key: string]: { symbol: string; decimals: number; crypto: BigNumber; fiat: BigNumber };\n+};\n+\n+export const useYieldClaimRewardsData = ({\n+    rewards,\n+}: UseYieldClaimRewardsDataProps): UseYieldClaimRewardsDataResult => {\n+    const allRewards = useMemo(\n+        () => rewards.data.accountsRewards.flatMap(accountRewards => accountRewards.rewards),\n+        [rewards.data.accountsRewards],\n+    );\n+\n+    const accountRewards = useMemo(\n+        () =>\n+            rewards.data.accountsRewards.map(item => ({\n+                account: item.account,\n+                fiat: item.totalClaimableFiatAmount,\n+            })) satisfies AccountRewards,\n+        [rewards.data.accountsRewards],\n+    );\n+\n+    const tokenRewards = useMemo(() => {\n+        const tokenMap: TokenMap = {};\n+\n+        for (const reward of allRewards) {\n+            const entry = tokenMap[reward.token.address] ?? {\n+                symbol: reward.token.symbol,\n+                decimals: reward.token.decimals,\n+                crypto: new BigNumber(0),\n+                fiat: new BigNumber(0),\n+            };\n+\n+            entry.crypto = entry.crypto.plus(reward.claimable);\n+            entry.fiat = entry.fiat.plus(reward.fiat.claimable ?? '0');\n+\n+            tokenMap[reward.token.address] = { ...entry };\n+        }\n+\n+        return Object.entries(tokenMap).map(([_, { symbol, decimals, ...entry }]) => {\n+            const crypto = subunitsToUnits({\n+                value: asAmountSubunit(entry.crypto),\n+                decimals,\n+            });\n+\n+            const fiat = asBaseCurrencyAmount(entry.fiat);\n+\n+            return { symbol, crypto, fiat };\n+        }) satisfies TokenRewards;\n+    }, [allRewards]);",
+      "comments": [
+        {
+          "databaseId": 3711500676,
+          "author": "cermakjiri",
+          "body": "NIT (memory):  all useMemo hooks can be combined into single one, all of them have the same dep (`rewards.data.accountsRewards`)",
+          "createdAt": "2026-08-04T10:30:28Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30791#discussion_r3711500676",
+          "isMine": true
+        },
+        {
+          "databaseId": 3711569842,
+          "author": "TomasBoda",
+          "body": "I agree, but I wanted to create a semantic distinction for better readability",
+          "createdAt": "2026-08-04T10:41:26Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30791#discussion_r3711569842",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G68",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "to-sorted",
+        "no-mutation"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30028,
+        "title": "Cardano staking updates",
+        "url": "https://github.com/trezor/trezor-suite/pull/30028",
+        "author": "tomasklim",
+        "state": "MERGED",
+        "createdAt": "2026-07-19T07:20:32Z",
+        "headRefOid": "7e62dbfeaae420a6bb64042264b12dccdd3ba28d"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6WS_VP",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "suite-common/wallet-utils/src/cardanoStakingUtils.ts",
+        "line": null,
+        "originalLine": 111,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-04T11:32:32Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30028#discussion_r3711920509",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/7e62dbfeaae420a6bb64042264b12dccdd3ba28d/suite-common/wallet-utils/src/cardanoStakingUtils.ts#L111",
+      "diffHunk": "@@ -92,27 +91,30 @@ export const poolBech32ToHex = (poolId: string): string => {\n     return Buffer.from(bytes).toString('hex');\n };\n \n-export const selectBestCardanoPool = (pools?: AdaPools['pools']) => {\n-    if (!pools || pools.length === 0) return CARDANO_EVERSTAKE_STAKING_POOL;\n-\n-    // find the one within the threshold\n-    const bestPool = pools.find(pool => pool.saturation < CARDANO_POOL_SATURATION_SAFE_THRESHOLD);\n-\n-    if (bestPool) {\n+export const selectBestCardanoPool = (pools?: AdaPools['pools'], currentPoolId?: string | null) => {\n+    // An account already delegated to an Everstake pool must never be moved to another\n+    // pool, no matter which UI flow composes the delegation.\n+    if (\n+        currentPoolId &&\n+        (EVERSTAKE_POOLS.includes(currentPoolId) || pools?.some(pool => pool.id === currentPoolId))\n+    ) {\n         return {\n-            hex: poolBech32ToHex(bestPool.id),\n-            bech32: bestPool.id,\n+            hex: poolBech32ToHex(currentPoolId),\n+            bech32: currentPoolId,\n         };\n     }\n \n-    // pick the last one (lowest saturation)\n-    const fallbackIndex = pools.length - 1;\n-    // @ts-expect-error: indexing with noUncheckedIndexedAccess\n-    const fallback: (typeof pools)[number] = pools[fallbackIndex];\n+    if (!pools || pools.length === 0) return CARDANO_EVERSTAKE_STAKING_POOL;\n+\n+    // Sort client-side instead of relying on the API ordering contract; new stakes\n+    // always go to the least saturated pool.\n+    const [bestPool] = [...pools].sort((a, b) => a.saturation - b.saturation);",
+      "comments": [
+        {
+          "databaseId": 3711920509,
+          "author": "cermakjiri",
+          "body": "nit: `pools.toSorted`",
+          "createdAt": "2026-08-04T11:32:32Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30028#discussion_r3711920509",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G69",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "extract-fn",
+        "early-return",
+        "nesting"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30028,
+        "title": "Cardano staking updates",
+        "url": "https://github.com/trezor/trezor-suite/pull/30028",
+        "author": "tomasklim",
+        "state": "MERGED",
+        "createdAt": "2026-07-19T07:20:32Z",
+        "headRefOid": "7e62dbfeaae420a6bb64042264b12dccdd3ba28d"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6WTJXX",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts",
+        "line": null,
+        "originalLine": 421,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-04T11:39:36Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30028#discussion_r3711981075",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/7e62dbfeaae420a6bb64042264b12dccdd3ba28d/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts#L421",
+      "diffHunk": "@@ -395,5 +402,23 @@ export const signTransaction =\n             return signedTx;\n         }\n \n-        return signedTx.payload.serializedTx;\n+        // Report the pool from the certificate that was actually signed, not a later\n+        // recomputation — a divergence from the account pool must stay observable.\n+        const fromPool = getCardanoAccountPoolId(account);\n+        const poolDelegation: StakingCardanoPoolDelegationPayload | undefined =\n+            formValues.stakeType === 'stake'\n+                ? {\n+                      fromPool: fromPool ? (EVERSTAKE_POOL_NAMES[fromPool] ?? fromPool) : undefined,\n+                      toPool: EVERSTAKE_POOL_NAMES[selectedPool.bech32] ?? selectedPool.bech32,\n+                      toPoolSaturation: cardanoPools.find(pool => pool.id === selectedPool.bech32)\n+                          ?.saturation,\n+                      poolsDataAvailable: cardanoPools.length > 0,\n+                      isEverstakeToEverstake:\n+                          fromPool !== null &&\n+                          fromPool !== selectedPool.bech32 &&\n+                          isCardanoStakedWithEverstake(account, cardanoPools),\n+                  }\n+                : undefined;",
+      "comments": [
+        {
+          "databaseId": 3711981075,
+          "author": "cermakjiri",
+          "body": "NIT (readability): It took me a while to digest this piece, I'd move it to `getPoolDelegation` with early `return` avoiding nesting.",
+          "createdAt": "2026-08-04T11:39:36Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30028#discussion_r3711981075",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G70",
+      "topic": "comments-and-docs",
+      "tags": [
+        "incomplete-comment"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30797,
+        "title": "feat(suite-desktop): ensure auto-tracked wrapped native assets",
+        "url": "https://github.com/trezor/trezor-suite/pull/30797",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-08-04T11:45:32Z",
+        "headRefOid": "f0c0c9ae1224757da8738a3abbc08f5d343c0706"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6WTvIt",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts",
+        "line": null,
+        "originalLine": 93,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-04T12:03:55Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30797#discussion_r3712209811",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/f0c0c9ae1224757da8738a3abbc08f5d343c0706/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts#L93",
+      "diffHunk": "@@ -85,27 +87,36 @@ export const submitWrapNativeTokenThunk = createThunk(\n                 return undefined;\n             }\n \n+            // Start tracking the wrapped native token so it shows up in the interface without the\n+            // user having to manually paste its contract address. Once it's part of account.tokens\n+            // it also survives account refreshes (see fetchAccountTokens). Dedupe so re-wrapping an\n+            // already-tracked token doesn't create a duplicate entry.",
+      "comments": [
+        {
+          "databaseId": 3712209811,
+          "author": "cermakjiri",
+          "body": "This comment misses some parts. Maybe adding one-line sentence comment could do it:\n```\n// Make sure re-wrapping doesn't create a duplicate\n```",
+          "createdAt": "2026-08-04T12:03:55Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30797#discussion_r3712209811",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G71",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval",
+        "pagination"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29445,
+        "title": "fix(suite): keep account graph data visible while refetching",
+        "url": "https://github.com/trezor/trezor-suite/pull/29445",
+        "author": "tomasklim",
+        "state": "MERGED",
+        "createdAt": "2026-07-05T17:33:47Z",
+        "headRefOid": "372eb0020be72615a95bf328f8a3526846e1b807"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6WUXFG",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "packages/suite/src/actions/wallet/graphActions.ts",
+        "line": 105,
+        "originalLine": 105,
+        "startLine": 105,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-04T12:29:54Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29445#discussion_r3712451459",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/372eb0020be72615a95bf328f8a3526846e1b807/packages/suite/src/actions/wallet/graphActions.ts#L105",
+      "diffHunk": "@@ -74,18 +86,24 @@ export const fetchAccountGraphData =\n                     descriptor: account.descriptor,\n                     symbol: account.symbol,\n                 },\n-                data: [],\n                 isLoading: true,\n                 error: false,\n             },\n         });\n \n         const baseCurrencyCode = selectBaseCurrency(getState());\n+\n+        const cachedData = selectAccountGraphData(getState(), account);\n+        // refetch one day earlier than the last cached point so the last cached bucket is always\n+        // recomputed, regardless of how backend bucket boundaries align with the local timezone\n+        const lastCachedPoint = cachedData && cachedData.length > 2 ? cachedData.at(-1) : undefined;\n+\n         const response = await TrezorConnect.blockchainGetAccountBalanceHistory({\n             coin: account.symbol,\n             identity: tryGetAccountIdentity(account),\n             descriptor: account.descriptor,\n-            groupBy: 3600 * 24, // day\n+            from: lastCachedPoint ? lastCachedPoint.time - DAY_IN_SECONDS : undefined,",
+      "comments": [
+        {
+          "databaseId": 3712451459,
+          "author": "cermakjiri",
+          "body": "ooff, so until now there wasn't any pagination. 😄 Nice improvement 👍 ",
+          "createdAt": "2026-08-04T12:29:54Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29445#discussion_r3712451459",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G72",
+      "topic": "data-fetching-tanstack-query",
+      "tags": [
+        "replace-thunk",
+        "tech-debt"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 29445,
+        "title": "fix(suite): keep account graph data visible while refetching",
+        "url": "https://github.com/trezor/trezor-suite/pull/29445",
+        "author": "tomasklim",
+        "state": "MERGED",
+        "createdAt": "2026-07-05T17:33:47Z",
+        "headRefOid": "372eb0020be72615a95bf328f8a3526846e1b807"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6WUawu",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/actions/wallet/graphActions.ts",
+        "line": 171,
+        "originalLine": 171,
+        "startLine": 171,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-04T12:32:06Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/29445#discussion_r3712475266",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/372eb0020be72615a95bf328f8a3526846e1b807/packages/suite/src/actions/wallet/graphActions.ts#L171",
+      "diffHunk": "@@ -127,7 +166,6 @@ export const fetchAccountGraphData =\n                         descriptor: account.descriptor,\n                         symbol: account.symbol,\n                     },\n-                    data: [],\n                     isLoading: false,\n                     error: true,\n                 },",
+      "comments": [
+        {
+          "databaseId": 3712475266,
+          "author": "cermakjiri",
+          "body": "I really don't like this thunk, it could be fairly easily replaced with tanstack query. But that's for another time, I know.",
+          "createdAt": "2026-08-04T12:32:06Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/29445#discussion_r3712475266",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G73",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "extract-fn",
+        "nonce-logic",
+        "correctness-question"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30910,
+        "title": "fix(suite-desktop): double-check nonces origination",
+        "url": "https://github.com/trezor/trezor-suite/pull/30910",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-08-05T13:44:55Z",
+        "headRefOid": "12d9c3c83e0083f174dc67d285823596bbfba921"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Wrxn2",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/wallet-utils/src/transactionUtils.ts",
+        "line": 182,
+        "originalLine": 182,
+        "startLine": 182,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-05T14:29:03Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721407524",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/12d9c3c83e0083f174dc67d285823596bbfba921/suite-common/wallet-utils/src/transactionUtils.ts#L182",
+      "diffHunk": "@@ -157,10 +174,12 @@ export const getEvmNonceInfo = (\n \n     // accountNonce (e.g. account.misc.nonce) can lag behind the local tx list if it hasn't been\n     // refreshed since a confirmed tx was locally picked up. A locally confirmed nonce proves a\n-    // higher true nonce exists, so it's a floor accountNonce can't be below. When no confirmed\n-    // nonce is locally known this is 0, so it never lowers accountNonce.\n-    const maxLocalConfirmedNonce = confirmedNonces.size > 0 ? Math.max(...confirmedNonces) + 1 : 0;\n-    const effectiveAccountNonce = Math.max(accountNonce, maxLocalConfirmedNonce);\n+    // higher true nonce exists, so it's a floor accountNonce can't be below. The floor walks up\n+    // contiguously rather than jumping to max(confirmedNonces): an isolated outlier (a corrupted\n+    // record, or a nonce that never belonged to this account) is then never reached — see\n+    // getEvmNonceInfoFromConfirmedNonce for the same reasoning.\n+    let effectiveAccountNonce = accountNonce;\n+    while (confirmedNonces.has(effectiveAccountNonce)) effectiveAccountNonce += 1;",
+      "comments": [
+        {
+          "databaseId": 3721407524,
+          "author": "cermakjiri",
+          "body": "So is it really ok not to take the highest one, right?\n\nI know it's minor but what about wrapping it to new fn so it's easily digestible (for other readers) by the fn name and if needed then the long comment?\n```ts\n/**\n   ...\n*/\nfunction getNextAvailableEvmNonce(confirmedNonces: Set<string>, accountNonce: string) {\n  let effectiveAccountNonce = accountNonce;\n\n   while (confirmedNonces.has(effectiveAccountNonce)) effectiveAccountNonce += 1\n\n  return effectiveAccountNonce  \n}",
+          "createdAt": "2026-08-05T14:29:03Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721407524",
+          "isMine": true
+        },
+        {
+          "databaseId": 3721473506,
+          "author": "53gur0",
+          "body": "the issue was that list of pending nonces also contained transactions and nonces that were not created by the user ",
+          "createdAt": "2026-08-05T14:36:59Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721473506",
+          "isMine": false
+        },
+        {
+          "databaseId": 3721561087,
+          "author": "cermakjiri",
+          "body": "okay",
+          "createdAt": "2026-08-05T14:47:44Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721561087",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G74",
+      "topic": "performance-and-memoization",
+      "tags": [
+        "missing-memo",
+        "pre-existing"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30910,
+        "title": "fix(suite-desktop): double-check nonces origination",
+        "url": "https://github.com/trezor/trezor-suite/pull/30910",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-08-05T13:44:55Z",
+        "headRefOid": "12d9c3c83e0083f174dc67d285823596bbfba921"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Wr1b2",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx",
+        "line": 90,
+        "originalLine": 90,
+        "startLine": 90,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-05T14:31:50Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721430142",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/12d9c3c83e0083f174dc67d285823596bbfba921/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx#L90",
+      "diffHunk": "@@ -87,7 +87,7 @@ export const EthereumNonce = ({ displayNonce, confirmedNonce, onCancel }: Ethere\n \n     const error = errors.ethereumNonce;\n \n-    const pendingSentTxs = transactions.filter(isPending).filter(isSentTransaction);\n+    const pendingSentTxs = transactions.filter(isPending).filter(isSignedByAccount);",
+      "comments": [
+        {
+          "databaseId": 3721430142,
+          "author": "cermakjiri",
+          "body": "uff, no useMemo anywhere... anyway that's for another PR (I know it was here before, I just help myself not commenting it) 😄 ",
+          "createdAt": "2026-08-05T14:31:50Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721430142",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G75",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "reuse-existing-util",
+        "address-comparison"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30910,
+        "title": "fix(suite-desktop): double-check nonces origination",
+        "url": "https://github.com/trezor/trezor-suite/pull/30910",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-08-05T13:44:55Z",
+        "headRefOid": "12d9c3c83e0083f174dc67d285823596bbfba921"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Wr22C",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/wallet-utils/src/transactionUtils.ts",
+        "line": 80,
+        "originalLine": 80,
+        "startLine": 80,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-05T14:32:45Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721438603",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/12d9c3c83e0083f174dc67d285823596bbfba921/suite-common/wallet-utils/src/transactionUtils.ts#L80",
+      "diffHunk": "@@ -70,11 +70,28 @@ export const isPending = (tx: WalletAccountTransaction | AccountTransaction) =>\n     return !!tx && (!tx.blockHeight || tx.blockHeight < 0);\n };\n \n-// Also matches 'contract': a contract-deployment tx is signed and broadcast from the account's own\n-// address and consumes an EVM nonce exactly like a plain send, so it must count toward the same\n-// nonce pool (see getEvmNonceInfo) even though blockbook classifies it under a distinct type.\n-export const isSentTransaction = (tx: WalletAccountTransaction | AccountTransaction) =>\n-    ['sent', 'self', 'contract'].includes(tx.type);\n+// isAccountOwned is set by enhanceVinVout at transform time; the descriptor comparison is the\n+// fallback for records where it is absent, and is case-insensitive because EVM addresses reach us in\n+// mixed EIP-55 casing (cf. isOutgoing in blockchain-link-utils).\n+const isSignedByDescriptor = (details: AccountTransaction['details'], descriptor: string) =>\n+    !!details?.vin?.some(\n+        vin =>\n+            vin.isAccountOwned ||\n+            vin.addresses?.some(address => address.toLowerCase() === descriptor.toLowerCase()),",
+      "comments": [
+        {
+          "databaseId": 3721438603,
+          "author": "cermakjiri",
+          "body": "what about using `areEvmAddressesEqual`?",
+          "createdAt": "2026-08-05T14:32:45Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721438603",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G76",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "fix-the-type",
+        "tx-type-modelling"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30910,
+        "title": "fix(suite-desktop): double-check nonces origination",
+        "url": "https://github.com/trezor/trezor-suite/pull/30910",
+        "author": "53gur0",
+        "state": "MERGED",
+        "createdAt": "2026-08-05T13:44:55Z",
+        "headRefOid": "12d9c3c83e0083f174dc67d285823596bbfba921"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6Wr665",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-common/wallet-utils/src/transactionUtils.ts",
+        "line": 93,
+        "originalLine": 93,
+        "startLine": 93,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-05T14:35:35Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721463180",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/12d9c3c83e0083f174dc67d285823596bbfba921/suite-common/wallet-utils/src/transactionUtils.ts#L93",
+      "diffHunk": "@@ -70,11 +70,28 @@ export const isPending = (tx: WalletAccountTransaction | AccountTransaction) =>\n     return !!tx && (!tx.blockHeight || tx.blockHeight < 0);\n };\n \n-// Also matches 'contract': a contract-deployment tx is signed and broadcast from the account's own\n-// address and consumes an EVM nonce exactly like a plain send, so it must count toward the same\n-// nonce pool (see getEvmNonceInfo) even though blockbook classifies it under a distinct type.\n-export const isSentTransaction = (tx: WalletAccountTransaction | AccountTransaction) =>\n-    ['sent', 'self', 'contract'].includes(tx.type);\n+// isAccountOwned is set by enhanceVinVout at transform time; the descriptor comparison is the\n+// fallback for records where it is absent, and is case-insensitive because EVM addresses reach us in\n+// mixed EIP-55 casing (cf. isOutgoing in blockchain-link-utils).\n+const isSignedByDescriptor = (details: AccountTransaction['details'], descriptor: string) =>\n+    !!details?.vin?.some(\n+        vin =>\n+            vin.isAccountOwned ||\n+            vin.addresses?.some(address => address.toLowerCase() === descriptor.toLowerCase()),\n+    );\n+\n+/**\n+ * Whether the account itself signed (and paid for) the transaction.\n+ *\n+ * Deliberately not `tx.type`, which is a display label: it reads 'sent' for any transaction moving\n+ * value out of the account — including one signed by a stranger, since an ERC-20 Transfer log or a\n+ * transferFrom(account, …) call may name any `from` — and 'failed' for the account's own reverted\n+ * sends. EVM nonce arithmetic needs authorship instead: a foreign transaction carries the *signer's*\n+ * nonce, which says nothing about this account, while an own failed or contract-deployment\n+ * transaction consumes a nonce exactly like a plain send.\n+ */\n+export const isSignedByAccount = (tx: Pick<WalletAccountTransaction, 'details' | 'descriptor'>) =>",
+      "comments": [
+        {
+          "databaseId": 3721463180,
+          "author": "cermakjiri",
+          "body": "If I understand it correctly, the `sent` type is basically useless / broken because of: \n\n> call may name any `from` — and 'failed' for the account's own reverted sends\n\nso wouldn't be better to fix the `sent` type or introduce new one... something in this direction?",
+          "createdAt": "2026-08-05T14:35:35Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30910#discussion_r3721463180",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G77",
+      "topic": "nullability-and-sentinel-values",
+      "tags": [
+        "empty-string-sentinel",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-07T07:48:49Z",
+        "headRefOid": "132bc2d7a32741a02b2270d1acff6ed8ed9dc22b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X2f7S",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-earn/src/hooks/useYieldBadge.tsx",
+        "line": null,
+        "originalLine": 41,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T11:37:28Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749106530",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-earn/src/hooks/useYieldBadge.tsx#L41",
+      "diffHunk": "@@ -0,0 +1,102 @@\n+import { useMemo } from 'react';\n+import { useSelector } from 'react-redux';\n+\n+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';\n+import { type MessageSystemRootState } from '@suite-common/message-system';\n+import { type EnhancedTokenInfo } from '@suite-common/token-definitions';\n+import { type NetworkSymbol } from '@suite-common/wallet-config';\n+import {\n+    getYieldVaultForOutputToken,\n+    getYieldVaultsForInputToken,\n+    hasYieldVaultPosition,\n+} from '@suite-common/wallet-core';\n+import { getApyPercent } from '@suite-common/wallet-utils';\n+import { type TokenInfo } from '@trezor/blockchain-link-types';\n+import { exhaustive } from '@trezor/type-utils';\n+\n+import { selectBestEnabledYieldVault } from '../selectors';\n+\n+interface YieldBadgeData {\n+    apy: number;\n+    vaultId: string;\n+    hasVaultPosition: boolean;\n+}\n+\n+interface UseYieldBadgeProps {\n+    networkSymbol?: NetworkSymbol;\n+    token?: EnhancedTokenInfo;\n+    accountTokens: TokenInfo[] | undefined;\n+    type: 'default' | 'defi';\n+    yieldOpportunities?: YieldDtoV2[];\n+}\n+\n+export const useYieldBadge = ({\n+    networkSymbol,\n+    token,\n+    accountTokens,\n+    type,\n+    yieldOpportunities,\n+}: UseYieldBadgeProps): YieldBadgeData | null => {\n+    const matchedVaults = useMemo(() => {\n+        if (!networkSymbol || !token) return [];",
+      "comments": [
+        {
+          "databaseId": 3749106530,
+          "author": "cermakjiri",
+          "body": "Is there real use case with undefined token.symbol and setting `''` seems like way to potential bug / unnecessary checks down stream. Therefore:\n```suggestion\n        if (!networkSymbol || !token || !token.symbol) return [];\n```",
+          "createdAt": "2026-08-10T11:37:28Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749106530",
+          "isMine": true
+        },
+        {
+          "databaseId": 3749396878,
+          "author": "TomasBoda",
+          "body": "done",
+          "createdAt": "2026-08-10T12:20:09Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749396878",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G78",
+      "topic": "nullability-and-sentinel-values",
+      "tags": [
+        "empty-string-sentinel",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-07T07:48:49Z",
+        "headRefOid": "132bc2d7a32741a02b2270d1acff6ed8ed9dc22b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X2gF2",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-earn/src/hooks/useYieldBadge.tsx",
+        "line": null,
+        "originalLine": 45,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T11:37:36Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749107437",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-earn/src/hooks/useYieldBadge.tsx#L45",
+      "diffHunk": "@@ -0,0 +1,102 @@\n+import { useMemo } from 'react';\n+import { useSelector } from 'react-redux';\n+\n+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';\n+import { type MessageSystemRootState } from '@suite-common/message-system';\n+import { type EnhancedTokenInfo } from '@suite-common/token-definitions';\n+import { type NetworkSymbol } from '@suite-common/wallet-config';\n+import {\n+    getYieldVaultForOutputToken,\n+    getYieldVaultsForInputToken,\n+    hasYieldVaultPosition,\n+} from '@suite-common/wallet-core';\n+import { getApyPercent } from '@suite-common/wallet-utils';\n+import { type TokenInfo } from '@trezor/blockchain-link-types';\n+import { exhaustive } from '@trezor/type-utils';\n+\n+import { selectBestEnabledYieldVault } from '../selectors';\n+\n+interface YieldBadgeData {\n+    apy: number;\n+    vaultId: string;\n+    hasVaultPosition: boolean;\n+}\n+\n+interface UseYieldBadgeProps {\n+    networkSymbol?: NetworkSymbol;\n+    token?: EnhancedTokenInfo;\n+    accountTokens: TokenInfo[] | undefined;\n+    type: 'default' | 'defi';\n+    yieldOpportunities?: YieldDtoV2[];\n+}\n+\n+export const useYieldBadge = ({\n+    networkSymbol,\n+    token,\n+    accountTokens,\n+    type,\n+    yieldOpportunities,\n+}: UseYieldBadgeProps): YieldBadgeData | null => {\n+    const matchedVaults = useMemo(() => {\n+        if (!networkSymbol || !token) return [];\n+\n+        const heldToken = {\n+            address: token.contract,\n+            symbol: token.symbol ?? '',",
+      "comments": [
+        {
+          "databaseId": 3749107437,
+          "author": "cermakjiri",
+          "body": "```suggestion\n            symbol: token.symbol,\n```",
+          "createdAt": "2026-08-10T11:37:36Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749107437",
+          "isMine": true
+        },
+        {
+          "databaseId": 3749397224,
+          "author": "TomasBoda",
+          "body": "done",
+          "createdAt": "2026-08-10T12:20:12Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749397224",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G79",
+      "topic": "readability-and-simplification",
+      "tags": [
+        "styling",
+        "copy-paste",
+        "design-system"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-07T07:48:49Z",
+        "headRefOid": "132bc2d7a32741a02b2270d1acff6ed8ed9dc22b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X2j-v",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-native/module-accounts-management/src/components/YourPositionCard.tsx",
+        "line": 30,
+        "originalLine": 53,
+        "startLine": 30,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T11:40:56Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749129439",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L30",
+      "diffHunk": "@@ -0,0 +1,218 @@\n+import { useSelector } from 'react-redux';\n+\n+import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';\n+import {\n+    type NetworkSymbol,\n+    getDisplaySymbol,\n+    getNetworkDisplaySymbolName,\n+} from '@suite-common/wallet-config';\n+import {\n+    type AccountsRootState,\n+    selectAccountByKey,\n+    selectAccountNetworkSymbol,\n+} from '@suite-common/wallet-core';\n+import {\n+    type Account,\n+    type AccountKey,\n+    type TokenAddress,\n+    type TokenInfoBranded,\n+    type TokenSymbol,\n+} from '@suite-common/wallet-types';\n+import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';\n+import { Box, Card, HStack, Text } from '@suite-native/atoms';\n+import {\n+    CryptoAmountFormatter,\n+    CryptoToFiatAmountFormatter,\n+    TokenAmountFormatter,\n+    TokenToFiatAmountFormatter,\n+} from '@suite-native/formatters';\n+import { TokenIcon } from '@suite-native/icons';\n+import {\n+    YieldBadge,\n+    useNativeYieldVault,\n+    useStakingRate,\n+    useYieldBadge,\n+} from '@suite-native/module-earn';\n+import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';\n+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';\n+\n+const cardStyle = prepareNativeStyle(utils => ({\n+    flexDirection: 'row',\n+    justifyContent: 'space-between',\n+    alignItem: 'center',\n+    marginHorizontal: utils.spacings.sp16,\n+    padding: utils.spacings.sp16,\n+    backgroundColor: utils.colors.surfaceFillRaised,\n+    borderRadius: utils.borders.radii.r16,\n+}));\n+\n+const cardContentStyle = prepareNativeStyle(_ => ({\n+    flexShrink: 1,\n+    justifyContent: 'flex-start',\n+    alignItems: 'flex-start',\n+}));",
+      "comments": [
+        {
+          "databaseId": 3749129439,
+          "author": "cermakjiri",
+          "body": "I know if I'd do this in Suite desktop, Growth team will say something... but I assume it's more relaxed in suite-native 😄 ",
+          "createdAt": "2026-08-10T11:40:56Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749129439",
+          "isMine": true
+        },
+        {
+          "databaseId": 3749401668,
+          "author": "TomasBoda",
+          "body": "I think I copied this from the previous asset card 😬",
+          "createdAt": "2026-08-10T12:20:51Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749401668",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G80",
+      "topic": "component-structure-and-files",
+      "tags": [
+        "hook-own-file"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-07T07:48:49Z",
+        "headRefOid": "132bc2d7a32741a02b2270d1acff6ed8ed9dc22b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X2lnu",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-accounts-management/src/components/YourPositionCard.tsx",
+        "line": null,
+        "originalLine": 103,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T11:42:16Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749138330",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L103",
+      "diffHunk": "@@ -0,0 +1,218 @@\n+import { useSelector } from 'react-redux';\n+\n+import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';\n+import {\n+    type NetworkSymbol,\n+    getDisplaySymbol,\n+    getNetworkDisplaySymbolName,\n+} from '@suite-common/wallet-config';\n+import {\n+    type AccountsRootState,\n+    selectAccountByKey,\n+    selectAccountNetworkSymbol,\n+} from '@suite-common/wallet-core';\n+import {\n+    type Account,\n+    type AccountKey,\n+    type TokenAddress,\n+    type TokenInfoBranded,\n+    type TokenSymbol,\n+} from '@suite-common/wallet-types';\n+import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';\n+import { Box, Card, HStack, Text } from '@suite-native/atoms';\n+import {\n+    CryptoAmountFormatter,\n+    CryptoToFiatAmountFormatter,\n+    TokenAmountFormatter,\n+    TokenToFiatAmountFormatter,\n+} from '@suite-native/formatters';\n+import { TokenIcon } from '@suite-native/icons';\n+import {\n+    YieldBadge,\n+    useNativeYieldVault,\n+    useStakingRate,\n+    useYieldBadge,\n+} from '@suite-native/module-earn';\n+import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';\n+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';\n+\n+const cardStyle = prepareNativeStyle(utils => ({\n+    flexDirection: 'row',\n+    justifyContent: 'space-between',\n+    alignItem: 'center',\n+    marginHorizontal: utils.spacings.sp16,\n+    padding: utils.spacings.sp16,\n+    backgroundColor: utils.colors.surfaceFillRaised,\n+    borderRadius: utils.borders.radii.r16,\n+}));\n+\n+const cardContentStyle = prepareNativeStyle(_ => ({\n+    flexShrink: 1,\n+    justifyContent: 'flex-start',\n+    alignItems: 'flex-start',\n+}));\n+\n+interface UseYourPositionCardYieldBadgeProps {\n+    account?: Account | null;\n+    token?: TokenInfoBranded | null;\n+    symbol?: NetworkSymbol | null;\n+}\n+\n+const useYourPositionCardYieldBadge = ({\n+    account,\n+    token,\n+    symbol,\n+}: UseYourPositionCardYieldBadgeProps) => {\n+    const { data: yieldOpportunities } = useAllYieldOpportunities();\n+\n+    const nativeYieldVault = useNativeYieldVault({ account: account ?? undefined });\n+\n+    const { rate: stakingRate } = useStakingRate({\n+        symbol: account?.symbol,\n+        accountKey: account?.key,\n+    });\n+\n+    const promoYieldBadge =\n+        !token && nativeYieldVault?.bestVault\n+            ? {\n+                  apy:\n+                      stakingRate !== null && isApyAvailable(stakingRate)\n+                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)\n+                          : nativeYieldVault.bestVault.apy,\n+                  vaultId: nativeYieldVault.bestVault.id,\n+              }\n+            : null;\n+\n+    const yieldBadge = useYieldBadge({\n+        networkSymbol: symbol ?? undefined,\n+        token: token ?? undefined,\n+        accountTokens: account?.tokens,\n+        type: token && isErc4626(token) ? 'defi' : 'default',\n+        yieldOpportunities,\n+    });\n+\n+    const usedYieldBadge = promoYieldBadge ?? yieldBadge;\n+\n+    const usedYieldBadgeVariant = (() => {\n+        if (promoYieldBadge) return 'promo' as const;\n+\n+        return yieldBadge?.hasVaultPosition ? ('active' as const) : ('inactive' as const);\n+    })();\n+\n+    return { yieldBadge: usedYieldBadge, yieldBadgeVariant: usedYieldBadgeVariant };\n+};",
+      "comments": [
+        {
+          "databaseId": 3749138330,
+          "author": "cermakjiri",
+          "body": "Let's put it to new file with the name of the hook. 🙏   ",
+          "createdAt": "2026-08-10T11:42:16Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749138330",
+          "isMine": true
+        },
+        {
+          "databaseId": 3749402129,
+          "author": "TomasBoda",
+          "body": "done",
+          "createdAt": "2026-08-10T12:20:55Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749402129",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G81",
+      "topic": "nullability-and-sentinel-values",
+      "tags": [
+        "narrow-upstream",
+        "component-props"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-07T07:48:49Z",
+        "headRefOid": "132bc2d7a32741a02b2270d1acff6ed8ed9dc22b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X2m4p",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-accounts-management/src/components/YourPositionCard.tsx",
+        "line": null,
+        "originalLine": 113,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T11:43:19Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749145328",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L113",
+      "diffHunk": "@@ -0,0 +1,218 @@\n+import { useSelector } from 'react-redux';\n+\n+import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';\n+import {\n+    type NetworkSymbol,\n+    getDisplaySymbol,\n+    getNetworkDisplaySymbolName,\n+} from '@suite-common/wallet-config';\n+import {\n+    type AccountsRootState,\n+    selectAccountByKey,\n+    selectAccountNetworkSymbol,\n+} from '@suite-common/wallet-core';\n+import {\n+    type Account,\n+    type AccountKey,\n+    type TokenAddress,\n+    type TokenInfoBranded,\n+    type TokenSymbol,\n+} from '@suite-common/wallet-types';\n+import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';\n+import { Box, Card, HStack, Text } from '@suite-native/atoms';\n+import {\n+    CryptoAmountFormatter,\n+    CryptoToFiatAmountFormatter,\n+    TokenAmountFormatter,\n+    TokenToFiatAmountFormatter,\n+} from '@suite-native/formatters';\n+import { TokenIcon } from '@suite-native/icons';\n+import {\n+    YieldBadge,\n+    useNativeYieldVault,\n+    useStakingRate,\n+    useYieldBadge,\n+} from '@suite-native/module-earn';\n+import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';\n+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';\n+\n+const cardStyle = prepareNativeStyle(utils => ({\n+    flexDirection: 'row',\n+    justifyContent: 'space-between',\n+    alignItem: 'center',\n+    marginHorizontal: utils.spacings.sp16,\n+    padding: utils.spacings.sp16,\n+    backgroundColor: utils.colors.surfaceFillRaised,\n+    borderRadius: utils.borders.radii.r16,\n+}));\n+\n+const cardContentStyle = prepareNativeStyle(_ => ({\n+    flexShrink: 1,\n+    justifyContent: 'flex-start',\n+    alignItems: 'flex-start',\n+}));\n+\n+interface UseYourPositionCardYieldBadgeProps {\n+    account?: Account | null;\n+    token?: TokenInfoBranded | null;\n+    symbol?: NetworkSymbol | null;\n+}\n+\n+const useYourPositionCardYieldBadge = ({\n+    account,\n+    token,\n+    symbol,\n+}: UseYourPositionCardYieldBadgeProps) => {\n+    const { data: yieldOpportunities } = useAllYieldOpportunities();\n+\n+    const nativeYieldVault = useNativeYieldVault({ account: account ?? undefined });\n+\n+    const { rate: stakingRate } = useStakingRate({\n+        symbol: account?.symbol,\n+        accountKey: account?.key,\n+    });\n+\n+    const promoYieldBadge =\n+        !token && nativeYieldVault?.bestVault\n+            ? {\n+                  apy:\n+                      stakingRate !== null && isApyAvailable(stakingRate)\n+                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)\n+                          : nativeYieldVault.bestVault.apy,\n+                  vaultId: nativeYieldVault.bestVault.id,\n+              }\n+            : null;\n+\n+    const yieldBadge = useYieldBadge({\n+        networkSymbol: symbol ?? undefined,\n+        token: token ?? undefined,\n+        accountTokens: account?.tokens,\n+        type: token && isErc4626(token) ? 'defi' : 'default',\n+        yieldOpportunities,\n+    });\n+\n+    const usedYieldBadge = promoYieldBadge ?? yieldBadge;\n+\n+    const usedYieldBadgeVariant = (() => {\n+        if (promoYieldBadge) return 'promo' as const;\n+\n+        return yieldBadge?.hasVaultPosition ? ('active' as const) : ('inactive' as const);\n+    })();\n+\n+    return { yieldBadge: usedYieldBadge, yieldBadgeVariant: usedYieldBadgeVariant };\n+};\n+\n+interface YourPositionCardProps {\n+    accountKey: AccountKey;\n+    tokenContract?: TokenAddress;\n+}\n+\n+export const YourPositionCard = ({ accountKey, tokenContract }: YourPositionCardProps) => {\n+    const { applyStyle } = useNativeStyles();\n+\n+    const account = useSelector((state: AccountsRootState) =>",
+      "comments": [
+        {
+          "databaseId": 3749145328,
+          "author": "cermakjiri",
+          "body": "This selection should be done outside this component so the types here can assert only `account` and doesn't have to always check for undefined/null cases 🙏 ",
+          "createdAt": "2026-08-10T11:43:19Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749145328",
+          "isMine": true
+        },
+        {
+          "databaseId": 3749402823,
+          "author": "TomasBoda",
+          "body": "done, also for `token`",
+          "createdAt": "2026-08-10T12:21:01Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749402823",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G82",
+      "topic": "nullability-and-sentinel-values",
+      "tags": [
+        "narrow-upstream",
+        "component-props"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-07T07:48:49Z",
+        "headRefOid": "132bc2d7a32741a02b2270d1acff6ed8ed9dc22b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X2nwb",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-accounts-management/src/components/YourPositionCard.tsx",
+        "line": null,
+        "originalLine": 122,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T11:44:03Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749150115",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L122",
+      "diffHunk": "@@ -0,0 +1,218 @@\n+import { useSelector } from 'react-redux';\n+\n+import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';\n+import {\n+    type NetworkSymbol,\n+    getDisplaySymbol,\n+    getNetworkDisplaySymbolName,\n+} from '@suite-common/wallet-config';\n+import {\n+    type AccountsRootState,\n+    selectAccountByKey,\n+    selectAccountNetworkSymbol,\n+} from '@suite-common/wallet-core';\n+import {\n+    type Account,\n+    type AccountKey,\n+    type TokenAddress,\n+    type TokenInfoBranded,\n+    type TokenSymbol,\n+} from '@suite-common/wallet-types';\n+import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';\n+import { Box, Card, HStack, Text } from '@suite-native/atoms';\n+import {\n+    CryptoAmountFormatter,\n+    CryptoToFiatAmountFormatter,\n+    TokenAmountFormatter,\n+    TokenToFiatAmountFormatter,\n+} from '@suite-native/formatters';\n+import { TokenIcon } from '@suite-native/icons';\n+import {\n+    YieldBadge,\n+    useNativeYieldVault,\n+    useStakingRate,\n+    useYieldBadge,\n+} from '@suite-native/module-earn';\n+import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';\n+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';\n+\n+const cardStyle = prepareNativeStyle(utils => ({\n+    flexDirection: 'row',\n+    justifyContent: 'space-between',\n+    alignItem: 'center',\n+    marginHorizontal: utils.spacings.sp16,\n+    padding: utils.spacings.sp16,\n+    backgroundColor: utils.colors.surfaceFillRaised,\n+    borderRadius: utils.borders.radii.r16,\n+}));\n+\n+const cardContentStyle = prepareNativeStyle(_ => ({\n+    flexShrink: 1,\n+    justifyContent: 'flex-start',\n+    alignItems: 'flex-start',\n+}));\n+\n+interface UseYourPositionCardYieldBadgeProps {\n+    account?: Account | null;\n+    token?: TokenInfoBranded | null;\n+    symbol?: NetworkSymbol | null;\n+}\n+\n+const useYourPositionCardYieldBadge = ({\n+    account,\n+    token,\n+    symbol,\n+}: UseYourPositionCardYieldBadgeProps) => {\n+    const { data: yieldOpportunities } = useAllYieldOpportunities();\n+\n+    const nativeYieldVault = useNativeYieldVault({ account: account ?? undefined });\n+\n+    const { rate: stakingRate } = useStakingRate({\n+        symbol: account?.symbol,\n+        accountKey: account?.key,\n+    });\n+\n+    const promoYieldBadge =\n+        !token && nativeYieldVault?.bestVault\n+            ? {\n+                  apy:\n+                      stakingRate !== null && isApyAvailable(stakingRate)\n+                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)\n+                          : nativeYieldVault.bestVault.apy,\n+                  vaultId: nativeYieldVault.bestVault.id,\n+              }\n+            : null;\n+\n+    const yieldBadge = useYieldBadge({\n+        networkSymbol: symbol ?? undefined,\n+        token: token ?? undefined,\n+        accountTokens: account?.tokens,\n+        type: token && isErc4626(token) ? 'defi' : 'default',\n+        yieldOpportunities,\n+    });\n+\n+    const usedYieldBadge = promoYieldBadge ?? yieldBadge;\n+\n+    const usedYieldBadgeVariant = (() => {\n+        if (promoYieldBadge) return 'promo' as const;\n+\n+        return yieldBadge?.hasVaultPosition ? ('active' as const) : ('inactive' as const);\n+    })();\n+\n+    return { yieldBadge: usedYieldBadge, yieldBadgeVariant: usedYieldBadgeVariant };\n+};\n+\n+interface YourPositionCardProps {\n+    accountKey: AccountKey;\n+    tokenContract?: TokenAddress;\n+}\n+\n+export const YourPositionCard = ({ accountKey, tokenContract }: YourPositionCardProps) => {\n+    const { applyStyle } = useNativeStyles();\n+\n+    const account = useSelector((state: AccountsRootState) =>\n+        selectAccountByKey(state, accountKey),\n+    );\n+\n+    const symbol = useSelector((state: AccountsRootState) =>\n+        selectAccountNetworkSymbol(state, accountKey),\n+    );\n+    const token = useSelector((state: TokensRootState) =>\n+        selectAccountTokenInfo(state, accountKey, tokenContract),\n+    );",
+      "comments": [
+        {
+          "databaseId": 3749150115,
+          "author": "cermakjiri",
+          "body": "Might be the case for `symbol` and `token` too 🙏 \nhttps://github.com/trezor/trezor-suite/pull/30994/changes#r3749145328",
+          "createdAt": "2026-08-10T11:44:03Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749150115",
+          "isMine": true
+        },
+        {
+          "databaseId": 3749403286,
+          "author": "TomasBoda",
+          "body": "done",
+          "createdAt": "2026-08-10T12:21:05Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749403286",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G83",
+      "topic": "data-fetching-tanstack-query",
+      "tags": [
+        "narrower-query-hook",
+        "over-fetching"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-07T07:48:49Z",
+        "headRefOid": "132bc2d7a32741a02b2270d1acff6ed8ed9dc22b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X2oxc",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-earn/src/components/YieldBadge.tsx",
+        "line": null,
+        "originalLine": 52,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T11:44:55Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749155737",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-earn/src/components/YieldBadge.tsx#L52",
+      "diffHunk": "@@ -0,0 +1,92 @@\n+import { Pressable } from 'react-native';\n+\n+import { useNavigation } from '@react-navigation/native';\n+\n+import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';\n+import { getYieldVaultContractAddress } from '@suite-common/wallet-core';\n+import { type Account, type TokenAddress, toTokenAddress } from '@suite-common/wallet-types';\n+import { Badge, type BadgeProps } from '@suite-native/atoms';\n+import { Translation, type TxKeyPath } from '@suite-native/intl';\n+import {\n+    AppTabsRoutes,\n+    EarnStackRoutes,\n+    type RootStackParamList,\n+    RootStackRoutes,\n+    type StackNavigationProps,\n+} from '@suite-native/navigation';\n+\n+type YieldBadgeVariant = 'inactive' | 'active' | 'promo';\n+\n+type YieldBadgeVariantConfig = {\n+    translationId: TxKeyPath;\n+    intent?: BadgeProps['intent'];\n+};\n+\n+const variantConfigMap: Record<YieldBadgeVariant, YieldBadgeVariantConfig> = {\n+    inactive: {\n+        translationId: 'moduleAccountManagement.accountDetailContentScreen.yieldBadge.upToRate',\n+        intent: 'brand',\n+    },\n+    active: {\n+        translationId: 'moduleAccountManagement.accountDetailContentScreen.yieldBadge.yieldRate',\n+        intent: 'brand',\n+    },\n+    promo: {\n+        translationId: 'moduleAccountManagement.accountDetailContentScreen.yieldBadge.promoRate',\n+        intent: 'brand',\n+    },\n+};\n+\n+interface YieldBadgeProps {\n+    apy: number;\n+    variant: YieldBadgeVariant;\n+    account: Account;\n+    vaultId: string;\n+    tokenContract?: TokenAddress;\n+}\n+\n+type NavigationProps = StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>;\n+\n+export const YieldBadge = ({ apy, variant, account, vaultId, tokenContract }: YieldBadgeProps) => {\n+    const navigation = useNavigation<NavigationProps>();\n+    const { data: yieldOpportunities } = useAllYieldOpportunities();",
+      "comments": [
+        {
+          "databaseId": 3749155737,
+          "author": "cermakjiri",
+          "body": "Let's use `useYieldOpportunity` instead of `useAllYieldOpportunities`",
+          "createdAt": "2026-08-10T11:44:55Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749155737",
+          "isMine": true
+        },
+        {
+          "databaseId": 3749403693,
+          "author": "TomasBoda",
+          "body": "done",
+          "createdAt": "2026-08-10T12:21:08Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749403693",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G84",
+      "topic": "nullability-and-sentinel-values",
+      "tags": [
+        "fallback-chain",
+        "balance-formatting",
+        "question"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-07T07:48:49Z",
+        "headRefOid": "132bc2d7a32741a02b2270d1acff6ed8ed9dc22b"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X20J5",
+        "isResolved": true,
+        "isOutdated": false,
+        "path": "suite-native/module-accounts-management/src/components/YourPositionCard.tsx",
+        "line": 52,
+        "originalLine": 134,
+        "startLine": 52,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T11:54:15Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749218834",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/132bc2d7a32741a02b2270d1acff6ed8ed9dc22b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx#L52",
+      "diffHunk": "@@ -0,0 +1,218 @@\n+import { useSelector } from 'react-redux';\n+\n+import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';\n+import {\n+    type NetworkSymbol,\n+    getDisplaySymbol,\n+    getNetworkDisplaySymbolName,\n+} from '@suite-common/wallet-config';\n+import {\n+    type AccountsRootState,\n+    selectAccountByKey,\n+    selectAccountNetworkSymbol,\n+} from '@suite-common/wallet-core';\n+import {\n+    type Account,\n+    type AccountKey,\n+    type TokenAddress,\n+    type TokenInfoBranded,\n+    type TokenSymbol,\n+} from '@suite-common/wallet-types';\n+import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';\n+import { Box, Card, HStack, Text } from '@suite-native/atoms';\n+import {\n+    CryptoAmountFormatter,\n+    CryptoToFiatAmountFormatter,\n+    TokenAmountFormatter,\n+    TokenToFiatAmountFormatter,\n+} from '@suite-native/formatters';\n+import { TokenIcon } from '@suite-native/icons';\n+import {\n+    YieldBadge,\n+    useNativeYieldVault,\n+    useStakingRate,\n+    useYieldBadge,\n+} from '@suite-native/module-earn';\n+import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';\n+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';\n+\n+const cardStyle = prepareNativeStyle(utils => ({\n+    flexDirection: 'row',\n+    justifyContent: 'space-between',\n+    alignItem: 'center',\n+    marginHorizontal: utils.spacings.sp16,\n+    padding: utils.spacings.sp16,\n+    backgroundColor: utils.colors.surfaceFillRaised,\n+    borderRadius: utils.borders.radii.r16,\n+}));\n+\n+const cardContentStyle = prepareNativeStyle(_ => ({\n+    flexShrink: 1,\n+    justifyContent: 'flex-start',\n+    alignItems: 'flex-start',\n+}));\n+\n+interface UseYourPositionCardYieldBadgeProps {\n+    account?: Account | null;\n+    token?: TokenInfoBranded | null;\n+    symbol?: NetworkSymbol | null;\n+}\n+\n+const useYourPositionCardYieldBadge = ({\n+    account,\n+    token,\n+    symbol,\n+}: UseYourPositionCardYieldBadgeProps) => {\n+    const { data: yieldOpportunities } = useAllYieldOpportunities();\n+\n+    const nativeYieldVault = useNativeYieldVault({ account: account ?? undefined });\n+\n+    const { rate: stakingRate } = useStakingRate({\n+        symbol: account?.symbol,\n+        accountKey: account?.key,\n+    });\n+\n+    const promoYieldBadge =\n+        !token && nativeYieldVault?.bestVault\n+            ? {\n+                  apy:\n+                      stakingRate !== null && isApyAvailable(stakingRate)\n+                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)\n+                          : nativeYieldVault.bestVault.apy,\n+                  vaultId: nativeYieldVault.bestVault.id,\n+              }\n+            : null;\n+\n+    const yieldBadge = useYieldBadge({\n+        networkSymbol: symbol ?? undefined,\n+        token: token ?? undefined,\n+        accountTokens: account?.tokens,\n+        type: token && isErc4626(token) ? 'defi' : 'default',\n+        yieldOpportunities,\n+    });\n+\n+    const usedYieldBadge = promoYieldBadge ?? yieldBadge;\n+\n+    const usedYieldBadgeVariant = (() => {\n+        if (promoYieldBadge) return 'promo' as const;\n+\n+        return yieldBadge?.hasVaultPosition ? ('active' as const) : ('inactive' as const);\n+    })();\n+\n+    return { yieldBadge: usedYieldBadge, yieldBadgeVariant: usedYieldBadgeVariant };\n+};\n+\n+interface YourPositionCardProps {\n+    accountKey: AccountKey;\n+    tokenContract?: TokenAddress;\n+}\n+\n+export const YourPositionCard = ({ accountKey, tokenContract }: YourPositionCardProps) => {\n+    const { applyStyle } = useNativeStyles();\n+\n+    const account = useSelector((state: AccountsRootState) =>\n+        selectAccountByKey(state, accountKey),\n+    );\n+\n+    const symbol = useSelector((state: AccountsRootState) =>\n+        selectAccountNetworkSymbol(state, accountKey),\n+    );\n+    const token = useSelector((state: TokensRootState) =>\n+        selectAccountTokenInfo(state, accountKey, tokenContract),\n+    );\n+\n+    const { yieldBadge, yieldBadgeVariant } = useYourPositionCardYieldBadge({\n+        account,\n+        token,\n+        symbol,\n+    });\n+\n+    if (!symbol) return null;\n+\n+    const tokenSymbol = token?.symbol ?? getDisplaySymbol(symbol);\n+    const tokenName = token?.name ?? getNetworkDisplaySymbolName(symbol);\n+    const balance = token?.balance ?? account?.formattedBalance ?? '0';",
+      "comments": [
+        {
+          "databaseId": 3749218834,
+          "author": "cermakjiri",
+          "body": "are we sure it can handle `formattedBalance` balance too?",
+          "createdAt": "2026-08-10T11:54:15Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749218834",
+          "isMine": true
+        },
+        {
+          "databaseId": 3749405165,
+          "author": "TomasBoda",
+          "body": "yes, it works. also on other places in the repo",
+          "createdAt": "2026-08-10T12:21:21Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/30994#discussion_r3749405165",
+          "isMine": false
+        }
+      ]
+    },
+    {
+      "gid": "G85",
+      "topic": "acknowledgements-and-pointers",
+      "tags": [
+        "approval"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 31076,
+        "title": "fix(suite-native): polish standalone wrap/unwrap UI",
+        "url": "https://github.com/trezor/trezor-suite/pull/31076",
+        "author": "izmy",
+        "state": "MERGED",
+        "createdAt": "2026-08-10T11:39:28Z",
+        "headRefOid": "2a75b8a91cd878be4898dbbbf987112e4a042dc9"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X4-oe",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx",
+        "line": 166,
+        "originalLine": 166,
+        "startLine": 166,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T13:39:23Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/31076#discussion_r3749997627",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/2a75b8a91cd878be4898dbbbf987112e4a042dc9/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx#L166",
+      "diffHunk": "@@ -163,7 +163,7 @@ export const getWrappedNativeCompleteRows = ({\n                     size=\"extraSmall\"\n                 />\n                 <Text variant=\"body-md-strong\" color=\"contentPrimary\" numberOfLines={1}>\n-                    -{sentAmount}\n+                    {sentAmount}",
+      "comments": [
+        {
+          "databaseId": 3749997627,
+          "author": "cermakjiri",
+          "body": "nice 👍 ",
+          "createdAt": "2026-08-10T13:39:23Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/31076#discussion_r3749997627",
+          "isMine": true
+        }
+      ]
+    },
+    {
+      "gid": "G86",
+      "topic": "typescript-type-safety",
+      "tags": [
+        "type-guard",
+        "is-network-symbol",
+        "suggestion"
+      ],
+      "classifiedBy": "override",
+      "pending": false,
+      "orphan": false,
+      "isOwnPr": false,
+      "pr": {
+        "number": 31071,
+        "title": "fix(suite-native): communicate weth vault as eth",
+        "url": "https://github.com/trezor/trezor-suite/pull/31071",
+        "author": "TomasBoda",
+        "state": "MERGED",
+        "createdAt": "2026-08-10T09:58:34Z",
+        "headRefOid": "a9f17868ba66f7bbd488e71aa765c728422c1ae9"
+      },
+      "thread": {
+        "id": "PRRT_kwDOCNxUSM6X1LU-",
+        "isResolved": true,
+        "isOutdated": true,
+        "path": "suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx",
+        "line": null,
+        "originalLine": 262,
+        "startLine": null,
+        "originalStartLine": null,
+        "diffSide": "RIGHT",
+        "subjectType": "LINE"
+      },
+      "myFirstAt": "2026-08-10T13:52:36Z",
+      "discussionUrl": "https://github.com/trezor/trezor-suite/pull/31071#discussion_r3750108169",
+      "codeUrl": "https://github.com/trezor/trezor-suite/blob/a9f17868ba66f7bbd488e71aa765c728422c1ae9/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx#L262",
+      "diffHunk": "@@ -256,14 +257,22 @@ export const StablecoinYieldTokenOverview = ({\n                         {depositedPosition && (\n                             <HStack alignItems=\"center\" spacing=\"sp8\">\n                                 <TokenIcon\n-                                    symbol={depositedPosition.symbol}\n+                                    symbol={\n+                                        wrappedNativeSymbol !== null\n+                                            ? (wrappedNativeSymbol as NetworkSymbol)",
+      "comments": [
+        {
+          "databaseId": 3748632607,
+          "author": "izmy",
+          "body": "`toTokenSymbol(wrappedNativeSymbol)`",
+          "createdAt": "2026-08-10T10:27:06Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/31071#discussion_r3748632607",
+          "isMine": false
+        },
+        {
+          "databaseId": 3749889159,
+          "author": "TomasBoda",
+          "body": "doesn't work here. the `symbol` prop expects a `NetworkSymbol`",
+          "createdAt": "2026-08-10T13:26:00Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/31071#discussion_r3749889159",
+          "isMine": false
+        },
+        {
+          "databaseId": 3750108169,
+          "author": "cermakjiri",
+          "body": "what about `wrappedNativeSymbol && isNetworkSymbol(wrappedNativeSymbol) ? ... : ...`?",
+          "createdAt": "2026-08-10T13:52:36Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/31071#discussion_r3750108169",
+          "isMine": true
+        },
+        {
+          "databaseId": 3756025755,
+          "author": "TomasBoda",
+          "body": "done",
+          "createdAt": "2026-08-11T07:29:04Z",
+          "url": "https://github.com/trezor/trezor-suite/pull/31071#discussion_r3756025755",
+          "isMine": false
+        }
+      ]
+    }
+  ],
+  "reviewSummaries": [
+    {
+      "pr": {
+        "number": 27621,
+        "title": "fix(suite-native): fee selector balance error",
+        "url": "https://github.com/trezor/trezor-suite/pull/27621",
+        "author": "BrantalikP"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-05-13T10:18:28Z",
+      "body": "LGTM as hotfix, I didn't test it though. ",
+      "url": "https://github.com/trezor/trezor-suite/pull/27621#pullrequestreview-4280552662",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 27763,
+        "title": "fix(suite): block yield tx broadcast when balance can't cover fee",
+        "url": "https://github.com/trezor/trezor-suite/pull/27763",
+        "author": "matusbalascak"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-05-14T14:03:15Z",
+      "body": "LGTM 👍 ",
+      "url": "https://github.com/trezor/trezor-suite/pull/27763#pullrequestreview-4290564707",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 27718,
+        "title": "feat(suite-native): yield deposit",
+        "url": "https://github.com/trezor/trezor-suite/pull/27718",
+        "author": "BrantalikP"
+      },
+      "state": "COMMENTED",
+      "submittedAt": "2026-05-22T10:19:04Z",
+      "body": "I still need to go through many files (especially `suite-native` ones) so here's at least the 1st batch. 😃 ",
+      "url": "https://github.com/trezor/trezor-suite/pull/27718#pullrequestreview-4344310603",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 28234,
+        "title": "feat(suite): add transaction data editor to tron send form",
+        "url": "https://github.com/trezor/trezor-suite/pull/28234",
+        "author": "matusbalascak"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-06-01T13:44:20Z",
+      "body": "I think we need some claude rule `if args.length > 2, then prefer object args over inline args`  😄 ",
+      "url": "https://github.com/trezor/trezor-suite/pull/28234#pullrequestreview-4401582356",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 28414,
+        "title": "Eth conversion utils",
+        "url": "https://github.com/trezor/trezor-suite/pull/28414",
+        "author": "marekrjpolak"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-06-15T06:52:23Z",
+      "body": "It looks clean and we get rid off [the dependency](https://bundlephobia.com/package/web3-utils@4.3.3), it looks good by me. Nice improvement 👍 ",
+      "url": "https://github.com/trezor/trezor-suite/pull/28414#pullrequestreview-4495021396",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 28796,
+        "title": "chore(schemas): remove dead EVM general schema code",
+        "url": "https://github.com/trezor/trezor-suite/pull/28796",
+        "author": "mroz22"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-06-18T09:52:23Z",
+      "body": "Nice, thanks ",
+      "url": "https://github.com/trezor/trezor-suite/pull/28796#pullrequestreview-4523761451",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 28888,
+        "title": "Bump Wallet Deps 26.6",
+        "url": "https://github.com/trezor/trezor-suite/pull/28888",
+        "author": "53gur0"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-06-19T07:24:22Z",
+      "body": "Apart the one type-check error, LGTM 👍 ",
+      "url": "https://github.com/trezor/trezor-suite/pull/28888#pullrequestreview-4530889138",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 28816,
+        "title": "feat(wallet-core): improve nonce discovery for EVM",
+        "url": "https://github.com/trezor/trezor-suite/pull/28816",
+        "author": "53gur0"
+      },
+      "state": "COMMENTED",
+      "submittedAt": "2026-06-22T13:56:09Z",
+      "body": "Some minors but otherwise LGTM. 👍  However another review by someone from Connect might be a good idea. 🙏    ",
+      "url": "https://github.com/trezor/trezor-suite/pull/28816#pullrequestreview-4544273998",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 29054,
+        "title": "perf(suite-desktop): tanstack query improvements",
+        "url": "https://github.com/trezor/trezor-suite/pull/29054",
+        "author": "53gur0"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-06-24T11:43:34Z",
+      "body": "Just two minors. Otherwise very nice improvements (and fixes)  🚀  and I've learnt several new things today, thanks 😄 ",
+      "url": "https://github.com/trezor/trezor-suite/pull/29054#pullrequestreview-4561767478",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 30536,
+        "title": "feat(suite-desktop): restore warp/unwrap broadcast toast titles",
+        "url": "https://github.com/trezor/trezor-suite/pull/30536",
+        "author": "53gur0"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-07-30T11:08:20Z",
+      "body": "LGTM",
+      "url": "https://github.com/trezor/trezor-suite/pull/30536#pullrequestreview-4818111495",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 30584,
+        "title": "feat(suite-desktop): don't allow to skip wrapping step if user has no WETH",
+        "url": "https://github.com/trezor/trezor-suite/pull/30584",
+        "author": "53gur0"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-07-30T11:20:08Z",
+      "body": "LGTM",
+      "url": "https://github.com/trezor/trezor-suite/pull/30584#pullrequestreview-4818203406",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 30994,
+        "title": "Mobile - Asset Detail Screen Revamp",
+        "url": "https://github.com/trezor/trezor-suite/pull/30994",
+        "author": "TomasBoda"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-08-10T12:26:43Z",
+      "body": "LGTM 🚀 ",
+      "url": "https://github.com/trezor/trezor-suite/pull/30994#pullrequestreview-4896680837",
+      "isOwnPr": false
+    },
+    {
+      "pr": {
+        "number": 31076,
+        "title": "fix(suite-native): polish standalone wrap/unwrap UI",
+        "url": "https://github.com/trezor/trezor-suite/pull/31076",
+        "author": "izmy"
+      },
+      "state": "APPROVED",
+      "submittedAt": "2026-08-10T13:40:09Z",
+      "body": "LGTM 🚀  ",
+      "url": "https://github.com/trezor/trezor-suite/pull/31076#pullrequestreview-4897316667",
+      "isOwnPr": false
+    }
+  ]
+}

--- a/perf-issues/react-hooks/PROGRESS.md
+++ b/perf-issues/react-hooks/PROGRESS.md
@@ -1,0 +1,170 @@
+# perf-issues/react-hooks — progress / resume state
+
+Sweep of the repo against [`skills/performance-react-hooks/SKILL.md`](../../skills/performance-react-hooks/SKILL.md).
+Nothing is filed on GitHub. These are local drafts for review; the next phase turns them into issues.
+
+- **Base commit:** branch `issues/perf-react-hooks` @ `9e0d5b6a45` (on top of `develop` @ `0c75e6199d`).
+  Every `file:line` must be valid at this commit.
+- **Excluded (already filed under [#28886](https://github.com/trezor/trezor-suite/issues/28886)):**
+  28880, 29027, 29147, 30497, 31109, 31122, 31123, 31124, 31125, 31126, 31127, 31128,
+  31129, 31130, 31131, 31132, 31133, 31134, 31136, 31137, 31138, 31139, 31140, 31141,
+  31142, 31372, 31374. React-hooks-relevant anchors among them:
+    - `packages/suite/src/hooks/wallet/useAccounts.ts:9` destructuring defaults — #31133
+    - `useFiatFromCryptoValue` whole-`Rate` selector / `BaseCurrencyValue` + `FiatValue` re-render storm — #28880
+    - `TransactionsGraph.tsx` `setWidth` / `GraphYAxisTick` layout-effect refire — #31137
+    - "enable React Compiler on web/desktop" as an initiative — #29147 (don't re-file; per-site
+      manual-memoization findings are still valid)
+- **Also excluded: anything already drafted locally** in
+  [`../asymptotic-complexity`](../asymptotic-complexity) (48 docs) and
+  [`../scheduling`](../scheduling) (34 docs). Before reporting a finding, check
+  `grep -rl "<basename>" perf-issues/asymptotic-complexity perf-issues/scheduling`.
+  Hook-adjacent anchors already drafted there: `VirtualizedList.tsx:233`,
+  `AccountLabelForOwnAddress.tsx:22`, `TransactionRenderer.tsx:46`, `TokenIconSetWrapper.tsx:26`,
+  `useEvmNonceInfo.ts:90`, `useStablecoinYieldListData.ts:111`, `transactionsSelectors.ts:281`,
+  `transactionUtils.ts:130` (getOwnEvmNonceSets), `tokenUtils.ts:24`/`:63`,
+  `getLocaleSeparators.ts:2`, `prepareDateTimeFormatter.ts:16`, `useUtxoSelection.ts:63`,
+  `suiteSyncOutputSelectors.ts:56`, native SearchForm debounce (scheduling `p2-14`), accounts
+  sidebar / token-search keystroke filtering (scheduling `p1-12`/`p1-13`), coin-control keystroke
+  rescan (scheduling `p2-05`), `TransactionSummary` render-body aggregation (scheduling `p2-06`),
+  native graph refetch on navigation (scheduling `p1-17`).
+- **Scope boundary:** in scope = the six skill sections (app-aware memoization, render-body
+  relocation, referential stability of deps, minimal deps, wasted-memo vs render/request loop,
+  `exhaustive-deps` suppressions, `useFreshRef`/`useCurrentRef` misuse) plus
+  selector-returns-fresh-reference re-renders (the Redux skill cross-link). Out of scope = pure
+  algorithmic complexity (→ asymptotic-complexity), long tasks / deferral (→ scheduling), forced
+  layout (→ dom), TanStack-query shape (→ data-fetching) unless it is an effect-refetch loop.
+
+## Repo ground truth (verified at base commit — scanners must not contradict this)
+
+- Web/desktop `packages/suite` `useSelector` (`src/hooks/suite/useSelector.ts:15`) defaults to
+  `shallowEqual`: a selector returning a fresh one-level object/array of stable references does
+  **not** re-render — but the returned reference is still fresh per call, so any `useMemo` /
+  `useEffect` depending on it refires anyway. Report those as dep-stability findings, not
+  re-render findings.
+- `suite-native` uses react-redux `useSelector` directly (reference equality): a selector returning
+  `.filter()`/`.map()`/fresh object re-renders its component on **every store dispatch**. React
+  Compiler does not fix this — the fresh reference comes from the store subscription, not from
+  unmemoized render work.
+- `suite-native` is compiled (`experiments.reactCompiler: true`, `suite-native/app/app.config.ts`);
+  don't report "missing useMemo/useCallback/memo" there. Do report: compiler bail-outs
+  (react-hook-form `watch()` in a compiled component), unstable effect deps that refetch, unstable
+  selector results, derived-state-in-effect.
+- `packages/suite`, `suite-common/*`, `packages/components` are **not** compiled — manual
+  memoization findings are valid there.
+- Stability helpers that already exist: `returnStableArrayIfEmpty`
+  (`suite-common/redux-utils/src/selectorsUtils.ts:20`), `createWeakMapSelector` (same file :45),
+  `useFreshRef` / `useCurrentRef` (`packages/react-utils`).
+
+## Phase 0 — candidate harvest (grep, no agents)
+
+`_scan/00-candidates.md` — categorized grep hits handed to every scan agent. Status: **done** —
+C1 exhaustive-deps disables: 34 · C2 native watch(): 0 (verify — may use different forms API) ·
+C2b web bare watch(): 5 · C3 derived useSelector: 52 · C4 `?? []/{}`: ~125 · C5 destructuring
+defaults: ~156 · C6 inline Provider value: 23 · C7 JSON.stringify dep: 1 · C8 useFreshRef/
+useCurrentRef sites: 41 · C9 account/device-keyed effect files: 31 · C10 setState-first effect
+files: 36.
+
+## Phase 1 — scan (raw findings land in `_scan/`)
+
+Batches of 2 agents (a prior audit stalled at 5 concurrent — keep ≤3). Each agent writes its own
+`_scan/NN-*.md`: one `## F-NN-x` section per finding with file:line, verbatim Before hunk, skill
+section, proposed fix sketch, severity guess (P1 hot/unbounded, P2 real-but-colder, P3 cleanup),
+confidence, and a "checked, clean" list. Findings must cite code the agent actually read.
+
+| #   | Area                                                                                                         | Output                          | Status                                    |
+| --- | ------------------------------------------------------------------------------------------------------------ | ------------------------------- | ----------------------------------------- |
+| 1   | `packages/suite/src/hooks` (142 files)                                                                       | `_scan/01-suite-hooks.md`       | **done** — 8 findings (3 P1, 3 P2, 2 P3)  |
+| 2   | `packages/suite/src/components/suite` + small dirs (connection, guide, onboarding, firmware, tx-simulation…) | `_scan/02-suite-components.md`  | **done** — 15 findings (5 P1, 4 P2, 6 P3) |
+| 3   | `packages/suite/src/components/wallet` + `components/earn` (305 files)                                       | `_scan/03-wallet-earn-comp.md`  | **done** — 9 findings (2 P1, 4 P2, 3 P3)  |
+| 4   | `packages/suite/src/views/wallet` (349 files)                                                                | `_scan/04-views-wallet.md`      | **done** — 9 findings (1 P1, 6 P2, 2 P3)  |
+| 5   | `packages/suite/src/views` rest (dashboard, settings, onboarding, suite…) + `src/support`                    | `_scan/05-views-rest.md`        | **done** — 8 findings (2 P1, 2 P2, 4 P3)  |
+| 6   | `suite-common/*` React surface (formatters, graph, connect-init…)                                            | `_scan/06-suite-common.md`      | **done** — 5 findings (2 P1, 3 P3)        |
+| 7   | `packages/components`, `product-components`, `react-utils`, `suite-desktop-ui`                               | `_scan/07-shared-components.md` | **done** — 7 findings (1 P1, 4 P2, 2 P3)  |
+| 8   | `suite-native` shared libs (atoms, accounts, device, transaction-management, navigation, forms, graph…)      | `_scan/08-native-shared.md`     | **done** — 4 findings (1 P1, 3 P3)        |
+| 9   | `suite-native/module-trading`, `module-earn`, `module-send` (biggest modules)                                | `_scan/09-native-modules-a.md`  | **done** — 10 findings (5 P1, 5 P3)       |
+| 10  | `suite-native` remaining `module-*` + `app`                                                                  | `_scan/10-native-modules-b.md`  | **done** — 6 findings (0 P1, 3 P2, 3 P3)  |
+
+### Batch log
+
+| Batch | Areas | Status                                     |
+| ----- | ----- | ------------------------------------------ |
+| 1     | 1, 2  | done — 23 findings (~690k subagent tokens) |
+| 2     | 3, 4  | done — 18 findings                         |
+| 3     | 5, 6  | done — 13 findings                         |
+| 4     | 7, 8  | done — 11 findings                         |
+| 5     | 9, 10 | done — 16 findings                         |
+
+**Phase 1 complete: 81 raw findings, ~3.4M subagent tokens.** All scans ran on sonnet, rolling
+≤2 concurrent.
+
+## Phase 2 — triage
+
+Dedupe + prioritise `_scan/*` into `_scan/_docmap.tsv` (docid, filename, source findings, source
+scan file). That file is the resume key for phase 3. Status: **done** — 81 findings → 43 documents
+(17 P1, 22 P2, 4 batched P3). Merges: F-01-3+F-02-1+F-02-15 (p1-03), F-05-2+F-05-3 (p1-12),
+F-09-1..5 (p1-17), F-02-6+F-04-6 (p2-03), F-03-2+F-07-3 (p2-07), F-10-3+F-10-6 (p2-22).
+
+## Phase 3 — write one doc per issue
+
+One file per proposed issue, structure of [#31137](https://github.com/trezor/trezor-suite/issues/31137):
+lead paragraph naming the skill section, then `## Where` (permalink to develop), `## Before`,
+`## After`, `## Why it matters`, `## Notes`, footer
+`<sub>Verified against issues/perf-react-hooks at 9e0d5b6a45. Part of #28886.</sub>`.
+Suggested labels when filing: `perf`, `no-QA`; parent #31374 (Memoization, loops and reference
+stability) under #28886. Writer house style: `_scan/_writer-brief.md`. Status: **in progress** —
+writers run in waves of ≤3 (sonnet), assignments grouped by scan file:
+W1 p1-01,p1-02,p1-03,p2-01,p2-02 **done** · W2 p1-04,p1-05,p1-06,p1-07,p2-04 **done** ·
+W3 p1-08,p1-09,p2-07,p2-08,p2-10 **done** · W4 p1-10,p2-11,p2-12,p2-13,p2-14 **done** ·
+W5 p2-03,p2-15,p2-05,p2-06 **done** · W6 p1-11,p1-12,p2-16,p3-02 **done** ·
+W7 p1-13,p1-14,p3-03 **done** · W8 p1-15,p2-17,p2-18,p2-19 **done** ·
+W9 p1-16,p2-20,p2-21,p2-22 **done** · W10 p1-17,p3-04 **done** · W11 p3-01 **done** ·
+p2-09 was missed by the wave plan and written by the main session directly (verified against both
+source files; upstream selector confirmed memoized).
+
+**Phase 3 complete: 43/43 documents on disk** (~2.4M subagent tokens across 11 writers, sonnet).
+
+Writer notes worth keeping (deviations writers made on evidence — the most load-bearing content):
+
+- **p3-01 dropped F-02-14** (TransactionRenderer): asymptotic-complexity `p2-16`'s keyed-selector fix
+  already eliminates the render-body re-derivation — nothing additive; reasoning noted in the doc.
+- **p3-01 halved F-01-8**: the `state` memo returns the live `account` verbatim, so narrowing its
+  deps would freeze `state.account` — only the `defaultValues` half is fixed.
+- **p2-12**: naive dep-narrowing has a staleness tradeoff (`buildTokenOptions` embeds whole `account`
+  by reference, `AccountAmount` reads `account.balance` off it) — flagged in Notes, not shipped silently.
+- **p2-06**: the scan's callback-ref fix doesn't type-check (`Column` ref prop is `RefObject`-only) —
+  doc proposes a 3-file restructure instead.
+- **p2-04**: proposed memo only holds if `useBluetoothConnection`'s handlers get `useCallback` first —
+  flagged as same-PR prerequisite.
+- **p1-06**: scan's dep needed `account?.formattedBalance` (union type) and its cross-reference pointed
+  at the wrong audit dir — both corrected in the doc.
+
+A filename listed in `_docmap.tsv` with no file on disk is unstarted work:
+
+```bash
+cut -f2 perf-issues/react-hooks/_scan/_docmap.tsv | while read f; do
+  [ -f "perf-issues/react-hooks/$f" ] || echo "MISSING $f"
+done
+```
+
+## Phase 4 — verification + README index
+
+Re-check every cited `file:line` against the working tree; write `README.md` index (tables like
+`../scheduling/README.md`). Status: **done** — 370 cited anchors across all 43 documents
+mechanically re-checked against the working tree at `9e0d5b6a45`: **0 broken**. All docs carry the
+required sections and footer (the three `p3-*` batch docs written by W7/W10/W11 nest per-finding
+`###` subsections instead of top-level Where/Before/After — content complete, style noted in
+README). Code-fence parity checked. `README.md` written: index tables, overlap boundaries, filing
+order, writer-deviation digest.
+
+## Done
+
+The audit is complete. Next phase (separate task): turn each document into a GitHub issue —
+labels `perf` + `no-QA`, parent #31374, filing order per `README.md`.
+
+## Resuming after a token cut
+
+1. Read this file top to bottom — the status columns are the state.
+2. Phase 1: any area `pending` → launch only that area's agent (prompt template lives in
+   `_scan/_agent-brief.md`), batch ≤2–3.
+3. Phase 2/3: `_docmap.tsv` missing → triage not done; else write missing doc files only.
+4. Keep this file updated after every batch — it is the only cross-session state.

--- a/perf-issues/react-hooks/README.md
+++ b/perf-issues/react-hooks/README.md
@@ -1,0 +1,145 @@
+# perf-issues/react-hooks — one document per proposed GitHub issue
+
+Issue-ready write-ups from the repo-wide sweep against
+[`skills/performance-react-hooks/SKILL.md`](../../skills/performance-react-hooks/SKILL.md).
+
+Each file is the **body of one future issue** on `trezor/trezor-suite`, following the structure of
+[#31137](https://github.com/trezor/trezor-suite/issues/31137): a lead paragraph naming the skill
+section, then `## Where`, `## Before`, `## After`, `## Why it matters`, `## Notes`, and a
+verification footer. The four `p3-*` batch documents keep the same top-level flow but nest
+per-finding `###` subsections (one issue, one PR each).
+
+- **Nothing here is filed yet.** These are drafts for review.
+- **Suggested labels**, matching #31137: `perf`, `no-QA`. **Parent:**
+  [#31374](https://github.com/trezor/trezor-suite/issues/31374) (Memoization, loops and reference
+  stability) under [#28886](https://github.com/trezor/trezor-suite/issues/28886).
+- **Base commit:** branch `issues/perf-react-hooks` @ `9e0d5b6a45`. All 370 cited `file:line`
+  anchors were mechanically re-verified against that tree: 0 broken.
+- **Raw scan output** lives in [`_scan/`](_scan/) — ten area files, 81 raw findings, merged into
+  the 43 documents below (`_scan/_docmap.tsv` maps documents ← findings). The scan files also
+  carry per-area "Checked, clean" lists — negative space that saves the next sweep from re-reading.
+
+## Before filing, read this
+
+**No number in these documents is a measurement.** The sweep verified locations, code and hook
+semantics by reading — every writer re-read the cited source before writing — but nothing was
+profiled. Trigger cadences ("every render", "every store dispatch", "every fiat tick") are
+mechanism statements, not timings.
+
+**The `After` hunks have not been compiled.** They are written against the surrounding types by
+reading, not by running `tsc`.
+
+**Read each document's Notes before filing.** Several writers overrode their scan input on
+evidence, and those corrections are the most load-bearing content in the set:
+
+- `p2-12` — the naive dep-narrowing has a real staleness tradeoff (`buildTokenOptions` embeds the
+  whole `account` by reference; `AccountAmount` reads `account.balance` off it).
+- `p2-06` — the scan's callback-ref fix doesn't type-check (`Column`'s ref prop is
+  `RefObject`-only); the doc proposes a restructure instead.
+- `p2-04` — the Provider memo only holds if `useBluetoothConnection`'s handlers get `useCallback`
+  first (same-PR prerequisite).
+- `p3-01` — dropped one scanned finding (`TransactionRenderer`) because
+  [`../asymptotic-complexity/p2-16`](../asymptotic-complexity/p2-16-transactionrendererx-transactionrenderer.md)'s
+  keyed-selector fix already subsumes it, and fixed only the safe half of the earn-form memo family
+  (narrowing the `state` memo would freeze `state.account`).
+- `p2-22` — corrected the scan's proposed dep (`account.symbol`, not `account.key` — the effect
+  body reads `.symbol`).
+
+**App split matters.** Web/desktop (`packages/suite`, `suite-common`, `packages/components`) is
+NOT compiled by React Compiler — manual memoization is the mechanism. `suite-native` IS compiled —
+native documents never add manual memoization; they fix the unstable reference at its source
+(selector memoization, dep narrowing, derive-in-render). `p1-16`'s `useMemo` is the deliberate
+exception: it _replaces_ `useState`+`useEffect`, removing state rather than adding memoization.
+
+## Overlaps with already-filed issues and sibling drafts (checked, additive — not duplicates)
+
+| Document         | Touches                                                         | Boundary                                                                                 |
+| ---------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `p1-05`, `p1-06` | [#31137](https://github.com/trezor/trezor-suite/issues/31137)   | #31137 is `setWidth`/layout-effect; these are the tooltip effect + interval-data rebuild |
+| `p1-10`          | `../asymptotic-complexity/p1-01`,`p1-09`; `../scheduling/p2-05` | those fix reducer/scan cost; this fixes the refetch trigger                              |
+| `p1-12`          | `../asymptotic-complexity/p2-26`                                | p2-26 owns the `stakingAccounts` selector signature; this owns the unmemoized pipeline   |
+| `p2-07`          | `../asymptotic-complexity/p2-17`                                | p2-17 passes the row's own accounts (n); this fixes the defeated memo chain              |
+| `p2-13`          | `../asymptotic-complexity/p2-28`                                | p2-28 memoizes per account; this fixes the per-keystroke rerun                           |
+| `p2-17`          | `../asymptotic-complexity/p2-11`                                | p2-11 is prefix sums; this is the caller-reset scroll debounce                           |
+| `p2-14`          | `../scheduling/p1-12`                                           | p1-12 defers the rebuild; this stops the needless tab-count recompute                    |
+
+Already filed and therefore **not** re-drafted here: `useAccounts.ts:9` destructuring defaults
+([#31133](https://github.com/trezor/trezor-suite/issues/31133)), the fiat-rate re-render storm
+([#28880](https://github.com/trezor/trezor-suite/issues/28880)), `TransactionsGraph` `setWidth`
+([#31137](https://github.com/trezor/trezor-suite/issues/31137)).
+
+## Filing order
+
+1. **`p1-11` and `p1-07` first** — two smallest diffs with app-shell blast radius (Provider values).
+2. **`p1-17`** — the native fee/allowance-compose family: five anchors, real `@trezor/connect`
+   dispatches refiring on background account churn, with three in-repo correct siblings as the
+   template. Then its web relatives **`p1-03`, `p1-04`, `p1-09`, `p1-10`, `p1-13`** (device/network
+   calls keyed on whole objects).
+3. **`p1-01`** — `useLayout`; biggest render-tree win, slightly larger refactor.
+4. **`p1-05` + `p1-06` together** — same graph-hover path, one PR.
+5. Rest of P1 (`p1-02`, `p1-08`, `p1-12`, `p1-14`, `p1-15`, `p1-16`), then P2 by user-visibility
+   (`p2-15` and `p2-18` are keystroke-path; `p2-20`–`p2-22` are native), then the four P3 batches.
+
+## P1 — hot path or unbounded blast radius (17)
+
+| Document                                                                      | Title                                                                                                              | Anchors                                     |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
+| [`p1-01`](p1-01-uselayout-effect-keyed-on-inline-jsx-rerenders-app-shell.md)  | `useLayout` effect keyed on inline JSX re-renders the whole app chrome on every page render                        | `useLayout.tsx:8`                           |
+| [`p1-02`](p1-02-useaccountsearch-provider-value-recreated-every-render.md)    | `useAccountSearch` context Provider recreates its value object every render                                        | `useAccountSearch.tsx:43`                   |
+| [`p1-03`](p1-03-cancel-tx-compose-refires-on-account-churn.md)                | Cancel-tx compose (hook + modal) re-dispatches on every account/tx reference churn                                 | `useEthereumCancelTxCompose.ts:115` +modal  |
+| [`p1-04`](p1-04-addtokenmodal-refetches-account-info-per-account-refresh.md)  | `AddTokenModal` re-fetches account info from the device on every account refresh                                   | `AddTokenModal.tsx:71`                      |
+| [`p1-05`](p1-05-graphtooltipbase-effect-keyed-on-whole-props.md)              | `GraphTooltipBase` effect keyed on the whole recharts `props` fires on every mouse move                            | `GraphTooltipBase.tsx:132`                  |
+| [`p1-06`](p1-06-transactionsgraph-rebuilds-interval-data-per-hover-render.md) | `TransactionsGraph` rebuilds its interval dataset on every hover-driven render                                     | `TransactionsGraph.tsx:85`                  |
+| [`p1-07`](p1-07-suitelayout-scrollcontext-value-unmemoized.md)                | `SuiteLayout`'s `ScrollContext.Provider` value is fresh every render, fanning to every transaction row             | `SuiteLayout.tsx:113`                       |
+| [`p1-08`](p1-08-feescontext-provider-hands-14-consumers-fresh-object.md)      | `FeesContext.Provider` hands 14 consumers a fresh object every render                                              | `CollapsibleFees.tsx:76`                    |
+| [`p1-09`](p1-09-yield-pending-tx-poll-keys-on-whole-account.md)               | Yield pending-tx poll interval keys on the whole `account`; the Tron sibling is the correct template               | `useYieldPendingTransactionTracking.ts:232` |
+| [`p1-10`](p1-10-coincontrol-refetches-utxo-transactions-on-account-churn.md)  | `CoinControl` re-fetches UTXO transaction history on every account reference change                                | `CoinControl.tsx:144`                       |
+| [`p1-11`](p1-11-responsivecontext-provider-rerenders-app-shell.md)            | `ResponsiveContext` Provider value re-renders the entire app shell on sidebar drag / resize                        | `ResponsiveContext.tsx:68`                  |
+| [`p1-12`](p1-12-assetsview-rebuilds-assetrow-props-every-render.md)           | `AssetsView` rebuilds every `AssetRow` prop per render, defeating the row memo; `AssetCoinLogo` recomputes per row | `AssetsView.tsx:92` +`AssetCoinLogo`        |
+| [`p1-13`](p1-13-useapprovalstep-effect-can-double-fire-quote-refresh.md)      | `useApprovalStep`'s effect keyed on an unmemoized `tx` can double-fire quote refresh mid-trade                     | `useApprovalStep.ts:49`                     |
+| [`p1-14`](p1-14-formatterprovider-memo-defeated-on-web.md)                    | `FormatterProvider`'s memo is defeated on web by an unmemoized config hook                                         | `useFormattersConfig.ts:7`                  |
+| [`p1-15`](p1-15-table-context-value-rerenders-all-rows-on-scroll-edge.md)     | `Table` context value re-renders every row/cell on scroll-shadow boundary crossings                                | `Table.tsx:68`                              |
+| [`p1-16`](p1-16-usetranslatedmessages-double-renders-app-at-cold-start.md)    | `useTranslatedMessages` double-renders the native app at cold start via needless state+effect                      | `useTranslatedMessages.ts:23`               |
+| [`p1-17`](p1-17-native-fee-compose-effects-key-on-whole-account.md)           | Five native fee/allowance-compose effects key on the whole `account` and refire on background churn                | `useResolvedYieldFlowData.ts` +4            |
+
+## P2 — real but colder (22)
+
+| Document                                                                | Title                                                                                                   | Anchors                                |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| [`p2-01`](p2-01-usetradingcomposetransaction-whole-device-dep.md)       | `useTradingComposeTransaction` keys its compose effect on the whole `device`                            | `useTradingComposeTransaction.ts:142`  |
+| [`p2-02`](p2-02-usetotalfiatbalance-recomputes-unmemoized.md)           | `useTotalFiatBalance` recomputes the whole-account-list balance unmemoized every render                 | `useTotalFiatBalance.ts:8`             |
+| [`p2-03`](p2-03-usecurrentref-read-inside-usememo-three-sites.md)       | `useCurrentRef` read inside `useMemo` at three sites — stale until an unrelated render                  | `useAccountWithTokensOptions.ts:57` +2 |
+| [`p2-04`](p2-04-connectionglobalmodalcontext-value-unmemoized.md)       | `ConnectionGlobalModalContext` Provider value is unmemoized                                             | `ConnectionGlobalModalContext.tsx:176` |
+| [`p2-05`](p2-05-suitebanners-filters-accounts-every-render.md)          | `SuiteBanners` filters the full account list on every render of an always-mounted component             | `SuiteBanners.tsx:119`                 |
+| [`p2-06`](p2-06-accountname-exhaustive-deps-suppression.md)             | `AccountName`'s `exhaustive-deps` suppression hides a ref-staleness gap                                 | `AccountName.tsx:23`                   |
+| [`p2-07`](p2-07-tokeniconset-memo-defeated-by-wrapper.md)               | `TokenIconSet`'s memo is correct but permanently defeated by its wrapper                                | `TokenIconSetWrapper.tsx:26`           |
+| [`p2-08`](p2-08-accountsection-gettokens-per-sidebar-row.md)            | `AccountSection` runs `getTokens()` unmemoized for every sidebar row                                    | `AccountSection.tsx:34`                |
+| [`p2-09`](p2-09-earn-staking-dashboard-filter-crosses-hook-boundary.md) | Staking dashboard `.filter()` crosses the hook boundary and defeats two downstream memos                | `useStakingTableData.ts:47`            |
+| [`p2-10`](p2-10-transactionitem-createtargets-unmemoized.md)            | `TransactionItem` rebuilds `createTargets()` on every render                                            | `TransactionItem.tsx:86`               |
+| [`p2-11`](p2-11-tokenselect-revalidation-keyed-on-whole-account.md)     | `TokenSelect` revalidation effect keyed on the whole `account`                                          | `TokenSelect.tsx:70`                   |
+| [`p2-12`](p2-12-usebuildtokenoptions-keyed-on-whole-account.md)         | `useBuildTokenOptions` keys its token-list memo on the whole `account` (staleness tradeoff — see Notes) | `useBuildTokenOptions.tsx:68`          |
+| [`p2-13`](p2-13-ethereumnonce-refilters-history-per-keystroke.md)       | `EthereumNonce` re-filters the account's transaction history on every keystroke                         | `EthereumNonce.tsx:90`                 |
+| [`p2-14`](p2-14-tokensnavigation-tab-counts-per-render.md)              | `TokensNavigation` recomputes tab counts over the full token list per render                            | `TokensNavigation.tsx:126`             |
+| [`p2-15`](p2-15-trading-forms-bare-watch-rerenders-per-keystroke.md)    | Five trading-form components call bare `watch()`, re-rendering on every field change                    | `TradingFormApproval.tsx:63` +4        |
+| [`p2-16`](p2-16-pinstep-effect-keyed-on-whole-device.md)                | `PinStep` status effect keyed on the whole `device` object                                              | `PinStep.tsx:49`                       |
+| [`p2-17`](p2-17-virtualizedlist-scroll-debounce-reset-by-caller.md)     | `VirtualizedList`'s scroll-end debounce is silently reset by its caller's unstable callback             | `VirtualizedList.tsx:126`              |
+| [`p2-18`](p2-18-usenetworkselect-memos-defeated-per-keystroke.md)       | `useNetworkSelect`'s memos are defeated on every keystroke by inline selector props                     | `useNetworkSelect.ts:15`               |
+| [`p2-19`](p2-19-menu-rebuilds-global-keydown-listeners.md)              | `Menu` rebuilds two global `document` keydown listeners on every render while open                      | `Menu.tsx:131`                         |
+| [`p2-20`](p2-20-selectfilterknowntokens-unmemoized-native.md)           | `selectFilterKnownTokens` is unmemoized — native consumers re-render on every dispatch                  | `tokenDefinitionsSelectors.ts:44`      |
+| [`p2-21`](p2-21-accountimportloading-stale-retry-closure.md)            | `AccountImportLoadingScreen`'s retry calls a stale closure                                              | `AccountImportLoadingScreen.tsx:56`    |
+| [`p2-22`](p2-22-native-analytics-effects-whole-account-deps.md)         | Native analytics effects keyed on whole `account`/`transaction` over-fire on background churn           | `AccountDetailContentScreen.tsx:24` +1 |
+
+## P3 — cleanups, batched by subsystem (4)
+
+| Document                                                    | Findings | Scope                                                                                     |
+| ----------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------- |
+| [`p3-01`](p3-01-cleanups-suite-hooks-and-components.md)     | 10       | `packages/suite` hooks + suite/wallet components                                          |
+| [`p3-02`](p3-02-cleanups-suite-views-and-support.md)        | 6        | `packages/suite` views (trading detail, tokens/nfts, onboarding, notifications) + support |
+| [`p3-03`](p3-03-cleanups-suite-common-and-design-system.md) | 5        | `suite-common` hooks + `packages/components` compound Providers                           |
+| [`p3-04`](p3-04-cleanups-suite-native.md)                   | 10       | `suite-native` shared libs + modules (one low-confidence item flagged verify-first)       |
+
+## Merges (raw findings → documents)
+
+`p1-03` ← F-01-3 + F-02-1 + F-02-15 · `p1-12` ← F-05-2 + F-05-3 · `p1-17` ← F-09-1…5 ·
+`p2-03` ← F-02-6 + F-04-6 · `p2-07` ← F-03-2 + F-07-3 · `p2-22` ← F-10-3 + F-10-6 ·
+dropped: F-02-14 (subsumed by `../asymptotic-complexity/p2-16` — reasoning in `p3-01`).

--- a/perf-issues/react-hooks/_scan/00-candidates.md
+++ b/perf-issues/react-hooks/_scan/00-candidates.md
@@ -1,0 +1,569 @@
+# Grep candidate harvest — react-hooks sweep
+
+Generated at base commit 9e0d5b6a45. Raw candidates only — every row needs verification by reading.
+Scan agents: take the rows under your area's path prefixes.
+
+## C1 — eslint-disable react-hooks/exhaustive-deps (each is a class-6 finding candidate)
+
+```
+packages/components/src/components/ResizableBox/ResizableBox.tsx:333:    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+packages/components/src/components/form/Select/customComponents.tsx:178:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/react-utils/src/hooks/useAsyncMemo.test.ts:21:            // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/react-utils/src/hooks/useAsyncMemo.test.ts:42:            // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/react-utils/src/hooks/useAsyncMemo.test.ts:61:            // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/react-utils/src/hooks/useAsyncMemo.test.ts:72:            // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/react-utils/src/hooks/useAsyncMemo.test.ts:9:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/react-utils/src/hooks/useAsyncMemo.ts:37:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/react-utils/src/hooks/useKeyPress.ts:32:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountName.tsx:53:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx:29:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/hooks/settings/backends/useBackendsForm.ts:87:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts:131:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts:209:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts:275:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts:98:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/hooks/wallet/useSendForm.ts:400:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/hooks/wallet/useSendForm.ts:415:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/support/suite/useConnectPopup.tsx:152:        // eslint-disable-next-line react-hooks/exhaustive-deps
+packages/suite/src/views/wallet/details/CoinjoinSetup/SetupSlider/SliderInput.tsx:90:    }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
+packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx:113:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-common/dependency-injection/src/useServices.tsx:68:    // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/device-authorization/src/hooks/usePinAction.tsx:142:            // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx:217:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx:71:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/module-check-backup/src/hooks/useCheckBackupOnMount.tsx:66:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/module-device-onboarding/src/screens/DeviceAuthenticityScreen.tsx:42:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx:70:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx:36:            // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/module-device-onboarding/src/screens/UninitializedDeviceLandingScreen.tsx:141:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/module-send/src/hooks/useSendForm.tsx:315:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/react-native-graph/src/AnimatedLineGraph.tsx:289:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/react-native-graph/src/AnimatedLineGraph.tsx:396:        // eslint-disable-next-line react-hooks/exhaustive-deps
+suite-native/react-native-graph/src/AnimatedLineGraph.tsx:451:        // eslint-disable-next-line react-hooks/exhaustive-deps
+```
+
+## C2 — react-hook-form watch( in suite-native (compiler bail-out candidates)
+
+```
+
+```
+
+## C2b — bare watch() in web packages/suite (whole-form re-render per keystroke)
+
+```
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx:63:    const { exchangeType, rateType } = watch();
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOffersWarnings.tsx:24:        const { countrySelect, countrySubdivisionSelect } = context.watch();
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon.ts:35:    const { amountInCrypto } = watch();
+packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx:44:    const { outputs, sendCryptoSelect, receiveCryptoSelect, exchangeType, rateType } = watch();
+packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx:30:    const { outputs } = watch();
+```
+
+## C3 — useSelector returning derived/fresh reference (multiline window 160 chars)
+
+```
+packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinBars.tsx:10:    const sessionCount = coinjoinAccounts.filter(
+packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinBars.tsx:8:useSelector(state => state.wallet.coinjoin.accounts);
+packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx:52:useSelector(state => state.wallet.blockchain);
+packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx:54:    return (
+packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx:55:        <Column gap={16} padding={4}>
+packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx:56:            <Column gap={12}>
+packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx:57:                {customBackends.map(
+packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx:81:useSelector(state => state.wallet.accounts);
+packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx:82:    const { networkType, symbol } = account;
+packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx:83:    const isMultirecipient = outputs.filter(
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx:58:useSelector(state => state.wallet.accounts);
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx:59:    const dispatch = useDispatch();
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx:61:    if (!device) {
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx:62:        return null;
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx:63:    }
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx:65:    const coinjoinAccounts = accounts.filter(
+packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx:45:useSelector(state =>
+packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx:46:        selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
+packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx:47:    ).filter(
+packages/suite/src/components/wallet/TokenIconSetWrapper.tsx:24:useSelector(state => selectCoinDefinitions(state, symbol));
+packages/suite/src/components/wallet/TokenIconSetWrapper.tsx:26:    const allTokensWithRates = accounts.flatMap(
+packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts:62:useSelector(state => {
+packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts:63:        const enabledVaultApys = wrappedNativeVaults
+packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts:64:            .filter(
+packages/suite/src/hooks/suite/useBioAuthDesktopApi.ts:16:useSelector(state => ({
+packages/suite/src/hooks/suite/useGraph.ts:12:useSelector(state => state.wallet.graph.selectedRange);
+packages/suite/src/hooks/suite/useGraph.ts:14:    const actions = useMemo(
+packages/suite/src/hooks/suite/useGraph.ts:15:        () => ({
+packages/suite/src/hooks/wallet/useTotalFiatBalance.ts:13:useSelector(state => state.tokenDefinitions);
+packages/suite/src/hooks/wallet/useTotalFiatBalance.ts:14:    const deviceAccounts: Account[] = accounts.map(
+packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx:78:useSelector(state => selectCoinDefinitions(state, network.symbol));
+packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx:79:        const stakingAccountsForAsset = stakingAccounts.filter(
+packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx:31:useSelector(state =>
+packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx:32:        selectFeaturesConfig(state, Feature.banners.dashboard.promo),
+packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx:33:    );
+packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx:35:    const deduplicatedBanners = allPromoBanners
+packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx:36:        .map(
+suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx:68:useSelector((state: TokensRootState) =>
+suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx:69:        selectAccountManuallyHiddenTokensCount(state, accountKey),
+suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx:70:    );
+suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx:72:    const tokenCount = sections.filter(
+suite-native/module-add-accounts/src/screens/AddCoinDiscoveryFinishedScreen.tsx:34:useSelector((state: AccountsRootState & DeviceRootState) =>
+suite-native/module-add-accounts/src/screens/AddCoinDiscoveryFinishedScreen.tsx:35:        selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
+suite-native/module-add-accounts/src/screens/AddCoinDiscoveryFinishedScreen.tsx:36:    ).filter(
+suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx:73:useSelector((state: TradingRootState) =>
+suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx:74:        selectBuyQuotesByPaymentMethodNative(state, paymentMethod),
+suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx:75:    );
+suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx:77:    const shouldShowPicker = (providers && Object.values(
+suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx:74:useSelector((state: TradingRootState) =>
+suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx:75:        selectSellQuotesByPaymentMethod(state, paymentMethod),
+suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx:76:    );
+suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx:78:    const shouldShowPicker = (providers && Object.values(
+```
+
+## C4 — ?? [] / ?? {} in .tsx (unstable fallback; verify hook relevance by reading)
+
+```
+packages/components/src/components/animations/recolorLottieAnimation.tsx:32:    appliedOpacities.set(opacity, new Set([...(appliedAlphas ?? []), alpha]));
+packages/suite/src/views/recovery/index.tsx:45:    const { pin, setPin, handlePinSubmit } = usePin(device?.buttonRequests ?? [], pinRequestId);
+packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/UtxoReceiveAddressModal.tsx:33:        const used = addresses?.used ?? [];
+packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/UtxoReceiveAddressModal.tsx:34:        const unused = addresses?.unused?.slice(0, MAX_UNUSED_ADDRESSES) ?? [];
+packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx:23:    const sortedTokens = account.tokens?.toSorted(sortTokensByName) ?? [];
+suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailProviderCard.tsx:35:    const { logo, companyName, supportUrl } = providerInfo ?? {};
+packages/product-components/src/components/DeviceAnimation/DeviceAnimation.stories.tsx:16:    const [firstModel, firstModelCfg] = modelEntries[0] ?? [];
+packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx:83:        const amount = (accounts[asset.network.symbol] ?? [])
+packages/suite/src/views/wallet/send/TotalSent/CardanoSentTokenInfo.tsx:25:            (formOutputs ?? []).filter(o => o.token).map(o => [o.token, o.amount]),
+packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx:15:    const { companyName, termsUrl } = provider ?? currentProviderMetadata ?? {};
+packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx:138:    const spendableUtxosOnPage = paginatedCategories[0] ?? [];
+packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx:139:    const lowAnonymityUtxosOnPage = paginatedCategories[1] ?? [];
+packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx:140:    const dustUtxosOnPage = paginatedCategories[2] ?? [];
+packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx:138:    const isNearbyDevice = (nearbyDevices ?? []).some(
+packages/suite/src/components/suite/bluetooth/BluetoothDebugInfo.tsx:33:    const isNearbyDevice = (nearbyDevices ?? []).find(
+packages/suite/src/views/settings/SettingsDebug/Backends.tsx:157:                    {Object.entries(identityConnections ?? {}).map(([identity, connection]) => (
+suite-native/module-dev-utils/src/screens/MessageSystemManagerScreen.tsx:37:        return (config?.actions ?? []).filter(({ message }) => {
+packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx:30:    const isEditingNonce = (enabledOptions ?? []).includes('ethereumNonce');
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx:90:        useModalLastValidParams(revokeParams, state.isRevokeModalOpen) ?? {};
+suite-native/trading-slippage/src/components/SlippageSummary.tsx:14:        useSelector(selectTradingExchangeSelectedQuote) ?? {};
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx:104:        useModalLastValidParams(approveParams, state.isApproveModalOpen) ?? {};
+packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.tsx:58:    const usedAddresses = addresses?.used.filter(matchesQuery) ?? [];
+packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.tsx:60:        addresses?.unused.slice(0, MAX_UNUSED_ADDRESSES).filter(matchesQuery) ?? [];
+packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/AdaStakingDashboard.tsx:54:    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+packages/suite/src/components/suite/Preloader/Preloader.test.tsx:116:        accounts: mockInitialAppState.wallet?.accounts ?? [],
+packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardNextRewards.tsx:27:    const { autocompoundBalance = '0' } = getStakingDataForNetwork(selectedAccount) ?? {};
+packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx:128:    } = getStakingDataForNetwork(account) ?? {};
+packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx:30:            addresses: target.addresses ?? [],
+suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx:61:        selectFilterKnownTokens(state, symbol, accountInfo.tokens ?? []),
+packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx:31:        getStakingDataForNetwork(selectedAccount) ?? {};
+packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx:44:    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx:75:    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx:46:            accounts: mockInitialAppState.wallet?.accounts ?? [],
+suite-native/transaction-management/src/hooks/useShowStayOnScreenAlert.tsx:38:            } = alertOptions ?? {};
+suite-native/transactions/src/components/TransactionList.tsx:218:                ...(accountTransactionsByMonth['no-blocktime'] ?? []),
+suite-native/transactions/src/components/TransactionList.tsx:231:                ...(accountTransactionsByMonth[monthKey] ?? []).flatMap(transaction =>
+suite-native/transactions/src/components/TransactionList.tsx:247:            ...(accountTransactionsByMonth[monthKey] ?? []),
+packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx:68:    const isFiatLoading = areTokenFiatRatesLoading(account, baseCurrencyCode, rates ?? {});
+packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewTronFeeNotes.tsx:28:        calculateTronFeeBreakdown(tx, tronResources, account.symbol) ?? {};
+packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:602:            return (rewards ?? []).map(reward => ({
+suite-native/transactions/src/components/TransactionName.tsx:147:        const { contractType, votes, unstakeAmount } = transaction.tronSpecific ?? {};
+suite-native/module-send/src/hooks/useSendForm.tsx:149:                utxos: account?.utxo ?? [],
+packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx:106:                      tokens: account.tokens ?? [],
+suite-native/module-send/src/screens/SendUtxoScreen.tsx:44:    const [tempSelectedUtxos, setTempSelectedUtxos] = useState<Utxo[]>(selectedUtxos ?? []);
+suite-native/module-send/src/screens/SendUtxoScreen.tsx:49:    const filteredUtxos = useFilteredUtxos(account?.utxo ?? [], searchQuery);
+suite-native/module-send/src/screens/SendUtxoScreen.tsx:89:            ) ?? [],
+suite-native/module-accounts-management/src/screens/AccountsScreen.tsx:26:        () => route.params?.networksFilter ?? [],
+packages/suite/src/components/earn/staking/tron/complete/TronVoteSummaryCard.tsx:13:    const apr = (representatives.data ?? []).find(({ address }) => address === votedAddress)?.apr;
+packages/suite/src/components/earn/staking/tron/complete/TronStakeSummaryCard.tsx:28:    const apr = (representatives.data ?? []).find(({ address }) => address === votedAddress)?.apr;
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx:61:                    ) ?? [],
+suite-native/module-connect-popup/src/screens/WalletConnectSessionPopupScreen.tsx:57:                ) ?? [],
+packages/suite/src/components/earn/staking/tron/vote/TronVoteRepresentativeSelect.tsx:45:            })) ?? [];
+packages/suite/src/components/earn/staking/tron/vote/TronVoteApr.tsx:19:    const selected = (representatives.data ?? []).find(({ address }) => address === representative);
+packages/suite/src/support/suite/useConnectPopupDesktop.tsx:75:                        const { method: _m, device: _d, ...safePayload } = params.payload ?? {};
+suite-native/device/src/components/DeviceDangerBannerExtension.tsx:54:    const { cause } = deviceDanger ?? {};
+suite-native/message-system/src/components/ContextMessage.tsx:30:    const { label, link } = cta ?? {};
+packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx:75:    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+packages/suite/src/components/suite/FormattedCryptoAmount.tsx:79:    } = getNetworkOptional(lowerCaseSymbol) ?? {};
+packages/suite/src/components/earn/modals/EarnClaimModal/EarnClaimModal.tsx:58:    const { claimableAmount = '0', restakedReward = '0' } = getStakingDataForNetwork(account) ?? {};
+suite-native/icons/src/TokenIcon.tsx:150:    const sourceUrls = resolvedUrls ?? [];
+suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx:36:    const { exchange } = selectedValue ?? {};
+suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx:72:    const { paymentMethod } = selectedValue ?? {};
+suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx:75:            const enabledCoins = getValues('enabledCoins') ?? {};
+packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx:50:    } = getStakingDataForNetwork(account) ?? {};
+packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx:46:    } = getStakingDataForNetwork(account) ?? {};
+suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx:36:    const { exchange } = selectedValue ?? {};
+suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx:73:    const { paymentMethod } = selectedValue ?? {};
+suite-native/module-trading/src/components/general/AccountList/AccountList.tsx:77:        }) ?? [];
+suite-native/module-earn/src/components/EarnDepositsCard.tsx:236:                items={stakingRow?.activeItems ?? []}
+suite-native/module-earn/src/components/EarnDepositsCard.tsx:243:                items={stablecoinYieldRow?.activeItems ?? []}
+suite-native/module-earn/src/components/SolanaStakingRewardsList.tsx:46:    const rewards = rewardsQuery.data?.rewards ?? [];
+suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx:27:    const { decimals } = findToken(sendAccount?.tokens, contractAddress) ?? {};
+suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.tsx:16:    const { decimals } = findToken(sendAccount?.tokens, contractAddress) ?? {};
+suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx:30:    const { exchange } = selectedValue ?? {};
+```
+
+### C4b — same in .ts hooks/selectors files only
+
+```
+packages/product-components/src/components/SearchAsset/hooks/useNetworkSelect.ts:15:    const { networks = [], includeAllOption, allLabel, selectedNetwork } = config ?? {};
+packages/suite/src/selectors/suite/suiteSelectors.ts:15:    state.suite.transport?.transports ?? [];
+suite-common/wallet-core/src/tokens/tokenSelectors.ts:32:            tokens: account.tokens ?? [],
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts:93:                tokens: account.tokens ?? [],
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts:113:                tokens: account.tokens ?? [],
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts:134:                tokens: account.tokens ?? [],
+suite-common/wallet-core/src/accounts/accountsSelectors.ts:313:        return account.misc.solExternalStakingAccounts ?? [];
+suite-common/wallet-core/src/accounts/accountsSelectors.ts:331:        const totalLamports = (account.misc.solExternalStakingAccounts ?? []).reduce(
+suite-native/tokens/src/tokensSelectors.ts:108:                    transaction?.tokens ?? [],
+suite-native/tokens/src/tokensSelectors.ts:126:                    transaction?.tokens ?? [],
+suite-native/tokens/src/tokensSelectors.ts:146:    return A.any(accounts, account => (account.tokens ?? []).some(token => !isNftToken(token)));
+packages/suite/src/hooks/earn/useWithdrawalForm.ts:77:    const { autocompoundBalance = '0' } = getStakingDataForNetwork(account) ?? {};
+suite-common/wallet-core/src/transactions/transactionsSelectors.ts:113:                response[accountKey] = (transactions[accountKey] ?? []).filter(isPending);
+suite-common/wallet-core/src/transactions/transactionsSelectors.ts:285:            const accountTransactions = transactions[account.key] ?? [];
+suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts:33:    const hasActiveStakingAccount = (account.misc?.solStakingAccounts ?? []).some(
+suite-common/bluetooth/src/bluetoothSelectors.ts:19:) => returnStableArrayIfEmpty(state.bluetooth.nearbyDevices ?? []);
+suite-common/bluetooth/src/bluetoothSelectors.ts:37:            const nearbyDevicesCopy = [...(nearbyDevices ?? [])];
+suite-common/device/src/deviceSelectors.ts:159:    device => device?.availableTranslations ?? {},
+suite-common/device/src/deviceSelectors.ts:189:    device => device?.buttonRequests ?? [],
+packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts:119:    const noProviders = Object.keys(exchangeInfo?.providerInfos ?? {}).length === 0;
+suite-common/message-system/src/useConditionControls.ts:31:            const head = (existing[0] ?? {}) as Record<string, unknown>;
+packages/suite/src/hooks/settings/backends/useDefaultUrls.ts:15:            return result.payload.blockchainLink?.url ?? [];
+packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellForm.ts:83:    const noProviders = Object.keys(sellInfo?.providerInfos ?? {}).length === 0;
+packages/suite/src/hooks/wallet/useTotalFiatBalance.ts:17:            tokens: account.tokens ?? [],
+packages/suite/src/hooks/wallet/useAccounts.ts:8:    const { addresses, descriptor, networkType, path } = account ?? {};
+packages/suite/src/hooks/wallet/useAccounts.ts:9:    const { unused: unusedAddresses = [], used: usedAddresses = [] } = addresses ?? {};
+packages/suite/src/hooks/wallet/useAccounts.ts:15:                return (unusedAddresses ?? []).concat(usedAddresses ?? []).reduce(
+suite-common/wallet-core/src/stake/stakeSelectors.ts:53:            const poolStats = data.ada?.pools ?? [];
+suite-common/trading/src/selectors/tradingSelectors.ts:472:        return getTradingCoinInfoByCryptoId(coins ?? {}, cryptoId);
+suite-common/trading/src/selectors/tradingSelectors.ts:483:        return getTradingCoinSymbolByCryptoId(coins ?? {}, cryptoId);
+suite-common/trading/src/selectors/tradingSelectors.ts:509:        getTradingNativeCoinSymbolByCryptoId(platforms ?? {}, coins ?? {}, cryptoId),
+suite-common/trading/src/hooks/useCoinsAndPlatforms.ts:15:        const coins = infoRef.current.coins ?? {};
+suite-common/trading/src/hooks/useCoinsAndPlatforms.ts:16:        const platforms = infoRef.current.platforms ?? {};
+suite-native/trading-state/src/selectors/commonSelectors.ts:295:                        account.tokens ?? [],
+suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts:40:    const { symbol } = account ?? {};
+packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts:73:                tokens: account.tokens ?? [],
+suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts:52:        const tokenAddresses = coinDefinitions?.data ?? [];
+suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts:59:                const [weekAgo, today] = timestampedFiatRates?.tickers ?? [];
+suite-native/banners/src/selectors.ts:33:        .flatMap(m => m?.feature ?? [])
+suite-native/coin-enabling/src/hooks/useHasEnabledCoin.ts:11:            Object.values(enabledCoins ?? {}).some(Boolean),
+suite-native/module-device-settings/src/selectors.ts:13:        ) ?? [],
+suite-native/accounts/src/selectors.ts:336:            ? (account.tokens ?? []).filter(token => !hiddenSet.has(token.contract.toLowerCase()))
+suite-native/accounts/src/selectors.ts:337:            : (account.tokens ?? [])
+suite-native/accounts/src/selectors.ts:436:            coinDefs?.hide ?? [],
+suite-native/accounts/src/selectors.ts:437:            coinDefs?.show ?? [],
+suite-native/module-trading/src/hooks/general/useTradingTransaction.ts:105:    const { selectedFee } = draft ?? {};
+suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts:46:    const { feeLimit, feePerUnit, maxFeePerGas, maxPriorityFeePerGas } = draft ?? {};
+suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts:132:        const { quoteId, isDex } = quote ?? {};
+suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts:78:            const { shouldReportAnalytics = true } = options ?? {};
+suite-native/module-earn/src/hooks/usePreparedTxFees.ts:281:    const localFeeLevels = feeDraftState?.feeLevels ?? {};
+suite-native/module-earn/src/hooks/useComposeEarnFees.ts:139:                } = formDraftRef.current ?? {};
+```
+
+## C5 — destructuring defaults = [] / = {} (skill's worked example shape)
+
+```
+packages/suite/src/reducers/store.ts:186:    options: { statePatch?: Record<string, any> } = {},
+suite-common/transaction-search/src/useFilteredUtxos.ts:9:    utxos: Utxo[] = [],
+packages/react-utils/src/hooks/timer/useCountdownTimer.ts:12:    { pastDeadlineLeadMs = 1000, isEnabled = true }: UseCountdownTimerOptions = {},
+suite-common/wallet-core/src/tokens/tokenUtils.ts:34:    tokens = [],
+suite-common/wallet-core/src/send/__fixtures__/evmFixtures.ts:38:    } = {},
+packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx:50:    transactions = [],
+suite-common/wallet-core/src/device/deviceThunks.ts:523:        { skipToggleModalConnection, isOsUnpairingFinished, skipDisconnect, deviceId } = {},
+suite-native/trading-history/src/components/TradeHistoryListItem/TradingDetailFeedback.test.tsx:21:        props: Partial<Parameters<typeof TradingDetailFeedback>[0]> = {},
+suite-common/wallet-core/src/discovery/discoveryActions.ts:41:        }: StartDiscoveryParams = {},
+suite-common/calldata/src/builder/createBuilder.ts:38:        context: unknown = {},
+suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldDeviceUtils.ts:47:    options: StablecoinYieldSupportOptions = {},
+suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts:69:    { onSuccess }: UseTxSimulationProps = {},
+suite-common/tx-simulation/src/hooks/useTxSimulation.ts:15:    { onSuccess }: Pick<UseTxSimulationProps, 'onSuccess'> = {},
+suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts:10:    overrides: Partial<TransactionValidation> = {},
+suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts:19:    overrides: Partial<TransactionSimulationError> = {},
+packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx:34:        tokens: accountTokens = [],
+suite-common/calldata/src/clearSigning.ts:122:    extra: ReadonlyArray<Deployment> = [],
+suite-native/trading-atoms/src/hooks/useSectionList.test.tsx:12:            data = [],
+suite-common/message-system/src/useExperiment.test.ts:28:    } = {},
+suite-common/wallet-core/src/selectors.test.ts:54:    accounts = [],
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx:328:        } = {},
+suite-common/redux-extra-dependencies/src/notImplemented.ts:34:    getterArgs: any = {},
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts:43:    tokens = [],
+suite-common/redux-utils/src/createSingleInstanceThunk.test.ts:20:        reducer: (state = {}, action) => {
+suite-common/suite-sync-quota-manager/src/challenge/mocks/createPrepareChallengeSessionDepsMock.ts:17:    patch = {},
+suite-common/suite-sync-quota-manager/src/device/mocks/createEnsureDeviceHasQuotaDepsMock.ts:19:    patch = {},
+packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx:111:    trades = [],
+suite-common/suite-sync-quota-manager/src/device/mocks/createEnsureOwnerHasAllocatedQuotaDepsMock.ts:16:    patch = {},
+packages/suite/src/views/settings/SettingsCoins/useNetworkSettingsSearch.ts:16:    { origin = 'network-settings' }: UseNetworkSettingsSearchOptions = {},
+suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.ts:11:    outputLabels: SuiteSyncOutput[] = [],
+suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.ts:26:    addressLabels: SuiteSyncAddress[] = [],
+suite-common/bluetooth/src/bluetoothActions.ts:84:        } = {},
+suite-common/suite-sync/src/suiteSyncSelectors.test.ts:18:    deviceOverrides: Parameters<typeof mockSuiteDevice>[0] = {},
+suite-common/suite-sync/src/suiteSyncSelectors.test.ts:19:    suiteSyncOverrides: Partial<SuiteSyncState> = {},
+suite-common/suite-sync/src/createEnsureSuiteSyncKeys.test.ts:34:    overrides: Partial<TrezorDevice> = {},
+suite-common/suite-sync/src/createEnsureSuiteSyncKeys.test.ts:35:    deviceStateOverrides: Partial<TrezorDevice['state']> | null = {},
+suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.test.ts:28:    overrides: Partial<CreateEnsureSuiteSyncOwnerDeps> = {},
+suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.test.tsx:93:        { inputIndex = 0 } = {},
+suite-common/connect-init/src/connectInitThunks.test.ts:47:    services: Partial<ConnectInitThunkDeps['services']> = {},
+packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts:75:            } = {},
+packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts:99:            } = {},
+packages/suite/src/actions/settings/deviceSettingsActions.ts:44:    (params: Parameters<typeof TrezorConnect.changePin>[0] = {}, skipSuccessToast?: boolean) =>
+suite-common/wallet-config/src/earnRewardsProvider.ts:15:    { isDebugMode = false }: { isDebugMode?: boolean } = {},
+suite-common/trading/src/tradeApi.ts:145:        body: BodyType = {},
+suite-common/trading/src/tradeApi.ts:174:        body: BodyType = {},
+packages/suite/src/actions/suite/suiteForgetDeviceThunk.ts:25:        }: ForgetDeviceThunkParams | undefined = {},
+suite-common/wallet-utils/src/stakingUtils.ts:280:    { withdrawTime, exitTime }: GetUnstakingPeriodInDays = {},
+suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewardsQueryEntries.ts:75:    { isDebugMode, skipEmptyAccountCheck = false }: MerklRewardsQueryEntriesOptions = {},
+suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewardsQueryEntries.ts:94:    { isDebugMode, skipEmptyAccountCheck }: MerklRewardsQueryEntriesOptions = {},
+suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useExtendMerklRewardsWithFiat.ts:24:    chainsRewards: MerklChainsRewards = [],
+packages/suite/src/hooks/suite/useMessageSystemYield.ts:13:    options: UseMessageSystemYieldOptions = {},
+suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts:56:    { getCoinSymbol }: ResolveTradeErrorOptions = {},
+suite-common/wallet-utils/src/ethUtils.test.ts:315:            targets = [],
+suite-common/wallet-utils/src/ethUtils.test.ts:316:            internalTransfers = [],
+suite-common/wallet-utils/src/ethUtils.test.ts:364:            targets = [],
+suite-common/wallet-utils/src/ethUtils.test.ts:365:            internalTransfers = [],
+suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts:27:    { simulationStatus = 'Success' }: { simulationStatus?: 'Success' | 'Error' } = {},
+suite-common/wallet-utils/src/accountUtils.ts:380:    { addresses, history: { transactions = [] }, page }: AccountInfo,
+suite-common/wallet-utils/src/tronUtils.test.ts:31:    overrides: Partial<TronAccountExtraData> = {},
+suite-native/module-send/src/utils.ts:16:    selectedUtxos = [],
+suite-common/wallet-utils/src/solanaStakingUtils.test.ts:10:    overrides: Partial<SolanaStakingAccount> = {},
+suite-native/module-send/src/selectors.test.ts:8:    overrides: Partial<NativeSendRootState['wallet']['send']> = {},
+suite-common/wallet-utils/src/tronStakingUtils.test.ts:400:    overrides: Partial<TronAccountExtraData> = {},
+packages/suite/src/actions/wallet/blockchainActions.test.ts:51:    { accounts, transactions, blockchain, fees }: Args = {},
+suite-common/suite-sync-storage/mocks/mockSuiteSyncStorage.ts:18:    overrides: MockSuiteSyncStorageOverrides = {},
+suite-common/earn-staking-api/src/staking/hooks/useEthereumValidatorsQueue.ts:21:    > = {},
+suite-common/earn-staking-api/src/staking/hooks/useSolStakingRewardsWarning.ts:11:    { limit = 1 }: UseSolStakingRewardsWarningOptions = {},
+suite-native/trading-analytics/src/hooks/useExchangeAnalyticReportCallback.test.ts:29:        overrides: PreloadedStatePartial<ExchangeAnalyticsPreloadedState> = {},
+suite-native/trading-analytics/src/hooks/useBuyAnalyticReportCallback.test.ts:27:        overrides: PreloadedStatePartial<BuyAnalyticsPreloadedState> = {},
+packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx:85:    options: { resolver?: Resolver<TradingBuyFormProps> } = {},
+suite-native/transaction-management/src/hooks/fees/useFeeSelection.ts:40:            }: CustomFeeParams = {},
+packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx:60:    overrides: Partial<TradingExchangeFormProps> = {},
+packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx:100:    dexQuotes = [],
+packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.test.tsx:151:    } = {},
+packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.test.tsx:132:    options: { resolver?: Resolver<TradingSellFormProps> } = {},
+suite-native/atoms/src/Text.tsx:96:            style = {},
+suite-native/atoms/src/Sheet/BottomSheetModal.tsx:62:            bottomSheetCustomProps = {},
+packages/suite/src/hooks/wallet/useEvmNonceInfo.ts:41:    { enabled = true }: UseEvmNonceInfoOptions = {},
+suite-native/atoms/src/DiscreetText/DiscreetText.tsx:31:    style = {},
+suite-native/discovery/src/discoverySelectors.test.ts:46:    overrides: PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>> = {},
+suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.test.tsx:12:        props: Partial<ReviewOutputItemValuesProps> = {},
+suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.test.tsx:13:        preloadedState = {},
+suite-native/graph/src/components/Graph.tsx:78:    points = [],
+suite-native/transaction-management/src/__fixtures__/feeLevels.ts:5:    overrides: Partial<PrecomposedTransactionFinal> = {},
+suite-native/transaction-management/src/selectors.test.ts:25:    overrides: Partial<NativeSendRootState['wallet']['send']> = {},
+suite-native/formatters/src/components/AmountText.tsx:18:    style = {},
+suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.test.tsx:14:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/state/src/receivePersistTransform.ts:6:    accounts: ReceiveState['accounts'] = {},
+suite-native/module-trading/src/components/buy/BuyFiatAmountInput.test.tsx:18:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/buy/BuyFiatAmountInput.test.tsx:28:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.test.tsx:21:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.test.tsx:31:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/hooks/general/useTradingFiatValues.test.ts:28:    walletOverrides: Record<string, unknown> = {},
+suite-native/module-trading/src/hooks/general/useWatchTrade.test.ts:70:        trades = [],
+suite-native/module-trading/src/hooks/general/useWatchTrade.test.ts:71:        accounts = [],
+suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.test.ts:14:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx:96:    payload: Partial<SimulationResult['payload']> = {},
+suite-native/module-trading/src/screens/TradingConfirmingScreen.test.tsx:104:        routeProps: Partial<RootStackParamList[RootStackRoutes.TradingConfirming]> = {},
+suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.test.tsx:62:        componentPreloadedState: PreloadedStatePartial<typeof defaultPreloadedState> = {},
+suite-native/module-trading/src/hooks/exchange/useExchangeSignTransaction.test.ts:52:    overrides = {},
+suite-native/module-trading/src/components/buy/BuyProviderPicker.test.tsx:34:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.test.tsx:24:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.test.tsx:36:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-settings/src/components/FaqCard.tsx:18:    values = {},
+suite-native/module-trading/src/components/concierge/ConciergeAlert.test.tsx:60:    errors = {},
+suite-native/module-trading/src/components/concierge/ConciergeAlert.test.tsx:61:    values = {},
+suite-native/trading-fixtures/src/__fixtures__/precomposedTransaction.ts:8:    overrides: Partial<PrecomposedTransactionFinal> = {},
+suite-native/module-earn/src/unstakeFormSchema.test.ts:19:    overrides: Partial<SolanaStakingAccount> = {},
+suite-native/module-trading/src/components/concierge/ConciergeTabContent.test.tsx:41:    overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListItem.test.tsx:89:        }: Partial<MyAssetListItemProps> = {},
+suite-native/module-earn/src/utils/getWrappedNativeYieldVaults.ts:21:    vaults = [],
+suite-native/accounts/src/selectors.ts:324:    hiddenContracts: string[] = [],
+suite-native/accounts/src/selectors.ts:325:    shownContracts: string[] = [],
+suite-native/staking/src/stakeNativeThunks.test.ts:134:    formDrafts = {},
+suite-native/staking/src/stakeNativeThunks.test.ts:135:    blockchain = {},
+suite-native/module-earn/src/hooks/useEarnDepositsCardData.test.ts:21:    overrides: Partial<Pick<ReturnType<typeof useMissingRateTickersQuery>, 'isFetching'>> = {},
+suite-native/module-earn/src/hooks/useEarnDepositsCardData.test.ts:65:    stakingItems = [],
+suite-native/module-earn/src/hooks/useMessageSystemYield.ts:13:    options: UseMessageSystemYieldOptions = {},
+suite-native/module-trading/src/components/general/TradingCoinAmountFormatter.test.tsx:13:        props: Partial<TradingCoinAmountFormatterProps> = {},
+suite-native/staking/src/stakeFormEthereumNativeThunks.test.ts:89:    overrides: Partial<PrecomposedTransactionFinal> = {},
+suite-native/staking/src/stakeFormEthereumNativeThunks.test.ts:140:    formDrafts = {},
+suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetHandle.test.tsx:26:        props: Partial<ProviderSheetHandleProps> = {},
+suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetHandle.test.tsx:27:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/general/TradeableAssetAccountBalance.test.tsx:20:        props: Partial<TradeableAssetAccountBalanceProps> = {},
+suite-native/module-trading/src/components/general/TradeableAssetAccountBalance.test.tsx:21:        preloadedState = {},
+suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.test.tsx:19:        props: Partial<ProviderSheetProps<TradingType, TradingTradeType>> = {},
+suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.test.tsx:20:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/general/HistoryButton.test.tsx:30:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-earn/src/components/SolanaUnstakeAmountBoundsAlert.test.tsx:18:    overrides: Partial<SolanaStakingAccount> = {},
+suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.test.tsx:14:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/ExchangePickersCard.test.tsx:41:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.test.tsx:31:        props: Partial<ExchangeReceiveAmountInputProps> = {},
+suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.test.tsx:32:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountInput.test.tsx:44:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountInput.test.tsx:57:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.test.tsx:37:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeInfo.test.tsx:19:        props: Partial<ExchangeInfoProps> = {},
+suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.test.tsx:27:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.test.tsx:13:        props: Partial<ExchangeToAccountTradePreviewCardProps> = {},
+suite-native/module-trading/src/components/sell/SellKYCWarning.test.tsx:16:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/sell/SellForm.test.tsx:46:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.test.tsx:51:        props: Partial<ExchangePreviewContinueButtonProps> = {},
+suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.test.tsx:52:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/sell/payment/SellProviderPicker.test.tsx:33:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewFooter.test.tsx:73:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.test.tsx:53:        props: Partial<SellPreviewViewProps> = {},
+suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewIssueBanner.test.tsx:44:    { isSimulationEnabled = true, isSimulation = true } = {},
+suite-native/module-trading/src/components/sell/SellPreview/SellPreviewContinueButton.test.tsx:44:        props: Partial<SellPreviewContinueButtonProps> = {},
+suite-native/module-trading/src/components/sell/SellPreview/SellPreviewContinueButton.test.tsx:45:        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/sell/send/SellSendAmountInput.test.tsx:33:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/sell/send/SellSendAmountInput.test.tsx:43:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.test.tsx:13:        props: Partial<SellFromAccountTradePreviewCardProps> = {},
+suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.test.tsx:13:        props: Partial<ExchangeFromAccountTradePreviewCardProps> = {},
+suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.test.tsx:37:        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+suite-native/module-trading/src/components/sell/SellPreview/SellInfo.test.tsx:18:        props: Partial<SellInfoProps> = {},
+suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.test.tsx:16:        props: Partial<SellToFiatTradePreviewCardProps> = {},
+```
+
+## C6 — Provider value={{ (inline context value, web packages only)
+
+```
+packages/components/src/components/Banner/Banner.tsx:140:                        <BannerContext.Provider value={{ intent }}>
+packages/components/src/components/Collapsible/Collapsible.tsx:33:        <CollapsibleContext.Provider
+packages/components/src/components/Collapsible/Collapsible.tsx:34:            value={{
+packages/components/src/components/List/List.tsx:84:        <ListContext.Provider
+packages/components/src/components/List/List.tsx:85:            value={{ bulletGap, bulletAlignment, bulletComponent, listStyleType }}
+packages/components/src/components/Modal/Modal.tsx:95:        <ModalContext.Provider value={{ intent }}>
+packages/components/src/components/Modal/ModalButton.tsx:15:        <ModalContext.Provider value={{ intent: modalIntent }}>
+packages/components/src/components/Modal/ModalProvider.tsx:38:        <ModalContext.Provider
+packages/components/src/components/Modal/ModalProvider.tsx:39:            value={{
+packages/components/src/components/StepList/StepList.tsx:63:        <StepListContext.Provider
+packages/components/src/components/StepList/StepList.tsx:64:            value={{
+packages/components/src/components/SubTabs/SubTabs.tsx:34:        <SubTabsContext.Provider value={{ activeItemId, size }}>
+packages/components/src/components/Table/Table.tsx:68:        <TableContext.Provider value={{ isRowHighlightedOnHover, hasBorders, typographyStyle }}>
+packages/components/src/components/Tabs/Tabs.tsx:108:        <TabsContext.Provider value={{ activeItemId, isDisabled, size, setTabRef }}>
+packages/suite/src/components/onboarding/OnboardingCancelButtonContext.tsx:19:        <CancelButtonContext.Provider value={{ onCancelHandler, setOnCancelHandler }}>
+packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx:113:        <ScrollContext.Provider value={{ scrollRef, topOffset }}>
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx:110:        <CancelTxContext.Provider
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx:111:            value={{ composedCancelTx, cancelFormState: formState, isComposing }}
+packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx:76:        <FeesContext.Provider
+packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx:77:            value={{
+packages/suite/src/hooks/suite/useAccountSearch.tsx:48:        <AccountSearchContext.Provider
+packages/suite/src/hooks/suite/useAccountSearch.tsx:49:            value={{
+packages/suite/src/support/suite/AccountHeaderProvider.tsx:22:        <AccountHeaderContext.Provider value={{ balanceSectionRef }}>
+```
+
+## C7 — JSON.stringify used as/inside a dep array
+
+```
+suite-common/tx-simulation/src/utils/getTxSimulationParams.ts:68:            params: [fromAddress, JSON.stringify(data)],
+```
+
+## C8 — useFreshRef / useCurrentRef call sites (class-7 review list)
+
+```
+packages/react-utils/src/hooks/useAsyncMemo.ts:20:    const getValueRef = useFreshRef(getValue);
+packages/react-utils/src/hooks/useFreshRef.test.ts:13:        const { result, rerender } = renderHook(({ value }) => useFreshRef(value), {
+packages/react-utils/src/hooks/useFreshRef.test.ts:25:        const { result, rerender } = renderHook(({ value }) => useFreshRef(value), {
+packages/react-utils/src/hooks/useFreshRef.test.ts:7:        const { result } = renderHook(() => useFreshRef('first'));
+packages/suite/src/components/dashboard/DashboardSection.tsx:41:        const collapseChangeRef = useCurrentRef(onCollapseChange);
+packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.ts:92:    const latestRef = useCurrentRef({ status, networkSymbol });
+packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts:149:    const methodsRef = useCurrentRef(methods);
+packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts:158:    const allowanceFlowDataRef = useCurrentRef({
+packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts:167:    const sessionRef = useCurrentRef(session);
+packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts:174:    const hasWrappedTokenBalanceRef = useCurrentRef(hasWrappedTokenBalance);
+packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts:214:    const latestRef = useCurrentRef({
+packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx:61:    const submitRef = useCurrentRef(onSubmit);
+packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts:57:    const fiatRatesRef = useCurrentRef(fiatRates);
+packages/suite/src/hooks/suite/useProxyImage.ts:42:    const inProgressRef = useCurrentRef(proxyImageQuery.isLoading);
+packages/suite/src/hooks/wallet/allowance/useAllowanceCompose.ts:137:    const composeRequestRef = useCurrentRef(composeRequest);
+packages/suite/src/hooks/wallet/allowance/useAllowanceCompose.ts:67:    const methodsRef = useCurrentRef(methods);
+packages/suite/src/hooks/wallet/allowance/useAllowanceModal.ts:94:    const composeRequestRef = useCurrentRef(composeRequest);
+packages/suite/src/hooks/wallet/allowance/useAllowanceModal.ts:95:    const onSelectApprovalTypeRef = useCurrentRef(onSelectApprovalType);
+packages/suite/src/hooks/wallet/allowance/useAllowanceModal.ts:96:    const onConfirmRef = useCurrentRef(onConfirm);
+packages/suite/src/hooks/wallet/allowance/useAllowanceModal.ts:97:    const onCancelRef = useCurrentRef(onCancel);
+packages/suite/src/hooks/wallet/allowance/useAllowanceSend.ts:25:    const methodsRef = useCurrentRef(methods);
+packages/suite/src/hooks/wallet/allowance/useAllowanceSend.ts:26:    const accountRef = useCurrentRef(account);
+packages/suite/src/hooks/wallet/trading/form/common/useTradingFindAccountOrToken.ts:56:    const findAccountOrTokenRef = useCurrentRef(findAccountOrToken);
+packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts:36:    const configRef = useCurrentRef(config);
+packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts:130:    const fetchFeesAndComposeRef = useCurrentRef(fetchFeesAndCompose);
+packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts:62:    const accountRef = useCurrentRef(account);
+packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts:63:    const composeRequestRef = useCurrentRef(composeRequest);
+packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellFormRedirectValues.ts:53:    const findAccountRef = useCurrentRef(findAccount);
+packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx:70:    const pagintionRef = useCurrentRef(pagination);
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx:57:    const setAmountLimitsRef = useCurrentRef(setAmountLimits);
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx:58:    const setValueRef = useCurrentRef(setValue);
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx:109:    const setAmountLimitsRef = useCurrentRef(setAmountLimits);
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx:110:    const setValueRef = useCurrentRef(setValue);
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx:112:    const onCryptoCurrencyChangeRef = useCurrentRef(helpers.onCryptoCurrencyChange);
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts:59:    const fiatRatesRef = useCurrentRef(fiatRates);
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts:90:    const fiatRatesRef = useCurrentRef(fiatRates);
+packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx:90:    const onCryptoCurrencyChangeRef = useCurrentRef(helpers.onCryptoCurrencyChange);
+suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts:29:    const queryEntriesRef = useFreshRef(queryEntries);
+suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewards.ts:30:    const chainsRewardsRef = useFreshRef(queryResult.data);
+suite-common/trading/src/hooks/useApprovalStep.ts:40:    const refreshQuotesRef = useCurrentRef(refreshQuotes);
+suite-common/trading/src/hooks/useCoinsAndPlatforms.ts:12:    const infoRef = useFreshRef(info);
+```
+
+## C9 — files with useEffect keyed on whole account/device/transaction object (agents grep inside)
+
+```
+packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts
+packages/suite/src/components/earn/staking/tron/hooks/useTronStakePendingTransactionTracking.ts
+packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+packages/suite/src/hooks/suite/useFirmwareUpgradeModal.ts
+packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.ts
+packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
+packages/suite/src/hooks/wallet/trading/useTradingDetail.ts
+packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts
+packages/suite/src/views/onboarding/index.tsx
+packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+packages/suite/src/views/wallet/nfts/index.tsx
+packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
+packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+packages/suite/src/views/wallet/tokens/index.tsx
+packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
+suite-common/trading/src/hooks/useTradingExchangeWatchApproval.ts
+suite-native/accounts/src/hooks/useResolvedAccountKey.ts
+suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx
+suite-native/module-earn/src/hooks/useComposeEarnFees.ts
+suite-native/module-send/src/hooks/useSendForm.tsx
+suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.tsx
+suite-native/module-trading/src/components/exchange/Approval/ExchangeRevokeDetails.tsx
+suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
+suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+```
+
+## C10 — files where a useEffect body starts with setState (derived-state / loop candidates)
+
+```
+packages/components/src/components/Modal/ModalProvider.tsx
+packages/components/src/components/PinInput/PinInput.tsx
+packages/components/src/components/VirtualizedList/VirtualizedList.tsx
+packages/components/src/utils/useScrollShadow.tsx
+packages/product-components/src/components/EditableText/EditableText.tsx
+packages/product-components/src/components/EmojiRatingSelector/EmojiRatingSelector.stories.tsx
+packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingStartStep.tsx
+packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx
+packages/suite/src/components/suite/bluetooth/BluetoothDebugInfo.tsx
+packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts
+packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+packages/suite/src/hooks/suite/useLayout.tsx
+packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts
+packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
+packages/suite/src/hooks/wallet/useSendForm.test.tsx
+packages/suite/src/views/settings/SettingsGeneral/DustPhishing.tsx
+packages/suite/src/views/wallet/send/Outputs/Address.tsx
+packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
+packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
+suite-common/device/src/usePinHook.ts
+suite-native/accounts/src/components/AccountsListWithFilter.tsx
+suite-native/accounts/src/components/NetworkFilterBottomSheet.tsx
+suite-native/atoms/src/Button/TextButton.tsx
+suite-native/module-earn/src/hooks/useYieldAllowanceFees.ts
+suite-native/module-earn/src/hooks/useYieldApprovalLimit.tsx
+suite-native/module-send/src/components/TronNoteInput.tsx
+suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.ts
+suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.ts
+suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.ts
+suite-native/module-trading/src/hooks/sell/useSellForm.ts
+suite-native/trading-residence/src/components/ConfirmLocationButton.test.tsx
+suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
+```

--- a/perf-issues/react-hooks/_scan/01-suite-hooks.md
+++ b/perf-issues/react-hooks/_scan/01-suite-hooks.md
@@ -1,0 +1,576 @@
+# Scan area 01 — packages/suite/src/hooks/**
+
+Base commit `9e0d5b6a45`. Covers `hooks/suite`, `hooks/wallet` (incl. `trading/*`, `allowance/*`,
+`form/*`), `hooks/earn`, `hooks/settings`, `hooks/guide`, `hooks/coinjoin`, `hooks/general` — all
+non-compiled (`packages/suite` is not React-Compiler-covered), so manual memoization findings are
+valid throughout.
+
+Excluded per brief / PROGRESS.md and confirmed still present at this commit (not re-filed):
+
+- `hooks/wallet/useAccounts.ts:9` (`useAccountAddressDictionary`'s `unusedAddresses`/`usedAddresses`
+  defaults) — #31133. The redundant `(unusedAddresses ?? []).concat(usedAddresses ?? [])` at line 15
+  is the same root cause (those two vars already default via line 9), not a separate defect.
+- `hooks/suite/useFiatFromCryptoValue.ts` whole-`Rate` selector (line 33-35) — #28880. Read the
+  whole file looking for an adjacent distinct defect; found none — `fiatRateKey` (line 31) is a
+  plain string recomputed per render, never stored in a dep array.
+- `hooks/wallet/form/useUtxoSelection.ts:63` — already drafted in `perf-issues/asymptotic-complexity`
+  per PROGRESS.md's anchor list.
+- `hooks/wallet/useEvmNonceInfo.ts` — PROGRESS.md's anchor is line 90 in that file's history; at
+  this commit the file is 95 lines and the candidate hit was line 41
+  (`{ enabled = true }: UseEvmNonceInfoOptions = {}`). Checked separately: `enabled` is destructured
+  straight to a primitive and only the primitive (`isEnabled`) reaches the `useMemo` dep array
+  (line 94), so the default-parameter object never leaks into a dependency. Not a finding, and not
+  the same line as the excluded anchor.
+
+## F-01-1 — `useLayout.tsx` effect keyed on inline JSX header/footer re-renders the whole app shell on every page render
+
+- **Class:** 1 (unstable dependency crossing the hook boundary) + 2 (effect calling a state setter
+  keyed on that unstable dependency)
+- **Where:** `packages/suite/src/hooks/suite/useLayout.tsx:8-10`, root cause in every call site,
+  e.g. `packages/suite/src/views/dashboard/index.tsx:17`,
+  `packages/suite/src/components/settings/SettingsLayout.tsx:90`,
+  `packages/suite/src/views/earn/index.tsx:6`,
+  `packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx:77`
+  (every other `useLayout(...)` call site in the repo does the same); Provider at
+  `packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx:101-104,129`.
+- **Trigger cadence:** every render of _any_ page/view component that calls `useLayout` with a JSX
+  header/footer argument (i.e. effectively every page in the app).
+- **Severity guess:** P1 (hot — this is the app's own layout hook, mounted on every route)
+- **Confidence:** high — verified the Provider architecture and that every current call site passes
+  inline JSX (grepped all `useLayout(` call sites; none memoize the header/footer element).
+
+### Before (verbatim from the file)
+
+```tsx
+// packages/suite/src/hooks/suite/useLayout.tsx
+export const useLayout = (title?: string, layoutHeader?: ReactNode, layoutFooter?: ReactNode) => {
+    const setLayout = useContext(LayoutContext);
+
+    useEffect(() => {
+        setLayout({ title, layoutHeader, layoutFooter });
+    }, [setLayout, title, layoutHeader, layoutFooter]);
+};
+```
+
+Every call site passes a freshly-created element, e.g.:
+
+```tsx
+// packages/suite/src/views/dashboard/index.tsx:17
+useLayout('Home', <PageHeader />, <DashboardFooter />);
+```
+
+`SuiteLayout.tsx` holds the payload in local state and spreads it into its own JSX, while `children`
+(the routed page, i.e. the component that just called `useLayout`) is passed through as a prop:
+
+```tsx
+// packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+const [{ title, layoutHeader, layoutFooter }, setLayoutPayload] =
+    useState<LayoutContextPayload>({});
+...
+<LayoutContext.Provider value={setLayoutPayload}>
+    ...
+    {layoutHeader}
+    <ContentContainer ...>{children}</ContentContainer>
+    {layoutFooter}
+    ...
+</LayoutContext.Provider>
+```
+
+### Proposed fix
+
+`layoutHeader`/`layoutFooter` are `ReactNode` — a JSX element is a plain object, so it is a fresh
+reference every render exactly like `?? []`/`?? {}`. Two independent fixes, either is sufficient:
+
+1. In `useLayout`, compare the _rendered output_ is unnecessary — instead have callers memoize the
+   element they pass (`useMemo(() => <PageHeader />, [...])`) so the reference is stable across
+   renders that don't actually change the header.
+2. Cheaper and centralized: in `SuiteLayout.tsx`, wrap the consumers of `layoutHeader`/`layoutFooter`
+   (or the `LayoutContext.Provider` subtree pieces that are not `children`) in `memo()` so a fresh
+   element with the same type/props still produces the same rendered DOM — this doesn't fix the
+   `useEffect` refiring, but stops the refire from cascading past a shallow-prop-equal boundary. The
+   real fix is (1); this hook cannot itself deduplicate a `ReactNode` it did not create.
+
+### Why it matters
+
+`SuiteLayout`'s `children` prop shields the _routed page itself_ from re-rendering (standard
+"children as a prop" composition — confirmed by reading `SuiteLayout.tsx`), so this is not an
+infinite loop. But `SuiteLayout`'s own direct JSX children — `Sidebar`, `SuiteBanners`,
+`ModalSwitcher`, `DiscoveryProgress`, `PowerMonitorManager`, `CoinjoinBars`, `GuideButton`,
+`AddPassphraseWalletFlow`, `SwitchDeviceLayer`, `Metadata` — are **not** wrapped in `memo()` (checked
+each file: none export a `memo(...)`-wrapped component), so all of them re-run their full render body
+(including their own selectors/hooks) every time `setLayoutPayload` fires. Since every current call
+site recreates its header/footer element on every render, this effect refires — and the whole shell
+re-renders — every time the _page itself_ re-renders for unrelated reasons (e.g. a fiat-rate tick on
+the dashboard, a form keystroke). `Sidebar` renders the accounts list (see F-01-2), so this is the
+widest-reaching finding in this file: it turns "this page re-rendered" into "the whole chrome
+re-rendered," on every route in the app.
+
+## F-01-2 — `useAccountSearch.tsx` context Provider recreates its value object every render
+
+- **Class:** 5 (missing memoization where identity matters — context Provider `value={{...}}`)
+- **Where:** `packages/suite/src/hooks/suite/useAccountSearch.tsx:44-56` (Provider body at 48-56)
+- **Trigger cadence:** every render of `ReduxAccountSearchProvider`'s owner,
+  `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx` (mounted once,
+  wraps the whole accounts sidebar) — which itself reads `useSelector(selectSelectedDevice)`
+  (unnarrowed device object) and `useSelector(selectDiscoveryOverallStatus)`, so it re-renders on
+  most device/discovery events, not just when search/filter state actually changes.
+- **Severity guess:** P1 (sidebar is rendered on essentially every wallet page)
+- **Confidence:** high — read the Provider, confirmed both `filters` (from a plain selector) and
+  `actions` (already correctly `useMemo`'d on `[dispatch]`) are individually stable, so the _only_
+  unstable piece is the inline spread; confirmed 6 consumers via `useAccountSearch()`, including
+  `AccountsList.tsx` (the accounts sidebar rows).
+
+### Before (verbatim from the file)
+
+```tsx
+export const ReduxAccountSearchProvider = ({ children }: { children: React.ReactNode }) => {
+    const filters = useSelector(state => selectAccountSearch(state));
+    const actions = useReduxAccountSearchActions();
+
+    return (
+        <AccountSearchContext.Provider
+            value={{
+                ...filters,
+                ...actions,
+            }}
+        >
+            {children}
+        </AccountSearchContext.Provider>
+    );
+};
+```
+
+### Proposed fix
+
+```tsx
+const value = useMemo(() => ({ ...filters, ...actions }), [filters, actions]);
+
+return <AccountSearchContext.Provider value={value}>{children}</AccountSearchContext.Provider>;
+```
+
+`filters` and `actions` are already stable individually, so this `useMemo` will actually hold.
+
+### Why it matters
+
+Every consumer of `useAccountSearch()` — `AccountSearchBox`, `AccountsList`, `CoinsFilter`,
+`AccountsMenuHeader`, plus `AddAccountModal` and `AssetActionButton` elsewhere — re-renders whenever
+`ReduxAccountSearchProvider` re-renders, regardless of whether the filter/search state actually
+changed, because a Context consumer re-renders on any new `value` reference. `AccountsMenu` (the
+Provider's mount point) reads `selectSelectedDevice` as a whole object, which per this sweep's other
+findings changes reference on most device-related store updates, so the sidebar's search/filter
+context churns considerably more than the underlying data does.
+
+## F-01-3 — `useEthereumCancelTxCompose.ts` re-composes the cancel transaction on every account/tx reference change
+
+- **Class:** 2 (effect refetch loop — silent, paced by store updates rather than network, but
+  unguarded by any value comparison)
+- **Where:** `packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts:115-120`
+- **Trigger cadence:** every render of `CancelTransactionModal` where `account` or `tx` gets a new
+  reference while the modal is open — confirmed the caller
+  (`packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx:101`)
+  reads `account` via a live `useSelector(state => selectAccountByKey(state, accountKey))` on every
+  render, not a snapshot taken when the modal opened.
+- **Severity guess:** P1 (real compose dispatch, not just a re-render; fires while a device-signing
+  flow is imminent)
+- **Confidence:** high — read the full effect and its only guards (type checks, not value
+  comparisons).
+
+### Before (verbatim from the file)
+
+```tsx
+useEffect(() => {
+    if (account.networkType !== 'ethereum' || !feeInfo || tx.rbfParams?.type !== 'ethereum') {
+        return;
+    }
+    mutate();
+}, [account, tx, feeInfo, mutate]);
+```
+
+### Proposed fix
+
+The guard conditions only ever check `account.networkType` and `tx.rbfParams?.type` — both stable
+for the lifetime of "the same pending tx being cancelled." Narrow the dependency array to what
+actually needs to trigger a recompose:
+
+```tsx
+}, [account.key, account.networkType, tx.txid, tx.rbfParams, feeInfo, mutate]);
+```
+
+`mutate`'s `mutationFn` closure already reads the live `account`/`tx` from the outer scope each time
+it's invoked (react-query captures the latest options internally), so narrowing the _trigger_ array
+doesn't lose freshness — it only stops re-triggering on irrelevant reference churn. `feeInfo` is
+already a `createWeakMapSelector` result (`selectConvertedNetworkFeeInfo`), so it's fine as-is.
+
+### Why it matters
+
+`account` comes from a live `selectAccountByKey` selector re-read on every render of the modal — any
+balance/nonce/history update to the account being cancelled produces a new object. Every one of those
+re-fires `mutate()`, which dispatches `composeSendFormTransactionFeeLevelsThunk` again — a real
+fee-compose operation — for no reason related to the actual inputs of the composition. Unlike the
+sibling compose hooks in this same area (`useCompose.ts`, `useStakeCompose.ts`, `useTradingComposeTransaction.ts`'s
+first effect), which all compare a primitive (blockHeight, descriptor+symbol) before recomposing,
+this effect has no such gate.
+
+## F-01-4 — `useTradingComposeTransaction.ts` second effect: whole `device` dependency + `accounts` read but omitted
+
+- **Class:** 2 (effect refetch, bounded-but-wasteful sub-type) with a Class 6 flavor (the
+  `eslint-disable` also hides a real omission)
+- **Where:** `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts:142-223`
+  (the `eslint-disable-next-line react-hooks/exhaustive-deps` at line 209)
+- **Trigger cadence:** every time `device` (whole `TrezorDevice` object) changes reference **while
+  `outputAddress` is still empty** — i.e. the window between selecting an account/asset and the first
+  successful address-placeholder compose. Once `outputAddress` is set, the `if` guard
+  (`hasAccountChanged || (!outputAddress && ...) || hasFeeInfoChanged`) absorbs further `device`
+  churn, so this is a real but narrow-window issue, not a continuous one.
+- **Severity guess:** P2 (real device I/O — `TrezorConnect.getAddress` — but only in a specific window)
+- **Confidence:** medium-high — read the whole effect and the sibling effect above it that solves
+  the identical problem correctly.
+
+### Before (verbatim from the file)
+
+The **first** effect in the same file already solves this correctly, keeping only `device?.state` in
+its deps and reading the live device through a ref for the actual work:
+
+```tsx
+const deviceRef = useRef(device);
+deviceRef.current = device;
+...
+useEffect(() => {
+    ...
+    deriveTronColdRecipient({ account, network, accounts: accountsRef.current, device: deviceRef.current })
+    ...
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [account?.descriptor, account?.symbol, account?.accountType, networkType, device?.state, network]);
+```
+
+The **second** effect does not reuse that pattern — it depends on the whole `device` object, and
+reads `accounts` (the whole accounts array, from `useSelector(selectAccounts)`) directly without
+listing it at all:
+
+```tsx
+const setStateAsync = async () => {
+    const address: string = await getComposeAddressPlaceholder(
+        account,
+        network,
+        device,
+        accounts,      // <-- used here, not in the dep array below
+        chunkify,
+    );
+    ...
+};
+...
+if (hasAccountChanged || (!outputAddress && account.symbol !== 'ada') || hasFeeInfoChanged) {
+    setStateAsync();
+}
+...
+// call effect only when listed dependencies will change
+// eslint-disable-next-line react-hooks/exhaustive-deps
+}, [
+    account?.symbol, account?.descriptor, chunkify, device, network,
+    state.account?.descriptor, state.account?.symbol,
+    initState.account?.descriptor, initState.account?.symbol, initState.feeInfo,
+    outputAddress, type,
+]);
+```
+
+### Proposed fix
+
+Reuse the file's own `deviceRef`/`accountsRef` (already declared above for the first effect) inside
+`setStateAsync`, and key the dependency array on `device?.state` like the first effect does:
+
+```tsx
+device: deviceRef.current,
+accounts: accountsRef.current,
+```
+
+with `device?.state` replacing `device` in the dependency array. `getComposeAddressPlaceholder` does
+need a real, current device object for `TrezorConnect.getAddress` (confirmed by reading
+`tradingUtils.ts:32-78`) — the ref supplies that without making it a re-trigger source.
+
+### Why it matters
+
+For Bitcoin-type accounts, `getComposeAddressPlaceholder` calls `TrezorConnect.getAddress` — real
+device/bridge I/O — to derive a placeholder receive address for the fee-estimate step of the
+sell/exchange flow. Reading `accounts` outside the dependency array also means the `legacyAccount`
+lookup inside `getComposeAddressPlaceholder`'s Bitcoin branch can run against a stale accounts
+snapshot from whenever this effect last fired, independent of the `device` issue above.
+
+## F-01-5 — `useSendForm.ts` "handle draft change" effect can never fire (dependency is a stable ref)
+
+- **Class:** 6 (wasted / dead code — the `eslint-disable` hides that the dependency array cannot do
+  what the code around it assumes)
+- **Where:** `packages/suite/src/hooks/wallet/useSendForm.ts:409-416`, contrasted with the only writer
+  of `draft.current` at lines 376-401.
+- **Trigger cadence:** once per mount, and only once — never again for the lifetime of the component.
+- **Severity guess:** P3 (dead code; a sibling effect happens to cover the same functional need)
+- **Confidence:** high on the mechanism (refs are referentially stable across renders, confirmed
+  `draft.current` has exactly one writer in the file), medium on real-world impact (see below).
+
+### Before (verbatim from the file)
+
+```tsx
+const draft = useRef<FormState | undefined>(undefined);
+...
+useEffect(() => {
+    const loadDraftValues = async () => {
+        const storedState = await dispatch(getSendFormDraftThunk()).unwrap();
+        const values = getLoadedValues(storedState);
+        reset(values, { keepDefaultValues: !!storedState });
+        if (storedState) {
+            draft.current = storedState;
+            composeDraft(storedState);   // already called directly here
+        }
+    };
+    ...
+}, [dispatch, getLoadedValues, findNetworkSymbolForProtocol, reset]);
+...
+// handle draft change
+useEffect(() => {
+    if (!draft.current) return;
+    composeDraft(draft.current);
+    draft.current = undefined;
+    // composeDraft is excluded because its reference changes with each feeInfo update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [draft]);
+```
+
+### Proposed fix
+
+`useRef`'s return value is the same object every render, so `[draft]` behaves like `[]`: this effect
+runs exactly once, immediately after mount — before the async `loadDraftValues` above has had a
+chance to set `draft.current`. So `draft.current` is guaranteed `undefined` at the one time this
+effect body executes, and it never runs again. Either delete this effect (the direct
+`composeDraft(storedState)` call in `loadDraftValues` plus the feeInfo-driven effect two lines below
+it, `useEffect(() => { composeDraft(getValues()); }, [composeDraft, getValues])`, already cover
+recomposing once a fresher `composeDraft` becomes available), or if the intent was genuinely "run
+again whenever a fresher `composeDraft` shows up," depend on `composeDraft` itself (with a `void
+draft;` per the exhaustive-deps skill section, since `draft.current` is read imperatively).
+
+### Why it matters
+
+This looks like it's meant to defer the actual compose call to a moment when `composeDraft` (whose
+identity changes with every `feeInfo` update, per the neighboring comment) is fresh, rather than
+using the `composeDraft` closure captured at mount time inside `loadDraftValues`. As written it can
+never do that — `draft.current` is also never reset to `undefined`, though nothing downstream reads
+`draft.current` again, so this looks inert rather than actively harmful today. Flagging per the
+"skill contradictions / eslint-disable hides staleness" honesty rule: the suppressed warning was
+almost certainly "missing dependency: `composeDraft`," and satisfying it properly (instead of adding
+the ref) would have been the actual fix.
+
+## F-01-6 — `useTotalFiatBalance.ts` recomputes the whole-account-list balance on every render, unmemoized
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/hooks/wallet/useTotalFiatBalance.ts:14-29`
+- **Trigger cadence:** every render of `PortfolioCard`
+  (`packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx:44,63`) and `WalletInstance`
+  (`packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx:69`). `PortfolioCard`
+  reads `currentFiatRates` via `useSelector(selectCurrentFiatRates)` and passes it straight into this
+  hook, so every fiat-rate tick re-runs the computation even when `accounts` itself is unchanged.
+- **Severity guess:** P2 (real, user-scaling list; but bounded to the dashboard's total-balance card)
+- **Confidence:** high — read the hook (no `useMemo`/`useCallback` at all) and its only two call
+  sites.
+
+### Before (verbatim from the file)
+
+```tsx
+export const useTotalFiatBalance = (
+    accounts: Account[],
+    baseCurrencyCode: BaseCurrencyCode,
+    rates?: RatesByKey,
+) => {
+    const tokenDefinitions = useSelector(state => state.tokenDefinitions);
+    const deviceAccounts: Account[] = accounts.map(account => {
+        const coinDefinitions = tokenDefinitions?.[account.symbol]?.coin;
+        const tokens = getTokens({
+            tokens: account.tokens ?? [],
+            symbol: account.symbol,
+            tokenDefinitions: coinDefinitions,
+        });
+
+        return { ...account, tokens: tokens.shownWithBalance };
+    });
+
+    const totalBaseCurrencyBalance = getTotalFiatBalance({
+        deviceAccounts,
+        baseCurrencyCode,
+        rates,
+    }).toString();
+
+    return totalBaseCurrencyBalance;
+};
+```
+
+### Proposed fix
+
+Wrap the body in `useMemo(..., [accounts, baseCurrencyCode, rates, tokenDefinitions])`. `getTokens`'s
+own internal cost is out of this sweep's scope (already a `tokenUtils.ts` candidate in the
+asymptotic-complexity doc set), but nothing here currently stops it from running on every fiat-rate
+tick regardless of whether `accounts` changed.
+
+### Why it matters
+
+`getTotalFiatBalance` iterates every account and calls `getAccountFiatBalance` per account
+(`suite-common/wallet-utils/src/accountUtils.ts:598-620`), and `useTotalFiatBalance` additionally maps
+every account through `getTokens` first. `PortfolioCard` is the dashboard's headline "total balance"
+card, `memo()`-wrapped but with no props, so it re-renders on every one of its several `useSelector`
+reads changing — `currentFiatRates` is the most frequent of those. None of that work is cached
+against the fiat rate actually changing the total, so it re-runs the full account/token walk on every
+tick.
+
+## F-01-7 — `useExchangeDexQuote.ts`: `fromAddress` effect keyed on the whole `account` object
+
+- **Class:** 1 (minimal-required-dependency violation feeding a `useEffect`)
+- **Where:** `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts:80-88`
+- **Trigger cadence:** every time `account` gets a new reference (any balance/tx/misc update) while
+  the exchange form's DEX path is active — no value comparison guards the `setValue` call.
+- **Severity guess:** P3 (cheap `setValue` call with an almost-always-identical value, not a network
+  op)
+- **Confidence:** high.
+
+### Before (verbatim from the file)
+
+```tsx
+useEffect(() => {
+    if (!account) {
+        return;
+    }
+
+    const fromAddress = isAccountBasedNetwork(account.symbol) ? account.descriptor : undefined;
+
+    setValue('fromAddress', fromAddress);
+}, [account, setValue]);
+```
+
+### Proposed fix
+
+```tsx
+}, [account?.symbol, account?.descriptor, setValue]);
+```
+
+Both fields read in the body are already primitives; nothing else in the effect needs the rest of
+`account`.
+
+### Why it matters
+
+The same hook, three lines later, already uses `useCurrentRef` twice specifically to avoid this exact
+shape of problem (`accountRef`, `fetchFeesAndComposeRef`) for the _fee-fetch_ effect — this earlier
+`fromAddress` effect is the one place in the file that didn't get the same treatment, and it's the
+cheapest to fix since the value it computes only ever depends on two primitives.
+
+## F-01-8 — Earn/staking form family: `defaultValues`/`state` memoized on the whole `account` prop
+
+- **Class:** 6 (wasted memoization — unstable dependency by construction, terminates, does not loop)
+- **Where:**
+    - `packages/suite/src/hooks/earn/useWithdrawalForm.ts:86-96,104-112`
+    - `packages/suite/src/hooks/earn/useStakeForm.ts:66-76,81-93`
+    - `packages/suite/src/hooks/earn/useClaimForm.ts:35-44,46-58`
+    - `packages/suite/src/hooks/wallet/useChangeDelegateForm.ts:48-57,59-68`
+    - `packages/suite/src/hooks/wallet/useRbfForm.ts:183-277` (`useRbfState`'s single large `useMemo`)
+- **Trigger cadence:** every render in which the `account` prop/parameter gets a new reference (all
+  five hooks take `account: Account` straight from a caller-side selector).
+- **Severity guess:** P3 (recomputation is real but not unbounded per the skill's "wasted, not a
+  loop" distinction — each hook's downstream `useStakeCompose`/`useCompose` consumer already guards
+  its actual compose dispatch behind a primitive `blockHeight` comparison, verified in
+  `packages/suite/src/hooks/wallet/form/useStakeCompose.ts:223-231` and
+  `.../form/useCompose.ts:245-253`)
+- **Confidence:** high on the shape (identical across all five files), medium on whether it's worth
+  fixing given the guarded consumers — noting it because the skill calls out "redundant memos get
+  flagged about as often as missing ones."
+
+### Before (verbatim, `useStakeForm.ts` shown; the other four are structurally identical)
+
+```tsx
+const defaultValues = useMemo(() => {
+    const stakingContractAddress = getStakingContractAddress(account, 'stake');
+    return { ...getStakeFormsDefaultValues({ address: stakingContractAddress, stakeType: 'stake' }), setMaxOutputId: undefined } as StakeFormState;
+}, [account]);
+...
+const state = useMemo(() => {
+    const feeInfo = getConvertedOrDefaultFeeInfo({ networkType: account.networkType, feeInfo: networkFees });
+    return { account, network, feeInfo, formValues: defaultValues };
+}, [account, defaultValues, networkFees, network]);
+```
+
+### Proposed fix
+
+`getStakingContractAddress`/`getStakeFormsDefaultValues` only need the account's `descriptor`
+/`symbol`/`networkType` (stable per account), not the live balance-bearing object. Narrowing to those
+fields would let the memo actually hold across balance ticks. Given this exact shape repeats five
+times, it may be worth a small shared helper (e.g. `useStakeFormState(account, stakeType)`) instead of
+five independent fixes.
+
+### Why it matters
+
+Each recompute re-derives `getStakeFormsDefaultValues`/`getStakingContractAddress`/
+`getConvertedOrDefaultFeeInfo` and reallocates the `state` object on every account-reference churn
+while a stake/withdraw/claim/delegate/RBF form is open. It does not cause extra dispatches — the
+compose sub-hooks it feeds already gate on `feeInfo.blockHeight` — so this is the "wasted memo,
+terminates" failure mode the skill explicitly distinguishes from a loop, not a request-loop finding.
+
+## Checked, clean
+
+- `packages/suite/src/hooks/suite/useBioAuthDesktopApi.ts:14-21` — `useSelector` returns a fresh
+  one-level object of primitives; nothing downstream depends on the object itself, only the
+  destructured primitives. Safe under `packages/suite`'s `shallowEqual` default.
+- `packages/suite/src/hooks/suite/useGraph.ts` — `selectedRange` is a direct primitive state read;
+  `actions` memo correctly depends on `[dispatch]` only.
+- `packages/suite/src/hooks/wallet/useAccounts.ts` — see exclusions above (#31133 covers the whole
+  file's actual defect).
+- `packages/suite/src/hooks/suite/useFiatFromCryptoValue.ts` — see exclusions above (#28880).
+- `packages/suite/src/hooks/wallet/form/useUtxoSelection.ts` — line 63 already drafted elsewhere;
+  rest of the file (the `useMemo`s for `composedInputs`/`preselectedUtxos`) correctly narrows deps.
+- `packages/suite/src/hooks/wallet/useEvmNonceInfo.ts` — see exclusions above; the file's own
+  `useMemo` (lines 86-94) correctly depends on primitives (`isEnabled`, `isLoading`) plus
+  `transactions`/`data`, not a fresh default object.
+- `packages/suite/src/hooks/wallet/form/useCompose.ts` and `.../form/useStakeCompose.ts` — both
+  effects that could refire on `state` identity churn (`state?.feeInfo` dep) explicitly compare
+  `state.feeInfo.blockHeight` against a ref before calling `composeRequest()`; this is the correct
+  "derive, don't loop" pattern from the skill and the reason the whole earn/staking form family
+  (F-01-8) doesn't escalate to a Class-2 loop despite feeding these hooks an unstable `state` object.
+- `packages/suite/src/hooks/wallet/form/useFees.ts` — three watchers compare each field against a
+  ref before calling `composeRequest`; same correct pattern.
+- `packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts` — textbook use of
+  `useCurrentRef(config)` to keep an unstable inline config object out of every effect's dependency
+  array; `AbortController`-based cancellation is correct.
+- `packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.ts` — uses a plain
+  `useRef` correctly for previous-value comparison (`previousFiatRef`), matching the skill's "good"
+  example rather than misusing `useFreshRef`/`useCurrentRef`.
+- All `useCurrentRef`/`useFreshRef` call sites read in this area — `useProxyImage.ts:42`,
+  `useAllowanceCompose.ts:67,137`, `useAllowanceModal.ts:94-97`, `useAllowanceSend.ts:25-26`,
+  `useTradingFindAccountOrToken.ts:56`, `useTradingQuoteRequest.ts:36`, `useExchangeDexQuote.ts:62-63,130`,
+  `useTradingSellFormRedirectValues.ts:53` — are all "read the freshest value imperatively" use
+  cases, the correct semantics for these helpers; none needs previous-value semantics (no Class 7
+  misuse found in this area).
+- `packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.ts:92-106` —
+  depends on the whole `accounts` array, but the very first line of the effect body
+  (`selectedAccountKey === account?.key`) returns before touching `accounts` in the steady state, so
+  repeated `accounts` churn is not actually wasteful here. Same shape/same conclusion in
+  `useTradingReceiveAddress.ts:144-173,175-291` (both effects guarded by `hasSelectionInitialized`
+  early-returns) and `useTradingVerifyAccount.ts:159-186`.
+- `packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts` — both effects already
+  narrowed to `account?.key`/`accountKey`/`prefilled.key`/`prefilled.cryptoId`.
+- `packages/suite/src/hooks/wallet/trading/useTradingDetail.ts` and
+  `.../suite/useFirmwareUpgradeModal.ts` — both narrow `device`/`isConnectionModalOpen` effects to
+  `device?.connected`, the correct pattern (contrast with F-01-4).
+- `packages/suite/src/hooks/wallet/form/useCoinjoinRegisteredUtxos.ts` — memo correctly depends on
+  `utxo` (destructured from `account`) and `sessionPrison`, not the whole `account`.
+- `packages/suite/src/hooks/suite/useAppShortcuts.tsx` — global `keydown` listener registered once
+  (`useEffect(..., [])`) with a manually-maintained "latest handler" ref, the correct hand-rolled
+  equivalent of `useCurrentRef` for this case.
+- `packages/suite/src/hooks/suite/useDiscovery.ts`, `useSelector.ts` (confirms the `shallowEqual`
+  default cited in PROGRESS.md's ground truth), `useBridgeDesktopApi.ts`, `useFilteredModal.ts`,
+  `useCancelTxContext.ts`, `general/usePagination.ts`, `settings/backends/useBackendReconnection.ts`,
+  `guide/useGuideLoadArticle.ts`, `guide/useGuideSearch.ts`, `coinjoin/useCoinjoinSessionPhase.ts`,
+  `coinjoin/useCoinjoinAccountLoadingProgress.ts`, `wallet/form/useSendFormOutputs.ts`,
+  `wallet/useSendFormFields.ts`, `wallet/useSendFormChangeHandlers.ts`, `wallet/useSendFormImport.ts`,
+  `wallet/allowance/useAllowanceCompose.ts`, `wallet/allowance/useAllowanceModal.ts`,
+  `wallet/allowance/useAllowanceSend.ts`, `wallet/trading/form/common/useTradingClearStaleQuotes.ts`,
+  `.../useTradingCurrencySwitcher.ts`, `.../useTradingFormReset.ts`, `.../useTradingSendAssetBalance.ts`,
+  `wallet/trading/form/exchange/useExchangeFormInputs.ts`, `wallet/trading/form/sell/useSellFormInputs.ts`,
+  `wallet/trading/form/buy/useBuyQuotes.ts`, `wallet/trading/form/sell/useSellQuotes.ts`,
+  `settings/backends/useBackendsForm.ts` (the one `eslint-disable` there intentionally resets local
+  form state only on `symbol` change to avoid clobbering in-progress edits — not a staleness bug),
+  `wallet/trading/form/buy/useTradingBuyForm.ts` (`setValue`-only effect omitting the always-stable
+  `setValue` itself), `wallet/trading/form/common/useTradingComposeTransaction.ts`'s first effect and
+  third effect (the omitted `setShowReserveBanner` there is a parent `useState` setter, always
+  stable) — read in full; no additional findings beyond what's listed above.

--- a/perf-issues/react-hooks/_scan/02-suite-components.md
+++ b/perf-issues/react-hooks/_scan/02-suite-components.md
@@ -1,0 +1,766 @@
+# Scan area 02 — packages/suite/src/components/suite + small dirs
+
+Area: `packages/suite/src/components/suite/**` (387 files) plus `components/{connection,guide,onboarding,
+firmware,tx-simulation,backup,recovery,dashboard,settings}` (79 files). Verified against
+`issues/perf-react-hooks` @ `9e0d5b6a45`. Web/desktop, not React-Compiler-covered — manual memoization
+findings are valid throughout this area.
+
+Excluded per `PROGRESS.md`: `TransactionsGraph.tsx` `setWidth`/`GraphYAxisTick` (#31137), `FiatValue`/
+fiat-rate storm (#28880). Neither is re-filed below; other graph-dir defects are reported since the
+exclusion is scoped to those two symbols only.
+
+---
+
+## F-02-1 — `CancelTransactionModal.tsx` recomposes the cancel tx on every unrelated account/tx refresh
+
+- **Class:** 2 (effect refetch / render loop — silent, unbounded)
+- **Where:** `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx:83-107`
+  (+ co-anchors that manufacture the unstable props: `TxDetailModal.tsx:92-99` builds `tx` with
+  `useMemo(..., [resolvedTx, filteredInternalTransfers])`, `TxDetailModal.tsx:109-114` builds
+  `chainedTxs` with `useMemo(..., [tx, transactions])`, `TxDetailModal.tsx:101` selects
+  `account` via `selectAccountByKey` (memoized in `suite-common/wallet-core/src/accounts/accountsSelectors.ts:123`
+  on `[selectAccounts, accountKey]` — `selectAccounts` gets a fresh top-level array reference on
+  _any_ account update, and for the account this modal is open on, that account's own object is
+  exactly what's changing while a cancel is pending))
+- **Trigger cadence:** every store update that gives the open account (or its pending tx) a fresh
+  object reference — i.e. every relevant blockchain sync tick while this modal is open, not per
+  render/keystroke
+- **Severity guess:** P1 (hot for its scenario: an actively-monitored pending tx is by definition
+  the record most likely to keep changing reference while the modal is open)
+- **Confidence:** high — traced `account`/`tx`/`chainedTxs` back through `TxDetailModal.tsx` to
+  their Redux sources; each is rebuilt whenever the underlying pending-tx/account record updates,
+  which is the exact condition under which a user opens this modal
+
+### Before (verbatim from the file)
+
+```tsx
+useEffect(() => {
+    if (account.networkType === 'ethereum') return;
+    if (tx.vsize === undefined) return;
+    if (!isComposeCancelTransactionPartialAccount(account)) return;
+
+    dispatch(composeCancelTransactionThunk({ account, tx, chainedTxs }))
+        .unwrap()
+        .then(precomposed => {
+            setUtxoComposedCancelTx({ ...precomposed, rbfType: 'cancel', prevTxid: tx.txid });
+            setUtxoCancelFormState({
+                feeLimit: '', // Eth only
+                feePerUnit: precomposed.feePerByte,
+                hasCoinControlBeenOpened: false,
+                isCoinControlEnabled: false,
+                options: ['broadcast'],
+                outputs: precomposed.outputs.map(output => ({
+                    ...DEFAULT_PAYMENT,
+                    ...output,
+                    amount: output.amount.toString(),
+                })),
+                selectedUtxos: [],
+            });
+        })
+        .catch(setUtxoError);
+}, [account, tx, dispatch, chainedTxs]);
+```
+
+### Proposed fix
+
+Depend on stable identifiers instead of the records: `account.key`, `tx.txid`, and something that
+identifies the chained set (e.g. a joined list of txids, or `chainedTxs?.length` if only the count
+matters for composition) — mirrors the skill's `AdaStakingDashboard.tsx:52` fix. Read `account`/`tx`/
+`chainedTxs` fresh inside the effect body via a `useFreshRef` (or just re-select by key) rather than
+closing over the possibly-stale outer values once the deps are narrowed.
+
+### Why it matters
+
+Every time the pending transaction's own record refreshes (new confirmation count, mempool update),
+this effect redispatches `composeCancelTransactionThunk`, re-running UTXO selection/fee composition
+for a cancel the user hasn't asked for again — while they're mid-review of a "cancel this stuck
+transaction" screen. Matches the skill's canonical "silent and unbounded" shape exactly, just with
+`composeCancelTransactionThunk` in place of the worked example's transaction fetch.
+
+---
+
+## F-02-2 — `AddTokenModal.tsx` re-fetches account info from the device on every account refresh
+
+- **Class:** 2 (effect refetch / render loop — silent, unbounded, real device/network round-trip)
+- **Where:** `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx:71-75`
+  (dispatcher: `loadTokenInfo`, `:34-69`, which calls `TrezorConnect.getAccountInfo`)
+- **Trigger cadence:** every store update that gives `selectSelectedAccount` a fresh account
+  reference, as long as the modal is open with a non-empty, currently-valid `contractAddress`
+- **Severity guess:** P1 (the dispatched work is an actual `TrezorConnect.getAccountInfo` call, not
+  just local computation)
+- **Confidence:** high — `account` is the whole object from `useSelector(selectSelectedAccount)`;
+  every other dep (`contractAddress`, `error`) is a primitive/string state value
+
+### Before (verbatim from the file)
+
+```tsx
+const account = useSelector(selectSelectedAccount);
+...
+const loadTokenInfo = useCallback(
+    async (acc: Account, contractAddress: string) => {
+        if (!acc) return;
+        setIsFetching(true);
+        const response = await TrezorConnect.getAccountInfo({
+            coin: asCoinSymbol(acc.symbol),
+            identity: tryGetAccountIdentity(acc),
+            descriptor: acc.descriptor,
+            details: 'tokenBalances',
+            contractFilter: contractAddress,
+            suppressBackupWarning: true,
+            protocols: acc.networkType === 'ethereum' ? ['erc4626'] : undefined,
+        });
+        ...
+    },
+    [translationString],
+);
+
+useEffect(() => {
+    if (account && !error && contractAddress) {
+        loadTokenInfo(account, contractAddress);
+    }
+}, [account, contractAddress, error, loadTokenInfo]);
+```
+
+### Proposed fix
+
+Depend on `account?.key` (or `descriptor`/`symbol`/`deviceState`) instead of `account`, and read the
+current account inside the effect (via the already-available `useSelector` value at call time, or a
+`useFreshRef`). Per the skill: "When an effect really must fetch, depend on the identifier and not
+the record."
+
+### Why it matters
+
+The user types a contract address once; from then on, any blockchain update to the selected account
+(new block, balance/nonce change) re-fires this effect and re-issues `getAccountInfo` against the
+device/backend with the same address, silently, for as long as the modal stays open. Unlike a UI
+computation, this is a real request each time.
+
+---
+
+## F-02-3 — `GraphTooltipBase`'s effect is keyed on the whole `props` object, so it fires on every mouse-move over the graph
+
+- **Class:** 1 (unstable hook dependency — whole object where a primitive would do) with a class-2
+  flavor (the effect calls a state setter in the parent)
+- **Where:** `packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx:131-142`
+  (co-anchor: the setter it drives, `TransactionsGraph.tsx:96` `onShow: (index: number) =>
+setHovered(index)`, wired in via `tooltipContentProps` at `TransactionsGraph.tsx:92-97` and spread
+  into `GraphTooltipAccount`/`GraphTooltipDashboard` at `:170-183`)
+- **Trigger cadence:** every recharts-internal re-render of the tooltip content while the pointer
+  moves over the chart — recharts recomputes `coordinate`/`viewBox` continuously during hover
+  tracking (this component positions itself off `props.coordinate!.x!` at `:159`, confirming those
+  fields update per-pointer-move, not just per active-index change), so effectively per animation
+  frame of mouse movement, not per distinct bar
+- **Severity guess:** P1 (hot — an everyday interaction: hovering the account/dashboard balance
+  graph)
+- **Confidence:** high — the dependency array is the literal, undestructured `props` parameter; the
+  component's own positioning logic depends on `coordinate` changing independently of `payload`
+
+### Before (verbatim from the file)
+
+```tsx
+export const GraphTooltipBase = (props: GraphTooltipBaseProps) => {
+    useEffect(() => {
+        if (!props.onShow || !props.extendedDataForInterval) {
+            return;
+        }
+
+        props.onShow(
+            props.extendedDataForInterval.findIndex(
+                item => item.time === props.payload?.[0]?.payload.time,
+            ),
+        );
+    }, [props]);
+```
+
+### Proposed fix
+
+Narrow the dependency to what actually identifies "which point is active":
+`props.payload?.[0]?.payload.time` (plus `props.onShow`, `props.extendedDataForInterval`). That
+alone makes the effect a no-op re-run whenever only `coordinate`/`viewBox` changed, and
+`setHovered` (in the parent) only fires on a genuine active-point change instead of on every pointer
+tick.
+
+### Why it matters
+
+Each firing also does `props.extendedDataForInterval.findIndex(...)` — an O(n) scan of the graph's
+full interval data — and calls `setHovered` in `TransactionsGraph`. `hovered` is a primitive so
+React bails out of re-rendering when the index repeats, but the effect body, the `findIndex` scan,
+and the setter call all still run on every one of those ticks. Combined with F-02-4 below (the
+parent's own unmemoized recompute on every `hovered`-driven render), this is the least-bounded
+render churn found in this area.
+
+---
+
+## F-02-4 — `TransactionsGraph` rebuilds the fake-interval-data series on every hover-driven render, not just when the underlying data changes
+
+- **Class:** 4 (render-body work that belongs in a `useMemo`) — the work is expensive enough over a
+  user-scaling list to earn one, per the skill's own carve-out ("earns a `useMemo` only if the work
+  is genuinely expensive over a real list")
+- **Where:** `packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx:85-88`
+  (co-anchor: `calcFakeGraphDataForTimestamps`,
+  `packages/suite/src/utils/wallet/graph/utils.ts:264-359` — three separate `timestamps.forEach`
+  passes, one containing a nested `data.some(...)`/`data.findIndex(...)` per tick, plus a final
+  `.sort()`)
+- **Trigger cadence:** every render of `TransactionsGraph`, including ones caused purely by
+  `hovered`/`maxYTickWidth` local state (mouse hover, per F-02-3) that have nothing to do with
+  `xTicks`/`data`/`account.formattedBalance`
+- **Severity guess:** P1 (compounds directly with F-02-3: hover moves the mouse → `setHovered` →
+  re-render → this recomputes from scratch)
+- **Confidence:** high — `extendedDataForInterval` is a plain `const`, not a `useMemo`, and the
+  component is `memo()`-wrapped only at its own prop boundary, which doesn't help against its own
+  internal state changes
+
+### Before (verbatim from the file)
+
+```tsx
+const [maxYTickWidth, setMaxYTickWidth] = useState(20);
+const [hovered, setHovered] = useState(-1);
+...
+const extendedDataForInterval =
+    variant === 'one-asset'
+        ? calcFakeGraphDataForTimestamps(xTicks, data, account.formattedBalance)
+        : calcFakeGraphDataForTimestamps(xTicks, data);
+```
+
+### Proposed fix
+
+`const extendedDataForInterval = useMemo(() => variant === 'one-asset' ? calcFakeGraphDataForTimestamps(xTicks, data, account.formattedBalance) : calcFakeGraphDataForTimestamps(xTicks, data), [variant, xTicks, data, account.formattedBalance]);`
+— none of those four inputs change on hover, so the memo absorbs every hover/resize-driven render.
+
+### Why it matters
+
+This is the one call site the skill explicitly carves out room for: real work over a real,
+range-scaling list (`xTicks` can be a year of daily ticks), recomputed on a state change
+(`hovered`) that has no bearing on the result. Out of scope for this sweep is _how expensive_ the
+function is per call (that's asymptotic-complexity's lane — see the unrelated `p2-06`/`p2-07`
+docs already filed for the upstream dashboard aggregation); in scope is that it reruns on every
+hover tick with no memo at all.
+
+---
+
+## F-02-5 — `SuiteLayout`'s `ScrollContext.Provider` value is a fresh object every render, defeating `memo()` on every visible `TransactionItem`
+
+- **Class:** 5 (missing memoization where identity matters — Provider value, many consumers,
+  expensive children)
+- **Where:** `packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx:113`
+  (consumer: `suite/router/src/useAnchor.ts:8`, `useContext(ScrollContext)`; consumer's own
+  callers: `packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx` — `memo()`-
+  wrapped at line 62, one instance per row of every visible transaction list)
+- **Trigger cadence:** every render of `SuiteLayout` — which happens on every page navigation (its
+  own `layoutHeader`/`layoutFooter`/`title` state, set via `LayoutContext` on route changes) and
+  every tablet/desktop breakpoint crossing (`isBelowTablet`)
+- **Severity guess:** P1 (cascades to every rendered `TransactionItem` row, a component the repo
+  went out of its way to `memo()`)
+- **Confidence:** high — verified both `scrollRef` (`useResetScrollOnUrl.ts:11`, a `useRef` created
+  once) and `topOffset` (a compile-time sum of three constants) are 100%-stable across renders, so a
+  `useMemo` here would always hit
+
+### Before (verbatim from the file)
+
+```tsx
+const { scrollRef } = useResetScrollOnUrl();
+const topOffset = HEADER_HEIGHT_NUMERIC + SUBPAGE_NAV_HEIGHT_NUMERIC + ANCHOR_SCROLL_OFFSET;
+...
+return (
+    <ScrollContext.Provider value={{ scrollRef, topOffset }}>
+```
+
+### Proposed fix
+
+`const scrollContextValue = useMemo(() => ({ scrollRef, topOffset }), [scrollRef, topOffset]);` and
+pass `value={scrollContextValue}`. Both inputs are stable for the component's whole lifetime, so
+this is a pure win with no correctness trade-off.
+
+### Why it matters
+
+`useAnchor` (via `ScrollContext`) is used by `TransactionItem` for every row's anchor-scroll/
+highlight behavior. Every `SuiteLayout` re-render — i.e. every page navigation — currently forces
+every visible, `memo()`-wrapped transaction row to re-render for no reason, purely because the
+Provider hands out a new object identity each time even though nothing inside it changed.
+
+---
+
+## F-02-6 — `useAccountWithTokensOptions` reads a `useCurrentRef` inside a `useMemo`, so the Send-picker's fiat sort lags a render behind rate ticks
+
+- **Class:** 7 (wrong ref hook for the moment of read — the skill names this exact shape: "the only
+  correct choice when the ref is read in render or inside a `useMemo`" is `useFreshRef`, not
+  `useCurrentRef`)
+- **Where:** `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts:57,59-98`
+- **Trigger cadence:** every fiat-rate tick while the Send asset picker is open
+- **Severity guess:** P2 (real staleness, but confined to a picker modal's sort/display order, not a
+  crash or data-loss path)
+- **Confidence:** high on the mechanism (`useCurrentRef`'s own effect runs after render/commit, so
+  `.current` read synchronously inside a `useMemo` body reflects the _previous_ commit's value, and
+  because the ref object itself never changes identity, listing it in the deps array doesn't cause a
+  re-run when `.current` is later updated either); medium on user-visible impact — would raise to
+  high if `selectCurrentFiatRates` is confirmed to tick frequently enough to matter in practice
+
+### Before (verbatim from the file)
+
+```tsx
+const fiatRates = useSelector(selectCurrentFiatRates);
+...
+const throttledAccounts = useThrottle(accounts, 1000);
+const fiatRatesRef = useCurrentRef(fiatRates);
+
+const accountsAndTokensSortedByCoin = useMemo(() => {
+    const fiatRates = fiatRatesRef.current;
+
+    if (!fiatRates) {
+        return [];
+    }
+    ...
+}, [fiatRatesRef, throttledAccounts, networkSymbolFilter, baseCurrencyCode, tokenDefinitions]);
+```
+
+### Proposed fix
+
+Swap `useCurrentRef(fiatRates)` for `useFreshRef(fiatRates)` (assigns during render, so `.current`
+is always the value from _this_ render), or — if the intent is deliberately to throttle fiat-rate
+churn the way `throttledAccounts` already does — apply `useThrottle(fiatRates, 1000)` explicitly and
+put the throttled value directly in the deps array instead of reading a ref inside the memo.
+
+### Why it matters
+
+Because the ref object is stable, listing `fiatRatesRef` in the memo's deps never triggers a
+recompute on its own; the memo only re-evaluates when `throttledAccounts`/`networkSymbolFilter`/
+`baseCurrencyCode`/`tokenDefinitions` change, and when it does, `.current` may still be the
+rate from before the _previous_ render's fiat-rate update. The fiat balances and fiat-value sort
+order shown in the global Send picker can lag real rate changes by more than the one render the
+ref-in-effect pattern is usually good for.
+
+---
+
+## F-02-7 — `ConnectionGlobalModalContext`'s Provider value is a fresh object every render, fanning out to every scanned-device row
+
+- **Class:** 5 (missing memoization where identity matters)
+- **Where:** `packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx:176-184`
+  (`useConnectionGlobalModal()`, `:67-168`, returns a new object literal every call; consumers:
+  `BluetoothDeviceListItem.tsx` — one instance per row in the nearby/known device list — and
+  `BluetoothScanningList.tsx`, `CantSeeTrezorModal.tsx`, `BluetoothConnectionModal.tsx`,
+  `ConnectDeviceGlobalModal.tsx`)
+- **Trigger cadence:** every render of the provider, which itself re-renders on every
+  `nearbyDevices`/`knownDevices`/`allDevices` update — i.e. continuously while a Bluetooth scan is
+  active
+- **Severity guess:** P2 (real, but the fan-out list — nearby BT devices — is inherently small, so
+  the absolute cost per tick is modest even though the pattern is the textbook Class-5 shape)
+- **Confidence:** high on the mechanism; medium on severity (bounded by how many devices are
+  typically visible during a scan)
+
+### Before (verbatim from the file)
+
+```tsx
+export const ConnectionGlobalModalProvider = ({ children }: ConnectionGlobalModalProviderProps) => {
+    const contextValue = useConnectionGlobalModal();
+
+    return (
+        <ConnectionGlobalModalReactContext.Provider value={contextValue}>
+            {children}
+        </ConnectionGlobalModalReactContext.Provider>
+    );
+};
+```
+
+### Proposed fix
+
+Wrap the returned object in `useMemo` inside `useConnectionGlobalModal`, keyed on its actual fields
+(`devices`, `selectedDevice`, the three derived device lists, the boolean/string state, and the
+handful of callbacks — the callbacks would need their own `useCallback` first since several are
+freshly defined on every call too).
+
+### Why it matters
+
+Every device found/updated during an active Bluetooth scan currently re-renders the whole connect
+flow, including every row's `BluetoothDeviceListItem`, regardless of whether that specific row's
+data changed.
+
+---
+
+## F-02-8 — `SuiteBanners` filters the full account list on every render of an always-mounted, frequently-re-rendering component
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx:119`
+- **Trigger cadence:** every render of `SuiteBanners`, which subscribes to `device` and
+  `state.suite.transport` (`:52,59`) among ~11 other selectors — both are among the most
+  frequently-updated slices in the app (device polling, transport status), and `SuiteBanners` is
+  mounted on every page via `SuiteLayout`
+- **Severity guess:** P2 (real, unmemoized, user-scaling list, on a globally-mounted component; not
+  P1 because `.some()` short-circuits and account counts are usually modest)
+- **Confidence:** medium — the instability of `device`/`transport` as frequent re-render triggers is
+  based on their established volatility elsewhere in this codebase (see PROGRESS.md's own framing of
+  `account`/`device` as reference-churning); I did not measure `SuiteBanners`'s actual re-render rate
+
+### Before (verbatim from the file)
+
+```tsx
+} else if (accounts.some(account => isCardanoStakedWithFiveBinaries(account))) {
+    banner = <CardanoOutdatedStakingBanner />;
+    priority = 20;
+}
+```
+
+### Proposed fix
+
+`useMemo(() => accounts.some(isCardanoStakedWithFiveBinaries), [accounts])`, or push the check into
+a memoized selector (`createWeakMapSelector`) so it only recomputes when `accounts` itself changes.
+
+### Why it matters
+
+`accounts` scales with how many accounts the user has enabled; recomputing this scan on every
+`device`/`transport` tick (which have nothing to do with account contents) is wasted work in a
+component that's always on-screen.
+
+---
+
+## F-02-9 — `AccountName`'s `exhaustive-deps` suppression hides a same-commit ref-staleness gap
+
+- **Class:** 6 (`eslint-disable react-hooks/exhaustive-deps` site — lying/misleading dep array)
+- **Where:** `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountName.tsx:23-54`
+  (co-anchor showing the ref's target actually mounts/unmounts across account switches:
+  `packages/suite/src/views/wallet/transactions/components/AccountOverviewBalance.tsx:85`
+  `<Column ref={balanceSectionRef}>`, rendered only in the `status === 'loaded'` branch, with
+  sibling skeleton/exception branches at
+  `packages/suite/src/views/wallet/transactions/Transactions.tsx:85,92,106,117`)
+- **Trigger cadence:** on an account switch that happens to coincide with the balance section's
+  loading→loaded transition while staying on the `wallet-index` route (so `isOverviewRoute` doesn't
+  itself flip and force a re-run)
+- **Severity guess:** P2 (a real edge case, not a hot path — this is a one-shot staleness bug, not a
+  loop)
+- **Confidence:** medium — the eslint-plugin-react-hooks warning being suppressed here is the
+  documented "ref value in a dependency array is not reactive" case (mutating `.current` doesn't
+  itself trigger a re-run); I traced a concrete scenario where the ref's _target_ DOM node changes
+  in the same commit as a component re-render, which the pre-commit dependency-array snapshot can
+  miss — but I have not confirmed at runtime that this specific interleaving actually occurs in the
+  current account-switch flow, hence not high
+
+### Before (verbatim from the file)
+
+```tsx
+useEffect(() => {
+    if (!isOverviewRoute) {
+        setIsScrolled(true);
+
+        return;
+    }
+
+    const target = balanceSectionRef?.current;
+    if (!target) {
+        setIsScrolled(false);
+
+        return;
+    }
+
+    const observer = new IntersectionObserver(/* ... */);
+    observer.observe(target);
+
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [balanceSectionRef?.current, isOverviewRoute]);
+```
+
+### Proposed fix
+
+Depend on something that actually changes reactively when the target should be re-observed — e.g. a
+small `useState`/callback-ref pair that captures the DOM node (so its identity change is a real
+state update React can diff), instead of reading `.current` inside the dependency array. That also
+lets the suppressed lint rule come back on.
+
+### Why it matters
+
+If the balance-section DOM node swaps out (component remount on loading→loaded) in the same commit
+that re-renders `AccountName` for an unrelated reason, the dependency array's _snapshot_ of
+`.current` (taken during render, before the commit's ref mutation) can match the previous render's
+snapshot, so React skips re-running the effect even though the observer is now watching a detached
+node — leaving the compact/expanded header state frozen until something else forces a re-run.
+
+---
+
+## F-02-10 — `useGlobalSendReceiveModal` stores router-derived state instead of deriving it in render
+
+- **Class:** 6 (derived state kept as `useState` + `useEffect` instead of computed during render)
+- **Where:** `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts:44-49`
+- **Trigger cadence:** every route-param change (navigation), i.e. bounded-but-wasteful, not a loop
+- **Severity guess:** P3 (cleanup — low-frequency trigger, one extra render plus a one-frame lag,
+  not a hot path)
+- **Confidence:** high that this is unnecessary state (the skill's own words: "State that can be
+  computed from what you already have is not state; derive it during render and there is no cycle
+  to have"); the resulting behavior gap (one-render lag opening/closing the modal on a URL-driven
+  navigation) is a minor, plausible but unverified side effect
+
+### Before (verbatim from the file)
+
+```tsx
+const routerParams = useSelector(selectRouterParams);
+const [activeModal, setActiveModal] = useState<GlobalSendReceiveType>(null);
+
+useEffect(() => {
+    setActiveModal(getDashboardParamModal(routerParams));
+}, [routerParams]);
+```
+
+### Proposed fix
+
+`const activeModal = getDashboardParamModal(routerParams);` computed directly in the hook body — no
+`useState`/`useEffect` needed, since `getDashboardParamModal` is a pure, cheap parse of the already-
+available `routerParams`. `openModal`/`closeModal` already call `dispatch(goto(...))`, which is what
+actually drives `routerParams`, so the local state is redundant with what render can derive
+directly.
+
+### Why it matters
+
+Every navigation currently costs an extra render cycle (state set in an effect, not during the
+triggering render) and, more subtly, a render where `activeModal` still reflects the _previous_
+route's value while `routerParams` already reflects the new one — a one-frame window where the
+open/closed state of the global Send/Receive modal can disagree with the URL.
+
+---
+
+## F-02-11 — `TransactionReviewOutputList` re-scans the whole accounts list in its render body
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx:81,117-120`
+- **Trigger cadence:** every render of the review modal (a handful of times per transaction sign,
+  once per device button-press-driven `reviewStep` change) — not per-frame, but unmemoized over an
+  unbounded, user-scaling list
+- **Severity guess:** P3 (real but cold — bounded number of re-renders per sign flow)
+- **Confidence:** medium — `findAccountsByAddress` is not memoized and `accounts` is the full
+  `state.wallet.accounts`, but I did not verify the typical size of that array in production usage
+
+### Before (verbatim from the file)
+
+```tsx
+const accounts = useSelector(state => state.wallet.accounts);
+...
+const isInternalTransfer =
+    isFirstOutputAddress &&
+    typeof outputs[0]?.value === 'string' &&
+    findAccountsByAddress(symbol, outputs[0]?.value, accounts).length > 0;
+```
+
+### Proposed fix
+
+Wrap in `useMemo(..., [symbol, outputs, accounts])`, or move the lookup to a memoized selector if
+one doesn't already exist for "accounts by address".
+
+### Why it matters
+
+Not hot, but a plain instance of the pattern the skill calls out: an unmemoized scan over a list
+that scales with how many accounts the user has, recomputed on every step of the review flow even
+when the accounts list hasn't changed.
+
+---
+
+## F-02-12 — `AddCoinjoinAccountButton` filters the full accounts list on every render
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx:58,65-70`
+- **Trigger cadence:** every render of this button (re-renders during the Tor-enable/coinjoin-account-
+  creation flow via its own `isLoading` state)
+- **Severity guess:** P3 (single button instance, not a per-row list — low absolute impact despite
+  the unbounded-list pattern)
+- **Confidence:** high that the filter is unmemoized and re-run on unrelated `isLoading` state
+  changes; the button is only instantiated once per "add account" modal session, not per row
+
+### Before (verbatim from the file)
+
+```tsx
+const accounts = useSelector(state => state.wallet.accounts);
+...
+const coinjoinAccounts = accounts.filter(
+    a =>
+        a.deviceState === device?.state?.staticSessionId &&
+        a.symbol === network.symbol &&
+        a.accountType === selectedAccount.accountType,
+);
+```
+
+### Proposed fix
+
+`useMemo(() => accounts.filter(...), [accounts, device?.state?.staticSessionId, network.symbol, selectedAccount.accountType])`.
+
+### Why it matters
+
+Minor on its own; listed for completeness since it's the same class-4 shape as F-02-8/F-02-11/
+F-02-13/F-02-14 and a cheap fix.
+
+---
+
+## F-02-13 — `CoinProtocolRenderer` chains `.filter()` onto a `useSelector` result, discarding the selector's own memoization
+
+- **Class:** 4 (render-body work; the selector itself is fine, the chained filter is the bug)
+- **Where:** `packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx:45-47`
+- **Trigger cadence:** every render of this toast (bounded lifetime — a few seconds — but re-renders
+  on any unrelated store dispatch that changes one of its ~4 other `useSelector` values)
+- **Severity guess:** P3 (short-lived component; real but cold)
+- **Confidence:** high that the `.filter()` is chained outside the selector function (so it reruns
+  regardless of whether `selectDeviceAccountsByNetworkSymbol`'s own memoization would have held);
+  medium on how often this toast actually re-renders in practice
+
+### Before (verbatim from the file)
+
+```tsx
+const networkAccounts = useSelector(state =>
+    selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
+).filter(a => new BigNumber(a.balance).gt(0));
+```
+
+### Proposed fix
+
+Move the balance filter inside the selector callback (`state => selectDeviceAccountsByNetworkSymbol(state, networkSymbol).filter(...)`) and wrap the whole thing in a `useMemo` if it needs to feed anything besides inline JSX/callback reads, or add the balance predicate to a dedicated memoized selector.
+
+### Why it matters
+
+Same "chained array method after the hook returns" trap called out in the skill's Class-1 section,
+just landing on render-body cost here rather than a downstream memo, since nothing currently
+consumes `networkAccounts`'s identity.
+
+---
+
+## F-02-14 — `TransactionRenderer` re-derives account/tx lookups from full accounts/transactions lists every render
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx:37-38,46-47,52-54`
+- **Trigger cadence:** every render of this toast while it's displayed (bounded lifetime, but
+  subscribes to `accounts`/`transactions`/`blockchain`/`devices`/`currentDevice`/`routeName`/
+  `routerApp` — any of which changing re-triggers the lookups)
+- **Severity guess:** P3 (short-lived toast; real but cold)
+- **Confidence:** medium — the lookups (`findAccountsByNetwork`, `findAccountsByDescriptor`,
+  `getAccountTransactions`, `findTransaction`) are plain, unmemoized function calls over
+  `accounts`/`transactions`; I did not verify their internal cost beyond "filter/find over a list"
+
+### Before (verbatim from the file)
+
+```tsx
+const accounts = useSelector(selectAccounts);
+const transactions = useSelector(selectTransactions);
+...
+const networkAccounts = findAccountsByNetwork(symbol, accounts);
+const account = findAccountsByDescriptor(descriptor, networkAccounts).at(0);
+...
+const accountTxs = getAccountTransactions(account.key, transactions);
+const tx = findTransaction(txid, accountTxs);
+```
+
+### Proposed fix
+
+`useMemo(() => { ...lookup chain... }, [symbol, descriptor, txid, accounts, transactions])`.
+
+### Why it matters
+
+Same pattern as F-02-11/F-02-13; grouped here because notifications were an explicit priority for
+this sweep, not because this instance is especially hot.
+
+---
+
+## F-02-15 — `CancelTransactionModal`'s own `CancelTxContext.Provider` value is also unmemoized (minor)
+
+- **Class:** 5 (missing memoization — Provider value)
+- **Where:** `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx:110-111`
+- **Trigger cadence:** every render of `CancelTransactionModal`
+- **Severity guess:** P3 (only 3 consumers, all within the same small modal subtree — not a
+  many-consumers/expensive-children case)
+- **Confidence:** high that the value is unmemoized; low severity is by design given the small,
+  contained consumer set
+
+### Before (verbatim from the file)
+
+```tsx
+<CancelTxContext.Provider
+    value={{ composedCancelTx, cancelFormState: formState, isComposing }}
+>
+```
+
+### Proposed fix
+
+`useMemo(() => ({ composedCancelTx, cancelFormState: formState, isComposing }), [composedCancelTx, formState, isComposing])` if this file is being touched anyway for F-02-1; not worth a standalone change otherwise.
+
+### Why it matters
+
+Included for completeness alongside F-02-1 since it's the same file and the same class of bug, but
+the consumer count is small enough that this is genuinely low priority on its own.
+
+---
+
+## Checked, clean
+
+- `packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinBars.tsx` —
+  `sessionCount` is derived via `.filter().length` but only the primitive `.length` enters the
+  `useMemo` dep array; `coinjoinAccounts` comes straight off an Immer-managed state slice. Memo
+  hits correctly.
+- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx` —
+  per-row `BackendRow` reads `blockchain[symbol]` from a stable slice; `customBackends` list is
+  small (user's manually-configured backends only).
+- `packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx` and
+  `BluetoothDebugInfo.tsx` — `(nearbyDevices ?? []).some/find` fresh-fallback pattern present, but
+  the list (physically nearby BT devices) is inherently small/bounded and doesn't feed a downstream
+  memo; not hot enough to report. `BluetoothDebugInfo`'s `TimeAgo` setState-in-effect is a correct
+  once-a-second ticker, not a loop.
+- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewTronFeeNotes.tsx:28` —
+  `calculateTronFeeBreakdown(...) ?? {}` is O(1) over a single tx, not a list; no downstream memo.
+- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx:602` —
+  `(rewards ?? []).map(...)` bounded to one tx's reward claims (single digits), not user-scaling.
+- `packages/suite/src/components/suite/FormattedCryptoAmount.tsx:79` — `getNetworkOptional(...) ?? {}`
+  resolves to a plain object-property lookup (`networks[symbol]`), not a list scan; despite being
+  used on effectively every amount in the UI, the per-call cost is O(1).
+- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx:54-64` —
+  `selectableAccounts` `useMemo` deps (`accounts` via `selectAllAccountsToList`, a
+  `createMemoizedSelector`; `pendingProposal?.networks`, backed by Immer structural sharing through
+  the plain `selectPendingProposal` accessor) are both genuinely stable across unrelated
+  dispatches; verified both selector definitions. Memo hits correctly — good counter-example to
+  keep in mind before assuming every `useMemo` over `useSelector` results is broken.
+- `packages/suite/src/components/onboarding/OnboardingCancelButtonContext.tsx:19` — inline Provider
+  value is fresh every render, but has exactly one consumer (`OnboardingLayout.tsx`) in a
+  low-frequency-render subtree; doesn't meet the "many consumers / expensive children" bar.
+- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx:62-66` —
+  effect correctly narrows to `device?.connected` (not the whole `device` object); checked both real
+  call sites (`ConfirmUnverifiedXpubModal.tsx` passes a `useCallback(..., [])`-memoized
+  `verifyProcess`, `ConfirmUnverifiedProceedModal.tsx` doesn't pass one at all) — genuinely stable,
+  a good example of the skill's "narrow to the identifier" guidance done right.
+- `packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingStartStep.tsx:14-16` — plain
+  prop-to-state sync effect keyed on a primitive (`props.isLoading`); standard, correct pattern.
+- `packages/suite/src/components/dashboard/DashboardSection.tsx:41-45` — `useCurrentRef(onCollapseChange)`
+  read inside a `useEffect` declared immediately after it; hook-declaration order guarantees the
+  ref's own internal effect updates `.current` before this component's effect reads it. Correct
+  choice for a read-in-effect (contrast with F-02-6, a read-in-`useMemo` case).
+- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx:61,68,76` —
+  `submitRef = useCurrentRef(onSubmit)` is only read inside click-driven callbacks
+  (`handleAccountClick`/`handleTokenClick`), well after any same-commit effect-ordering concern
+  applies. Correct usage.
+- `packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx` —
+  only keyed selector lookups (`selectAccountByKey`, `selectTradingCoinSymbolByCryptoId`), no list
+  scans.
+- `packages/suite/src/components/suite/labeling/AccountLabeling.tsx`,
+  `WalletLabeling.tsx`, `packages/suite/src/components/suite/Metadata.tsx` — the "labeling/metadata"
+  priority area for this sweep; all O(1) or small-list work, no unstable deps or fresh-selector
+  issues found. (Note: the generic `Labeling` metadata-editing component used by `AccountDetails.tsx`
+  lives in the separate top-level `suite/labeling` package, not under `packages/suite/src/components`,
+  so it's out of this area's scope.)
+- `packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts` —
+  properly memoized, real dependency list.
+- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AccountAmount.tsx`,
+  `AssetRowAccountWithBalance.tsx` — O(1) per-row arithmetic/markup, no hook issues.
+- `packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx:20` —
+  `getSeenAndUnseenNotifications(notifications)` is unmemoized in the render body, but the
+  notifications list is small/capped in practice; doesn't meet the "real, unbounded" bar for a
+  formal finding.
+- `packages/suite/src/components/connection/hook/useBluetoothScanning.ts` and
+  `useBluetoothConnection.tsx` — deps are correctly narrow throughout; one very minor imprecision
+  (`useBluetoothScanning.ts:73-78` depends on the whole `devices` array where only `.length` is
+  read) but the dispatched action is an idempotent status-set, not worth a formal finding.
+- `packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx`,
+  `ReduxModal.tsx`, `Preloader.tsx` — routing/lifecycle branch logic; effects keyed on stable
+  primitives (`dispatch`, `isAnalyticsConsentConfirmed`); no issues found beyond F-02-5 (already
+  reported against `SuiteLayout.tsx`, which these components render into).
+- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx` —
+  no independent hook logic of its own; delegates to `useRbf` from
+  `packages/suite/src/hooks/wallet/useRbfForm.ts`, which is area 01's file (`packages/suite/src/hooks`),
+  not this area's — flagging here only as a pointer in case area 01 hasn't checked whether `useRbf`
+  has the same whole-`account`/`chainedTxs` dependency shape as F-02-1.
+- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx` —
+  its own `tx`/`chainedTxs`/`filteredInternalTransfers` `useMemo`s are internally consistent with
+  their own inputs; the instability that reaches `CancelTransactionModal.tsx` (F-02-1) is inherent
+  to how account/tx records are tracked upstream in Redux, not an authoring bug in this file's
+  memos, so it's cited as a co-anchor there rather than flagged on its own.
+- `packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx`,
+  `GraphTooltipDashboard.tsx`, `GraphBar.tsx` — operate on a single data point per call (O(1)), no
+  issues independent of F-02-3/F-02-4.

--- a/perf-issues/react-hooks/_scan/03-wallet-earn-comp.md
+++ b/perf-issues/react-hooks/_scan/03-wallet-earn-comp.md
@@ -1,0 +1,622 @@
+# Area 03 — `packages/suite/src/components/wallet/**` + `packages/suite/src/components/earn/**`
+
+Scanned against `skills/performance-react-hooks/SKILL.md`. Base commit `issues/perf-react-hooks` @
+`9e0d5b6a45`. Candidates verified from `_scan/00-candidates.md` rows whose path starts with
+`packages/suite/src/components/wallet/` or `packages/suite/src/components/earn/` (29 rows), plus a
+manual sweep of per-row components (`TransactionItem/*`, `AccountsMenu/AccountItem/*`) and the
+earn/staking dashboards per the brief's Method.
+
+## F-03-1 — `CustomFeeTron.tsx` mount-only effect can miss the async `estimatedFeeLimit`
+
+- **Class:** 6 (wasted/wrong memoization — `eslint-disable exhaustive-deps` hides staleness)
+- **Where:** `packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx:23-30`
+- **Trigger cadence:** once, on mount of the Tron custom-fee panel
+- **Severity guess:** P3
+- **Confidence:** medium — depends on whether `estimatedFeeLimit` is already populated in the form
+  by the time this panel mounts in the common flow; I did not trace every caller's timing. What
+  would change my mind: proof that `composeRequest` always resolves and calls
+  `setValue('estimatedFeeLimit', …)` before a user can reach the custom-fee tab.
+
+### Before (verbatim from the file)
+
+```tsx
+export const CustomFeeTron = () => {
+    const locale = useSelector(selectLanguage);
+    const { translationString } = useTranslation();
+
+    const { control, getValues, setValue } = useFormContext<FormState>();
+    const { errors } = useFormState<FormState>();
+
+    const estimatedFeeLimit = getValues('estimatedFeeLimit');
+
+    useEffect(() => {
+        if (getValues(FEE_LIMIT) === '' && estimatedFeeLimit) {
+            setValue(FEE_LIMIT, estimatedFeeLimit);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+```
+
+`estimatedFeeLimit` is read once via `getValues` at first render and the effect's dep array is
+`[]`, so it only ever sees the mount-time value. `estimatedFeeLimit` itself is written later by
+`setValue('estimatedFeeLimit', composed.estimatedFeeLimit)` from async compose thunks
+(`useStakeCompose.ts:145`, `useCompose.ts:161`, `useSendFormCompose.ts:228`,
+`useTradingComposeTransaction.ts:273`) — i.e. it can genuinely arrive after this component has
+already mounted and run its effect once.
+
+### Proposed fix
+
+Depend on `estimatedFeeLimit` instead of `[]` (drop the disable comment): `}, [estimatedFeeLimit, getValues, setValue])`. Guard re-entry with a ref (`hasAutofilledRef`) if the intent is
+"only autofill the very first time it becomes available," since the field's own emptiness check
+(`getValues(FEE_LIMIT) === ''`) already prevents clobbering a value the user typed.
+
+### Why it matters
+
+If `estimatedFeeLimit` is still `undefined` when this panel first mounts, the field is never
+autofilled with the recommended value even after compose resolves — sibling `CustomFeeEthereum.tsx`
+avoids this class of bug entirely by only reading `getValues('estimatedFeeLimit')` inside
+`onClick` handlers, never in a mount effect.
+
+---
+
+## F-03-2 — `TokenIconSetWrapper` recomputes its whole token chain on every render (distinct from the filed complexity finding)
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/components/wallet/TokenIconSetWrapper.tsx:26-60`
+- **Trigger cadence:** every render of the component, i.e. once per network row of the dashboard's
+  My Assets table/grid, on every parent re-render (fiat-rate ticks, account updates)
+- **Severity guess:** P2
+- **Confidence:** high
+
+**Already drafted under `perf-issues/asymptotic-complexity/p2-17-tokeniconsetwrapperx-tokeniconsetwrapper.md`** — that
+finding is about the _n_ being wrong (whole unfiltered `accounts` list instead of the row's own
+accounts). This is a **distinct hooks-class defect at the same lines**: even after that fix lands,
+the `flatMap` → `reduce` → `sort` chain below has no `useMemo` at all, so it re-executes from
+scratch on every render regardless of whether `accounts`/`symbol`/rates actually changed. The
+complexity doc mentions this only as an optional aside ("Optionally also wrap … in a `useMemo`");
+this is the hooks-class write-up of that aside.
+
+### Before (verbatim from the file)
+
+```tsx
+export const TokenIconSetWrapper = ({ accounts, symbol }: TokenIconSetWrapperProps) => {
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const fiatRates = useSelector(selectCurrentFiatRates);
+    const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
+
+    const allTokensWithRates = accounts.flatMap(account =>
+        enhanceTokensWithRates(account.tokens, baseCurrencyCode, symbol, fiatRates),
+    );
+
+    if (!allTokensWithRates.length) return null;
+
+    const tokens = getTokens<TokensWithRates>({
+        tokens: allTokensWithRates,
+        symbol,
+        tokenDefinitions: coinDefinitions,
+    })?.shownWithBalance;
+
+    const aggregatedTokens = Object.values(
+        tokens.reduce((acc: Record<string, TokensWithRates>, token) => {
+            /* … BigNumber allocations per token … */
+            return acc;
+        }, {}),
+    );
+
+    const sortedAggregatedTokens = aggregatedTokens.sort(sortTokensWithRates);
+```
+
+### Proposed fix
+
+Wrap the `flatMap`/`getTokens`/`reduce`/`sort` chain in one `useMemo` keyed on
+`[accounts, symbol, baseCurrencyCode, fiatRates, coinDefinitions]`. Note the early
+`if (!allTokensWithRates.length) return null` has to move after the memo (or become a check on the
+memoized result) since hooks can't follow a conditional return.
+
+### Why it matters
+
+`packages/suite` is not React-Compiler-compiled, so nothing memoizes this automatically. Once the
+complexity fix narrows `accounts` to the row's own accounts, this chain still redoes 2+ BigNumber
+allocations per token and a full sort on every unrelated re-render of the row (e.g. a fiat-rate
+tick touching a sibling network) instead of only when this row's own tokens/rates change.
+
+---
+
+## F-03-3 — `TargetAddressLabel` feeds a fresh `[]` into a `createWeakMapSelector`, defeating its cache
+
+- **Class:** 3 (selector returns fresh reference — memoized selector whose argument is a fresh
+  array per call)
+- **Where:** `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx:28-34`
+  (+ `suite/address/src/labels/selectAddressLabelsForAccount.ts:35-50`, the `addresses` input-selector at :47-50)
+- **Trigger cadence:** every render of this component _and_ every store dispatch (react-redux calls
+  the `useSelector` callback on every dispatch to check for changes) — once per transaction target
+  that lacks a resolved `addresses` array
+- **Severity guess:** P3
+- **Confidence:** high on the mechanism; medium on real-world magnitude — `Target.addresses` is
+  `string[]` optional (`packages/blockchain-link-types/src/common.ts:202`), so this only fires for
+  targets without a resolved address (e.g. non-standard outputs), and the `reduce` over the
+  resulting `[]` is itself trivial _unless_ Suite Sync is enabled, in which case the combiner also
+  rebuilds a label map over the account's **entire** `suiteSyncAddressLabels` list before intersecting
+  it with (empty) `addresses`. I did not measure how large that list gets for real users.
+
+### Before (verbatim from the file)
+
+```tsx
+const isLocalTarget = (type === 'sent' || type === 'self') && target.isAccountTarget;
+const addressLabels = useSelector(state =>
+    selectAddressLabelsForAccount(state, {
+        addresses: target.addresses ?? [],
+        accountKey,
+        deviceStaticId: deviceStaticSessionId,
+    }),
+);
+```
+
+Co-anchor — the selector's own passthrough input, `selectAddressLabelsForAccount.ts:47-50`:
+
+```tsx
+        (
+            _state: SelectAddressLabelsForAccountState,
+            { addresses }: SelectAddressLabelsForAccountParams,
+        ) => addresses,
+```
+
+`selectAddressLabelsForAccount` is built with `createWeakMapSelector` specifically so repeated
+calls with the same arguments hit a cache. Every time `target.addresses` is `undefined`, the call
+site hands it a brand-new `[]`, so this one input never matches the previous call by reference and
+the whole combiner (three possible `.reduce()` branches) reruns.
+
+### Proposed fix
+
+Module-level constant: `const EMPTY_ADDRESSES: string[] = [];` and use
+`addresses: target.addresses ?? EMPTY_ADDRESSES`. That alone restores the weak-map cache hit for
+every target that lacks a resolved address.
+
+### Why it matters
+
+`TargetAddressLabel` is rendered once per transaction target across every visible transaction row,
+so on an active wallet (frequent dispatches from blockchain/ticker updates) this recomputes the
+labeling combiner far more often than the underlying data changes — pure waste, not a re-render
+(the `LabelsMap` output is absorbed by `packages/suite`'s `shallowEqual` `useSelector` wrapper).
+
+---
+
+## F-03-4 — `AccountSection` calls `getTokens()` unmemoized for every sidebar row, on every sidebar render
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx:28-50`
+  (destructuring default at :34, the call at :46-50)
+- **Trigger cadence:** every render of `AccountSection`, i.e. every visible account in the sidebar,
+  on every render of `AccountsList`/`Accounts` (neither `AccountSection` nor `AccountItemsGroup` is
+  `memo()`-wrapped) — not gated behind search/filter state, so this runs continuously, not just
+  while typing
+- **Severity guess:** P2
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+export const AccountSection = ({
+    account,
+    forceOnlyItemClick,
+    hideStaking,
+    selected,
+    onItemClick,
+}: AccountSectionProps) => {
+    const {
+        symbol,
+        accountType,
+        index,
+        descriptor,
+        formattedBalance,
+        tokens: accountTokens = [],
+    } = account;
+
+    const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
+
+    const showGroup = hasNetworkFeatures(account, 'tokens');
+
+    const isStakeShownStored = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key),
+    );
+    const isStakeShown = !hideStaking && isStakeShownStored;
+
+    const tokens = getTokens({
+        tokens: accountTokens,
+        symbol: account.symbol,
+        tokenDefinitions: coinDefinitions,
+    });
+```
+
+### Proposed fix
+
+Wrap the `getTokens(...)` call in `useMemo(() => getTokens({ tokens: accountTokens, symbol: account.symbol, tokenDefinitions: coinDefinitions }), [accountTokens, account.symbol, coinDefinitions])`,
+and back the destructuring default with a module-level `EMPTY_TOKENS` constant (not `= []`) so the
+memo's own dependency is stable — otherwise the memo would never hit for token-less accounts either.
+
+### Why it matters
+
+The sidebar (`AccountsMenu`) is mounted on every Suite route per `perf-issues/scheduling/p1-13`,
+which already covers the _search-filter_ path's duplicate `getTokens` call. This is the _base_
+render path: it runs for every account unconditionally, so any unrelated re-render of `AccountsList`
+(new `coinjoinIsPreloading`, `accountLegacyLabels`, `discoveryStatus`, …) re-walks every visible
+account's whole token list, which on a busy EVM account can be long.
+
+---
+
+## F-03-5 — `FeesContext.Provider` hands 14 consumers a fresh object every render
+
+- **Class:** 5 (missing memoization where identity matters — inline Provider `value={{...}}`)
+- **Where:** `packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx:76-85`
+  (+ `packages/suite/src/components/wallet/Fees/context/FeesContext.ts:23`, 14 consumer files via
+  `useFeesContext()`: `CollapsibleFeesHeaderContent.tsx`, `CollapsibleFeesHeader.tsx`,
+  `StandardFee.tsx`, `BitcoinFeeCards.tsx`, `EthereumFeeCards.tsx`, `MiscFeeCards.tsx`,
+  `MaximumFee.tsx`, `CustomFee.tsx`, `CustomFeeEthereum.tsx`, `CustomFeeMisc.tsx`, `CurrentFee.tsx`,
+  `CustomFeeTooLowBanner.tsx`, `TronFee.tsx`, `DustPreventionNotice.tsx`)
+- **Trigger cadence:** every render of `CollapsibleFees` — which mounts on every send/stake/
+  claim/unstake/RBF screen and re-renders on every `useWatch({name: 'selectedFee'})` tick, i.e.
+  effectively per keystroke/interaction in the surrounding form
+- **Severity guess:** P1
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+    return (
+        <FeesContext.Provider
+            value={{
+                networkSymbol,
+                networkType,
+                feeInfo,
+                changeFeeLevel,
+                selectedFeeLevel,
+                composedLevels,
+                tronResources,
+            }}
+        >
+```
+
+### Proposed fix
+
+```tsx
+const contextValue = useMemo(
+    () => ({ networkSymbol, networkType, feeInfo, changeFeeLevel, selectedFeeLevel, composedLevels, tronResources }),
+    [networkSymbol, networkType, feeInfo, changeFeeLevel, selectedFeeLevel, composedLevels, tronResources],
+);
+// ...
+<FeesContext.Provider value={contextValue}>
+```
+
+`changeFeeLevel`/`feeInfo`/`composedLevels` are props from callers further up (`useFees`,
+`useCompose`, etc.) — verify they're themselves stable before relying on this memo to hold; if not,
+that's a follow-on fix in `src/hooks/wallet` (outside this area).
+
+### Why it matters
+
+React context has no shallow-compare step: every consumer re-renders whenever the `value` reference
+changes, regardless of which field it actually reads. A fresh object literal on every render of
+`CollapsibleFees` means all 14 consumers re-render together on every keystroke in the amount/fee
+form, not just the ones whose data changed.
+
+---
+
+## F-03-6 — Yield pending-tx poll effect keys on the whole `account` object; the Tron sibling does it correctly
+
+- **Class:** 2 (effect refetch/render loop — bounded-but-wasteful variant; minimal-required-deps)
+- **Where:** `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts:213-232`
+  (co-anchor, the correct counterpart: `packages/suite/src/components/earn/staking/tron/hooks/useTronStakePendingTransactionTracking.ts:46-56`)
+- **Trigger cadence:** while a yield deposit/withdraw/wrap/unwrap/claim tx is pending — every time
+  `account` gets a new reference (each `fetchAndUpdateAccountThunk` tick that touches this account,
+  or any other unrelated update to it), the interval is torn down and rebuilt
+- **Severity guess:** P1
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+// Snapshot latest values for the unmount-leftPending effect so we don't re-bind on every render.
+const latestRef = useCurrentRef({
+    isCurrentlyPending,
+    pendingTransaction,
+    flowType,
+    vault,
+    networkSymbol: account.symbol,
+});
+
+useEffect(() => {
+    if (!isCurrentlyPending) {
+        return;
+    }
+
+    const interval = setInterval(() => {
+        dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
+    }, pollIntervalMs);
+
+    return () => clearInterval(interval);
+}, [account, dispatch, isCurrentlyPending, pollIntervalMs]);
+```
+
+The callback only ever needs `account.key`. Its sibling in the Tron staking flow does exactly this
+same interval pattern with the narrow dep already:
+
+```tsx
+// useTronStakePendingTransactionTracking.ts:46-56 — correct
+useEffect(() => {
+    if (!isCurrentlyPending) {
+        return;
+    }
+
+    const interval = setInterval(() => {
+        dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
+    }, pollIntervalMs);
+
+    return () => clearInterval(interval);
+}, [account.key, dispatch, isCurrentlyPending, pollIntervalMs]);
+```
+
+### Proposed fix
+
+Change the yield version's dependency array from `[account, dispatch, isCurrentlyPending, pollIntervalMs]`
+to `[account.key, dispatch, isCurrentlyPending, pollIntervalMs]` — matching the Tron sibling exactly.
+No other change needed; the callback body already only reads `account.key`.
+
+### Why it matters
+
+This is the repo's documented flagship bug shape (`skills/performance-react-hooks/SKILL.md`'s
+"account is a new object after every blockchain update" example, ref #23523) recurring in the yield
+module while its Tron staking sibling already has the fix. Every unrelated account mutation during
+a pending tx (a poll tick from _this same effect_, or any other blockchain update touching the
+account) clears and restarts the poll timer instead of letting it run to term, which can delay or
+disrupt detection of the pending transaction's confirmation — the one thing this hook exists to
+track.
+
+---
+
+## F-03-7 — Earn staking dashboard: a `.filter()` crosses the hook boundary and defeats two downstream `useMemo`s
+
+- **Class:** 1 (unstable dependency crossing a hook boundary), compounding into class 6 (the
+  downstream memos are pure overhead)
+- **Where:** `packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts:45-53`
+  → `packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx:56-92,94-144`
+- **Trigger cadence:** every render of the staking dashboard table (mounted on the Earn dashboard;
+  re-renders on every fiat-rate tick via `currentRates`, plus any unrelated parent re-render)
+- **Severity guess:** P2
+- **Confidence:** high
+
+### Before (verbatim from the files)
+
+```tsx
+// useStakingTableData.ts:45-53
+const accounts = useSelector(selectVisibleDeviceAccounts);
+
+const stakingAccounts = accounts.filter(
+    account =>
+        account.symbol === 'eth' ||
+        account.symbol === 'sol' ||
+        account.symbol === 'ada' ||
+        account.symbol === 'trx',
+);
+```
+
+`stakingAccounts` — a fresh array from a bare `.filter()`, every render — is then passed as a prop
+into `useStakingAccountsVisibility`, crossing the hook boundary:
+
+```tsx
+// useStakingAccountsVisibility.tsx:56-63 and :65-77 — also unmemoized, also fresh every render
+const [accountsStakingActive, accountsStakingNotActive] = arrayPartition(
+    stakingAccounts,
+    (account: Account) => {
+        /* ... */
+    },
+);
+
+const [accountsSufficientFunds, accountsInsufficientFunds] = arrayPartition(
+    accountsStakingNotActive,
+    (account: Account) => {
+        /* ... */
+    },
+);
+
+const alwaysVisibleAccounts = useMemo(
+    () => [
+        ...accountsStakingActive.toSorted(compareEarnByAmountDesc(getAccountStakedAmountInFiat)),
+        ...accountsSufficientFunds.toSorted(compareEarnByAmountDesc(getAccountBalanceInFiat)),
+    ],
+    [
+        accountsStakingActive,
+        accountsSufficientFunds,
+        getAccountStakedAmountInFiat,
+        getAccountBalanceInFiat,
+    ],
+);
+```
+
+Both `useMemo` calls in `useStakingAccountsVisibility` (`alwaysVisibleAccounts` at :79-92 and
+`collapsedInsufficientFundsAccounts` at :94-144) depend on `accountsStakingActive` /
+`accountsSufficientFunds` / `alwaysVisibleAccounts` — every one of which is itself a fresh
+`arrayPartition()`/spread result computed directly in the hook body, never memoized. Neither
+`useMemo` can ever hit: they recompute on every render regardless of whether `stakingAccounts`'s
+contents actually changed.
+
+### Proposed fix
+
+Memoize at the source and at each derivation step: wrap `stakingAccounts` in
+`useMemo(() => accounts.filter(...), [accounts])` in `useStakingTableData.ts`, then wrap both
+`arrayPartition(...)` calls in `useStakingAccountsVisibility.tsx` in their own `useMemo`s keyed on
+`[stakingAccounts]` / `[accountsStakingNotActive]` respectively, so the two existing `useMemo`s
+downstream finally see stable inputs.
+
+### Why it matters
+
+This is the earn/staking dashboard the skill's worked example points at. As written, the two
+`useMemo`s that sort and merge the account list provide no caching at all — they, and the two
+`arrayPartition` scans feeding them, rerun in full on every dashboard render (including every
+fiat-rate tick), which is pure overhead rather than a bug, but it is exactly the class the skill
+calls "this repo's actual recurring pain."
+
+---
+
+## F-03-8 — `TransactionItem` rebuilds `createTargets()` unmemoized on every render
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx:86`
+  (+ `suite-common/wallet-core/src/transactions/target/createTargets.ts:59-67`)
+- **Trigger cadence:** every render of `TransactionItem` — once per transaction row; `TransactionItem`
+  is `memo()`-wrapped (protects against unchanged-prop re-renders from its parent list) but still
+  re-renders on its own `useSelector(selectSelectedAccount)` / `useSelector(selectAccountByKey)` /
+  `useSelector(selectIsPhishingTransaction)` subscriptions firing
+- **Severity guess:** P2
+- **Confidence:** medium-high — the per-call cost scales with `transaction.targets.length +
+internalTransfers.length + tokens.length`, which is small for a plain transfer but can be large
+  for coinjoin rounds/batch sends (this file tree has a dedicated `CoinjoinBatchItem.tsx`); I did
+  not measure real-world output counts.
+
+### Before (verbatim from the file)
+
+```tsx
+export const TransactionItem = memo(
+    ({ transaction, accountKey, isActionDisabled, isPending, network, accountType, disableBumpFee, index }: TransactionItemProps) => {
+        const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(transaction.symbol);
+        const account = useSelector(selectSelectedAccount) || null;
+        const networkFeatures = network.accountTypes[accountType]?.features ?? network.features;
+        const dispatch = useDispatch();
+        const { anchorRef, shouldHighlight } = useAnchor(`${AccountTransactionBaseAnchor}/${transaction.txid}`);
+        const { type } = transaction;
+
+        const allOutputs = account !== null ? createTargets({ transaction, account }) : [];
+```
+
+`createTargets` (`suite-common/wallet-core/src/transactions/target/createTargets.ts:59-67`) does
+three `.map()`/`.filter()` passes (`targets`, `internalTransfers`, `tokens`) and spreads the results
+into one array — called fresh on every render, feeding `<TransactionTargetsList allOutputs={allOutputs} />`.
+
+### Proposed fix
+
+`const allOutputs = useMemo(() => (account !== null ? createTargets({ transaction, account }) : EMPTY_TARGETS), [account, transaction]);`
+with a module-level `EMPTY_TARGETS: Target[] = []` constant for the `null` branch.
+
+### Why it matters
+
+Rendered once per transaction in a list that can be long-running (pagination aside, coinjoin/batch
+transactions push output counts well above a typical 1-3 target transfer); recomputes on every
+self-triggered re-render of the row even when the transaction itself hasn't changed.
+
+---
+
+## F-03-9 — `TransactionTarget` linear-scans the account's full Suite-Sync output-label list, unmemoized
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx:79-83,193-195`
+- **Trigger cadence:** every render of `TransactionTarget` (not `memo()`-wrapped) — including every
+  time the global `selectLabelingValueBeingEdited` flag changes (any output label anywhere starting
+  or stopping edit), which re-renders every mounted target row at once
+- **Severity guess:** P3
+- **Confidence:** medium — the list this scans is genuinely user-scaling (every Suite-Sync output
+  label the account has ever had set), but only non-trivial for heavy Suite-Sync users; I did not
+  measure typical sizes. This sits close to the asymptotic-complexity boundary (linear scan instead
+  of an index) — I'm reporting only the "unmemoized, reruns on unrelated re-renders" half, which is
+  the hooks angle; the O(n) lookup shape itself is out of scope here.
+
+### Before (verbatim from the file)
+
+```tsx
+const suiteSyncOutputLabels = useSelector(state =>
+    isSuiteSyncEnabled
+        ? selectSuiteSyncOutputLabels(state, transaction.deviceState)
+        : returnStableArrayIfEmpty<SuiteSyncOutput>(),
+);
+// ...
+const outputLabel =
+    suiteSyncOutputLabels.find(it => it.txId === transaction.txid && it.txTargetId === targetId)
+        ?.label ?? (isLegacyLabelingVisible ? targetMetadata : undefined);
+```
+
+### Proposed fix
+
+`useMemo(() => suiteSyncOutputLabels.find(it => it.txId === transaction.txid && it.txTargetId === targetId)?.label, [suiteSyncOutputLabels, transaction.txid, targetId])`,
+then fold in the `isLegacyLabelingVisible ? targetMetadata : undefined` fallback outside the memo.
+
+### Why it matters
+
+The rest of this same component (`amount`, `amountComponent`, `fiatAmountComponent`, `label`) is
+already carefully `useMemo`'d with narrow deps — this one line is the odd one out, redone on every
+render including the ones caused by a sibling row's label entering edit mode.
+
+---
+
+## Checked, clean
+
+- `packages/suite/src/components/earn/staking/tron/vote/TronVoteRepresentativeSelect.tsx:38-52` —
+  correct pattern: `useMemo` depends on `representatives.data` itself (not a `?? []`-guarded copy),
+  so the fallback only applies to the memo's _return_ value, not its dependency. Good counter-example.
+- `TronVoteSummaryCard.tsx:13`, `TronStakeSummaryCard.tsx:28`, `TronVoteApr.tsx:19` — all do
+  `(representatives.data ?? []).find(...)` directly in the render body, but Tron's Super
+  Representative list is protocol-capped (~127) and these aren't per-row list items; below the
+  skill's "unbounded/user-scaling" bar for class 4.
+- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx:68`
+  (`rates ?? {}`) — feeds a plain util call (`areTokenFiatRatesLoading`), not a memo/callback/effect
+  dep or a selector argument; the fresh-object concern doesn't propagate. The underlying
+  whole-fiat-rates-map subscription shape is the general pattern already covered by #28880.
+- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx:93-152` (incl.
+  `:106` `tokens: account.tokens ?? []`) and `AccountItemsGroup.tsx:68` — both already fully covered,
+  including the exact hooks-class fix (`useMemo` + `useDeferredValue`), by
+  `perf-issues/scheduling/p1-13-accounts-sidebar-filters-urgently-on-every-keystroke.md`; not
+  duplicated here.
+- `EarnStakingAccountRow.tsx:75`, `EarnClaimModal.tsx:58`, `UnstakeInputs.tsx:50`,
+  `UnstakeForm.tsx:46` — all `getStakingDataForNetwork(account) ?? {}`, but every destructured field
+  (`canClaim`, `claimableAmount`, `restakedReward`, `autocompoundBalance`, `depositedBalance`) is a
+  string/boolean primitive. Primitives compare by value under `Object.is`, so the fallback object's
+  _reference_ freshness never reaches a memo/effect/selector dependency — not the class-1 bug despite
+  matching the grep shape.
+- `EarnClaimModal.tsx:89-91` (`useEffect(() => onClaimChange(claimableAmount), [onClaimChange, claimableAmount])`)
+  — traced `onClaimChange` through `packages/suite/src/hooks/earn/useClaimForm.ts:91-101` to a
+  `useCallback` chain (`clearErrors`/`setValue` from react-hook-form, `onCryptoAmountChange` itself
+  `useCallback`'d) that is stable in practice; effect only refires on a genuine value change.
+- `packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts:29-81`
+  — `wrappedNativeVaults` is correctly `useMemo`'d; the two downstream `useSelector` calls redo
+  `.some()`/`.filter().map().filter()` on every dispatch, but the source array is capped to vaults
+  matching one account's symbol (a handful at most) and both selectors return primitives
+  (boolean/number), so there's no re-render amplification — below the reporting bar.
+- C8 sites in this area — `useWrappedNativeFlowAnalytics.ts:92`,
+  `useYieldFlow.ts:149,158,167,174`, `useYieldPendingTransactionTracking.ts:214` — all use
+  `useCurrentRef` to snapshot the latest value for a callback/cleanup-effect that runs later, which
+  is the correct use case; none need _previous_-value semantics, so no class-7 misuse in this area.
+  Several pass an inline object literal (e.g. `{ status, networkSymbol }`), which makes
+  `useCurrentRef`'s own internal effect re-run every render instead of only on real change — harmless
+  since that effect body is just a ref assignment, not worth a separate finding.
+- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts:47-54` and
+  `useTronStakePendingTransactionTracking.ts:46-56` — both correctly depend on `account.key`, not
+  `account`; the latter is the direct correct counterpart cited in F-03-6.
+- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx` —
+  `amount`, `amountComponent`, `fiatAmountComponent`, `label` are all correctly `useMemo`'d with
+  narrow deps, and the Suite-Sync labels fallback correctly uses `returnStableArrayIfEmpty` rather
+  than `?? []` (see F-03-9 for the one line in this file that isn't memoized).
+- `packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees.ts`,
+  `hooks/useTransactionMaxFee.ts`, `StandardFee/hooks/useNetworkFeeOptions.ts` — internal `useMemo`
+  deps are consistent; whether `feeInfo.levels`/`composedLevels` are themselves referentially stable
+  depends on each caller's construction in `packages/suite/src/hooks/wallet/form/useFees.ts` and
+  friends, which is outside this area (`src/hooks`) — not verified either way.
+- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeEthereum.tsx` — uses
+  `watch()` (with a comment explaining why, over `getValues`) for cross-field validation triggers,
+  and only reads `getValues` inside callbacks/validators, not in a bare mount-effect like its Tron
+  sibling (F-03-1).
+- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountRow.tsx`
+  and `AccountItemContent/BaseCurrency.tsx` — plain presentational components, selectors return
+  primitives, no memoization concerns.
+- `AccountLabelForOwnAddress.tsx` (referenced from `TargetAddressLabel.tsx` and
+  `TransactionTarget.tsx`) lives under `packages/suite/src/components/suite/labeling/`, outside this
+  area's path prefixes (`components/wallet`, `components/earn`) — not scanned here; already drafted
+  under `perf-issues/asymptotic-complexity` per PROGRESS.md.
+- C9 candidate files outside this area's path prefix (`SuiteBanners.tsx`, `AddTokenModal.tsx`,
+  `ConfirmUnverifiedModal.tsx`, etc.) belong to area 02, already done.
+- `packages/suite/src/components/earn/yield/{wrap/WrapNativeToken.tsx, unwrap/UnwrapNativeToken.tsx,
+common/YieldApproveModal.tsx, common/YieldAmountCard.tsx, hooks/useYieldFiatInput.ts,
+withdraw/useYieldWithdraw.ts, withdraw/YieldWithdrawForm.tsx}`,
+  `earn/dashboard/yield/{EarnYieldTable.tsx, EarnYieldApyTooltip.tsx}`,
+  `earn/modals/{shared/VotingDelegations/VotingDelegationsOptions.tsx, EarnInANutshell/EarnInANutshellModal.tsx}`,
+  `earn/staking/tron/hooks/useTronStakeFees.ts`,
+  `wallet/CoinjoinAccountDiscoveryProgress/RotatingFacts.tsx`,
+  `wallet/Fees/CollapsibleFees/StandardFee/EthereumFeeCards.tsx` — all `useEffect`/`useMemo`/
+  `useCallback` usages checked have narrow, correct deps, guard re-entry with refs or value
+  comparisons before calling `setState`, or key off primitives; no unstable-dependency or
+  effect-loop pattern found.

--- a/perf-issues/react-hooks/_scan/04-views-wallet.md
+++ b/perf-issues/react-hooks/_scan/04-views-wallet.md
@@ -1,0 +1,546 @@
+# Scan area 04 — packages/suite/src/views/wallet
+
+Area: `packages/suite/src/views/wallet/**` (~360 files) — send form, receive, transactions list,
+coinmarket/trading views, staking, tokens, coin-control. Verified against `issues/perf-react-hooks`
+@ `9e0d5b6a45`. Web/desktop, not React-Compiler-covered — manual memoization findings are valid
+throughout this area.
+
+Excluded per the agent brief / `PROGRESS.md` (skipped as exact defects, not re-filed below):
+`useUtxoSelection.ts:63` UTXO scans + coin-control keystroke rescan (asymptotic-complexity
+`p1-09` + scheduling `p2-05`), `TransactionsGraph.tsx` `setWidth` (#31137, lives outside this area
+anyway), token search / accounts-sidebar keystroke filtering (scheduling `p1-12`/`p1-13`),
+`TransactionSummary` render-body aggregation (scheduling `p2-06`), `TransactionsGroup.tsx:52`
+`getErc4626Contracts` loop-invariant hoist (asymptotic-complexity `p3-03`, already proposes the
+`useMemo` fix).
+
+---
+
+## F-04-1 — `CoinControl.tsx` re-fetches UTXO transaction history on every account reference change, not just on mount
+
+- **Class:** 2 (effect refetch / render loop — silent, real network/backend round-trip)
+- **Where:** `packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx:144-155`
+- **Trigger cadence:** every store update that gives the open account a fresh object reference while
+  the Coin Control panel is open in the send form — i.e. every relevant blockchain sync tick during
+  UTXO selection, not merely once at mount
+- **Severity guess:** P1 (hot for its scenario — composing a Bitcoin-like transaction is exactly the
+  moment the account is actively syncing/fee-polling, and this dispatches a real thunk each time)
+- **Confidence:** high — the effect body only reads `account.key`; `account` itself is unused inside
+  the callback, so the whole-object dependency is provably wider than necessary. This is a distinct
+  defect from the already-excluded `useUtxoSelection.ts:63` O(n²) scan and the scheduling `p2-05`
+  keystroke-rescan doc — those are about the UTXO list computation and the search box; this is about
+  the dependency array of the fetch effect that seeds it, and both existing docs describe this fetch
+  as happening "on mount" (`CoinControl.tsx:145`/`:147`), which undersells the actual cadence
+
+### Before (verbatim from the file)
+
+```tsx
+// fetch all transactions so that we can show a transaction timestamp for each UTXO
+useEffect(() => {
+    const promise = dispatch(
+        fetchUtxoTransactionsForAccountThunk({
+            accountKey: account.key,
+        }),
+    );
+
+    return () => {
+        promise.abort();
+    };
+}, [account, dispatch]);
+```
+
+### Proposed fix
+
+Depend on `account.key` instead of `account` (mirrors the skill's `AdaStakingDashboard.tsx:52`
+pattern). Nothing else in the effect body needs the live `account` reference.
+
+### Why it matters
+
+Every time the open account's own record refreshes while a user is selecting UTXOs to compose a
+transaction — new block, balance/UTXO-set update — this effect aborts the in-flight
+`fetchUtxoTransactionsForAccountThunk` promise and redispatches it. `asymptotic-complexity/p1-01`
+already documents that this same thunk drives an O(m²) `unshift` reducer path for
+coinjoin-sized UTXO sets; narrowing this dependency wouldn't fix that reducer, but it would stop
+multiplying its cost by however many times the account reference churns while the panel stays open,
+instead of paying it once.
+
+---
+
+## F-04-2 — `TokenSelect.tsx`'s amount-revalidation effect depends on the whole `account` object for a check that only needs two static fields
+
+- **Class:** 1 (unstable/wider-than-necessary hook dependency) with a class-2 flavor (it's an effect,
+  so the extra dependency causes real re-execution, not just a wasted memo)
+- **Where:** `packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx:70-75`
+  (co-anchor: `hasNetworkFeatures`, `suite-common/wallet-utils/src/accountUtils.ts:1045-1053`, reads
+  only `account.symbol`/`account.accountType` via `getNetworkAccountFeatures`)
+- **Trigger cadence:** every store update that gives the currently-edited send-form account a fresh
+  reference while this output row is mounted (i.e. while the user is filling in a Send form output)
+- **Severity guess:** P2 (real repeated work — re-reads the amount field and calls `setAmount` again
+  — but idempotent in the common case, not a network call)
+- **Confidence:** high that the dependency is wider than the check needs (`hasNetworkFeatures`
+  provably never reads balance/UTXO/tx fields); medium on how visible the repeated `setAmount` call
+  is to the user, since I did not trace whether `setAmount` itself has further re-render side effects
+
+### Before (verbatim from the file)
+
+```tsx
+useEffect(() => {
+    if (hasNetworkFeatures(account, 'tokens') && !isSetMaxActive) {
+        const amountValue = getValues(`outputs.${outputId}.amount`);
+        if (amountValue) setAmount(outputId, amountValue);
+    }
+}, [account, outputId, tokenWatch, setAmount, getValues, isSetMaxActive]);
+```
+
+### Proposed fix
+
+Depend on `account.symbol` (or `account.accountType`, whichever `hasNetworkFeatures` actually
+branches on for this network) instead of `account`. `tokenWatch` is already the reactive trigger for
+"the user changed token"; `account` is only along for the network-features check.
+
+### Why it matters
+
+`account` gets a fresh object reference on every relevant blockchain sync tick (per this sweep's
+ground truth). As written, this effect re-runs the amount re-validation/re-format on every one of
+those ticks while a Send output row is open, not just when the user actually changes the selected
+token — pure repeated work for a check that never changes for the account's lifetime.
+
+---
+
+## F-04-3 — `useBuildTokenOptions` keys its token-list memo on the whole `account` object, so it never caches while the Send token picker is open
+
+- **Class:** 1 (unstable hook dependency — memo never hits because the dep is wider than the closure)
+- **Where:** `packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildTokenOptions.tsx:68-84`
+  (consumer: `SelectTokenAssetModal.tsx:72-75`, the Send-form "select token" modal)
+- **Trigger cadence:** every render of `SelectTokenAssetModal` caused by an `account` reference
+  change (blockchain sync tick) while the modal is open, not just when `account.tokens` actually
+  changes
+- **Severity guess:** P2 (real — rebuilds and re-sorts the full token list with fiat-rate enhancement
+  each time — but scoped to a modal's lifetime, not an always-mounted component)
+- **Confidence:** high — the memo body only reads `account.tokens` and `account.symbol` (both passed
+  into `buildTokenOptions`/`enhanceTokensWithRates`); the full `account` object is listed as the dep
+
+### Before (verbatim from the file)
+
+```tsx
+return useMemo(() => {
+    const tokensWithRates = enhanceTokensWithRates(
+        account.tokens,
+        baseCurrencyCode,
+        account.symbol,
+        fiatRates,
+    );
+
+    const sortedTokensWithRates = tokensWithRates.sort(sortTokensWithRates);
+
+    return buildTokenOptions(
+        account,
+        sortedTokensWithRates,
+        coinDefinitions,
+        expandedHiddenTokensGroups,
+    );
+}, [account, baseCurrencyCode, fiatRates, coinDefinitions, expandedHiddenTokensGroups]);
+```
+
+### Proposed fix
+
+Narrow the dep to `account.tokens` and `account.symbol` (both already destructured/used inside);
+`buildTokenOptions` still receives the full `account` object as an argument, only the dependency
+array needs narrowing.
+
+### Why it matters
+
+`sortTokensWithRates` allocates a `BigNumber` per comparison and this modal's own token counts scale
+with the account's ERC-20/SPL list (including the spam/airdrop tail the complexity audit already
+documents elsewhere). Because the memo is keyed on the whole `account`, it recomputes on every
+account refresh while the picker is open even though the token list and rates usually haven't
+changed — the memo is present in the code but structurally cannot hit.
+
+---
+
+## F-04-4 — `EthereumNonce` re-filters the account's entire transaction history on every keystroke of the custom-nonce input
+
+- **Class:** 4 (render-body work that belongs elsewhere — unmemoized filter/map over `transactions`)
+- **Where:** `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx:47,90-94`
+- **Trigger cadence:** every keystroke in the nonce-override field (`nonceValue = useWatch({ name:
+'ethereumNonce', control })` at `:50` drives this component's re-renders)
+- **Severity guess:** P2 (real per-keystroke unbounded-list work, matching the brief's "send-form
+  fields / per-keystroke re-render chains" priority — not P1 because the nonce-override UI is an
+  opt-in advanced action, not the default Send flow)
+- **Confidence:** high that the filter/map chain is unmemoized and re-runs every render; medium on
+  real-world severity since I did not verify typical EVM account transaction-history sizes
+
+### Before (verbatim from the file)
+
+```tsx
+const transactions = useSelector(state => selectAccountTransactions(state, account.key));
+...
+const nonceValue = useWatch({ name: 'ethereumNonce', control });
+...
+const pendingSentTxs = transactions.filter(isPending).filter(isSignedByAccount);
+
+const pendingNonces = pendingSentTxs
+    .map(tx => tx.ethereumSpecific?.nonce)
+    .filter((nonce): nonce is number => typeof nonce === 'number');
+```
+
+### Proposed fix
+
+`const { pendingSentTxs, pendingNonces } = useMemo(() => {...}, [transactions])` — neither derived
+value depends on `nonceValue`, so this is a pure win: the recompute would only fire when the
+account's transaction list actually changes, not on every character typed into the nonce field.
+
+### Why it matters
+
+`selectAccountTransactions` returns the account's whole transaction list; filtering it twice plus a
+map/filter chain on every keystroke while overriding a nonce is exactly the render-body-work-over-an-
+unbounded-list shape the skill calls out, just gated behind a less-common entry point than the main
+Send form fields.
+
+---
+
+## F-04-5 — `TokensNavigation`'s tab-count computation runs `getTokens` over the full account token list on every render, including every keystroke in the sibling search box
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/views/wallet/tokens/TokensNavigation.tsx:126-131` (parent:
+  `packages/suite/src/views/wallet/tokens/index.tsx:20,67-73` and
+  `packages/suite/src/views/wallet/nfts/index.tsx:14,36-41`, both of which hold `searchQuery` in
+  state and pass it down as a prop that `TokensNavigation` binds to its own `<Input value=...>`)
+- **Trigger cadence:** every render of `TokensNavigation` — which includes every keystroke in the
+  token/NFT search box, since `searchQuery` is one of its props, even though this specific
+  computation does not use `searchQuery` at all
+- **Severity guess:** P2 (real, unmemoized, over a list the complexity audit already documents as
+  unbounded/spam-tail-prone; not P1 here because the scheduling doc frames the per-keystroke path's
+  urgency as the table rows, not this count, and I have not measured typical token-list sizes)
+- **Confidence:** high that this exact line is unmemoized and keystroke-adjacent; flagging explicitly
+  that `perf-issues/scheduling/p1-12-token-search-rebuilds-the-unvirtualised-table-per-keystroke.md`
+  already names this precise line in its own Notes section ("Also left alone: the unmemoised
+  `getTokens` for the tab counts at `TokensNavigation.tsx:126`... making it cheaper is a complexity
+  fix, not a scheduling one") but explicitly declines to fix it — this finding is that it's also a
+  missing-memoization defect, not only a complexity one, since the call doesn't even depend on the
+  value (`searchQuery`) that's forcing its re-execution
+
+### Before (verbatim from the file)
+
+```tsx
+const tokens = getTokens({
+    tokens: selectedAccount.account.tokens || [],
+    symbol: selectedAccount.account.symbol,
+    tokenDefinitions,
+    isNft,
+});
+```
+
+### Proposed fix
+
+`useMemo(() => getTokens({ tokens: selectedAccount.account.tokens || [], symbol:
+selectedAccount.account.symbol, tokenDefinitions, isNft }), [selectedAccount.account.tokens,
+selectedAccount.account.symbol, tokenDefinitions, isNft])`. None of those inputs change per
+keystroke, so this absorbs the search-box-driven re-renders entirely.
+
+### Why it matters
+
+This call exists only to produce the tab-count badges (`normalTokens.length`, `erc4626Tokens.length`,
+`tokens.hiddenWithBalance.length`); it is loop-invariant with respect to the search string that is
+currently forcing it to re-run on every keystroke. `HiddenTokensTable.tsx:23-35` has the identical
+missing-memo shape and is already flagged (not filed) in the same scheduling doc's Notes — not
+re-reported here as its own finding, but named for triage since a shared fix likely covers both.
+
+---
+
+## F-04-6 — Two Trading asset-picker hooks read `useCurrentRef(fiatRates)` inside a `useMemo`, so fiat sort order lags a render behind rate ticks
+
+- **Class:** 7 (wrong ref hook for the moment of read — same shape the skill names explicitly: read
+  in a `useMemo` needs `useFreshRef`, not `useCurrentRef`)
+- **Where:**
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts:90,92-93,171-179`
+  and
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts:59,61-62,180`
+- **Trigger cadence:** every fiat-rate tick while the Trading Buy/Sell asset picker is open
+- **Severity guess:** P2 (real staleness confined to a picker's sort/display order, same grade as the
+  precedent finding)
+- **Confidence:** high on the mechanism (identical to area 02's already-reported `F-02-6` on the
+  sibling `GlobalSendModal/hooks/useAccountWithTokensOptions.ts` — this is the same bug pattern
+  appearing in two more, differently-located files with the same name/shape, both inside this area);
+  medium on user-visible impact, same caveat as `F-02-6`
+
+### Before (verbatim from the file — `useAgregatedAccountsWithTokens.ts`)
+
+```tsx
+const throttledAccounts = useThrottle(accounts, 3000);
+const fiatRatesRef = useCurrentRef(fiatRates);
+
+return useMemo(() => {
+    const fiatRates = fiatRatesRef.current;
+
+    if (!fiatRates) {
+        return [];
+    }
+    ...
+}, [throttledAccounts, baseCurrencyCode, fiatRatesRef, tokenDefinitions]);
+```
+
+The Sell-asset-picker `useAccountWithTokensOptions.ts` repeats the identical pattern at its own
+lines 90 (`useCurrentRef(fiatRates)`) and 92-93 (`const fiatRates = fiatRatesRef.current;` inside its
+`useMemo`, deps at `:171-179`).
+
+### Proposed fix
+
+Swap `useCurrentRef(fiatRates)` for `useFreshRef(fiatRates)` in both files (assigns during render, so
+`.current` is always this render's value when read synchronously inside the memo body).
+
+### Why it matters
+
+Because the ref object itself is stable, listing it in the memo's deps never triggers a recompute on
+its own; the memo only re-evaluates when the other listed deps change, and when it does, `.current`
+can still hold the rate from before the previous render's update. Same failure mode, same fix, as the
+already-reported instance in area 02 — worth fixing together since all three hooks appear to descend
+from the same copy-pasted shape.
+
+---
+
+## F-04-7 — Five Trading-form action components call `watch()` with no field name, so they re-render on every keystroke anywhere in the form
+
+- **Class:** 6 (wasted/wrong memoization) — the skill's own wording for this class is scoped to
+  "`react-hook-form`'s `watch()` inside **compiled suite-native** code (compiler bail-out)"; these
+  files are `packages/suite` (not compiled), so there is no compiler auto-memoization to bail out of.
+  I'm reporting this anyway because the harvest explicitly carved out a `C2b` category for exactly
+  this shape in web code ("bare `watch()` in web `packages/suite` — whole-form re-render per
+  keystroke"), and the mechanism is the closest web analogue: an unscoped subscription that forces a
+  wider re-render than the component's own output needs, the same underlying problem the compiled
+  case has a name for. Flagging the class stretch explicitly per the honesty rules — triage may want
+  to re-bucket this as a new observation rather than class 6.
+- **Where:**
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx:63`,
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOffersWarnings.tsx:24`,
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon.ts:35`,
+  `packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx:44`,
+  `packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx:30`
+- **Trigger cadence:** every keystroke in any field of the active trading form (amount, address,
+  country, payment method, ...), for every one of these five components/hooks simultaneously since
+  `useTradingFormOfferCommon` is called from inside both action components
+- **Severity guess:** P2 (real wasted render work — several `useSelector` calls and derived booleans
+  re-run per unrelated keystroke — not P1 since the trading form isn't a per-row list, so the
+  multiplier is "one component tree", not "one per row")
+- **Confidence:** medium — high confidence the subscription is unscoped and wider than needed;
+  medium on how much this actually costs per keystroke since I did not profile it, and medium on
+  classification (see Class note above) — would raise to high with a render-count measurement showing
+  these components actually commit on unrelated-field keystrokes, and drop this if a maintainer
+  considers unscoped `watch()` acceptable/intentional here for reasons I didn't find in the code
+
+### Before (verbatim from the file — `TradingFormApproval.tsx`)
+
+```tsx
+const {
+    watch,
+    approveTransaction,
+    ...
+} = context;
+...
+const { exchangeType, rateType } = watch();
+```
+
+(`TradingFormOffersWarnings.tsx:24` — `const { countrySelect, countrySubdivisionSelect } =
+context.watch();`; `useTradingFormOfferCommon.ts:35` — `const { amountInCrypto } = watch();`;
+`TradingFormOfferExchangeActions.tsx:44` — `const { outputs, sendCryptoSelect, receiveCryptoSelect,
+exchangeType, rateType } = watch();`; `TradingFormOfferSellActions.tsx:30` — `const { outputs } =
+watch();`)
+
+### Proposed fix
+
+Replace each with a scoped subscription — `useWatch({ control, name: ['exchangeType', 'rateType'] })`
+(or individual `useWatch({ control, name: 'exchangeType' })` calls) — the same pattern already used
+correctly elsewhere in this area:
+`TradingFormInputFiat.tsx:74-80` (`useWatch({ control, name: TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT
+})`, four scoped calls in one file) and `TradingFormInputCryptoAmount.tsx:181-184`.
+
+### Why it matters
+
+An unscoped `watch()` subscribes the calling component to every field change in the form, not just
+the destructured ones. Typing an amount, picking a country, or any other field edit re-renders all
+five of these components even when the fields they actually read haven't changed — the exact
+"whole-form re-render per keystroke" shape the grep harvest was built to catch, just without a
+compiler in the room to call it a bail-out.
+
+---
+
+## F-04-8 — Trading Detail pages scan the full accounts list with a bare `.find()` instead of a keyed selector
+
+- **Class:** 4 (render-body work that belongs elsewhere — the fix already exists as a selector)
+- **Where:**
+  `packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx:53,77`,
+  `packages/suite/src/views/wallet/trading/sell/TradingSellDetail/TradingSellDetailContent.tsx:46,70`,
+  `packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx:108-109`,
+  `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell.tsx:43`
+- **Trigger cadence:** every render of the relevant Trade Detail/offer page (driven mainly by trade
+  status polling, not per-keystroke)
+- **Severity guess:** P3 (cleanup — cold path, four small call sites, cheap fix)
+- **Confidence:** high that the pattern is unmemoized and repeated across all four files; the accounts
+  list itself is likely reference-stable between renders (`selectAccounts`), so this is about the
+  repeated scan, not a churn problem
+
+### Before (verbatim, `TradingSellDetailContent.tsx`)
+
+```tsx
+const accounts = useSelector(selectAccounts);
+...
+const sendAccount = accounts.find(account => account.key === trade?.sendAccountKey);
+```
+
+(`TradingBuyDetailContent.tsx:77` and `TradingOfferSell.tsx:43` repeat the identical
+`accounts.find(account => account.key === trade?....AccountKey)` shape; `TradingExchangeDetailContent.tsx:108-109`
+does it twice, once per side of the trade.)
+
+### Proposed fix
+
+`useSelector(state => selectAccountByKey(state, trade?.sendAccountKey))` (already imported/used
+elsewhere in this area, e.g. `TradingFormInputCryptoAmount.tsx:186`) instead of selecting the whole
+list and scanning it per render.
+
+### Why it matters
+
+Minor on its own — grouped because it's the same cheap, repeated pattern across four files and a
+keyed selector already exists in the codebase for exactly this lookup.
+
+---
+
+## F-04-9 — `Tokens`/`Nfts` route guards key their redirect effect on the whole `selectedAccount` object
+
+- **Class:** 1 (unstable hook dependency — wider than the condition actually needs)
+- **Where:** `packages/suite/src/views/wallet/tokens/index.tsx:24,28-36`,
+  `packages/suite/src/views/wallet/nfts/index.tsx:16,20-27`
+- **Trigger cadence:** every store update that gives `state.wallet.selectedAccount` a fresh reference
+  (i.e. every relevant account/blockchain sync tick) while either route is mounted
+- **Severity guess:** P3 (bounded-but-wasteful — the guarded action, `dispatch(goto(...))`, only
+  actually fires when the network genuinely lacks the feature or the route is wrong, both stable
+  conditions, so nearly every re-run is a no-op comparison)
+- **Confidence:** high that the dependency is wider than the read fields (`.status`,
+  `.network?.features`/`hasNetworkFeatures(selectedAccount.account, ...)`); low severity is by
+  design given how inert the effect body is in the common case
+
+### Before (verbatim, `tokens/index.tsx`)
+
+```tsx
+useEffect(() => {
+    if (
+        selectedAccount.status === 'loaded' &&
+        !hasNetworkFeatures(selectedAccount.account, 'tokens') &&
+        routeName !== 'wallet-index'
+    ) {
+        dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+    }
+}, [selectedAccount, dispatch, routeName]);
+```
+
+`nfts/index.tsx:20-27` repeats the same shape against `selectedAccount.network?.features`.
+
+### Proposed fix
+
+Depend on `selectedAccount.status` and `selectedAccount.account?.symbol` (the field
+`hasNetworkFeatures`/`.network?.features` actually keys off) instead of the whole `selectedAccount`
+object.
+
+### Why it matters
+
+Listed for completeness alongside the higher-severity findings above — same "whole object where a
+primitive would do" shape, but the guarded action is idempotent and rare, so this is cleanup rather
+than a real render/request cost.
+
+---
+
+## Checked, clean
+
+- `packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/AdaStakingDashboard.tsx:43-52`
+  and `EthStakingDashboard/EthStakingDashboard.tsx:59-68` — both already depend on `accountKey`, not
+  `account`, for their `fetchAllTransactionsForAccountThunk` effect. This is the skill's own "good"
+  worked example (`AdaStakingDashboard.tsx:52`) — confirmed still correct at this commit, no
+  surviving sibling of the pre-#23523 bug found in either file.
+- `packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx` —
+  `pagintionRef = useCurrentRef(pagination)` at `:70` is read inside the very next `useEffect`
+  (`:72-75`), not a memo; hook-declaration order guarantees `useCurrentRef`'s own effect commits
+  first, so `.current` is fresh by the time this effect reads it. Correct usage, contrast with F-04-6.
+- `packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx`
+  and its child cards — no `useEffect`/`useMemo` at all; nothing to check.
+- `packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx:35-55`
+  — `prevIsClaimPending` is a plain `useRef` assigned on the last line of its effect, matching the
+  skill's "good" `TransactionReviewModalBody.tsx:59` previous-value pattern exactly.
+- `packages/suite/src/views/wallet/staking/components/EthStakingDashboard/InstantStakeBanner.tsx:43-55`
+  and `StakingDashboard/hooks/useIsTxStatusShown.ts:13-39` — same correct plain-`useRef`
+  previous-value pattern, both reset-on-account-change then compare-and-update at the end of the
+  effect.
+- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumOptions.tsx:29-52` — uses
+  `useWatch({ name: 'options', control })` (scoped) rather than bare `watch()`, and its own code
+  comments explicitly explain why the EVM-nonce fetch is gated on `isEditingNonce` rather than
+  running on every account update. Good example, contrast with F-04-7.
+- `packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx`,
+  `TronOptions.tsx`, `send/Options/BitcoinOptions/Locktime/Locktime.tsx`,
+  `send/Options/shared/TransactionData.tsx`, `send/Outputs/Outputs.tsx`,
+  `send/Outputs/Amount/Amount.tsx`, `send/Outputs/Address.tsx` — all `watch()`/`useWatch()` calls in
+  this group pass explicit field names (single string or array), and every `useEffect` dependency
+  array is narrow (primitives or explicitly-watched fields). No issues found.
+- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx:74-80`
+  and `TradingFormInputCryptoAmount.tsx:181-184` — both use scoped `useWatch({ control, name: ... })`
+  calls; good counter-examples to F-04-7 in the same file family.
+- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx:57-58`,
+  `TradingExchangeFormInputs.tsx:109-112`, `TradingSellFormInputs.tsx:90` — all `useCurrentRef(...)`
+  values here are only read inside click-driven `useCallback` bodies (`handleCryptoSelect`,
+  `handleSellAssetSelect`, etc.), never in render or in a `useMemo`; by the time a user clicks, the
+  ref's own effect has already committed the latest value. Correct usage, contrast with F-04-6.
+- `packages/suite/src/views/wallet/trading/concierge/TradingConciergeForm.tsx:28-32` — effect keyed
+  on `otcData` (a query-result object) only sets a primitive `country` string derived from it;
+  didn't find a churn problem, though I did not trace whether the underlying query hook returns a
+  stable `data` reference across refetches — low-confidence pass, not filed as a finding.
+- `packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx` and
+  `trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx` — one-shot parse-and-redirect / trade-
+  status-polling effects with narrow or intentionally-whole-but-low-frequency deps; no loop shape.
+- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx`
+  — despite the name, this is a plain component, not a Context Provider; no inline `value={{...}}`.
+- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx:60-62` — effect depends
+  only on `dispatch`; fine.
+- `packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/UtxoReceiveAddressModal.tsx:32-44`
+  — `addresses?.used ?? []` / `addresses?.unused?.slice(...) ?? []` fresh-fallback patterns are used
+  only inside the `useMemo` body (deps are `[addresses, search]`), so the fallback doesn't defeat the
+  memo. Correct usage despite matching the `?? []` grep signature.
+- `packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx:137-140`
+  — `suiteSyncOutputLabels.find(...)` per row is the same missing-index shape already covered by the
+  `suiteSyncOutputSelectors.ts:56` exclusion / `asymptotic-complexity/p3-03`'s `TransactionTarget.tsx`
+  finding; a complexity/indexing defect, not a hooks one, so not re-filed here.
+- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx`,
+  `TransactionListActions/TransactionListActions.tsx`, `useFetchTransactions.ts` — read closely for
+  the C9/C10 candidates in this file set. `TransactionList.tsx:75-79`'s anchor-fetch effect lists
+  `account` in its deps but never reads it in the body (only `anchor`/`fetchedAll`/`fetchAll`, the
+  latter itself keyed correctly on `accountKey`) — genuinely dead dependency, but because `fetchAll`
+  internally no-ops once `fetchedAll` is true and the deps also include `fetchedAll`, this doesn't
+  compound into a request loop; not filed given the low real-world impact after tracing it through.
+  `TransactionListActions.tsx:44-69`'s `onSearch` callback also depends on whole `account` where only
+  `account.key` is read, feeding a low-frequency effect (`transactionHistoryPrefill`, a one-shot
+  deep-link value) — same "wider than necessary" shape as F-04-2/F-04-9 but lower value than either
+  (rarely-set trigger value), not filed as its own entry.
+- `packages/suite/src/views/wallet/transactions/Transactions.tsx`,
+  `components/AccountOverviewBalance.tsx`, `TradeBox/TradeBox.tsx`,
+  `TradeBox/hooks/useTradeBoxEarnOptions.ts` — no unstable deps or unmemoized list scans found;
+  `useTradeBoxEarnOptions` delegates to `src/hooks/earn/*` (area 01's territory).
+- `packages/suite/src/views/wallet/receive/Receive.tsx` — simple selector reads, no derived-list or
+  effect logic at all.
+- `packages/suite/src/views/wallet/details/CoinjoinSetup/SetupSlider/SliderInput.tsx:86-90` — the
+  `// eslint-disable-line react-hooks/exhaustive-deps` omitting `inputValue` is justified, not a
+  lying dependency array: `inputValue` tracks the user's own in-progress edits, and including it
+  would make the effect fire on every keystroke and, worse, overwrite the user's local edit with the
+  (now-stale) `value` prop mid-typing. Verified this is the "adjusting state from props, ignore local
+  edits" pattern, not a suppressed bug.
+- `packages/suite/src/views/wallet/details/CoinjoinSetup/AnonymityLevelSetup.tsx:89-138` — `labels`
+  `useMemo(..., [])` is a genuinely static array; memo correctly never recomputes (could be hoisted
+  to a module constant instead, but that's a stylistic nit, not a bug — not filed).
+- `packages/suite/src/views/wallet/anonymize/*`, `labels/Bip329Labels.tsx`,
+  `sign-verify/SignVerifyPage.tsx`, `details/index.tsx`, `details/RescanAccount.tsx`,
+  `details/CoinjoinLogs.tsx`, `details/AccountNonce.tsx`, `details/CoinjoinSetup/{SkipRoundsSetup,MaxMiningFeeSetup,CoinjoinSetup,SetupSlider}.tsx`
+  — none of these use `useEffect`/`useMemo`/`useCallback` at all; nothing to check.
+- `packages/suite/src/views/wallet/send/TotalSent/CardanoSentTokenInfo.tsx:18-35` — `useWatch({...,
+defaultValue: [] })` plus a redundant `formOutputs ?? []` inside the memo body; low-confidence,
+  narrow-impact edge case (only matters if `outputs` is ever actually `undefined`, which is unlikely
+  given the form always registers it) — noted but not filed as a formal finding.
+- No inline Context `Provider value={{...}}` literals found anywhere under this area (`grep -rn
+"\.Provider value={{"` returned nothing) — class 5 does not apply to any file in this tree.
+- No `useSelector(state => ...)` call in this area returns an inline `.filter()`/`.map()`/
+  `Object.values()`/spread result directly (checked via targeted grep); the derived-selector-storm
+  shape (class 3) appears to be absorbed by memoized selectors imported from `suite-common` and
+  `suite-common/wallet-core` throughout this tree.

--- a/perf-issues/react-hooks/_scan/05-views-rest.md
+++ b/perf-issues/react-hooks/_scan/05-views-rest.md
@@ -1,0 +1,652 @@
+# Scan area 05 — packages/suite/src/views (rest) + packages/suite/src/support
+
+Area: `packages/suite/src/views/**` except `views/wallet` (dashboard, settings, onboarding, suite,
+earn, firmware, backup, recovery, view-only, password-manager, start, connect-popup — 250 files) plus
+`packages/suite/src/support/**` (34 files: Preloader-adjacent app shell, connect-popup bridges,
+router/theme/intl/responsive providers, event listeners). Verified against `issues/perf-react-hooks`
+@ `9e0d5b6a45`. Web/desktop, not React-Compiler-covered — manual memoization findings are valid
+throughout.
+
+Excluded per the agent brief / `PROGRESS.md` (skipped as exact defects, not re-filed below):
+`perf-issues/asymptotic-complexity/p2-26-transactionsselectors-selectanyaccountisstakingactive.md`
+already covers `selectAnyAccountIsStakingActive`'s array-argument memo-key problem and the
+`AssetsView.tsx:156` loop-invariant `stakingAccounts` hoist (see F-05-2's relationship note — that
+doc's fix does not fully resolve the broader memo-defeat this file reports separately).
+`perf-issues/react-hooks/_scan/01-suite-hooks.md` F-01-6 already covers `useTotalFiatBalance.ts`
+being unmemoized, citing `WalletInstance.tsx:69` (this area) as one of its two call sites — not
+re-filed. `01-suite-hooks.md` F-01-1 already covers the sibling `LayoutContext.Provider` (in
+`hooks/suite/useLayout.tsx`, not this area) being an unmemoized value with many consumers — the
+context _declaration_ lives in `support/suite/LayoutContext.ts` (this area) but carries zero logic,
+so nothing to add there. `02-suite-components.md` F-02-9 already covers `AccountName.tsx`'s own
+`exhaustive-deps` suppression (a ref-staleness bug, different mechanism from this doc's F-05-8, which
+is about the Provider's inline value object).
+
+---
+
+## F-05-1 — `ResponsiveContext.tsx`'s Provider value is a fresh object every render, re-rendering the entire app shell on every pixel of sidebar/window resize
+
+- **Class:** 5 (missing memoization on a context Provider value, many consumers)
+- **Where:** `packages/suite/src/support/suite/ResponsiveContext.tsx:75-92` (the
+  `ResponsiveContextProvider` component); consumed via `useResponsiveContext()` in 14+ files across
+  `components/wallet/WalletLayout/AccountsMenu/*`, `components/suite/layouts/SuiteLayout/*`
+  (`Sidebar.tsx`, `Navigation.tsx`, `NavigationItem.tsx`, `DeviceSelector.tsx`,
+  `SidebarDeviceStatus.tsx`, `ExpandedSidebarOnly.tsx`, `CollapsedSidebarOnly.tsx`,
+  `useResponsiveContextOnChange.tsx`), `components/guide/GuideRouter.tsx`, and this area's own
+  `support/suite/ContentFlex.tsx` / `ConditionalRender.tsx`. Mounted once at the app root
+  (`support/suite/Main.tsx:36`, inside `<ConnectedThemeProvider>`, wrapping every route for the whole
+  session).
+- **Trigger cadence:** every pointer-move event while the user drags the sidebar's resize handle
+  (`components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx:179` —
+  `onWidthResizeMove={handleSidebarWidthUpdate}` calls `setSidebarWidth` on every move tick of the
+  drag), and on every debounced `ResizeObserver` tick of the main content area
+  (`components/suite/layouts/SuiteLayout/useResponsiveContextOnChange.tsx:33,39` —
+  `setContentWidth`). Also on `setAutoCollapsed`/`setForcedSidebarWidth`/`setUserResizingSidebar`/
+  `setAutoCollapseSuppressed`, all called from `Sidebar.tsx`'s resize lifecycle.
+- **Severity guess:** P1 — hottest finding in this area. The Provider wraps literally the whole app
+  for the whole session (support/ mounts app-wide per this sweep's brief), the trigger is a
+  continuous high-frequency pointer interaction (not a rare event), and the fan-out is 14+ files
+  including the sidebar, navigation, account list rows, and device selector — every one of them
+  re-renders on every drag tick regardless of which single field it actually reads.
+- **Confidence:** high — read the Provider, confirmed no `useMemo` wraps `value`; confirmed the
+  consumer count via `grep -rl useResponsiveContext`; confirmed `setSidebarWidth`/`setContentWidth`
+  are wired to continuous-motion handlers (`onWidthResizeMove`, a debounced `ResizeObserver`), not
+  one-shot events.
+
+### Before (verbatim from the file)
+
+```tsx
+// packages/suite/src/support/suite/ResponsiveContext.tsx
+export const ResponsiveContextProvider = ({ children }: { children: React.ReactNode }) => {
+    const sidebarWidthFromRedux = useSelector(selectSidebarWidth);
+    const dispatch = useDispatch();
+    const initialSidebarWidth = normalizePersistedSidebarWidth(sidebarWidthFromRedux);
+
+    const [sidebarWidthManual, setSidebarWidthManual] = useState<number>(initialSidebarWidth);
+    const [sidebarWidthRaw, setSidebarWidthRaw] = useState<number>(initialSidebarWidth);
+    const [forcedSidebarWidth, setForcedSidebarWidth] = useState<number | undefined>(undefined);
+    const [contentWidth, setContentWidth] = useState<number | undefined>(undefined);
+    const [autoCollapsed, setAutoCollapsed] = useState<boolean>(false);
+    const [userResizingSidebar, setUserResizingSidebar] = useState<boolean>(false);
+    const [autoCollapseSuppressed, setAutoCollapseSuppressed] = useState<boolean>(false);
+    // ...effectiveWidth/isSidebarCollapsed useMemo'd correctly...
+
+    const setSidebarWidth = (width: number) => {
+        /* ... */
+    };
+
+    const value: ResponsiveContextType = {
+        sidebarWidth: effectiveWidth,
+        setSidebarWidth,
+        lastManualSidebarWidth: sidebarWidthManual,
+        forcedSidebarWidth,
+        setForcedSidebarWidth,
+        isSidebarCollapsed,
+        contentWidth,
+        setContentWidth,
+        autoCollapsed,
+        setAutoCollapsed,
+        userResizingSidebar,
+        setUserResizingSidebar,
+        autoCollapseSuppressed,
+        setAutoCollapseSuppressed,
+    };
+
+    return <ResponsiveContext.Provider value={value}>{children}</ResponsiveContext.Provider>;
+};
+```
+
+Note that `effectiveWidth` and `isSidebarCollapsed` _are_ correctly `useMemo`'d a few lines above
+(`:52-60`) — the component clearly has memoization awareness, it just wasn't applied to the object
+that actually matters (the Provider `value` itself, which wraps them and 12 other fields in a fresh
+literal).
+
+### Proposed fix
+
+Wrap `value` in `useMemo`, depending on all 14 fields (or split the context into two — a rarely-
+changing "capabilities" context and a frequently-changing "dimensions" context — if per-field
+granularity is wanted later, but a single `useMemo` is the immediate, low-risk fix):
+
+```tsx
+const value = useMemo<ResponsiveContextType>(
+    () => ({
+        sidebarWidth: effectiveWidth,
+        setSidebarWidth,
+        lastManualSidebarWidth: sidebarWidthManual,
+        forcedSidebarWidth,
+        setForcedSidebarWidth,
+        isSidebarCollapsed,
+        contentWidth,
+        setContentWidth,
+        autoCollapsed,
+        setAutoCollapsed,
+        userResizingSidebar,
+        setUserResizingSidebar,
+        autoCollapseSuppressed,
+        setAutoCollapseSuppressed,
+    }),
+    [
+        effectiveWidth,
+        sidebarWidthManual,
+        forcedSidebarWidth,
+        isSidebarCollapsed,
+        contentWidth,
+        autoCollapsed,
+        userResizingSidebar,
+        autoCollapseSuppressed,
+    ],
+);
+```
+
+The setters (`setSidebarWidth`, `setForcedSidebarWidth`, etc.) are plain closures redefined every
+render too — `setSidebarWidth` should become a `useCallback`, the `useState` setters
+(`setForcedSidebarWidth` etc.) are already stable by React's contract.
+
+### Why it matters
+
+Every consumer of `useResponsiveContext()` re-renders whenever _any_ field changes, because the
+context value's reference changes as a whole. During a sidebar drag or a window resize, that's
+dozens of re-renders per second propagated to the sidebar itself, every navigation item, the account
+list, the device selector, and the guide router — most of which only read one field (e.g.
+`isSidebarCollapsed`) that may not even have changed on that particular tick.
+
+---
+
+## F-05-2 — `AssetsView.tsx` builds every prop of `AssetRow`/`AssetCard` fresh on every render, so `AssetRow`'s `memo()` wrap is comprehensively defeated on the dashboard's hot path
+
+- **Class:** 4 (render-body work that belongs elsewhere) + 5 (unstable props defeating a `memo()`'d
+  child)
+- **Where:** `packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx:110-165` (the `assets` /
+  `assetSymbols` / `assetsData` construction, entirely inline in the render body, no `useMemo`
+  anywhere in this component) and `:167-172` (`useAssetsFiatBalances(...)`, a plain function called
+  directly in render, not a real hook — it calls no hooks itself); consumed by
+  `AssetTable.tsx:49-63` (`assetsData.map(...)` spreading fresh props onto `<AssetRow memo .../>`)
+  and `AssetCard.tsx:78-90` (same shape, though `AssetCard` itself isn't `memo()`'d so this half is
+  moot). `AssetRow` is `memo()`-wrapped at `AssetTable/AssetRow.tsx:48`.
+- **Trigger cadence:** every render of `AssetsView` — driven by `useSelector(selectAllAccountsToList)`,
+  `useDiscovery()`/`isDiscoveryRunning`, `useSelector(selectDiscoveryOverallStatus)`,
+  `useSelector(selectCurrentFiatRates)`, all of which change during active discovery/sync (the
+  scenario this sweep's brief calls out as the dashboard's heaviest dispatch traffic).
+- **Severity guess:** P1 — this is the dashboard's main asset table/card grid, exactly the component
+  the brief flags as rendering during discovery, and the memo wrap around each row is currently
+  providing close to zero protection.
+- **Confidence:** high on the mechanism for `assetTokens` and `assetsFiatBalances` specifically (read
+  both computations, confirmed no memoization anywhere in the chain, confirmed `getNetwork()` at
+  least _is_ reference-stable so `network` isn't also a culprit, confirmed `selectAllAccountsToList`
+  is a `createMemoizedSelector` so the `accounts` field is stable). Medium on total real-world
+  render-storm size since I did not profile it.
+
+### Relationship to `perf-issues/asymptotic-complexity/p2-26`
+
+`p2-26` already documents that `AssetsView.tsx:156`'s `stakingAccounts: accounts.filter(...)` is a
+loop-invariant fresh array feeding `selectAnyAccountIsStakingActive`'s memo, and proposes hoisting it
+plus memoizing `stakingAccountsForAsset` in `AssetRow`/`AssetCard`. That fix is real but **narrower
+than the actual defect**: `AssetRow` is `memo()`-wrapped, and `memo()` does a shallow comparison of
+_every_ prop — fixing only `stakingAccounts` still leaves `assetTokens` (built via a fresh
+`.reduce()` per asset, below) and `assetsFiatBalances` (a fresh array from a plain function call,
+shared across siblings but new every `AssetsView` render) as independently-fresh props. Either one
+alone is sufficient to defeat the whole memo. This finding is scoped to those remaining fields, which
+`p2-26`'s fix does not touch.
+
+### Before (verbatim from the file)
+
+```tsx
+// AssetsView.tsx:92 (component start) ... 110-165 (relevant excerpt)
+const assets: PartialRecord<NetworkSymbol, Account[]> = {};
+accounts.forEach(account => { /* groups accounts by symbol into `assets`, fresh object every render */ });
+
+const assetSymbols = typedObjectKeys(assets).filter(symbol => isNetworkSymbol(symbol));
+
+const assetsData: AssetData[] = assetSymbols.map((symbol): AssetData => {
+    const network = getNetwork(symbol);
+    // ...
+    const assetTokens = assets[symbol]?.reduce((allTokens: TokenInfo[], account) => {
+        if (account.tokens) {
+            allTokens.push(...account.tokens);
+        }
+
+        return allTokens;
+    }, []);
+
+    const assetFailed = accounts.find(f => f.symbol === network.symbol && f.failed);
+
+    return {
+        network,
+        failed: !!assetFailed,
+        assetNativeCryptoBalance: /* ... */,
+        assetTokens: assetTokens?.length ? assetTokens : [],
+        stakingAccounts: accounts.filter(/* p2-26's territory */),
+        accounts,               // stable — passthrough of the memoized selector result
+        isStakeNetwork: getNetworkFeatures(symbol).includes('staking'),
+    };
+});
+
+const assetsFiatBalances = useAssetsFiatBalances(assetsData, assets, baseCurrencyCode, currentFiatRates);
+// useAssetsFiatBalances (line 72-90) is a plain `.reduce()` — not a hook, calls no hooks, allocates
+// a fresh array on every call
+```
+
+```tsx
+// AssetTable.tsx:49-63 — spreads the fresh assetTokens/assetsFiatBalances straight onto memo(AssetRow)
+{
+    assetsData.map((asset, i) => (
+        <AssetRow
+            key={asset.network.symbol + i}
+            assetTokens={asset.assetTokens}
+            stakingAccounts={asset.stakingAccounts}
+            assetsFiatBalances={assetsFiatBalances}
+            accounts={asset.accounts}
+            /* ...+ 5 more props... */
+        />
+    ));
+}
+```
+
+### Proposed fix
+
+Wrap the `assets` / `assetSymbols` / `assetsData` pipeline in a single `useMemo` keyed on
+`[accounts]` (everything downstream — `getNetwork`, `getNetworkFeatures`, `isSupported*StakingNetworkSymbol`
+— is a pure function of `accounts` plus static config), and wrap `useAssetsFiatBalances`'s call site
+(or the hook itself) similarly, keyed on `[assetsData, assets, baseCurrencyCode, currentFiatRates]`.
+With `assetsData` itself memoized, `asset.assetTokens` and `asset.accounts` become stable references
+across renders where `accounts` hasn't changed, which is the common case during a discovery tick that
+only touches one account.
+
+### Why it matters
+
+`AssetRow` (table view) is explicitly `memo()`-wrapped specifically to avoid re-rendering every asset
+row when unrelated state changes — but because `AssetsView` hands it a brand-new `assetTokens` array
+and a brand-new shared `assetsFiatBalances` array on every single render, that memo currently never
+holds. Every fiat-rate tick or account-sync tick during discovery re-renders every asset row in full,
+which is precisely the scenario this sweep was asked to weight heavily.
+
+---
+
+## F-05-3 — `AssetCoinLogo` recomputes the whole portfolio's percentage breakdown once per asset row/card instead of once per table
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/views/dashboard/AssetsView/AssetCoinLogo.tsx:26-29`; rendered once
+  per row from both `AssetTable/AssetRow.tsx` (table view) and `AssetCard/AssetCardInfo.tsx:18-22`
+  (card view) — i.e. every asset on the dashboard, in either view mode.
+- **Trigger cadence:** every render of every `AssetCoinLogo` instance, which is every render of its
+  parent row/card (see F-05-2 — currently every `AssetsView` render, once memoized there will still
+  be at least once per genuine asset-list change).
+- **Severity guess:** P2 — real and scales quadratically with the number of enabled assets (each of
+  N rows recomputes percentages for all N assets, i.e. O(N²) work per table render instead of O(N)),
+  but the practical N (distinct networks with a visible balance) is usually small enough that this is
+  "real but colder" rather than an immediate hot-path fire.
+- **Confidence:** high that the recomputation is unmemoized and repeated per row; medium on
+  real-world cost since `calculateAssetsPercentage`'s own complexity wasn't profiled.
+
+### Before (verbatim from the file)
+
+```tsx
+export const AssetCoinLogo = ({ symbol, assetsFiatBalances, index }: AssetCoinLogoProps) => {
+    const locale = useSelector(selectLanguage);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+
+    const assetPercentage = assetsFiatBalances
+        ? calculateAssetsPercentage(assetsFiatBalances).find(
+              (asset: AssetFiatBalanceWithPercentage) => asset.symbol === symbol,
+          )?.fiatPercentage
+        : undefined;
+    // ...
+};
+```
+
+### Proposed fix
+
+Move `calculateAssetsPercentage(assetsFiatBalances)` up one level — compute it once in
+`AssetsView`/`AssetTable` (memoized on `[assetsFiatBalances]`) and pass each row its own
+`percentageShare: number | undefined` directly, instead of passing the whole `assetsFiatBalances`
+array down to every row for it to re-derive and re-search.
+
+### Why it matters
+
+Not currently flagged by the asymptotic-complexity audit (checked — no hit for
+`calculateAssetsPercentage`/`AssetCoinLogo`). The fix is a relocation, not an algorithm change, which
+is why it's reported here rather than there.
+
+---
+
+## F-05-4 — `PinStep.tsx`'s status-detection effect depends on the whole `device` object, so it can re-fire `goToNextStep()` on unrelated device updates after PIN setup already succeeded
+
+- **Class:** 1 (unstable/wider-than-necessary hook dependency) with a class-2 flavor (the effect
+  dispatches a step-advance action, not just a wasted memo)
+- **Where:** `packages/suite/src/views/onboarding/steps/PinStep.tsx:49-70`
+- **Trigger cadence:** every store update that gives the currently-onboarding `device` a fresh object
+  reference (any feature/state field changing, not just `buttonRequests`/`features.pin_protection`)
+  while `PinStep` is still mounted — which includes the window between `goToNextStep()` being
+  dispatched and the parent's `activeStepId`-keyed `useMemo`
+  (`packages/suite/src/views/onboarding/index.tsx:56-88`) actually swapping the rendered step
+  component out.
+- **Severity guess:** P2 — a real, if narrow-window, wrong-dependency bug in a flow every onboarding
+  user passes through once; not P1 because the window during which `PinStep` stays mounted after
+  success is normally short.
+- **Confidence:** medium — high confidence the dependency is provably wider than what the body reads
+  (`device.buttonRequests`, `device.features.pin_protection`); medium on whether `goToNextStep()`
+  and/or the onboarding step reducer are idempotent against being dispatched multiple times in a row
+  for the same transition (did not trace that reducer) — if they are, this degrades to wasted work
+  rather than a skip-ahead bug.
+
+### Before (verbatim from the file)
+
+```tsx
+useEffect(() => {
+    if (device?.features) {
+        const buttonRequests = device.buttonRequests.map(r => r.code);
+        if (buttonRequests.includes('PinMatrixRequestType_NewFirst')) {
+            if (buttonRequests.includes('PinMatrixRequestType_NewSecond')) {
+                setStatus('repeat-pin');
+            } else {
+                setStatus('enter-pin');
+            }
+        }
+
+        if (device?.features.pin_protection) {
+            setStatus('success');
+            goToNextStep();
+        }
+    }
+}, [device, goToNextStep]);
+```
+
+### Proposed fix
+
+Derive the three booleans the body actually branches on in the render body (already reading
+`device.buttonRequests`/`device.features` there anyway) and depend on those primitives instead of
+`device`:
+
+```tsx
+const hasNewFirst = !!device?.buttonRequests.some(r => r.code === 'PinMatrixRequestType_NewFirst');
+const hasNewSecond = !!device?.buttonRequests.some(
+    r => r.code === 'PinMatrixRequestType_NewSecond',
+);
+const hasPinProtection = !!device?.features?.pin_protection;
+
+useEffect(() => {
+    if (!device?.features) return;
+    if (hasNewFirst) setStatus(hasNewSecond ? 'repeat-pin' : 'enter-pin');
+    if (hasPinProtection) {
+        setStatus('success');
+        goToNextStep();
+    }
+}, [device?.features, hasNewFirst, hasNewSecond, hasPinProtection, goToNextStep]);
+```
+
+(`device?.features` alone, as a presence check, is still acceptable here since the guard is boolean;
+narrowing further isn't necessary once the two content-bearing conditions are primitives.)
+
+### Why it matters
+
+Nothing in this effect guards against re-invoking `goToNextStep()` once `status` is already
+`'success'`. As written, every device-reference churn while `pin_protection` remains `true` calls
+`goToNextStep()` again for as long as `PinStep` stays mounted, which — if the onboarding step
+reducer isn't itself idempotent against repeat "advance" dispatches — risks skipping past the
+following step during exactly the frequent-device-update window that PIN setup itself creates.
+
+---
+
+## F-05-5 — `onboarding/index.tsx`'s THP redirect effect depends on `device`, which the effect body never reads
+
+- **Class:** 1 (unstable/dead hook dependency)
+- **Where:** `packages/suite/src/views/onboarding/index.tsx:37-41`
+- **Trigger cadence:** every store update that gives the onboarding `device` a fresh reference while
+  `activeStepId !== STEP.ID_FIRMWARE_STEP && thpStep === 'ConfirmOnlyConnection'` holds (i.e. while
+  waiting on a THP-only-connection confirmation outside the firmware step).
+- **Severity guess:** P3 — the dependency is provably dead (not referenced in the body at all), but
+  the guarded action is `dispatch(goto({ routeName: 'suite-index' }))`, which is very likely a no-op
+  once already on that route, so the realistic cost is a handful of redundant dispatches rather than
+  a visible loop.
+- **Confidence:** high that `device` is unused in the effect body (only `activeStepId`/`thpStep` are
+  read); low-to-medium on real severity since I did not trace whether the router thunk short-circuits
+  a `goto` to the current route.
+
+### Before (verbatim from the file)
+
+```tsx
+useEffect(() => {
+    if (activeStepId !== STEP.ID_FIRMWARE_STEP && thpStep === 'ConfirmOnlyConnection') {
+        dispatch(goto({ routeName: 'suite-index' }));
+    }
+}, [device, thpStep, activeStepId, dispatch]);
+```
+
+### Proposed fix
+
+Drop `device` from the dependency array — it isn't read anywhere in the effect.
+
+### Why it matters
+
+Listed for completeness: a dead dependency here means the effect re-runs (and re-evaluates the
+condition, redispatching `goto` if still true) on every device-reference churn instead of only when
+`activeStepId`/`thpStep` actually change, for no benefit.
+
+---
+
+## F-05-6 — `NotificationsView` re-filters the whole notification list into two buckets on every render
+
+- **Class:** 4 (render-body work that belongs elsewhere)
+- **Where:** `packages/suite/src/views/suite/notifications/index.tsx:27-32`
+- **Trigger cadence:** every render of the Activity/Notifications page (tab switches, debug-mode
+  toggle, any `notifications` state change) — both `.filter()` calls run regardless of which tab is
+  active or whether `notifications` itself changed.
+- **Severity guess:** P3 — `NotificationGroup` (the consumer) isn't `memo()`-wrapped, so there's no
+  memo being defeated, and this page is visited occasionally rather than being an always-mounted
+  hot path; the notification list does grow over a long session, but the recompute is a single-pass
+  filter, not a nested scan.
+- **Confidence:** high that both filters are unmemoized; low confidence this is worth prioritizing
+  over other findings in this file — included for completeness since it matches the class cleanly and
+  the fix is a one-line `useMemo`.
+
+### Before (verbatim from the file)
+
+```tsx
+const notifications = useSelector(state => state.notifications);
+const hasUnseenNotifications = useSelector(selectHasUnseenTransactionNotifications);
+const transactionNotifications = notifications.filter(isTransactionNotification);
+const activityNotifications = notifications.filter(
+    notification => !isTransactionNotification(notification),
+);
+```
+
+### Proposed fix
+
+`const { transactionNotifications, activityNotifications } = useMemo(() => ({ transactionNotifications: notifications.filter(isTransactionNotification), activityNotifications: notifications.filter(n => !isTransactionNotification(n)) }), [notifications]);`
+
+### Why it matters
+
+Minor — grouped here because it is a clean instance of the class and cheap to fix, not because it is
+a hot path.
+
+---
+
+## F-05-7 — `useConnectPopupDesktop` hand-rolls `useFreshRef` instead of using the existing helper
+
+- **Class:** 7 (wrong ref hook / manual ref-assign-in-render pattern that should be one of the
+  helpers — the "reverse" case the skill names explicitly)
+- **Where:** `packages/suite/src/support/suite/useConnectPopupDesktop.tsx:34-36`
+- **Trigger cadence:** N/A — this is a style/consistency finding, not a bug. The ref is read inside an
+  async event-listener callback (`desktopApi.on('connect-popup/call', async params => { ... const
+device = selectedDeviceRef.current; ... })`) registered once inside a `useEffect`, which needs the
+  _latest_ device at call time — exactly `useFreshRef`'s contract.
+- **Severity guess:** P3 (cleanup) — behaviorally correct as written (assignment happens
+  unconditionally in the render body, so `.current` is always fresh), just not using the sanctioned
+  helper.
+- **Confidence:** high — `packages/react-utils/src/hooks/useFreshRef.ts` does exactly this pattern
+  (assign during render).
+
+### Before (verbatim from the file)
+
+```tsx
+const selectedDevice = useSelector(selectSelectedDevice);
+const selectedDeviceRef = useRef(selectedDevice);
+selectedDeviceRef.current = selectedDevice;
+```
+
+### Proposed fix
+
+`const selectedDeviceRef = useFreshRef(selectedDevice);` (import from `@trezor/react-utils`).
+
+### Why it matters
+
+No functional difference today, but hand-rolling the pattern means a future edit (e.g. someone
+"cleaning up" by moving the assignment into a `useEffect`) would silently change it into the
+`useCurrentRef` shape and introduce a one-render staleness bug — using the named helper makes the
+intent self-documenting and removes that risk.
+
+---
+
+## F-05-8 — `AccountHeaderProvider`'s inline Provider value is rebuilt every render
+
+- **Class:** 5 (missing memoization on a context Provider value)
+- **Where:** `packages/suite/src/support/suite/AccountHeaderProvider.tsx:22`; consumed by
+  `AccountName.tsx` (via `useOptionalAccountHeaderContext`) and
+  `views/wallet/transactions/components/AccountOverviewBalance.tsx:56` (via
+  `useAccountHeaderContext`), both mounted for the wallet page's header — provider itself instantiated
+  per-wallet-page-render from `components/wallet/WalletLayout/WalletLayout.tsx:23,90`.
+- **Trigger cadence:** every render of `WalletLayout`/`WalletPageHeader` (essentially every account
+  view render), even though the wrapped `balanceSectionRef` is a stable `useRef` that never itself
+  changes identity.
+- **Severity guess:** P3 — same mechanism as F-05-1, but only two real consumers (not "many"), and
+  one of them (`AccountName`) only reads through `.current` inside an effect dependency rather than
+  reacting to the object identity directly, so the practical churn cost is much smaller.
+- **Confidence:** high on the mechanism; low on real-world visible cost given the small consumer
+  count and their low render cost.
+
+### Before (verbatim from the file)
+
+```tsx
+export const AccountHeaderProvider = ({
+    balanceSectionRef: providedBalanceSectionRef,
+    children,
+}: AccountHeaderProviderProps) => {
+    const internalBalanceSectionRef = useRef<HTMLDivElement>(null);
+    const balanceSectionRef = providedBalanceSectionRef ?? internalBalanceSectionRef;
+
+    return (
+        <AccountHeaderContext.Provider value={{ balanceSectionRef }}>
+            {children}
+        </AccountHeaderContext.Provider>
+    );
+};
+```
+
+### Proposed fix
+
+`const value = useMemo(() => ({ balanceSectionRef }), [balanceSectionRef]);` then
+`<AccountHeaderContext.Provider value={value}>`.
+
+### Why it matters
+
+Cheap, correct fix for the same class of bug as F-05-1, at much smaller scale — included so the
+pattern is caught here rather than only at the one file where it happens to matter a lot.
+
+---
+
+## Checked, clean
+
+- `packages/suite/src/support/suite/useConnectPopup.tsx:152` — the `eslint-disable
+react-hooks/exhaustive-deps` suppressing `onMessagesConsumed` looked like a Class-6 candidate (C1
+  harvest), but both call sites (`useConnectPopupWeb.tsx:57-59`, `useConnectPopupWebextension.tsx:63-65`)
+  pass a `useCallback(() => setIncomingMessages(prev => prev.slice(1)), [])` — a genuinely stable,
+  never-changing reference. Per the skill's own guidance ("confirm the dependency is genuinely
+  unstable at its declaration first"), omitting a provably-stable dependency doesn't hide any
+  staleness here. Good contrast case for F-05-7/Class 7's "reverse" pattern — this one is a
+  correctly-inert suppression, not a lying array.
+- `packages/suite/src/support/suite/useConnectPopupDesktop.tsx:40-165` (main init effect) — deps
+  `[dispatch, analytics, lifecycle.status]`; registers/cleans up `desktopApi.on(...)` listeners each
+  run, cleanup always runs before the next registration. No stacking-listener or loop risk found.
+- `packages/suite/src/support/suite/RouterHandler.tsx`, `Protocol.tsx`, `Resize.tsx`,
+  `OnlineStatus.tsx`, `Autodetect.tsx`, `ConnectedIntlProvider.tsx`, `ConnectedThemeProvider.tsx`,
+  `ThemeProvider.tsx`, `ErrorBoundary.tsx`, `useTor.tsx`, `useTorReconnectionLifecycle.ts`,
+  `useConnectPopupModals.tsx`, `useConnectPopupWeb.tsx`, `useConnectPopupWebextension.tsx`,
+  `ConditionalRender.tsx`, `ContentFlex.tsx` — all effects/memos/callbacks keyed on primitives or
+  provably-stable refs/DI services; `Protocol.tsx` in particular is a clean worked example of wrapping
+  handlers in `useCallback` before depending on them. `extraDependencies.ts`,
+  `createConnectInitHooks.ts`, `createConnectLoggerFactory.ts`, `createGetBinFilesBaseUrl.ts`,
+  `preloadStore.ts`, `screens/*`, `styles/*`, `test-utils/*` — zero React hooks in any of these;
+  nothing in this skill's scope to check.
+- `packages/suite/src/support/suite/LayoutContext.ts` — just a `createContext` type + no-op default,
+  zero logic; the actual unmemoized-Provider-value bug for this context is in `hooks/suite/useLayout.tsx`
+  (area 01's territory, already filed as F-01-1).
+- `packages/suite/src/views/dashboard/AssetsView/AssetActionButton.tsx:36` — `accounts.find(...)` runs
+  only inside a click handler (`onClick`), not the render body; not a render-loop concern.
+- `packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx` — exemplary: `memo()`-wrapped,
+  `isDeviceEmpty`/`failedAccounts`/`hasLoadedNonEmptyAccount` all correctly `useMemo`'d on `[accounts]`.
+- `packages/suite/src/views/dashboard/PortfolioCard/DashboardGraph.tsx` — main effect
+  (`:94-114`, deps `[graph, selectedDeviceState]`) legitimately needs several fields of `graph`
+  (`.isLoading`, `.selectedRange.label/startDate/endDate`), so depending on the container object is
+  the idiomatic choice, not a bug. `failedAccounts = graph.error?.filter(...)` at `:61` is unmemoized
+  but bounded by the (usually zero) count of sync-failed accounts — too small/cold to be worth a
+  separate finding.
+- `packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx:83` (`accounts[asset.network.symbol]
+?? []`) and `assetsViewUtils.ts:29,34` (`?? []` fallbacks) — both fallbacks are read once inline,
+  not stored across renders or fed into a memo/effect dependency; not a Class-1 instance, and already
+  covered as part of F-05-2's broader "this whole pipeline needs one `useMemo`" fix.
+- `packages/suite/src/views/dashboard/OnboardingFeedbackBanner/OnboardingFeedbackBanner.tsx`,
+  `AssetCoinName.tsx`, `AssetCoinLogo.tsx` (aside from F-05-3), `DashboardFooter.tsx`,
+  `BannerCarousel.tsx` (previous-index tracking is a plain `useRef` mutated inside a click handler and
+  reset inside an effect — correct pattern, not a Class-7 candidate), `EmptyWallet.tsx`,
+  skeleton components — no unstable deps or unmemoized unbounded-list scans found.
+- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx:60`
+  (`instances.filter(i => i.state)`) and `AddWalletButton.tsx:28` (`instances.find(...)`) — both
+  render-body list ops, but `instances` (hidden-wallet count per physical device) doesn't meet the
+  "unbounded/user-scaling" bar; `DeviceItem`'s own effect (`:62-79`) already depends on narrow
+  primitives (`device.id`, `device.connected`), a good contrast to F-05-4.
+- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx:67,69`
+  (`getAllAccounts(instance.state, accounts)` fed into `useTotalFiatBalance`) — already covered by
+  area 01's F-01-6, which explicitly names this call site.
+- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusTextThp.tsx:47-56` — effect
+  keyed on `[isLoading]`, a derived boolean primitive; correct.
+- `packages/suite/src/views/suite/SwitchDevice/SwitchDevice.tsx`, `SwitchDeviceModal.tsx`,
+  `SmallDeviceItem.tsx`, `bridge/index.tsx` — plain, non-derived `useSelector` reads only, no
+  effects/memos to check.
+- `packages/suite/src/views/suite/bridge-requested/index.tsx:26-33` — `goToWallet` is a
+  `useCallback(..., [dispatch])`; effect deps `[popupCall, goToWallet]` — `popupCall` comes straight
+  from a plain state-slice selector, not a derived one; no evidence of over-triggering found.
+- `packages/suite/src/views/onboarding/steps/BackupTypeStep.tsx:57-61`, `DeviceTutorialStep.tsx:19-21`,
+  `earn/tron/EarnTronRedirect.tsx`, `earn/yield/unwrap/index.tsx`, `earn/yield/wrap/index.tsx`,
+  `earn/yield/useEarnLayout.tsx:168-192` — all effects keyed on primitives/stable callbacks; no
+  wide-object or fresh-array dependencies found.
+- `packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx:193-199` —
+  `humanizedModelColor = useMemo(..., [device])` is wider than needed (only reads
+  `device.features.internal_model`/`.unit_color`), but the memoized work is an O(1) object-lookup
+  chain — per the skill, not worth its own finding outside a batch cleanup doc. Same file's other
+  effect (`:185-191`) is correctly narrow.
+- `packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInitialStep.tsx:122-123` and
+  `packages/suite/src/views/firmware/Steps/StepInitial.tsx:33-34` (`devices.filter(d =>
+d?.connected)` + `unique(...).length`) — `devices` is bounded by physical-device count (typically
+  1-3), not unbounded/user-scaling; too cold/small for a finding.
+- `packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx`,
+  `SettingsCoins/useNetworkSettingsSearch.ts` — `allSearchableNetworks` correctly `useMemo`'d with a
+  narrow dep list; the four `filterNetworks(...)` calls in the render body operate on the fixed
+  Trezor-supported-coin list (~30-60 items, not user-scaling) — below the Class-4 bar.
+- `packages/suite/src/views/settings/SettingsGeneral/{DustPhishing,Experimental,BaseCurrency,Language,
+AutoStart,ShowOnTray,McpServer}.tsx`, `SettingsDevice/{ChangeLanguage,ForgetDevice/ForgetDeviceModal,
+ForgetDevice/UnplugDeviceModal}.tsx`, `SettingsConnectedApps/SettingsConnectedApps.tsx`,
+  `SettingsDebug/{Backends,CoinjoinApi}.tsx` — all effects/memos have narrow, stable, or provably-
+  bounded dependencies. Two good worked examples worth naming: `DustPhishing.tsx:23-25`
+  (`useEffect(() => setDustThreshold(dustPhishingThreshold), [dustPhishingIsEnabled,
+dustPhishingThreshold])`) is the correct "sync local editable copy when the source of truth
+  changes" pattern; `SettingsConnectedApps.tsx:36-40` depends on `tabs.length` rather than the fresh
+  `tabs` array itself, exactly the primitive-narrowing the skill recommends.
+  `ForgetDeviceModal.tsx:76-88`'s `if (initialDeviceStateRef.current === null) { ... }` guard is a
+  deliberate "capture once, ever" pattern (not `useFreshRef`/`useCurrentRef` territory — those assign
+  every render/effect; this assigns exactly once by design) — correct, not a Class-7 finding.
+- `packages/suite/src/views/recovery/index.tsx:45` (`usePin(device?.buttonRequests ?? [], ...)`) —
+  the `?? []` fallback crosses a hook boundary (matches the Class-1 harvest shape), but
+  `usePinHook.ts`'s only effect depends on `buttonRequests.length` (a primitive), not the array
+  itself, so the fresh reference never defeats anything. Confirmed by reading `usePinHook.ts:33-35`.
+  Good example of the pattern being safe in this specific case.
+- `packages/suite/src/views/view-only/**`, `password-manager/**`, `connect-popup/index.tsx`,
+  `start/**`, `backup/**` — no `useEffect`/`useMemo`/`useCallback` at all (grep-confirmed); the few
+  `useSelector` calls present are plain, non-derived state reads used only for conditional rendering.
+  Nothing in this skill's scope to check.
+- No inline `Provider value={{...}}` literal exists anywhere in this area besides
+  `AccountHeaderProvider.tsx` (F-05-8) and `ResponsiveContext.tsx`'s variable-form value (F-05-1) —
+  confirmed via `grep -rn "Provider value=" `across the whole area; `LayoutContext.ts` has no
+  Provider at all (declared elsewhere, area 01's territory).
+- No `react-hook-form` `watch()` call (bare or scoped) exists anywhere in this area — grep-confirmed
+  across all `views/*` (non-wallet) and `support/*`; Class 2/2b/6-watch does not apply here.
+- No `useFreshRef`/`useCurrentRef` call sites exist anywhere in this area (grep-confirmed) besides the
+  one hand-rolled equivalent reported as F-05-7.

--- a/perf-issues/react-hooks/_scan/06-suite-common.md
+++ b/perf-issues/react-hooks/_scan/06-suite-common.md
@@ -1,0 +1,506 @@
+# Scan area 06 — suite-common/** React surface
+
+Base commit `9e0d5b6a45`. Covers the ~45 files matching
+`rg -l "from 'react'" suite-common -g '*.ts' -g '*.tsx' -g '!*test*'` plus ~28 additional files that
+define `use*` hooks without a direct `'react'` import (they compose other hooks — `useSelector`,
+`useQuery` — instead): `trading/*`, `earn-stablecoin-api/*`, `earn-stablecoin/*`, `earn-staking-api/*`,
+`staking/*`, `message-system/*`, `formatters/*`, `dependency-injection/*`, `device/usePinHook.ts`,
+`firmware*`, `logger/*`, `connect-popup/*`, `discreet-mode/*`, `react-query/*`, `redux-utils/*`,
+`wallet-core/{fees,formDrafts,accounts,settings,fiat-rates,stablecoin-yield}/*`,
+`transaction-search/*`, `tx-simulation/*`, `bluetooth/bluetoothSelectors.ts`,
+`device/deviceSelectors.ts`, `wallet-core/{tokens,transactions,stake}Selectors.ts`. No `wallet-graph`,
+`connect-init`, `toast-notifications`, `analytics`, or `validators` package under `suite-common`
+contains any hook or JSX — `connect-init`/`toast-notifications` are thunks/selectors/types only,
+`analytics` is event-shape definitions only, `validators` is yup schemas only, and
+`suite-common/graph` (the actual wallet-graph data package) has no `'react'` import anywhere. Verified
+via `find`/`rg`, not assumed.
+
+Excluded per brief / PROGRESS.md, not re-filed:
+
+- `suite-common/wallet-core/src/tokens/tokenUtils.ts` (`getTokens`'s `tokens = []` default, candidate
+  line 34) — same function already drafted as `p2-25-tokenutils-gettokens.md` in asymptotic-complexity.
+- `suite-common/wallet-core/src/transactions/transactionsSelectors.ts:285` (`transactions[account.key]
+?? []` inside `selectAnyAccountIsStakingActive`) — drafted as
+  `p2-26-transactionsselectors-selectanyaccountisstakingactive.md`.
+- `getLocaleSeparators.ts:2`, `prepareDateTimeFormatter.ts:16` — Intl caching, drafted in
+  asymptotic-complexity per the brief.
+
+## F-06-1 — `useApprovalStep`'s effect keyed on the whole `tx` object can double-fire `refreshQuotes()` while an approval is confirming
+
+- **Class:** 1 (unstable value produced by `useAllowanceTxTracking`, crossing the hook boundary into
+  `useApprovalStep`'s effect deps) + 2 (the effect calls an async side-effecting function on every
+  refire, not just once per real status change — a bounded-but-wasteful duplicate-request pattern)
+- **Where:** `suite-common/trading/src/hooks/useAllowanceTxTracking.ts:76-80` (unmemoized return) and
+  `suite-common/trading/src/hooks/useApprovalStep.ts:49-85` (the effect), specifically the dependency
+  array at line 85. Consumer chain: `packages/suite/src/hooks/wallet/allowance/useAllowance.ts:12-18`
+  returns `{ tx, state }` from a plain object literal (also unmemoized) into
+  `AllowanceContext.Provider value={allowanceContextValue}` at
+  `packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx:27` (and the same pattern
+  in `YieldDeposit.tsx:43` / `YieldWithdraw.tsx:39`), consumed by
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx:45,80-85`.
+- **Trigger cadence:** every render of the `AllowanceContext.Provider` owner (`TradingExchangeForm` /
+  `YieldDeposit` / `YieldWithdraw`) while an approval is confirmed but not yet cleared (the async
+  window between `status.isConfirmed` becoming true and the `.finally()` callback clearing
+  `approvalTxid`/`txApprovalType`).
+- **Severity guess:** P1 (live trading/token-approval flow; duplicate network calls, not just a wasted
+  render)
+- **Confidence:** high on the mechanism (read every hop end-to-end); medium on how often the Provider
+  actually re-renders during that window in practice — would drop to P2 if `TradingExchangeForm` /
+  `YieldDeposit` / `YieldWithdraw` provably never re-render while `status.isConfirmed && txApprovalType`
+  is true (their own selectors — `selectHasRunningDiscovery`, `selectAreFeesLoading`, quote polling —
+  make that unlikely, but I did not instrument it).
+
+### Before (verbatim from the file)
+
+```ts
+// useAllowanceTxTracking.ts:38-81 — return value is a fresh object literal every call
+export const useAllowanceTxTracking = ({ accountKey }: UseAllowanceTxTrackingParams) => {
+    const [approvalTxid, setApprovalTxid] = useState<string | null>(null);
+    const transaction = useSelector((state: TransactionsRootState & AccountsRootState) =>
+        approvalTxid ? selectTransactionByAccountKeyAndTxid(state, accountKey, approvalTxid) : null,
+    );
+    const status = useMemo<TransactionStatus>(() => {
+        /* ... */
+    }, [transaction]);
+
+    return {
+        approvalTxid,
+        status,
+        setApprovalTxid,
+    };
+};
+```
+
+```ts
+// useApprovalStep.ts:43-85 — effect #1 correctly narrows to tx.approvalTxid; effect #2 depends on
+// the whole `tx` object and calls refreshQuotesRef.current() every time it refires while confirmed
+useEffect(() => {
+    if (tx.approvalTxid && !txApprovalType) {
+        setTxApprovalType(currentApprovalType);
+    }
+}, [tx.approvalTxid, currentApprovalType, txApprovalType]);
+
+useEffect(() => {
+    const thisRunId = ++effectRunIdRef.current;
+    const { approvalTxid, status, setApprovalTxid } = tx;
+    if (!approvalTxid) return;
+
+    if (status.isPending) {
+        setApprovalStep('LOADING');
+        return;
+    }
+    if (status.isFailed) {
+        setApprovalStep('REQUIRED');
+        return;
+    }
+
+    if (status.isConfirmed && txApprovalType) {
+        setApprovalStep(txApprovalType === 'APPROVE' ? 'APPROVED' : 'REQUIRED');
+
+        refreshQuotesRef
+            .current()
+            .catch(error => {
+                console.error('Failed to refresh quotes after approval:', error);
+            })
+            .finally(() => {
+                if (effectRunIdRef.current !== thisRunId) return;
+                setApprovalTxid(null);
+                setTxApprovalType(null);
+            });
+    }
+}, [tx, txApprovalType, refreshQuotesRef]);
+```
+
+### Proposed fix
+
+Either is sufficient, (1) is cheaper since `tx` also flows through a React Context in `packages/suite`:
+
+1. In `useAllowanceTxTracking`, wrap the return in `useMemo(() => ({ approvalTxid, status,
+setApprovalTxid }), [approvalTxid, status, setApprovalTxid])` — `setApprovalTxid` is a `useState`
+   setter (stable by React), `status` is already its own stable memo, so this holds a single reference
+   until `approvalTxid` itself changes.
+2. In `useApprovalStep`'s second effect, narrow the dependency to the primitives effect #1 already
+   uses correctly: `tx.approvalTxid`, `tx.status.isPending`, `tx.status.isFailed`,
+   `tx.status.isConfirmed` — none of `tx`'s own fields need the wrapper object's identity.
+
+### Why it matters
+
+Every re-render of the Provider while a token approval sits in the "confirmed, waiting for the async
+cleanup" window re-fires the effect and calls `refreshQuotesRef.current()` again — a second, concurrent
+`refreshQuotes()` — because nothing in the dependency array or the effect body deduplicates on `tx`'s
+_content_, only its (unstable) reference. `effectRunIdRef` only guards the `.finally()` cleanup racing
+itself; it does not stop the extra call from being issued. This is the SKILL's "silent and unbounded"
+shape (an effect keyed on a fresh whole-object dependency, calling something that talks to the network)
+landing in a real-money approval flow (buy/sell/exchange token allowance, and the earn Yield
+deposit/withdraw allowance flow), not a cosmetic re-render.
+
+## F-06-2 — `FormatterProvider`'s memo is defeated on web, forcing every formatter component to remount app-wide
+
+- **Class:** 1 (unstable `config` value produced outside `suite-common`, crossing into
+  `FormatterProvider`'s own `useMemo`) — consequence matches Class 5's blast radius (a Provider whose
+  value churns has "many consumers", here effectively the whole app)
+- **Where:** `suite-common/formatters/src/FormatterProvider.tsx:86-93` (the `useMemo` whose `config`
+  dep is unstable) and `suite-common/formatters/src/makeFormatter.tsx:46-58` (`makeFormatter` returns a
+  brand-new component function on every call, which is what makes a stale `config` painful rather than
+  just wasteful). Root cause: `packages/suite/src/hooks/suite/useFormattersConfig.ts:7-18` returns a
+  plain object literal every render, **not** wrapped in `useMemo` — contrast with the native version
+  at `suite-native/formatters-config/src/hooks/useFormattersConfig.ts:17-25`, which does exactly the
+  right thing (`useMemo(..., [baseCurrencyCode, bitcoinAmountUnit, locale])`). Consumed at
+  `packages/suite/src/support/suite/Main.tsx:28,46` (`<FormatterProvider config={formattersConfig}>`),
+  which wraps essentially the entire web/desktop app (`packages/suite-web/src/MainWeb.tsx:30-48`).
+- **Trigger cadence:** every render of `Main`/`MainWeb` for _any_ reason — `MainWeb` is a plain
+  (non-`memo`'d) function component whose body re-runs whenever its own hooks
+  (`useTor`, `useConnectPopupWeb`, `useConnectPopupWebextension`, `useDebugLanguageShortcut`) cause a
+  re-render, cascading a fresh `children` prop into `Main`.
+- **Severity guess:** P1 (blast radius, not frequency — see "Why it matters")
+- **Confidence:** medium. High confidence on the mechanism (verified `useFormattersConfig.ts` has no
+  memo, verified `FormatterProvider`'s memo depends on that object, verified `makeFormatter` mints a
+  new component per call). Medium confidence on cadence — I did not instrument how often `MainWeb`
+  actually re-renders in a running app; would lower to P2 if it's provably render-once-then-static.
+
+### Before (verbatim from the file)
+
+```ts
+// packages/suite/src/hooks/suite/useFormattersConfig.ts:7-18 — no useMemo
+export const useFormattersConfig = (): FormatterProviderConfig => {
+    const locale = useSelector(selectLanguage);
+    const bitcoinAmountUnit = useSelector(selectBitcoinAmountUnit);
+    const baseCurrency = useSelector(selectBaseCurrency);
+
+    return {
+        locale,
+        baseCurrency,
+        bitcoinAmountUnit,
+        is24HourFormat: true,
+    };
+};
+```
+
+```tsx
+// suite-common/formatters/src/FormatterProvider.tsx:83-100
+export const FormatterProvider = ({ config, children }: FormatterProviderProps) => {
+    const intl = useIntl();
+
+    const contextValue = useMemo(() => {
+        const extendedConfig = { ...config, intl };
+
+        return getFormatters(extendedConfig);
+    }, [config, intl]);
+
+    return (
+        <FormatterProviderContext.Provider value={contextValue}>
+            {children}
+        </FormatterProviderContext.Provider>
+    );
+};
+```
+
+Compare the native hook, which gets this right:
+
+```ts
+// suite-native/formatters-config/src/hooks/useFormattersConfig.ts:12-26
+export const useFormattersConfig = (): FormatterProviderConfig => {
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const bitcoinAmountUnit = useSelector(selectBitcoinAmountUnit);
+    const locale = useSelector(selectLocale);
+
+    return useMemo(
+        () => ({ locale, bitcoinAmountUnit, is24HourFormat, baseCurrency: baseCurrencyCode }),
+        [baseCurrencyCode, bitcoinAmountUnit, locale],
+    );
+};
+```
+
+### Proposed fix
+
+Mirror the native hook: wrap `packages/suite/src/hooks/suite/useFormattersConfig.ts`'s return in
+`useMemo(() => ({ locale, baseCurrency, bitcoinAmountUnit, is24HourFormat: true }), [locale,
+baseCurrency, bitcoinAmountUnit])`. This is a one-file fix in `packages/suite` (out of this area's
+write scope, flagged here because it's the root cause of a `suite-common` memo miss) — no change
+needed in `FormatterProvider.tsx` itself, its `useMemo` is already correctly structured and will start
+holding once `config` is stable.
+
+### Why it matters
+
+`getFormatters()` calls `prepareCryptoAmountFormatter`, `prepareDisplaySymbolFormatter`,
+`prepareBaseCurrencyAmountFormatter`, `prepareDateFormatter`, `prepareTimeFormatter`, and
+`prepareDateTimeFormatter`, each of which calls `makeFormatter(...)` and gets back a **new React
+component function** (verified in `prepareCryptoAmountFormatter.ts:145-161`). When `FormatterProvider`'s
+memo misses, all six of those formatter "components" get new identities, and every
+`<CryptoAmountFormatter>` / `<DateFormatter>` / etc. anywhere below `Main` — i.e. every displayed
+amount, balance, date and time in the entire web/desktop app — is a different component type on the
+next render, so React unmounts and remounts it rather than just re-rendering it. That's strictly worse
+than a redundant render: lost local state and effects in whatever the formatter wraps, and layout
+thrash, on every single formatted value in the tree, triggered by something as unrelated as a Tor
+status change in `MainWeb`.
+
+## F-06-3 — `useServices`'s dependency spread is correct, but two call sites feed it an inline selector and silently defeat the memo
+
+- **Class:** 1 (unstable value crossing into `useSelectedServices`'s `useMemo`) / 6 (pre-existing
+  `eslint-disable react-hooks/exhaustive-deps` — verified non-lying for the _intended_ usage, but blind
+  to misuse)
+- **Where:** `suite-common/dependency-injection/src/useServices.tsx:65-70` (`useSelectedServices`, the
+  disable is at line 68). Misused at
+  `packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts:16-18` and
+  `packages/suite/src/views/settings/SettingsDebug/Transport.tsx:59-61`, both of which pass
+  `(services): TransportsDep => ({ createTransports: services.createTransports })` — a fresh arrow
+  function literal — directly as the selector argument, instead of a module-level `select*Dep`
+  constant like the other 359 call sites in the repo.
+- **Trigger cadence:** every render of `useOpenSuiteDesktop`'s caller (bridge troubleshooting screen,
+  the "open in Suite Desktop" error modal) and every render of the `Transport` debug-settings page.
+- **Severity guess:** P3 (both call sites are cold troubleshooting/debug screens today, not a hot path)
+- **Confidence:** high — `[services, ...selectors]` spreads the rest-param's _elements_ into the dep
+  array, so for the established convention (callers pass stable, module-level `select*Dep` functions)
+  the disable is not lying; it's an ESLint static-analysis limitation on the dynamic-length spread. The
+  two inline-arrow call sites are a real, demonstrated exception to that convention.
+
+### Before (verbatim from the file)
+
+```ts
+// suite-common/dependency-injection/src/useServices.tsx:65-70
+const useSelectedServices = (selectors: ServiceSelector<any>[]) => {
+    const services = useServicesContext();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return React.useMemo(() => selectServices(services, ...selectors), [services, ...selectors]);
+};
+```
+
+```tsx
+// packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts:16-18 — inline selector, fresh every render
+const { createTransports } = useServices((services): TransportsDep => ({
+    createTransports: services.createTransports,
+}));
+```
+
+### Proposed fix
+
+At the two call sites, hoist the selector to a module-level constant the way every other `useServices`
+caller does, e.g. `const selectCreateTransportsDep = (services: Services): TransportsDep => ({
+createTransports: services.createTransports });` declared outside the component. No change needed in
+`useServices.tsx` — the spread-based dependency array is the correct mechanism for a variable-length
+selector list; it just assumes (and cannot itself enforce) that every element is stable.
+
+### Why it matters
+
+`selectServices` (`Object.assign({}, ...selectors.map(selector => selector(services)))`) reruns every
+render at both sites, so `createTransports` gets a new identity each time regardless of whether
+`services` changed — a wasted memo, not a loop (the returned function isn't itself an effect/memo
+dependency downstream at either call site today). Flagged because it's a demonstrated, silent way to
+defeat this shared `suite-common` hook's whole reason for existing, and the failure mode gets worse if
+the pattern is copied into a hotter call site later.
+
+## F-06-4 — `useFilteredUtxos`'s default parameter is the SKILL's canonical unstable-fallback shape
+
+- **Class:** 1 (unstable dependency: default parameter `= []`)
+- **Where:** `suite-common/transaction-search/src/useFilteredUtxos.ts:8-19`. Only current consumer:
+  `suite-native/module-send/src/screens/SendUtxoScreen.tsx:49`
+  (`useFilteredUtxos(account?.utxo ?? [], searchQuery)`).
+- **Trigger cadence:** would refire the `useMemo` every render whenever `utxos` is omitted or
+  `undefined` is passed.
+- **Severity guess:** P3 (cleanup) — currently latent rather than live.
+- **Confidence:** medium. The one real call site never relies on the hook's own default (it always
+  passes an explicit second value), and that call site sits inside a `suite-native` component, which is
+  React-Compiler-compiled — the compiler very likely memoizes `account?.utxo ?? []` as an expression
+  within that component, so today's actual impact is probably nil. This hook ships from `suite-common`
+  though (memoize for the web consumer per this skill's own rule), and a future web caller — or any
+  caller that omits the argument entirely — would hit the un-memoized default directly.
+
+### Before (verbatim from the file)
+
+```ts
+// suite-common/transaction-search/src/useFilteredUtxos.ts:8-19
+export const useFilteredUtxos = (
+    utxos: Utxo[] = [],
+    query: string = '',
+    outputLabels?: SearchOutputLabels,
+) =>
+    useMemo(() => {
+        if (!query.trim()) {
+            return utxos;
+        }
+
+        return utxos.filter(utxo => filterUtxos(utxo, query, outputLabels));
+    }, [utxos, query, outputLabels]);
+```
+
+### Proposed fix
+
+Module-level constant: `const EMPTY_UTXOS: Utxo[] = [];` and default to that instead of `[]`, matching
+the skill's worked example.
+
+### Why it matters
+
+Today's only caller works around it with its own `?? []` rather than relying on the hook's default, so
+the live risk is low and likely compiler-mitigated on the native side. Reported because it's an exact
+match for the skill's canonical anti-pattern in a `suite-common` file that explicitly ships to the
+(uncompiled) web app too, and the empty-query branch (`return utxos;`) means the hook returns that fresh
+default array's reference straight back out — the cheapest possible fix, worth doing before a web
+consumer appears.
+
+## F-06-5 — `useWrappedNativePendingTx` rescans the account's whole transaction history on every render
+
+- **Class:** 4 (render-body work over an unbounded list, in a hook body)
+- **Where:** `suite-common/wallet-core/src/stablecoin-yield/hooks/useWrappedNativePendingTx.ts:50-56`
+  (`trackedTransaction` computed inline, not in a `useMemo`); the scan itself is
+  `suite-common/wallet-utils/src/wrappedNativePendingTxUtils.ts:19-41`
+  (`findTrackedWrappedNativeTransaction`, up to two `Array.prototype.find` passes over `transactions`).
+- **Trigger cadence:** every render of whatever component calls this hook (the wrap/unwrap pending-tx
+  screen), not just when `transactions`/`txid`/`trackedNonce` actually change — `transactions` itself
+  is a stable, weak-map-memoized reference from `selectAccountTransactions` (verified — it only changes
+  when the account's tx list genuinely changes), so this is wasted rescanning on unrelated re-renders,
+  not a loop.
+- **Severity guess:** P3 — single-instance hook (one active wrap/unwrap flow at a time, not a per-row
+  list), so it doesn't multiply the way a list-row component would, but the list it scans (an account's
+  full transaction history) is genuinely user-scaling.
+- **Confidence:** medium — confirmed the scan is unmemoized and the input can be large; did not measure
+  how often the containing screen re-renders for reasons unrelated to the tracked tx.
+
+### Before (verbatim from the file)
+
+```ts
+// suite-common/wallet-core/src/stablecoin-yield/hooks/useWrappedNativePendingTx.ts:43-56
+const transactions = useSelector((state: TransactionsRootState) =>
+    selectAccountTransactions(state, account?.key ?? null),
+);
+// ...
+const trackedTransaction = txid
+    ? findTrackedWrappedNativeTransaction({
+          transactions,
+          txid,
+          nonce: trackedNonce?.txid === txid ? trackedNonce.nonce : undefined,
+      })
+    : undefined;
+```
+
+### Proposed fix
+
+`useMemo(() => txid ? findTrackedWrappedNativeTransaction({ transactions, txid, nonce: ... }) :
+undefined, [transactions, txid, trackedNonce])` — `transactions` is already a stable reference from the
+memoized selector, so this will only recompute when the tx list, txid, or tracked nonce genuinely
+change.
+
+### Why it matters
+
+Bounded impact today (one screen instance, not a list), but the fix is a two-line `useMemo` wrap with an
+already-stable dependency available, so there's no reason to pay an O(n) double-scan of the account's
+transaction history on renders the polling effect didn't cause.
+
+## Checked, clean
+
+- **`trading/*` hooks generally well-built.** `useCoinsAndPlatforms.ts`'s `useFreshRef(info)` +
+  `infoRef.current.coins ?? {}` / `.platforms ?? {}` (candidates at :15-16) only fires inside a
+  `useCallback` body invoked imperatively later — the fresh fallback is consumed immediately, never
+  stored as a dep, so the callback (deps `[infoRef]`) stays stable; correct use of `useFreshRef`
+  (latest-value-at-call-time, not previous-value). `useTradingUtils.ts` and `useTradingAssets.ts` call
+  `getCoinsAndPlatforms()` the same way (imperatively inside `useCallback` bodies) — same non-issue.
+- **`useListDataFilter.ts` / `useSectionDataFilter.ts`** memoize correctly; every current consumer
+  (`useCountryFilteredData.ts`, `useCountrySubdivisionFilteredData.ts`) passes module-level `const`
+  filter/sort callbacks, so the memo holds. (The two `suite-native` consumers were not inspected —
+  out of this area.)
+- **`useDexExchangeTxSimulation.ts`**: `useMemo` deps include the whole `account` object, which looks
+  like the classic "keyed on account, refetches every block" shape — but `composeDexTxSimulationAction`
+  is O(1) object construction (verified), and the actual network call
+  (`useNetworkTxSimulation`/`useTxSimulation`) keys its `useQuery` on `input.params` — TanStack Query
+  hashes query keys structurally, so a fresh-reference-but-same-value `params` does not trigger a
+  refetch. Wasted recompute, not a request loop; not worth an individual finding (O(1) work).
+- **Same TanStack Query protection verified for**: `useGetMerklRewards.ts`, `useGetMerklRewardsQueryEntries.ts`
+  (its own `useMemo` deps are correct — `accounts` is the caller's responsibility, and the one
+  `packages/suite` caller I traced, `useMerklRewards.ts:27-31`, does memoize it), `useTxSimulation.ts`,
+  `useNetworkTxSimulation.ts`, `useDappScan.ts`, `useHasSufficientFundsForGas.ts`,
+  `useEthereumValidatorsQueue.ts`, `useSolanaRewardsHistory.ts`, `useSolanaRewardsTotal.ts`,
+  `useTronStakingStats.ts`, `useAllYieldOpportunities.ts`, `useGetVaultByAddress.ts`,
+  `useGetYieldOpportunities.ts`, `useYieldOpportunity.ts`, `useFetchOtc.ts`,
+  `useMissingRateTickersQuery.ts`, `useCommonApplicationLogs.ts` (device-telemetry query key spreads a
+  `Set` into an array every render — harmless, react-query hashes it, and the set itself is tiny). The
+  three `@tanstack/query/exhaustive-deps` disables in this group (`useNetworkTxSimulation.ts:71`,
+  `useSolanaRewardsHistory.ts:78`, `useMissingRateTickersQuery.ts:25`) are a different lint rule from
+  `react-hooks/exhaustive-deps` (data-fetching's territory per PROGRESS.md), each carries its own
+  reasoning comment, and none hide a staleness bug — read all three.
+- **`useExtendMerklRewardsWithFiat.ts` / `usePairRewardsWithAccounts.ts` /
+  `useTotalClaimableRewardsAmountOfAccounts.ts` / `useYieldVaultName.ts`**: narrow, correct `useMemo`
+  deps throughout.
+- **`useAllowanceTxTracking.ts`'s own `status` memo** (deps `[transaction]`) is fine in isolation — the
+  problem is only the unmemoized wrapper return (F-06-1).
+- **`selectTradingCoinInfoByCryptoId` / `selectTradingCoinSymbolByCryptoId` /
+  `selectTradingNativeCoinSymbolByCryptoId`** (`tradingSelectors.ts:465-510`, candidates at :472,:483,
+  :509 `?? {}`): all three fallbacks live inside `createMemoizedSelector` compute functions — the fresh
+  `{}` never crosses the selector's own memo boundary, so no downstream memo is defeated. Complexity of
+  the coins/platforms lookup itself is out of scope (already covered by
+  `p3-05-cleanups-suite-common-shared-packages.md` and `p2-32-...md`).
+- **Same "fallback lives inside the memo boundary" pattern verified clean for**: `tokenSelectors.ts:32`
+  (`selectAccountTokens`), `accountsSelectors.ts:313,331` (`selectSolExternalStakingAccounts`,
+  `selectSolExternalStakingAccountsTotalStaked`), `transactionsSelectors.ts:113`
+  (`selectAllPendingTransactions`), `deviceSelectors.ts:159,189` (`selectAvailableDeviceTranslations`,
+  `selectDeviceButtonRequests`), `bluetoothSelectors.ts:37` (inside `prepareSelectAllDevices`).
+  `bluetoothSelectors.ts:19` (`selectNearbyDevices`) already uses `returnStableArrayIfEmpty` — the
+  brief's own "already clean" example. `stakeSelectors.ts:53`'s `data.ada?.pools ?? []` is a local
+  scratch var for `.find()` — the selector (`selectPoolStatsApy`) always returns a number or `null`,
+  never the array itself, so there's no fresh-reference-return for the "ALSO YOURS" native-`useSelector`
+  concern to apply to.
+- **`useFormDraft.ts`**: `selectDeepCopyOfFormDraft` (`formDrafts/selectors.ts:14-15`) looks like it
+  would return a fresh `JSON.parse(JSON.stringify(...))` object every call (matching Class 3), but it's
+  wrapped in `createWeakMapSelector` — memoized on the underlying `formDraft` reference, so it returns
+  the same cached deep-copy instance when the store slice hasn't changed. Verified by reading the
+  selector, not assumed from the name.
+- **`useGetMerklRewardsQueryEntries.ts:75,94`**'s `= {}` default (`MerklRewardsQueryEntriesOptions`) is
+  safe: only the destructured primitives (`isDebugMode`, `skipEmptyAccountCheck`) reach the `useMemo`
+  dep array, never the wrapper object itself.
+- **`message-system/*`**: `messageSystemSelectors.ts` is uniformly built on `createWeakMapSelector`
+  (`createMemoizedSelector`) with `returnStableArrayIfEmpty` where needed — correctly handles the
+  parameterized-selector-called-from-multiple-components hazard that a plain `reselect` single-slot
+  cache would thrash on. All of `useExperiment.ts`, `useMessageSystemEarnDashboard.ts`,
+  `useMessageSystemStaking.ts`, `useMessageSystemWrappedNative.ts`, `useMessageSystemYield.ts` consume
+  these selectors via raw `react-redux` `useSelector` (suite-common can't reach the shallowEqual-wrapped
+  one from `packages/suite`), but since every consumed selector is weak-map-memoized and `domain`
+  arguments are static string constants from `Feature` (`messageSystemTypes.ts:37-65`), there's no
+  fresh-reference-per-dispatch re-render. `ExperimentWrapper.tsx` and `useMessageSystemMessageForm.ts`
+  are correctly memoized. `useConditionControls.ts`'s `(existing[0] ?? {})` (candidate :31) is a local
+  var inside an `addCondition` callback, never a dependency, and the whole file is a message-system
+  admin/authoring tool, not a user-facing hot path.
+- **`usePinHook.ts`** (C10 candidate — effect starts with `setState`): `useEffect(() =>
+setSubmitted(false), [buttonRequests.length])` is correctly narrowed to the primitive `.length`
+  already (not the whole array) and is a legitimate one-shot reset on a new PIN/wipe-code request, not
+  a loop.
+- **`useTradingExchangeWatchApproval.ts`** (C9 candidate): effect deps are `[account, status, isEnabled,
+dispatch]` — `account` is the whole object, but the effect only starts a `setInterval` and doesn't
+  refetch on identity churn beyond restarting the interval timer; `status` (a string from a memoized
+  selector) is the real gate. Not flagged individually — `account` churning would restart the polling
+  interval, which is a much milder failure than a request-per-render loop, and I could not establish
+  `account` actually gets a fresh reference on unrelated updates without leaving this area's file set.
+- **`useDisplayBaseCurrency.ts`, `useRefetchFees.ts`, `wallet-core/accounts/hooks/useSelector.ts`,
+  `trading/hooks/useSelector.ts`**: the latter two are the local shallowEqual-wrapped `useSelector`
+  re-implementations `suite-common` needs because it can't import `packages/suite`'s version — correct
+  and consistently used within their own packages' hooks (spot-checked `useProviderMetadataChangeEffect.ts`'s
+  use of raw `react-redux` `useSelector` instead of the local wrapper: the two selectors it reads
+  return direct state/property lookups, never fresh literals, so the missing shallowEqual doesn't
+  matter there).
+- **`useServices.tsx`'s eslint-disable itself** (line 68) is not a lying dependency array — `[services,
+...selectors]` spreads the rest-param's elements, which for the codebase's established
+  module-level-selector convention faithfully lists every true dependency; ESLint just can't verify a
+  dynamic-length spread statically. See F-06-3 for the two sites that break the convention.
+- **`useFreshRef`/`useCurrentRef`** — all 4 call sites in `suite-common` checked individually and are
+  correct for their semantics (latest-value-at-call-time, not previous-value):
+  `useGetMerklRewards.ts:29-30` (two `useFreshRef`s read inside an async polling loop),
+  `useApprovalStep.ts:40` (`useCurrentRef` for an imperative "call the latest callback" pattern — its
+  own effect runs before the later effects in the same component, so `.current` is already fresh by the
+  time they read it), `useCoinsAndPlatforms.ts:12`. No Class-7 misuse found.
+- **No `react-hook-form` `watch()` calls anywhere in `suite-common`** — the package only imports
+  `react-hook-form` for the `FieldValues` type (`useFormDraft.ts` and a few reducers), never `useForm`
+  itself. No Class-6 compiler-bail-out candidates here.
+- **No inline `Provider value={{...}}` in `suite-common`** — the only two Providers with non-trivial
+  values (`FormatterProvider`, `ServicesProvider`) both already pass a variable, not an inline literal
+  (`FormatterProvider`'s variable just isn't memoized upstream — F-06-2).
+- **False positives from the candidate grep, verified by reading:**
+  `toast-notifications/src/types.ts` (only `import type { CSSProperties } from 'react'` — no runtime
+  code); `suite-common/walletconnect/src/walletConnectUtils.tsx` (`.tsx` extension but no JSX/hooks at
+  all); `tx-simulation/src/utils/getTxSimulationParams.ts:68` (`JSON.stringify(data)` builds an API
+  request-body string, unrelated to any dependency array); `formatters/mocks/MockedFormatterProvider.tsx`
+  (unmemoized `getFormatters()` call, same shape as F-06-2, but it's a test-only mock provider, not
+  shipped code).
+- **`useReportDeviceCompromised.ts`, `useFirmwareInstallation.ts`, `useTxSimulationPopupCall.ts`,
+  `usePinHook.ts`, `useGetter.ts`, `ReactQueryProvider.tsx`/`ReactNativeQueryProvider.tsx`,
+  `useSelectorDeepComparison.ts`, `discreetModeUtils.ts`/`useDiscreetMode.ts`,
+  `useExcludedUtxos.ts`, `useStakingEntryPeriodEstimateInDays.ts`**: read in full, all use narrow
+  primitive `useMemo`/`useCallback`/`useEffect` deps or plain `useContext`/`useState`, nothing crosses a
+  hook boundary unstably.

--- a/perf-issues/react-hooks/_scan/07-shared-components.md
+++ b/perf-issues/react-hooks/_scan/07-shared-components.md
@@ -1,0 +1,618 @@
+# Area 07 — packages/components, product-components, react-utils, suite-desktop-ui
+
+Scope: `packages/components/src/**`, `packages/product-components/src/**`, `packages/react-utils/src/**`
+(including auditing all C8 `useFreshRef`/`useCurrentRef` call sites for class-7 misuse),
+`packages/suite-desktop-ui/src/**`. All four ship to the uncompiled web/desktop app, so manual
+memoization findings are valid everywhere in this area (`packages/components` also ships to native,
+but native-vs-web doesn't change the fix here — memoize for the web consumer per the skill).
+
+Design-system primitives render at high multiplicity — one unstable dependency in `Table`, `Menu`,
+`Select`, `TokenIconSet` etc. multiplies through every row/instance across the whole app. Severity
+below is weighted for that.
+
+---
+
+## F-07-1 — `Table`'s context value forces every row/cell to re-render on scroll-shadow boundary crossings, independent of row data
+
+- **Class:** 5 (missing memoization where identity matters — inline Provider value with many consumers)
+- **Where:** `packages/components/src/components/Table/Table.tsx:62-68` (Provider), consumed at
+  `packages/components/src/components/Table/TableRow.tsx:94` and
+  `packages/components/src/components/Table/TableCell.tsx:72`; trigger source
+  `packages/components/src/utils/useScrollShadow.tsx:70-83`
+- **Trigger cadence:** every render of `Table` — including `Table`'s own internal state changes
+  (scroll-shadow visibility toggling at top/bottom/left/right), not just parent-driven re-renders
+- **Severity guess:** P1 (hot: every `Table` instance across the app — transaction tables, asset
+  tables, settings tables — and the trigger is a completely ordinary user action)
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+export const Table = ({
+    children,
+    margin,
+    colWidths,
+    isRowHighlightedOnHover = false,
+    hasBorders = true,
+    typographyStyle = 'body-md',
+    backgroundColor = 'surfaceFillRaised',
+}: TableProps) => {
+    const { scrollElementRef, onScroll, ShadowContainer, ShadowRight, ShadowLeft } =
+        useScrollShadow({
+            backgroundColor,
+        });
+
+    return (
+        <TableContext.Provider value={{ isRowHighlightedOnHover, hasBorders, typographyStyle }}>
+```
+
+`TableRow`/`TableCell` both call `useTable()` (`useContext(TableContext)`) to read
+`isRowHighlightedOnHover`/`hasBorders`/`typographyStyle`. Neither is wrapped in `memo()`, but that
+doesn't matter here: React re-renders every context consumer when the Provider's value changes
+identity, bypassing the normal "same `children` reference" bailout entirely — so even a `Table`
+whose row JSX is unchanged still re-renders every row when only the Provider value is fresh.
+
+`useScrollShadow` (`packages/components/src/utils/useScrollShadow.tsx:70-83`) calls
+`setIsScrolledToTop`/`setIsScrolledToBottom`/`setIsScrolledToLeft`/`setIsScrolledToRight` from the
+`onScroll` handler; React bails out via `Object.is` so this is bounded to boundary crossings (not
+every scroll pixel), but each crossing re-renders `Table` — with nothing in `children` having
+changed — and mints a fresh Provider value.
+
+### Proposed fix
+
+```tsx
+const tableContextValue = useMemo(
+    () => ({ isRowHighlightedOnHover, hasBorders, typographyStyle }),
+    [isRowHighlightedOnHover, hasBorders, typographyStyle],
+);
+```
+
+Use `tableContextValue` as the Provider's `value`. All three inputs are already primitives, so this
+memo is cheap and will actually hold across the boundary-crossing re-renders described above.
+
+### Why it matters
+
+Any `Table` with many rows (a transaction list, an asset table) re-renders every `TableRow` and
+`TableCell` — including their `Text`/formatting children — the moment the user scrolls it to an
+edge, even though no row's underlying data changed. The cost scales with row count and repeats on
+every top/bottom/left/right boundary crossing for the lifetime of the table.
+
+---
+
+## F-07-2 — `VirtualizedList`'s scroll-end debounce is silently reset by its only real caller, churning the scroll listener
+
+- **Class:** 1 (unstable hook dependency crossing a component boundary)
+- **Where:** `packages/components/src/components/VirtualizedList/VirtualizedList.tsx:126` (memo),
+  `:149-203` (`handleScroll`, depends on the memo), `:205-212` (scroll-listener effect, depends on
+  `handleScroll`); triggered by
+  `packages/suite/src/components/suite/asset-picker/components/AssetsList/AssetsList.tsx:28`
+  (outside my area — cited as the demonstrated consumer)
+- **Trigger cadence:** once per "near the end of the list" scroll event (`loadMoreBufferCount`
+  threshold), for as long as the user keeps scrolling a long asset/coin list
+- **Severity guess:** P2 (real, reproducible with the sole current caller; bounded to load-more
+  moments rather than every scroll frame)
+- **Confidence:** high — traced end to end through both files
+
+### Before (verbatim from the file)
+
+```tsx
+// VirtualizedList.tsx:126
+const debouncedOnScrollEnd = useMemo(() => debounce(onScrollEnd, 1000), [onScrollEnd]);
+```
+
+```tsx
+// AssetsList.tsx:27-28 (the only real consumer, packages/suite — not my area, cited as evidence)
+const [end, setEnd] = useState(items.length);
+const onScrollEnd = useCallback(() => setEnd(end + 1000), [end]);
+```
+
+`onScrollEnd` is a `useCallback` whose own dependency is the state it sets (`end`), so its identity
+changes every time it fires. `debounce()` (defined at `VirtualizedList.tsx:19-33`) closes over a
+fresh, independent `timeout` variable each call, so recreating it discards whatever debounce/timer
+bookkeeping the previous instance had. `handleScroll` (`:149-203`) depends on `debouncedOnScrollEnd`
+at `:196`, and the scroll-listener effect (`:205-212`) depends on `handleScroll`, so the whole chain
+— including a `removeEventListener`/`addEventListener` pair on the scrollable container — re-runs
+every time `AssetsList` re-renders after a load-more trigger. (Separately, `AssetsList.tsx` passes
+the _entire_ `items` array to `VirtualizedList` regardless of `end`, so the `end`/`setEnd` state
+this defeats doesn't appear to gate anything today — but that's a correctness/dead-code question
+for `packages/suite`, not this file.)
+
+### Proposed fix
+
+Decouple the debounce's lifetime from the caller's callback identity with the ref hook this area
+owns:
+
+```tsx
+import { useFreshRef } from '@trezor/react-utils';
+
+const onScrollEndRef = useFreshRef(onScrollEnd);
+const debouncedOnScrollEnd = useMemo(
+    () => debounce(() => onScrollEndRef.current(), 1000),
+    [onScrollEndRef],
+);
+```
+
+`useFreshRef`'s returned ref object is stable for the component's lifetime, so the `useMemo` now
+only runs once, `handleScroll`'s identity stops churning, and the scroll listener is registered
+once instead of on every load-more trigger — while still always calling the latest `onScrollEnd`.
+Note: `packages/components/package.json` doesn't currently depend on `@trezor/react-utils` — add
+it as a workspace dependency (both are same-layer `packages/*`, so this doesn't cross the layering
+rule).
+
+### Why it matters
+
+Every scroll-near-the-end event during a long scroll session through `VirtualizedList`'s one real
+consumer (the asset/coin picker, which can hold every network's tokens) tears down and rebuilds the
+scroll subscription and the debounce timer, instead of the debounce staying stable for the
+component's lifetime as its 1000 ms wait implies it should.
+
+---
+
+## F-07-3 — `TokenIconSet`'s memo is correctly written but permanently defeated by its real caller
+
+- **Class:** 1 (unstable dependency crossing a component boundary into a `useMemo`)
+- **Where:** `packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx:30-55`;
+  fed by `packages/suite/src/components/wallet/TokenIconSetWrapper.tsx:62-68` (outside my area —
+  already flagged there as `_scan/03-wallet-earn-comp.md` F-03-2, for the _wrapper's own_
+  unmemoized `flatMap`/`reduce`/`sort` chain; this is the distinct, downstream symptom in my area's
+  file)
+- **Trigger cadence:** every render of the dashboard's "My Assets" per-network row (fiat-rate ticks,
+  sibling account updates, any unrelated re-render of the row)
+- **Severity guess:** P2
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+// TokenIconSet.tsx:30-37
+const visibleTokensContent = useMemo(() => {
+    const visibleTokens = maxVisibleIcons !== null ? tokens.slice(0, maxVisibleIcons) : tokens;
+
+    return visibleTokens.map(token => {
+        /* … */
+    });
+}, [tokens, maxVisibleIcons, symbol, size, gap, length]);
+```
+
+```tsx
+// TokenIconSetWrapper.tsx:62-68 (the sole real caller)
+const sortedAggregatedTokens = aggregatedTokens.sort(sortTokensWithRates);
+const size = sortedAggregatedTokens.length === 1 ? 24 : 20;
+
+return (
+    <TokenIconSet size={size} gap={6} symbol={symbol} tokens={sortedAggregatedTokens} isCentered />
+);
+```
+
+`TokenIconSet`'s own `useMemo` is written correctly, but `sortedAggregatedTokens` is a brand-new
+array on every render of `TokenIconSetWrapper` (no memo at the source, per F-03-2), so the `tokens`
+dependency here is never referentially stable and the memo never hits.
+
+### Proposed fix
+
+Nothing to change in `TokenIconSet.tsx` itself — the memo is correctly shaped. The fix lives at the
+call site (F-03-2's proposed fix: wrap the wrapper's `flatMap`/`getTokens`/`reduce`/`sort` chain in
+one `useMemo`). Documented here because the _symptom_ — a `useMemo` that can never cache — is
+visible in this area's file and is easy to miss when reading `TokenIconSet.tsx` in isolation and
+concluding it's already optimal.
+
+### Why it matters
+
+Once F-03-2 lands, this memo starts paying off for free; until then, every token-icon row on the
+dashboard's My Assets table rebuilds its full `<TokenIcon>` element list from scratch on every
+unrelated re-render (e.g. a fiat-rate tick touching a sibling network), regardless of this file's
+own correct `useMemo`.
+
+---
+
+## F-07-4 — `useNetworkSelect`'s three memos are defeated every keystroke by its real callers' inline `selectConfig`
+
+- **Class:** 1 (unstable dependency crossing a component boundary; also class 5's destructuring
+  default shape)
+- **Where:** `packages/product-components/src/components/SearchAsset/hooks/useNetworkSelect.ts:14-41`;
+  fed by `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx:49-64`
+  and its near-duplicate
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx`
+  (both outside my area); search-state evidence in
+  `.../AssetSearchWithNetworkFilter/hooks/useSearchFilter.ts:9-12`
+- **Trigger cadence:** every keystroke in the asset-search input (confirmed: `useSearchFilter`
+  holds `search` in local `useState` inside the same component that builds `selectConfig`)
+- **Severity guess:** P2 (real per-keystroke cadence in a common Send/Trading flow; tempered by the
+  network list itself being small)
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+// useNetworkSelect.ts:14-29
+export const useNetworkSelect = (config?: SearchAssetSelectConfig) => {
+    const { networks = [], includeAllOption, allLabel, selectedNetwork } = config ?? {};
+
+    const allOptions = useMemo(() => {
+        const networkOptions = networks
+            .map(symbol => {
+                /* … */
+            })
+            .filter(isNotNull);
+
+        return includeAllOption
+            ? [{ label: allLabel ?? 'All networks', value: undefined }, ...networkOptions]
+            : networkOptions;
+    }, [networks, includeAllOption, allLabel]);
+    // … selectedOption and options useMemo both chain off allOptions
+```
+
+```tsx
+// AssetSearchWithNetworkFilter.tsx:43, 49-57 (real caller, rebuilt every keystroke)
+const networks = protocolSymbol ? [protocolSymbol] : enabledNetworks;
+// …
+const selectConfig = isBitcoinOnlyFirmware
+    ? undefined
+    : {
+          networks,
+          selectedNetwork: networkFilter,
+          onChange: setNetworkFilter,
+          includeAllOption: !protocolSymbol,
+          allLabel: translationString('TR_ALL_NETWORKS'),
+      };
+```
+
+`selectConfig` is an inline object literal rebuilt on every render of
+`AssetSearchWithNetworkFilterInner`, which re-renders on every keystroke because `search` is local
+`useState` in the same component (`useSearchFilter.ts:9-12`). When `protocolSymbol` is set,
+`networks` itself is also a fresh `[protocolSymbol]` array every render. Either way, all three of
+`useNetworkSelect`'s internal `useMemo`s (`allOptions`, `selectedOption`, `options`) recompute every
+keystroke and feed a fresh `options` array into the `<Select>` underneath.
+
+### Proposed fix
+
+In `useNetworkSelect.ts`, hoist a module-level empty-array constant for the destructuring default
+(the `config ?? {}` / `networks = []` shape from the skill's own worked example):
+
+```tsx
+const EMPTY_NETWORKS: NetworkSymbol[] = [];
+const { networks = EMPTY_NETWORKS, includeAllOption, allLabel, selectedNetwork } = config ?? {};
+```
+
+That only fixes the "no config at all" path. The keystroke-cadence defeat needs the fix in the
+caller (outside my area): memoize `selectConfig` (and `networks` when derived from
+`protocolSymbol`) with `useMemo` keyed on its primitive inputs, so `useNetworkSelect` actually
+receives a stable `config` across re-renders that don't change the network list.
+
+### Why it matters
+
+Two near-duplicate `AssetSearchWithNetworkFilter` components (global Send/Receive, and the Trading
+asset picker) both feed `useNetworkSelect` an unmemoized config, so every character typed into
+either asset search box redoes the network-options list and options-minus-selected filtering,
+purely as pipeline overhead on a hot per-keystroke path — small per call, but avoidable and
+compounding with every keystroke.
+
+---
+
+## F-07-5 — `Menu`'s keyboard-navigation effects rebuild two global `document` keydown listeners on every render
+
+- **Class:** 1 (unstable dependency: `.filter()` result feeding two `useEffect` dependency arrays)
+- **Where:** `packages/components/src/components/Menu/Menu.tsx:131` (unmemoized filter),
+  `:137-160` and `:163-195` (both effects depend on it)
+- **Trigger cadence:** every render of an open `Menu` (any prop or parent-state change while a
+  dropdown/context menu is mounted), not just when `items` actually changes
+- **Severity guess:** P2 (global-listener churn on a very widely reused primitive; bounded — no
+  render loop, no missed events in practice — but real waste on every render, not just per-open)
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+// Menu.tsx:128-134
+export const Menu = forwardRef<HTMLUListElement, MenuProps>(
+    ({ items, content, onClose, ...rest }, ref) => {
+        const frameProps = pickAndPrepareFrameProps(rest, allowedMenuFrameProps);
+        const visibleItems = items?.filter(item => !item.isHidden);
+        const [focusedItemIndex, setFocusedItemIndex] = useState(
+            visibleItems?.length ? visibleItems.findIndex(item => !item.isDisabled) : null,
+        );
+
+        // handle selecting an item
+        useEffect(() => {
+            const handleKeyDown = (e: KeyboardEvent) => { /* … */ };
+
+            if (focusedItemIndex !== null && visibleItems?.length) {
+                document.addEventListener('keydown', handleKeyDown);
+
+                return () => {
+                    document.removeEventListener('keydown', handleKeyDown);
+                };
+            }
+        }, [focusedItemIndex, visibleItems, onClose]);
+
+        // handle keyboard navigation
+        useEffect(() => {
+            const handleKeyDown = (e: KeyboardEvent) => { /* … */ };
+
+            if (focusedItemIndex !== null && visibleItems?.length) {
+                document.addEventListener('keydown', handleKeyDown);
+
+                return () => {
+                    document.removeEventListener('keydown', handleKeyDown);
+                };
+            }
+        }, [visibleItems, focusedItemIndex]);
+```
+
+`visibleItems` is a plain `.filter()` call in the render body — a new array every render regardless
+of whether any item's `isHidden` flag actually changed. Both effects list it as a dependency, so
+every render of an open `Menu` tears down and re-adds two separate `document`-level `keydown`
+listeners, even when nothing about the visible items changed.
+
+### Proposed fix
+
+```tsx
+const visibleItems = useMemo(() => items?.filter(item => !item.isHidden), [items]);
+```
+
+### Why it matters
+
+`Menu` backs essentially every dropdown/context menu in the app. While a menu is open, any
+re-render of it (a parent state change, a prop update unrelated to `items`) currently causes two
+global keyboard-listener teardown/rebuild cycles instead of zero; both effects would instead only
+re-run when the actual visible-items set changes.
+
+---
+
+## F-07-6 — Compound-component `Context.Provider` values are unmemoized object literals across the design system
+
+- **Class:** 5 (missing memoization where identity matters — inline Provider value)
+- **Where:**
+    - `packages/components/src/components/Collapsible/Collapsible.tsx:33-39` → consumed at
+      `CollapsibleContent.tsx:30`, `CollapsibleToggle.tsx:25`
+    - `packages/components/src/components/Tabs/Tabs.tsx:108` → consumed at `TabsItem.tsx:63`
+    - `packages/components/src/components/List/List.tsx:84-86` → consumed at `ListItem.tsx:62`
+    - `packages/components/src/components/SubTabs/SubTabs.tsx:34` → consumed at `SubTabsItem.tsx:50`
+    - `packages/components/src/components/StepList/StepList.tsx:63-72`
+    - `packages/components/src/components/Banner/Banner.tsx:140`
+    - `packages/components/src/components/Modal/Modal.tsx:95`,
+      `packages/components/src/components/Modal/ModalButton.tsx:15`,
+      `packages/components/src/components/Modal/ModalProvider.tsx:38-43`
+- **Trigger cadence:** every render of the outer compound component (open/close toggle for
+  `Collapsible`, `ResizeObserver`-driven indicator updates for `Tabs`, any prop change for the rest)
+- **Severity guess:** P3 (same mechanism as F-07-1, but typical consumer counts here are small — a
+  handful of tabs/steps/list items/modal buttons — rather than table-sized row counts)
+- **Confidence:** high on the mechanism; low-to-medium on real-world impact per instance since it
+  depends on how many children each usage actually has
+
+### Before (two representative examples, verbatim)
+
+```tsx
+// Tabs.tsx:93-108 — updateIndicator fires from a ResizeObserver, re-rendering Tabs and
+// re-creating this value even when the tab set itself hasn't changed
+useEffect(() => {
+    updateIndicator();
+    if (!containerRef.current) return undefined;
+    const observer = new ResizeObserver(() => updateIndicator());
+    observer.observe(containerRef.current);
+
+    return () => observer.disconnect();
+}, [updateIndicator]);
+
+return (
+    <TabsContext.Provider value={{ activeItemId, isDisabled, size, setTabRef }}>
+```
+
+```tsx
+// Collapsible.tsx:32-40
+return (
+    <CollapsibleContext.Provider
+        value={{
+            contentId,
+            isOpen: isOpen ?? uncontrolledIsOpen,
+            toggle: setUncontrolledIsOpen,
+            gap,
+        }}
+    >
+```
+
+### Proposed fix
+
+Wrap each Provider's `value` in a `useMemo` keyed on its own primitive fields, e.g.:
+
+```tsx
+// Tabs.tsx
+const tabsContextValue = useMemo(
+    () => ({ activeItemId, isDisabled, size, setTabRef }),
+    [activeItemId, isDisabled, size, setTabRef],
+);
+```
+
+Same shape for the other six files (each Provider's fields are already primitives or stable
+setters, so this is a pure win with no new dependency wrinkles).
+
+### Why it matters
+
+None of `CollapsibleContent`/`CollapsibleToggle`/`TabsItem`/`ListItem`/`SubTabsItem` are wrapped in
+`memo()`, so this is currently harmless in the common case where the compound component's `children`
+are reconstructed by the same render that changes the Provider's inputs. It stops being harmless the
+moment the outer component re-renders on its _own_ internal state (as `Tabs` already does via its
+`ResizeObserver`, and `Collapsible` does via its open/close toggle) while `children` is otherwise
+unchanged — that re-renders every consumer for no visible-output reason. Grouped as one cleanup
+entry rather than seven, per the skill's own caution that redundant-memo write-ups shouldn't be
+over-weighted relative to real loops.
+
+---
+
+## F-07-7 — `usePopover`'s floating-ui `middleware` array is unmemoized, unlike the identical pattern in `TooltipFloatingUi`
+
+- **Class:** 1 (unstable array literal feeding a hook's positioning logic) / 6 (inconsistent
+  memoization of the same pattern within one package)
+- **Where:** `packages/components/src/components/Popover/Popover.tsx:61-75`; contrast with the
+  already-correct `packages/components/src/components/Tooltip/TooltipFloatingUi.tsx:86-95`
+- **Trigger cadence:** every render of any component using `usePopover`/`Popover`
+- **Severity guess:** P3 (mechanism is clear and provable, but only 2 current call sites, neither
+  in a per-row hot path)
+- **Confidence:** high on the mechanism (floating-ui's own docs recommend memoizing `middleware`
+  for exactly this reason, and this codebase already does it correctly one file over)
+
+### Before (verbatim from the file)
+
+```tsx
+// Popover.tsx:61-75 — no useMemo
+const data = useFloating({
+    placement: calculatedPlacement,
+    open,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: [
+        offset(popoverOffset),
+        flip({
+            crossAxis: calculatedPlacement.includes('-'),
+            fallbackAxisSideDirection: 'end',
+            padding: 5,
+        }),
+        shift({ padding: 5 }),
+    ],
+});
+```
+
+```tsx
+// TooltipFloatingUi.tsx:86-95 — the sibling hook in the same package does memoize the equivalent array
+const middleware = useMemo(() => {
+    const middlewareArray = [
+        offset(offsetValue),
+        ...(!disableFlip ? [flip()] : []),
+        shiftFloatingUI(shift || { padding: 8 }),
+        arrow({ element: arrowRef }),
+    ];
+
+    return middlewareArray;
+}, [offsetValue, shift, disableFlip, arrowRef]);
+```
+
+### Proposed fix
+
+```tsx
+const middleware = useMemo(
+    () => [
+        offset(popoverOffset),
+        flip({
+            crossAxis: calculatedPlacement.includes('-'),
+            fallbackAxisSideDirection: 'end',
+            padding: 5,
+        }),
+        shift({ padding: 5 }),
+    ],
+    [popoverOffset, calculatedPlacement],
+);
+```
+
+then pass `middleware` into `useFloating`.
+
+### Why it matters
+
+An unstable `middleware` array is exactly the case `TooltipFloatingUi.tsx` was written to avoid
+(floating-ui's `useFloating` uses the array's identity to decide when to redo position/flip/shift
+calculations under `autoUpdate`). Every render of a `Popover` consumer currently pays that
+recalculation cost for no reason; low severity today only because there are just two call sites.
+
+---
+
+## Checked, clean
+
+- `packages/react-utils/src/hooks/useFreshRef.ts`, `useCurrentRef.ts` — implementations match the
+  skill's description exactly (render-time assign vs. effect-time assign); no bugs in the
+  primitives themselves.
+- `packages/react-utils/src/hooks/useAsyncMemo.ts:20` (C8) — `useFreshRef(getValue)` is read inside
+  a `useEffect` purely to call the _latest_ `getValue` without listing an unstable callback in
+  `deps`; this is not previous-value semantics, so it's a correct use of `useFreshRef`, not a
+  class-7 misuse.
+- `packages/react-utils/src/hooks/useFreshRef.test.ts` — hook's own unit tests, not a consumer.
+- `packages/react-utils/src/hooks/useKeyPress.ts` — dead code, zero call sites anywhere in the repo
+  (verified by grep). Its `[]`-effect closes over the first render's `targetKey`/handlers forever,
+  which would be a real class-6 staleness bug if `targetKey` ever varied across a hook instance's
+  lifetime — but nothing calls it, so not reported as a live finding.
+- `packages/react-utils/src/hooks/useOnClickOutside.ts` — dead code, zero call sites anywhere in
+  the repo (verified by grep).
+- `packages/react-utils/src/hooks/useOnce.ts`, `usePreviousDefined.ts`, `useWindowFocus.ts`,
+  `useTextareaCursorPosition.ts`, `useAsyncClickHandler.ts`, `useClickCooldown.ts`,
+  `useDidUpdate.ts` (no call sites within this area), `useDebounce.ts`, `useDebouncedValue.ts`,
+  `timer/useCountdownTimer.ts`, `timer/useTimer.ts` — all reviewed; deps are correctly scoped to
+  primitives/stable refs/setters. `useCountdownTimer`'s `{ pastDeadlineLeadMs = 1000, isEnabled =
+true } = {}` (C5) only ever produces primitives from the destructure, so the fresh `{}` per
+  render never reaches a memo/effect dependency array — a case where the C5 grep shape is present
+  but the class-1 mechanism it warns about doesn't apply.
+- `packages/components/src/components/ResizableBox/ResizableBox.tsx:333` (C1) — mount-only
+  `getBoundingClientRect()` capture; the omitted `widthState`/`heightState` reads are only
+  meaningful once (at mount, to detect "uninitialized"), so `[]` introduces no staleness.
+- `packages/components/src/components/form/Select/customComponents.tsx:178` (C1) — mount-only
+  scroll-into-view for the selected `<Option>`. This `Select` wrapper does not expose
+  `isMulti`/`closeMenuOnSelect` (grep-verified: no consumer uses multi-select), so in the only
+  supported mode, a selection change always accompanies a menu close/reopen (fresh mount) — no
+  realistic case where `isSelected` flips on an already-mounted, non-remounted `Option`.
+- `packages/components/src/components/form/Select/Select.tsx` — `memoizedComponents` depends on
+  the passthrough `components` prop and `handleOnChange` depends on `onChange`; both would be
+  defeated by an unstable caller, but grep confirms zero current consumers pass a `components`
+  prop, and `ReactSelect` itself isn't memoized to benefit from a stable `onChange` — latent
+  fragility, not a live defect.
+- `packages/components/src/components/Tooltip/TooltipFloatingUi.tsx` — `middleware` useMemo
+  (`:86-95`) correctly depends on `[offsetValue, shift, disableFlip, arrowRef]`; unlike
+  `Popover.tsx` (F-07-7), this one is memoized. `shift` is a passthrough prop that could defeat it
+  if any caller ever passed an inline object, but grep confirms zero current callers pass `shift`
+  at all.
+- `packages/components/src/components/animations/LottieAnimation.tsx` — `animationData` useMemo
+  depends on `colorReplacements`; its only consumer (`packages/suite/.../GuideButton.tsx`) already
+  wraps the array it passes in its own `useMemo`, so no live defeat.
+- `packages/components/src/components/animations/recolorLottieAnimation.tsx:32` — plain Lottie-JSON
+  mutation utility, not a component or hook; the `?? []` here is not a hook dependency at all
+  (grep-harvest false positive, confirmed by reading).
+- `packages/components/src/utils/useScrollShadow.tsx` — the four scroll-position booleans only
+  actually trigger a re-render on boundary crossings (`Object.is` bails out every other scroll
+  tick); correct use of derived state, not a render loop. (This is the mechanism cited as the
+  trigger for F-07-1, but the hook itself is written correctly.)
+- `packages/components/src/utils/frameProps.tsx:112-128` (`pickAndPrepareFrameProps`) — unmemoized
+  `reduce` over a small, fixed-size array of prop names (a handful of literals per call site); O(1)
+  by the skill's own carve-out, not a class-4 candidate. Line 123 is the already-excluded
+  asymptotic-complexity draft `p3-06-cleanups-connect-components-and-utils-primitives.md`.
+- `packages/components/src/components/VirtualizedList/VirtualizedList.tsx:233` (and the related
+  `firstItemTop`/`itemHeights` prefix-sum work) — already covered by
+  `perf-issues/asymptotic-complexity/p2-11-virtualizedlistx-virtualizedlistcomponent.md`, including
+  its side-note on `setIndexes` (`:183`) always allocating a fresh object per scroll event. F-07-2
+  above is a distinct hooks-class defect at a different line (`:126`) in the same file.
+- `packages/suite/src/components/wallet/TokenIconSetWrapper.tsx` — its own render-body
+  `flatMap`/`reduce`/`sort` chain is already covered by `_scan/03-wallet-earn-comp.md` F-03-2; only
+  the downstream consequence inside my area's `TokenIconSet.tsx` is reported here (F-07-3).
+- `packages/components/src/components/PinInput/PinInput.tsx`,
+  `packages/product-components/src/components/EditableText/EditableText.tsx`,
+  `packages/product-components/src/components/InputWithOptions/InputWithOptions.tsx`,
+  `packages/product-components/src/components/PasswordStrengthIndicator/PasswordStrengthIndicator.tsx` —
+  effects/callbacks all keyed on primitives or correctly-scoped local state; no unstable
+  dependencies found. All are single-instance form widgets (low multiplicity) regardless.
+- `packages/components/src/components/loaders/Spinner/Spinner.tsx` — `useMemo` chain
+  (`colorsReplace` → `memoizedAnimations` → `lottieProps`) all keyed on theme/variant-derived
+  primitives; correctly written despite being one of the highest-multiplicity components in the app.
+- `packages/components/src/components/form/Input`, `Checkbox`, `Radio`, `Switch` — no hooks at all
+  (pure presentational props → JSX); nothing to check.
+- `packages/product-components/src/components/NetworkIconSet/NetworkIconSet.tsx` — same
+  `useMemo`-over-array-prop shape as `TokenIconSet.tsx` (F-07-3), but its one real consumer
+  (`packages/suite/.../PortfolioCard/EmptyWallet.tsx`) renders once, not per-row; not written up
+  given the low multiplicity.
+- `packages/product-components/src/components/NumberInput/NumberInput.tsx` — intricate manual
+  previous-value tracking (`previousFormValueRef`, `previousDisplayValueRef`) correctly uses plain
+  `useRef` with a top-of-effect read / conditional end-of-effect write, not `useFreshRef`/
+  `useCurrentRef` — no class-7 misuse; deps on `formatDisplayValue`/`handleChange` etc. are
+  correctly scoped `useCallback`s.
+- `packages/components/src/components/Table/TableRow.tsx`, `TableCell.tsx`,
+  `packages/components/src/components/Tabs/TabsItem.tsx`,
+  `packages/components/src/components/List/ListItem.tsx` — none wrapped in `memo()` (confirmed
+  while investigating F-07-1/F-07-6); noted because it's precisely _why_ the context-value fix
+  matters (context re-renders bypass the bailout memo would otherwise not even be needed for).
+- `packages/suite-desktop-ui/src/**` (all files) — `DesktopUpdater.tsx` narrows its effect/callback
+  dependencies to primitives (`desktopUpdate.enabled`, `.allowPrerelease`, `.latest`) rather than
+  the whole Redux slice — a good example of the skill's "minimal required dependencies" guidance.
+  `Available.tsx`, `Downloading.tsx`, `JustUpdated.tsx`, `EarlyAccessEnable.tsx`,
+  `EarlyAccessDisable.tsx`, `Ready.tsx`, `MainDesktop.tsx`, `TorLoadingScreen.tsx` are all
+  singleton/low-multiplicity modal or shell components with correctly-scoped hooks; no
+  react-hooks-class findings in this package.
+- C3 (selector returns fresh reference) — not applicable anywhere in this area except
+  `suite-desktop-ui`'s two `useSelector` call sites (`DesktopUpdater.tsx`, `Available.tsx`), both
+  of which read a slice/sub-object directly with no `.map`/`.filter`/spread; `packages/components`,
+  `product-components`, and `react-utils` have no Redux access at all.
+- C9 (whole-account/device-keyed effects) — no matches in this area; none of these four packages
+  hold domain models (accounts/devices) directly.

--- a/perf-issues/react-hooks/_scan/08-native-shared.md
+++ b/perf-issues/react-hooks/_scan/08-native-shared.md
@@ -1,0 +1,447 @@
+# Scan area 08 — suite-native shared libraries (not module-*, not app)
+
+Base commit `9e0d5b6a45`. Covers all non-`module-*`, non-`app` top-level `suite-native/*` packages:
+`atoms`, `accounts`, `device`, `device-authorization`, `device-manager`, `device-bootloader-mode`,
+`device-mutex`, `device-onboarding`, `transaction-management`, `transactions`, `navigation`, `forms`,
+`graph`, `react-native-graph`, `trading-atoms`, `trading-residence`, `trading-state`, `trading-history`,
+`trading-browser-auth`, `trading-analytics`, `trading-slippage`, `trading-consts`, `trading-debug`,
+`trading-fixtures`, `trading-provider-utils`, `trading-quote-utils`, `trading-types`, `analytics`,
+`analytics-redux`, `storage`, `state`, `formatters`, `formatters-config`, `intl`, `tokens`, `staking`,
+`assets`, `discovery`, `bluetooth`, `biometrics`, `blockchain`, `passphrase`, `firmware`,
+`confirm-on-trezor`, `banners`, `banner-flags`, `coin-enabling`, `icons`, `labeling`, `link`, `markdown`,
+`message-system`, `qr-code`, `receive`, `scrollview`, `search`, `sentry`, `services`, `settings`,
+`storybook`, `suite-sync`, `swipeable-walkthrough`, `theme`, `thp`, `toasts`, `tx-simulation`,
+`video-assets`, `wallet`, `activity-center`, `add-coin-account`, `address`, `alerts`, `app-init`,
+`clipboard`, `config`, `connection-status`, `experimental-features`, `feature-feedback`,
+`feature-flags`, `feedback-form`, `helpers`, `in-app-rating`, `platform-encryption-native`,
+`swipeable-walkthrough`, `test-utils`, `test-utils-store`.
+
+**Repo ground truth confirmed independently while scanning:** every file read uses bare
+`import { useSelector } from 'react-redux'` (reference equality, no `shallowEqual` wrapper) — matches
+PROGRESS.md. Zero bare `.watch(` calls anywhere in this tree (`grep -rn "\.watch(\|[^e]watch("` returns
+nothing outside `useWatch`) — C2's "0" is confirmed, not just unverified. Zero `useFreshRef`/
+`useCurrentRef` usage anywhere in this tree — class 7 is a non-issue for this area specifically (all 41
+repo-wide call sites from C8 live in `packages/suite` or `module-*`). This codebase's selector layer is
+unusually disciplined: `suite-native/accounts`, `tokens`, `transactions`, `assets`, `discovery`,
+`bluetooth`, `device`, `banners` all build on `createWeakMapSelector` (aliased `createMemoizedSelector`)
+consistently, and several plain (non-memoized) selectors have an explicit code comment stating they
+deliberately return a primitive so raw `useSelector` `===` doesn't over-render (e.g.
+`selectSingleDeviceAccountKeyForNetworkSymbol`, `suite-native/assets/src/assetsSelectors.ts:109-110`).
+
+Checked against exclusions per `grep -rl "<basename>" perf-issues/asymptotic-complexity
+perf-issues/scheduling` plus the PROGRESS.md anchor list: `AccountsListTokenItem.tsx`,
+`TransactionNotificationItem.tsx`, `EarnDepositsCardRow.tsx`, `TransactionList.tsx`'s `?? []` uses (all
+inside an already-memoized `useMemo`, not the drafted `p1-16` balance-history reduction), native
+SearchForm (`suite-native/search`), native graph refetch-on-navigation — none of my findings below
+overlap these.
+
+## F-08-1 — `useTranslatedMessages` derives i18n messages via `useState`+`useEffect` instead of `useMemo`, so the **entire app tree** double-renders (once with empty translations) on every cold start
+
+- **Class:** 2 (effect that calls `setState`, immediately after mount, holding state that is fully
+  computable during render — the SKILL's "state that can be computed from what you already have is not
+  state" principle; native rule (d) derived-state-in-effect) — landing at the highest possible blast
+  radius, the i18n Provider that wraps the whole app.
+- **Where:** `suite-native/intl/src/hooks/useTranslatedMessages.ts:23-34` (the hook) consumed by
+  `suite-native/intl/src/IntlProvider.tsx:24-35` (`<ReactIntlProvider messages={messages}>{children}</...>`,
+  where `children` is the entire app — `IntlProvider` is a top-of-tree provider). Compounded by
+  `suite-native/intl/src/hooks/useSystemLocaleListener.ts:19-31`, called from the same `IntlProvider`,
+  which dispatches a possibly-different system locale on mount, so on a cold start where the OS locale
+  differs from the persisted one there can be a _third_ full-tree render.
+- **Trigger cadence:** every cold app start (mount of `IntlProvider`), unconditionally — not a rare edge
+  case.
+- **Severity guess:** P1 — the blast radius is the entire component tree (every `<Translation>` /
+  `formatMessage` call in the app), and it happens on every launch, at the most latency-sensitive moment
+  (time-to-interactive).
+- **Confidence:** high. Read the full chain end-to-end: `LANGUAGE_TRANSLATIONS_MAP[locale]` entries are
+  `require(...)`'d JSON, resolved synchronously at module load — there is no asynchronous reason for this
+  to live in an effect at all.
+
+### Before (verbatim from the file)
+
+```ts
+// suite-native/intl/src/hooks/useTranslatedMessages.ts:23-34
+export const useTranslatedMessages = () => {
+    const [messages, setMessages] = useState<{ [key: string]: string }>({});
+    const supportedLanguageLocale = useSelector(selectSupportedLanguageLocale);
+
+    useEffect(() => {
+        const localizedMessages = LANGUAGE_TRANSLATIONS_MAP[supportedLanguageLocale];
+
+        setMessages({ ...englishFallback, ...localizedMessages });
+    }, [supportedLanguageLocale]);
+
+    return messages;
+};
+```
+
+```tsx
+// suite-native/intl/src/IntlProvider.tsx:24-35
+export const IntlProvider = ({ children }: { children: React.ReactNode }) => {
+    useSystemLocaleListener();
+
+    const locale = useSelector(selectLocale);
+    const messages = useTranslatedMessages();
+
+    return (
+        <ReactIntlProvider locale={locale} defaultLocale={DEFAULT_LOCALE} messages={messages}>
+            {children}
+        </ReactIntlProvider>
+    );
+};
+```
+
+### Proposed fix
+
+Replace the `useState`+`useEffect` pair with a direct derivation (no effect needed at all, since the
+lookup is synchronous):
+
+```ts
+export const useTranslatedMessages = () => {
+    const supportedLanguageLocale = useSelector(selectSupportedLanguageLocale);
+
+    return useMemo(
+        () => ({ ...englishFallback, ...LANGUAGE_TRANSLATIONS_MAP[supportedLanguageLocale] }),
+        [supportedLanguageLocale],
+    );
+};
+```
+
+`useMemo` here is legitimate even under React Compiler because it changes _behavior_, not just
+micro-optimizes: it makes the first render already carry the correct `messages`, instead of
+initializing to `{}` and correcting one commit later.
+
+### Why it matters
+
+On mount, `messages` starts as `{}`. `react-intl`'s `IntlProvider` treats every translation id as missing
+when `messages` is empty and calls its `onError` handler (`console.error` by default) once per missing
+id — with dozens of `<Translation>` calls rendered on a typical first screen, this is dozens of
+`console.error` calls on every cold start, which per this repo's own logging rules are Sentry-captured on
+every platform. Immediately after, the effect fires, calls `setMessages`, and the **entire subtree under
+`IntlProvider` — i.e. the whole app** — re-renders a second time with the real messages. This is not a
+narrow, list-row-scoped defect; it is a guaranteed double-render (occasionally triple, see
+`useSystemLocaleListener`) of the whole app on every single launch.
+
+## F-08-2 — `usePinAction`'s `exhaustive-deps` suppression cites a dependency shape the code no longer has
+
+- **Class:** 6 (pre-existing `eslint-disable react-hooks/exhaustive-deps`, C1 candidate) — the comment's
+  stated reason doesn't match the current code, which is exactly the "lying dependency array" smell the
+  skill warns about, even though I could not prove an active bug in either of today's two call sites.
+- **Where:** `suite-native/device-authorization/src/hooks/usePinAction.tsx:86-145`. The suppressed
+  `useFocusEffect`/`useCallback` is at lines 137-144; the dependency array it excludes `handlePinAction`
+  from is the `useCallback` at line 135.
+- **Trigger cadence:** every time this screen regains focus, or `isDeviceConnectionGuardVisible` flips
+  false, while a stale `handlePinAction` closure could be in scope.
+- **Severity guess:** P3 — the mismatch is real, but I traced every dependency of `handlePinAction`
+  (`analytics` via `useServices(selectNativeAnalyticsDep)` — stable, confirmed the module-level selector
+  and jotai-backed `showToast`/`showAlert` singletons; `device?.path` — a narrowed primitive; `navigation`
+  — stable; `onSuccess`/`handleError` — confirmed stable in the
+  `DevicePinProtectionStackNavigator.tsx:48` call site, `onSuccess: navigation.goBack`, no `onError`
+  passed) and found it **fully stable in that caller today**, so the suppression there is provably
+  unneeded rather than actively hiding a bug. The second caller
+  (`module-device-onboarding/src/screens/CreatePinScreen.tsx:59-63`) passes `onSuccess`/`onError` as
+  screen-local callbacks I did not verify (out of this area's remit).
+- **Confidence:** medium — high confidence the comment is stale/inaccurate, medium confidence on whether
+  it currently masks real staleness (would raise to P2/high if `handlePinCreated`/`handlePinCanceled` in
+  `CreatePinScreen.tsx` turn out to be unstable across renders).
+
+### Before (verbatim from the file)
+
+```tsx
+// suite-native/device-authorization/src/hooks/usePinAction.tsx:86-145
+const handlePinAction = useCallback(async () => {
+    // ...
+    const result = await requestPrioritizedDeviceAccess(() =>
+        TrezorConnect.changePin({
+            device: { path: device?.path },
+            remove,
+        }),
+    );
+    // ...
+}, [analytics, type, device?.path, showSuccess, onSuccess, handleError, navigation]);
+
+useFocusEffect(
+    useCallback(() => {
+        if (!isDeviceConnectionGuardVisible) handlePinAction();
+
+        // handlePinAction is excluded as it depends on device object that could unintentionally trigger the useEffect
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isDeviceConnectionGuardVisible]),
+);
+```
+
+### Proposed fix
+
+The comment's justification ("depends on device object") describes code from before `device` was
+narrowed to `device?.path` (a primitive). Either: (a) re-verify and simply add `handlePinAction` to the
+inner `useCallback`'s deps now that its only object-shaped input is narrowed, or (b) if a genuinely
+unstable prop (`onSuccess`/`onError` in some caller) is the real reason, replace the suppression with a
+`useEffectEvent`/ref-based "read latest `handlePinAction` imperatively" pattern so the rule stays live
+instead of silenced.
+
+### Why it matters
+
+An `eslint-disable` whose comment no longer matches the code is exactly the situation the skill calls a
+"lying dependency array" — the next person to touch this file has no reliable signal about what's really
+being protected against, and if `CreatePinScreen.tsx`'s callbacks are ever made unstable (e.g. an inline
+arrow introduced during a refactor), this suppression would silently start serving stale
+`onSuccess`/`onError` closures with no lint error to catch it.
+
+## F-08-3 — `FormState`-typed objects used as whole-object effect dependencies in the fee hooks
+
+- **Class:** 1 (value crosses a prop/hook boundary as a whole object) + 2 (feeds effects that dispatch
+  thunks) — the skill's "depend on the identifier, not the record" guidance, applied to a form snapshot
+  instead of an account/device.
+- **Where:** `suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts:55-98` (effect deps
+  include `formState` directly) and `suite-native/transaction-management/src/hooks/fees/useCustomFee.ts:98-162`
+  (`handleValuesChange`'s deps include `formState`, which then feeds the effect at line 151-162 via
+  `debounce(handleValuesChange)`).
+- **Trigger cadence:** would be "every render that produces a new `formState` reference" — cancels an
+  in-flight `AbortController`-guarded fee calculation and restarts it (`useMaxSpendableAmount`), or resets
+  the debounce timer before it fires (`useCustomFee`).
+- **Severity guess:** P3. I verified `useMaxSpendableAmount`'s **only** current caller
+  (`suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.ts:34-38`) never passes
+  `formState` at all (it's optional and omitted), so that instance is dormant today, not live. I could not
+  verify `useCustomFee`'s `formState` (threaded in as a plain prop through
+  `CustomFee.tsx`/`FeesContent.tsx`/`FeeSelector(Row).tsx`/`FeesBottomSheet.tsx`, all within this area,
+  but originating from a caller in `module-send`, outside it) — if that source is a redux-persisted form
+  draft (this repo's usual pattern, and likely given `selectFormDraftByPrefix` exists one file over in
+  `suite-native/transaction-management/src/selectors.ts:134-145` for the same purpose, direct state
+  lookups, not `getValues()` snapshots), this is a non-issue in practice.
+- **Confidence:** medium — the dependency _shape_ is confirmed unstable-by-construction (a whole
+  externally-supplied object, not narrowed to the primitive fields actually read), but whether either
+  caller currently supplies an unstable reference is unresolved for one of the two (would need
+  `module-send`'s draft-selector chain, out of this area, to close out `useCustomFee`; would drop entirely
+  for `useMaxSpendableAmount` if no other caller is ever added).
+
+### Before (verbatim from the file)
+
+```ts
+// suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts:55-98
+useEffect(() => {
+    if (!accountKey || !enabled || !symbol) {
+        setMaxSpendableAmount(undefined);
+        return;
+    }
+    if (tokenBalance) {
+        setMaxSpendableAmount(tokenBalance);
+        return;
+    }
+    const controller = new AbortController();
+    const calculateMaxAmount = async () => {
+        try {
+            await dispatch(updateFeeInfoThunk({ networkSymbol: symbol })).unwrap();
+            const { normal, economy, low, high } = await dispatch(
+                calculateFeeLevelsMaxAmountThunk(
+                    {
+                        formState: formState ?? buildDefaultFormState({ tokenContract }),
+                        accountKey,
+                    },
+                    { signal: controller.signal },
+                ),
+            ).unwrap();
+            if (!controller.signal.aborted) {
+                setMaxSpendableAmount(high ?? normal ?? low ?? economy);
+            }
+        } catch {
+            if (controller.signal.aborted) return;
+            setMaxSpendableAmount(undefined);
+        }
+    };
+    calculateMaxAmount();
+    return () => controller.abort();
+}, [dispatch, accountKey, tokenContract, formState, tokenBalance, enabled, symbol]);
+```
+
+### Proposed fix
+
+Narrow to what the effect actually needs to react to. If `formState` must be read at fetch time but the
+effect shouldn't restart merely because the caller re-created the object, read it through a
+`useEffectEvent` (already used correctly elsewhere in this area, see
+`suite-native/trading-slippage/src/hooks/useSlippageLifecycle.ts:16,36`) so it's available imperatively
+without being a reactive dependency. If specific `formState` fields (e.g. `selectedFee`) genuinely should
+retrigger the calculation, destructure those primitives at the call site and pass them individually.
+
+### Why it matters
+
+Both hooks drive the "max spendable amount" / custom-fee-preview UI during active user input in a send
+flow. If either upstream caller ever passes a freshly-constructed `formState` per render or per keystroke
+(a live `getValues()` snapshot rather than a stable draft reference), the guarded async work
+(`AbortController`, `debounce`) means it degrades gracefully rather than looping — but a value that
+restarts every keystroke may never resolve while the user is actively typing.
+
+## F-08-4 — `AccountsListWithFilter` copies a prop into state via an effect (derived-state-in-effect), currently inert only because every caller happens to pass a stable value
+
+- **Class:** 2 (derived-state-in-effect, native rule (d)) — structurally the same shape as F-08-1 but far
+  smaller blast radius (one screen, not the whole app) and currently never triggered.
+- **Where:** `suite-native/accounts/src/components/AccountsListWithFilter.tsx:39,46,55-57`.
+- **Trigger cadence:** would fire on every render where the `networksFilter` prop's reference changes;
+  today it fires exactly once per mount because all 3 call sites pass a referentially stable value (a
+  module constant default, or a `useMemo` in `AccountsScreen.tsx:25-28` keyed on `route.params`, which
+  itself only changes when navigation params really change).
+- **Severity guess:** P3 — verified inert today; flagged because the component's own contract (accepting
+  an arbitrary `networksFilter?: NetworkSymbol[]` prop) invites a future caller to pass an inline array
+  literal, silently reintroducing an extra render per parent re-render and (worse) discarding any
+  in-progress user filter selection every time the parent re-renders.
+- **Confidence:** high on the mechanism; the "currently inert" claim is confirmed by reading all 3
+  callers (`AccountsScreen.tsx`, `ReceiveAccountsScreen.tsx`, `SendAccountsScreen.tsx`).
+
+### Before (verbatim from the file)
+
+```tsx
+// suite-native/accounts/src/components/AccountsListWithFilter.tsx:35-57
+export const AccountsListWithFilter = ({
+    onSelectAccount,
+    title,
+    flowType,
+    networksFilter = EMPTY_NETWORKS_FILTER,
+    // ...
+}: AccountsListWithFilterProps) => {
+    const [searchValue, setSearchValue] = useState('');
+    const [isSearchActive, setIsSearchActive] = useState(false);
+    const [filteredNetworks, setFilteredNetworks] = useState<NetworkSymbol[]>(networksFilter);
+    // ...
+    useEffect(() => {
+        setFilteredNetworks(networksFilter);
+    }, [networksFilter]);
+```
+
+### Proposed fix
+
+Derive instead of duplicating: either drop the local echo entirely and treat `networksFilter` as the
+source of truth for the "no user override yet" case (track only the user's override in state, defaulting
+to the prop when absent), or — if the reset-on-prop-change behavior is intentional (clearing a user's
+local filter edits whenever the caller's base filter changes) — key a `useState` initializer off a
+`key` prop instead of syncing via effect, per React's documented "resetting state with a key" pattern.
+
+### Why it matters
+
+Not live today, but it is exactly the anti-pattern this skill's "distinguish a wasted memo from a render
+loop" section calls out — "state that can be computed from what you already have is not state" — and it's
+one call-site change away from becoming an active extra-render-per-parent-render bug, or a UX bug (a
+user's in-progress network filter selection getting silently reset if the parent ever re-renders with a
+fresh-but-equal `networksFilter` array).
+
+## Checked, clean
+
+- **Per-row FlashList/FlatList item components (the hot path this sweep prioritized):**
+  `TransactionListItem.tsx`, `TokenTransferListItem.tsx`, `TransactionListItemContainer.tsx`
+  (`suite-native/transactions`) — every `useSelector` resolves to either a `createWeakMapSelector`
+  (`selectAccountByKey`, `selectTransactionBlockTimeById`) or a selector that only ever returns a
+  primitive or an existing-array-element reference (`selectIsPhishingTransaction` — unmemoized but
+  returns one of a handful of module-level singleton constants by design, comment at
+  `token-definitions/src/phishing/utils.ts:102`; `selectTransactionFiatRate` — direct nested-property
+  lookup, primitive). `AccountsListItem.tsx`, `TokenBadge`, `AssetItem.tsx`, `AdaAccountsListStakingItem.tsx`,
+  `AccountsListNetworkGroup.tsx`, `AccountsListAccountTypeGroup.tsx`, `WalletItem.tsx`/`WalletItemBase.tsx`,
+  `TradeHistoryListItem.tsx` (no `useSelector` at all) — same story, verified each selector individually
+  (`selectFormattedAccountType`, `selectActiveAndDefiTokensCount`, `selectAccountFiatBalance`,
+  `selectAccountHasStaking`, `selectHasDeviceAnyFailedAccountForNetworkSymbol`,
+  `selectSingleDeviceAccountKeyForNetworkSymbol`, `selectHasDeviceAnyTokensForNetwork`,
+  `selectHasAnyDeviceAccountsWithStaking`, `selectIsCardanoStakedWithFiveBinaries`,
+  `selectIsCardanoStakedOutsideEverstake`, `selectFilteredDeviceAccountsByNetworkSymbolAndAccountType`,
+  `selectDeviceTotalFiatBalanceByDeviceState`) are each either weak-map memoized or explicitly documented
+  to return a primitive.
+- **`TransactionList.tsx`** (`suite-native/transactions`): the `?? []` hits at lines 218/231/247 are
+  local intermediate values _inside_ an already-correct `useMemo(..., [transactions, tokenContract])` —
+  they never reach the dependency array, so they don't reproduce the skill's canonical bug shape. Its
+  selectors (`selectAccountTransactionsWithTokenTransfers`,
+  `selectAccountStakeTypeTransactionsWithTokenTransfers`) are `createWeakMapSelector`-based.
+- **`useResolvedAccountKey.ts`** (C9 candidate, `suite-native/accounts/src/hooks`): effect deps include
+  the whole `account` object (line 66), but `account` comes from `selectAccountByKey` — memoized,
+  `.find()`-based, so it's a stable reference that only changes when the account's data genuinely
+  changes; using the whole object here is appropriate (the effect reads `account.symbol`/`.accountType`/
+  `.index`), not the "fresh object every render" failure mode C9 screens for.
+- **`NetworkFilterBottomSheet.tsx`** (`suite-native/accounts`, C10 candidate): its
+  `useEffect(() => setPendingSelection(selectedNetworks), [selectedNetworks])` looks like F-08-4's shape
+  but is a legitimate "draft that resyncs to the committed value, but allows local edits before commit"
+  pattern (`selectedNetworks` only changes via explicit Apply/Clear button presses in the parent, and a
+  `useRef` mirrors the committed value for the Dismiss-without-saving case) — bounded by user action, not
+  by render cadence.
+- **`useCustomFee.ts`** (`suite-native/transaction-management/src/hooks/fees`): correctly uses
+  `useWatch`/`useFormContext` (never bare `watch()`); the `getValues()` call at line 71 is intentionally
+  non-reactive (relies on the sibling `useWatch` calls to trigger the re-render that makes the fresh
+  `getValues()` read current) — a recognized RHF pattern, not a bug. See F-08-3 for the one real concern
+  in this file.
+- **`TextButton.tsx`** (`suite-native/atoms`, C10 candidate): its effect calls `setAnimatedColor`, which
+  mutates a Reanimated `useSharedValue.value` — not a React `setState` — so it cannot trigger the
+  "effect stores fresh reference → re-render → new reference" cycle the skill describes; independent of
+  whether `setAnimatedColor`'s identity is stable across renders (not reportable regardless, since native
+  is compiled).
+- **`AnimatedLineGraph.tsx`** (`suite-native/react-native-graph`, 3 of the 5 C1 candidates): all three
+  `eslint-disable`s are Reanimated-specific — the omitted dependencies (`commands`, `startPulsating`) are
+  `useSharedValue` objects or callbacks built only from `useSharedValue`s, which are ref-like and
+  referentially stable regardless of whether they're listed, so the suppressions are legitimate
+  ESLint-can't-prove-it-but-it's-fine cases, not staleness bugs. `setFingerX`'s disable (line 396,
+  extra `pathRange.x` dependency) is a documented Reanimated-worklet quirk ("IDK why"), unrelated to
+  React re-render mechanics.
+- **`FirmwareInstallationScreenContent.tsx:208-218`** (C1 candidate): the empty-deps effect is a
+  deliberate run-once-on-mount kickoff (`setTimeout` then `startFirmwareUpdate()`), the standard and
+  accepted shape for "do X once using the initial closure."
+- **`useFirmware.tsx`** (`suite-native/firmware`): the "maybe stuck" timeout effect
+  (`[progress, status, setMayBeStuckedTimeout, resetMayBeStuckedTimeout]`) resetting on every `progress`
+  tick is the intended behavior (reset the stuck-timer on real progress), not a bug.
+- **`Graph.tsx`** (`suite-native/graph`): the `delayedLoading` effect only depends on the `loading`
+  boolean prop — a deliberate flicker-avoidance delay, bounded, unrelated to the already-excluded
+  `p1-16`/`p1-17` balance-history/refetch-on-navigation issues.
+- **`useFiatFromCryptoValue.ts`** (`suite-native/formatters`): uses
+  `selectFiatRatesByFiatRateKey(state, fiatRateKey)` — a direct keyed lookup returning the specific
+  `Rate` object straight from the store, **not** the "whole rates object" pattern behind the excluded web
+  issue `#28880` (`BaseCurrencyValue`/`FiatValue` re-render storm) — confirmed by reading
+  `suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts:35-39`; this is a materially different,
+  already-correct implementation.
+- **`useServices`/`analytics` dependency stability** (`suite-common/dependency-injection/src/useServices.tsx`,
+  used from `usePinAction.tsx`, `useRedirectOnPassphraseCompletion.ts`, `useBluetoothAdapter.ts`): traced
+  fully — `selectNativeAnalyticsDep` is a module-level constant selector, `useSelectedServices`'s
+  `useMemo` deps (`[services, ...selectors]`) spread stable elements, so `analytics` is a stable
+  reference across renders; not a source of instability anywhere it's used in this area.
+- **Effect+`dispatch` sites checked individually** (the highest-value class per the brief):
+  `BiometricsModalRenderer.tsx`, `useBlockchainConnectionManager.ts`, `useBluetoothAdapter.ts`,
+  `useRedirectOnPassphraseCompletion.ts` (all 3 effects — `device`/`selectSelectedDevice` is a direct,
+  stable state-path read, not a fresh allocation), `useBrowserAuth.ts`, `TradingHistory.tsx` (`trades`
+  from `selectDeviceTradingTradesOrderedByDate`, weak-map memoized; the `tradeToBeOpened`-consuming
+  effect self-clears via `dispatch(tradingActions.clearTradeOrderIdToBeOpened())`, bounded),
+  `SlippageBottomSheet.tsx`, `useMaxSpendableAmount.ts` (F-08-3), `useCustomFee.ts` (F-08-3) — all either
+  keyed on confirmed-primitive/confirmed-memoized deps or already guarded against re-entry.
+- **`?? []`/`?? {}` C4 candidates verified by reading, all false positives** (destructured value is
+  either a primitive extracted immediately, or consumed only inside a callback body that never becomes a
+  hook dependency, never the object itself crossing into a memo/effect dep):
+  `useFeeCalculation.ts:40` (`{ symbol } = account ?? {}` — only the primitive `symbol` escapes),
+  `useShowStayOnScreenAlert.tsx:38` (inside a `useCallback` body, called imperatively),
+  `useHasEnabledCoin.ts:11` (`Object.values(enabledCoins ?? {}).some(Boolean)` — the `useWatch` `compute`
+  option, only the boolean crosses the hook boundary), `DiscoveryCoinsFilter.tsx:75` (inside a
+  `useCallback` body), `TradeDetailProviderCard.tsx:35`, `SlippageSummary.tsx:14`,
+  `DeviceDangerBannerExtension.tsx:54`, `ContextMessage.tsx:30`, `TransactionName.tsx:147` (all
+  render-body destructuring consumed directly in JSX, not stored as a dependency).
+- **`forms` package foundations** (`suite-native/forms/src/hooks/useField.ts`,
+  `useFormContext.ts`): `useField` is built on `useController` (react-hook-form's per-field subscription
+  primitive), never `watch()`; confirms the C2 "zero native `watch()`" result is architectural, not
+  incidental.
+- **Derived-state-in-effect / setState-first-effect sweep beyond the C10 grep window** (broadened search
+  for `useEffect` bodies calling a `set*` within their first ~6 lines, 30 hits reviewed): all bounded by a
+  guard condition or keyed on primitives, except F-08-1 and F-08-4 above. Specifically checked clean:
+  `PromoBannerCarousel.tsx` (clamps `activeIndex` only when `count` actually shrinks past it),
+  `useIsDiscoveryDurationTooLong.tsx` (interval keyed on primitive timestamp/boolean),
+  `useOnForegroundCallback.ts` (flag-guarded, self-resetting), `ConfirmOnTrezorWrapper.tsx` (timeout keyed
+  on layout primitives), `DeviceSwitch.tsx` (nav listener, stable deps), `useBluetoothManager.ts` /
+  `useBluetoothAlerts.ts` (`showOrHideBluetoothAlert`'s identity is intentionally keyed on the two status
+  primitives it needs to react to — traced the full dependency chain), `useProviderConfirmationStatus.ts`,
+  `useSlippageLifecycle.ts` (textbook `useEffectEvent` usage for the "read latest callback" need),
+  `PinOnKeypad.tsx` (`useWindowDimensions()` — library-managed change detection, not a fresh-per-render
+  object), `TronFeeLimitContent.tsx`, `useWaitForButtonRequest.ts` (flag-guarded).
+- **`StoreProvider.tsx`/`StorageProvider.tsx`** (`suite-native/state`, `suite-native/storage`): pure
+  composition, no hooks/effects, checked given their app-root position (same category as the
+  `IntlProvider` in F-08-1) — nothing to report.
+- **`useCryptoFiatConverters.ts`, `useFormattersConfig.ts`** (`suite-native/formatters`,
+  `formatters-config`): return fresh objects/functions per render, but native is compiler-managed and
+  `useFormattersConfig.ts` is explicitly cited as the _correct_ reference example in
+  `_scan/06-suite-common.md`'s F-06-2 (contrasted against a web-side miss) — nothing new to add.
+- **Selector memoization audit across `accounts`, `tokens`, `staking` (all 4 chains),
+  `transaction-management`, `transactions`, `assets`, `bluetooth`, `device`, `discovery`, `graph`,
+  `banners`, `trading-state`'s `commonSelectors.ts`/`buySelectors.ts`/`sellSelectors.ts`/
+  `exchangeSelectors.ts`/`residenceSelectors.ts`**: every exported selector classified as either
+  memoized (`createWeakMapSelector`/`createSelector`) or a plain function verified to return a primitive,
+  an existing reference via `.find()`, or a value that's reduced to a primitive (e.g. `.length > 0`)
+  before ever reaching a `useSelector` call site. The two selectors whose names suggested unmemoized list
+  construction (`selectAccountsWithTokensToSellSectionListByTradingType`,
+  `selectVisibleDeviceAccountsByNetworkSymbolSorted`, `suite-native/trading-state/src/selectors/commonSelectors.ts:242-451`)
+  turned out to be `createWeakMapSelector`-wrapped on closer read (the factory call is on the line after
+  the `=`, easy to misread with a naive one-line grep).

--- a/perf-issues/react-hooks/_scan/09-native-modules-a.md
+++ b/perf-issues/react-hooks/_scan/09-native-modules-a.md
@@ -1,0 +1,851 @@
+# Area 09 — suite-native/module-trading, module-earn, module-send
+
+Scope: `suite-native/module-trading/**` (~631 files), `suite-native/module-earn/**` (~630 files),
+`suite-native/module-send/**` (~130 files). All three are compiled by React Compiler
+(`experiments.reactCompiler: true`), so no "missing useMemo/useCallback/memo" findings below —
+every finding is a compiler bail-out, an unstable effect/memo dependency, an unstable selector
+result, or a derived-state issue, per the native ground rules in `PROGRESS.md`.
+
+**Headline pattern**: five independent hooks across all three modules key a fee/allowance
+**composition effect** — the thing that calls `TrezorConnect`/dispatches a compose thunk — on the
+_whole_ Redux `account` object instead of `accountKey`/`account?.symbol`. Since `account` gets a
+fresh reference on every blockchain-driven update (balance tick, new tx, discovery), each of these
+effects refires and re-dispatches its compose/allowance thunk any time the account changes for a
+reason that has nothing to do with what the user is doing on screen. This is exactly the skill's
+"silent and unbounded" class-2 example, found five times independently (send, earn/staking,
+earn/yield deposit, earn/yield approval, trading/exchange EVM approval) — three of the five
+authored well after the others sit right next to a **correct** sibling in the same package
+(`useYieldWithdrawFees.ts`, `useYieldPendingTransactionTracking.ts`,
+`useComposeTradingTransaction.ts`) that explicitly avoids the same trap, so the fix already has an
+in-repo template.
+
+No `react-hook-form` bare `.watch()` calls exist anywhere in this area (confirmed by grep across
+all three modules) — every form-field read goes through `useWatch`/`useFormContext`, so class-6's
+compiler bail-out does not apply here. `useQuery` is not called directly in any of these three
+modules either (query hooks are consumed from `@suite-common/*`, out of this area's scope).
+
+---
+
+## F-09-1 — The yield deposit/withdraw/approval fee-and-allowance chain recomputes on every account update because `useResolvedYieldFlowData` keys its memo on the whole `account` object
+
+- **Class:** 1 (unstable dependency crossing a hook boundary) driving class 2 (effect refetch) in
+  four downstream consumers
+- **Where:**
+    - Root: `suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts:240-249` (the `resolvedFlowData` memo)
+    - Consumer 1: `suite-native/module-earn/src/hooks/useYieldApprovalFees.ts:26-57` (`approvalTransaction` memo depends on `flowData`)
+    - Consumer 2: `suite-native/module-earn/src/hooks/useYieldAllowanceFees.ts:95-106,174-177` (`composeAllowanceFeeParams` memo + the effect that debounces `composeAllowanceTransactionThunk`)
+    - Consumer 3: `suite-native/module-earn/src/hooks/useYieldDepositFees.ts:40-72` (`composeTransaction` callback depends on `flowData`) feeding `suite-native/module-earn/src/hooks/usePreparedTxFees.ts:296-325` (the debounced compose effect that every yield-flow fee hook shares)
+    - Consumer 4: `suite-native/module-earn/src/hooks/useRefreshYieldDepositAllowanceOnIdle.ts:19-32` (effect depends on the whole `resolvedFlowData`, dispatches `initYieldAllowanceThunk`)
+    - `useResolvedYieldFlowData` is imported by 20 files (`grep -rl useResolvedYieldFlowData suite-native/module-earn/src` — every Yield deposit/withdraw/approval/complete screen plus the four hooks above), so any consumer that puts `flowData`/`resolvedFlowData` in an effect or memo dependency inherits this instability.
+- **Trigger cadence:** every Redux update that touches the account backing the open yield flow (balance tick, new pending/confirmed tx, discovery) while any deposit/withdraw/approval screen is mounted — not just when the user changes the typed amount or the vault data actually changes
+- **Severity guess:** P1 (hot: this is the entire stablecoin-yield deposit/withdraw/approval review path, and the effects it drives dispatch real compose/allowance thunks, one of which — `useRefreshYieldDepositAllowanceOnIdle` — literally calls `TrezorConnect`-backed allowance-check logic)
+- **Confidence:** high for the root memo and the two direct consumers I traced fully
+  (`useYieldApprovalFees`/`useYieldAllowanceFees`); medium for the `usePreparedTxFees` fan-out
+  (verified the dependency chain, but did not instrument a real re-render count)
+
+### Before (verbatim from the file)
+
+`useResolvedYieldFlowData.ts:230-249` — the root memo takes the raw `useSelector` account, not a key:
+
+```tsx
+export const useResolvedYieldFlowData = ({
+    accountKey,
+    tokenContract,
+    displayError = true,
+    yieldId,
+}: YieldFlowProps) => {
+    const { data: yieldOpportunities } = useAllYieldOpportunities();
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    ...
+    const resolvedFlowData = useMemo(
+        () =>
+            resolveYieldFlowData({
+                account,
+                tokenContract,
+                yieldId,
+                yieldOpportunities: yieldOpportunities ?? emptyYieldOpportunities,
+            }),
+        [account, tokenContract, yieldId, yieldOpportunities],
+    );
+```
+
+`resolveYieldFlowData` (same file, ~line 193) builds `flowData.token`/`flowData.receiptToken` as
+**new object literals** every time it runs, so even the nested fields are fresh, not just the
+top-level `flowData` wrapper.
+
+`useYieldApprovalFees.ts:26-57` — the allowance-transaction memo recomputes on every account tick
+even though it only reads vault/token metadata that doesn't change with the account's balance:
+
+```tsx
+const approvalTransaction = useMemo<YieldAllowanceFeeTransaction | null>(() => {
+    if (!amount || !flowData) {
+        return null;
+    }
+    const allowanceAmount = getYieldApprovalAllowanceAmount({
+        amount,
+        approvalLimitType,
+        tokenContract,
+        tokenDecimals: flowData.token.decimals,
+        tokenSymbol: flowData.token.symbol,
+    });
+    const contractAddress = getApprovalContractAddress({ flowType: 'deposit', flowData });
+    const spender = flowData.vault.outputToken?.address;
+    ...
+    return { allowanceAmount, modalState: { amount, contractAddress, spender, txType: 'approve' } };
+}, [amount, approvalLimitType, flowData, tokenContract]);
+```
+
+`useYieldAllowanceFees.ts:95-106` and `:174-177` — `composeAllowanceFeeParams` depends on the same
+`flowData`, and the effect that fires from it debounces straight into a dispatch:
+
+```tsx
+const composeAllowanceFeeParams = useMemo((): ComposeAllowanceFeeParams | null => {
+    if (!isEnabled || !flowData || !formDraftKey || !feeInfo || !transaction) {
+        return null;
+    }
+    return { feeInfo, flowData, formDraftKey, transaction };
+}, [feeInfo, flowData, formDraftKey, isEnabled, transaction]);
+...
+useEffect(() => {
+    setIsComposingAllowanceFee(composeAllowanceFeeParams !== null);
+    debounce(composeAllowanceFee);
+}, [composeAllowanceFee, composeAllowanceFeeParams, debounce]);
+```
+
+`useYieldDepositFees.ts:40-72` — `composeTransaction`'s identity changes with `flowData`, and it is
+itself a dependency of the shared debounce-then-compose effect in `usePreparedTxFees.ts:296-325`:
+
+```tsx
+const composeTransaction = useCallback(
+    async (composeAmount: string): Promise<ComposeTxResult<ComposedDepositTransaction>> => {
+        if (!flowData) {
+            return { type: 'error', isFeeEstimationError: false };
+        }
+        try {
+            const result = await dispatch(
+                composeYieldDepositTransactionThunk({ amount: composeAmount, flowData }),
+            ).unwrap();
+            ...
+        } catch {
+            return { type: 'error', isFeeEstimationError: false };
+        }
+    },
+    [dispatch, flowData],
+);
+```
+
+`useRefreshYieldDepositAllowanceOnIdle.ts` (whole hook) — the clearest case, the effect body doesn't
+even need the vault/token display fields it drags along:
+
+```tsx
+export const useRefreshYieldDepositAllowanceOnIdle = ({
+    allowanceStatus,
+    resolvedFlowData,
+}: UseRefreshYieldDepositAllowanceOnIdleParams) => {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (resolvedFlowData.resolutionStatus !== 'resolved' || allowanceStatus !== 'idle') {
+            return;
+        }
+
+        void dispatch(
+            initYieldAllowanceThunk({
+                flowData: resolvedFlowData.flowData,
+                flowKey: resolvedFlowData.flowKey,
+                flowType: 'deposit',
+                shouldSkipApprovalStep: false,
+            }),
+        );
+    }, [allowanceStatus, dispatch, resolvedFlowData]);
+};
+```
+
+### The in-repo fix already exists as a sibling
+
+`useYieldWithdrawFees.ts:75-77` documents and implements the correct pattern for the exact same
+problem — narrow the effect's dependencies to only the inputs that should trigger a fresh compose,
+and read everything else (including `flowData`) through a ref at call time:
+
+```tsx
+// Only the inputs that should trigger a fresh (network) fee composition. The fee context
+// (feeInfo, selected/custom fee, flowData) is read from refs at compose time instead, so it can't
+// re-trigger the effect — most importantly the fee draft that the compose itself writes.
+type ComposeWithdrawFeeParams = {
+    amount: string;
+    flowType: YieldWithdrawFlowType;
+    formDraftKey: string;
+};
+```
+
+(`flowDataRef.current = flowData` is assigned during render at `useYieldWithdrawFees.ts:344`, then
+read inside the async compose function — the `useFreshRef` shape.)
+
+### Proposed fix
+
+Apply the `useYieldWithdrawFees.ts` pattern to the other three hooks: keep `flowData` out of the
+`useMemo`/`useCallback`/`useEffect` dependency arrays that only exist to trigger network work, and
+read it through a `useRef`/`useFreshRef` at call time instead. Where the memoized _value_ really is
+consumed for display (`useYieldApprovalFees`'s `allowanceAmount`/`contractAddress`/`spender`), narrow
+the root cause instead: `useResolvedYieldFlowData`'s memo should not need to recompute the whole
+`flowData` bundle (vault/APY/display fields) every time `account` ticks for reasons unrelated to the
+token balance it actually reads — at minimum, split "vault/display resolution" (stable once loaded)
+from "balance-dependent fields" (`token.balance`, `depositedSharesAmount`) so consumers that only need
+the former aren't invalidated by every account update.
+
+### Why it matters
+
+Every one of these effects dispatches a thunk that talks to `@trezor/connect` (fee estimation,
+allowance-transaction building, or an on-chain allowance read). While a user is reviewing a deposit,
+withdrawal, or approval screen, any unrelated background account update (their own balance ticking,
+a new incoming transaction, discovery still running) re-fires the relevant compose/allowance thunk —
+work that should only happen when the user changes the amount or the fee level. `useRefreshYieldDepositAllowanceOnIdle` is the sharpest case: it re-dispatches an allowance check every time
+`resolvedFlowData` gets a new identity while `allowanceStatus` happens to still read `'idle'`.
+
+---
+
+## F-09-2 — Native send form re-fetches network fee info on every account update, not just network-symbol changes
+
+- **Class:** 2 (effect refetch keyed on an unstable — and here, unnecessarily wide — dependency)
+- **Where:** `suite-native/module-send/src/hooks/useSendForm.tsx:335-337`
+- **Trigger cadence:** every render where the `account` selector returns a new reference — i.e.
+  every blockchain-driven update to the account being sent from (balance tick, new tx, discovery) —
+  while the Send screen is open, not just when the account's network/symbol actually changes
+- **Severity guess:** P1 (hot: this is the plain "send" screen, the single most common wallet action)
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+// TODO: Fetch periodically. So if the user stays on the screen for a long time, the fee info is updated in the background.
+useEffect(() => {
+    if (account) dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol }));
+}, [account, dispatch]);
+```
+
+This is the skill's own canonical bad example, almost verbatim: `account` is the full Redux object,
+but the callback only ever reads `account.symbol`.
+
+### Proposed fix
+
+```tsx
+useEffect(() => {
+    if (account) dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol }));
+}, [account?.symbol, dispatch]);
+```
+
+### Why it matters
+
+`account.symbol` essentially never changes for a mounted send-form instance, so this effect should
+fire once. As written it re-dispatches `updateFeeInfoThunk` (a network fee-info fetch) on every
+account update for the lifetime of the Send screen — e.g. while the user is composing a transaction
+and their own balance/transaction list is still syncing in the background.
+
+---
+
+## F-09-3 — The same send form's debounced fee-composition effect refires on background account churn, not just on keystrokes or fee-level changes
+
+- **Class:** 2 (effect refetch keyed on an unstable dependency chain)
+- **Where:** `suite-native/module-send/src/hooks/useSendForm.tsx:203-276` (`updateFormState`
+  callback, `account` at line 269) feeding the effect at `suite-native/module-send/src/hooks/useSendForm.tsx:319-321`
+- **Trigger cadence:** every keystroke in the form (intended) **and** every time the selected
+  account's reference changes for any other reason (not intended) — both are debounced together
+  through the same 300 ms `useDebounce()` window (`packages/react-utils/src/hooks/useDebounce.ts`)
+- **Severity guess:** P1 (hot: same send screen as F-09-2; the debounce narrows frequency but not
+  occurrence, and because `useDebounce` cancels-and-restarts on every call, sustained background
+  account churn can also delay a real keystroke-driven fee recompute rather than only duplicate it)
+- **Confidence:** medium — I traced the dependency chain and confirmed `account` (whole object) is
+  both a dep of `updateFormState` and, through it, of the debounced effect; I did not instrument how
+  often `account`'s reference actually changes in a live session, so the real-world frequency is an
+  estimate, not a measurement
+
+### Before (verbatim from the file)
+
+```tsx
+const updateFormState = useCallback(async () => {
+    if (account && network && networkFeeInfo) {
+        const response = await dispatch(
+            composeSendFormTransactionFeeLevelsThunk({
+                formState: constructFormDraft({
+                    formValues: getValues(),
+                    tokenContract,
+                    selectedUtxos,
+                }),
+                composeContext: { account, network, feeInfo: networkFeeInfo, excludedUtxos },
+            }),
+        );
+        ...
+    }
+}, [
+    accountKey,
+    dispatch,
+    getValues,
+    tokenContract,
+    account,
+    network,
+    networkFeeInfo,
+    setError,
+    excludedUtxos,
+    selectedUtxos,
+    trigger,
+]);
+...
+// Triggered for every change of watchedFormValues.
+useEffect(() => {
+    debounce(updateFormState);
+}, [updateFormState, watchedFormValues, debounce, selectedUtxos, isNetworkReserveEnabled]);
+```
+
+### Proposed fix
+
+`composeSendFormTransactionFeeLevelsThunk`'s `composeContext.account` genuinely needs the full
+account object (it's passed to the compose call, not just read for a field), so the honest fix is
+the ref pattern from `useYieldWithdrawFees.ts`/`useEvmApprovalFees.ts` (read `account` through a ref
+inside `updateFormState` instead of listing it as a `useCallback` dependency), so the callback's
+_identity_ — and therefore the debounced effect above it — only changes when `watchedFormValues`,
+`selectedUtxos`, or `isNetworkReserveEnabled` actually change.
+
+### Why it matters
+
+The comment on the file's other effect ("TODO: Fetch periodically... fee info is updated in the
+background") shows the account is expected to update repeatedly while this screen is open. Each such
+update currently re-arms the debounce for a full `composeSendFormTransactionFeeLevelsThunk` call —
+the same UTXO-selection/fee-composition work the skill and `perf-issues/scheduling` already flag as
+expensive — even when the user has typed nothing new.
+
+---
+
+## F-09-4 — Earn/staking fee composition (`useComposeEarnFees`) recomputes and re-dispatches on every account update
+
+- **Class:** 2 (effect refetch keyed on an unstable dependency)
+- **Where:** `suite-native/module-earn/src/hooks/useComposeEarnFees.ts:97-199`, specifically the
+  effect at `:193-199`; `composeFeeLevels`'s own `account` dependency at `:190` widens the same effect
+- **Trigger cadence:** every account update (balance/tx/discovery) while the earn deposit/stake
+  fee-review step is open, in addition to the intended triggers (`formState` changes, focus changes)
+- **Severity guess:** P1 (dispatches a real compose thunk — `composeSendFormTransactionFeeLevelsThunk`
+  or `composeSolanaStakingTransactionFeeLevelsNativeThunk` — behind only a 300 ms debounce)
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+const account = useSelector((state: AccountsRootState) =>
+    selectAccountByKey(state, accountKey),
+);
+...
+const composeFeeLevels = useCallback(
+    async (requestId: number) => {
+        if (!formState || !account || !feeInfo) { ... }
+        setIsComposingFeeLevels(true);
+        try {
+            ...
+            const response =
+                account.networkType === 'solana'
+                    ? await dispatch(composeSolanaStakingTransactionFeeLevelsNativeThunk({ ... }))
+                    : await dispatch(
+                          composeSendFormTransactionFeeLevelsThunk({
+                              formState: mergedFormState,
+                              composeContext: { account, feeInfo, network: getNetwork(account.symbol) },
+                          }),
+                      );
+            ...
+        } finally { ... }
+    },
+    [dispatch, formState, account, feeInfo, saveDraft, accountKey, formDraftPrefix],
+);
+
+useEffect(() => {
+    if (!isFocused) return;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setIsComposingFeeLevels(!!formState && !!account && !!feeInfo);
+    debounce(() => composeFeeLevels(requestId));
+}, [isFocused, account, debounce, composeFeeLevels, feeInfo, formState]);
+```
+
+Also worth a one-line style note while in this file: `formDraftRef.current = formDraft;` is assigned
+directly during render at line 95 — functionally identical to `useFreshRef(formDraft)`
+(`packages/react-utils/src/hooks/useFreshRef.ts`), just reimplemented by hand (class 7, "manual
+ref-assign-in-render pattern that should be one of the helpers"). Not a bug — `formDraftRef` is only
+read later inside the async `composeFeeLevels`, so the render-time-assign semantics are exactly what's
+wanted — just worth consolidating onto the shared helper for consistency with the rest of the file's
+own imports (`@suite-native/react-utils` isn't even imported here for this purpose).
+
+### Proposed fix
+
+Same shape as F-09-1/F-09-2: `composeFeeLevels` needs `account` as a value (passed whole into the
+compose thunk's `composeContext`), so keep reading it, but do so through a ref populated during
+render, and drop `account` from both `composeFeeLevels`'s and the effect's dependency arrays. The
+effect should key on `formState`, `isFocused`, and `feeInfo` only.
+
+### Why it matters
+
+This is the earn-module twin of F-09-3 — the deposit/stake review screen recomputes and redispatches
+fee composition on background account churn instead of only on the inputs the user actually changed
+(amount, fee level).
+
+---
+
+## F-09-5 — EVM approval fee composition re-runs on every account update, more directly than the others (whole `account` sits in the effect's own dependency array)
+
+- **Class:** 2 (effect refetch keyed on an unstable dependency)
+- **Where:** `suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts:102-112`
+- **Trigger cadence:** every account update to the exchange's selected send account while the DEX
+  approval/revoke review screen is open, in addition to the intended triggers (quote/fee-level
+  changes)
+- **Severity guess:** P1 (dispatches `composeEvmApprovalFeeLevelsThunk`, an actual approve/revoke
+  transaction fee estimate, ahead of a swap that requires ERC20 allowance)
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+const account = useSelector((state: AccountsRootState) =>
+    selectAccountByKey(state, sendAccount?.key),
+);
+...
+const composeFeesRef = useRef(composeFees);
+composeFeesRef.current = composeFees;
+
+useEffect(() => {
+    composeFeesRef.current();
+}, [
+    quote?.dexTx?.data,
+    quote?.approvalType,
+    account,
+    feeInfo,
+    selectedFeeLevel,
+    customFee,
+    approvalTypeOverride,
+]);
+```
+
+This file already uses the ref-read pattern for `composeFees` itself (so the _callback_ isn't a
+dependency), but it still lists the whole `account` object directly in the triggering effect's own
+dependency array — the ref indirection doesn't help here because the effect re-runs (and calls
+`composeFeesRef.current()`) whenever `account` changes reference, regardless of the ref.
+
+### Proposed fix
+
+```tsx
+useEffect(() => {
+    composeFeesRef.current();
+}, [
+    quote?.dexTx?.data,
+    quote?.approvalType,
+    account?.key,
+    account?.symbol,
+    feeInfo,
+    selectedFeeLevel,
+    customFee,
+    approvalTypeOverride,
+]);
+```
+
+(`composeFees` itself still closes over the full `account` via its own deps at line 91 and is read
+through the ref, so the actual compose call keeps getting the current account — only the _trigger_
+needs narrowing.)
+
+### Why it matters
+
+Same shape as F-09-1/F-09-4 one file over: the DEX-swap approval screen recomposes approval fees
+(a real `@trezor/connect` fee-estimation round trip) on every background update to the account paying
+for the swap, not just when the quote or fee level the user is looking at changes.
+
+---
+
+## F-09-6 — `ExchangeApprovalDetails`/`ExchangeRevokeDetails` re-run a no-op guard effect on every account update
+
+- **Class:** 2 (effect refetch keyed on an unstable dependency — bounded-but-wasteful sub-case, not
+  a request loop)
+- **Where:** `suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.tsx:31-35`
+  and `suite-native/module-trading/src/components/exchange/Approval/ExchangeRevokeDetails.tsx:24-28`
+  (identical pattern in both files)
+- **Trigger cadence:** every account update to the exchange's selected send account, on both the
+  approval and revoke review screens
+- **Severity guess:** P3 (the effect body is a cheap truthiness check with no dispatch/setState in
+  the common case, so this is wasted re-invocation, not a storm)
+- **Confidence:** high
+
+### Before (verbatim from the file)
+
+```tsx
+const account = useSelector(selectExchangeSelectedSendAccount);
+...
+useEffect(() => {
+    if (!account) {
+        console.error('No account selected for exchange approval details');
+    }
+}, [account]);
+```
+
+(`ExchangeRevokeDetails.tsx` is byte-for-byte the same shape with a different message string.)
+
+### Proposed fix
+
+```tsx
+useEffect(() => {
+    if (!account) {
+        console.error('No account selected for exchange approval details');
+    }
+}, [!!account]);
+```
+
+### Why it matters
+
+Low value on its own — included because it's a clean, easy example of the same "whole object where a
+primitive would do" habit as the other findings in this file, on a screen (`selectExchangeSelectedSendAccount`
+is already a `createWeakMapSelector`-memoized value, so the object only changes when the account
+itself actually does) where the fix is a one-character diff.
+
+---
+
+## F-09-7 — `useWatchTrade`'s analytics-tracking effect depends on `account` but never reads it
+
+- **Class:** 6 / minimal-required-dependencies (an effect dependency wider than the closure actually
+  needs — `account` isn't referenced in the effect body at all)
+- **Where:** `suite-native/module-trading/src/hooks/general/useWatchTrade.ts:57-69`
+- **Trigger cadence:** every account update to the account whose trade is being watched, on the
+  trade-tracking/order-status screen (buy/sell/exchange order confirmation)
+- **Severity guess:** P3 (cheap body — a ref comparison and a conditional analytics call — so this is
+  cleanup, not a hot-path fix)
+- **Confidence:** high — re-read the full effect body below; `account` genuinely does not appear
+  inside it
+
+### Before (verbatim from the file)
+
+```tsx
+const account = useSelector((state: AccountsRootState) =>
+    selectAccountByKey(state, accountKey),
+);
+const trade = useSelector((state: TradingRootState) =>
+    selectTradingTradeByOrderId(state, orderId),
+);
+...
+useEffect(() => {
+    const currentStatus = getTradeStatusStep(trade);
+    if (currentStatus !== previousStatus.current) {
+        previousStatus.current = currentStatus;
+
+        if (trade && currentStatus) {
+            analytics.report({
+                type: events.tradingStatusEvent.name,
+                payload: { type: trade.tradeType, status: currentStatus },
+            });
+        }
+    }
+}, [trade, account, previousStatus, analytics]);
+```
+
+The second effect in the same file (`:71-85`, the one that actually dispatches
+`tradingThunks.watchTradeThunk`) legitimately needs `account` — I checked it separately and its
+`(!hasRefreshed || shouldReload) && shouldRefresh` guard means `account` churn alone can't cause a
+duplicate dispatch there, only a harmless extra re-run of the guard check, so I'm not filing that one.
+
+### Proposed fix
+
+Drop `account` (and the always-stable `previousStatus` ref) from this effect's dependency array —
+only `trade` and `analytics` are read:
+
+```tsx
+}, [trade, analytics]);
+```
+
+### Why it matters
+
+Minor on its own (the body is cheap), but it's a clean instance of "wider than the closure" with zero
+ambiguity — worth fixing in the same pass as F-09-5 since it's three lines above in a sibling hook of
+the same module.
+
+---
+
+## F-09-8 — Two "flow complete" summary screens memoize display rows against the whole `account`, needing only `.symbol`
+
+- **Class:** 1 / minimal-required-dependencies (unstable-by-construction memo dependency)
+- **Where:** `suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx:117-167` and
+  `suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx:58-79`
+- **Trigger cadence:** every account update while the post-transaction "complete" screen is mounted
+  (which, per F-09-1's chain, includes the account-refresh that happens right after the just-signed
+  transaction is picked up — so it recomputes at least once by design — plus any further update while
+  the user is still looking at the summary)
+- **Severity guess:** P3 (cold path — a one-time completion screen, not a review/edit loop; the
+  recomputed work is string formatting, not a network call)
+- **Confidence:** high that `account` is over-wide; medium on real-world impact since this screen is
+  typically dismissed quickly
+
+### Before (verbatim from the file)
+
+`YieldWithdrawCompleteScreen.tsx:117-167` (only `account.symbol` is read, at lines 126/131/159):
+
+```tsx
+const rows = useMemo(() => {
+    if (resolutionStatus !== 'resolved' || !session || !vault.outputToken) {
+        return [];
+    }
+    ...
+    const underlyingSymbol = hasUnwrappedOutput
+        ? toTokenSymbol(getNetworkDisplaySymbol(account.symbol))
+        : toTokenSymbol(vault.token.symbol);
+    ...
+    return getYieldWithdrawCompleteRows({
+        accountSymbol: account.symbol,
+        ...
+    });
+}, [CryptoAmountFormatter, account, isSharesInput, resolutionStatus, session, vault]);
+```
+
+`WrappedNativeTokenCompleteContent.tsx:58-79` (same shape, only `account.symbol` read at lines 73):
+
+```tsx
+const rows = useMemo(() => {
+    if (!account || !wrappedNative) {
+        return [];
+    }
+    ...
+    return getWrappedNativeCompleteRows({
+        accountSymbol: account.symbol,
+        ...
+    });
+}, [CryptoAmountFormatter, account, amount, flowType, nativeSymbol, wrappedNative]);
+```
+
+### Proposed fix
+
+Depend on `account?.symbol` in both memos (guarding the early-return with the same `!account` check
+before the memo, or moving the null-check into the deps as `account?.symbol` plus a separate boolean).
+
+### Why it matters
+
+Low severity given the screen's lifetime, but grouped with F-09-1 because it's fed by the same
+`useResolvedYieldFlowData`/`account` chain — narrowing the deps here is a one-line piece of the same
+fix.
+
+---
+
+## F-09-9 — `eslint-disable react-hooks/exhaustive-deps` in native `useSendForm.tsx` (C1 candidate)
+
+- **Class:** 6 (exhaustive-deps suppression)
+- **Where:** `suite-native/module-send/src/hooks/useSendForm.tsx:291-316`
+- **Trigger cadence:** once per mount of the send-form hook (by design)
+- **Severity guess:** P3 (documented intent, plausibly correct given how this screen is navigated to)
+- **Confidence:** medium — I could not find a bug this hides, but I also could not fully rule one out
+  without live-testing the token/draft-switch navigation path; flagging per the brief's mandate to
+  review every C1 site in-area
+
+### Before (verbatim from the file)
+
+```tsx
+useEffect(() => {
+    const prefillValuesFromStoredDraft = async () => {
+        if (sendFormDraft?.outputs) {
+            form.reset({
+                ...getDefaultValues({
+                    tokenContract,
+                    isDestinationTagEnabled:
+                        network?.networkType === 'ripple' || network?.networkType === 'stellar',
+                }),
+                ...sendFormDraft,
+            });
+            if (!tokenContract) await calculateNormalFeeMaxAmount();
+            setTimeout(() => {
+                trigger();
+            }, 0);
+        }
+    };
+
+    prefillValuesFromStoredDraft();
+    // this effect should be triggered only for the first render to fill the form with the stored draft on entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, []);
+```
+
+### Why this is plausibly fine (and what would change my mind)
+
+`useSendForm(accountKey, tokenContract)` takes `accountKey`/`tokenContract` as hook parameters, and
+this screen is reached via navigation params rather than by the same hook instance being reused
+across a different account/token — so a fresh mount per account/token is the expected shape, and
+`sendFormDraft` is sourced from a non-persisted-on-native Redux slice (`wallet.send` is not in
+`suite-native/state/src/reducers.ts`'s `persistedKeys: ['accounts', 'transactions']`), so there's no
+redux-persist rehydration race to worry about either. What would change my mind: if
+`SendStackRoutes.SendOutputs` is ever reachable via a param update on an _already-mounted_ screen
+instance (e.g. switching the token for the same account without unmounting), this mount-only draft
+prefill would silently skip the new token's stored draft.
+
+### Proposed fix
+
+If the navigation shape above is confirmed (fresh mount per account/token), leave as-is but replace
+the blanket `eslint-disable` with the skill's suggested alternative — list the dependencies and
+neutralize the ones that are intentionally excluded with a `void` statement so the rule stays live:
+`void sendFormDraft; void tokenContract; void network; void calculateNormalFeeMaxAmount; void trigger; void form;`
+inside the effect, deps `[]` removed in favor of an explicit comment-per-omitted-value. If the
+navigation shape is _not_ guaranteed, key the effect on `accountKey`/`tokenContract` instead of `[]`.
+
+---
+
+## F-09-10 (low confidence) — `SendUtxoScreen` crosses the hook boundary with `account?.utxo ?? []`
+
+- **Class:** 1 (unstable dependency crossing a hook boundary)
+- **Where:** `suite-native/module-send/src/screens/SendUtxoScreen.tsx:49`, consumed by
+  `suite-common/transaction-search/src/useFilteredUtxos.ts:9-17`
+- **Trigger cadence:** every render of `SendUtxoScreen` in which `account.utxo` is nullish
+- **Severity guess:** P3 (the fallback only matters when `account.utxo` is undefined, which should be
+  rare-to-never on a coin-control screen only reachable for UTXO-based accounts with UTXOs to select)
+- **Confidence:** low — flagging the pattern match per the skill's exact "crosses the hook boundary"
+  shape, but I could not find a realistic path where `account.utxo` is nullish while this screen is
+  mounted, so the practical impact may be zero
+
+### Before (verbatim from the file)
+
+```tsx
+const account = useSelector((state: AccountsRootState) => selectAccountByKey(state, accountKey));
+const filteredUtxos = useFilteredUtxos(account?.utxo ?? [], searchQuery);
+```
+
+`useFilteredUtxos` (`suite-common/transaction-search/src/useFilteredUtxos.ts`, not excluded in
+`asymptotic-complexity`/`scheduling`):
+
+```tsx
+export const useFilteredUtxos = (
+    utxos: Utxo[] = [],
+    query: string = '',
+    outputLabels?: SearchOutputLabels,
+) =>
+    useMemo(() => {
+        if (!query.trim()) {
+            return utxos;
+        }
+        return utxos.filter(utxo => filterUtxos(utxo, query, outputLabels));
+    }, [utxos, query, outputLabels]);
+```
+
+### Proposed fix
+
+A module-level `const EMPTY_UTXOS: Utxo[] = [];` fallback instead of `?? []` at the call site would
+close the gap for free and costs nothing even if the edge case never triggers.
+
+### Why it matters
+
+Included for completeness/pattern-matching rather than because I found real impact — the memo inside
+`useFilteredUtxos` would only fail to hold its reference during whatever render(s) `account.utxo` is
+nullish, and downstream (`filteredUtxos.length > 0 ? <UtxoList /> : ...`) only reads `.length`, not
+identity, so I did not find a consumer that would actually suffer even in the edge case.
+
+- Note: `SendUtxoScreen.tsx:88` (`onSelectionSubmit`'s `account?.utxo?.filter(...) ?? []`) is already
+  drafted as an O(n×m) algorithmic-complexity finding in
+  `perf-issues/asymptotic-complexity/p3-04-cleanups-suite-native-mobile-app.md` — that's a different
+  defect class (the `?? []` there is a plain event-handler fallback, not a hook dependency), so I did
+  not re-file it here, per the brief's instruction to say so when a distinct hooks-class defect
+  exists at an already-covered anchor. I did not find a distinct hooks-class defect at that line.
+
+---
+
+## Checked, clean
+
+- `suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx` and
+  `.../sell/payment/SellProviderPicker.tsx` — `selectedValue ?? {}` only feeds a primitive
+  destructure; the quotes selectors (`selectBuyQuotesByPaymentMethodNative`,
+  `selectSellQuotesByPaymentMethod`) are built on `createMemoizedSelector` =
+  `createWeakMapSelector.withTypes<TradingRootState>()` (`suite-native/trading-state/src/reducers/index.ts:15`), so they're stable across dispatches.
+- `suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx` — same
+  `selectedValue ?? {}` primitive-destructure shape, no memo/effect consumes it.
+- `suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.tsx` and
+  `.../exchange/ExchangeFormQuoteDebugView.tsx` — `findToken(...) ?? {}` is render-body work only
+  (class 4, web/suite-common only, out of scope for compiled native); `ExchangeFormQuoteDebugView`
+  uses `useWatch` (not bare `watch()`) and is a debug-only view.
+- `suite-native/module-trading/src/components/general/AccountList/AccountList.tsx` +
+  `suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.ts` — the `?? []` on
+  the hook's return is dead code (the hook's own `useMemo` always resolves to an array, never
+  `undefined`); the `useMemo`'s own deps (`accounts`, `selectedAccount`, `translate`, `mode`) are
+  sound.
+- `suite-native/module-earn/src/components/EarnDepositsCard.tsx` +
+  `EarnActiveItemsBottomSheet.tsx` — the `?? []` fallbacks (`stakingRow?.activeItems ?? []` etc.)
+  only feed a `FlashList`'s `data` prop; no effect/memo in `EarnActiveItemsBottomSheet` keys on
+  `items`'s identity.
+- `suite-native/module-earn/src/components/SolanaStakingRewardsList.tsx` — `rewardsQuery.data?.rewards ?? []` is TanStack Query data (stable while `data` hasn't refetched); `renderItem`'s own deps
+  are `[account.symbol]`, not `rewards`.
+- `suite-native/module-earn/src/hooks/useMessageSystemYield.ts` (native wrapper) +
+  `suite-common/message-system/src/useMessageSystemYield.ts` (core) — the wrapper passes a fresh
+  `{ type, vaultContractAddress, locale }` object every render, but the core hook destructures all
+  three into primitives immediately and only uses them inside further `useSelector` calls — the
+  fresh wrapper object never reaches a memo/effect dependency array.
+- `suite-native/module-earn/src/hooks/useStakingListData.ts` — the `.filter()`/`.forEach()` work
+  runs inside a `useMemo` keyed on `[accounts, areTestnetsEnabled]`; `accounts` comes from
+  `selectVisibleDeviceAccounts` (shared, already-established selector).
+- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts` — **good pattern**, cited above as
+  the fix template for F-09-1: explicitly reads `feeInfo`/`flowData`/fee-draft state through refs at
+  compose time (comment at `:75-77`, `flowDataRef.current = flowData` at `:344`) specifically so
+  they can't re-trigger the compose effect.
+- `suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts` — **good pattern**:
+  destructures `accountKey`/`accountSymbol` from `account` immediately (`:168-169`) before any
+  selector/effect use; the polling-interval effect (`:227-237`) depends on
+  `[accountKey, dispatch, pollIntervalMs, shouldPollPendingTransaction]` — primitives only.
+- `suite-native/module-earn/src/hooks/useYieldApprovalLimit.tsx` — trivial `useState`+`useEffect`
+  sync from a primitive prop default; no instability.
+- `suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.ts`,
+  `useReceiveAccountChangeEffect.ts`, `useSendAccountAssetBalance.ts` — these intentionally write
+  the _whole_ selected account/receive-account into the form (`setValue('sendAccount', sendAccount)`),
+  so depending on the whole object is correct; the account itself comes from
+  `createMemoizedSelectorWithAccounts`-built selectors (`selectExchangeSelectedSendAccount` etc.,
+  `suite-native/trading-state/src/selectors/exchangeSelectors.ts:35`), so it's stable modulo real
+  data changes. `useSendAccountAssetBalance`'s second effect (`:60-71`) is a good minimal-deps
+  example (`sendAsset?.contractAddress, sendAccount?.symbol, accountKey` — primitives only).
+- `suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts` —
+  `options ?? {}` (line 78) is a per-invocation callback parameter (evaluated when the returned
+  function is called from a user action), not a render-time hook dependency; `collision` configs
+  passed by all four callers (`ExchangeSendAssetPicker.tsx`, `ExchangeTradeableAssetPicker.tsx`, and
+  two callers that don't pass `collision` at all) are module-level constants, not inline literals.
+- `suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.ts` +
+  `suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts` — the inline
+  `{ accountKey, tokenContract, symbol }` object at the call site is fresh every render (crosses the
+  hook boundary), but `useMaxSpendableAmount` destructures it into primitives at the parameter list
+  and its own effect deps are `[dispatch, accountKey, tokenContract, formState, tokenBalance, enabled, symbol]` — all primitives (the one non-primitive, `formState`, is never passed by this
+  module's single caller, confirmed via `grep -rn "useMaxSpendableAmount(" suite-native`).
+- `suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts` — **good
+  pattern**: `composeTradingTransaction` reads `store.getState()` imperatively inside the callback
+  instead of subscribing via `useSelector`, so it never depends on `account`/`draft` at all; its
+  `useCallback` deps (`[dispatch, store, tradeType, getNetworkFeeInfo]`) are all stable.
+- `suite-native/module-trading/src/hooks/general/useTradingTransaction.ts` — `draft ?? {}` (line 105) is sourced from `selectDeepCopyOfFormDraft`, which despite doing a `JSON.parse(JSON.stringify(...))` deep clone internally, _is_ wrapped in `createWeakMapSelector` keyed on the
+  underlying `selectFormDraft` result (`suite-common/wallet-core/src/formDrafts/selectors.ts:14-16`)
+  — it only re-clones when the stored draft object actually changes, not on every call. Same for the
+  shared `useFormDraft` hook (`suite-common/wallet-core/src/formDrafts/useFormDraft.ts`) used by
+  `useComposeEarnFees.ts`/`useYieldAllowanceFees.ts`/`usePreparedTxFees.ts`.
+- `suite-native/module-trading/src/hooks/buy/useBuyForm.ts`, `hooks/sell/useSellForm.ts`,
+  `hooks/exchange/useExchangeForm.ts` (and their `useBuyQuotesChangeEffect`/
+  `useSellQuotesChangeEffect`/`useExchangeQuotesChangeEffect`/`useExchangeQuoteChangeEffect`/
+  `useDexQuoteApprovalInfoChangeEffect`/`useValidations` sub-hooks) — every selector used
+  (`selectValidTradingBuyQuotesNative`, `selectValidTradingSellQuotes`, `selectGroupedExchangeQuotes`,
+  `selectExchangeSelectedSendAccount`, `selectExchangeAmountLimits`, `selectTradingExchangeProviders`)
+  is either `createWeakMapSelector`-backed or a plain state accessor — traced each definition in
+  `suite-common/trading/src/selectors/tradingSelectors.ts` and
+  `suite-native/trading-state/src/selectors/exchangeSelectors.ts`.
+  `useDexQuoteApprovalInfoChangeEffect` additionally self-guards its prefetch dispatch with
+  `pendingPrefetchQuoteIds`/`lastProcessedQuoteId` refs, so `sendAccount` reference churn can't cause
+  a duplicate `prefetchDexQuoteApprovalThunk` dispatch even though `sendAccount` is in its deps.
+- `suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.ts` — textbook correct
+  previous-value tracking: plain `useRef` assigned at the _end_ of the effect body, matching the
+  skill's own "good - `TransactionReviewModalBody.tsx:59`" shape exactly.
+- `suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.ts` +
+  `useReceiveAccountPreselectionEffect.ts` — primitive (`exchange: string`, `isFocused: boolean`) or
+  already-memoized-selector deps only.
+- `suite-native/module-send/src/components/TronNoteInput.tsx` — `useEffect(() => setLocalNote(value), [value])` seeds an editable local draft buffer from an external `useWatch`-sourced value; this is
+  the accepted "sync local edit-state from an external source" exception, not derivable state, since
+  the user can diverge from `value` while the bottom sheet is open. Uses `useWatch` (imported directly
+  from `react-hook-form`, not `@suite-native/forms` — a minor import-path inconsistency, not a perf
+  issue, since both are the same safe hook).
+- `suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts` +
+  `useAddressChecksum.ts` + `useContractAddressCheck.ts` + `useTokenAlert.ts` — the per-keystroke
+  effect is intentionally keystroke-driven (real-time inline address validation); the one network
+  call in the chain (`TrezorConnect.getAccountInfo` in `useContractAddressCheck.ts`) is gated on
+  `isFilledValidAddress` (a _complete_ valid address, not a partial one) and latched by
+  `wasContractAlertDisplayed`, so it cannot fire per-keystroke on an incomplete address.
+- `suite-native/module-send/src/screens/SendUtxoScreen.tsx:52-62` (the `fetchUtxoTransactionsForAccountThunk` mount effect) — deps `[accountKey, dispatch]`, correct minimal-key shape.
+- `suite-native/module-send/src/hooks/useSendForm.tsx` — the excluded-UTXOs `useMemo` (`:146-154`,
+  `utxos: account?.utxo ?? []`) is a false positive for class 1: the `?? []` is inside the memo
+  _body_ (an argument to `getExcludedUtxos`), not the dependency array, which lists the raw
+  `account?.utxo` reference; the memo only recomputes when that reference (or the other two deps)
+  actually changes.
+- `suite-native/module-trading` test-helper default parameters (`overrides: PreloadedStatePartial<...> = {}` and similar, dozens of hits in C4/C5) — these are `.test.tsx`/`.test.ts` mock-builder
+  functions, not render-path hooks; a fresh `{}` per test-helper call has no render/effect
+  consequence. Not itemized individually.

--- a/perf-issues/react-hooks/_scan/10-native-modules-b.md
+++ b/perf-issues/react-hooks/_scan/10-native-modules-b.md
@@ -1,0 +1,484 @@
+# Scan area 10 — suite-native remaining `module-*` + `app`
+
+Base commit `9e0d5b6a45`. Scope: every `suite-native/module-*` except `module-trading`, `module-earn`,
+`module-send` (area 09), plus `suite-native/app/**`. Concretely: `module-accounts-import`,
+`module-accounts-management`, `module-activity-center`, `module-add-accounts`,
+`module-authenticity-checks`, `module-authorize-device`, `module-check-backup`, `module-connect-popup`,
+`module-demo-account-questionnaire`, `module-dev-utils`, `module-device-onboarding`,
+`module-device-settings`, `module-home`, `module-onboarding`, `module-passphrase`, `module-receive`,
+`module-settings`, `module-stellar-token-management`, `module-transactions`, `app`. `module-notifications`,
+`module-security`, `module-staking` named in the task prompt do not exist at this commit — not a scan
+gap, the directories aren't there (`module-activity-center` is presumably the closest living relative of
+"notifications").
+
+**Method:** built an exact file list (528 non-test `.ts`/`.tsx` files under each module's `src/` +
+`app/src/`, excluding the stale `libDev` build-output mirrors that duplicate the tree and inflate a naive
+`find`). Ran the class-1/2/3/6/7 grep signatures from the brief across that exact list (not sampled),
+then read every hit plus the brief's Method-mandated hot paths (home graph, receive flow, account/tx
+detail) end to end, tracing selector definitions into `suite-common`/`suite-native/*` shared libs where
+the re-render/refetch question actually resolves.
+
+## Note on the task prompt's C1 claim
+
+The prompt states "candidates C1 has several [eslint-disable exhaustive-deps] in
+module-accounts-management, module-authorize-device, module-connect-popup, module-onboarding." Verified
+both against `00-candidates.md` and a direct repo grep: **none of those four modules contain an
+`exhaustive-deps` disable** at this commit. The six that actually exist in this area's scope are in
+`module-accounts-import` (1), `module-check-backup` (1), and `module-device-onboarding` (4) — see
+`00-candidates.md` C1. All six are reviewed below (F-10-2, F-10-5, "Checked, clean").
+
+## F-10-1 — `AccountImportConfirmFormScreen`'s token selector is unmemoized, so the screen and its `FlashList` re-render on every store dispatch while any known token has a balance
+
+- **Class:** 3 (selector returns fresh reference) compounded by 1 (fresh `?? []` argument crossing into
+  the selector call).
+- **Where:** `suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx:60-62,68`
+  (the `useSelector` call and the `nonEmptyTokens` derivation that consumes it), root cause in
+  `suite-common/token-definitions/src/tokenDefinitionsSelectors.ts:44-51`
+  (`selectFilterKnownTokens`).
+- **Trigger cadence:** every store dispatch while this screen is mounted (the account-import confirmation
+  step), whenever `selectFilterKnownTokens`'s filter result is non-empty.
+- **Severity guess:** P2 — real and unbounded for the lifetime of one screen (not per-keystroke, not a
+  root provider), confined to a single, short-lived screen with exactly one call site.
+- **Confidence:** high. Read `selectFilterKnownTokens`'s full body and confirmed it is a plain function,
+  not wrapped in `createSelector`/`createWeakMapSelector` — only its `returnStableArrayIfEmpty` wrapper
+  stabilizes the **empty** case; any non-empty result is a freshly-`.filter()`'d array on every
+  invocation. `useSelector` calls its selector argument on every dispatch to diff the result, and native
+  `useSelector` (bare `react-redux`, confirmed repo-wide ground truth) uses reference equality, so a fresh
+  array on every dispatch re-renders the component every time, regardless of whether tokens changed.
+
+### Before (verbatim from the file)
+
+```tsx
+// suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx:60-68
+const knownTokens = useSelector((state: TokenDefinitionsRootState) =>
+    selectFilterKnownTokens(state, symbol, accountInfo.tokens ?? []),
+);
+
+const deviceNetworkAccounts = useSelector((state: AccountsRootState) =>
+    selectAccountsByNetworkAndDeviceState(state, PORTFOLIO_TRACKER_DEVICE_STATE, symbol),
+);
+
+const nonEmptyTokens = knownTokens.filter(info => parseFloat(info.balance ?? '0') > 0);
+```
+
+```ts
+// suite-common/token-definitions/src/tokenDefinitionsSelectors.ts:44-51
+export const selectFilterKnownTokens = (
+    state: TokenDefinitionsRootState,
+    symbol: NetworkSymbol,
+    tokens: TokenInfo[],
+) =>
+    returnStableArrayIfEmpty(
+        tokens.filter(token => selectCoinDefinition(state, symbol, token.contract as TokenAddress)),
+    );
+```
+
+### Proposed fix
+
+Wrap `selectFilterKnownTokens` with `createWeakMapSelector` (keyed on `state`, `symbol`, and the `tokens`
+array reference) so a repeat call with the same inputs returns the cached array instead of a fresh
+`.filter()` result. Independently, fix the call site's `accountInfo.tokens ?? []`: since `accountInfo` is
+a stable prop (navigation param, not recreated per render), hoist a module-level `const EMPTY_TOKENS:
+TokenInfo[] = []` instead of an inline `?? []`, so the argument itself is stable even before the selector
+is fixed.
+
+### Why it matters
+
+`AccountImportConfirmFormScreen` renders a `FlashList` of `nonEmptyTokens` plus the account-label `Form`.
+Every unrelated Redux dispatch that happens to land while this screen is open (blockchain/discovery
+events for any enabled account, not just the one being imported) re-renders the whole screen and hands
+`FlashList` a new `data` array reference, which is more disruptive to `FlashList`'s internal recycling
+than a plain re-render.
+
+## F-10-2 — `AccountImportLoadingScreen`'s retry flow calls a stale `handleResult` closure without awaiting the retry, so tapping "Try Again" can re-show the same error before the retry resolves
+
+- **Class:** 6 (`eslint-disable react-hooks/exhaustive-deps` with a dependency array that omits a value
+  the callback actually reads through a stale closure).
+- **Where:** `suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx:56-73`
+  (`safelyShowImportError`, deps `[error, showImportError]`, omitting `handleResult`) called from
+  `:79-88` (`handleResult`, itself not memoized) and `:81` (the exact call). Co-anchor:
+  `suite-native/module-accounts-import/src/useShowImportError.ts:81-91` (`onPressPrimaryButton: onRetry`
+  fires on a user tap, arbitrarily later).
+- **Trigger cadence:** once per user tap of "Try Again" on the import-error alert.
+- **Severity guess:** P2 — not a render loop, but a real correctness bug in an error-recovery path with
+  direct user impact (retry may appear to silently re-fail).
+- **Confidence:** medium — the closure-staleness mechanism is fully traced and verifiable from the code
+  (see Before), but I did not run the app to confirm the exact race resolves the way I describe on-device;
+  React's state-update batching could narrow or widen the window.
+
+### Before (verbatim from the file)
+
+```tsx
+// suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx:56-73
+const safelyShowImportError = useCallback(
+    async (onRetry?: () => Promise<void>) => {
+        await resolveAfter(1000);
+        showImportError(error, () => {
+            if (!onRetry) return;
+            onRetry();
+
+            // This is needed because handleResult calls safelyShowImportError, which calls handleResult,
+            // so one of them is always going to be used before it was defined. However, the functionality is fine here so it's not a problem.
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define, react-hooks/immutability
+            handleResult();
+        });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [error, showImportError],
+);
+```
+
+`onRetry` here is `fetchAccountInfo` (line 81), an `async` function. It is invoked without `await`, and
+`handleResult()` — a plain, unmemoized closure captured whenever `safelyShowImportError` was last created
+— runs on the very next line, reading `error`/`accountInfo` from whatever render produced _that_ closure,
+not from the retry's eventual outcome.
+
+### Proposed fix
+
+Await the retry before deciding what to do next, and stop relying on a closure-captured `handleResult`:
+`await onRetry?.()` inside the alert callback, then re-derive the "did it succeed" check from the
+callback's own return value or from state read imperatively at that point, rather than calling a
+pre-existing `handleResult` reference. This removes the temporal-dead-zone problem that forced the
+disable in the first place.
+
+### Why it matters
+
+The code comment already flags the mutual-recursion awkwardness but concludes "the functionality is fine
+here" — tracing the actual call order shows the retry's result is not awaited before `handleResult()`
+re-checks `error`/`accountInfo`, so the error alert can plausibly reappear (or the retry's outcome can be
+silently dropped) exactly when a user is trying to recover from a failed account import.
+
+## F-10-3 — `AccountDetailContentScreen`'s analytics-report effect depends on the whole `account` object, so it refires (and double-reports) on every data update to the currently-viewed account
+
+- **Class:** 1 (minimal required dependencies — "`accountKey`, not `account`" — applied to an effect
+  rather than a fetch).
+- **Where:** `suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx:24-39`.
+  Co-anchor: `suite-native/module-accounts-management/src/screens/AccountDetailScreen.tsx:36-38`, where
+  `account` is sourced from `selectAccountByKey` (memoized, `.find()`-based — confirmed in
+  `_scan/08-native-shared.md`'s clean list — so it returns a **new** reference precisely when that
+  account's Redux entry is genuinely replaced: new transaction, balance/history update, label change,
+  etc., not on unrelated renders).
+- **Trigger cadence:** every time the open account's data updates while this screen is focused — bounded
+  by real blockchain/backend activity, not per-render, but well above "once per screen view."
+- **Severity guess:** P2 — not a performance/render-loop issue (the re-render itself is legitimate,
+  content actually changed), but a data-quality bug: `assetDetailEvent` analytics fires again on every
+  refresh of the account being viewed, not once per navigation.
+- **Confidence:** high on the mechanism; medium on real-world frequency (depends on how often the
+  specific account being viewed receives new transactions/balance updates while the screen stays open).
+  This file is also cited in `perf-issues/scheduling/p1-17-...md`, but that doc is about
+  `AccountDetailGraph`'s refetch-vs-navigation-transition race (a different line, different mechanism,
+  same screen) — no overlap with this finding.
+
+### Before (verbatim from the file)
+
+```tsx
+// suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx:24-39
+const token = useSelector((state: TokensRootState) =>
+    selectAccountTokenInfo(state, account.key, tokenContract),
+);
+
+useEffect(() => {
+    if (account) {
+        analytics.report({
+            type: events.assetDetailEvent.name,
+            payload: {
+                assetSymbol: account.symbol,
+                tokenSymbol: token?.symbol,
+                tokenAddress: token?.contract,
+            },
+        });
+    }
+}, [account, token?.symbol, token?.contract, analytics, token]);
+```
+
+(Note the dep array also lists both `token` and its two destructured fields — redundant, and a sign the
+array was widened rather than narrowed while chasing a lint warning.)
+
+### Proposed fix
+
+Depend on `account.key` (already available, a stable string) instead of `account`, and drop the
+redundant `token`/`token?.symbol`/`token?.contract` triple down to the two primitive fields actually used
+in the payload:
+
+```tsx
+useEffect(() => {
+    analytics.report({
+        type: events.assetDetailEvent.name,
+        payload: {
+            assetSymbol: account.symbol,
+            tokenSymbol: token?.symbol,
+            tokenAddress: token?.contract,
+        },
+    });
+}, [account.key, token?.symbol, token?.contract, analytics]);
+```
+
+(`account` is a required prop here, not optional, so the `if (account)` guard was already dead code.)
+
+### Why it matters
+
+Account Detail is one of the most frequently visited screens in the app. As written, every balance tick
+or new transaction for the account the user happens to be looking at fires another `assetDetailEvent`,
+so the metric silently stops meaning "the user opened this asset's detail screen" and starts meaning
+"...and then some unrelated amount of data refreshed while they stayed there."
+
+## F-10-4 — `useDayCoinPriceChange` computes a derived percentage via a second `useEffect` + `setState` instead of `useMemo`, costing an extra render on every price refresh
+
+- **Class:** 2 / native rule (d), derived-state-in-effect.
+- **Where:** `suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts:82-88`. Sole
+  consumer: `suite-native/module-accounts-management/src/components/AssetPriceCard.tsx:74-77`.
+- **Trigger cadence:** once on mount and again every 30s poll tick (`REFRESH_INTERVAL`, line 22) for as
+  long as `AssetPriceCard` is mounted on the Account Detail screen.
+- **Severity guess:** P3 — single, non-list component; the extra render is real but cheap and infrequent.
+- **Confidence:** high on the mechanism (this is the skill's canonical "state that can be computed from
+  what you already have" shape, verbatim).
+
+### Before (verbatim from the file)
+
+```ts
+// suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts:82-88
+useEffect(() => {
+    if (isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(weekAgoValue)) {
+        setValuePercentageChange(percentageDiff(weekAgoValue, currentValue.toNumber()));
+    } else {
+        setValuePercentageChange(null);
+    }
+}, [currentValue, weekAgoValue]);
+```
+
+### Proposed fix
+
+Derive it during render — no state, no second effect:
+
+```ts
+const valuePercentageChange =
+    isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(weekAgoValue)
+        ? percentageDiff(weekAgoValue, currentValue.toNumber())
+        : null;
+```
+
+Drop the `valuePercentageChange`/`setValuePercentageChange` `useState` entirely.
+
+### Why it matters
+
+Every time the hook's first effect resolves a new price pair (mount, and every 30s thereafter),
+`currentValue`/`weekAgoValue` update, the component renders once with the new prices but a stale
+`valuePercentageChange`, then the second effect fires and forces a second render with the corrected
+value — a guaranteed double-render per price refresh for no reason, since the value is a pure function of
+state already in hand.
+
+## F-10-5 — `DeviceTutorialScreen` pairs `useFocusEffect` (re-runs on every focus) with an empty dependency array and a comment claiming "first render only," permanently freezing the `device` it acts on
+
+- **Class:** 6 (`eslint-disable react-hooks/exhaustive-deps` whose stated intent contradicts the hook
+  actually used).
+- **Where:** `suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx:22-38`.
+- **Trigger cadence:** every time this screen regains focus (if reachable more than once) — unknown
+  today whether that happens in practice.
+- **Severity guess:** P3 — I could not find a back-navigation path onto this screen in this area's slice
+  of the navigator (it's reached via `navigation.replace`, which removes the previous screen from the
+  stack), so it is plausibly equivalent to mount-once today.
+- **Confidence:** medium. The mismatch between the hook's documented semantics and the comment is certain
+  (read verbatim below); whether it's currently exercised more than once is not something I could fully
+  rule out without tracing every navigator that can push/replace onto `DeviceTutorial`.
+
+### Before (verbatim from the file)
+
+```tsx
+// suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx:19-38
+export const DeviceTutorialScreen = ({
+    navigation,
+}: StackProps<DeviceOnboardingStackParamList, DeviceOnboardingStackRoutes.DeviceTutorial>) => {
+    const device = useSelector(selectSelectedDevice);
+    useInterceptNativeNavigation();
+
+    useFocusEffect(
+        useCallback(() => {
+            const showTutorial = async () => {
+                await requestPrioritizedDeviceAccess(() =>
+                    TrezorConnect.showDeviceTutorial({ device }),
+                );
+                navigation.replace(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
+            };
+            showTutorial();
+
+            // This use effect should be triggered only during the first render
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []),
+    );
+```
+
+### Proposed fix
+
+Either (a) the intent is genuinely "run once, ever" — use a plain `useEffect(() => {...}, [])` instead of
+`useFocusEffect`, since `useFocusEffect`'s entire purpose is re-running on focus; or (b) the intent is
+"re-show the tutorial trigger with the current device every time this screen is focused" — in which case
+add `device` to the `useCallback` deps and drop the disable. Either reading is a one-line fix; the current
+combination asserts both semantics at once and they don't agree.
+
+### Why it matters
+
+If a future navigator change ever pushes (rather than replaces) onto this screen, or renders it inside a
+navigator that preserves mounted screens, `useFocusEffect` will fire again on refocus but with the
+`device` object frozen from the very first focus — silently calling `TrezorConnect.showDeviceTutorial`
+with a stale device if the connected device changed in between. No lint error would catch this; the
+suppression is exactly the "lying dependency array" shape the skill warns about, whether or not it is
+live today.
+
+## F-10-6 — `TransactionDetailScreen`'s analytics-report effect has the same whole-object dependency shape as F-10-3, lower frequency
+
+- **Class:** 1 (minimal required dependencies).
+- **Where:** `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx:58-69` (deps
+  `[transaction, tokenTransfer, analytics]`); `transaction` sourced from
+  `suite-native/transaction-management/src/hooks/useTransactionDetails.ts:28-33`
+  (`selectTransactionByAccountKeyAndTxid`, a keyed store lookup — not verified memoized to the same
+  standard as `selectAccountByKey`, see Confidence). This file is also cited in
+  `perf-issues/scheduling/p1-03-...md` at line 53 (`useFetchMissingTransactionFiatRates`) — a different
+  line and a different concern (asymptotic scan cost vs. this effect's dependency shape); no overlap.
+- **Trigger cadence:** every time the open transaction's own record updates (e.g. pending → confirmed) —
+  a transaction typically makes that transition once, so this is much lower-frequency than F-10-3's
+  whole-account case.
+- **Severity guess:** P3 — same mechanism as F-10-3, but the triggering object (`transaction`) changes far
+  less often than `account` does in practice (one confirmation transition vs. every balance/history tick).
+- **Confidence:** medium — I did not trace `selectTransactionByAccountKeyAndTxid`'s own memoization the
+  way F-10-3's `selectAccountByKey` was independently confirmed clean in area 08; if it turns out to
+  return a fresh object on unrelated dispatches (unlike the accounts selector), this would be as frequent
+  as F-10-3, not rarer.
+
+### Before (verbatim from the file)
+
+```tsx
+// suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx:58-69
+useEffect(() => {
+    if (transaction) {
+        analytics.report({
+            type: events.transactionDetailEvent.name,
+            payload: {
+                assetSymbol: transaction.symbol,
+                tokenSymbol: tokenTransfer?.symbol,
+                tokenAddress: tokenTransfer?.contract,
+            },
+        });
+    }
+}, [transaction, tokenTransfer, analytics]);
+```
+
+### Proposed fix
+
+Same shape as F-10-3: depend on the stable identifiers already destructured from `route.params`
+(`txid`, `accountKey`) instead of the `transaction`/`tokenTransfer` objects derived from them.
+
+### Why it matters
+
+Same data-quality concern as F-10-3 (duplicate `transactionDetailEvent` reports), scoped to whatever rate
+the viewed transaction's own record changes while the detail screen is open.
+
+## Checked, clean
+
+- **Home screen portfolio graph** (`PortfolioGraph.tsx`, `PortfolioLineGraph.tsx`,
+  `homescreenSelectors.ts`, all of `module-home`): every selector consumed is either a named,
+  `createWeakMapSelector`-based selector from `@suite-native/graph`/`@suite-common/device` (package
+  already swept clean in area 08) or a direct state-path read; no inline derivation in the module-home
+  layer itself. `HomeScreen.tsx`, `TransferButtons.tsx`, `HomescreenAlerts.tsx`,
+  `SuiteSyncKeysAlert.tsx`, etc. — every `useSelector` in this module resolves to a plain named selector,
+  none matched the fresh-reference grep signatures.
+- **Receive flow** (`module-receive`, the brief's named hot path): `ReceiveAddressListScreen.tsx`,
+  `ReceiveAddressListGenerateButton.tsx`, `ReceiveAddressCard.tsx`, and `module-receive/src/selectors.ts`
+  — the local selectors file is a model example: `createWeakMapSelector`-wrapped where derivation happens
+  (`selectReceiveAccountSuiteSyncAddressLabels`, `selectReceiveAccountLabeledUnusedAddresses`) with
+  module-level `EMPTY_ADDRESS_LABELS`/`EMPTY_RECEIVE_INFOS` constants (the skill's own "good" pattern),
+  and plain pass-throughs elsewhere that delegate to already-memoized `suite-common` selectors
+  (`selectAccountByKey`, `selectTouchedAddresses`, `selectPendingAccountAddresses` — each individually
+  confirmed `createMemoizedSelector`-based by reading their definitions). `ReceiveAddressListScreen.tsx`'s
+  own `useMemo`/`useCallback` deps are correctly narrowed (`addresses.length`, `currentFreshAddress?.path`,
+  not the whole array/object).
+- **`suite-native/app` root composition** (`App.tsx`, `useGlobalHooks.tsx`,
+  `RootStackNavigatorGlobalHooksWrapper.tsx`, `ModalsRenderer.tsx`, `BannersRenderer.tsx`,
+  `useReportAppInitToAnalytics.ts`, `InitRoseniteDevTools.tsx`): both `useEffect`s in `App.tsx` key on
+  stable/primitive deps (`dispatch`, `isAppReady`) and the mount-dispatch is additionally ref-guarded.
+  `FormatterProvider config={formattersConfig}` — `useFormattersConfig` returns a fresh object per render
+  by design, but this is already documented as the _correct_ reference pattern in `_scan/06-suite-common.md`
+  F-06-2, not a new finding. No `Context.Provider` is authored directly in `app/src` — all providers are
+  imported from already-audited packages.
+- **`useGlobalHooks.tsx`'s `useReportDeviceCompromised({ device })`**: the inline `{ device }` wrapper
+  crosses into `@suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts`, which looked like
+  a class-1 cross-hook-boundary risk at first read, but `useCommonData` (line 25-35 of that file)
+  immediately destructures `device` into four primitives and memoizes on those, never on `device` or the
+  wrapper object itself — correctly narrowed, matches the skill's own prescription exactly.
+- **`useConnectPopupNavigation.ts`** (`module-connect-popup`, mounted once at the app root via
+  `useGlobalHooks`, so any instability here would be highest-blast-radius): all three effects' object
+  deps (`connectPopupCall` from `selectConnectPopupCall`, `walletConnectProposal` from
+  `selectPendingProposal`) resolve to plain `state.x.y` property reads in their reducers — confirmed by
+  reading both selector definitions — so they're stable across unrelated dispatches; the third effect
+  additionally self-guards via a `lastProposalId` ref keyed on `eventId`.
+- **`ConnectPopupScreen.tsx`**: `setAddressConfirmation(popupCall)` inside a `useEffect` whose own deps
+  include `addressConfirmation` looks like derived-state-in-effect at first glance, but (a) `popupCall`
+  is stable (see above) so the effect isn't refiring per-render, and (b) the self-referential dependency
+  is a legitimate "remember a value across a later, different Redux state" bridge (the confirmation data
+  is gone from `popupCall` by the time state reaches `'deeplink-callback'`), not simple derivable state.
+  It repeats itself exactly once per relevant transition and then bails via `Object.is` on the identical
+  `popupCall` reference — bounded, not filed.
+- **`AccountDetailGraph.tsx`**: `accountItem` from `selectAccountItemForGraph`
+  (`module-accounts-management/src/selectors.ts:31`) is `createWeakMapSelector`-based;
+  `accounts = useMemo(() => accountItem ? [accountItem] : undefined, [accountItem])` correctly narrowed;
+  `graphInstanceId` is recomputed every render via `getAccountGraphInstanceId` but returns a primitive
+  string, so its presence in the cleanup-effect's deps is harmless regardless.
+- **`module-device-settings/src/selectors.ts`** (`selectDeviceAutoConnectCredentials`, a C4b candidate):
+  the `?? []` fallback lives inside a `createWeakMapSelector` combiner — reselect-style memoization
+  returns the same cached array between recomputations of its own inputs (`device`, `thpCredentials`),
+  so the fallback allocation only happens on genuine input changes, not per render.
+- **`useInactiveStellarTokens.ts`** (C4b candidate, `?? []` at line 52): the value it's derived from,
+  `coinDefinitions?.data`, traces back to `selectCoinDefinitions` — a plain `state.tokenDefinitions?.[symbol]?.coin`
+  property read, stable unless that state slice is genuinely replaced; the surrounding `useMemo`s are
+  correctly keyed on that stable reference.
+- **`AccountAssetsScreen.tsx`** (C3 candidate): all four `useSelector` calls
+  (`selectAccountByKey`, `selectAccountListSectionsWithZeroBalanceGroup`,
+  `selectAccountDefiTokensCount`, `selectAccountManuallyHiddenTokensCount`) resolve to memoized
+  selectors; the `sections.filter(...)` at line 72 is render-body work over a small, bounded per-account
+  section list and native is compiled — not reportable per this area's native rules regardless.
+- **`AddCoinDiscoveryFinishedScreen.tsx`** (C3 candidate): `selectDeviceAccountsByNetworkSymbol` is
+  `createMemoizedSelector`-based; the trailing `.filter(a => !a.empty)` runs on the render body only
+  (feeds JSX directly, not a further hook dependency) — not reportable on native.
+- **`AccountsScreen.tsx`**'s `networksFilter` `useMemo` (C4 candidate): same reasoning already
+  established in `_scan/08-native-shared.md` F-08-4 — the memo's dependency
+  (`route.params?.networksFilter`) only changes on genuine navigation-param changes, so the `?? []`
+  fallback allocation is correctly gated.
+- **`WalletConnectSessionPopupScreen.tsx`** (C4/C3 candidate): `selectAllAccountsToList` is
+  `createMemoizedSelector`-based; `selectPendingProposal` is a plain stable state-path read; the
+  `selectableAccounts` `useMemo` deps are therefore both legitimately stable.
+- **`MessageSystemManagerScreen.tsx`** (C4 candidate, dev-only debug screen): `selectMessageSystemConfig`
+  is a plain `state.messageSystem.config` read, stable; the `filteredActions` `useMemo` is correctly
+  gated on it.
+- **Four of the six C1 `eslint-disable exhaustive-deps` sites are the accepted "run exactly once, using
+  the mount-time closure" idiom**, matching the precedent already established for
+  `FirmwareInstallationScreenContent.tsx` in `_scan/08-native-shared.md`: `DeviceAuthenticityScreen.tsx:38-43`,
+  `DeviceDisconnectedScreen.tsx:49-71`, `UninitializedDeviceLandingScreen.tsx:131-142`, and
+  `useCheckBackupOnMount.tsx:29-67` (this last one's captured `dispatch`/`navigation`/`analytics` are each
+  independently stable, so there is no closure-staleness risk to flag, unlike F-10-2).
+- **`DeviceAuthenticityStackNavigator.tsx`**: the `checkDeviceAuthenticity`/`handleSuccess`/`handleFailure`
+  effect is self-guarded by an `isAuthenticityCheckStarted` state flag, so it's bounded to one dispatch
+  regardless of whether those callbacks are stable across renders.
+- **`AddCoinDiscoveryRunningScreen.tsx`** (C9-adjacent): the `changeCoinVisibility` dispatch branch is
+  guarded by `!enabledNetworkSymbols.includes(networkSymbol)`, which becomes false once the dispatch's
+  own effect lands in the store — self-terminating on data content, not on reference identity, so it
+  doesn't matter whether `enabledNetworkSymbols` itself is a stable reference.
+- **`ConnectBluetoothDeviceScreen.tsx` / `TurnOnAndUnlockDeviceScreen.tsx`** (bluetooth device list
+  effects): both key on `selectNearbyPairableBluetoothDevices`, `createMemoizedSelector`-based in
+  `suite-native/bluetooth` (package already broadly confirmed clean in area 08).
+- **`useIsConnectPopupOpened.ts`**: standard React Navigation `getParent()`/`addListener('state', ...)`
+  idiom; `rootNavigation` is a library-managed stable reference.
+- **`ManualTokenInputScreen.tsx`** (stellar token add flow): its two validation effects key on primitive
+  strings (`assetCode`, `issuerAddress`) only — standard validate-on-change, no instability.
+- **Full `useEffect` inventory across all 528 in-scope files** (one exhaustive grep, not a sample): every
+  call site was read in context; besides the six findings above, the remainder are either keyed on
+  primitives, cleanup-only, guarded by a ref/state flag that self-terminates after one run, or (for
+  `useStellarFeeScreen.ts`'s sheet reveal/close effect) call idempotent UI actions where even an unstable
+  dependency wouldn't produce an observable bug — not filed for that reason.
+- **Zero `watch()` calls, zero `useFreshRef`/`useCurrentRef` sites** anywhere in this area's scope,
+  confirmed by grep against the exact 528-file list (matches C2's repo-wide "0" and extends area 08's
+  "all 41 `useFreshRef`/`useCurrentRef` sites live in `packages/suite` or `module-trading`" finding to the
+  rest of `module-*`).
+- **Class 4 (render-body relocation) and class 5 (Provider-value memoization) are out of scope for this
+  entire area**: every file here is `suite-native` (React-Compiler-compiled) or the compiled app shell;
+  class 5 is explicitly web-only per the brief, and class 4 render-body work is compiler-handled on
+  native, so neither was evaluated as a finding source here even where `.filter`/`.map` appear in render
+  bodies.

--- a/perf-issues/react-hooks/_scan/_agent-brief.md
+++ b/perf-issues/react-hooks/_scan/_agent-brief.md
@@ -1,0 +1,110 @@
+# Scan agent brief — react-hooks perf sweep
+
+You are one scan agent in a repo-wide sweep of trezor-suite against
+`skills/performance-react-hooks/SKILL.md`. Read that skill file first, end to end. Then read
+`perf-issues/react-hooks/PROGRESS.md` — its "Repo ground truth" and exclusion lists are binding.
+Your task prompt names your area (directories) and your output file.
+
+## What counts as a finding (the only seven classes)
+
+1. **Unstable hook dependency** — `?? []`, `?? {}`, destructuring/parameter defaults `= []`/`= {}`,
+   an inline arrow/object, or a `.filter()`/`.map()`/`.slice()`/spread result feeding a `useMemo`,
+   `useCallback` or `useEffect` dep array — directly, or across a hook boundary (value produced in
+   component, consumed in a custom hook's memo). `exhaustive-deps` cannot see these. The memo below
+   never hits / the effect refires per render.
+2. **Effect refetch / render loop** — a `useEffect` that dispatches a fetch/thunk or calls
+   `setState`, keyed on an unstable dep (whole `account`/`device` object, fresh array). Classify:
+   silent request loop (fetch writes back to store → paced by network), synchronous setState loop,
+   or bounded-but-wasteful. This is the highest-value class — look hardest for it.
+3. **Selector returns fresh reference** — `useSelector(state => ...map/filter/Object.values/{...})`
+   or a non-memoized exported selector that allocates. On native (no shallowEqual): re-render on
+   every dispatch. On web (shallowEqual default): absorbed at the component, but still unstable as
+   a downstream dep → report as class 1 if it feeds a memo/effect. A memoized selector whose
+   argument is a fresh array/object per call (memo never holds) also lands here.
+4. **Render-body work that belongs elsewhere** — bare `.find`/`.filter`/`.sort`/`.reduce` over
+   `accounts`, `tokens`, `transactions`, `utxos`, `vaults` or similar unbounded lists in a
+   component body (web/suite-common only — native is compiled). Only report if the list is real
+   (unbounded or user-scaling), not a 5-element constant.
+5. **Missing memoization where identity matters (web only)** — context Provider `value={{...}}` /
+   inline object recreated per render with many consumers; unstable prop defeating a `memo()`d
+   child that is expensive (lists, rows). Don't report generic "could add memo".
+6. **Wasted / wrong memoization** — `useMemo`/`useCallback` whose deps are unstable by
+   construction (memo never hits, pure overhead); memoizing O(1) arithmetic (only worth reporting
+   in a batch cleanup doc); `eslint-disable react-hooks/exhaustive-deps` sites where the lying dep
+   array hides a bug or staleness (each is a finding — cite what the array omits); react-hook-form
+   `watch()` inside compiled suite-native code (compiler bail-out — the whole component loses
+   auto-memoization).
+7. **Wrong ref hook for previous-value semantics** — `useFreshRef`/`useCurrentRef` used where the
+   code needs the _previous_ value in an effect (transition detection): `useFreshRef` assigns
+   during render so the transition is never seen; `useCurrentRef`'s own effect runs first. Also the
+   reverse: a manual ref-assign-in-render pattern that should be one of the helpers.
+
+Out of scope (other audits own these): algorithmic complexity of the work itself, long-task
+chunking, forced layout, converting fetches to TanStack Query. If a finding is "this filter is
+O(n²)" → skip; if it is "this filter re-runs per render because its dep is unstable" → yours.
+
+## Method
+
+1. Start from your area's rows in `perf-issues/react-hooks/_scan/00-candidates.md` (grep harvest) —
+   verify each candidate by reading the file. A candidate is not a finding until you've read the
+   surrounding hook/component and can say what re-runs and why it matters.
+2. Then sweep on your own: prioritize hot paths — per-row components in lists (transactions,
+   accounts, tokens, UTXOs), things rendered during discovery/sync, form fields that re-render per
+   keystroke, dashboard/graph. Use grep for the class signatures, read the hits.
+3. For every reported finding, read enough context to name the _consumer_ that re-runs (which
+   memo/effect/child) and the _trigger_ cadence (every render / every dispatch / every keystroke /
+   every fiat-rate tick).
+4. Check exclusions: `grep -rl "<basename>" perf-issues/asymptotic-complexity perf-issues/scheduling`
+   plus the anchor list in PROGRESS.md. If an anchor is already drafted/filed, skip it (note it
+   under "checked, already covered").
+
+## Output — write to your assigned `_scan/NN-<area>.md`
+
+For each finding, one section:
+
+````markdown
+## F-<areaNN>-<n> — <one-line title: file + what re-runs>
+
+- **Class:** 1–7 (name it)
+- **Where:** `path/from/repo/root.tsx:line` (+ every co-anchor)
+- **Trigger cadence:** every render of X / every store dispatch / per keystroke / per row
+- **Severity guess:** P1 (hot or unbounded) / P2 (real but colder) / P3 (cleanup)
+- **Confidence:** high / medium (say what would change your mind)
+
+### Before (verbatim from the file)
+
+```tsx
+<exact code, enough lines to compile the picture>
+```
+````
+
+### Proposed fix
+
+<2–6 lines: the mechanism (module constant / returnStableArrayIfEmpty / narrow the dep to the
+primitive / derive-don't-store / move to memoized selector / plain useRef), and any type/import
+it needs.>
+
+### Why it matters
+
+<1–3 sentences naming consumer + cadence. No invented numbers — nothing here is measured.>
+
+```
+
+End the file with `## Checked, clean` — the files/patterns you inspected that are fine or already
+covered, one line each with a reason. That negative space is kept forever; it saves the next
+sweep from re-reading them.
+
+## Honesty rules
+
+- Before hunks verbatim from the working tree; cite lines you actually read.
+- No measurements, no invented milliseconds.
+- If unsure which class or whether the dep is really unstable at its declaration, say so in
+  Confidence and keep it — triage decides.
+- Skill contradictions (you find the skill's claim false in code) are findings too — flag them
+  loudly; a prior audit caught a deprecated-stub API this way.
+
+## Return value (your final message)
+
+≤8 lines: finding count by severity, the single hottest finding (one sentence), anything that
+blocks other areas. Do NOT paste the findings back — they live in your file.
+```

--- a/perf-issues/react-hooks/_scan/_docmap.tsv
+++ b/perf-issues/react-hooks/_scan/_docmap.tsv
@@ -1,0 +1,44 @@
+docid	filename	sev	sources	scanfiles	note
+p1-01	p1-01-uselayout-effect-keyed-on-inline-jsx-rerenders-app-shell.md	P1	F-01-1	01-suite-hooks.md
+p1-02	p1-02-useaccountsearch-provider-value-recreated-every-render.md	P1	F-01-2	01-suite-hooks.md
+p1-03	p1-03-cancel-tx-compose-refires-on-account-churn.md	P1	F-01-3,F-02-1,F-02-15	01-suite-hooks.md,02-suite-components.md	MERGE: hook (F-01-3) + its modal caller (F-02-1) are one defect chain — one doc, both anchors; fold F-02-15 (CancelTxContext provider value) in as a same-PR cleanup note.
+p1-04	p1-04-addtokenmodal-refetches-account-info-per-account-refresh.md	P1	F-02-2	02-suite-components.md
+p1-05	p1-05-graphtooltipbase-effect-keyed-on-whole-props.md	P1	F-02-3	02-suite-components.md	Distinct from filed #31137 (setWidth) — state that explicitly in the lead.
+p1-06	p1-06-transactionsgraph-rebuilds-interval-data-per-hover-render.md	P1	F-02-4	02-suite-components.md	Distinct from filed #31137 — say so; cross-reference p1-05 as sibling draft (hover cadence source).
+p1-07	p1-07-suitelayout-scrollcontext-value-unmemoized.md	P1	F-02-5	02-suite-components.md
+p1-08	p1-08-feescontext-provider-hands-14-consumers-fresh-object.md	P1	F-03-5	03-wallet-earn-comp.md
+p1-09	p1-09-yield-pending-tx-poll-keys-on-whole-account.md	P1	F-03-6	03-wallet-earn-comp.md	Cite the correct Tron sibling (useTronStakePendingTransactionTracking.ts:56) as the in-repo fix template.
+p1-10	p1-10-coincontrol-refetches-utxo-transactions-on-account-churn.md	P1	F-04-1	04-views-wallet.md	Note relation to asymptotic-complexity drafts on the same path (additive, not duplicate).
+p1-11	p1-11-responsivecontext-provider-rerenders-app-shell.md	P1	F-05-1	05-views-rest.md
+p1-12	p1-12-assetsview-rebuilds-assetrow-props-every-render.md	P1	F-05-2,F-05-3	05-views-rest.md	MERGE: parent props pipeline (F-05-2) + per-row AssetCoinLogo recompute (F-05-3) — one doc, two anchors; note additive to asymptotic-complexity p2-26.
+p1-13	p1-13-useapprovalstep-effect-can-double-fire-quote-refresh.md	P1	F-06-1	06-suite-common.md
+p1-14	p1-14-formatterprovider-memo-defeated-on-web.md	P1	F-06-2	06-suite-common.md	Fix is in packages/suite (useFormattersConfig.ts); native counterpart is the correct sibling.
+p1-15	p1-15-table-context-value-rerenders-all-rows-on-scroll-edge.md	P1	F-07-1	07-shared-components.md
+p1-16	p1-16-usetranslatedmessages-double-renders-app-at-cold-start.md	P1	F-08-1	08-native-shared.md	Native: fix is derive-in-render (useMemo is fine here — it replaces state, not adds memoization; explain per native rules).
+p1-17	p1-17-native-fee-compose-effects-key-on-whole-account.md	P1	F-09-1,F-09-2,F-09-3,F-09-4,F-09-5	09-native-modules-a.md	MERGE: one family doc, five anchors (yield deposit/withdraw/approval chain, useSendForm ×2, useComposeEarnFees, useEvmApprovalFees); cite the three correct siblings the scan names as fix template.
+p2-01	p2-01-usetradingcomposetransaction-whole-device-dep.md	P2	F-01-4	01-suite-hooks.md
+p2-02	p2-02-usetotalfiatbalance-recomputes-unmemoized.md	P2	F-01-6	01-suite-hooks.md
+p2-03	p2-03-usecurrentref-read-inside-usememo-three-sites.md	P2	F-02-6,F-04-6	02-suite-components.md,04-views-wallet.md	MERGE: identical class-7 defect at 3 sites (Send picker + two Trading asset pickers) — one doc, all anchors, one fix pattern (useFreshRef or list the dep).
+p2-04	p2-04-connectionglobalmodalcontext-value-unmemoized.md	P2	F-02-7	02-suite-components.md
+p2-05	p2-05-suitebanners-filters-accounts-every-render.md	P2	F-02-8	02-suite-components.md
+p2-06	p2-06-accountname-exhaustive-deps-suppression.md	P2	F-02-9	02-suite-components.md
+p2-07	p2-07-tokeniconset-memo-defeated-by-wrapper.md	P2	F-03-2,F-07-3	03-wallet-earn-comp.md,07-shared-components.md	MERGE: wrapper recompute (F-03-2) defeats inner memo (F-07-3) — one doc; explicitly distinct from asymptotic-complexity p2-17 (pass row's own accounts).
+p2-08	p2-08-accountsection-gettokens-per-sidebar-row.md	P2	F-03-4	03-wallet-earn-comp.md
+p2-09	p2-09-earn-staking-dashboard-filter-crosses-hook-boundary.md	P2	F-03-7	03-wallet-earn-comp.md
+p2-10	p2-10-transactionitem-createtargets-unmemoized.md	P2	F-03-8	03-wallet-earn-comp.md
+p2-11	p2-11-tokenselect-revalidation-keyed-on-whole-account.md	P2	F-04-2	04-views-wallet.md
+p2-12	p2-12-usebuildtokenoptions-keyed-on-whole-account.md	P2	F-04-3	04-views-wallet.md
+p2-13	p2-13-ethereumnonce-refilters-history-per-keystroke.md	P2	F-04-4	04-views-wallet.md	Hooks angle only — complexity of the scan itself stays out; check overlap with asymptotic-complexity p2-28 (getOwnEvmNonceSets) and cross-reference instead of duplicating.
+p2-14	p2-14-tokensnavigation-tab-counts-per-render.md	P2	F-04-5	04-views-wallet.md
+p2-15	p2-15-trading-forms-bare-watch-rerenders-per-keystroke.md	P2	F-04-7	04-views-wallet.md	Five anchors, one doc (web trading forms; scoped watch()/useWatch fix).
+p2-16	p2-16-pinstep-effect-keyed-on-whole-device.md	P2	F-05-4	05-views-rest.md
+p2-17	p2-17-virtualizedlist-scroll-debounce-reset-by-caller.md	P2	F-07-2	07-shared-components.md	Distinct from asymptotic-complexity p2-11 (prefix sums) — say so.
+p2-18	p2-18-usenetworkselect-memos-defeated-per-keystroke.md	P2	F-07-4	07-shared-components.md
+p2-19	p2-19-menu-rebuilds-global-keydown-listeners.md	P2	F-07-5	07-shared-components.md
+p2-20	p2-20-selectfilterknowntokens-unmemoized-native.md	P2	F-10-1	10-native-modules-b.md	Fix in suite-common/token-definitions selector; consumer evidence is the native screen.
+p2-21	p2-21-accountimportloading-stale-retry-closure.md	P2	F-10-2	10-native-modules-b.md
+p2-22	p2-22-native-analytics-effects-whole-account-deps.md	P2	F-10-3,F-10-6	10-native-modules-b.md	MERGE: same defect shape, two screens — one doc, both anchors.
+p3-01	p3-01-cleanups-suite-hooks-and-components.md	P3	F-01-5,F-01-7,F-01-8,F-02-10,F-02-11,F-02-12,F-02-13,F-02-14,F-03-1,F-03-3,F-03-9	01-suite-hooks.md,02-suite-components.md,03-wallet-earn-comp.md	BATCH doc: one ### section per finding (Where/Before/After compressed); one issue, one PR.
+p3-02	p3-02-cleanups-suite-views-and-support.md	P3	F-04-8,F-04-9,F-05-5,F-05-6,F-05-7,F-05-8	04-views-wallet.md,05-views-rest.md	BATCH doc.
+p3-03	p3-03-cleanups-suite-common-and-design-system.md	P3	F-06-3,F-06-4,F-06-5,F-07-6,F-07-7	06-suite-common.md,07-shared-components.md	BATCH doc.
+p3-04	p3-04-cleanups-suite-native.md	P3	F-08-2,F-08-3,F-08-4,F-09-6,F-09-7,F-09-8,F-09-9,F-09-10,F-10-4,F-10-5	08-native-shared.md,09-native-modules-a.md,10-native-modules-b.md	BATCH doc; F-09-10 is low-confidence — include with an explicit verify-first caveat.

--- a/perf-issues/react-hooks/_scan/_writer-brief.md
+++ b/perf-issues/react-hooks/_scan/_writer-brief.md
@@ -1,0 +1,83 @@
+# Writer brief — one document per proposed GitHub issue (react-hooks sweep)
+
+You write issue-ready documents into `perf-issues/react-hooks/`. Each document is the body of one
+future GitHub issue on `trezor/trezor-suite`. Follow this brief exactly; it is the house style for
+the whole set.
+
+## Inputs you must read first
+
+1. This file.
+2. `skills/performance-react-hooks/SKILL.md` — name the skill section your finding belongs to.
+3. Your assigned `## F-*` section(s) in the `_scan/NN-*.md` file named by your assignment.
+4. **The actual source files** — re-read every cited location in the working tree before writing.
+   The scan's Before hunk is a claim, not a fact; if the code differs, the file wins and you adjust
+   (and say so in Notes).
+
+## Document structure (structure of issue #31137 — keep the section order exactly)
+
+````markdown
+<Lead paragraph: one or two sentences. "Extracted from the `skills/performance-react-hooks/SKILL.md`
+audit — section _"<section name>"_. Found by sweep, not named in the doc.">
+
+## Where
+
+[`<repo-relative-path>:<line>`](https://github.com/trezor/trezor-suite/blob/develop/<path>#L<line>)
+<one bullet or line per co-anchor if more than one>
+
+## Before
+
+```tsx
+<verbatim code from the working tree — enough lines that a reviewer sees the defect without opening
+the file; include the dep array for hook findings>
+```
+````
+
+## After
+
+```tsx
+<the proposed fix, compiling against the surrounding types as best you can tell by reading; keep
+the diff minimal — this is a proposal, not a patch>
+```
+
+## Why it matters
+
+<1–3 sentences: the consumer that re-runs, the trigger cadence (every render / every store dispatch /
+every keystroke / every fiat tick / every background account update), and what that costs the user.
+NO INVENTED NUMBERS — nothing in this sweep was measured. If you cite a figure it must come from a
+linked issue that measured it, attributed.>
+
+## Notes
+
+<bullets: compile requirements (imports/types the After needs), which app consumes this (web is
+uncompiled / native is compiled — for native code do NOT propose adding manual memoization; fix the
+reference at its source), adjacent clean code worth mentioning, the in-repo "correct sibling" if the
+scan found one (this is the strongest evidence — cite it), honest sizing if n is small, optional
+same-PR cleanups.>
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>
+
+```
+
+## Rules
+
+- **Permalinks** point at `blob/develop/...#L<n>` (the branch will merge; develop is where reviewers
+  read). The `file:line` text itself must be valid at 9e0d5b6a45 in the working tree.
+- **Title** (used as filename + README row, and later the issue title): one sentence, active voice,
+  names the component/hook and the defect — e.g. "CoinControl refetches UTXO transactions on every
+  account object churn". Filename: `p<severity>-<nn>-<kebab-title-trimmed>.md`.
+- **Severity** comes from your assignment row (triage already decided it); do not re-rank, but if
+  the code you re-read contradicts the scan (defect absent, already fixed, dep actually stable),
+  STOP writing that doc and report it back instead — a wrong issue is worse than a missing one.
+- **Fix mechanism vocabulary** (pick what the skill prescribes): narrow the dep to the primitive
+  (`account.key`, `accountKey`, `symbol`); module-level constant for `[]`/`{}` fallbacks;
+  `returnStableArrayIfEmpty` in selectors; memoized selector (`createWeakMapSelector`) instead of
+  render-body derivation; `useMemo` around a Provider value or expensive derivation (web only);
+  derive-don't-store instead of setState-in-effect; plain `useRef` assign-at-end for previous-value
+  semantics; scoped `watch('field')`/`useWatch` instead of bare `watch()`.
+- **Native docs**: the fix is never "add useMemo" — the compiler owns memoization. Fix the source of
+  the unstable reference (selector, dep narrowing, derive in render).
+- **No cross-doc dependencies**: each document must stand alone when pasted into a GitHub issue.
+  Reference other *filed* issues by number; reference sibling drafts by their `p*-nn` id in Notes
+  only, marked "(sibling draft, not yet filed)".
+- Suggested labels when filing (goes nowhere in the doc body): `perf`, `no-QA`; parent #31374.
+```

--- a/perf-issues/react-hooks/p1-01-uselayout-effect-keyed-on-inline-jsx-rerenders-app-shell.md
+++ b/perf-issues/react-hooks/p1-01-uselayout-effect-keyed-on-inline-jsx-rerenders-app-shell.md
@@ -1,0 +1,125 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Keep hook dependencies referentially stable"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/hooks/suite/useLayout.tsx:8-10`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/suite/useLayout.tsx#L8-L10)
+
+Root cause is in every call site, since none of them memoize the header/footer element they pass, e.g.:
+
+- [`packages/suite/src/views/dashboard/index.tsx:17`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/dashboard/index.tsx#L17)
+- [`packages/suite/src/components/settings/SettingsLayout.tsx:90`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/settings/SettingsLayout.tsx#L90)
+- [`packages/suite/src/views/earn/index.tsx:6`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/earn/index.tsx#L6)
+- [`packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx:77`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx#L77)
+
+Provider that receives the payload and spreads it into its own JSX:
+[`packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx:102-103,129`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx#L102-L103)
+
+## Before
+
+```tsx
+// packages/suite/src/hooks/suite/useLayout.tsx
+export const useLayout = (title?: string, layoutHeader?: ReactNode, layoutFooter?: ReactNode) => {
+    const setLayout = useContext(LayoutContext);
+
+    useEffect(() => {
+        setLayout({ title, layoutHeader, layoutFooter });
+    }, [setLayout, title, layoutHeader, layoutFooter]);
+};
+```
+
+Every call site passes a freshly created element:
+
+```tsx
+// packages/suite/src/views/dashboard/index.tsx:17
+useLayout('Home', <PageHeader />, <DashboardFooter />);
+```
+
+`SuiteLayout.tsx` holds the payload in state and spreads it into its own JSX. `children` (the routed
+page that just called `useLayout`) is passed through as a prop and is shielded from this re-render;
+its siblings are not:
+
+```tsx
+// packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+const [{ title, layoutHeader, layoutFooter }, setLayoutPayload] =
+    useState<LayoutContextPayload>({});
+...
+<LayoutContext.Provider value={setLayoutPayload}>
+    <Body data-testid="@suite-layout/body">
+        <Columns>
+            <Sidebar />
+            <MainContent>
+                {!isBelowTablet && <CoinjoinBars />}
+                <SuiteBanners />
+                <AppWrapper data-testid="@app" ref={scrollRef}>
+                    {layoutHeader}
+                    <ContentContainer ...>{children}</ContentContainer>
+                    {layoutFooter}
+                </AppWrapper>
+            </MainContent>
+        </Columns>
+    </Body>
+</LayoutContext.Provider>
+```
+
+## After
+
+A `ReactNode` is a plain object, so it needs the same treatment as any other inline object literal
+crossing a hook boundary — memoize it at the call site instead of passing it fresh:
+
+```tsx
+// packages/suite/src/views/dashboard/index.tsx
+import { useMemo } from 'react';
+...
+export const Dashboard = () => {
+    const header = useMemo(() => <PageHeader />, []);
+    const footer = useMemo(() => <DashboardFooter />, []);
+
+    useLayout('Home', header, footer);
+    useNotificationForDisconnectedDevice();
+    ...
+```
+
+`useLayout` itself cannot fix this — it receives the element already-fresh and has no way to
+deduplicate a `ReactNode` it did not create.
+
+## Why it matters
+
+Every render of a page component that calls `useLayout` with inline JSX recreates the header/footer
+element, so the effect's dependency array sees a new reference and `setLayoutPayload` fires again —
+for example on a fiat-rate tick on the dashboard, or a keystroke that re-renders a form page. None of
+`SuiteLayout`'s own direct JSX children (`Sidebar`, `SuiteBanners`, `ModalSwitcher`,
+`DiscoveryProgress`, `PowerMonitorManager`, `CoinjoinBars`, `GuideButton`, `AddPassphraseWalletFlow`,
+`SwitchDeviceLayer`, `Metadata`) are wrapped in `memo()`, so all of them re-run their own render bodies
+— including their own selectors and hooks, such as `Sidebar`'s accounts list — on every one of those
+refires. The routed page itself is shielded by the standard `children`-as-a-prop pattern, so this is
+not a loop, but it turns "this page re-rendered" into "the whole chrome re-rendered" on nearly every
+route in the app.
+
+## Notes
+
+- Compile requirement: `dashboard/index.tsx` currently has no `'react'` import at all; the fix adds
+  `import { useMemo } from 'react';`. The same per-call-site change is needed at every `useLayout(...)`
+  call site that passes JSX — about 16 of the ~19 total call sites in the repo.
+  [`views/connect-popup/index.tsx:6`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/connect-popup/index.tsx#L6)
+  passes `null`, and
+  [`views/suite/bridge-deprecated/index.tsx:18`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/suite/bridge-deprecated/index.tsx#L18)/[`bridge-requested/index.tsx:41`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/suite/bridge-requested/index.tsx#L41)
+  pass no header/footer argument at all, so those three are already stable and don't need touching.
+- Cheaper, centralized complementary fix worth doing in the same PR: wrap `SuiteLayout.tsx`'s direct
+  JSX children other than `children` in `memo()`. That bounds the re-render to a shallow prop-equality
+  check at each of those boundaries without depending on every current and future `useLayout` call
+  site remembering to memoize its header/footer. It does not by itself stop the `useEffect` from
+  refiring — the fix above is still required to eliminate that — but it stops the refire from
+  cascading into each child's own render body.
+- This is `packages/suite`, not React-Compiler-covered (native's `experiments.reactCompiler: true`
+  only applies to `suite-native`), so manual `useMemo` is the correct and only mechanism here.
+- Same file, separate defect, not fixed here: `SuiteLayout.tsx:113`'s
+  `ScrollContext.Provider value={{ scrollRef, topOffset }}` is also an unmemoized Provider value
+  (sibling draft p1-07, not yet filed).
+- `Sidebar` renders the accounts list via `AccountsMenu`
+  (`packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx:15`), the same
+  subtree covered by a separate, independent Provider-value defect (sibling draft p1-02, not yet
+  filed) — the two compound but neither depends on the other being fixed.
+- Honest sizing: every page in the app calls `useLayout`, so despite each individual call-site fix
+  being a one-line `useMemo`, this is the widest-reaching finding in this scan file.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-02-useaccountsearch-provider-value-recreated-every-render.md
+++ b/perf-issues/react-hooks/p1-02-useaccountsearch-provider-value-recreated-every-render.md
@@ -1,0 +1,77 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/hooks/suite/useAccountSearch.tsx:43-57`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/suite/useAccountSearch.tsx#L43-L57)
+(Provider's JSX at `:47-56`)
+
+Provider's mount point, whose own re-renders drive this:
+[`packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx:22-23,47`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx#L22-L23)
+
+## Before
+
+```tsx
+export const ReduxAccountSearchProvider = ({ children }: { children: React.ReactNode }) => {
+    const filters = useSelector(state => selectAccountSearch(state));
+    const actions = useReduxAccountSearchActions();
+
+    return (
+        <AccountSearchContext.Provider
+            value={{
+                ...filters,
+                ...actions,
+            }}
+        >
+            {children}
+        </AccountSearchContext.Provider>
+    );
+};
+```
+
+`filters` comes from a plain selector and `actions` is already correctly memoized on `[dispatch]`
+(`useReduxAccountSearchActions`, same file), so both inputs are individually stable — only the inline
+spread creating the `value` object is not.
+
+## After
+
+```tsx
+export const ReduxAccountSearchProvider = ({ children }: { children: React.ReactNode }) => {
+    const filters = useSelector(state => selectAccountSearch(state));
+    const actions = useReduxAccountSearchActions();
+
+    const value = useMemo(() => ({ ...filters, ...actions }), [filters, actions]);
+
+    return <AccountSearchContext.Provider value={value}>{children}</AccountSearchContext.Provider>;
+};
+```
+
+`useMemo` is already imported in this file (used by `useReduxAccountSearchActions`), so no new import
+is needed. Because `filters` and `actions` are already stable individually, this memo will actually
+hold across renders where neither changed.
+
+## Why it matters
+
+Every consumer of `useAccountSearch()` — `AccountSearchBox`, `AccountsList` (the accounts sidebar
+rows), `CoinsFilter`, `AccountsMenuHeader`, plus `AddAccountModal` and `AssetActionButton` elsewhere —
+re-renders whenever `ReduxAccountSearchProvider` re-renders, because a Context consumer re-renders on
+any new `value` reference regardless of whether the fields inside it actually changed.
+`ReduxAccountSearchProvider`'s mount point, `AccountsMenu`, reads `selectSelectedDevice` as a whole,
+unnarrowed device object and `selectDiscoveryOverallStatus`, both of which change reference on most
+device/discovery-related store updates — so the sidebar's search/filter context churns considerably
+more often than the underlying filter/search state does.
+
+## Notes
+
+- No new imports beyond `useMemo`, already present in this file.
+- `packages/suite` is not React-Compiler-covered, so this manual memoization is the correct and only
+  mechanism here (contrast with `suite-native`, where a compiled component would need the source of
+  the instability fixed instead).
+- `AccountsMenu` is the Provider's only mount point in the app
+  (`packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx:47`), and is
+  itself rendered by `Sidebar`, which every page's shell mounts — see sibling draft p1-01 (not yet
+  filed), which covers a separate defect that re-renders this same `Sidebar` subtree on every page
+  render. The two compound but neither depends on the other being fixed.
+- Confirmed 6 consumers via `useAccountSearch()`: `AccountSearchBox.tsx`, `AccountsList.tsx`,
+  `AccountsMenuHeader.tsx`, `CoinsFilter.tsx`, `AddAccountModal.tsx`, `AssetActionButton.tsx`.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-03-cancel-tx-compose-refires-on-account-churn.md
+++ b/perf-issues/react-hooks/p1-03-cancel-tx-compose-refires-on-account-churn.md
@@ -1,0 +1,165 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Distinguish a wasted memo from a render loop"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts:115-120`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts#L115-L120)
+
+[`packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx:83-107`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx#L83-L107)
+(this is `useEthereumCancelTxCompose`'s only caller, and carries the same defect a second time for
+non-Ethereum accounts)
+
+Co-anchors that manufacture the fresh `account`/`tx`/`chainedTxs` references both effects depend on,
+all in the modal's parent:
+
+- [`TxDetailModal.tsx:101`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx#L101) — `account`, via `selectAccountByKey`
+- [`TxDetailModal.tsx:92-99`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx#L92-L99) — `tx`
+- [`TxDetailModal.tsx:109-114`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx#L109-L114) — `chainedTxs`
+
+## Before
+
+### 1. `useEthereumCancelTxCompose.ts` — Ethereum path
+
+```tsx
+useEffect(() => {
+    if (account.networkType !== 'ethereum' || !feeInfo || tx.rbfParams?.type !== 'ethereum') {
+        return;
+    }
+    mutate();
+}, [account, tx, feeInfo, mutate]);
+```
+
+### 2. `CancelTransactionModal.tsx` — Bitcoin/UTXO path
+
+```tsx
+useEffect(() => {
+    if (account.networkType === 'ethereum') return;
+    if (tx.vsize === undefined) return;
+    if (!isComposeCancelTransactionPartialAccount(account)) return;
+
+    dispatch(composeCancelTransactionThunk({ account, tx, chainedTxs }))
+        .unwrap()
+        .then(precomposed => {
+            setUtxoComposedCancelTx({ ...precomposed, rbfType: 'cancel', prevTxid: tx.txid });
+            setUtxoCancelFormState({
+                feeLimit: '', // Eth only
+                feePerUnit: precomposed.feePerByte,
+                hasCoinControlBeenOpened: false,
+                isCoinControlEnabled: false,
+                options: ['broadcast'],
+                outputs: precomposed.outputs.map(output => ({
+                    ...DEFAULT_PAYMENT,
+                    ...output,
+                    amount: output.amount.toString(),
+                })),
+                selectedUtxos: [],
+            });
+        })
+        .catch(setUtxoError);
+}, [account, tx, dispatch, chainedTxs]);
+```
+
+Both guard blocks only ever check type tags (`account.networkType`, `tx.rbfParams?.type`) or an
+`undefined` check (`tx.vsize`), never a value that changes on an ordinary balance/history refresh.
+`account` reaches both effects via `TxDetailModal`'s `selectAccountByKey(state, accountKey)`, memoized
+on `[selectAccounts, accountKey]` — `selectAccounts` returns a fresh top-level array on _any_ account
+update, and the account this modal is open on is, by definition, the one most likely to be updating
+while the modal is open.
+
+## After
+
+### 1. `useEthereumCancelTxCompose.ts`
+
+```tsx
+useEffect(() => {
+    if (account.networkType !== 'ethereum' || !feeInfo || tx.rbfParams?.type !== 'ethereum') {
+        return;
+    }
+    mutate();
+}, [account.key, account.networkType, tx.txid, tx.rbfParams, feeInfo, mutate]);
+```
+
+`mutate`'s `mutationFn` closure already reads `account`/`tx`/`feeInfo` fresh from the enclosing hook
+scope each time it actually runs (react-query re-creates `mutationFn` every render and always invokes
+the latest one), so narrowing the trigger array doesn't lose freshness — it only stops re-triggering on
+reference churn that isn't one of the values the guard cares about. `feeInfo` is already a
+`createMemoizedSelector`/`createWeakMapSelector`-backed result (`selectConvertedNetworkFeeInfo`), so
+it's fine to leave as-is.
+
+### 2. `CancelTransactionModal.tsx`
+
+```tsx
+const chainedTxIds = chainedTxs?.map(chainedTx => chainedTx.txid).join();
+
+useEffect(() => {
+    if (account.networkType === 'ethereum') return;
+    if (tx.vsize === undefined) return;
+    if (!isComposeCancelTransactionPartialAccount(account)) return;
+
+    dispatch(composeCancelTransactionThunk({ account, tx, chainedTxs }))
+        .unwrap()
+        .then(precomposed => {
+            setUtxoComposedCancelTx({ ...precomposed, rbfType: 'cancel', prevTxid: tx.txid });
+            setUtxoCancelFormState({
+                feeLimit: '', // Eth only
+                feePerUnit: precomposed.feePerByte,
+                hasCoinControlBeenOpened: false,
+                isCoinControlEnabled: false,
+                options: ['broadcast'],
+                outputs: precomposed.outputs.map(output => ({
+                    ...DEFAULT_PAYMENT,
+                    ...output,
+                    amount: output.amount.toString(),
+                })),
+                selectedUtxos: [],
+            });
+        })
+        .catch(setUtxoError);
+}, [account.key, account.networkType, tx.txid, tx.vsize, chainedTxIds, dispatch]);
+```
+
+Same reasoning as (1): this effect is a plain component effect (not a memoized custom-hook return
+value), so whichever render's closure actually fires already carries that render's own `account`/`tx`/
+`chainedTxs` — narrowing the array only changes when it fires, not what it sees. `tx.vsize` is folded
+into the array because the guard's own `undefined` check is a real transition condition the account/tx
+identity alone wouldn't capture. `chainedTxIds` gives `composeCancelTransactionThunk`'s
+`chainedTxs`-dependent fee calculation (`calculateNewFee` → `calculateChainedTransactionsFeeForRbf`) a
+primitive that identifies the chained set without retriggering on every unrelated reference churn of
+the array itself.
+
+## Why it matters
+
+This is the skill's own "silent and unbounded" shape, occurring twice: every time the pending
+transaction's own record refreshes (new confirmation count, mempool update) while this modal is open,
+both effects redispatch a real fee-compose operation —
+`composeSendFormTransactionFeeLevelsThunk`/`composeCancelTransactionThunk` — for a cancel the user
+hasn't asked for again, while they're mid-review of a "cancel this stuck transaction" screen. Unlike
+the sibling compose hooks in this same area (`useCompose.ts`, `useStakeCompose.ts`), which both
+compare a primitive (`state.feeInfo.blockHeight`) against a ref before calling `composeRequest()`,
+neither of these two effects has any such gate — they refire on every reference change of
+`account`/`tx` regardless of whether anything the guard checks actually changed.
+
+## Notes
+
+- Same-PR cleanup, same file: `CancelTransactionModal.tsx:110-111`'s own
+  `CancelTxContext.Provider value={{ composedCancelTx, cancelFormState: formState, isComposing }}` is
+  also unmemoized. Small consumer count (3, all in the same modal subtree), so it isn't worth a
+  standalone doc, but since this file is being touched anyway for the fix above:
+    ```tsx
+    const cancelTxContextValue = useMemo(
+        () => ({ composedCancelTx, cancelFormState: formState, isComposing }),
+        [composedCancelTx, formState, isComposing],
+    );
+    ```
+    used as `<CancelTxContext.Provider value={cancelTxContextValue}>`. Needs `useMemo` added to this
+    file's existing `import { useEffect, useState } from 'react';`.
+- No new imports needed for the two effect fixes themselves — `account.key`, `tx.txid`, `tx.rbfParams`,
+  `tx.vsize` are all already-accessible properties.
+- `packages/suite` is not React-Compiler-covered, so both fixes rely on manual dependency-array
+  narrowing rather than a compiler.
+- `TxDetailModal.tsx`'s own `tx`/`chainedTxs` `useMemo`s are themselves correctly narrowed to their
+  actual inputs (`[resolvedTx, filteredInternalTransfers]` and `[tx, transactions]`) — they are not a
+  separate defect; they simply propagate the instability that originates from `resolvedTx`/`accounts`
+  being fresh Redux objects on every relevant store update, which is exactly what this doc's fix
+  insulates the two compose effects from.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-04-addtokenmodal-refetches-account-info-per-account-refresh.md
+++ b/perf-issues/react-hooks/p1-04-addtokenmodal-refetches-account-info-per-account-refresh.md
@@ -1,0 +1,134 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Distinguish a wasted
+memo from a render loop"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx:71`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx#L71)
+
+- Dispatched work: [`AddTokenModal.tsx:34`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx#L34) — `loadTokenInfo`, which calls `TrezorConnect.getAccountInfo`.
+
+## Before
+
+```tsx
+const account = useSelector(selectSelectedAccount);
+...
+const loadTokenInfo = useCallback(
+    async (acc: Account, contractAddress: string) => {
+        if (!acc) return;
+        setIsFetching(true);
+        const response = await TrezorConnect.getAccountInfo({
+            coin: asCoinSymbol(acc.symbol),
+            identity: tryGetAccountIdentity(acc),
+            descriptor: acc.descriptor,
+            details: 'tokenBalances',
+            contractFilter: contractAddress,
+            suppressBackupWarning: true,
+            protocols: acc.networkType === 'ethereum' ? ['erc4626'] : undefined,
+        });
+
+        if (response.success) {
+            const isInvalidToken = response.payload.tokens?.find(
+                t => t.contract === t.name && t.decimals === 0 && !t.symbol,
+            );
+            if (!isInvalidToken) {
+                setTokenInfo(response.payload.tokens);
+            } else {
+                // not a valid token
+                setError(translationString('TR_ADD_TOKEN_TOKEN_NOT_VALID'));
+            }
+        } else {
+            setTokenInfo(undefined);
+            setError(
+                translationString('TR_ADD_TOKEN_TOAST_ERROR', {
+                    error: response.error.message,
+                }),
+            );
+        }
+        setIsFetching(false);
+    },
+    [translationString],
+);
+
+useEffect(() => {
+    if (account && !error && contractAddress) {
+        loadTokenInfo(account, contractAddress);
+    }
+}, [account, contractAddress, error, loadTokenInfo]);
+```
+
+## After
+
+```tsx
+const account = useSelector(selectSelectedAccount);
+const accountRef = useFreshRef(account);
+...
+const loadTokenInfo = useCallback(
+    async (acc: Account, contractAddress: string) => {
+        if (!acc) return;
+        setIsFetching(true);
+        const response = await TrezorConnect.getAccountInfo({
+            coin: asCoinSymbol(acc.symbol),
+            identity: tryGetAccountIdentity(acc),
+            descriptor: acc.descriptor,
+            details: 'tokenBalances',
+            contractFilter: contractAddress,
+            suppressBackupWarning: true,
+            protocols: acc.networkType === 'ethereum' ? ['erc4626'] : undefined,
+        });
+
+        if (response.success) {
+            const isInvalidToken = response.payload.tokens?.find(
+                t => t.contract === t.name && t.decimals === 0 && !t.symbol,
+            );
+            if (!isInvalidToken) {
+                setTokenInfo(response.payload.tokens);
+            } else {
+                // not a valid token
+                setError(translationString('TR_ADD_TOKEN_TOKEN_NOT_VALID'));
+            }
+        } else {
+            setTokenInfo(undefined);
+            setError(
+                translationString('TR_ADD_TOKEN_TOAST_ERROR', {
+                    error: response.error.message,
+                }),
+            );
+        }
+        setIsFetching(false);
+    },
+    [translationString],
+);
+
+useEffect(() => {
+    const currentAccount = accountRef.current;
+
+    if (currentAccount && !error && contractAddress) {
+        loadTokenInfo(currentAccount, contractAddress);
+    }
+}, [accountRef, account?.key, contractAddress, error, loadTokenInfo]);
+```
+
+## Why it matters
+
+The user types a contract address once; from then on, any Redux update that hands `selectSelectedAccount`
+a fresh `account` reference — a new block, a balance or nonce change — re-fires this effect and
+re-issues a real `TrezorConnect.getAccountInfo` device/backend round-trip with the same address,
+silently, for as long as the modal stays open. Unlike a UI recomputation, this is an actual request
+repeated with no new input from the user.
+
+## Notes
+
+- Compile requirement: add `import { useFreshRef } from '@trezor/react-utils';` (already a
+  `packages/suite` workspace dependency — see `packages/suite/package.json`; sorts after the
+  `@trezor/connect-common` import in the existing block).
+- `packages/suite` is web/desktop and not React-Compiler-covered, so this is a manual fix, not
+  something the compiler would absorb.
+- `account?.key` is read directly off the already-destructured `account` for the dependency array;
+  the reducer also exports a ready-made `selectSelectedAccountKey` selector
+  (`suite/account/src/selectedAccountReducer.ts:53`) that returns the same primitive straight from
+  the store, as an alternative to deriving it locally.
+- Mirrors the skill's own worked example (`AdaStakingDashboard.tsx:52`): "When an effect really must
+  fetch, depend on the identifier and not the record."
+- `error`/`contractAddress` stay as-is in the dependency array; only `account` needed narrowing.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-05-graphtooltipbase-effect-keyed-on-whole-props.md
+++ b/perf-issues/react-hooks/p1-05-graphtooltipbase-effect-keyed-on-whole-props.md
@@ -1,0 +1,77 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Minimal required
+dependencies"_. Found by sweep, not named in the doc. Distinct from the already-filed
+[#31137](https://github.com/trezor/trezor-suite/issues/31137), which covers this same directory's
+`TransactionsGraph.tsx` `setWidth`/`GraphYAxisTick` layout-effect refire — this is a separate defect,
+in `GraphTooltipBase`'s own effect.
+
+## Where
+
+[`packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx:132`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx#L132)
+
+- Setter it drives: [`TransactionsGraph.tsx:96`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx#L96)
+  — `onShow: (index: number) => setHovered(index)`, part of `tooltipContentProps`
+  ([`:92-97`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx#L92-L97))
+  spread into `GraphTooltipAccount`/`GraphTooltipDashboard`
+  ([`:170-183`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx#L170-L183)).
+
+## Before
+
+```tsx
+export const GraphTooltipBase = (props: GraphTooltipBaseProps) => {
+    useEffect(() => {
+        if (!props.onShow || !props.extendedDataForInterval) {
+            return;
+        }
+
+        props.onShow(
+            props.extendedDataForInterval.findIndex(
+                item => item.time === props.payload?.[0]?.payload.time,
+            ),
+        );
+    }, [props]);
+```
+
+## After
+
+```tsx
+export const GraphTooltipBase = (props: GraphTooltipBaseProps) => {
+    const activeTime = props.payload?.[0]?.payload.time;
+
+    useEffect(() => {
+        if (!props.onShow || !props.extendedDataForInterval) {
+            return;
+        }
+
+        props.onShow(props.extendedDataForInterval.findIndex(item => item.time === activeTime));
+    }, [props.onShow, props.extendedDataForInterval, activeTime]);
+```
+
+## Why it matters
+
+`GraphTooltipBase` positions itself off `props.coordinate`/`props.viewBox` (lines 159-160), fields
+recharts updates continuously while the pointer moves over the chart, independently of whether the
+active data point has actually changed. Because the effect's dependency is the whole `props` object,
+it re-runs on every one of those ticks, not just when the active point changes: each run does an
+O(n) `findIndex` scan over the full `extendedDataForInterval` and calls `props.onShow` (`setHovered`
+in the parent `TransactionsGraph`). `setHovered`'s primitive argument means React bails out of an
+actual re-render when the index repeats, but the scan and the call itself still run on every pointer
+tick, on every hover of the account or dashboard balance graph.
+
+## Notes
+
+- No new imports; `activeTime` is a plain `const` derived from a prop already read inside the
+  effect (`props.payload?.[0]?.payload.time`, the same expression currently inlined in the
+  `findIndex` callback).
+- `props.onShow` is itself a fresh inline arrow defined at `TransactionsGraph.tsx:96` (not
+  `useCallback`-wrapped), so the residual re-run cadence after this fix is bounded by
+  `TransactionsGraph`'s own render rate rather than eliminated outright — still a large reduction
+  from "every pointer tick" to "every time the parent re-renders." Stabilizing that arrow is outside
+  this finding's anchor.
+- Sibling draft p1-06 (not yet filed) covers a related but distinct defect one component up:
+  `TransactionsGraph`'s own `extendedDataForInterval` is recomputed unmemoized on every render,
+  including the ones this effect's `setHovered` call triggers. The two compound but are independent
+  fixes; this doc's fix stands on its own regardless of whether that one lands.
+- `packages/suite` is web/desktop, not React-Compiler-covered — this dependency-narrowing fix is
+  manual and has no compiler alternative.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-06-transactionsgraph-rebuilds-interval-data-per-hover-render.md
+++ b/perf-issues/react-hooks/p1-06-transactionsgraph-rebuilds-interval-data-per-hover-render.md
@@ -1,0 +1,76 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body
+work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+Distinct from the already-filed [#31137](https://github.com/trezor/trezor-suite/issues/31137), which
+covers this same file's `setWidth`/`GraphYAxisTick` layout-effect refire — this is a separate defect,
+the unmemoized `extendedDataForInterval` computation.
+
+## Where
+
+[`packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx:85`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx#L85)
+
+- Recomputed function: [`packages/suite/src/utils/wallet/graph/utils.ts:263`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/utils/wallet/graph/utils.ts#L263)
+  — `calcFakeGraphDataForTimestamps`: three separate `timestamps.forEach` passes, one containing a
+  nested `data.some(...)`/`data.findIndex(...)` per tick, plus a final `.sort()`.
+
+## Before
+
+```tsx
+const [maxYTickWidth, setMaxYTickWidth] = useState(20);
+const [hovered, setHovered] = useState(-1);
+...
+// calculate fake data for full interval (eg. 1 year) even for ticks/timestamps without txs
+const extendedDataForInterval =
+    variant === 'one-asset'
+        ? calcFakeGraphDataForTimestamps(xTicks, data, account.formattedBalance)
+        : calcFakeGraphDataForTimestamps(xTicks, data);
+```
+
+## After
+
+```tsx
+const [maxYTickWidth, setMaxYTickWidth] = useState(20);
+const [hovered, setHovered] = useState(-1);
+...
+// calculate fake data for full interval (eg. 1 year) even for ticks/timestamps without txs
+const extendedDataForInterval = useMemo(
+    () =>
+        variant === 'one-asset'
+            ? calcFakeGraphDataForTimestamps(xTicks, data, account.formattedBalance)
+            : calcFakeGraphDataForTimestamps(xTicks, data),
+    [variant, xTicks, data, account?.formattedBalance],
+);
+```
+
+## Why it matters
+
+`TransactionsGraph` is `memo()`-wrapped, but that only guards against unchanged-prop re-renders from
+its parent — it does nothing for the component's own `hovered`/`maxYTickWidth` state, which the
+hover interaction (see sibling draft p1-05, not yet filed — `GraphTooltipBase`'s effect calling
+`setHovered` on every pointer tick) and the Y-axis width measurement update on every relevant tick.
+Every one of those re-renders currently recomputes `extendedDataForInterval` from scratch — three
+linear passes over `xTicks` plus a nested scan of `data` per tick plus a final sort — even though
+none of `variant`, `xTicks`, `data`, or the account's formatted balance changed. `xTicks` scales with
+the selected range (a year of daily ticks for the "all" range), so the recompute is not free.
+
+## Notes
+
+- Compile requirement: add `useMemo` to the existing `import { memo, useState } from 'react';` on
+  line 1.
+- The dependency array uses `account?.formattedBalance`, not the unguarded `account.formattedBalance`:
+  outside the `variant === 'one-asset'` branch, `account` types as `Account | undefined`
+  (`TransactionsGraphProps` is a `CryptoGraphProps | FiatGraphProps` union where only the crypto
+  variant carries a required `account`) — exactly why the existing
+  `calcYDomain(minMaxValues, account?.formattedBalance)` one line above already optional-chains it.
+- Sibling draft p1-05 (not yet filed) is the specific hover-cadence source; the two are independent
+  fixes that compound in the same component, and this fix stands on its own regardless of whether
+  that one lands.
+- Out of scope for this finding: the internal cost of `calcFakeGraphDataForTimestamps` itself is
+  asymptotic-complexity's lane. The related upstream dashboard-aggregation cost sits in the
+  scheduling sweep's own local drafts (not yet filed):
+  `perf-issues/scheduling/p2-06-transactionsummary-aggregates-in-the-render-body.md` and
+  `perf-issues/scheduling/p2-07-preparegraphdataasync-is-a-settimeout-zero-poor-mans-worker.md`. In
+  scope here is only that this call reruns exclusively when its real inputs change.
+- `packages/suite` is web/desktop, not React-Compiler-covered — `useMemo` is the only mechanism
+  available at runtime.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-07-suitelayout-scrollcontext-value-unmemoized.md
+++ b/perf-issues/react-hooks/p1-07-suitelayout-scrollcontext-value-unmemoized.md
@@ -1,0 +1,70 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body
+work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx:113`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx#L113)
+
+- Consumer: [`suite/router/src/useAnchor.ts:8`](https://github.com/trezor/trezor-suite/blob/develop/suite/router/src/useAnchor.ts#L8)
+  — `useContext(ScrollContext)`.
+- Consumer's caller: [`packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx:62`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx#L62)
+  — `memo()`-wrapped, one instance per row of every visible transaction list.
+
+## Before
+
+```tsx
+const wrapperRef = useRef<HTMLDivElement>(null);
+const { scrollRef } = useResetScrollOnUrl();
+const topOffset = HEADER_HEIGHT_NUMERIC + SUBPAGE_NAV_HEIGHT_NUMERIC + ANCHOR_SCROLL_OFFSET;
+
+useClearAnchorHighlightOnClick(wrapperRef);
+
+return (
+    <ScrollContext.Provider value={{ scrollRef, topOffset }}>
+        <Wrapper ref={wrapperRef} data-testid="@suite-layout">
+```
+
+## After
+
+```tsx
+const wrapperRef = useRef<HTMLDivElement>(null);
+const { scrollRef } = useResetScrollOnUrl();
+const topOffset = HEADER_HEIGHT_NUMERIC + SUBPAGE_NAV_HEIGHT_NUMERIC + ANCHOR_SCROLL_OFFSET;
+
+useClearAnchorHighlightOnClick(wrapperRef);
+
+const scrollContextValue = useMemo(() => ({ scrollRef, topOffset }), [scrollRef, topOffset]);
+
+return (
+    <ScrollContext.Provider value={scrollContextValue}>
+        <Wrapper ref={wrapperRef} data-testid="@suite-layout">
+```
+
+## Why it matters
+
+React re-renders every consumer of a context whenever the Provider hands it a new `value` reference,
+regardless of `memo()` on the consumer — `memo()` only blocks re-renders coming from unchanged
+props, not from a subscribed context. `SuiteLayout` creates a fresh `{ scrollRef, topOffset }` object
+on every one of its own re-renders (every page navigation sets `layoutHeader`/`layoutFooter`/`title`
+via `LayoutContext`; every tablet/desktop breakpoint crossing flips `isBelowTablet`), even though
+`scrollRef` (a `useRef` created once in `useResetScrollOnUrl`) and `topOffset` (a compile-time sum of
+constants) never actually change. `useAnchor` — called by every visible `TransactionItem`, a
+component the repo explicitly `memo()`-wrapped — reads this context directly, so every page
+navigation currently forces every rendered transaction row to re-render for no reason.
+
+## Notes
+
+- Compile requirement: add `useMemo` to the existing `import { type ReactNode, useRef, useState } from 'react';`
+  on line 1.
+- Correct in-repo sibling for this exact shape:
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetOptionsContext.tsx:26-29`
+  already computes its Provider value via `useMemo` keyed on its constituent props before handing it
+  to `.Provider value={contextValue}` — the same pattern proposed here.
+- Both inputs to the memo are stable for the component's whole lifetime (verified
+  `useResetScrollOnUrl.ts:11`, a `useRef` created once, and the `topOffset` arithmetic, a sum of
+  three module-level constants), so this memo will always hit — a pure win with no correctness
+  trade-off.
+- `packages/suite` is web/desktop, not React-Compiler-covered — `useMemo` is the only mechanism
+  available at runtime; this is not something to fix in the native app.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-08-feescontext-provider-hands-14-consumers-fresh-object.md
+++ b/perf-issues/react-hooks/p1-08-feescontext-provider-hands-14-consumers-fresh-object.md
@@ -1,0 +1,67 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx:76`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx#L76)
+
+Context definition: [`packages/suite/src/components/wallet/Fees/context/FeesContext.ts:23`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/Fees/context/FeesContext.ts#L23)
+
+14 consumers via `useFeesContext()`, all under `packages/suite/src/components/wallet/Fees/`: `CollapsibleFees/CollapsibleFeesHeaderContent.tsx`, `CollapsibleFees/CollapsibleFeesHeader.tsx`, `CollapsibleFees/StandardFee/StandardFee.tsx`, `CollapsibleFees/StandardFee/BitcoinFeeCards.tsx`, `CollapsibleFees/StandardFee/EthereumFeeCards.tsx`, `CollapsibleFees/StandardFee/MiscFeeCards.tsx`, `CollapsibleFees/MaximumFee.tsx`, `CollapsibleFees/CustomFee/CustomFee.tsx`, `CollapsibleFees/CustomFee/CustomFeeEthereum.tsx`, `CollapsibleFees/CustomFee/CustomFeeMisc.tsx`, `CollapsibleFees/CustomFee/CurrentFee.tsx`, `CollapsibleFees/CustomFee/CustomFeeTooLowBanner.tsx`, `CollapsibleFees/TronFee/TronFee.tsx`, `DustPreventionNotice.tsx`.
+
+## Before
+
+```tsx
+    return (
+        <FeesContext.Provider
+            value={{
+                networkSymbol,
+                networkType,
+                feeInfo,
+                changeFeeLevel,
+                selectedFeeLevel,
+                composedLevels,
+                tronResources,
+            }}
+        >
+```
+
+## After
+
+```tsx
+    const contextValue = useMemo(
+        () => ({
+            networkSymbol,
+            networkType,
+            feeInfo,
+            changeFeeLevel,
+            selectedFeeLevel,
+            composedLevels,
+            tronResources,
+        }),
+        [
+            networkSymbol,
+            networkType,
+            feeInfo,
+            changeFeeLevel,
+            selectedFeeLevel,
+            composedLevels,
+            tronResources,
+        ],
+    );
+
+    return (
+        <FeesContext.Provider value={contextValue}>
+```
+
+## Why it matters
+
+React context has no shallow-compare bail-out: every consumer of `FeesContext` re-renders whenever the Provider's `value` reference changes, regardless of which field it actually reads. `CollapsibleFees` mounts on every send/stake/claim/unstake/RBF screen and re-renders on every `useWatch({ name: 'selectedFee' })` tick — effectively per keystroke/interaction in the surrounding fee form — so all 14 consumers (every fee-card variant, both custom-fee panels, the header, the too-low banner, the Tron fee panel, the dust notice) currently re-render together on each of those ticks, not just the ones whose data actually changed.
+
+## Notes
+
+- `useMemo` is already imported in this file (it's used for `isTrc20Transfer`, `defaultFeeLevel`, and `selectedFeeLevel`), so this fix needs no new import.
+- Checked, not just flagged: `changeFeeLevel` (`packages/suite/src/hooks/wallet/form/useFees.ts:129`) is a plain arrow function rebuilt on every call to `useFees()`, not a `useCallback` — so on a render where `CollapsibleFees`'s _parent_ itself re-renders, this memo's own `changeFeeLevel` dependency is fresh again and the memo still recomputes. The fix still fully holds for the cadence called out above — a `useWatch`-driven re-render of `CollapsibleFees` in isolation, parent untouched, so `changeFeeLevel`/`feeInfo`/`composedLevels` arrive as the same prop references as the previous render — which is the hot path this doc is about. Full end-to-end stability additionally needs `changeFeeLevel` wrapped in `useCallback` in `useFees.ts`; that's outside `components/wallet/Fees` and not covered by this doc.
+- `feeInfo`'s and `composedLevels`'s own stability at their producers (`useFees`, `useCompose`, and neighbors in `src/hooks/wallet`) wasn't independently re-verified beyond the point above; if either is also rebuilt per render, the same caveat applies to it.
+- None of the 14 consumers are `memo()`-wrapped. That's not a problem once the Provider value itself is stable, and isn't proposed here since it isn't the bottleneck.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-09-yield-pending-tx-poll-keys-on-whole-account.md
+++ b/perf-issues/react-hooks/p1-09-yield-pending-tx-poll-keys-on-whole-account.md
@@ -1,0 +1,69 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Minimal required dependencies"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts:232`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts#L232)
+
+Correct in-repo sibling: [`packages/suite/src/components/earn/staking/tron/hooks/useTronStakePendingTransactionTracking.ts:56`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/staking/tron/hooks/useTronStakePendingTransactionTracking.ts#L56)
+
+## Before
+
+```tsx
+useEffect(() => {
+    if (!isCurrentlyPending) {
+        return;
+    }
+
+    const interval = setInterval(() => {
+        dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
+    }, pollIntervalMs);
+
+    return () => clearInterval(interval);
+}, [account, dispatch, isCurrentlyPending, pollIntervalMs]);
+```
+
+## After
+
+```tsx
+useEffect(() => {
+    if (!isCurrentlyPending) {
+        return;
+    }
+
+    const interval = setInterval(() => {
+        dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
+    }, pollIntervalMs);
+
+    return () => clearInterval(interval);
+}, [account.key, dispatch, isCurrentlyPending, pollIntervalMs]);
+```
+
+The Tron staking sibling already implements this exact interval with the narrow dependency — matched line for line:
+
+```tsx
+// useTronStakePendingTransactionTracking.ts:46-56 — correct
+useEffect(() => {
+    if (!isCurrentlyPending) {
+        return;
+    }
+
+    const interval = setInterval(() => {
+        dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
+    }, pollIntervalMs);
+
+    return () => clearInterval(interval);
+}, [account.key, dispatch, isCurrentlyPending, pollIntervalMs]);
+```
+
+## Why it matters
+
+This is the skill's own documented flagship shape — "`account` is a new object after every blockchain update" — recurring in the yield module while its Tron staking sibling already carries the fix. While a yield deposit/withdraw/wrap/unwrap/claim tx is pending, any unrelated mutation of `account` (including the poll tick this same effect fires) tears down and restarts the `setInterval` instead of letting it run to term, which can delay or disrupt detection of the pending transaction's own confirmation — the one thing this hook exists to track.
+
+## Notes
+
+- The callback body already only reads `account.key`; this is a dependency-array-only change, nothing else in the effect needs to move.
+- No new import required.
+- `packages/suite` is not React-Compiler-compiled, so this dependency has to be narrowed by hand — the compiler wouldn't fix it even if it ran here, since the defect is an unstable `useEffect` dependency, not a missing memo.
+- Cite `useTronStakePendingTransactionTracking.ts:56` when filing — same poll pattern, same file tree, already correct, and the strongest available evidence that the narrower dependency is sufficient and intended here.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-10-coincontrol-refetches-utxo-transactions-on-account-churn.md
+++ b/perf-issues/react-hooks/p1-10-coincontrol-refetches-utxo-transactions-on-account-churn.md
@@ -1,0 +1,52 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Distinguish a wasted memo from a render loop"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx:144-155`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx#L144-L155)
+
+## Before
+
+```tsx
+// fetch all transactions so that we can show a transaction timestamp for each UTXO
+useEffect(() => {
+    const promise = dispatch(
+        fetchUtxoTransactionsForAccountThunk({
+            accountKey: account.key,
+        }),
+    );
+
+    return () => {
+        promise.abort();
+    };
+}, [account, dispatch]);
+```
+
+## After
+
+```tsx
+// fetch all transactions so that we can show a transaction timestamp for each UTXO
+useEffect(() => {
+    const promise = dispatch(
+        fetchUtxoTransactionsForAccountThunk({
+            accountKey: account.key,
+        }),
+    );
+
+    return () => {
+        promise.abort();
+    };
+}, [account.key, dispatch]);
+```
+
+## Why it matters
+
+The effect body only ever reads `account.key` — the thunk call and the abort cleanup don't touch any other field of `account` — so this is the skill's own "silent and unbounded" shape: it re-fires on every store update that gives the open account a fresh reference, not only once when the Coin Control panel mounts. Composing a Bitcoin-like transaction is precisely when the account is actively syncing (new blocks, balance/UTXO-set updates), so each of those ticks aborts the in-flight `fetchUtxoTransactionsForAccountThunk` promise and redispatches it while the user is mid-selection.
+
+## Notes
+
+- Dependency-array-only change; nothing else in the effect needs to move, and no new import is required.
+- `packages/suite` is not React-Compiler-covered, so this dependency has to be narrowed by hand.
+- Correct in-repo sibling for the identical shape, in this same scan area: `AdaStakingDashboard.tsx:43-52` and `EthStakingDashboard.tsx:59-68` already depend on `accountKey` rather than `account` for their own `fetchAllTransactionsForAccountThunk` effect (verified: both list `[accountKey, dispatch]`) — `AdaStakingDashboard.tsx:52` is also the skill's own named "good" worked example for this exact pattern.
+- Additive, not duplicate, alongside drafts on this same coin-control path in `perf-issues/asymptotic-complexity/` (sibling drafts, not yet filed): `p1-01-addtransaction-reducer-scans-the-whole-account-history-onc.md` documents that this same thunk's reducer path (the `unshift` branch of `addTransaction`, taken because this call passes no `page`/`perPage`) is itself O(m²) per dispatch — narrowing this dependency doesn't touch that reducer cost, it only stops multiplying it by however many times `account` churns while the panel stays open, instead of paying it once per mount. `p1-09-coin-control-the-remaining-o-n-squared-utxo-scans-in-useut.md` (which proposes extending filed #31125) and `perf-issues/scheduling/p2-05-coin-control-rescans-the-utxo-set-per-keystroke.md` are about a different hook entirely — `useUtxoSelection.ts`'s own UTXO-array scans and the search box's keystroke-driven rescan — neither touches this fetch effect's dependency array, so this doc doesn't duplicate either.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-11-responsivecontext-provider-rerenders-app-shell.md
+++ b/perf-issues/react-hooks/p1-11-responsivecontext-provider-rerenders-app-shell.md
@@ -1,0 +1,142 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body
+work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/support/suite/ResponsiveContext.tsx:68-92`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/support/suite/ResponsiveContext.tsx#L68-L92)
+— `ResponsiveContextProvider`'s `setSidebarWidth` closure and its Provider `value` object, both
+rebuilt every render.
+
+Mounted once at the app root, wrapping every route for the whole session:
+
+- [`packages/suite/src/support/suite/Main.tsx:36`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/support/suite/Main.tsx#L36) — inside `<ConnectedThemeProvider>`.
+
+Trigger-cadence co-anchors:
+
+- [`packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx:179`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx#L179) — `onWidthResizeMove={handleSidebarWidthUpdate}`, wired to a `requestAnimationFrame`-throttled `window` `mousemove` listener inside `ResizableBox` (`packages/components/src/components/ResizableBox/ResizableBox.tsx:347,392,415`) while the user drags the sidebar's resize handle.
+- [`packages/suite/src/components/suite/layouts/SuiteLayout/useResponsiveContextOnChange.tsx:33`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/useResponsiveContextOnChange.tsx#L33) and [`:39`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/useResponsiveContextOnChange.tsx#L39) — a debounced `ResizeObserver` on the main content area.
+
+16 consumer files call `useResponsiveContext()`, including `Sidebar.tsx`, `Navigation.tsx`,
+`NavigationItem.tsx`, `DeviceSelector.tsx`, `SidebarDeviceStatus.tsx`, `SuiteLayout.tsx`,
+`AccountsMenu.tsx`, `AccountsList.tsx`, `AccountItemsGroup.tsx`, `AccountItemSkeleton.tsx`,
+`GuideRouter.tsx`, `ConditionalRender.tsx`, and `ContentFlex.tsx`.
+
+## Before
+
+```tsx
+// packages/suite/src/support/suite/ResponsiveContext.tsx
+const setSidebarWidth = (width: number) => {
+    if (typeof forcedSidebarWidth === 'number' && !userResizingSidebar) return;
+    const clamped = Math.max(width, SIDEBAR_MIN_WIDTH);
+    setSidebarWidthRaw(clamped);
+    setSidebarWidthManual(clamped);
+};
+
+const value: ResponsiveContextType = {
+    sidebarWidth: effectiveWidth,
+    setSidebarWidth,
+    lastManualSidebarWidth: sidebarWidthManual,
+    forcedSidebarWidth,
+    setForcedSidebarWidth,
+    isSidebarCollapsed,
+    contentWidth,
+    setContentWidth,
+    autoCollapsed,
+    setAutoCollapsed,
+    userResizingSidebar,
+    setUserResizingSidebar,
+    autoCollapseSuppressed,
+    setAutoCollapseSuppressed,
+};
+
+return <ResponsiveContext.Provider value={value}>{children}</ResponsiveContext.Provider>;
+```
+
+No `useMemo`/`useCallback` appears anywhere in this component for either `setSidebarWidth` or
+`value`, even though `effectiveWidth` and `isSidebarCollapsed` a few lines above (`:52-60`) are
+already correctly `useMemo`'d.
+
+## After
+
+```tsx
+const setSidebarWidth = useCallback(
+    (width: number) => {
+        if (typeof forcedSidebarWidth === 'number' && !userResizingSidebar) return;
+        const clamped = Math.max(width, SIDEBAR_MIN_WIDTH);
+        setSidebarWidthRaw(clamped);
+        setSidebarWidthManual(clamped);
+    },
+    [forcedSidebarWidth, userResizingSidebar],
+);
+
+const value = useMemo<ResponsiveContextType>(
+    () => ({
+        sidebarWidth: effectiveWidth,
+        setSidebarWidth,
+        lastManualSidebarWidth: sidebarWidthManual,
+        forcedSidebarWidth,
+        setForcedSidebarWidth,
+        isSidebarCollapsed,
+        contentWidth,
+        setContentWidth,
+        autoCollapsed,
+        setAutoCollapsed,
+        userResizingSidebar,
+        setUserResizingSidebar,
+        autoCollapseSuppressed,
+        setAutoCollapseSuppressed,
+    }),
+    [
+        effectiveWidth,
+        setSidebarWidth,
+        sidebarWidthManual,
+        forcedSidebarWidth,
+        isSidebarCollapsed,
+        contentWidth,
+        autoCollapsed,
+        userResizingSidebar,
+        autoCollapseSuppressed,
+    ],
+);
+
+return <ResponsiveContext.Provider value={value}>{children}</ResponsiveContext.Provider>;
+```
+
+Wrapping `value` alone would not be sufficient: `setSidebarWidth` is itself a fresh closure every
+render, and it's one of `value`'s own fields, so the `useMemo` would still miss on every render
+unless `setSidebarWidth` is stabilized first.
+
+## Why it matters
+
+React re-renders every `useContext` subscriber whenever the Provider's `value` reference changes,
+regardless of which single field that subscriber actually reads. `ResponsiveContextProvider` wraps
+the whole app for the whole session, and its 16 consumers include the sidebar itself, every
+navigation item, the account list rows, and the device selector. Two triggers make the churn
+continuous rather than occasional: the sidebar's resize handle re-invokes `setSidebarWidth` on every
+animation-frame tick of a `mousemove`-driven drag, and the content area's `ResizeObserver` invokes
+`setContentWidth` on every qualifying width change (window resize, sidebar collapse/expand, DevTools
+panel toggle). Each of those ticks currently re-renders the full 16-file consumer set, not just the
+one or two components that actually read the field that changed.
+
+## Notes
+
+- Compile requirement: add `useCallback` to the file's existing
+  `import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';` —
+  `useMemo` is already imported.
+- The `useState` setters used as-is in the object (`setForcedSidebarWidth`, `setContentWidth`,
+  `setAutoCollapsed`, `setUserResizingSidebar`, `setAutoCollapseSuppressed`) are already
+  reference-stable for the component's lifetime per React's contract, so they need no `useCallback`
+  of their own and `exhaustive-deps` won't ask for them in the `useMemo` array above.
+- Correct in-repo sibling for the Provider-value shape:
+  [`AssetOptionsContext.tsx:26-29`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetOptionsContext.tsx#L26-L29)
+  already wraps its Provider value in `useMemo` keyed on its real inputs.
+- `effectiveWidth`/`isSidebarCollapsed` (`ResponsiveContext.tsx:52-60`) are already correctly
+  `useMemo`'d — this file has memoization awareness, it just wasn't applied to the object that
+  actually crosses the Provider boundary.
+- Splitting the context into a rarely-changing "capabilities" half and a frequently-changing
+  "dimensions" half would cut fan-out further, but a single `useMemo` is the minimal, low-risk fix
+  proposed here.
+- `packages/suite` is web/desktop, not React-Compiler-covered — this is a manual fix and the only
+  mechanism available at runtime.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-12-assetsview-rebuilds-assetrow-props-every-render.md
+++ b/perf-issues/react-hooks/p1-12-assetsview-rebuilds-assetrow-props-every-render.md
@@ -1,0 +1,233 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body
+work before memoizing it, and memoize only what pays"_, covering two compounding defects on the
+dashboard's asset table/grid: the parent's unmemoized prop pipeline, and a per-row component that
+independently re-derives portfolio-wide data. Found by sweep, not named in the doc.
+
+## Where
+
+1. [`packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx:92-172`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx#L92-L172)
+   — the `assets`/`assetSymbols`/`assetsData` construction and the `useAssetsFiatBalances` call,
+   entirely unmemoized in the render body. Feeds `AssetRow`'s `memo()` wrap
+   ([`AssetTable/AssetRow.tsx:48`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx#L48))
+   via [`AssetTable.tsx:49-63`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetTable.tsx#L49-L63),
+   and feeds `AssetCard.tsx:246-261` (not itself `memo()`-wrapped).
+2. [`packages/suite/src/views/dashboard/AssetsView/AssetCoinLogo.tsx:22-31`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/dashboard/AssetsView/AssetCoinLogo.tsx#L22-L31)
+   — `calculateAssetsPercentage(assetsFiatBalances)` re-run once per row/card instance. Rendered
+   from both [`AssetTable/AssetRow.tsx:136-139`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx#L136-L139)
+   (table view) and [`AssetCard/AssetCardInfo.tsx:18-22`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCardInfo.tsx#L18-L22)
+   (card view).
+
+## Before
+
+### 1. `AssetsView.tsx` — no memoization anywhere in the prop pipeline
+
+```tsx
+const useAssetsFiatBalances = (
+    assetsData: AssetData[],
+    accounts: { [key: string]: Account[] },
+    localCurrency: BaseCurrencyCode,
+    currentFiatRates?: RatesByKey,
+) =>
+    assetsData.reduce<AssetFiatBalance[]>((acc, asset) => {
+        /* ...unchanged... */
+        return [...acc, { fiatBalance, symbol: asset.network.symbol }];
+    }, []);
+
+export const AssetsView = () => {
+    const accounts = useSelector(selectAllAccountsToList);
+    // ...
+
+    const assets: PartialRecord<NetworkSymbol, Account[]> = {};
+    accounts.forEach(account => {
+        /* groups into `assets` — fresh object every render */
+    });
+
+    const assetSymbols = typedObjectKeys(assets).filter(symbol => isNetworkSymbol(symbol));
+
+    const assetsData: AssetData[] = assetSymbols.map((symbol): AssetData => {
+        const network = getNetwork(symbol);
+        const assetTokens = assets[symbol]?.reduce(/* ... */);
+        const assetFailed = accounts.find(f => f.symbol === network.symbol && f.failed);
+
+        return {
+            network,
+            failed: !!assetFailed,
+            assetNativeCryptoBalance: /* ... */,
+            assetTokens: assetTokens?.length ? assetTokens : [],
+            stakingAccounts: accounts.filter(/* p2-26's territory, untouched by this doc */),
+            accounts,
+            isStakeNetwork: getNetworkFeatures(symbol).includes('staking'),
+        };
+    });
+
+    const assetsFiatBalances = useAssetsFiatBalances(
+        assetsData,
+        assets,
+        baseCurrencyCode,
+        currentFiatRates,
+    );
+    // ...
+```
+
+`useAssetsFiatBalances` is named like a hook but calls none — it's a plain `.reduce()` invoked
+directly in the render body, allocating a fresh array every call.
+
+### 2. `AssetCoinLogo.tsx` — re-derives the whole portfolio's percentages per instance
+
+```tsx
+export const AssetCoinLogo = ({ symbol, assetsFiatBalances, index }: AssetCoinLogoProps) => {
+    const locale = useSelector(selectLanguage);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+
+    const assetPercentage = assetsFiatBalances
+        ? calculateAssetsPercentage(assetsFiatBalances).find(
+              (asset: AssetFiatBalanceWithPercentage) => asset.symbol === symbol,
+          )?.fiatPercentage
+        : undefined;
+    const { color: networkColor } = getNetworkConfig(symbol);
+    // ...
+};
+```
+
+`calculateAssetsPercentage` is an O(n) `reduce` + O(n) `map` over every asset
+(`suite-common/assets/src/utils.ts:13-36`); calling it once per row/card for N assets is O(N²) per
+render of the whole table/grid.
+
+## After
+
+### 1. `AssetsView.tsx` — memoize the pipeline; make `useAssetsFiatBalances` a genuine hook
+
+```tsx
+const useAssetsFiatBalances = (
+    assetsData: AssetData[],
+    accounts: { [key: string]: Account[] },
+    localCurrency: BaseCurrencyCode,
+    currentFiatRates?: RatesByKey,
+) =>
+    useMemo(
+        () =>
+            assetsData.reduce<AssetFiatBalance[]>((acc, asset) => {
+                /* ...unchanged body... */
+                return [...acc, { fiatBalance, symbol: asset.network.symbol }];
+            }, []),
+        [assetsData, accounts, localCurrency, currentFiatRates],
+    );
+
+export const AssetsView = () => {
+    const accounts = useSelector(selectAllAccountsToList);
+    // ...
+
+    const { assets, assetSymbols, assetsData } = useMemo(() => {
+        const assets: PartialRecord<NetworkSymbol, Account[]> = {};
+        accounts.forEach(account => {
+            /* ...unchanged... */
+        });
+
+        const assetSymbols = typedObjectKeys(assets).filter(symbol => isNetworkSymbol(symbol));
+
+        const assetsData: AssetData[] = assetSymbols.map((symbol): AssetData => {
+            /* ...unchanged body... */
+        });
+
+        return { assets, assetSymbols, assetsData };
+    }, [accounts]);
+
+    const assetsFiatBalances = useAssetsFiatBalances(
+        assetsData,
+        assets,
+        baseCurrencyCode,
+        currentFiatRates,
+    );
+
+    const percentageBySymbol = useMemo(
+        () =>
+            new Map(
+                calculateAssetsPercentage(assetsFiatBalances).map(a => [a.symbol, a.fiatPercentage]),
+            ),
+        [assetsFiatBalances],
+    );
+    // ...at both render sites, pass percentageShare={percentageBySymbol.get(asset.network.symbol)}
+    // instead of assetsFiatBalances={assetsFiatBalances} to <AssetRow>/<AssetCard>
+```
+
+### 2. `AssetCoinLogo.tsx` — accept the scalar directly
+
+```tsx
+type AssetCoinLogoProps = {
+    symbol: NetworkSymbol;
+    percentageShare?: number;
+    index?: number;
+};
+
+export const AssetCoinLogo = ({ symbol, percentageShare, index }: AssetCoinLogoProps) => {
+    const locale = useSelector(selectLanguage);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+    const { color: networkColor } = getNetworkConfig(symbol);
+
+    return (
+        <Row justifyContent="center">
+            <Tooltip
+                content={localizePercentage({
+                    valueInFraction: (percentageShare ?? 0) / 100,
+                    locale,
+                    numDecimals: 2,
+                })}
+                cursor="pointer"
+            >
+                <AssetShareIndicator
+                    symbol={symbol}
+                    networkColor={networkColor}
+                    size={24}
+                    percentageShare={percentageShare}
+                    index={index}
+                />
+            </Tooltip>
+        </Row>
+    );
+};
+```
+
+`AssetTable/AssetRow.tsx`, `AssetCard/AssetCard.tsx`, and `AssetCard/AssetCardInfo.tsx` each need the
+same mechanical change: replace their `assetsFiatBalances: AssetFiatBalance[]` prop (used in each of
+those three files solely to forward to `<AssetCoinLogo>`) with `percentageShare?: number`, and pass
+through the value looked up by their caller — `percentageShare` is already `AssetShareIndicator`'s
+own prop name (`packages/product-components/src/components/AssetShareIndicator/AssetShareIndicator.tsx:24`),
+so this aligns with an existing convention rather than inventing one.
+
+## Why it matters
+
+`AssetRow` is explicitly `memo()`-wrapped, but `AssetsView` hands it a brand-new `assetTokens` array
+and a brand-new shared `assetsFiatBalances` array on every single render — either one alone is
+enough to defeat a shallow-prop `memo()` comparison entirely, so today the wrap provides close to no
+protection. `AssetsView` re-renders on every discovery tick, every `selectCurrentFiatRates` chunk,
+and every account-sync update, none of which are scoped to a single row, so every asset row/card on
+the dashboard currently re-renders in full on all of them. Layered on top, `AssetCoinLogo` —
+instantiated once per row in both the table and card layouts — independently re-derives the whole
+portfolio's percentage breakdown on every one of its own renders, so a dashboard with N enabled
+assets does O(N²) work in that single derivation alone, per render, even after the parent-level
+memoization fix, unless the percentage is also lifted out and computed once.
+
+## Notes
+
+- Boundary with `perf-issues/asymptotic-complexity/p2-26` (sibling draft, not yet filed): that doc's
+  territory is the `stakingAccounts: accounts.filter(...)` line inside the `assetSymbols.map` above
+  (left unchanged here) — a loop-invariant O(accounts) scan repeated once per asset symbol, plus
+  `selectAnyAccountIsStakingActive`'s array-argument selector never hitting its own weakMap memo.
+  This doc's fix wraps that same line inside the new outer `useMemo`, which incidentally makes
+  `asset.stakingAccounts`'s _reference_ stable across renders where `accounts` hasn't changed (today
+  it's as unstable as every other field here) — but it does not hoist the filter out of the map or
+  touch the selector's signature, so the per-recompute cost p2-26 targets is untouched. The two
+  fixes are additive; land either one first without blocking the other.
+- Compile requirement: `useMemo` is already imported in `AssetsView.tsx`. `AssetCoinLogo.tsx` drops
+  its now-unused `calculateAssetsPercentage`/`AssetFiatBalanceWithPercentage`/`AssetFiatBalance`
+  imports from `@suite-common/assets`.
+- `AssetCard` (grid view) is not itself `memo()`-wrapped, so finding 1's "restores a defeated memo"
+  benefit applies only to the table view's `AssetRow`; finding 2's relocation benefits both layouts
+  equally, since it doesn't depend on the row component being memoized.
+- Mechanical prop-rename, not a logic change, across `AssetTable.tsx`, `AssetTable/AssetRow.tsx`,
+  `AssetCard/AssetCard.tsx`, and `AssetCard/AssetCardInfo.tsx`: each currently threads
+  `assetsFiatBalances` through to `<AssetCoinLogo>` and touches it nowhere else.
+- `packages/suite` is not React-Compiler-covered — both memoizations are manual and load-bearing at
+  runtime.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-13-useapprovalstep-effect-can-double-fire-quote-refresh.md
+++ b/perf-issues/react-hooks/p1-13-useapprovalstep-effect-can-double-fire-quote-refresh.md
@@ -1,0 +1,128 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Distinguish a wasted memo from a render loop"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`suite-common/trading/src/hooks/useApprovalStep.ts:49-85`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/trading/src/hooks/useApprovalStep.ts#L49-L85) — the effect that can double-fire; its dependency array is at line 85.
+
+Root cause: [`suite-common/trading/src/hooks/useAllowanceTxTracking.ts:76-80`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/trading/src/hooks/useAllowanceTxTracking.ts#L76-L80) returns a fresh object literal on every call.
+
+Consumer chain that puts the unstable value behind a Provider (any of these re-rendering re-fires the effect above):
+
+- [`packages/suite/src/hooks/wallet/allowance/useAllowance.ts:15-18`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/allowance/useAllowance.ts#L15-L18) — also returns a plain, unmemoized `{ tx, state }` object
+- [`packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx:27`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx#L27)
+- [`packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx:43`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx#L43)
+- [`packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx:39`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx#L39)
+
+Effect consumer: [`packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx:45,80-85`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx#L45-L85)
+
+## Before
+
+```ts
+// useAllowanceTxTracking.ts:38-81 — return value is a fresh object literal every call
+export const useAllowanceTxTracking = ({ accountKey }: UseAllowanceTxTrackingParams) => {
+    const [approvalTxid, setApprovalTxid] = useState<string | null>(null);
+
+    const transaction = useSelector((state: TransactionsRootState & AccountsRootState) =>
+        approvalTxid ? selectTransactionByAccountKeyAndTxid(state, accountKey, approvalTxid) : null,
+    );
+
+    const status = useMemo<TransactionStatus>(() => {
+        // ...status derivation, unchanged
+    }, [transaction]);
+
+    return {
+        approvalTxid,
+        status,
+        setApprovalTxid,
+    };
+};
+```
+
+```ts
+// useApprovalStep.ts:43-85 — effect #1 correctly narrows to tx.approvalTxid; effect #2 depends on
+// the whole `tx` object and calls refreshQuotesRef.current() every time it refires while confirmed
+useEffect(() => {
+    if (tx.approvalTxid && !txApprovalType) {
+        setTxApprovalType(currentApprovalType);
+    }
+}, [tx.approvalTxid, currentApprovalType, txApprovalType]);
+
+useEffect(() => {
+    const thisRunId = ++effectRunIdRef.current;
+
+    const { approvalTxid, status, setApprovalTxid } = tx;
+    if (!approvalTxid) {
+        return;
+    }
+
+    if (status.isPending) {
+        setApprovalStep('LOADING');
+
+        return;
+    }
+
+    if (status.isFailed) {
+        setApprovalStep('REQUIRED');
+
+        return;
+    }
+
+    if (status.isConfirmed && txApprovalType) {
+        setApprovalStep(txApprovalType === 'APPROVE' ? 'APPROVED' : 'REQUIRED');
+
+        refreshQuotesRef
+            .current()
+            .catch(error => {
+                console.error('Failed to refresh quotes after approval:', error);
+            })
+            .finally(() => {
+                if (effectRunIdRef.current !== thisRunId) {
+                    return;
+                }
+                setApprovalTxid(null);
+                setTxApprovalType(null);
+            });
+    }
+}, [tx, txApprovalType, refreshQuotesRef]);
+```
+
+## After
+
+```ts
+// useAllowanceTxTracking.ts — wrap the return in useMemo
+export const useAllowanceTxTracking = ({ accountKey }: UseAllowanceTxTrackingParams) => {
+    const [approvalTxid, setApprovalTxid] = useState<string | null>(null);
+
+    const transaction = useSelector((state: TransactionsRootState & AccountsRootState) =>
+        approvalTxid ? selectTransactionByAccountKeyAndTxid(state, accountKey, approvalTxid) : null,
+    );
+
+    const status = useMemo<TransactionStatus>(() => {
+        // ...status derivation, unchanged
+    }, [transaction]);
+
+    return useMemo(
+        () => ({
+            approvalTxid,
+            status,
+            setApprovalTxid,
+        }),
+        [approvalTxid, status, setApprovalTxid],
+    );
+};
+```
+
+`setApprovalTxid` is a `useState` setter (stable by React) and `status` is already its own stable memo, so this holds a single reference until `approvalTxid` itself actually changes — which stabilizes `tx` all the way through the `AllowanceContext.Provider` hop and into `useApprovalStep`'s second effect, with no change needed in `useApprovalStep.ts` itself.
+
+## Why it matters
+
+Every re-render of the `AllowanceContext.Provider` owner (`TradingExchangeForm`, `YieldDeposit`, or `YieldWithdraw`) while a token approval sits in the confirmed-but-not-yet-cleared window re-fires `useApprovalStep`'s second effect and calls `refreshQuotesRef.current()` again — a second, concurrent `refreshQuotes()` — because nothing in the dependency array or the effect body deduplicates on `tx`'s _content_, only its reference; `effectRunIdRef` only guards the `.finally()` cleanup racing itself, it does not stop the extra call from being issued. This is the skill's "silent and unbounded" shape — an effect keyed on a fresh whole-object dependency, calling something that talks to the network — landing in a real-money flow: the buy/sell/exchange token-allowance approval and the Earn Yield deposit/withdraw allowance approval.
+
+## Notes
+
+- Compile requirement: none — `useMemo` is already imported in `useAllowanceTxTracking.ts` (`import { useMemo, useState } from 'react';`).
+- Which app: `suite-common/trading` ships to both `packages/suite` (uncompiled — manual memoization is the only mechanism) and `suite-native` (compiled). Per the skill, memoize for the web consumer regardless — `suite-common` itself is never compiled either way. `suite-native/module-trading/src/screens/TradingConfirmingScreen.tsx:56-60` also calls `useAllowanceTxTracking` directly, but destructures `status`/`approvalTxid`/`setApprovalTxid` immediately rather than holding the whole `tx` object, so it isn't independently exposed to this defect — it simply benefits from the fix without needing one of its own.
+- Alternative/complementary fix, equally valid per the sweep: narrow `useApprovalStep`'s second effect's dependency array (line 85) from `[tx, txApprovalType, refreshQuotesRef]` to the primitives effect #1 already uses correctly (`tx.approvalTxid`, `tx.status.isPending`, `tx.status.isFailed`, `tx.status.isConfirmed`), destructuring them from `tx` inside the effect body instead of relying on `tx`'s own identity. Fixing `useAllowanceTxTracking.ts` is the cheaper of the two because `tx` also flows through the `AllowanceContext.Provider` value, so stabilizing it at the source is a same-PR win for that Provider's identity too, on top of the effect fix.
+- Honest sizing: the double-fire needs the Provider owner itself to re-render while `status.isConfirmed && txApprovalType` is true — plausible given its own polling/discovery selectors (`selectHasRunningDiscovery`, `selectAreFeesLoading`, quote polling), but not something this sweep measured. Flagged as P1 because the cost of firing is a real, concurrent network call in a money-moving flow, not because the frequency is proven high.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-14-formatterprovider-memo-defeated-on-web.md
+++ b/perf-issues/react-hooks/p1-14-formatterprovider-memo-defeated-on-web.md
@@ -1,0 +1,96 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Check which app you are in before adding or removing a memo"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/hooks/suite/useFormattersConfig.ts:7-18`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/suite/useFormattersConfig.ts#L7-L18) — no `useMemo` around the returned config object.
+
+Consumed at [`packages/suite/src/support/suite/Main.tsx:28`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/support/suite/Main.tsx#L28) (the hook call) and [line 46](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/support/suite/Main.tsx#L46) (`<FormatterProvider config={formattersConfig}>`), which wraps the whole web/desktop app at [`packages/suite-web/src/MainWeb.tsx:30-48`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite-web/src/MainWeb.tsx#L30-L48).
+
+The memo this defeats: [`suite-common/formatters/src/FormatterProvider.tsx:86-93`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/formatters/src/FormatterProvider.tsx#L86-L93). What a miss costs: [`suite-common/formatters/src/makeFormatter.tsx:50-57`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/formatters/src/makeFormatter.tsx#L50-L57) returns a brand-new component function on every call.
+
+Correct in-repo sibling: [`suite-native/formatters-config/src/hooks/useFormattersConfig.ts:12-26`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/formatters-config/src/hooks/useFormattersConfig.ts#L12-L26).
+
+## Before
+
+```ts
+// packages/suite/src/hooks/suite/useFormattersConfig.ts:7-18 — no useMemo
+export const useFormattersConfig = (): FormatterProviderConfig => {
+    const locale = useSelector(selectLanguage);
+    const bitcoinAmountUnit = useSelector(selectBitcoinAmountUnit);
+    const baseCurrency = useSelector(selectBaseCurrency);
+
+    return {
+        locale,
+        baseCurrency,
+        bitcoinAmountUnit,
+        is24HourFormat: true,
+    };
+};
+```
+
+```tsx
+// suite-common/formatters/src/FormatterProvider.tsx:83-100 — this memo is already correctly
+// written; it just never receives a stable `config` to hold onto
+export const FormatterProvider = ({ config, children }: FormatterProviderProps) => {
+    const intl = useIntl();
+
+    const contextValue = useMemo(() => {
+        const extendedConfig = {
+            ...config,
+            intl,
+        };
+
+        return getFormatters(extendedConfig);
+    }, [config, intl]);
+
+    return (
+        <FormatterProviderContext.Provider value={contextValue}>
+            {children}
+        </FormatterProviderContext.Provider>
+    );
+};
+```
+
+## After
+
+```ts
+// packages/suite/src/hooks/suite/useFormattersConfig.ts
+import { useMemo } from 'react';
+
+import { selectLanguage } from '@suite/settings';
+import { type FormatterProviderConfig } from '@suite-common/formatters';
+import { selectBaseCurrency, selectBitcoinAmountUnit } from '@suite-common/wallet-core';
+
+import { useSelector } from 'src/hooks/suite/useSelector';
+
+export const useFormattersConfig = (): FormatterProviderConfig => {
+    const locale = useSelector(selectLanguage);
+    const bitcoinAmountUnit = useSelector(selectBitcoinAmountUnit);
+    const baseCurrency = useSelector(selectBaseCurrency);
+
+    return useMemo(
+        () => ({
+            locale,
+            baseCurrency,
+            bitcoinAmountUnit,
+            is24HourFormat: true,
+        }),
+        [locale, baseCurrency, bitcoinAmountUnit],
+    );
+};
+```
+
+This mirrors the native hook exactly (same dependency list, same shape). No change needed in `FormatterProvider.tsx` — its own `useMemo` is already correctly structured and will start holding as soon as `config` is stable.
+
+## Why it matters
+
+`getFormatters()` calls six `prepare*Formatter` functions (`prepareCryptoAmountFormatter`, `prepareDisplaySymbolFormatter`, `prepareBaseCurrencyAmountFormatter`, `prepareDateFormatter`, `prepareTimeFormatter`, `prepareDateTimeFormatter`), each of which calls `makeFormatter(...)` and gets back a _new React component function_. `MainWeb` is a plain, non-`memo`'d component whose body re-runs whenever its own hooks (`useTor`, `useConnectPopupWeb`, `useConnectPopupWebextension`, `useDebugLanguageShortcut`) cause a re-render; every such re-render calls `useFormattersConfig()` again, returns a fresh object, and misses `FormatterProvider`'s memo — so all six formatter "components" get new identities on that render. Every `<CryptoAmountFormatter>`, `<DateFormatter>`, etc. anywhere below `Main` — every displayed amount, balance, date and time in the entire web/desktop app — is then a different component type on the next render, so React unmounts and remounts it instead of re-rendering it: lost local state and effects in whatever the formatter wraps, and layout thrash, triggered by something as unrelated as a Tor status change.
+
+## Notes
+
+- Compile requirement: adds `import { useMemo } from 'react';` to `packages/suite/src/hooks/suite/useFormattersConfig.ts`, which currently has no `'react'` import at all.
+- Which app: this is a `packages/suite` (web/desktop) file — uncompiled, so manual `useMemo` is the only mechanism available at runtime, per the skill's "check which app you are in" rule. `suite-native/formatters-config/src/hooks/useFormattersConfig.ts:12-26` is the correct in-repo sibling and does exactly the right thing already (`useMemo(..., [baseCurrencyCode, bitcoinAmountUnit, locale])`); the fix above mirrors it line for line.
+- `FormatterProvider.tsx` itself (in `suite-common/formatters`, ships to both apps) needs no change — its own `useMemo` deps (`[config, intl]`) are already correct; it was only ever fed an unstable `config`.
+- Honest sizing: this is flagged P1 for blast radius (essentially every formatted value in the app), not measured frequency — whether `MainWeb` re-renders once per session or many times per minute in a running app was not instrumented here.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-15-table-context-value-rerenders-all-rows-on-scroll-edge.md
+++ b/perf-issues/react-hooks/p1-15-table-context-value-rerenders-all-rows-on-scroll-edge.md
@@ -1,0 +1,97 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body
+work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/components/src/components/Table/Table.tsx:68`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Table/Table.tsx#L68)
+
+- Consumers: [`TableRow.tsx:94`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Table/TableRow.tsx#L94)
+  and [`TableCell.tsx:72`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Table/TableCell.tsx#L72)
+  — both call `useTable()` (`useContext(TableContext)`).
+- Trigger source: [`packages/components/src/utils/useScrollShadow.tsx:73-83`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/utils/useScrollShadow.tsx#L73-L83)
+  — the four `setIsScrolledTo*` calls fired from `onScroll`, which re-render `Table` on every
+  scroll-shadow boundary crossing.
+
+## Before
+
+```tsx
+// Table.tsx:53-68
+export const Table = ({
+    children,
+    margin,
+    colWidths,
+    isRowHighlightedOnHover = false,
+    hasBorders = true,
+    typographyStyle = 'body-md',
+    backgroundColor = 'surfaceFillRaised',
+}: TableProps) => {
+    const { scrollElementRef, onScroll, ShadowContainer, ShadowRight, ShadowLeft } =
+        useScrollShadow({
+            backgroundColor,
+        });
+
+    return (
+        <TableContext.Provider value={{ isRowHighlightedOnHover, hasBorders, typographyStyle }}>
+```
+
+Both row-level consumers read the context directly:
+
+```tsx
+// TableRow.tsx:94
+const { isRowHighlightedOnHover, hasBorders } = useTable();
+
+// TableCell.tsx:72
+const { hasBorders, typographyStyle = 'body-md' } = useTable();
+```
+
+`isRowHighlightedOnHover`, `hasBorders`, and `typographyStyle` only ever change when `Table`'s own
+props change, but the object literal wrapping them is fresh on every render of `Table` — including
+renders `Table` triggers on itself. `useScrollShadow` (`useScrollShadow.tsx:73-83`) calls
+`setIsScrolledToTop`/`setIsScrolledToBottom`/`setIsScrolledToLeft`/`setIsScrolledToRight` from the
+`onScroll` handler; `Object.is` bails those state updates out to boundary crossings only, but each
+crossing still re-renders `Table` and mints a new Provider value.
+
+## After
+
+```tsx
+const tableContextValue = useMemo(
+    () => ({ isRowHighlightedOnHover, hasBorders, typographyStyle }),
+    [isRowHighlightedOnHover, hasBorders, typographyStyle],
+);
+
+return (
+    <TableContext.Provider value={tableContextValue}>
+```
+
+## Why it matters
+
+React re-renders every consumer of a context whenever the Provider's `value` reference changes,
+independent of `memo()` on the consumer — context propagation bypasses that bail-out entirely. Any
+`Table` instance with many rows (a transaction table, an asset table, a settings table) currently
+re-renders every `TableRow` and `TableCell` — and their `Text`/formatting children — the moment the
+user scrolls it to an edge, even though no row's underlying data changed and the trigger is a
+completely ordinary user action. The cost scales with row count and repeats on every
+top/bottom/left/right boundary crossing for the table's lifetime.
+
+## Notes
+
+- Compile requirement: add `useMemo` to the existing `import { type ReactNode } from 'react';` on
+  `Table.tsx:1`.
+- All three memo inputs are `Table`'s own destructured props/defaults (all primitives), so this memo
+  is cheap and will always hit across the boundary-crossing re-renders described above — a pure win
+  with no correctness trade-off.
+- `TableRow`/`TableCell` are not wrapped in `memo()` (confirmed while reading both files), but that
+  doesn't change what needs fixing: a `memo()`-wrapped component that reads a changed context via
+  `useContext` still re-renders, so wrapping the rows/cells would not by itself have prevented this
+  — the fix has to be at the Provider.
+- `useScrollShadow.tsx` itself is written correctly — the four scroll-position booleans are
+  legitimate derived state, bailed out via `Object.is` on every non-boundary scroll tick. It's cited
+  here only as the trigger source, not as something to change.
+- Correct in-repo sibling for this exact shape:
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetOptionsContext.tsx:26-29`
+  already wraps its Provider value in `useMemo` keyed on its constituent props.
+- `packages/components` ships to both the uncompiled `packages/suite` web/desktop app and the
+  React-Compiler-covered `suite-native`; per this area's scope, native-vs-web doesn't change the fix
+  — memoize for the web consumer.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-16-usetranslatedmessages-double-renders-app-at-cold-start.md
+++ b/perf-issues/react-hooks/p1-16-usetranslatedmessages-double-renders-app-at-cold-start.md
@@ -1,0 +1,80 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Distinguish a wasted memo from a render loop"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`suite-native/intl/src/hooks/useTranslatedMessages.ts:23-34`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/intl/src/hooks/useTranslatedMessages.ts#L23-L34)
+
+Consumed at [`suite-native/intl/src/IntlProvider.tsx:24-35`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/intl/src/IntlProvider.tsx#L24-L35) — `<ReactIntlProvider messages={messages}>{children}</ReactIntlProvider>`, where `children` is the entire app; `IntlProvider` sits at the root of the component tree.
+
+Compounding factor, same provider: [`suite-native/intl/src/hooks/useSystemLocaleListener.ts:19-31`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/intl/src/hooks/useSystemLocaleListener.ts#L19-L31) — also called from `IntlProvider`, dispatches a possibly-different system locale on mount, so a cold start where the OS locale differs from the persisted one can add a _third_ full-tree render on top of the two below.
+
+## Before
+
+```ts
+// suite-native/intl/src/hooks/useTranslatedMessages.ts:23-34
+export const useTranslatedMessages = () => {
+    const [messages, setMessages] = useState<{ [key: string]: string }>({});
+    const supportedLanguageLocale = useSelector(selectSupportedLanguageLocale);
+
+    useEffect(() => {
+        const localizedMessages = LANGUAGE_TRANSLATIONS_MAP[supportedLanguageLocale];
+
+        setMessages({ ...englishFallback, ...localizedMessages });
+    }, [supportedLanguageLocale]);
+
+    return messages;
+};
+```
+
+```tsx
+// suite-native/intl/src/IntlProvider.tsx:24-35
+export const IntlProvider = ({ children }: { children: React.ReactNode }) => {
+    useSystemLocaleListener();
+
+    const locale = useSelector(selectLocale);
+    const messages = useTranslatedMessages();
+
+    return (
+        <ReactIntlProvider locale={locale} defaultLocale={DEFAULT_LOCALE} messages={messages}>
+            {children}
+        </ReactIntlProvider>
+    );
+};
+```
+
+`LANGUAGE_TRANSLATIONS_MAP`'s entries (`useTranslatedMessages.ts:9-18`) are `require(...)`'d JSON, resolved synchronously at module load — there is no asynchronous work here to justify holding the merged result in an effect at all.
+
+## After
+
+```ts
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+// ...
+
+export const useTranslatedMessages = () => {
+    const supportedLanguageLocale = useSelector(selectSupportedLanguageLocale);
+
+    return useMemo(
+        () => ({ ...englishFallback, ...LANGUAGE_TRANSLATIONS_MAP[supportedLanguageLocale] }),
+        [supportedLanguageLocale],
+    );
+};
+```
+
+This is `suite-native` (React-Compiler-compiled) code, where the standing rule is "the fix is never add `useMemo` — the compiler owns memoization." That rule is about not layering a redundant cache in front of a computation the compiler would already auto-memoize; it doesn't apply here the way it looks like it might. `useMemo` isn't being added on top of an existing, already-correct render-body expression — it's replacing a `useState`+`useEffect` pair, i.e. removing a piece of state and the effect that kept it in sync, which is the skill's own "state that can be computed from what you already have is not state" principle applied literally. The behavior change this buys — the first render already carries the correct `messages`, instead of `{}` corrected a commit later — is not something the compiler would have provided by leaving the `useState`/`useEffect` pair in place; the compiler auto-memoizes computations, it does not turn stored state back into derived state. Worth noting for whoever picks this up: a plain, non-memoized `const messages = { ...englishFallback, ...LANGUAGE_TRANSLATIONS_MAP[supportedLanguageLocale] };` (no `useMemo` at all) fixes the double-render just as correctly, since the compiler will auto-memoize that computed value on its own — `useMemo` vs. a bare `const` is a style choice on this file, not a correctness difference; it's shown here only to mirror the derive-during-render idiom the skill itself uses for this exact bug class.
+
+## Why it matters
+
+On mount, `messages` starts as `{}`. Every `<Translation>`/`formatMessage` call that renders before the effect resolves has no matching entry in an empty `messages` object, so `react-intl` treats each one as missing and calls its `onError` handler — `console.error` by default, which per this repo's own logging rules is Sentry-captured on every platform. The effect then fires, calls `setMessages`, and the entire subtree under `IntlProvider` — i.e. the whole app, since this provider sits at the root — re-renders a second time with the real messages. `useSystemLocaleListener`, mounted in the same provider, can independently dispatch a different system locale on that same cold start and force a third full-tree render before the UI settles. This lands at the single most latency-sensitive moment in the app's lifecycle — cold start, time-to-interactive — unconditionally, on every launch, not as a rare edge case.
+
+## Notes
+
+- Compile requirement: drop `useState`/`useEffect` from the existing `import { useEffect, useState } from 'react';` and replace with `import { useMemo } from 'react';`. No other import changes.
+- Which app: `suite-native` (compiled) — see the After section for why keeping `useMemo` here is fixing a state/effect problem, not adding manual memoization the compiler would otherwise own; nothing about this proposal conflicts with the "don't add memoization on native" rule.
+- `useSystemLocaleListener` (same file's sibling hook, called from the same `IntlProvider`) is a genuinely asynchronous `AppState` subscription, not a derivable value — it's a compounding factor on the same cold start, not a second instance of this bug, and isn't proposed for change here.
+- Honest sizing: one hook, one call site (`IntlProvider`) — but that call site is the app-root i18n provider, so the P1 severity reflects blast radius (every component under it, on every launch), not fan-out count; the exact frequency/cost of the resulting `console.error` calls was not measured.
+- Confidence: high — the lookup table's `require(...)`'d JSON entries are resolved synchronously at module load, so there's no async dependency the original effect could have been guarding against.
+- Same defect class recurs at much smaller scale elsewhere in native code: `suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts:82-88` derives a percentage via a second `useEffect`+`setState` instead of computing it in render (one price card, not the app root); tracked as `p3-04` (sibling draft, not yet filed).
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p1-17-native-fee-compose-effects-key-on-whole-account.md
+++ b/perf-issues/react-hooks/p1-17-native-fee-compose-effects-key-on-whole-account.md
@@ -1,0 +1,443 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Distinguish a wasted memo from a render loop"_ (the "silent and unbounded" class). Found by sweep, not named in the doc.
+
+## Where
+
+1. **Yield deposit/withdraw/approval fee-and-allowance chain** — `useResolvedYieldFlowData`'s root memo plus four downstream consumers, all in `suite-native/module-earn/src/hooks/`:
+    - [`useResolvedYieldFlowData.ts:240-249`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts#L240-L249) — root memo (context; not itself changed, see Notes)
+    - [`useYieldApprovalFees.ts:26-57`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldApprovalFees.ts#L26-L57) — consumer 1 (`approvalTransaction` memo)
+    - [`useYieldAllowanceFees.ts:95-106`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldAllowanceFees.ts#L95-L106) + [`:174-177`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldAllowanceFees.ts#L174-L177) — consumer 2 (`composeAllowanceFeeParams` memo + the debounce effect that dispatches from it)
+    - [`useYieldDepositFees.ts:40-72`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldDepositFees.ts#L40-L72) — consumer 3 (`composeTransaction` callback), feeding the shared debounced compose effect at [`usePreparedTxFees.ts:296-325`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/usePreparedTxFees.ts#L296-L325)
+    - [`useRefreshYieldDepositAllowanceOnIdle.ts:13-33`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useRefreshYieldDepositAllowanceOnIdle.ts#L13-L33) — consumer 4, the clearest case (whole hook)
+2. **Native send form — network fee-info effect** — [`useSendForm.tsx:335-337`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-send/src/hooks/useSendForm.tsx#L335-L337)
+3. **Native send form — debounced fee-composition effect** — [`useSendForm.tsx:264-276`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-send/src/hooks/useSendForm.tsx#L264-L276) (`updateFormState`'s `account` dependency, listed at line 269) feeding [`useSendForm.tsx:319-321`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-send/src/hooks/useSendForm.tsx#L319-L321)
+4. **Earn/staking fee composition (`useComposeEarnFees`)** — [`useComposeEarnFees.ts:120-199`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useComposeEarnFees.ts#L120-L199)
+5. **EVM approval fee composition (`useEvmApprovalFees`)** — [`useEvmApprovalFees.ts:102-112`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts#L102-L112)
+
+## Before
+
+### 1. Yield deposit/withdraw/approval chain
+
+#### Root memo (context — not part of the fix)
+
+```tsx
+// useResolvedYieldFlowData.ts:240-249
+const resolvedFlowData = useMemo(
+    () =>
+        resolveYieldFlowData({
+            account,
+            tokenContract,
+            yieldId,
+            yieldOpportunities: yieldOpportunities ?? emptyYieldOpportunities,
+        }),
+    [account, tokenContract, yieldId, yieldOpportunities],
+);
+```
+
+`resolveYieldFlowData` builds `flowData.token`/`flowData.receiptToken` as **new object literals** on every call, so any blockchain-driven update to `account` (balance tick, new tx, discovery) produces a fresh `resolvedFlowData`/`flowData` here, even when the fields a given consumer actually reads haven't changed. This memo's own dependency on `account` is correct — its output embeds `account.symbol` and token balances read from it — so it is not part of the proposed fix below; the four consumers are.
+
+#### Consumer 1 — `useYieldApprovalFees.ts:26-57`
+
+```tsx
+const approvalTransaction = useMemo<YieldAllowanceFeeTransaction | null>(() => {
+    if (!amount || !flowData) {
+        return null;
+    }
+    const allowanceAmount = getYieldApprovalAllowanceAmount({
+        amount,
+        approvalLimitType,
+        tokenContract,
+        tokenDecimals: flowData.token.decimals,
+        tokenSymbol: flowData.token.symbol,
+    });
+    const contractAddress = getApprovalContractAddress({ flowType: 'deposit', flowData });
+    const spender = flowData.vault.outputToken?.address;
+    // ...
+}, [amount, approvalLimitType, flowData, tokenContract]);
+```
+
+#### Consumer 2 — `useYieldAllowanceFees.ts:95-106,174-177`
+
+```tsx
+const composeAllowanceFeeParams = useMemo((): ComposeAllowanceFeeParams | null => {
+    if (!isEnabled || !flowData || !formDraftKey || !feeInfo || !transaction) {
+        return null;
+    }
+    return { feeInfo, flowData, formDraftKey, transaction };
+}, [feeInfo, flowData, formDraftKey, isEnabled, transaction]);
+
+// :174-177 — fires the real dispatch (composeAllowanceFee -> composeAllowanceTransactionThunk)
+useEffect(() => {
+    setIsComposingAllowanceFee(composeAllowanceFeeParams !== null);
+    debounce(composeAllowanceFee);
+}, [composeAllowanceFee, composeAllowanceFeeParams, debounce]);
+```
+
+#### Consumer 3 — `useYieldDepositFees.ts:40-72`
+
+```tsx
+const composeTransaction = useCallback(
+    async (composeAmount: string): Promise<ComposeTxResult<ComposedDepositTransaction>> => {
+        if (!flowData) {
+            return { type: 'error', isFeeEstimationError: false };
+        }
+        const result = await dispatch(
+            composeYieldDepositTransactionThunk({ amount: composeAmount, flowData }),
+        ).unwrap();
+        // ...
+    },
+    [dispatch, flowData],
+);
+```
+
+#### Consumer 4 (clearest case) — `useRefreshYieldDepositAllowanceOnIdle.ts` (whole hook)
+
+```tsx
+export const useRefreshYieldDepositAllowanceOnIdle = ({
+    allowanceStatus,
+    resolvedFlowData,
+}: UseRefreshYieldDepositAllowanceOnIdleParams) => {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (resolvedFlowData.resolutionStatus !== 'resolved' || allowanceStatus !== 'idle') {
+            return;
+        }
+
+        void dispatch(
+            initYieldAllowanceThunk({
+                flowData: resolvedFlowData.flowData,
+                flowKey: resolvedFlowData.flowKey,
+                flowType: 'deposit',
+                shouldSkipApprovalStep: false,
+            }),
+        );
+    }, [allowanceStatus, dispatch, resolvedFlowData]);
+};
+```
+
+The effect body doesn't need the vault/token display fields `resolvedFlowData` drags along — it only ever reads `.resolutionStatus`, `.flowData`, `.flowKey`.
+
+### 2. Native send form — network fee-info effect
+
+```tsx
+// useSendForm.tsx:334-337
+// TODO: Fetch periodically. So if the user stays on the screen for a long time, the fee info is updated in the background.
+useEffect(() => {
+    if (account) dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol }));
+}, [account, dispatch]);
+```
+
+This is the skill's own canonical bad example, almost verbatim: `account` is the full Redux object, but the callback only ever reads `account.symbol`.
+
+### 3. Native send form — debounced fee-composition effect
+
+```tsx
+// useSendForm.tsx:203-276 (updateFormState) — account is read as a value AND listed as a dep
+const updateFormState = useCallback(async () => {
+    if (account && network && networkFeeInfo) {
+        const response = await dispatch(
+            composeSendFormTransactionFeeLevelsThunk({
+                formState: constructFormDraft({
+                    formValues: getValues(),
+                    tokenContract,
+                    selectedUtxos,
+                }),
+                composeContext: { account, network, feeInfo: networkFeeInfo, excludedUtxos },
+            }),
+        );
+        // ...
+    }
+}, [
+    accountKey,
+    dispatch,
+    getValues,
+    tokenContract,
+    account,
+    network,
+    networkFeeInfo,
+    setError,
+    excludedUtxos,
+    selectedUtxos,
+    trigger,
+]);
+
+// :319-321 — re-arms on every identity change of updateFormState
+useEffect(() => {
+    debounce(updateFormState);
+}, [updateFormState, watchedFormValues, debounce, selectedUtxos, isNetworkReserveEnabled]);
+```
+
+### 4. Earn/staking fee composition (`useComposeEarnFees`)
+
+```tsx
+// useComposeEarnFees.ts:120-191 (composeFeeLevels) — account read directly, listed at line 190
+const composeFeeLevels = useCallback(
+    async (requestId: number) => {
+        if (!formState || !account || !feeInfo) {
+            /* ... */
+        }
+        const response =
+            account.networkType === 'solana'
+                ? await dispatch(composeSolanaStakingTransactionFeeLevelsNativeThunk({/* ... */}))
+                : await dispatch(
+                      composeSendFormTransactionFeeLevelsThunk({
+                          formState: mergedFormState,
+                          composeContext: { account, feeInfo, network: getNetwork(account.symbol) },
+                      }),
+                  );
+        // ...
+    },
+    [dispatch, formState, account, feeInfo, saveDraft, accountKey, formDraftPrefix],
+);
+
+// :193-199
+useEffect(() => {
+    if (!isFocused) return;
+    // ...
+    debounce(() => composeFeeLevels(requestId));
+}, [isFocused, account, debounce, composeFeeLevels, feeInfo, formState]);
+```
+
+### 5. EVM approval fee composition (`useEvmApprovalFees`)
+
+```tsx
+// useEvmApprovalFees.ts:102-112
+useEffect(() => {
+    composeFeesRef.current();
+}, [
+    quote?.dexTx?.data,
+    quote?.approvalType,
+    account,
+    feeInfo,
+    selectedFeeLevel,
+    customFee,
+    approvalTypeOverride,
+]);
+```
+
+This file already uses the ref-read pattern for `composeFees` itself (`composeFeesRef.current = composeFees;`, line 100), but it still lists the whole `account` object directly in the _triggering_ effect's own dependency array — the ref indirection doesn't help here because the effect re-runs (and calls `composeFeesRef.current()`) whenever `account` changes reference, regardless of the ref.
+
+## After
+
+### 1. Yield deposit/withdraw/approval chain
+
+#### Consumer 1 — narrow to the primitives actually read (not a ref-read candidate)
+
+```tsx
+const approvalTransaction = useMemo<YieldAllowanceFeeTransaction | null>(() => {
+    if (!amount || !flowData) {
+        return null;
+    }
+    // ...body unchanged: still reads flowData.token.decimals/.symbol/.contractAddress and
+    // flowData.vault.outputToken?.address...
+}, [
+    amount,
+    approvalLimitType,
+    flowData?.token.decimals,
+    flowData?.token.symbol,
+    flowData?.token.contractAddress,
+    flowData?.vault.outputToken?.address,
+    tokenContract,
+]);
+```
+
+#### Consumer 2 — ref-read `flowData`/`feeInfo`
+
+```tsx
+const flowDataRef = useFreshRef(flowData);
+const feeInfoRef = useFreshRef(feeInfo);
+
+const composeAllowanceFeeParams = useMemo((): ComposeAllowanceFeeParams | null => {
+    const currentFlowData = flowDataRef.current;
+    const currentFeeInfo = feeInfoRef.current;
+
+    if (!isEnabled || !currentFlowData || !formDraftKey || !currentFeeInfo || !transaction) {
+        return null;
+    }
+
+    return { feeInfo: currentFeeInfo, flowData: currentFlowData, formDraftKey, transaction };
+}, [flowDataRef, feeInfoRef, formDraftKey, isEnabled, transaction]);
+```
+
+The effect at `:174-177` is unchanged — it already only depends on `composeAllowanceFeeParams`/`composeAllowanceFee`/`debounce`, so stabilizing the memo's identity is what stops it from re-triggering on background account churn.
+
+#### Consumer 3 — ref-read `flowData`
+
+```tsx
+const flowDataRef = useFreshRef(flowData);
+
+const composeTransaction = useCallback(
+    async (composeAmount: string): Promise<ComposeTxResult<ComposedDepositTransaction>> => {
+        const currentFlowData = flowDataRef.current;
+
+        if (!currentFlowData) {
+            return { type: 'error', isFeeEstimationError: false };
+        }
+        const result = await dispatch(
+            composeYieldDepositTransactionThunk({
+                amount: composeAmount,
+                flowData: currentFlowData,
+            }),
+        ).unwrap();
+        // ... (remaining `flowData.*` reads become `currentFlowData.*`)
+    },
+    [dispatch, flowDataRef],
+);
+```
+
+`composeTransaction` now only changes identity when `dispatch` does (never, in practice), which stabilizes the shared debounced compose effect in `usePreparedTxFees.ts:296-325` that consumes it — no separate change needed there.
+
+#### Consumer 4 — ref-read `resolvedFlowData` (full hunk)
+
+```tsx
+export const useRefreshYieldDepositAllowanceOnIdle = ({
+    allowanceStatus,
+    resolvedFlowData,
+}: UseRefreshYieldDepositAllowanceOnIdleParams) => {
+    const dispatch = useDispatch();
+    const resolvedFlowDataRef = useFreshRef(resolvedFlowData);
+
+    useEffect(() => {
+        const currentFlowData = resolvedFlowDataRef.current;
+
+        if (currentFlowData.resolutionStatus !== 'resolved' || allowanceStatus !== 'idle') {
+            return;
+        }
+
+        void dispatch(
+            initYieldAllowanceThunk({
+                flowData: currentFlowData.flowData,
+                flowKey: currentFlowData.flowKey,
+                flowType: 'deposit',
+                shouldSkipApprovalStep: false,
+            }),
+        );
+    }, [allowanceStatus, dispatch, resolvedFlowDataRef]);
+};
+```
+
+### 2. Native send form — network fee-info effect
+
+```tsx
+useEffect(() => {
+    if (account) dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol }));
+}, [account?.symbol, dispatch]);
+```
+
+### 3. Native send form — debounced fee-composition effect
+
+```tsx
+const accountRef = useFreshRef(account);
+
+const updateFormState = useCallback(async () => {
+    const currentAccount = accountRef.current;
+
+    if (currentAccount && network && networkFeeInfo) {
+        const response = await dispatch(
+            composeSendFormTransactionFeeLevelsThunk({
+                formState: constructFormDraft({
+                    formValues: getValues(),
+                    tokenContract,
+                    selectedUtxos,
+                }),
+                composeContext: {
+                    account: currentAccount,
+                    network,
+                    feeInfo: networkFeeInfo,
+                    excludedUtxos,
+                },
+            }),
+        );
+        // ... (remaining `account.*` reads become `currentAccount.*`)
+    }
+}, [
+    accountKey,
+    accountRef,
+    dispatch,
+    getValues,
+    tokenContract,
+    network,
+    networkFeeInfo,
+    setError,
+    excludedUtxos,
+    selectedUtxos,
+    trigger,
+]);
+
+// unchanged — already reacts correctly once updateFormState stops churning
+useEffect(() => {
+    debounce(updateFormState);
+}, [updateFormState, watchedFormValues, debounce, selectedUtxos, isNetworkReserveEnabled]);
+```
+
+### 4. Earn/staking fee composition (`useComposeEarnFees`)
+
+```tsx
+const accountRef = useFreshRef(account);
+
+const composeFeeLevels = useCallback(
+    async (requestId: number) => {
+        const currentAccount = accountRef.current;
+
+        if (!formState || !currentAccount || !feeInfo) {
+            /* ... */
+        }
+        const response =
+            currentAccount.networkType === 'solana'
+                ? await dispatch(composeSolanaStakingTransactionFeeLevelsNativeThunk({/* ... */}))
+                : await dispatch(
+                      composeSendFormTransactionFeeLevelsThunk({
+                          formState: mergedFormState,
+                          composeContext: {
+                              account: currentAccount,
+                              feeInfo,
+                              network: getNetwork(currentAccount.symbol),
+                          },
+                      }),
+                  );
+        // ...
+    },
+    [accountRef, dispatch, formState, feeInfo, saveDraft, accountKey, formDraftPrefix],
+);
+
+useEffect(() => {
+    if (!isFocused) return;
+    // ...
+    debounce(() => composeFeeLevels(requestId));
+}, [isFocused, debounce, composeFeeLevels, feeInfo, formState]);
+```
+
+### 5. EVM approval fee composition (`useEvmApprovalFees`)
+
+```tsx
+useEffect(() => {
+    composeFeesRef.current();
+}, [
+    quote?.dexTx?.data,
+    quote?.approvalType,
+    account?.key,
+    account?.symbol,
+    feeInfo,
+    selectedFeeLevel,
+    customFee,
+    approvalTypeOverride,
+]);
+```
+
+`composeFees` itself still closes over the full `account` via its own deps (line 91) and is read through `composeFeesRef`, so the actual compose call keeps getting the current account — only the _trigger_ needed narrowing.
+
+## Why it matters
+
+Every effect in this family dispatches a thunk that ultimately calls into `@trezor/connect`-backed fee estimation, transaction composition, or allowance building — `composeSendFormTransactionFeeLevelsThunk`, `composeYieldDepositTransactionThunk`, `composeAllowanceTransactionThunk`, `initYieldAllowanceThunk`, `composeEvmApprovalFeeLevelsThunk`, `composeSolanaStakingTransactionFeeLevelsNativeThunk`. `account` — and the `flowData`/`resolvedFlowData` wrapper built from it — gets a fresh reference on every blockchain-driven update (balance tick, new pending/confirmed transaction, discovery still running), which has nothing to do with what the user is doing on the send/deposit/withdraw/approval review screen currently open. As written, each of these five hooks re-triggers its own real compose or allowance dispatch on any such background update, not just when the user changes the amount or fee level. `useRefreshYieldDepositAllowanceOnIdle` is the sharpest case: it re-dispatches an on-chain allowance check every time `resolvedFlowData` gets a new identity while `allowanceStatus` happens to still read `'idle'`.
+
+## Notes
+
+- **In-repo fix template (strongest evidence):** [`useYieldWithdrawFees.ts:75-82`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts#L75-L82) documents and implements exactly this pattern for the same problem (`ComposeWithdrawFeeParams`'s comment: "the fee context ... is read from refs at compose time instead, so it can't re-trigger the effect"), with the ref assigned during render at [`:343-344`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts#L343-L344) and the real triggering effect narrowed to primitives/content-derived strings at [`:519-531`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts#L519-L531) (`amount`, `formDraftKey`, `feeInfoRevision`, `hasFeeInfo`, `isEnabled` — never `flowData` or `feeInfo` themselves).
+- Second correct sibling in the same module: [`useYieldPendingTransactionTracking.ts:168-169`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts#L168-L169) destructures `accountKey`/`accountSymbol` from `account` immediately, before any effect, so its polling-interval effect at [`:227-237`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts#L227-L237) depends on primitives only (`[accountKey, dispatch, pollIntervalMs, shouldPollPendingTransaction]`).
+- Third correct sibling, a different module: [`useComposeTradingTransaction.ts:60-93`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts#L60-L93) (`module-trading`) reads `store.getState()` imperatively inside its callback instead of subscribing via `useSelector`, so it never depends on `account`/`draft` at all — its own `useCallback` deps (`[dispatch, store, tradeType, getNetworkFeeInfo]`) are stable regardless of account churn.
+- Compile requirements: `useFreshRef` needs importing from `@trezor/react-utils` — extend the existing `useDebounce` import in `useYieldAllowanceFees.ts`, `useComposeEarnFees.ts`, and `useSendForm.tsx`; add a fresh import in `useYieldDepositFees.ts` and `useRefreshYieldDepositAllowanceOnIdle.ts`. `useEvmApprovalFees.ts` needs no new import — its fix is dependency-array-only.
+- All five files are `suite-native`, compiled by React Compiler: per this repo's native rule, the fix is never "add `useMemo`/`useCallback`" — it's narrowing a dependency array to primitives, or reading the wide value through a ref populated during render, exactly as the three siblings above already do.
+- `useYieldApprovalFees.ts`'s `approvalTransaction` memo is the one item in this family that is _not_ a ref-read candidate: unlike the other four, its return value is itself consumed downstream for display/composition (`allowanceAmount`, `contractAddress`, `spender`), so ref-reading `flowData` there would make the returned value stale instead of just delaying a dispatch. Its fix is a plain narrowing to the exact primitive fields the memo body reads — `flowData.token.decimals`/`.symbol`/`.contractAddress` (the last one read internally by `getApprovalContractAddress` for the hardcoded `'deposit'` flow type used here, confirmed at `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldApprovalThunks.ts:92-98`) and `flowData.vault.outputToken?.address` — per the skill's "Minimal required dependencies" guidance rather than the ref-read pattern.
+- Honest sizing: `useResolvedYieldFlowData` is imported by roughly 20 files across `module-earn` (every yield deposit/withdraw/approval/complete screen), so the underlying account-tick churn is much wider than the four hooks fixed here — only these four were traced in this sweep to a confirmed live compose/allowance dispatch as the consequence.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-01-usetradingcomposetransaction-whole-device-dep.md
+++ b/perf-issues/react-hooks/p2-01-usetradingcomposetransaction-whole-device-dep.md
@@ -1,0 +1,173 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Minimal required dependencies"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts:142-223`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts#L142-L223)
+(`eslint-disable-next-line react-hooks/exhaustive-deps` at
+[line 209](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts#L209))
+
+## Before
+
+```tsx
+useEffect(() => {
+    let isMounted = true;
+
+    if (!account || !network) {
+        setState(initState);
+        setComposedLevels(undefined);
+
+        return;
+    }
+
+    const hasAccountChanged = !(
+        state.account?.descriptor === initState.account?.descriptor &&
+        state.account?.symbol === initState.account?.symbol
+    );
+
+    const accountKey =
+        initState.account && `${initState.account.symbol}:${initState.account.descriptor}`;
+    if (replaceablePlaceholderRef.current.accountKey !== accountKey) {
+        replaceablePlaceholderRef.current = {
+            accountKey,
+            address: getValues('outputs')?.[0]?.address,
+        };
+    }
+
+    const setStateAsync = async () => {
+        const address: string = await getComposeAddressPlaceholder(
+            account,
+            network,
+            device,
+            accounts,
+            chunkify,
+        );
+
+        if (!isMounted) {
+            return;
+        }
+
+        const currentOutput = getValues('outputs')?.[0];
+
+        if (currentOutput && typeof address === 'string') {
+            const isReplaceable =
+                currentOutput.address !== address &&
+                (!currentOutput.address ||
+                    currentOutput.address === replaceablePlaceholderRef.current.address);
+            if (isReplaceable) {
+                setValue(TRADING_FORM_OUTPUT_ADDRESS, address);
+            }
+            setState(initState);
+        }
+    };
+
+    // update fee info only if the block height has increased.
+    // note: This approach may not be ideal for Bitcoin, as fees can change within the same block
+    const hasFeeInfoChanged = feeInfo.blockHeight - state.feeInfo.blockHeight > 0;
+
+    if (hasAccountChanged || (!outputAddress && account.symbol !== 'ada') || hasFeeInfoChanged) {
+        setStateAsync();
+    }
+
+    return () => {
+        isMounted = false;
+    };
+    // call effect only when listed dependencies will change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [
+    account?.symbol,
+    account?.descriptor,
+    chunkify,
+    device,
+    network,
+    state.account?.descriptor,
+    state.account?.symbol,
+    initState.account?.descriptor,
+    initState.account?.symbol,
+    initState.feeInfo,
+    outputAddress,
+    type,
+]);
+```
+
+`device` (the whole `TrezorDevice` object) sits in the dependency array, and `accounts` (the whole
+accounts array, from `useSelector(selectAccounts)`) is read inside `setStateAsync` without being
+listed at all. The `eslint-disable` hides both: the intentional narrowing this comment is meant to
+justify, and the accidental omission of `accounts`.
+
+## After
+
+The very first effect in this same file already solves this exact problem for a Tron-specific derive,
+by keeping only `device?.state` in its own dependency array and reading the live device/accounts
+through refs that are updated on every render:
+
+```tsx
+// already present a few lines above, in this same file
+const accountsRef = useRef(accounts);
+accountsRef.current = accounts;
+const deviceRef = useRef(device);
+deviceRef.current = device;
+```
+
+Reusing those refs in the second effect:
+
+```tsx
+const setStateAsync = async () => {
+    const address: string = await getComposeAddressPlaceholder(
+        account,
+        network,
+        deviceRef.current,
+        accountsRef.current,
+        chunkify,
+    );
+    // ... unchanged
+};
+...
+// call effect only when listed dependencies will change
+// eslint-disable-next-line react-hooks/exhaustive-deps
+}, [
+    account?.symbol,
+    account?.descriptor,
+    chunkify,
+    device?.state,
+    network,
+    state.account?.descriptor,
+    state.account?.symbol,
+    initState.account?.descriptor,
+    initState.account?.symbol,
+    initState.feeInfo,
+    outputAddress,
+    type,
+]);
+```
+
+## Why it matters
+
+For Bitcoin-type accounts, `getComposeAddressPlaceholder` calls `TrezorConnect.getAddress` — real
+device/bridge I/O — to derive a placeholder receive address for the sell/exchange form's fee-estimate
+step. Today that call re-fires on every render in which `device` gets a new reference while
+`outputAddress` is still empty — the window between selecting an account/asset and the first
+successful address-placeholder compose. Once `outputAddress` is set the `if` guard absorbs further
+`device` churn, so this is a real but narrow-window issue rather than a continuous one. Reading
+`accounts` outside the dependency array also means the `legacyAccount` lookup inside
+`getComposeAddressPlaceholder`'s Bitcoin branch can run against a stale accounts snapshot from
+whenever this effect last happened to fire, independent of the `device` issue.
+
+## Notes
+
+- Compile requirement: none beyond what the file already imports — `useRef` is already imported
+  (`import { useEffect, useMemo, useRef, useState } from 'react';`), and `deviceRef`/`accountsRef` are
+  already declared above this effect for the sibling Tron-derive effect.
+- The in-repo correct sibling is the first effect in this same file
+  ([`useTradingComposeTransaction.ts:79-106`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts#L79-L106)),
+  which already depends on `device?.state` instead of `device` and reads the live values through
+  these same two refs — this fix makes the second effect consistent with a pattern already proven in
+  the file, not a new one.
+- `packages/suite` is not React-Compiler-covered, so the ref-based fix is manual, same as the sibling
+  effect it mirrors.
+- The `eslint-disable-next-line react-hooks/exhaustive-deps` stays after this fix, exactly as it does
+  on the sibling effect — `deviceRef`/`accountsRef`/`state`/`initState` fields are read imperatively or
+  intentionally excluded, so the suppression continues to be necessary, not incidental.
+- Honest sizing: the trigger window is narrow (only while `outputAddress` is still empty), so this is
+  real but colder than an unbounded loop — matches its P2 assignment.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-02-usetotalfiatbalance-recomputes-unmemoized.md
+++ b/perf-issues/react-hooks/p2-02-usetotalfiatbalance-recomputes-unmemoized.md
@@ -1,0 +1,109 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/hooks/wallet/useTotalFiatBalance.ts:8-32`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts#L8-L32)
+
+Call sites:
+
+- [`packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx:63`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx#L63)
+- [`packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx:69`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx#L69)
+
+## Before
+
+```tsx
+export const useTotalFiatBalance = (
+    accounts: Account[],
+    baseCurrencyCode: BaseCurrencyCode,
+    rates?: RatesByKey,
+) => {
+    const tokenDefinitions = useSelector(state => state.tokenDefinitions);
+    const deviceAccounts: Account[] = accounts.map(account => {
+        const coinDefinitions = tokenDefinitions?.[account.symbol]?.coin;
+        const tokens = getTokens({
+            tokens: account.tokens ?? [],
+            symbol: account.symbol,
+            tokenDefinitions: coinDefinitions,
+        });
+
+        return { ...account, tokens: tokens.shownWithBalance };
+    });
+
+    const totalBaseCurrencyBalance = getTotalFiatBalance({
+        deviceAccounts,
+        baseCurrencyCode,
+        rates,
+    }).toString();
+
+    return totalBaseCurrencyBalance;
+};
+```
+
+No `useMemo`/`useCallback` anywhere in the hook — the `accounts.map` and `getTotalFiatBalance` call
+both re-run on every render regardless of whether `accounts` changed.
+
+## After
+
+```tsx
+import { useMemo } from 'react';
+
+import { type Account, type RatesByKey } from '@suite-common/wallet-types';
+import { getTotalFiatBalance } from '@suite-common/wallet-utils/src/accountUtils';
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+
+import { useSelector } from 'src/hooks/suite';
+import { getTokens } from 'src/utils/wallet/tokenUtils';
+
+export const useTotalFiatBalance = (
+    accounts: Account[],
+    baseCurrencyCode: BaseCurrencyCode,
+    rates?: RatesByKey,
+) => {
+    const tokenDefinitions = useSelector(state => state.tokenDefinitions);
+
+    return useMemo(() => {
+        const deviceAccounts: Account[] = accounts.map(account => {
+            const coinDefinitions = tokenDefinitions?.[account.symbol]?.coin;
+            const tokens = getTokens({
+                tokens: account.tokens ?? [],
+                symbol: account.symbol,
+                tokenDefinitions: coinDefinitions,
+            });
+
+            return { ...account, tokens: tokens.shownWithBalance };
+        });
+
+        return getTotalFiatBalance({
+            deviceAccounts,
+            baseCurrencyCode,
+            rates,
+        }).toString();
+    }, [accounts, baseCurrencyCode, rates, tokenDefinitions]);
+};
+```
+
+## Why it matters
+
+`getTotalFiatBalance` iterates every account and calls `getAccountFiatBalance` per account
+(`suite-common/wallet-utils/src/accountUtils.ts:598-620`), and this hook additionally maps every
+account through `getTokens` first. `PortfolioCard` is the dashboard's headline "total balance" card —
+`memo()`-wrapped but with no props, so it re-renders on every one of its several `useSelector` reads
+changing, `currentFiatRates` being the most frequent. None of that account/token walk is currently
+cached against the fiat rate actually changing the total, so it re-runs in full on every rate tick even
+when `accounts` itself is unchanged.
+
+## Notes
+
+- Compile requirement: adds `import { useMemo } from 'react';` — the file currently has no `'react'`
+  import at all.
+- `packages/suite` is not React-Compiler-covered, so this manual `useMemo` is the correct mechanism
+  here.
+- `getTokens`'s own internal algorithmic cost is out of scope for this doc — it's tracked separately in
+  `perf-issues/asymptotic-complexity/p2-25-tokenutils-gettokens.md` (not yet filed). This fix only stops
+  that work from re-running on renders where `accounts`/`baseCurrencyCode`/`rates`/`tokenDefinitions`
+  are all unchanged; it does not change `getTokens`'s own complexity.
+- Two call sites benefit identically: `PortfolioCard.tsx:63` (passes live `accounts`,
+  `currentFiatRates`) and `WalletInstance.tsx:69` (passes a per-device-filtered `deviceAccounts` list
+  and the same global `currentFiatRates`).
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-03-usecurrentref-read-inside-usememo-three-sites.md
+++ b/perf-issues/react-hooks/p2-03-usecurrentref-read-inside-usememo-three-sites.md
@@ -1,0 +1,134 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Pick the ref hook by when `.current` is read"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts:57,59-98`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts#L57-L98) — global Send asset picker
+
+[`packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts:90,92-93,171-179`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts#L90-L179) — Trading sell-asset picker (same name, different file, from the same copy-pasted shape)
+
+[`packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts:59,61-62,180`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts#L59-L180) — Trading buy-asset picker
+
+## Before
+
+All three hooks share the identical shape: a `useCurrentRef(fiatRates)` declared alongside a
+`useThrottle`d accounts list, then read through `.current` inside the very next `useMemo`.
+
+```tsx
+// useAccountWithTokensOptions.ts (GlobalSendModal) :55-98
+// Accounts are constantly being updated in Redux. So throttle them to significantly reduce re-renders
+const throttledAccounts = useThrottle(accounts, 1000);
+const fiatRatesRef = useCurrentRef(fiatRates);
+
+const accountsAndTokensSortedByCoin = useMemo(() => {
+    const fiatRates = fiatRatesRef.current;
+
+    if (!fiatRates) {
+        return [];
+    }
+
+    const networkAccounts = filterAccountsByNetworkSymbol(throttledAccounts, networkSymbolFilter);
+
+    return networkAccounts.map(account => {
+        /* ...builds sorted tokens/hidden-tokens per account using `fiatRates`... */
+    });
+}, [fiatRatesRef, throttledAccounts, networkSymbolFilter, baseCurrencyCode, tokenDefinitions]);
+```
+
+The other two repeat the same two-part shape, just with more logic inside the memo body:
+
+```tsx
+// useAccountWithTokensOptions.ts (TradingFormInputSellAsset/AssetPickerModal) :88-93,171-179
+const throttledAccounts = useThrottle(accounts, 1000);
+const fiatRatesRef = useCurrentRef(fiatRates);
+
+const { networks, accountsWithTokens, supportedCryptoIds } = useMemo(() => {
+    const fiatRates = fiatRatesRef.current;
+
+    if (!fiatRates) {
+        return { accountsWithTokens: [], networks: [], supportedCryptoIds: new Set() };
+    }
+    /* ...validAccounts / supportedNetworkAccounts / sorted tokens, all keyed off `fiatRates`... */
+}, [
+    fiatRatesRef,
+    throttledAccounts,
+    networkSymbolFilter,
+    includedCryptoIds,
+    tokenDefinitions,
+    baseCurrencyCode,
+    excludedCryptoIds,
+]);
+```
+
+```tsx
+// useAgregatedAccountsWithTokens.ts (TradingFormInputBuyAsset) :58-62,180
+const throttledAccounts = useThrottle(accounts, 3000);
+const fiatRatesRef = useCurrentRef(fiatRates);
+
+return useMemo(() => {
+    const fiatRates = fiatRatesRef.current;
+
+    if (!fiatRates) {
+        return [];
+    }
+    /* ...aggregates accounts/tokens per network and sorts by fiat balance... */
+}, [throttledAccounts, baseCurrencyCode, fiatRatesRef, tokenDefinitions]);
+```
+
+## After
+
+Per the skill: "the only correct choice when the ref is read in render or inside a `useMemo`" is
+`useFreshRef`, not `useCurrentRef`. `useFreshRef` assigns `.current` synchronously during render, so
+it already holds this render's value by the time the memo body (declared right after it, in the same
+render) reads it — `useCurrentRef` only assigns in an effect that runs after commit, so a memo that
+recomputes for some unrelated reason can still read the _previous_ commit's rate. The fix is the same
+one-line swap at all three sites; nothing else in any of the three hooks changes:
+
+```tsx
+import { useFreshRef } from '@trezor/react-utils';
+
+// ...
+
+const fiatRatesRef = useFreshRef(fiatRates);
+```
+
+## Why it matters
+
+`fiatRatesRef` is a stable ref object, so listing it in each memo's own dependency array (already done
+at all three sites) never by itself triggers a recompute — these memos only re-evaluate when
+`throttledAccounts`/`networkSymbolFilter`/`baseCurrencyCode`/`tokenDefinitions`/etc. change. When one
+of those does force a recompute, `useCurrentRef`'s `.current` can still be the fiat rate from _before_
+the previous render's rate update, because its own internal effect updates it only after commit. The
+sorted fiat balances and fiat-based ordering shown in the Send asset picker and both Trading asset
+pickers can therefore lag the real fiat rate by more than the usual one-render window the
+ref-updated-in-an-effect pattern is normally good for.
+
+## Notes
+
+- No new imports needed beyond swapping the named import (`useCurrentRef` → `useFreshRef`) — both are
+  exported from `@trezor/react-utils`
+  ([`packages/react-utils/src/index.ts:14-15`](https://github.com/trezor/trezor-suite/blob/develop/packages/react-utils/src/index.ts#L14-L15)).
+- Alternative considered and not proposed: keep `useCurrentRef` but make the throttle explicit —
+  `const throttledFiatRates = useThrottle(fiatRates, 1000)`, put `throttledFiatRates` directly in the
+  memo's own deps instead of a ref. That would also fix the staleness, but it changes the recompute
+  cadence (the memo would now also re-run on every throttle-interval fiat tick, not only when the other
+  listed deps change), which is a bigger behavioral change than the codebase currently has anywhere
+  else in these three hooks. `useFreshRef` is the smaller, skill-prescribed fix, since these reads all
+  happen inside a `useMemo`, not a later effect or callback.
+- All three files are `packages/suite`, not React-Compiler-covered, so this is a manual fix either way.
+- In-repo contrast confirming the mechanism: `packages/suite/src/components/dashboard/DashboardSection.tsx:41-45`'s
+  `useCurrentRef(onCollapseChange)` is read inside a `useEffect` declared immediately after it (not a
+  memo) — hook-declaration order guarantees that ref's own effect commits before the reading effect
+  runs, so `useCurrentRef` is the _correct_ choice there. Same for
+  `packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx:70-75`.
+  `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx:61,68,76`
+  and
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx:57-58`/`TradingExchangeFormInputs.tsx:109-112`/`TradingSellFormInputs.tsx:90`
+  all read their own `useCurrentRef` values only inside click-driven callbacks, well after any
+  same-commit ordering concern applies — also correct. This doc's three sites are the only ones in
+  either scanned area where a `useCurrentRef` is read inside a `useMemo` body.
+- Confidence is high on the mechanism (verified `useFreshRef`/`useCurrentRef`'s own implementations at
+  `packages/react-utils/src/hooks/useFreshRef.ts` and `useCurrentRef.ts`) and medium on user-visible
+  impact, since how often `selectCurrentFiatRates` actually ticks in practice wasn't measured for this
+  sweep.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-04-connectionglobalmodalcontext-value-unmemoized.md
+++ b/perf-issues/react-hooks/p2-04-connectionglobalmodalcontext-value-unmemoized.md
@@ -1,0 +1,146 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body
+work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx:176`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx#L176)
+
+- Value source: [`ConnectionGlobalModalContext.tsx:67`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/connection/context/ConnectionGlobalModalContext.tsx#L67)
+  — `useConnectionGlobalModal`, returns a new object literal on every call.
+- Per-row consumer: [`packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx:81`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx#L81)
+  — one instance per row of the nearby/known device list; also consumed directly by
+  `BluetoothScanningList.tsx`, `CantSeeTrezorModal.tsx`, `BluetoothConnectionModal.tsx`, and
+  `ConnectDeviceGlobalModal.tsx` (all under `packages/suite/src/components/connection/`).
+
+## Before
+
+```tsx
+export const ConnectionGlobalModalProvider = ({ children }: ConnectionGlobalModalProviderProps) => {
+    const contextValue = useConnectionGlobalModal();
+
+    return (
+        <ConnectionGlobalModalReactContext.Provider value={contextValue}>
+            {children}
+        </ConnectionGlobalModalReactContext.Provider>
+    );
+};
+```
+
+## After
+
+```tsx
+const useConnectionGlobalModal = () => {
+    // ...unchanged: dispatch, showHints/shouldPairAgain/showRemoveFromOsBluetooth state,
+    // defaultConnectionMode/nearbyDevices/knownDevices selectors, isBluetoothMode...
+
+    const toggleBluetoothMode = useCallback(() => {
+        dispatch(setConnectionMode(isBluetoothMode ? 'cable' : 'bluetooth'));
+    }, [dispatch, isBluetoothMode]);
+
+    const toggleShowHints = useCallback(() => setShowHints(prev => !prev), []);
+
+    const toggleShouldPairAgain = useCallback(() => setShouldPairAgain(prev => !prev), []);
+
+    const openShowRemoveFromOsBluetooth = useCallback(() => {
+        setShouldPairAgain(false);
+        setShowRemoveFromOsBluetooth(prev => !prev);
+    }, []);
+
+    const closeShowRemoveFromOsBluetooth = useCallback(() => {
+        setShowRemoveFromOsBluetooth(false);
+        toggleShouldPairAgain();
+    }, [toggleShouldPairAgain]);
+
+    // ...unchanged: allDevices/devices, useBluetoothScanning, useBluetoothConnection,
+    // shouldShowBluetoothUnPairDeviceList...
+
+    return useMemo(
+        () => ({
+            shouldPairAgain,
+            showHints,
+            isBluetoothMode,
+            devices,
+            selectedDevice,
+            allDevices,
+            toggleBluetoothMode,
+            toggleShowHints,
+            toggleShouldPairAgain,
+            handlePairingCancel,
+            onConnect,
+            onReScanClick,
+            openShowRemoveFromOsBluetooth,
+            closeShowRemoveFromOsBluetooth,
+            showRemoveFromOsBluetooth,
+            notConnectedKnownDevices,
+            shouldShowBluetoothUnPairDeviceList,
+            notConnectedNearbyDevices,
+            manuallyPairedConnectedDevices,
+        }),
+        [
+            shouldPairAgain,
+            showHints,
+            isBluetoothMode,
+            devices,
+            selectedDevice,
+            allDevices,
+            toggleBluetoothMode,
+            toggleShowHints,
+            toggleShouldPairAgain,
+            handlePairingCancel,
+            onConnect,
+            onReScanClick,
+            openShowRemoveFromOsBluetooth,
+            closeShowRemoveFromOsBluetooth,
+            showRemoveFromOsBluetooth,
+            notConnectedKnownDevices,
+            shouldShowBluetoothUnPairDeviceList,
+            notConnectedNearbyDevices,
+            manuallyPairedConnectedDevices,
+        ],
+    );
+};
+```
+
+`ConnectionGlobalModalProvider` itself needs no change — it already just forwards
+`useConnectionGlobalModal()`'s return value straight into `.Provider value={contextValue}`.
+
+## Why it matters
+
+`useConnectionGlobalModal` re-runs on every render of the provider — which happens continuously
+while a Bluetooth scan is active, since `nearbyDevices`/`knownDevices`/`allDevices` get fresh
+references on every device update — and returns a brand-new object every time, bundling
+frequently-changing scan state together with per-row data. Every direct consumer of the context,
+including `BluetoothDeviceListItem` (one instance per nearby/known device row), re-renders on every
+one of those ticks: React re-renders a `useContext` subscriber whenever the Provider value's
+reference changes, independent of whether the fields that component actually reads were among the
+ones that changed.
+
+## Notes
+
+- Compile requirement: add `useCallback`/`useMemo` to the
+  `import { type ReactNode, createContext, useContext, useState } from 'react';` line.
+- `toggleShowHints`/`toggleShouldPairAgain`/the toggle inside `openShowRemoveFromOsBluetooth` switch
+  to the updater-function form of `setState` (`prev => !prev`) so they can carry an empty
+  dependency array without capturing a stale `showHints`/`shouldPairAgain` closure; a naive
+  `useCallback(() => setShowHints(!showHints), [showHints])` would defeat its own memoization by
+  changing identity on every toggle.
+- This memo only fully holds once its own inputs are stable. `onConnect` and `handlePairingCancel`
+  (`packages/suite/src/components/connection/hook/useBluetoothConnection.tsx:67` and `:89`) are
+  plain, non-`useCallback` async functions in that sibling hook, so they are still fresh on every
+  call even after this file's fix — that hook needs the same treatment in the same PR for this
+  `useMemo` to actually stop recomputing. `onReScanClick`
+  (`packages/suite/src/components/connection/hook/useBluetoothScanning.ts:39`), by contrast, is
+  already `useCallback`-wrapped and safe to depend on as-is.
+- Correct in-repo sibling for the Provider-value shape:
+  `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetOptionsContext.tsx:26-29`
+  already wraps its Provider value in `useMemo` keyed on its real inputs.
+- `BluetoothDeviceListItem` is not currently `memo()`-wrapped, so this fix's benefit today is fewer
+  unrelated re-renders across the whole connect-flow subtree rather than "restoring a defeated
+  memo" — but it also means a future `memo()` on that row would otherwise be silently defeated by
+  this same context churn, the same shape as `TransactionItem`/`ScrollContext` in sibling draft
+  p1-07 (not yet filed).
+- Honest sizing: the fan-out list (nearby/known Bluetooth devices) is inherently small, so the
+  absolute cost per tick is modest even though the pattern is the textbook shape.
+- `packages/suite` is web/desktop, not React-Compiler-covered — this is a manual fix.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-05-suitebanners-filters-accounts-every-render.md
+++ b/perf-issues/react-hooks/p2-05-suitebanners-filters-accounts-every-render.md
@@ -1,0 +1,71 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx:119`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/banners/SuiteBanners/SuiteBanners.tsx#L119)
+
+Rendered on effectively every page via
+[`SuiteLayout.tsx:135`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx#L135)
+(also mounted from `ConnectAppBar.tsx`, `WelcomeLayoutWithoutModalSwitcher.tsx`, and
+`OnboardingLayout.tsx`).
+
+## Before
+
+```tsx
+const device = useSelector(selectSelectedDevice);
+const isOnline = useSelector(state => state.suite.online);
+const bannerMessage = useSelector(selectBannerMessage);
+const firmwareRevisionError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+const firmwareHashError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
+const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
+const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
+const transport = useSelector(state => state.suite.transport);
+const accounts = useSelector(selectVisibleDeviceAccounts);
+// ...
+} else if (accounts.some(account => isCardanoStakedWithFiveBinaries(account))) {
+    banner = <CardanoOutdatedStakingBanner />;
+    priority = 20;
+}
+```
+
+## After
+
+```tsx
+const hasCardanoAccountStakedWithFiveBinaries = useMemo(
+    () => accounts.some(isCardanoStakedWithFiveBinaries),
+    [accounts],
+);
+// ...
+} else if (hasCardanoAccountStakedWithFiveBinaries) {
+    banner = <CardanoOutdatedStakingBanner />;
+    priority = 20;
+}
+```
+
+## Why it matters
+
+`SuiteBanners` is mounted on essentially every screen and subscribes to `device` and
+`state.suite.transport` alongside ~9 other selectors — both device polling and transport status are
+among the most frequently-updated slices in this app. As written, every one of those ticks re-runs
+`accounts.some(isCardanoStakedWithFiveBinaries)` from scratch even though neither `device` nor
+`transport` has anything to do with the account list. `.some()` short-circuits on the first match, but
+for a user with no affected Cardano account it still walks every enabled account, every time, purely
+because an unrelated selector changed reference.
+
+## Notes
+
+- `useMemo` needs importing — `SuiteBanners.tsx` currently imports only `useEffect, useState` from
+  `react`.
+- In-repo precedent for pushing this further into a memoized selector, if preferred over a local
+  `useMemo`:
+  `suite-native/staking/src/cardanoStakingSelectors.ts:89-94`'s
+  `selectFirstCardanoAccountStakedWithFiveBinaries` already does the equivalent scan
+  (`accounts.find(account => account.visible && isCardanoStakedWithFiveBinaries(account))`) as a
+  `createMemoizedSelector` over `selectDeviceAccounts`. A `packages/suite`/`suite-common` sibling built
+  the same way (`createWeakMapSelector` over `selectVisibleDeviceAccounts`) would fix this at the
+  source rather than per-consumer, but isn't required for this specific finding — the local `useMemo`
+  above is the minimal fix for the one call site the scan found.
+- Confidence on this finding is medium on real-world severity (the scan didn't measure `SuiteBanners`'s
+  actual re-render rate); the fix itself is a pure, low-risk win regardless.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-06-accountname-exhaustive-deps-suppression.md
+++ b/perf-issues/react-hooks/p2-06-accountname-exhaustive-deps-suppression.md
@@ -1,0 +1,190 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Never add a new `eslint-disable` for `exhaustive-deps`"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountName.tsx:23-54`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountName.tsx#L23-L54)
+
+Co-anchors showing the ref's target genuinely mounts/unmounts across the loading→loaded transition:
+
+- [`AccountOverviewBalance.tsx:85`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/transactions/components/AccountOverviewBalance.tsx#L85) — `<Column ref={balanceSectionRef}>`, reached only once `status === 'loaded' && account` (the two branches above it, `status === 'exception'` and `status !== 'loaded'`, return `null`/a skeleton with no ref at all)
+- [`Transactions.tsx:46-48,85,92,106,117`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/transactions/Transactions.tsx#L46-L48) — the four places `<AccountOverviewBalance>` is rendered all sit behind `selectedAccount.status !== 'loaded'`'s early return at `:46-48`
+- [`AccountHeaderProvider.tsx`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/support/suite/AccountHeaderProvider.tsx) — the shared context both files above and `AccountName.tsx` thread the same ref object through
+
+## Before
+
+```tsx
+useEffect(() => {
+    if (!isOverviewRoute) {
+        setIsScrolled(true);
+
+        return;
+    }
+
+    const target = balanceSectionRef?.current;
+    if (!target) {
+        setIsScrolled(false);
+
+        return;
+    }
+
+    const observer = new IntersectionObserver(
+        ([entry]) => {
+            if (entry) {
+                setIsScrolled(!entry.isIntersecting);
+            }
+        },
+        {
+            root: null,
+            threshold: 0,
+            rootMargin: `-${HEADER_HEIGHT} 0px 0px 0px`,
+        },
+    );
+
+    observer.observe(target);
+
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [balanceSectionRef?.current, isOverviewRoute]);
+```
+
+`balanceSectionRef?.current` is a mutable ref read; mutating `.current` never itself schedules a
+re-render, so this dependency array item is only ever re-evaluated against whatever `.current` happens
+to hold _during a render triggered by something else_. If `AccountName`'s own re-render and the
+balance section's DOM remount land in the same commit, the array is diffed before that commit's ref
+mutation runs, so the snapshot can match the previous render's and the effect silently skips
+re-running against the new node.
+
+## After
+
+The ref needs to become something reactive at its source — `AccountName.tsx` alone cannot fix this,
+since it only reads the ref, it doesn't attach it. `Column`'s `ref` prop
+(`packages/components/src/components/Flex/Flex.tsx:144`) is typed as a plain
+`React.RefObject<HTMLElement | null>`, not the full callback-ref union, so the shared ref itself has to
+stay a ref for attachment — but the context that threads it between the header and body subtrees can
+also expose the attached node as state:
+
+### 1. `AccountHeaderProvider.tsx`
+
+```tsx
+import React, { createContext, useContext, useRef, useState } from 'react';
+
+type AccountHeaderContextValue = {
+    balanceSectionRef: React.RefObject<HTMLDivElement | null>;
+    balanceSectionNode: HTMLDivElement | null;
+    setBalanceSectionNode: (node: HTMLDivElement | null) => void;
+};
+
+// ...
+
+export const AccountHeaderProvider = ({
+    balanceSectionRef: providedBalanceSectionRef,
+    children,
+}: AccountHeaderProviderProps) => {
+    const internalBalanceSectionRef = useRef<HTMLDivElement>(null);
+    const balanceSectionRef = providedBalanceSectionRef ?? internalBalanceSectionRef;
+    const [balanceSectionNode, setBalanceSectionNode] = useState<HTMLDivElement | null>(null);
+
+    return (
+        <AccountHeaderContext.Provider
+            value={{ balanceSectionRef, balanceSectionNode, setBalanceSectionNode }}
+        >
+            {children}
+        </AccountHeaderContext.Provider>
+    );
+};
+```
+
+### 2. `AccountOverviewBalance.tsx` — mirror the ref into that state after every commit
+
+```tsx
+const { balanceSectionRef, setBalanceSectionNode } = useAccountHeaderContext();
+
+useEffect(() => {
+    setBalanceSectionNode(balanceSectionRef.current);
+});
+```
+
+(Declared with the component's other hooks, above its `status === 'exception'` / `status !== 'loaded'`
+early returns. No dependency array — it runs after every commit of this component, which is exactly
+when `balanceSectionRef.current` may have changed; the state setter itself bails out via `Object.is`
+when the node is unchanged, so this doesn't add extra re-renders.)
+
+### 3. `AccountName.tsx` — depend on the state, not on `.current`
+
+```tsx
+const accountHeaderContext = useOptionalAccountHeaderContext();
+const balanceSectionNode = accountHeaderContext?.balanceSectionNode ?? null;
+const isOverviewRoute = routeName === 'wallet-index';
+
+useEffect(() => {
+    if (!isOverviewRoute) {
+        setIsScrolled(true);
+
+        return;
+    }
+
+    if (!balanceSectionNode) {
+        setIsScrolled(false);
+
+        return;
+    }
+
+    const observer = new IntersectionObserver(
+        ([entry]) => {
+            if (entry) {
+                setIsScrolled(!entry.isIntersecting);
+            }
+        },
+        {
+            root: null,
+            threshold: 0,
+            rootMargin: `-${HEADER_HEIGHT} 0px 0px 0px`,
+        },
+    );
+
+    observer.observe(balanceSectionNode);
+
+    return () => observer.disconnect();
+}, [balanceSectionNode, isOverviewRoute]);
+```
+
+No `eslint-disable` left — `balanceSectionNode` is a plain state value, so the dependency array is
+exhaustive and honest. Because it's real React state, a change to it always schedules a fresh render of
+`AccountName` in its own right (it's read through context, not sampled mid-render off a mutable
+object), which is what removes the same-commit race entirely.
+
+## Why it matters
+
+If the balance-section DOM node swaps out (component remount on the loading→loaded transition) in the
+same commit that re-renders `AccountName` for an unrelated reason, today's dependency array can miss
+it: React compares the _render-time_ snapshot of `balanceSectionRef?.current` against the previous
+render's snapshot, before the commit that actually mutates `.current` happens, so the two can appear
+equal even though the observer now points at a detached node. When that happens, the compact/expanded
+header state (`isScrolled`) freezes until something else forces the effect to re-run — a stuck-looking
+header, not a crash, which is exactly why it's easy to miss in review and why the suppression was
+reached for instead.
+
+## Notes
+
+- Compile requirements: `AccountHeaderProvider.tsx` needs `useState` added to its existing
+  `import React, { createContext, useContext, useRef } from 'react';`. `AccountOverviewBalance.tsx`
+  needs a new `import { useEffect } from 'react';` — it currently has no React import at all (a
+  function component using only `useSelector` and the account-header-context hook).
+  `AccountName.tsx` needs no new imports; it already imports `useEffect`/`useState`.
+- `WalletLayout.tsx:82,90` creates the externally-shared `balanceSectionRef` and passes the _same_
+  `RefObject` into two separate `<AccountHeaderProvider>` instances (one wrapping the page header via
+  `useLayout`, one wrapping the account body) — that's how a header component can observe a DOM node
+  that actually lives in the body subtree. This file needs no change: the provider still accepts and
+  forwards the same prop, it just also mirrors the attached node into state internally.
+- This is a bigger diff than most findings in this sweep (three files, not one) because the ref is
+  deliberately shared across two separate component subtrees via `AccountHeaderProvider`, and
+  `AccountName.tsx` only ever reads that ref — it never attaches it. There's no fix scoped to
+  `AccountName.tsx` alone; the reactivity has to be added at the shared source.
+- Confidence on the exact runtime trigger (an account switch landing in the same commit as the balance
+  section's own loading→loaded remount) is medium — the scan traced the mechanism but didn't confirm
+  the interleaving happens in production. The restructure is still worth doing on its own merits: it's
+  the only `eslint-disable-next-line react-hooks/exhaustive-deps` either scanned area (`packages/suite/src/components/suite`,
+  `packages/suite/src/views/wallet`) found on a `useEffect`, and removing it re-enables the lint rule's
+  protection for this file going forward.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-07-tokeniconset-memo-defeated-by-wrapper.md
+++ b/perf-issues/react-hooks/p2-07-tokeniconset-memo-defeated-by-wrapper.md
@@ -1,0 +1,106 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — sections _"Relocate render-body work before memoizing it, and memoize only what pays"_ and _"Keep hook dependencies referentially stable"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/wallet/TokenIconSetWrapper.tsx:26`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/TokenIconSetWrapper.tsx#L26) (also line 60) — unmemoized `flatMap`/`getTokens`/`reduce`/`sort` chain
+
+[`packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx:30`](https://github.com/trezor/trezor-suite/blob/develop/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx#L30) — the correctly-written `useMemo` the wrapper defeats every render
+
+## Before
+
+```tsx
+// TokenIconSetWrapper.tsx:26-60 — no useMemo anywhere in this chain
+const allTokensWithRates = accounts.flatMap(account =>
+    enhanceTokensWithRates(account.tokens, baseCurrencyCode, symbol, fiatRates),
+);
+
+if (!allTokensWithRates.length) return null;
+
+const tokens = getTokens<TokensWithRates>({
+    tokens: allTokensWithRates,
+    symbol,
+    tokenDefinitions: coinDefinitions,
+})?.shownWithBalance;
+
+const aggregatedTokens = Object.values(
+    tokens.reduce((acc: Record<string, TokensWithRates>, token) => {
+        const { contract, balance, fiatValue } = token;
+
+        if (!acc[contract]) {
+            acc[contract] = {
+                ...token,
+                balance: balance ?? '0',
+                fiatValue: fiatValue ?? BigNumber(0),
+            };
+        } else {
+            const existingBalance = parseFloat(acc[contract].balance ?? '0');
+            const newBalance = existingBalance + parseFloat(balance ?? '0');
+            acc[contract].balance = newBalance.toString();
+
+            acc[contract].fiatValue = acc[contract].fiatValue.plus(fiatValue);
+        }
+
+        return acc;
+    }, {}),
+);
+
+const sortedAggregatedTokens = aggregatedTokens.sort(sortTokensWithRates);
+```
+
+```tsx
+// TokenIconSet.tsx:30-55 — this memo is written correctly; `tokens` (== sortedAggregatedTokens
+// above) is simply never referentially stable across renders, so it never hits
+const visibleTokensContent = useMemo(() => {
+    const visibleTokens = maxVisibleIcons !== null ? tokens.slice(0, maxVisibleIcons) : tokens;
+
+    return visibleTokens.map(token => {
+        /* … */
+    });
+}, [tokens, maxVisibleIcons, symbol, size, gap, length]);
+```
+
+## After
+
+The fix lives entirely in `TokenIconSetWrapper.tsx` — wrap the whole chain in one `useMemo`, and turn the early `return null` into a check on the memoized result so it doesn't follow a conditional hook call:
+
+```tsx
+const sortedAggregatedTokens = useMemo(() => {
+    const allTokensWithRates = accounts.flatMap(account =>
+        enhanceTokensWithRates(account.tokens, baseCurrencyCode, symbol, fiatRates),
+    );
+
+    const tokens = getTokens<TokensWithRates>({
+        tokens: allTokensWithRates,
+        symbol,
+        tokenDefinitions: coinDefinitions,
+    })?.shownWithBalance;
+
+    const aggregatedTokens = Object.values(
+        tokens.reduce((acc: Record<string, TokensWithRates>, token) => {
+            // ...same reduce body as today, unchanged...
+            return acc;
+        }, {}),
+    );
+
+    return aggregatedTokens.sort(sortTokensWithRates);
+}, [accounts, symbol, baseCurrencyCode, fiatRates, coinDefinitions]);
+
+if (!sortedAggregatedTokens.length) return null;
+
+const size = sortedAggregatedTokens.length === 1 ? 24 : 20;
+```
+
+`TokenIconSet.tsx` itself needs no change — its `useMemo` starts caching correctly as soon as it receives a stable `tokens` prop.
+
+## Why it matters
+
+`TokenIconSetWrapper` renders once per network row of the dashboard's My Assets table/grid, and re-renders on every fiat-rate tick or account update touching _any_ row, not just its own. Every one of those re-renders currently redoes the full `flatMap` → `getTokens` (2+ BigNumber allocations per token) → `reduce` → `sort` chain from scratch, and the fresh array it produces feeds straight into `TokenIconSet`'s otherwise-correctly-written `useMemo`, which as a result can never actually cache — so the per-icon `<TokenIcon>` element list is also rebuilt from scratch on every one of those renders, regardless of whether this row's own tokens or rates changed.
+
+## Notes
+
+- Compile requirement: add `import { useMemo } from 'react';` to `TokenIconSetWrapper.tsx` — the file currently has no React import at all.
+- Boundary with `p2-17-tokeniconsetwrapperx-tokeniconsetwrapper.md` in `perf-issues/asymptotic-complexity/` (sibling draft, not yet filed): that doc fixes _what_ is passed in — `accounts` should be the row's own accounts, not the whole device's account list, an O(n)-sizing fix. This doc fixes _how often_ the chain re-runs regardless of n — there is no memoization at all today. The two are independent and additive; landing one doesn't obsolete the other. That doc's own Notes section already flags this same missing memo as an optional aside ("Optionally also wrap … in a `useMemo`"); this is the hooks-class write-up of that aside, extended to also cover the downstream `TokenIconSet` symptom.
+- `packages/suite` is not React-Compiler-compiled, so the wrapper needs the manual `useMemo`. `TokenIconSet.tsx` lives in `packages/product-components`, which also ships to `suite-native`, but nothing changes there since that file needs no edit.
+- `size` (line 61 today) can stay outside the memo — it's an O(1) derivation from the memoized array's `.length` and doesn't need its own memoization.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-08-accountsection-gettokens-per-sidebar-row.md
+++ b/perf-issues/react-hooks/p2-08-accountsection-gettokens-per-sidebar-row.md
@@ -1,0 +1,95 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx:34`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx#L34) (destructuring default)
+[`packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx:46`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx#L46) (unmemoized call)
+
+## Before
+
+```tsx
+export const AccountSection = ({
+    account,
+    forceOnlyItemClick,
+    hideStaking,
+    selected,
+    onItemClick,
+}: AccountSectionProps) => {
+    const {
+        symbol,
+        accountType,
+        index,
+        descriptor,
+        formattedBalance,
+        tokens: accountTokens = [],
+    } = account;
+
+    const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
+
+    const showGroup = hasNetworkFeatures(account, 'tokens');
+
+    const isStakeShownStored = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key),
+    );
+    const isStakeShown = !hideStaking && isStakeShownStored;
+
+    const tokens = getTokens({
+        tokens: accountTokens,
+        symbol: account.symbol,
+        tokenDefinitions: coinDefinitions,
+    });
+```
+
+## After
+
+```tsx
+const EMPTY_TOKENS: Account['tokens'] = [];
+
+export const AccountSection = ({
+    account,
+    forceOnlyItemClick,
+    hideStaking,
+    selected,
+    onItemClick,
+}: AccountSectionProps) => {
+    const {
+        symbol,
+        accountType,
+        index,
+        descriptor,
+        formattedBalance,
+        tokens: accountTokens = EMPTY_TOKENS,
+    } = account;
+
+    const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
+
+    const showGroup = hasNetworkFeatures(account, 'tokens');
+
+    const isStakeShownStored = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key),
+    );
+    const isStakeShown = !hideStaking && isStakeShownStored;
+
+    const tokens = useMemo(
+        () =>
+            getTokens({
+                tokens: accountTokens,
+                symbol: account.symbol,
+                tokenDefinitions: coinDefinitions,
+            }),
+        [accountTokens, account.symbol, coinDefinitions],
+    );
+```
+
+## Why it matters
+
+Neither `AccountSection` nor its parents (`AccountItemsGroup`, `AccountsList`) are `memo()`-wrapped, and this path isn't gated behind search/filter state, so it runs continuously: any unrelated re-render of the sidebar (a new `coinjoinIsPreloading`, `accountLegacyLabels`, or `discoveryStatus` value) re-walks every visible account's whole token list through `getTokens`, unconditionally, once per account, on every render — a cost that scales with how many tokens a busy EVM account holds.
+
+## Notes
+
+- Compile requirement: add `import { useMemo } from 'react';` — this file has no React import today.
+- The `tokens: accountTokens = []` default is replaced with a module-level `EMPTY_TOKENS` constant so the new memo's own `accountTokens` dependency is stable too — otherwise the memo would never cache for token-less accounts, the same `?? []`-in-a-dependency shape the skill's own `useAccounts.ts:9` example warns about.
+- Distinct from `p1-13-accounts-sidebar-filters-urgently-on-every-keystroke.md` in `perf-issues/scheduling/` (sibling draft, not yet filed), which already covers the _search-filter_ path's duplicate `getTokens` call in `AccountsList.tsx`. This doc is the _base_ render path that runs unconditionally for every account regardless of search/filter state.
+- Sibling draft (not yet filed): `p3-01-cleanups-suite-hooks-and-components.md` batches the same-file-tree `TargetAddressLabel.tsx` fix (an `EMPTY_ADDRESSES` constant), the identical "module-level empty-array constant" mechanism applied to a different call site in this same scan area.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-09-earn-staking-dashboard-filter-crosses-hook-boundary.md
+++ b/perf-issues/react-hooks/p2-09-earn-staking-dashboard-filter-crosses-hook-boundary.md
@@ -1,0 +1,144 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Keep hook
+dependencies referentially stable"_. Found by sweep, not named in the doc. This one chain exhibits
+both dependency shapes the skill calls provably invisible to `exhaustive-deps`: a value derived
+from a call expression (`accounts.filter(...)`), and a dependency that crosses the hook boundary
+(the fresh array is passed as a prop into `useStakingAccountsVisibility`, feeding `useMemo`s
+inside it).
+
+## Where
+
+- [`packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts:47`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts#L47) — bare `.filter()` in the hook body
+- [`packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx:56`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx#L56) and [`:65`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx#L65) — two bare `arrayPartition` calls on that prop
+- [`useStakingAccountsVisibility.tsx:79`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx#L79) and [`:94`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx#L94) — the two `useMemo`s whose dependencies are those fresh arrays, so they can never hit
+
+## Before
+
+```tsx
+// useStakingTableData.ts:45-53
+const accounts = useSelector(selectVisibleDeviceAccounts);
+
+const stakingAccounts = accounts.filter(
+    account =>
+        account.symbol === 'eth' ||
+        account.symbol === 'sol' ||
+        account.symbol === 'ada' ||
+        account.symbol === 'trx',
+);
+```
+
+```tsx
+// useStakingAccountsVisibility.tsx:56-92 (abridged) — stakingAccounts arrives as a prop
+const [accountsStakingActive, accountsStakingNotActive] = arrayPartition(
+    stakingAccounts,
+    (account: Account) => {
+        const stakedAmount = getAccountTotalStakingBalance(account);
+
+        return stakedAmount !== null && stakedAmount !== '0';
+    },
+);
+
+const [accountsSufficientFunds, accountsInsufficientFunds] = arrayPartition(
+    accountsStakingNotActive,
+    (account: Account) => {
+        /* ... */
+    },
+);
+
+const alwaysVisibleAccounts = useMemo(
+    () => [
+        ...accountsStakingActive.toSorted(compareEarnByAmountDesc(getAccountStakedAmountInFiat)),
+        ...accountsSufficientFunds.toSorted(compareEarnByAmountDesc(getAccountBalanceInFiat)),
+    ],
+    [
+        accountsStakingActive,
+        accountsSufficientFunds,
+        getAccountStakedAmountInFiat,
+        getAccountBalanceInFiat,
+    ],
+);
+```
+
+`accountsStakingActive` and `accountsSufficientFunds` are fresh `arrayPartition` tuples on every
+render, so `alwaysVisibleAccounts` recomputes every render — and the second `useMemo`
+(`collapsedInsufficientFundsAccounts`, `:94-144`) depends on `alwaysVisibleAccounts` and
+`accountsInsufficientFunds`, so it recomputes every render too. Both memos are pure overhead as
+written.
+
+## After
+
+```tsx
+// useStakingTableData.ts — useMemo is already imported on line 1
+const stakingAccounts = useMemo(
+    () =>
+        accounts.filter(
+            account =>
+                account.symbol === 'eth' ||
+                account.symbol === 'sol' ||
+                account.symbol === 'ada' ||
+                account.symbol === 'trx',
+        ),
+    [accounts],
+);
+```
+
+```tsx
+// useStakingAccountsVisibility.tsx — useMemo is already imported on line 1
+const [accountsStakingActive, accountsStakingNotActive] = useMemo(
+    () =>
+        arrayPartition(stakingAccounts, (account: Account) => {
+            const stakedAmount = getAccountTotalStakingBalance(account);
+
+            return stakedAmount !== null && stakedAmount !== '0';
+        }),
+    [stakingAccounts],
+);
+
+const [accountsSufficientFunds, accountsInsufficientFunds] = useMemo(
+    () =>
+        arrayPartition(accountsStakingNotActive, (account: Account) => {
+            const minStakingAmount = getStakingLimitsByNetworkSymbol(
+                account.symbol,
+            )?.MIN_AMOUNT_FOR_STAKING_DASHBOARD;
+
+            return (
+                minStakingAmount !== undefined &&
+                new BigNumber(account.formattedBalance).gte(minStakingAmount)
+            );
+        }),
+    [accountsStakingNotActive],
+);
+```
+
+With stable inputs, the two existing `useMemo`s (`alwaysVisibleAccounts`,
+`collapsedInsufficientFundsAccounts`) finally hold without any change to their own code.
+
+## Why it matters
+
+The staking table is mounted on the Earn dashboard and re-renders on every fiat-rate tick (four
+`useCryptoCurrentRate` subscriptions feed `currentRates`) and on any parent re-render. On each of
+those renders the whole chain — the filter, both partitions, two `toSorted` calls and the
+`sortByCoin` passes inside the memos — reruns in full, even though its input (`accounts`) is
+referentially stable between store changes. This is the bounded, wasteful case the skill
+distinguishes from a render loop: it terminates, but the memoization that is already written there
+provides no caching at all.
+
+## Notes
+
+- Compiles as written: both files already import `useMemo` on line 1; no new imports, no type
+  changes. `packages/suite` is not compiled by React Compiler, so manual memoization is the
+  mechanism.
+- The upstream selector is not the problem: `selectVisibleDeviceAccounts`
+  (`suite-common/wallet-core/src/accounts/accountsSelectors.ts:50`) is built with
+  `createMemoizedSelector` and `returnStableArrayIfEmpty`, so `accounts` keeps one reference until
+  device accounts actually change — keying the new `useMemo` on `[accounts]` genuinely holds.
+  The instability is introduced entirely by this hook chain.
+- The two `useCallback` helpers (`getAccountStakedAmountInFiat`, `getAccountBalanceInFiat`) are
+  keyed on the memoized `currentRates` object and are already stable between rate changes — they
+  are correctly listed and not part of the defect.
+- `collapsedAccounts` / `expandedAccounts` / `displayedAccounts` (`:146-153`) stay as plain
+  derivations — they are cheap spreads over the memoized arrays, and memoizing them would be the
+  redundant-memo antipattern the skill warns about.
+- Honest sizing: n is the visible device's account count — dozens, not thousands. The waste is
+  real and fiat-tick-driven, but this is P2, not P1.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-10-transactionitem-createtargets-unmemoized.md
+++ b/perf-issues/react-hooks/p2-10-transactionitem-createtargets-unmemoized.md
@@ -1,0 +1,98 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx:86`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx#L86)
+
+Co-anchor, the function called there (three unmemoized passes per call): [`suite-common/wallet-core/src/transactions/target/createTargets.ts:59`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/wallet-core/src/transactions/target/createTargets.ts#L59)
+
+## Before
+
+```tsx
+export const TransactionItem = memo(
+    ({
+        transaction,
+        accountKey,
+        isActionDisabled,
+        isPending,
+        network,
+        accountType,
+        disableBumpFee,
+        index,
+    }: TransactionItemProps) => {
+        const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(transaction.symbol);
+
+        const account = useSelector(selectSelectedAccount) || null;
+
+        const networkFeatures = network.accountTypes[accountType]?.features ?? network.features;
+
+        const dispatch = useDispatch();
+        const { anchorRef, shouldHighlight } = useAnchor(
+            `${AccountTransactionBaseAnchor}/${transaction.txid}`,
+        );
+
+        const { type } = transaction;
+
+        const allOutputs = account !== null ? createTargets({ transaction, account }) : [];
+```
+
+```tsx
+// createTargets.ts:59-67 — three .map()/.filter() passes, spread into a new array, every call
+export const createTargets = ({ transaction, account }: CreateCombineTargetsParams): Target[] => {
+    const { targets, tokens, internalTransfers } = transaction;
+
+    return [
+        ...targets.map(createSimpleTarget),
+        ...filteredInternalTransfers(internalTransfers, account).map(createInternalTarget),
+        ...tokens.filter(token => token.type !== 'self').map(createTokenTarget),
+    ];
+};
+```
+
+## After
+
+```tsx
+const EMPTY_TARGETS: Target[] = [];
+
+export const TransactionItem = memo(
+    ({
+        transaction,
+        accountKey,
+        isActionDisabled,
+        isPending,
+        network,
+        accountType,
+        disableBumpFee,
+        index,
+    }: TransactionItemProps) => {
+        const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(transaction.symbol);
+
+        const account = useSelector(selectSelectedAccount) || null;
+
+        const networkFeatures = network.accountTypes[accountType]?.features ?? network.features;
+
+        const dispatch = useDispatch();
+        const { anchorRef, shouldHighlight } = useAnchor(
+            `${AccountTransactionBaseAnchor}/${transaction.txid}`,
+        );
+
+        const { type } = transaction;
+
+        const allOutputs = useMemo(
+            () => (account !== null ? createTargets({ transaction, account }) : EMPTY_TARGETS),
+            [account, transaction],
+        );
+```
+
+## Why it matters
+
+`TransactionItem` is rendered once per transaction row in a list that can be long-running. It's `memo()`-wrapped against unchanged props from its parent, but that doesn't help here: it still re-renders on its own `useSelector` subscriptions (`selectSelectedAccount`, `selectAccountByKey`, `selectIsPhishingTransaction`), and each of those redoes all three `.map()`/`.filter()` passes inside `createTargets` from scratch even though the transaction itself hasn't changed. Cost scales with `targets.length + internalTransfers.length + tokens.length` — small for a plain transfer, larger for coinjoin rounds or batch sends (this same directory has a dedicated `CoinjoinBatchItem.tsx` for that case).
+
+## Notes
+
+- Compile requirement: add `useMemo` to the existing `import { memo } from 'react';`, and add `type Target` to the existing `@suite-common/wallet-core` import in this file (it already pulls in `createTargets`, `selectAccountByKey`, `selectIsPhishingTransaction`, `useDisplayBaseCurrency` from the same package). `Target` is exported from that package's barrel too — confirmed via the sibling consumer `TransactionTargetsList.tsx:1`, `import { type Target } from '@suite-common/wallet-core';`.
+- `EMPTY_TARGETS` is a module-level constant, not an inline `: []`, so the `account === null` branch doesn't itself produce a fresh reference on every render.
+- Honest sizing: confidence is medium-high, not high — the per-call cost is small for a typical 1-3-target transfer and wasn't measured for coinjoin/batch cases; this is proposed on the shape of the defect (unconditional recompute of derived data on a per-row, self-re-rendering component), not a measured number.
+- Adjacent, same component tree, not part of this fix: `TransactionTarget.tsx`'s `outputLabel` lookup has the identical one-line unmemoized-render-body shape one level down (a `.find()` over `suiteSyncOutputLabels` in the render body); tracked separately in sibling draft `p3-01-cleanups-suite-hooks-and-components.md` (not yet filed).
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-11-tokenselect-revalidation-keyed-on-whole-account.md
+++ b/perf-issues/react-hooks/p2-11-tokenselect-revalidation-keyed-on-whole-account.md
@@ -1,0 +1,53 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Minimal required dependencies"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx:70-75`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx#L70-L75)
+
+Co-anchor — what the effect's `account`-shaped check actually reads: [`suite-common/wallet-utils/src/accountUtils.ts:1045-1053`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/wallet-utils/src/accountUtils.ts#L1045-L1053), `hasNetworkFeatures`, which only branches on `account.symbol`/`account.accountType` via `getNetworkAccountFeatures`.
+
+## Before
+
+```tsx
+useEffect(() => {
+    if (hasNetworkFeatures(account, 'tokens') && !isSetMaxActive) {
+        const amountValue = getValues(`outputs.${outputId}.amount`);
+        if (amountValue) setAmount(outputId, amountValue);
+    }
+}, [account, outputId, tokenWatch, setAmount, getValues, isSetMaxActive]);
+```
+
+## After
+
+```tsx
+useEffect(() => {
+    if (hasNetworkFeatures(account, 'tokens') && !isSetMaxActive) {
+        const amountValue = getValues(`outputs.${outputId}.amount`);
+        if (amountValue) setAmount(outputId, amountValue);
+    }
+}, [
+    account.symbol,
+    account.accountType,
+    outputId,
+    tokenWatch,
+    setAmount,
+    getValues,
+    isSetMaxActive,
+]);
+```
+
+`hasNetworkFeatures(account, 'tokens')` inside the body keeps receiving the full `account` object — `getNetworkAccountFeatures` reads both `symbol` and `accountType` off it (`Pick<Account, 'symbol' | 'accountType'>`), so both stay in the dependency array; only the wider `account` reference itself is dropped.
+
+## Why it matters
+
+`account` gets a fresh object reference on every relevant blockchain sync tick, and as written this effect re-runs the amount re-validation on every one of those ticks while a Send output row is mounted — not only when the user actually changes the selected token via `tokenWatch`, which is already the intended trigger. `account.symbol`/`account.accountType` are stable for the lifetime of one send-form session on one account, so the network-features check they gate never actually changes value between those spurious re-runs; the repeated `getValues`/`setAmount` call is pure repeated work.
+
+## Notes
+
+- Compile requirement: none — `account.symbol` and `account.accountType` are already-accessible properties, no new import.
+- `packages/suite` is not React-Compiler-covered, so this dependency has to be narrowed by hand.
+- `tokenWatch` remains the reactive trigger for "the user changed token"; `account` was only ever in the array for the network-features gate.
+- Same fix pattern, same file tree, as `p2-12-usebuildtokenoptions-keyed-on-whole-account.md` (sibling draft, not yet filed) — both narrow a wide `account` dependency down to the fields a helper (`hasNetworkFeatures` here, `enhanceTokensWithRates` there) actually reads, while still passing the full object into the helper call itself.
+- Confidence caveat carried over from the audit: it's clear the dependency is wider than the check needs, but how visible the repeated `setAmount` call is to the user depends on whether `setAmount` itself has further re-render side effects — not traced as part of this doc.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-12-usebuildtokenoptions-keyed-on-whole-account.md
+++ b/perf-issues/react-hooks/p2-12-usebuildtokenoptions-keyed-on-whole-account.md
@@ -1,0 +1,73 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Minimal required dependencies"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildTokenOptions.tsx:68-84`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildTokenOptions.tsx#L68-L84)
+
+Consumer: [`packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx:72-75`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx#L72-L75) — the Send-form "select token" modal opened from `TokenSelect.tsx`.
+
+## Before
+
+```tsx
+return useMemo(() => {
+    const tokensWithRates = enhanceTokensWithRates(
+        account.tokens,
+        baseCurrencyCode,
+        account.symbol,
+        fiatRates,
+    );
+
+    const sortedTokensWithRates = tokensWithRates.sort(sortTokensWithRates);
+
+    return buildTokenOptions(
+        account,
+        sortedTokensWithRates,
+        coinDefinitions,
+        expandedHiddenTokensGroups,
+    );
+}, [account, baseCurrencyCode, fiatRates, coinDefinitions, expandedHiddenTokensGroups]);
+```
+
+## After
+
+```tsx
+return useMemo(() => {
+    const tokensWithRates = enhanceTokensWithRates(
+        account.tokens,
+        baseCurrencyCode,
+        account.symbol,
+        fiatRates,
+    );
+
+    const sortedTokensWithRates = tokensWithRates.sort(sortTokensWithRates);
+
+    return buildTokenOptions(
+        account,
+        sortedTokensWithRates,
+        coinDefinitions,
+        expandedHiddenTokensGroups,
+    );
+}, [
+    account.tokens,
+    account.symbol,
+    baseCurrencyCode,
+    fiatRates,
+    coinDefinitions,
+    expandedHiddenTokensGroups,
+]);
+```
+
+`buildTokenOptions` still receives the full `account` object as an argument — only the dependency array narrows to the two fields the memo body reads before calling it.
+
+## Why it matters
+
+`sortTokensWithRates` allocates a `BigNumber` per comparison, and this modal's own token count scales with the account's ERC-20/SPL list. Keyed on the whole `account`, the memo recomputes on every account refresh while the picker is open even though the token list and rates usually haven't changed — the memo is present in the code but structurally cannot hit, because `account` gets a fresh reference on every relevant blockchain sync tick.
+
+## Notes
+
+- Compile requirement: none — `account.tokens`/`account.symbol` are already read inside the memo body today, no new import.
+- `packages/suite` is not React-Compiler-covered, so this has to be narrowed by hand.
+- **Read past the memo body before filing this as written.** `buildTokenOptions` (this file, lines 22-53) passes the closed-over `account` object itself into `createAccountOption(account)` and `createHiddenTokensOption({ account, ... })` (`packages/suite/src/components/suite/asset-picker/utils/index.ts:24-38,62-67`), and each returned option carries that same `account` reference by field, not a copy. `SelectTokenAssetModal.tsx:151-153` renders the `'account'`-type option through `AssetRowAccountWithBalance`, whose `AccountAmount` sub-component reads `account.balance` directly off that embedded object (`AccountAmount.tsx:14-17`) rather than through its own live selector. So narrowing the outer dependency to `account.tokens`/`account.symbol` trades "recomputes on every unrelated field change" for "the picker's own account-row balance can lag a live balance-only account update for as long as the picker stays open, until the next tokens/symbol-triggered recompute." The token-row path (`AssetRowToken.tsx`) only reads `account.symbol` off the embedded object, already covered, so this caveat is scoped to the account-level balance row specifically. Worth deciding explicitly when filing — add `account.balance` (and any other field `AccountAmount` grows to read) to the dependency array, or accept the staleness window given this is a short-lived modal — but shipping the narrow array silently is not a free lunch, since it is a behavior change the current (unfixed) code does not have.
+- Same fix pattern, same file tree, as `p2-11-tokenselect-revalidation-keyed-on-whole-account.md` (sibling draft, not yet filed).
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-13-ethereumnonce-refilters-history-per-keystroke.md
+++ b/perf-issues/react-hooks/p2-13-ethereumnonce-refilters-history-per-keystroke.md
@@ -1,0 +1,53 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx:90-94`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx#L90-L94)
+
+Trigger: [`EthereumNonce.tsx:50`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx#L50) — `useWatch({ name: 'ethereumNonce', control })` re-renders this component on every keystroke in the custom-nonce input.
+
+## Before
+
+```tsx
+const transactions = useSelector(state => selectAccountTransactions(state, account.key));
+...
+const nonceValue = useWatch({ name: 'ethereumNonce', control });
+...
+const pendingSentTxs = transactions.filter(isPending).filter(isSignedByAccount);
+
+const pendingNonces = pendingSentTxs
+    .map(tx => tx.ethereumSpecific?.nonce)
+    .filter((nonce): nonce is number => typeof nonce === 'number');
+```
+
+## After
+
+```tsx
+import { useMemo, useState } from 'react';
+...
+const { pendingSentTxs, pendingNonces } = useMemo(() => {
+    const pending = transactions.filter(isPending).filter(isSignedByAccount);
+
+    return {
+        pendingSentTxs: pending,
+        pendingNonces: pending
+            .map(tx => tx.ethereumSpecific?.nonce)
+            .filter((nonce): nonce is number => typeof nonce === 'number'),
+    };
+}, [transactions]);
+```
+
+## Why it matters
+
+`selectAccountTransactions` returns the account's whole transaction list, and `EthereumNonce` re-renders on every keystroke in the custom-nonce field via `nonceValue = useWatch(...)` at line 50. Neither `pendingSentTxs` nor `pendingNonces` reads `nonceValue` — both derive only from `transactions` — so today's unmemoized filter-twice-then-map chain re-runs the full scan on every character typed, purely because it happens to sit in the same render as a field that does need to update per keystroke.
+
+## Notes
+
+- Compile requirement: add `useMemo` to the file's existing `import { useState } from 'react';`.
+- `packages/suite` is not React-Compiler-covered, so this manual `useMemo` is the correct mechanism here.
+- Pure win, not a tradeoff: neither derived value reads `nonceValue`, `bumpedNonce`, or anything else that changes per keystroke, so the memo can only recompute when the account's transaction list actually changes.
+- `applyFeeBump` (further down the same file) reads `pendingSentTxs` via `.find(...)` unchanged, just now sourced from the memoized array instead of a render-body local.
+- Related but distinct: `perf-issues/asymptotic-complexity/p2-28-transactionutils-getownevmnoncesets.md` (sibling draft, not yet filed) covers a different whole-history scan in the Ethereum nonce space — `getOwnEvmNonceSets` in `suite-common/wallet-utils/src/transactionUtils.ts`, consumed by `useEvmNonceInfo`/`TransactionItem` for the account's main transaction-list rows, once per rendered row. That doc's fix is caching an expensive scan once per account instead of once per row; this doc's fix is not re-running a cheaper, separate scan on every keystroke in an unrelated field. Different file, different consumer, same general shape (an EVM nonce computation walking the account's whole transaction history) — worth a shared glance if either lands, but neither obsoletes the other, and this doc does not repeat that draft's complexity/big-O claim.
+- Confidence caveat carried over from the audit: real-world severity depends on typical EVM account transaction-history sizes, which weren't measured for this doc.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-14-tokensnavigation-tab-counts-per-render.md
+++ b/perf-issues/react-hooks/p2-14-tokensnavigation-tab-counts-per-render.md
@@ -1,0 +1,49 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/views/wallet/tokens/TokensNavigation.tsx:126-131`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx#L126-L131)
+
+Parents that own the search box driving this component's re-renders, both holding `searchQuery` in state and passing it down as a prop `TokensNavigation` binds to its own `<Input value={searchQuery}>` (`TokensNavigation.tsx:184`):
+
+- [`packages/suite/src/views/wallet/tokens/index.tsx:20`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/tokens/index.tsx#L20) (state), [`:67-73`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/tokens/index.tsx#L67-L73) (passed down)
+- [`packages/suite/src/views/wallet/nfts/index.tsx:14`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/nfts/index.tsx#L14) (state), [`:36-41`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/nfts/index.tsx#L36-L41) (passed down)
+
+## Before
+
+```tsx
+const tokens = getTokens({
+    tokens: selectedAccount.account.tokens || [],
+    symbol: selectedAccount.account.symbol,
+    tokenDefinitions,
+    isNft,
+});
+```
+
+## After
+
+```tsx
+const tokens = useMemo(
+    () =>
+        getTokens({
+            tokens: selectedAccount.account.tokens || [],
+            symbol: selectedAccount.account.symbol,
+            tokenDefinitions,
+            isNft,
+        }),
+    [selectedAccount.account.tokens, selectedAccount.account.symbol, tokenDefinitions, isNft],
+);
+```
+
+## Why it matters
+
+This call only feeds the tab-count badges (`normalTokens.length`, `erc4626Tokens.length`, `tokens.hiddenWithBalance.length` in `getSubTabConfig`) — verified that `getTokens` here is never passed a `searchQuery` argument at all, unlike the filtered call the active table makes with the same helper — yet every keystroke in the sibling token/NFT search box changes the parent's `searchQuery` state, which re-renders `TokensNavigation` as a normal prop update and re-runs this unmemoized `getTokens` call over the account's full token list on every one of those keystrokes.
+
+## Notes
+
+- Compile requirement: add `useMemo` to the file's existing `import { type Dispatch, type SetStateAction, useEffect } from 'react';` — no other React import is present.
+- `packages/suite` is not React-Compiler-covered, so this has to be memoized by hand.
+- `selectedAccount.account.tokens || []` stays inside the memo callback exactly as today, so the fallback's fresh-array identity never reaches the dependency array — `selectedAccount.account.tokens` (the pre-fallback value) is what's listed, which is the same "fallback inside the memo body, not in the deps" shape the scan's own "Checked, clean" pass confirmed elsewhere in this area (`UtxoReceiveAddressModal.tsx`).
+- `HiddenTokensTable.tsx:23-35` (verified) has the identical shape — an unmemoized `getTokens` call whose result (`tokens`, used for `hiddenTokensCount`/`unverifiedTokensCount`) also doesn't depend on `searchQuery` — and is already named, not filed, in `perf-issues/scheduling/p1-12-token-search-rebuilds-the-unvirtualised-table-per-keystroke.md`'s Notes ("Also left alone: the unmemoised `getTokens` for the tab counts at `TokensNavigation.tsx:126`... making it cheaper is a complexity fix, not a scheduling one"). That doc and this one are additive: it targets the per-keystroke _table row rebuild_; this one targets the _tab-count badge_ computation next to it, which — as verified above — doesn't even receive the value forcing its re-execution. Worth triaging together since a shared fix likely covers both call sites, but this doc stands alone.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-15-trading-forms-bare-watch-rerenders-per-keystroke.md
+++ b/perf-issues/react-hooks/p2-15-trading-forms-bare-watch-rerenders-per-keystroke.md
@@ -1,0 +1,234 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Check which app you are in before adding or removing a memo"_ (the section that names `react-hook-form`'s `watch()` as a hazard). Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx:63`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx#L63)
+
+[`packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOffersWarnings.tsx:24`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOffersWarnings.tsx#L24)
+
+[`packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon.ts:35`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon.ts#L35)
+
+[`packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx:44`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx#L44)
+
+[`packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx:30`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx#L30)
+
+## Before
+
+```tsx
+// TradingFormApproval.tsx:47-63 — destructures `watch` off the trading-form context, then calls it bare
+const {
+    watch,
+    approveTransaction,
+    revokeApproval,
+    refreshQuotes,
+    confirmApproval,
+    isScheduledQuotesRefresh,
+    isComposing,
+    form: {
+        state: { isFormLoading, isFormInvalid },
+        helpers,
+    },
+} = context;
+// ...
+const { exchangeType, rateType } = watch();
+```
+
+```tsx
+// TradingFormOffersWarnings.tsx:16-27
+const context = useTradingFormContext();
+const {
+    isAmountEmpty,
+    form: { state },
+} = context;
+
+const isSubdivisionMissing = (() => {
+    if (!isTradingBuyContext(context) && !isTradingSellContext(context)) return false;
+    const { countrySelect, countrySubdivisionSelect } = context.watch();
+
+    return isCountrySubdivisionEmpty(countrySelect?.value, countrySubdivisionSelect?.value);
+})();
+```
+
+```tsx
+// useTradingFormOfferCommon.ts:26-35
+const context = useTradingFormContext();
+const {
+    isAmountEmpty,
+    watch,
+    form: { state },
+    type,
+} = context;
+const account = useSelector(reduxState => selectTradingSendAccount(reduxState, type));
+
+const { amountInCrypto } = watch();
+```
+
+```tsx
+// TradingFormOfferExchangeActions.tsx:29-44
+const context = useTradingFormContext<'exchange'>();
+const {
+    watch,
+    shouldSendInSats,
+    tradingReceiveAddress,
+    isLoadingQuote,
+    setIsLoadingQuote,
+    confirmTrade,
+    isComposing,
+    form: { state, helpers },
+} = context;
+const account = useSelector(reduxState => selectTradingSendAccount(reduxState, 'exchange'));
+
+const modalControls = useReceiveAddressModalControls();
+
+const { outputs, sendCryptoSelect, receiveCryptoSelect, exchangeType, rateType } = watch();
+```
+
+```tsx
+// TradingFormOfferSellActions.tsx:19-30
+const context = useTradingFormContext<'sell'>();
+const {
+    watch,
+    shouldSendInSats,
+    sellInfo,
+    form: { state, helpers },
+} = context;
+const account = useSelector(reduxState => selectTradingSendAccount(reduxState, 'sell'));
+
+const isNetworkFeeMissing = useSelector(selectIsTradingNetworkFeeMissing);
+
+const { outputs } = watch();
+```
+
+`useTradingFormOfferCommon` is itself called from inside both `TradingFormOfferExchangeActions` and
+the sell/buy equivalents, so its own bare `watch()` compounds with each caller's.
+
+## After
+
+The three files that already pin a concrete form type (`useTradingFormContext<'exchange'>()` /
+`useTradingFormContext<'sell'>()` / `useTradingFormContext<TradingExchangeType>()`) get `control`
+directly off `context` — `TradingExchangeFormContextProps`/`TradingSellFormContextProps` both extend
+react-hook-form's `UseFormReturn<TFieldValues>`, which already includes `control`:
+
+```tsx
+// TradingFormApproval.tsx
+import { useWatch } from 'react-hook-form';
+// ...
+const {
+    control,
+    approveTransaction,
+    revokeApproval,
+    refreshQuotes,
+    confirmApproval,
+    isScheduledQuotesRefresh,
+    isComposing,
+    form: {
+        state: { isFormLoading, isFormInvalid },
+        helpers,
+    },
+} = context;
+// ...
+const [exchangeType, rateType] = useWatch({ control, name: ['exchangeType', 'rateType'] });
+```
+
+```tsx
+// TradingFormOfferExchangeActions.tsx
+const [outputs, sendCryptoSelect, receiveCryptoSelect, exchangeType, rateType] = useWatch({
+    control: context.control,
+    name: ['outputs', 'sendCryptoSelect', 'receiveCryptoSelect', 'exchangeType', 'rateType'],
+});
+```
+
+```tsx
+// TradingFormOfferSellActions.tsx
+const [outputs] = useWatch({ control: context.control, name: ['outputs'] });
+```
+
+The two files that call `useTradingFormContext()` with no concrete type parameter
+(`TradingFormOffersWarnings.tsx`, `useTradingFormOfferCommon.ts`) get `control` the same way the
+already-correct sibling `TradingFormInputCryptoAmount.tsx:179` does — a cast to the union form-props
+type:
+
+```tsx
+// TradingFormOffersWarnings.tsx
+import { type UseFormReturn, useWatch } from 'react-hook-form';
+import { type TradingAllFormProps } from 'src/types/trading/tradingForm';
+// ...
+const context = useTradingFormContext();
+const { control } = context as UseFormReturn<TradingAllFormProps>;
+const {
+    isAmountEmpty,
+    form: { state },
+} = context;
+
+const [countrySelect, countrySubdivisionSelect] = useWatch({
+    control,
+    name: ['countrySelect', 'countrySubdivisionSelect'],
+});
+
+const isSubdivisionMissing =
+    (isTradingBuyContext(context) || isTradingSellContext(context)) &&
+    isCountrySubdivisionEmpty(countrySelect?.value, countrySubdivisionSelect?.value);
+```
+
+(`useWatch` is a hook and has to be called unconditionally at the top level, so this also moves the
+logic out of the IIFE the original `context.watch()` call lived in — `(A || B) && C` here is the same
+boolean shape as the original `if (!A && !B) return false;` guard, just without needing an early
+return.)
+
+```tsx
+// useTradingFormOfferCommon.ts
+const context = useTradingFormContext();
+const { control } = context as UseFormReturn<TradingAllFormProps>;
+const {
+    isAmountEmpty,
+    form: { state },
+    type,
+} = context;
+// ...
+const [amountInCrypto] = useWatch({ control, name: ['amountInCrypto'] });
+```
+
+## Why it matters
+
+None of these `watch()` calls scope a field name, so each subscribes its component to _every_ field
+change in the active trading form, not just the ones it destructures. Typing an amount, picking a
+country, or changing any other field currently re-renders all five of these
+components/hooks (`useTradingFormOfferCommon` runs inside both action components, multiplying the
+effect) on every keystroke anywhere in the form, including the several `useSelector` calls and derived
+booleans each one recomputes as part of that re-render — work whose inputs didn't actually change.
+
+## Notes
+
+- Class caveat, carried over from the sweep's own harvest: the skill's `watch()`/`useWatch()` guidance
+  is written for **compiled `suite-native`**, where a bail-out silently drops the whole component's
+  React-Compiler auto-memoization. These five files are `packages/suite` (not React-Compiler-covered),
+  so there's no compiler bail-out here — the defect is the plainer "unscoped subscription re-renders
+  wider than it needs to" problem. It's reported here because it's the closest web analogue and the
+  sweep's harvest named it as a distinct category; triage may reasonably re-bucket it rather than treat
+  it as a hooks-skill violation in the strict sense the skill describes.
+- Correct siblings already in this exact file family prove both `control`-extraction styles compile
+  here today: `TradingFormInputFiat.tsx:74-80` (four `useWatch({ control, name: ... })` calls, with
+  `control` obtained via a separate `useFormContext<TradingAllFormProps>()` call) and
+  `TradingFormInputCryptoAmount.tsx:179-184` (`const { control } = context as UseFormReturn<TradingAllFormProps>;`
+  then `useWatch({ control, name: TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT })`) — the After above
+  mirrors the second file's cast style for the two union-typed contexts.
+- `sendCryptoSelect` (used successfully in that proven sibling) isn't present on the Buy form's props
+  either, so the union cast already has precedent for fields that don't exist on every member of
+  `TradingAllFormProps`; `amountInCrypto` (`suite-common/trading/src/types.ts:194,252,302` —
+  `TRADING_FORM_AMOUNT_IN_CRYPTO`) is present on all three form types, so it's on firmer ground than
+  that. `countrySelect`/`countrySubdivisionSelect` (`types.ts:190-191,300-301`) exist on Buy and Sell
+  but not on `MinimalExchangeFormProps`, matching this file's own runtime guard — worth a type-check
+  pass when implementing, but not expected to behave differently from the proven `sendCryptoSelect`
+  case.
+- `useWatch` with an array `name` returns a tuple in the same order, not an object — each `After`
+  above switches from `const { field } = watch()` to `const [field] = useWatch({ control, name: ['field'] })`,
+  destructuring by position instead of by key.
+- None of the five files import `useWatch` today; `react-hook-form` is already a direct dependency used
+  throughout this same form tree (see the correct siblings above), so this only adds an import line,
+  not a new package dependency.
+- `packages/suite` is not React-Compiler-covered, so this is a manual fix regardless of classification
+  — there's no compiler to lean on either way.
+- Confidence is medium: high that the subscription is unscoped and wider than needed, medium on
+  real-world cost per keystroke (not profiled for this sweep) and on the class-6 stretch noted above.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-16-pinstep-effect-keyed-on-whole-device.md
+++ b/perf-issues/react-hooks/p2-16-pinstep-effect-keyed-on-whole-device.md
@@ -1,0 +1,97 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Minimal required
+dependencies"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/suite/src/views/onboarding/steps/PinStep.tsx:49-70`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/onboarding/steps/PinStep.tsx#L49-L70)
+
+## Before
+
+```tsx
+useEffect(() => {
+    // This is where we detect requests from a device, figure out whether the PIN functionality got enabled,
+    // and set a status of the setup process accordingly
+    if (device?.features) {
+        // enter-pin and repeat-pin" states are set only while working with T1B1 (T2T1 sends different request ButtonRequest_PinEntry and everything is done in touchscreen).
+        // They are used to show better context-aware UI/texts (Right now it only changes a header from "Set a new PIN" to "Confirm PIN").
+        // As the whole process on T2T1 is done via touchscreen we don't really need to track anything besides 'initial' and 'success' states.
+        const buttonRequests = device.buttonRequests.map(r => r.code);
+        if (buttonRequests.includes('PinMatrixRequestType_NewFirst')) {
+            if (buttonRequests.includes('PinMatrixRequestType_NewSecond')) {
+                setStatus('repeat-pin');
+            } else {
+                setStatus('enter-pin');
+            }
+        }
+
+        if (device?.features.pin_protection) {
+            setStatus('success');
+            goToNextStep();
+        }
+    }
+}, [device, goToNextStep]);
+```
+
+`device` is the whole `TrezorDevice` object from `useSelector(selectSelectedDevice)`, which gets a
+fresh reference on any feature/state change, not just the two fields this effect actually branches
+on. Nothing in the body guards against re-running the `pin_protection` branch once `status` is
+already `'success'`.
+
+## After
+
+```tsx
+const hasNewFirst = !!device?.buttonRequests.some(r => r.code === 'PinMatrixRequestType_NewFirst');
+const hasNewSecond = !!device?.buttonRequests.some(
+    r => r.code === 'PinMatrixRequestType_NewSecond',
+);
+const hasPinProtection = !!device?.features?.pin_protection;
+
+useEffect(() => {
+    // This is where we detect requests from a device, figure out whether the PIN functionality got enabled,
+    // and set a status of the setup process accordingly
+    if (!device?.features) return;
+
+    if (hasNewFirst) {
+        setStatus(hasNewSecond ? 'repeat-pin' : 'enter-pin');
+    }
+
+    if (hasPinProtection && status !== 'success') {
+        setStatus('success');
+        goToNextStep();
+    }
+}, [device?.features, hasNewFirst, hasNewSecond, hasPinProtection, status, goToNextStep]);
+```
+
+## Why it matters
+
+`PinStep` keeps rendering (as `null`, via the `status === 'success'` check further down the
+component) for as long as it stays mounted after PIN setup succeeds — the window until the parent's
+`activeStepId`-keyed step switch
+([`views/onboarding/index.tsx:56-88`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/onboarding/index.tsx#L56-L88))
+swaps the rendered step component out. Depending on the whole `device` object means this effect
+re-runs on any device-reference churn during that window, and as written nothing stops it from
+calling `goToNextStep()` again on every one of those re-runs for as long as `pin_protection` stays
+true. Narrowing the dependency array to the actual booleans already shrinks the re-run window to
+genuine value transitions instead of incidental reference churn; adding the `status !== 'success'`
+guard closes the remaining gap directly, so the branch that advances onboarding can fire at most
+once per PIN setup regardless of how many device updates arrive afterward.
+
+## Notes
+
+- Compile requirement: none — `device?.buttonRequests`/`device?.features?.pin_protection` are
+  already-accessible fields (`buttonRequests: ButtonRequest[]` is non-optional on the device type;
+  only `device` itself and `device.features` are optional).
+- The scan's own proposed fix narrows the dependency array but does not add the `status !== 'success'`
+  guard; this doc adds it because the "Why it matters" risk (`goToNextStep()` re-invoked after
+  success) is only fully closed once the effect is idempotent against being re-entered, not just
+  less frequently triggered. Confirmed safe against a re-render loop: `setStatus('success')` inside
+  the guarded branch flips `status` to the very value the guard checks, so the branch cannot re-fire
+  on the next render it causes.
+- `packages/suite` is not React-Compiler-covered, so this is a manual dependency-array fix, not a
+  memoization one — `hasNewFirst`/`hasNewSecond`/`hasPinProtection` are already O(1)/cheap booleans
+  derived in the render body, not something that itself needs `useMemo`.
+- Whether the onboarding step reducer is idempotent against repeat "advance" dispatches was not
+  traced; this fix removes the repeat-dispatch risk at its source regardless of that reducer's own
+  behavior.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-17-virtualizedlist-scroll-debounce-reset-by-caller.md
+++ b/perf-issues/react-hooks/p2-17-virtualizedlist-scroll-debounce-reset-by-caller.md
@@ -1,0 +1,104 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Keep hook dependencies
+referentially stable"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/components/src/components/VirtualizedList/VirtualizedList.tsx:126`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/VirtualizedList/VirtualizedList.tsx#L126)
+
+- Chain: `handleScroll` ([`:149-203`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/VirtualizedList/VirtualizedList.tsx#L149-L203))
+  depends on the memo (`:196`); the scroll-listener effect
+  ([`:205-212`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/VirtualizedList/VirtualizedList.tsx#L205-L212))
+  depends on `handleScroll`.
+- Triggering caller (outside this area, cited as evidence):
+  [`packages/suite/src/components/suite/asset-picker/components/AssetsList/AssetsList.tsx:27-28`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/asset-picker/components/AssetsList/AssetsList.tsx#L27-L28)
+
+## Before
+
+```tsx
+// VirtualizedList.tsx:19-33 — debounce() closes over its own fresh `timeout` per call
+function debounce<T extends (...args: unknown[]) => void>(
+    func: T,
+    wait: number,
+): (...args: Parameters<T>) => void {
+    let timeout: TimerId | null = null;
+
+    return (...args: Parameters<T>) => {
+        if (timeout !== null) {
+            clearTimeout(timeout);
+        }
+        timeout = setTimeout(() => {
+            func(...args);
+        }, wait);
+    };
+}
+```
+
+```tsx
+// VirtualizedList.tsx:126
+const debouncedOnScrollEnd = useMemo(() => debounce(onScrollEnd, 1000), [onScrollEnd]);
+```
+
+```tsx
+// AssetsList.tsx:27-28 — the only real consumer today (packages/suite, outside this area, cited as evidence)
+const [end, setEnd] = useState(items.length);
+const onScrollEnd = useCallback(() => setEnd(end + 1000), [end]);
+```
+
+`onScrollEnd`'s own dependency is the state it sets (`end`), so its identity changes every time it
+fires. Recreating `debouncedOnScrollEnd` discards whatever debounce/timer bookkeeping the previous
+`debounce()` instance was holding, and both `handleScroll` (depends on `debouncedOnScrollEnd` at
+`:196`) and the scroll-listener effect (depends on `handleScroll`) re-run in turn — tearing down and
+re-adding the `scroll` listener on the scrollable container.
+
+## After
+
+```tsx
+import { useFreshRef } from '@trezor/react-utils';
+
+// ...
+
+const onScrollEndRef = useFreshRef(onScrollEnd);
+const debouncedOnScrollEnd = useMemo(
+    () => debounce(() => onScrollEndRef.current(), 1000),
+    [onScrollEndRef],
+);
+```
+
+`useFreshRef`'s returned ref object is stable for the component's lifetime (a plain `useRef` under
+the hood), so this `useMemo` now runs once, `handleScroll`'s identity stops churning, and the scroll
+listener is registered once instead of on every load-more trigger — while still always calling the
+latest `onScrollEnd`.
+
+## Why it matters
+
+Every scroll-near-the-end event during a long scroll session through `VirtualizedList`'s one real
+consumer today (the asset/coin picker, which can hold every network's tokens) currently tears down
+and rebuilds the scroll subscription and the debounce timer, instead of the debounce staying stable
+for the component's lifetime as its 1000 ms wait implies it should.
+
+## Notes
+
+- Compile requirement: `packages/components/package.json` does not currently list
+  `@trezor/react-utils` as a dependency (checked) — add it as a workspace dependency. Both packages
+  are same-layer `packages/*`, and `@trezor/react-utils` has no dependency back on
+  `@trezor/components` (checked its `package.json`), so this doesn't cross the layering rule or
+  create a cycle.
+- Distinct from `perf-issues/asymptotic-complexity/p2-11-virtualizedlistx-virtualizedlistcomponent.md`
+  (sibling draft, not yet filed): that doc fixes the O(w²) prefix-sum recomputation in the same file
+  (`firstItemTop`/`itemTop` around lines 219-237) and the O(n) linear start-index scan at line 156 —
+  an algorithmic-complexity defect that fires on every scroll event regardless of dependency
+  stability. This doc fixes a different defect at a different line (`:126`) — the debounce/listener
+  identity churning from an unstable callback crossing the component boundary. The two are
+  independent and additive; landing one does not obsolete the other.
+- Aside, not fixed here: `AssetsList.tsx` (`packages/suite`, outside this area) passes the _entire_
+  `items` array to `VirtualizedList` regardless of `end`, so the `end`/`setEnd` state this defect
+  defeats doesn't appear to gate anything today — that's a correctness/dead-code question for
+  `packages/suite`, separate from the hooks-class defect documented here.
+- `packages/components` ships to both the uncompiled `packages/suite` web/desktop app and the
+  React-Compiler-covered `suite-native`; per this area's scope, native-vs-web doesn't change the fix
+  — memoize for the web consumer.
+- Honest sizing: bounded to "near the end of the list" scroll events (the `loadMoreBufferCount`
+  threshold), not every scroll frame — real and reproducible with the sole current caller, but not a
+  render loop.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-18-usenetworkselect-memos-defeated-per-keystroke.md
+++ b/perf-issues/react-hooks/p2-18-usenetworkselect-memos-defeated-per-keystroke.md
@@ -1,0 +1,166 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Keep hook dependencies
+referentially stable"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/product-components/src/components/SearchAsset/hooks/useNetworkSelect.ts:15`](https://github.com/trezor/trezor-suite/blob/develop/packages/product-components/src/components/SearchAsset/hooks/useNetworkSelect.ts#L15)
+
+- Real caller 1 (outside this area, cited as evidence):
+  [`.../GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx:43,49-57`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx#L49-L57)
+  — global Send/Receive asset search.
+- Real caller 2, near-duplicate (outside this area):
+  [`.../TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx:37-43`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx#L37-L43)
+  — Trading asset picker.
+- Search-state evidence: [`.../GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useSearchFilter.ts:12`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useSearchFilter.ts#L12)
+  — `search` is local `useState`, updated on every keystroke.
+
+## Before
+
+```tsx
+// useNetworkSelect.ts:14-41
+export const useNetworkSelect = (config?: SearchAssetSelectConfig) => {
+    const { networks = [], includeAllOption, allLabel, selectedNetwork } = config ?? {};
+
+    const allOptions = useMemo(() => {
+        const networkOptions = networks
+            .map(symbol => {
+                const network = getNetwork(symbol);
+
+                return network ? { label: network.name, value: network.symbol } : null;
+            })
+            .filter(isNotNull);
+
+        return includeAllOption
+            ? [{ label: allLabel ?? 'All networks', value: undefined }, ...networkOptions]
+            : networkOptions;
+    }, [networks, includeAllOption, allLabel]);
+
+    const selectedOption = useMemo(
+        () => allOptions.find(option => option.value === selectedNetwork),
+        [allOptions, selectedNetwork],
+    );
+
+    const options = useMemo(
+        () => allOptions.filter(option => option.value !== selectedNetwork),
+        [allOptions, selectedNetwork],
+    );
+
+    return { options, selectedOption };
+};
+```
+
+```tsx
+// AssetSearchWithNetworkFilter.tsx:43,49-57 (GlobalSendReceive) — rebuilt every keystroke
+const networks = protocolSymbol ? [protocolSymbol] : enabledNetworks;
+// ...
+const selectConfig = isBitcoinOnlyFirmware
+    ? undefined
+    : {
+          networks,
+          selectedNetwork: networkFilter,
+          onChange: setNetworkFilter,
+          includeAllOption: !protocolSymbol,
+          allLabel: translationString('TR_ALL_NETWORKS'),
+      };
+```
+
+```tsx
+// TradingFormInputAssetPicker/AssetSearchWithNetworkFilter.tsx:37-43 — same shape, inline in JSX
+selectConfig={{
+    networks,
+    selectedNetwork: networkFilter,
+    onChange: setNetworkFilter,
+    includeAllOption: true,
+    allLabel: translationString('TR_ALL_NETWORKS'),
+}}
+```
+
+Both callers rebuild their `selectConfig` object literal every render. The `GlobalSendReceive`
+component owns `search` as local `useState` (`useSearchFilter.ts:12`) and re-renders on every
+keystroke; the Trading variant receives `search` as a prop from `AssetPickerModal`, which owns the
+same shape of local `useState` one level up
+(`packages/suite/src/components/suite/asset-picker/hooks/useSearchFilter.ts:5`). Either way, a fresh
+`config` object reaches `useNetworkSelect` on every keystroke, so all three of its internal
+`useMemo`s (`allOptions`, `selectedOption`, `options`) recompute along with it.
+
+## After
+
+In `useNetworkSelect.ts`, hoist a module-level empty-array constant for the destructuring default —
+this is the skill's own `?? []` worked example:
+
+```tsx
+const EMPTY_NETWORKS: NetworkSymbol[] = [];
+
+export const useNetworkSelect = (config?: SearchAssetSelectConfig) => {
+    const { networks = EMPTY_NETWORKS, includeAllOption, allLabel, selectedNetwork } = config ?? {};
+    // ...unchanged
+```
+
+That only fixes the "no config at all" path — `useNetworkSelect` cannot deduplicate a `config` object
+it did not create. The per-keystroke cadence needs the fix in the caller (outside this area):
+memoize `selectConfig` (and `networks`, where it's derived from `protocolSymbol`) on its primitive
+inputs, e.g. in the `GlobalSendReceive` variant:
+
+```tsx
+const networks = useMemo(
+    () => (protocolSymbol ? [protocolSymbol] : enabledNetworks),
+    [protocolSymbol, enabledNetworks],
+);
+
+const selectConfig = useMemo(
+    () =>
+        isBitcoinOnlyFirmware
+            ? undefined
+            : {
+                  networks,
+                  selectedNetwork: networkFilter,
+                  onChange: setNetworkFilter,
+                  includeAllOption: !protocolSymbol,
+                  allLabel: translationString('TR_ALL_NETWORKS'),
+              },
+    [
+        isBitcoinOnlyFirmware,
+        networks,
+        networkFilter,
+        setNetworkFilter,
+        protocolSymbol,
+        translationString,
+    ],
+);
+```
+
+with the same shape applied to the Trading variant's inline object.
+
+## Why it matters
+
+Two near-duplicate `AssetSearchWithNetworkFilter` components — the global Send/Receive asset search
+and the Trading asset picker — both feed `useNetworkSelect` an unmemoized config, so every character
+typed into either search box redoes the network-options list and the options-minus-selected
+filtering as pure pipeline overhead, on a hot per-keystroke path. Small per call, but avoidable and
+it compounds with every keystroke while either picker is open.
+
+## Notes
+
+- Compile requirement: `useNetworkSelect.ts` already imports `useMemo`; no new import needed for the
+  in-area fix.
+- Checked, not just flagged: the caller-side memo sketched above will actually hold.
+  `setNetworkFilter` (`useNetworkFilter.ts`) is a plain `useState` setter, stable forever.
+  `enabledNetworks` (`selectEnabledNetworks`,
+  `suite-common/wallet-core/src/settings/walletSettingsReducer.ts:118`) returns the Redux-stored
+  array directly (only substituting a shared empty array via `returnStableArrayIfEmpty` when it's
+  empty), so it's referentially stable across renders that don't change that slice of state.
+  `translationString` (`suite/intl/src/hooks/useTranslation.ts:17-26`) is a `useCallback` keyed on
+  `[intl]` from `react-intl`, stable in practice. None of these were flagged as unstable in this
+  area's scan, and independent verification confirms they aren't.
+- The caller-side fix lives in two files outside this area (`packages/suite`), so it isn't verified
+  here to the same depth as `useNetworkSelect.ts` itself — sketched above as the necessary follow-up,
+  not a patch.
+- Honest sizing: the network list itself is small (one entry per enabled network), so the
+  per-keystroke cost of the defeated memos is modest — the finding is about avoidable, compounding
+  waste on a hot path, not a slow operation.
+- `packages/product-components` ships to both the uncompiled `packages/suite` web/desktop app and
+  the React-Compiler-covered `suite-native`; per this area's scope, native-vs-web doesn't change the
+  in-area fix — memoize for the web consumer. Both caller files are `packages/suite` (also
+  uncompiled), so their proposed `useMemo` fix is likewise a manual, permanent one.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-19-menu-rebuilds-global-keydown-listeners.md
+++ b/perf-issues/react-hooks/p2-19-menu-rebuilds-global-keydown-listeners.md
@@ -1,0 +1,117 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Keep hook dependencies
+referentially stable"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`packages/components/src/components/Menu/Menu.tsx:131`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Menu/Menu.tsx#L131)
+(unmemoized `.filter()`)
+
+- Both effects depend on it: [`:137-160`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Menu/Menu.tsx#L137-L160)
+  (select-on-Enter/Space) and [`:163-195`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Menu/Menu.tsx#L163-L195)
+  (arrow-key navigation).
+
+## Before
+
+```tsx
+// Menu.tsx:128-134
+export const Menu = forwardRef<HTMLUListElement, MenuProps>(
+    ({ items, content, onClose, ...rest }, ref) => {
+        const frameProps = pickAndPrepareFrameProps(rest, allowedMenuFrameProps);
+        const visibleItems = items?.filter(item => !item.isHidden);
+        const [focusedItemIndex, setFocusedItemIndex] = useState(
+            visibleItems?.length ? visibleItems.findIndex(item => !item.isDisabled) : null,
+        );
+
+        // handle selecting an item
+        useEffect(() => {
+            const handleKeyDown = (e: KeyboardEvent) => {
+                if (!visibleItems?.length || focusedItemIndex === null) {
+                    return;
+                }
+
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+
+                    const focusedItem = visibleItems[focusedItemIndex];
+
+                    if (focusedItem?.closeOnClick !== false) onClose?.();
+                    focusedItem?.onClick?.();
+                }
+            };
+
+            if (focusedItemIndex !== null && visibleItems?.length) {
+                document.addEventListener('keydown', handleKeyDown);
+
+                return () => {
+                    document.removeEventListener('keydown', handleKeyDown);
+                };
+            }
+        }, [focusedItemIndex, visibleItems, onClose]);
+
+        // handle keyboard navigation
+        useEffect(() => {
+            const handleKeyDown = (e: KeyboardEvent) => {
+                if (
+                    (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
+                    visibleItems &&
+                    visibleItems.length > 0 &&
+                    focusedItemIndex !== null
+                ) {
+                    e.preventDefault();
+                    let indexCandidate = focusedItemIndex;
+                    const direction = e.key === 'ArrowUp' ? -1 : 1;
+                    const getNextIndex = (index: number, dir: number) =>
+                        (index + dir + visibleItems.length) % visibleItems.length;
+
+                    do {
+                        indexCandidate = getNextIndex(indexCandidate, direction);
+                    } while (
+                        visibleItems[indexCandidate]?.isDisabled &&
+                        indexCandidate !== focusedItemIndex
+                    );
+
+                    setFocusedItemIndex(indexCandidate);
+                }
+            };
+
+            if (focusedItemIndex !== null && visibleItems?.length) {
+                document.addEventListener('keydown', handleKeyDown);
+
+                return () => {
+                    document.removeEventListener('keydown', handleKeyDown);
+                };
+            }
+        }, [visibleItems, focusedItemIndex]);
+```
+
+`visibleItems` is a plain `.filter()` call in the render body — a new array every render regardless
+of whether any item's `isHidden` flag actually changed. Both effects list it as a dependency, so
+every render of an open `Menu` tears down and re-adds two separate `document`-level `keydown`
+listeners, even when nothing about the visible items changed.
+
+## After
+
+```tsx
+const visibleItems = useMemo(() => items?.filter(item => !item.isHidden), [items]);
+```
+
+## Why it matters
+
+`Menu` backs essentially every dropdown/context menu in the app. While a menu is open, any re-render
+of it (a parent state change, a prop update unrelated to `items`) currently causes two global
+keyboard-listener teardown/rebuild cycles instead of zero; both effects would instead only re-run
+when the actual visible-items set changes.
+
+## Notes
+
+- Compile requirement: add `useMemo` to the existing
+  `import React, { forwardRef, useEffect, useState } from 'react';` on `Menu.tsx:1`.
+- Bounded, not a loop: neither effect's own body sets state that feeds back into `visibleItems` or
+  `items`, so this is wasted teardown/rebuild work, not a render or request cycle — no events are
+  missed in practice, but the two listeners churn on every unrelated re-render of an open menu
+  instead of only when `items` changes.
+- `packages/components` ships to both the uncompiled `packages/suite` web/desktop app and the
+  React-Compiler-covered `suite-native`; per this area's scope, native-vs-web doesn't change the fix
+  — memoize for the web consumer.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-20-selectfilterknowntokens-unmemoized-native.md
+++ b/perf-issues/react-hooks/p2-20-selectfilterknowntokens-unmemoized-native.md
@@ -1,0 +1,86 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Relocate render-body work before memoizing it, and memoize only what pays"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`suite-common/token-definitions/src/tokenDefinitionsSelectors.ts:44-51`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/token-definitions/src/tokenDefinitionsSelectors.ts#L44-L51) — `selectFilterKnownTokens`, a plain function, not memoized.
+
+Consumer evidence (the native screen this re-renders): [`suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx:60-68`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx#L60-L68)
+
+## Before
+
+```ts
+// suite-common/token-definitions/src/tokenDefinitionsSelectors.ts:44-51
+export const selectFilterKnownTokens = (
+    state: TokenDefinitionsRootState,
+    symbol: NetworkSymbol,
+    tokens: TokenInfo[],
+) =>
+    returnStableArrayIfEmpty(
+        tokens.filter(token => selectCoinDefinition(state, symbol, token.contract as TokenAddress)),
+    );
+```
+
+```tsx
+// suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx:60-68
+const knownTokens = useSelector((state: TokenDefinitionsRootState) =>
+    selectFilterKnownTokens(state, symbol, accountInfo.tokens ?? []),
+);
+
+const deviceNetworkAccounts = useSelector((state: AccountsRootState) =>
+    selectAccountsByNetworkAndDeviceState(state, PORTFOLIO_TRACKER_DEVICE_STATE, symbol),
+);
+
+const nonEmptyTokens = knownTokens.filter(info => parseFloat(info.balance ?? '0') > 0);
+```
+
+`selectFilterKnownTokens` is a plain function, not wrapped in `createSelector`/`createWeakMapSelector`. `returnStableArrayIfEmpty` only stabilizes the case where the filtered result is empty; any account with at least one known token gets a fresh `.filter()` array on every call. `useSelector` invokes its selector on every dispatch to diff the result, and native `useSelector` (bare `react-redux`, no `shallowEqual` wrapper) uses reference equality, so a fresh array re-renders the component regardless of whether the token list actually changed.
+
+## After
+
+```ts
+// suite-common/token-definitions/src/tokenDefinitionsSelectors.ts
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+// ...
+import { filterKnownTokens, isTokenDefinitionKnown } from './tokenDefinitionsUtils';
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<TokenDefinitionsRootState>();
+
+export const selectFilterKnownTokens = createMemoizedSelector(
+    [
+        (state: TokenDefinitionsRootState, symbol: NetworkSymbol) =>
+            getSimpleCoinDefinitionsByNetwork(state.tokenDefinitions, symbol),
+        (_state: TokenDefinitionsRootState, symbol: NetworkSymbol) => symbol,
+        (_state: TokenDefinitionsRootState, _symbol: NetworkSymbol, tokens: TokenInfo[]) => tokens,
+    ],
+    (coinDefinitions, symbol, tokens) =>
+        returnStableArrayIfEmpty(filterKnownTokens(coinDefinitions, symbol, tokens)),
+);
+```
+
+`filterKnownTokens` (`tokenDefinitionsUtils.ts:42-46`, already in this same file's directory) does exactly this filter over a plain `SimpleTokenStructure`, so the combiner reuses it instead of re-deriving `isTokenDefinitionKnown` inline; `getSimpleCoinDefinitionsByNetwork` (this same file, lines 11-14) already extracts the one slice that actually changes when token definitions are (re)loaded (`state.tokenDefinitions[symbol].coin.data`), instead of the whole `state`. The result now recomputes only when `tokens`, `symbol`, or that specific coin-definitions slice change — not on every dispatch.
+
+At the call site, hoist the `?? []` fallback to a module-level constant so a stable reference reaches the selector whenever `accountInfo.tokens` is absent:
+
+```tsx
+// suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
+const EMPTY_TOKENS: TokenInfo[] = [];
+
+// ...
+const knownTokens = useSelector((state: TokenDefinitionsRootState) =>
+    selectFilterKnownTokens(state, symbol, accountInfo.tokens ?? EMPTY_TOKENS),
+);
+```
+
+## Why it matters
+
+`AccountImportConfirmFormScreen` is the account-import confirmation step; while it's mounted, `knownTokens` (and the `nonEmptyTokens` derived from it) get a fresh array reference on every store dispatch, not just on token-definition updates — including blockchain/discovery events for any other enabled account on the device, not only the one being imported. Each of those re-renders the screen and hands its `FlashList` a new `data` array reference, which is more disruptive to `FlashList`'s row recycling than a plain re-render.
+
+## Notes
+
+- Compile requirement: add `createWeakMapSelector` to the existing `import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';`, and add `filterKnownTokens` to the existing `import { isTokenDefinitionKnown } from './tokenDefinitionsUtils';` (that import stays — `isTokenDefinitionKnown` is still used by `selectCoinDefinition`, unchanged, a few lines below). No import changes needed in the native screen beyond none — `TokenInfo` is already imported there.
+- Native rule: `AccountImportConfirmFormScreen.tsx` is `suite-native` (React-Compiler-compiled), so the fix cannot be "wrap `knownTokens`/`nonEmptyTokens` in a `useMemo` at the call site" — it has to land in the selector itself, per the rule of fixing the unstable reference at its source. Once `selectFilterKnownTokens` returns a stable reference, the render-body `nonEmptyTokens = knownTokens.filter(...)` derivation is exactly the kind of render-body work the compiler already auto-memoizes correctly on its own — it only needs `knownTokens` itself to stop changing identity for no reason.
+- Correct in-repo siblings for this exact combination (strongest evidence this is the right shape): [`suite-native/graph/src/selectors.ts:28-59`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/graph/src/selectors.ts#L28-L59) (`selectPortfolioGraphAccountItems`) and [`suite-native/trading-state/src/selectors/commonSelectors.ts:287-296`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/trading-state/src/selectors/commonSelectors.ts#L287-L296) (inside `selectAccountsWithTokensToSellSectionListByTradingType`) both already call `getSimpleCoinDefinitionsByNetwork` + `filterKnownTokens` inside a `createWeakMapSelector` combiner for the same "which of this account's tokens are known" computation. `selectFilterKnownTokens` is the one selector in this family that was never converted.
+- `returnStableArrayIfEmpty` was already doing its job for the genuinely-empty-result case; the gap this fix closes is the non-empty case, a real `.filter()` result, which it was never designed to cover.
+- Honest sizing: single call site, one screen, for the account-import flow's lifetime — not a root provider, not a keystroke handler. Severity is P2 (real and unbounded for that screen's duration), not P1.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-21-accountimportloading-stale-retry-closure.md
+++ b/perf-issues/react-hooks/p2-21-accountimportloading-stale-retry-closure.md
@@ -1,0 +1,124 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Never add a new `eslint-disable` for `exhaustive-deps`"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx:56-88`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx#L56-L88) — `safelyShowImportError` (56-73), called from `handleResult` (79-88).
+
+Co-anchor: [`suite-native/module-accounts-import/src/useShowImportError.ts:81-91`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-accounts-import/src/useShowImportError.ts#L81-L91) — `onPressPrimaryButton: onRetry` is wired to the alert's "Try Again" button and fires on a user tap, arbitrarily later than when the closure below was captured.
+
+## Before
+
+```tsx
+// suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx:56-88
+const safelyShowImportError = useCallback(
+    async (onRetry?: () => Promise<void>) => {
+        // Delay displaying the error message to avoid freezing the app on iOS. If an error occurs too quickly during the
+        // transition from ScanQRCodeModalScreen, the error modal won't appear, resulting in a frozen app.
+        await resolveAfter(1000);
+        showImportError(error, () => {
+            if (!onRetry) return;
+            onRetry();
+
+            // This is needed because handleResult calls safelyShowImportError, which calls handleResult,
+            // so one of them is always going to be used before it was defined. However, the functionality is fine here so it's not a problem.
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define, react-hooks/immutability
+            handleResult();
+        });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [error, showImportError],
+);
+
+useEffect(() => {
+    fetchAccountInfo();
+}, [fetchAccountInfo]);
+
+const handleResult = () => {
+    if (error || !accountInfo) {
+        safelyShowImportError(fetchAccountInfo);
+    } else {
+        navigation.navigate(AccountsImportStackRoutes.AccountImportSummary, {
+            accountInfo,
+            networkSymbol,
+        });
+    }
+};
+```
+
+`onRetry` here is `fetchAccountInfo`, an `async` function. It's invoked without `await`, and `handleResult()` — a plain, unmemoized closure captured whenever `safelyShowImportError`'s `useCallback` last recomputed (deps `[error, showImportError]`) — runs on the very next line, reading `error`/`accountInfo` from whatever render produced _that_ closure, not from the retry's eventual outcome.
+
+## After
+
+```tsx
+const fetchAccountInfo = useCallback(async () => {
+    try {
+        const response = await dispatch(
+            getAccountInfoThunk({ symbol: networkSymbol, baseCurrencyCode, xpubAddress }),
+        ).unwrap();
+
+        if (response) {
+            setAccountInfo(response);
+            setAccountInfoFetchResult('success');
+        }
+
+        return response ?? null;
+    } catch (response) {
+        setError(response);
+        setAccountInfoFetchResult('error');
+
+        return null;
+    }
+}, [dispatch, baseCurrencyCode, networkSymbol, xpubAddress]);
+
+const safelyShowImportError = useCallback(async () => {
+    // Delay displaying the error message to avoid freezing the app on iOS. If an error occurs too quickly during the
+    // transition from ScanQRCodeModalScreen, the error modal won't appear, resulting in a frozen app.
+    await resolveAfter(1000);
+    showImportError(error, async () => {
+        const retriedAccountInfo = await fetchAccountInfo();
+
+        if (retriedAccountInfo) {
+            navigation.navigate(AccountsImportStackRoutes.AccountImportSummary, {
+                accountInfo: retriedAccountInfo,
+                networkSymbol,
+            });
+        } else {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            safelyShowImportError();
+        }
+    });
+}, [error, showImportError, fetchAccountInfo, navigation, networkSymbol]);
+
+useEffect(() => {
+    fetchAccountInfo();
+}, [fetchAccountInfo]);
+
+const handleResult = () => {
+    if (error || !accountInfo) {
+        safelyShowImportError();
+    } else {
+        navigation.navigate(AccountsImportStackRoutes.AccountImportSummary, {
+            accountInfo,
+            networkSymbol,
+        });
+    }
+};
+```
+
+`fetchAccountInfo` now returns its own outcome (`AccountInfo | null`) instead of only writing to state, so the retry path can `await` it and act on the value it just produced — never on a `handleResult` reference captured from an earlier render.
+
+## Why it matters
+
+`AccountImportLoadingScreen` is the loading step for adding a watch-only account, and "Try Again" is the only recovery path a user has after a failed lookup. As written, tapping it fires the retry (`onRetry()`) without waiting for it, then immediately calls a `handleResult` reference that was captured whenever `safelyShowImportError`'s `useCallback` last recomputed — reading `error`/`accountInfo` from that earlier render, not from the retry that was just kicked off. Since the retry hasn't resolved yet at that point, the check can re-run against the same stale failure state and re-show the identical error alert before the retry had any chance to succeed, making a working retry look like it failed again.
+
+## Notes
+
+- Compile requirement: none beyond the code shown — `fetchAccountInfo` now returns `Promise<AccountInfo | null>` instead of `Promise<void>`, which only affects the two call sites shown here.
+- Dropped the `onRetry?: () => Promise<void>` parameter from `safelyShowImportError`: it only ever had one caller (`handleResult`, always passing `fetchAccountInfo`), so hardcoding it removes the exact indirection that made the un-awaited call easy to miss, without losing any real flexibility.
+- The `// eslint-disable-next-line react-hooks/exhaustive-deps` on `safelyShowImportError` is gone: its new dependency array (`error`, `showImportError`, `fetchAccountInfo`, `navigation`, `networkSymbol`) lists every bare identifier the body reads, now that the retry's outcome no longer routes through the separately-declared `handleResult`.
+- One suppression remains, of a different rule, and it isn't new: `safelyShowImportError` still calls itself to re-show the alert if a retry fails again, which is a genuine forward self-reference and needs `@typescript-eslint/no-use-before-define`. The original file already carried this exact category of suppression for a two-hop `handleResult` → `safelyShowImportError` → `handleResult` cycle; this fix reduces it to a one-hop self-call for the same "keep offering retry until it works or the user leaves" behavior, not a new category of suppression for this file.
+- `handleResult` itself is unchanged — it still reads `error`/`accountInfo` from component state and is still passed as `AccountImportLoader`'s `onComplete`, which is driven by that component's own loading-animation-gated completion signal (`AccountImportLoader.tsx:74`, `<Spinner loadingState={spinnerLoadingState} onComplete={onComplete} />` — not re-traced further here, out of this doc's scope). This fix only changes what happens after a manual retry, where the outcome is now read from `fetchAccountInfo`'s own return value instead of through that shared callback.
+- `suite-native` is React-Compiler-compiled, but nothing here is a memoization fix — this is a control-flow/closure-correctness fix (await the retry, read its own result), unrelated to the compiler either way.
+- Confidence: medium, carried over from the scan — the closure-staleness mechanism and the missing `await` are both directly verifiable from the code; whether the alert visibly reappears every time or only under specific state-update timing was not confirmed on-device.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p2-22-native-analytics-effects-whole-account-deps.md
+++ b/perf-issues/react-hooks/p2-22-native-analytics-effects-whole-account-deps.md
@@ -1,0 +1,110 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — section _"Minimal required dependencies"_. Found by sweep, not named in the doc.
+
+## Where
+
+[`suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx:24-39`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx#L24-L39)
+
+[`suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx:58-69`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx#L58-L69) — same defect shape, a different screen.
+
+Co-anchors establishing that both effects' whole-object dependency is a real, changing reference, not a stable one:
+
+- [`AccountDetailScreen.tsx:36-38`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-accounts-management/src/screens/AccountDetailScreen.tsx#L36-L38) — `account` comes from `selectAccountByKey`, which returns a new reference whenever that account's Redux entry is genuinely replaced (new transaction, balance/history update, label change).
+- [`useTransactionDetails.ts:28-33`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/transaction-management/src/hooks/useTransactionDetails.ts#L28-L33) — `transaction` comes from `selectTransactionByAccountKeyAndTxid`, which is `createMemoizedSelector`-based ([`transactionsSelectors.ts:130`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/wallet-core/src/transactions/transactionsSelectors.ts#L130), a typed alias of `createWeakMapSelector`) — the same stability profile, so it only returns a new reference when the transaction record itself changes.
+
+## Before
+
+### 1. `AccountDetailContentScreen.tsx:24-39`
+
+```tsx
+const token = useSelector((state: TokensRootState) =>
+    selectAccountTokenInfo(state, account.key, tokenContract),
+);
+
+useEffect(() => {
+    if (account) {
+        analytics.report({
+            type: events.assetDetailEvent.name,
+            payload: {
+                assetSymbol: account.symbol,
+                tokenSymbol: token?.symbol,
+                tokenAddress: token?.contract,
+            },
+        });
+    }
+}, [account, token?.symbol, token?.contract, analytics, token]);
+```
+
+`account` is a required (non-optional) prop on this component, so `if (account)` is dead code, and the dependency array also lists both `token` and its two destructured fields — redundant, and a sign the array was widened rather than narrowed while chasing a lint warning.
+
+### 2. `TransactionDetailScreen.tsx:58-69`
+
+```tsx
+useEffect(() => {
+    if (transaction) {
+        analytics.report({
+            type: events.transactionDetailEvent.name,
+            payload: {
+                assetSymbol: transaction.symbol,
+                tokenSymbol: tokenTransfer?.symbol,
+                tokenAddress: tokenTransfer?.contract,
+            },
+        });
+    }
+}, [transaction, tokenTransfer, analytics]);
+```
+
+Unlike `account` above, `transaction` here genuinely can be `undefined` (this same component returns `null` a few lines later via `if (!transaction) return null;`), so the guard is load-bearing, not dead code.
+
+## After
+
+### 1. `AccountDetailContentScreen.tsx`
+
+```tsx
+useEffect(() => {
+    analytics.report({
+        type: events.assetDetailEvent.name,
+        payload: {
+            assetSymbol: account.symbol,
+            tokenSymbol: token?.symbol,
+            tokenAddress: token?.contract,
+        },
+    });
+}, [account.symbol, token?.symbol, token?.contract, analytics]);
+```
+
+The dead `if (account)` guard is dropped, and the redundant `token`/`token?.symbol`/`token?.contract` triple is narrowed to the two primitive fields actually read. The dependency is `account.symbol`, not `account.key`: the effect body reads `account.symbol`, and `react-hooks/exhaustive-deps` tracks member-expression dependencies per exact accessed path — a sibling field like `account.key` wouldn't satisfy the `account.symbol` usage and would leave the array lying again. `account.symbol` is stable for the life of one account (a given account's coin never changes), so it's just as effective as `account.key` at stopping the effect from refiring on unrelated data updates to the same account.
+
+### 2. `TransactionDetailScreen.tsx`
+
+```tsx
+useEffect(() => {
+    const assetSymbol = transaction?.symbol;
+    if (!assetSymbol) return;
+
+    analytics.report({
+        type: events.transactionDetailEvent.name,
+        payload: {
+            assetSymbol,
+            tokenSymbol: tokenTransfer?.symbol,
+            tokenAddress: tokenTransfer?.contract,
+        },
+    });
+}, [transaction?.symbol, tokenTransfer?.symbol, tokenTransfer?.contract, analytics]);
+```
+
+`transaction` can't just lose its guard the way `account` above did, since it's genuinely nullable here. Hoisting `transaction?.symbol` into a local before the guard keeps the truthiness check on the same primitive that's already in the dependency array, instead of on the whole `transaction` object — a real transaction always has a non-empty `symbol`, so this preserves the original "only report once we actually have a transaction" behavior.
+
+## Why it matters
+
+Both effects report an analytics event meant to mean "the user opened this screen," but as written they refire on every change to the whole record they read a couple of fields from — turning the metric into "...and then some unrelated amount of data refreshed while they stayed there." Account Detail is one of the most frequently visited screens in the app, and its `account` object is by definition the one most likely to receive a balance or history update while it's open, so `assetDetailEvent` can fire repeatedly per visit. Transaction Detail's own record changes far less often — typically one pending→confirmed transition — so `transactionDetailEvent` duplicates at a much lower rate; same mechanism, colder path.
+
+## Notes
+
+- Compile requirement: none — every value in both new dependency arrays is already destructured/available in scope; no new imports in either file.
+- Native: both files are `suite-native` (React-Compiler-compiled). This is a dependency-narrowing and redundant-dependency cleanup only; no memoization is added anywhere in this doc.
+- Adjustment from the scan: the scan's own sketch for anchor 1 suggested depending on `account.key`, but the effect body reads `account.symbol` — depending on a different, sibling field of the same object wouldn't actually satisfy `exhaustive-deps` for the property that's read (see the After section above), so this doc depends on `account.symbol` instead, which is both what's read and equally stable per account.
+- Went one step past the scan's own "medium confidence" note on anchor 2 and confirmed `selectTransactionByAccountKeyAndTxid` is `createMemoizedSelector`-based (`transactionsSelectors.ts:130`, `createWeakMapSelector.withTypes<...>()` at line 48 of the same file) — the same stability profile already confirmed for `selectAccountByKey` in the area-08 scan. Both anchors' underlying selectors only return a new reference on a genuine data change, so narrowing the effect's own dependency is what removes the redundant reports, not a workaround for an unstable selector underneath.
+- Merge rationale: identical defect shape (an analytics-report effect keyed on the whole domain record instead of the handful of primitive fields it reports) on two different screens — one doc, both anchors, per this sweep's triage.
+- Honest sizing: the mechanism is fully traced and verifiable from the code in both files; how often either screen's underlying record actually updates while a user has it open in practice was not measured for this sweep.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p3-01-cleanups-suite-hooks-and-components.md
+++ b/perf-issues/react-hooks/p3-01-cleanups-suite-hooks-and-components.md
@@ -1,0 +1,361 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — ten small, independent cleanups across `packages/suite/src/hooks/{wallet,earn}` and `packages/suite/src/components/{suite,wallet}`. Each is low-severity and self-contained; batched into one issue because none justifies its own PR. Found by sweep, not named in the doc.
+
+### `useSendForm.ts`: "handle draft change" effect can never fire
+
+**Where:** [`packages/suite/src/hooks/wallet/useSendForm.ts:409-416`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/useSendForm.ts#L409-L416), contrasted with the only writer of `draft.current` at [lines 376-401](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/useSendForm.ts#L376-L401).
+
+**Before:**
+
+```tsx
+useEffect(() => {
+    const loadDraftValues = async () => {
+        const storedState = await dispatch(getSendFormDraftThunk()).unwrap();
+        // ...
+        if (storedState) {
+            draft.current = storedState;
+            composeDraft(storedState); // already called directly here
+        }
+    };
+    // ...
+}, [dispatch, getLoadedValues, findNetworkSymbolForProtocol, reset]);
+
+// handle draft change
+useEffect(() => {
+    if (!draft.current) return;
+    composeDraft(draft.current);
+    draft.current = undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [draft]);
+```
+
+**After:** `useRef()`'s return value is the same object every render, so `[draft]` behaves like `[]` — this effect runs once, immediately after mount, before the async `loadDraftValues` above can ever set `draft.current`. It is dead code today. Delete it:
+
+```tsx
+// deleted — the direct composeDraft(storedState) call above, plus the feeInfo-driven
+// effect two lines below (useEffect(() => composeDraft(getValues()), [composeDraft, getValues])),
+// already cover recomposing once a fresher composeDraft is available
+```
+
+### `useExchangeDexQuote.ts`: `fromAddress` effect keyed on the whole `account` object
+
+**Where:** [`packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts:80-88`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts#L80-L88).
+
+**Before:**
+
+```tsx
+useEffect(() => {
+    if (!account) {
+        return;
+    }
+    const fromAddress = isAccountBasedNetwork(account.symbol) ? account.descriptor : undefined;
+    setValue('fromAddress', fromAddress);
+}, [account, setValue]);
+```
+
+**After:**
+
+```tsx
+}, [account?.symbol, account?.descriptor, setValue]);
+```
+
+Both fields read in the body are already primitives. The same hook already uses `useCurrentRef` twice elsewhere (`accountRef`, `fetchFeesAndComposeRef` at line 130) to avoid this exact shape for its fee-fetch effect — this is the one place that didn't get the same treatment.
+
+### Earn/staking form family (`useStakeForm.ts`, `useWithdrawalForm.ts`, `useClaimForm.ts`, `useChangeDelegateForm.ts`, `useRbfForm.ts`): `defaultValues`/`state` memoized on the whole `account` prop
+
+**Where:** [`useStakeForm.ts:66-76`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/earn/useStakeForm.ts#L66-L76) + [`:81-93`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/earn/useStakeForm.ts#L81-L93), [`useWithdrawalForm.ts:86-96`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/earn/useWithdrawalForm.ts#L86-L96) + [`:104-112`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/earn/useWithdrawalForm.ts#L104-L112), [`useClaimForm.ts:35-44`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/earn/useClaimForm.ts#L35-L44) + [`:46-58`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/earn/useClaimForm.ts#L46-L58), [`useChangeDelegateForm.ts:48-57`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts#L48-L57) + [`:59-68`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts#L59-L68), [`useRbfForm.ts:183-277`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/wallet/useRbfForm.ts#L183-L277) (`useRbfState`'s single larger `useMemo`, folding the same idea plus more).
+
+**Before** (`useStakeForm.ts`; the other three form hooks are structurally identical):
+
+```tsx
+const defaultValues = useMemo(() => {
+    const stakingContractAddress = getStakingContractAddress(account, 'stake');
+
+    return {
+        ...getStakeFormsDefaultValues({ address: stakingContractAddress, stakeType: 'stake' }),
+        setMaxOutputId: undefined,
+    } as StakeFormState;
+}, [account]);
+
+const state = useMemo(() => {
+    const feeInfo = getConvertedOrDefaultFeeInfo({
+        networkType: account.networkType,
+        feeInfo: networkFees,
+    });
+
+    return { account, network, feeInfo, formValues: defaultValues };
+}, [account, defaultValues, networkFees, network]);
+```
+
+**After:**
+
+```tsx
+}, [account.descriptor, account.symbol, account.networkType]);
+```
+
+`getStakingContractAddress` only switches on `account.networkType` and reads `account.symbol`/`account.descriptor` (verified in `suite-common/staking/src/staking.ts:24-34`); `getStakeFormsDefaultValues` takes no account fields at all. So `defaultValues` narrows safely in all four form hooks (`useWithdrawalForm.ts` additionally keeps its existing `autocompoundBalance` dependency). `state`'s own memo returns the live `account` object verbatim, so — unlike `defaultValues` — its array can't be narrowed away from `account` without freezing `state.account` stale; leave `state` as-is. `useRbfForm.ts`'s single combined memo builds a derived `rbfAccount` genuinely reading `utxo`/`addresses`/`balance`/`accountType` off the live object, so the same fix doesn't apply there either — no concrete change proposed for that file.
+
+### `useGlobalSendReceiveModal`: stores router-derived state instead of deriving it in render
+
+**Where:** [`packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts:44-49`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts#L44-L49).
+
+**Before:**
+
+```tsx
+const routerParams = useSelector(selectRouterParams);
+const [activeModal, setActiveModal] = useState<GlobalSendReceiveType>(null);
+
+useEffect(() => {
+    setActiveModal(getDashboardParamModal(routerParams));
+}, [routerParams]);
+```
+
+**After:**
+
+```tsx
+export function useGlobalSendReceiveModal() {
+    const dispatch = useDispatch();
+    const goToWithAnalytics = useGoToWithAnalytics();
+    const routerParams = useSelector(selectRouterParams);
+    const activeModal = getDashboardParamModal(routerParams);
+
+    const openModal = (modal: NonNullable<GlobalSendReceiveType>) => {
+        dispatch(goto({ routeName: 'suite-index', params: { modal } }));
+    };
+
+    const closeModal = (routeName?: Route['name'], account?: Account) => {
+        if (routeName && account) {
+            goToWithAnalytics({
+                routeName,
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            });
+        } else {
+            dispatch(goto({ routeName: 'suite-index' }));
+        }
+    };
+
+    return { activeModal, openModal, closeModal };
+}
+```
+
+`getDashboardParamModal` is a pure, cheap parse of the already-available `routerParams`, so no `useState`/`useEffect` is needed; this also drops the two now-redundant `setActiveModal(...)` calls from `openModal`/`closeModal`.
+
+### `TransactionReviewOutputList`: re-scans the whole accounts list in its render body
+
+**Where:** [`packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx:81`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx#L81), [`:117-120`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx#L117-L120).
+
+**Before:**
+
+```tsx
+const accounts = useSelector(state => state.wallet.accounts);
+// ...
+const isInternalTransfer =
+    isFirstOutputAddress &&
+    typeof outputs[0]?.value === 'string' &&
+    findAccountsByAddress(symbol, outputs[0]?.value, accounts).length > 0;
+```
+
+**After:**
+
+```tsx
+const isInternalTransfer = useMemo(
+    () =>
+        isFirstOutputAddress &&
+        typeof outputs[0]?.value === 'string' &&
+        findAccountsByAddress(symbol, outputs[0]?.value, accounts).length > 0,
+    [isFirstOutputAddress, outputs, symbol, accounts],
+);
+```
+
+### `AddCoinjoinAccountButton`: filters the full accounts list on every render
+
+**Where:** [`packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx:58`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx#L58), [`:65-70`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx#L65-L70).
+
+**Before:**
+
+```tsx
+const accounts = useSelector(state => state.wallet.accounts);
+// ...
+if (!device) {
+    return null;
+}
+
+const coinjoinAccounts = accounts.filter(
+    a =>
+        a.deviceState === device?.state?.staticSessionId &&
+        a.symbol === network.symbol &&
+        a.accountType === selectedAccount.accountType,
+);
+```
+
+**After:**
+
+```tsx
+const coinjoinAccounts = useMemo(
+    () =>
+        accounts.filter(
+            a =>
+                a.deviceState === device?.state?.staticSessionId &&
+                a.symbol === network.symbol &&
+                a.accountType === selectedAccount.accountType,
+        ),
+    [accounts, device?.state?.staticSessionId, network.symbol, selectedAccount.accountType],
+);
+
+if (!device) {
+    return null;
+}
+```
+
+The `useMemo` has to move above the existing `if (!device) return null` guard — hooks can't follow a conditional return; `device?.state?.staticSessionId` stays optional-chained so this is safe before the null check.
+
+### `CoinProtocolRenderer`: chains `.filter()` onto a `useSelector` result, discarding the selector's own memoization
+
+**Where:** [`packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx:45-47`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx#L45-L47).
+
+**Before:**
+
+```tsx
+const networkAccounts = useSelector(state =>
+    selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
+).filter(a => new BigNumber(a.balance).gt(0));
+```
+
+**After:**
+
+```tsx
+const networkAccounts = useSelector(state =>
+    selectDeviceAccountsByNetworkSymbol(state, networkSymbol).filter(a =>
+        new BigNumber(a.balance).gt(0),
+    ),
+);
+```
+
+Moves the filter inside the selector callback so it runs against the selector's own result in one pass instead of chaining a fresh `.filter()` after every `useSelector` re-check.
+
+### `CustomFeeTron.tsx`: mount-only effect can miss the async `estimatedFeeLimit`
+
+**Where:** [`packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx:23-30`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx#L23-L30).
+
+**Before:**
+
+```tsx
+const estimatedFeeLimit = getValues('estimatedFeeLimit');
+
+useEffect(() => {
+    if (getValues(FEE_LIMIT) === '' && estimatedFeeLimit) {
+        setValue(FEE_LIMIT, estimatedFeeLimit);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, []);
+```
+
+**After:**
+
+```tsx
+useEffect(() => {
+    if (getValues(FEE_LIMIT) === '' && estimatedFeeLimit) {
+        setValue(FEE_LIMIT, estimatedFeeLimit);
+    }
+}, [estimatedFeeLimit, getValues, setValue]);
+```
+
+Drop the disable comment; the field's own emptiness check already prevents clobbering a value the user typed, so no extra re-entry guard is needed. Sibling `CustomFeeEthereum.tsx` avoids this class of bug entirely by only reading `getValues('estimatedFeeLimit')` inside `onClick` handlers, never in a mount effect.
+
+### `TargetAddressLabel`: feeds a fresh `[]` into a `createWeakMapSelector`, defeating its cache
+
+**Where:** [`packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx:28-34`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx#L28-L34) (+ [`suite/address/src/labels/selectAddressLabelsForAccount.ts:47-50`](https://github.com/trezor/trezor-suite/blob/develop/suite/address/src/labels/selectAddressLabelsForAccount.ts#L47-L50), the weak-map-memoized selector's `addresses` passthrough input).
+
+**Before:**
+
+```tsx
+const addressLabels = useSelector(state =>
+    selectAddressLabelsForAccount(state, {
+        addresses: target.addresses ?? [],
+        accountKey,
+        deviceStaticId: deviceStaticSessionId,
+    }),
+);
+```
+
+**After:**
+
+```tsx
+const EMPTY_ADDRESSES: string[] = [];
+// ...
+const addressLabels = useSelector(state =>
+    selectAddressLabelsForAccount(state, {
+        addresses: target.addresses ?? EMPTY_ADDRESSES,
+        accountKey,
+        deviceStaticId: deviceStaticSessionId,
+    }),
+);
+```
+
+Restores the weak-map cache hit for every target lacking a resolved address — same shape as the skill's own `useAccounts.ts` worked example.
+
+### `TransactionTarget`: linear-scans the account's full Suite-Sync output-label list, unmemoized
+
+**Where:** [`packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx:79-83`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx#L79-L83), [`:193-195`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx#L193-L195).
+
+**Before:**
+
+```tsx
+const suiteSyncOutputLabels = useSelector(state =>
+    isSuiteSyncEnabled
+        ? selectSuiteSyncOutputLabels(state, transaction.deviceState)
+        : returnStableArrayIfEmpty<SuiteSyncOutput>(),
+);
+// ...
+const outputLabel =
+    suiteSyncOutputLabels.find(it => it.txId === transaction.txid && it.txTargetId === targetId)
+        ?.label ?? (isLegacyLabelingVisible ? targetMetadata : undefined);
+```
+
+**After:**
+
+```tsx
+const matchedOutputLabel = useMemo(
+    () =>
+        suiteSyncOutputLabels.find(it => it.txId === transaction.txid && it.txTargetId === targetId)
+            ?.label,
+    [suiteSyncOutputLabels, transaction.txid, targetId],
+);
+const outputLabel = matchedOutputLabel ?? (isLegacyLabelingVisible ? targetMetadata : undefined);
+```
+
+Matches the file's own pattern — `amount`/`amountComponent`/`fiatAmountComponent`/`label` a few lines above are already carefully `useMemo`'d with narrow deps; this is the one line that fell through.
+
+## Why it matters
+
+None of these ten sit on a hot, continuously-firing path — that's why all are P3 rather than individually filed:
+
+1. **`useSendForm.ts`** — dead code today, not a runtime cost; the `eslint-disable` masks the missing-dependency warning that would have caught it at review time.
+2. **`useExchangeDexQuote.ts`** — every account-reference churn (any balance/tx update) while the DEX exchange path is active re-runs a cheap `setValue` call with an almost-always-identical value.
+3. **Earn/staking form family** — every account-reference churn while a stake/withdraw/claim/delegate/RBF form is open re-derives `defaultValues` and reallocates `state`; each hook's compose sub-hook already gates its actual dispatch behind a primitive `feeInfo.blockHeight` comparison, so this is wasted recomputation, not a request loop.
+4. **`useGlobalSendReceiveModal`** — every navigation currently costs an extra render cycle (state set in an effect, not the triggering render) and a one-frame window where the open/closed state of the global Send/Receive modal can disagree with the URL.
+5. **`TransactionReviewOutputList`** — re-scans the full accounts list on every render of the review modal (a handful of times per sign flow); cold, but the same unmemoized-scan shape as the three findings below.
+6. **`AddCoinjoinAccountButton`** — re-filters the full accounts list on every re-render of the button (driven by its own `isLoading` state), despite being a single button instance, not a per-row list.
+7. **`CoinProtocolRenderer`** — the chained `.filter()` reruns on every unrelated store dispatch that changes any of this toast's ~4 other selector values, discarding the selector's own memoization.
+8. **`CustomFeeTron.tsx`** — if `estimatedFeeLimit` resolves after this panel mounts (it's written later by async compose thunks), the fee-limit field is never autofilled with the recommended value for the rest of the session.
+9. **`TargetAddressLabel`** — react-redux re-invokes every `useSelector` callback on every store dispatch, so this recomputes the labeling combiner far more often than the underlying data changes, for every transaction target lacking a resolved address; pure waste absorbed by `packages/suite`'s `shallowEqual` wrapper rather than a visible re-render.
+10. **`TransactionTarget`** — re-scans the account's full Suite-Sync output-label list on every render, including every time a sibling row's label enters or exits edit mode (the global `selectLabelingValueBeingEdited` flag re-renders every mounted target row at once).
+
+## Notes
+
+- All ten sites are in `packages/suite`, which is **not** React-Compiler-covered — every fix above is a manual `useMemo`/dependency-array change, not something a compiler would otherwise absorb.
+- Compile requirements: add `useMemo` to the existing `'react'` import in `TransactionReviewOutputList.tsx` (currently `import { useEffect, useRef } from 'react';`) and in `AddCoinjoinAccountButton.tsx` (currently `import { useState } from 'react';`); `TransactionTarget.tsx` already imports `useMemo`. `useGlobalSendReceiveModal.ts`'s `import { useEffect, useState } from 'react';` becomes entirely unused after the fix and should be deleted (verified: neither hook is used anywhere else in the file). `TargetAddressLabel.tsx` needs a new module-level `EMPTY_ADDRESSES: string[] = []` constant, no import change. The remaining findings (`useSendForm.ts`, `useExchangeDexQuote.ts`, the earn/staking family, `CustomFeeTron.tsx`, `CoinProtocolRenderer.tsx`) need no import changes.
+- `useSendForm.ts`: deleting the effect also leaves `draft.current = storedState` (line 384) and the `draft` ref declaration itself (line 110) with no remaining reader anywhere in the file (confirmed by grepping every `draft` occurrence) — remove those two in the same change rather than leaving an unread write behind.
+- `useGlobalSendReceiveModal.ts`: `goto` is a `createThunk` (`suite/router/src/routerThunks.ts:84-114`) whose body dispatches `onLocationChange` synchronously with no `await` beforehand, so `routerParams` updates in the same tick as the `dispatch(goto(...))` call — confirmed removing the optimistic `setActiveModal` calls does not introduce a visible open/close lag.
+- F-02-14 (`TransactionRenderer.tsx`, same scan batch) is intentionally **not** included here — see the standalone note at the end of this doc.
+
+### Excluded finding: `TransactionRenderer.tsx` (F-02-14)
+
+The scan's F-02-14 flagged `packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx:37-38,46-47,52-54` for the same class of defect as this doc (unmemoized `findAccountsByNetwork`/`findAccountsByDescriptor`/`getAccountTransactions`/`findTransaction` lookups re-run every render), with a proposed fix of wrapping the lookup chain in a `useMemo` keyed on `[symbol, descriptor, txid, accounts, transactions]`.
+
+`perf-issues/asymptotic-complexity/p2-16-transactionrendererx-transactionrenderer.md` already drafts a fix for the exact same lines: replace the scanning lookups entirely with the memoized keyed selectors `selectAccountByKey`/`selectTransactionByAccountKeyAndTxid`, consumed directly via `useSelector`. That rewrite doesn't just fix the O(n) scan — it also eliminates the render-body re-derivation this finding describes, since a `useSelector`-backed weak-map selector only produces a new reference when the underlying entity actually changes, which is strictly better than memoizing the old scan on `[accounts, transactions]` (both of which are whole-store arrays that change reference on any unrelated account/transaction update, so that `useMemo` would rarely have hit anyway). Proposing a `useMemo` around code that the sibling doc replaces outright would just create a merge conflict with no independent benefit, so F-02-14 is dropped from this batch with nothing additive left to add.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p3-02-cleanups-suite-views-and-support.md
+++ b/perf-issues/react-hooks/p3-02-cleanups-suite-views-and-support.md
@@ -1,0 +1,236 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — six small, independent cleanups
+across `packages/suite/src/views/wallet/trading`, `views/wallet/{tokens,nfts}`, `views/onboarding`,
+`views/suite/notifications`, and `support/suite`. Each is low-severity and self-contained; batched
+into one issue because none justifies its own PR. Found by sweep, not named in the doc.
+
+## Where
+
+1. Trading Detail pages scan the full accounts list with a bare `.find()` instead of a keyed
+   selector — [`TradingBuyDetailContent.tsx:53,77`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx#L53),
+   [`TradingSellDetailContent.tsx:46,70`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/TradingSellDetailContent.tsx#L46),
+   [`TradingExchangeDetailContent.tsx:61,108-109`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx#L61),
+   [`TradingOfferSell.tsx:34,43`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferSell/TradingOfferSell.tsx#L34).
+2. `Tokens`/`Nfts` route guards key their redirect effect on the whole `selectedAccount` object —
+   [`views/wallet/tokens/index.tsx:24,28-36`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/tokens/index.tsx#L24-L36),
+   [`views/wallet/nfts/index.tsx:16,20-27`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/wallet/nfts/index.tsx#L16-L27).
+3. `onboarding/index.tsx`'s THP redirect effect depends on `device`, never read in the body —
+   [`views/onboarding/index.tsx:37-41`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/onboarding/index.tsx#L37-L41).
+4. `NotificationsView` re-filters the whole notification list into two buckets every render —
+   [`views/suite/notifications/index.tsx:27-32`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/suite/notifications/index.tsx#L27-L32).
+5. `useConnectPopupDesktop` hand-rolls `useFreshRef` instead of using the existing helper —
+   [`support/suite/useConnectPopupDesktop.tsx:34-36`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/support/suite/useConnectPopupDesktop.tsx#L34-L36).
+6. `AccountHeaderProvider`'s inline Provider value is rebuilt every render —
+   [`support/suite/AccountHeaderProvider.tsx:14-26`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/support/suite/AccountHeaderProvider.tsx#L14-L26).
+
+## Before
+
+### 1. Trading Detail pages: bare `accounts.find()` instead of a keyed selector
+
+```tsx
+// TradingSellDetailContent.tsx:46,70 — identical shape in TradingBuyDetailContent.tsx,
+// TradingOfferSell.tsx, and twice in TradingExchangeDetailContent.tsx (once per trade side)
+const accounts = useSelector(selectAccounts);
+// ...
+const sendAccount = accounts.find(account => account.key === trade?.sendAccountKey);
+```
+
+### 2. `tokens/index.tsx` / `nfts/index.tsx`: redirect effect keyed on whole `selectedAccount`
+
+```tsx
+// tokens/index.tsx:24,28-36
+const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+// ...
+useEffect(() => {
+    if (
+        selectedAccount.status === 'loaded' &&
+        !hasNetworkFeatures(selectedAccount.account, 'tokens') &&
+        routeName !== 'wallet-index'
+    ) {
+        dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+    }
+}, [selectedAccount, dispatch, routeName]);
+```
+
+(`nfts/index.tsx:20-27` repeats the same shape against `selectedAccount.network?.features`, deps
+`[selectedAccount, dispatch]`.)
+
+### 3. `onboarding/index.tsx`: dead `device` dependency on the THP redirect effect
+
+```tsx
+useEffect(() => {
+    if (activeStepId !== STEP.ID_FIRMWARE_STEP && thpStep === 'ConfirmOnlyConnection') {
+        dispatch(goto({ routeName: 'suite-index' }));
+    }
+}, [device, thpStep, activeStepId, dispatch]);
+```
+
+### 4. `notifications/index.tsx`: re-filters the whole notification list every render
+
+```tsx
+const notifications = useSelector(state => state.notifications);
+const hasUnseenNotifications = useSelector(selectHasUnseenTransactionNotifications);
+const transactionNotifications = notifications.filter(isTransactionNotification);
+const activityNotifications = notifications.filter(
+    notification => !isTransactionNotification(notification),
+);
+```
+
+### 5. `useConnectPopupDesktop.tsx`: hand-rolled ref-assign-in-render instead of `useFreshRef`
+
+```tsx
+const selectedDevice = useSelector(selectSelectedDevice);
+const selectedDeviceRef = useRef(selectedDevice);
+selectedDeviceRef.current = selectedDevice;
+```
+
+### 6. `AccountHeaderProvider.tsx`: inline Provider value rebuilt every render
+
+```tsx
+export const AccountHeaderProvider = ({
+    balanceSectionRef: providedBalanceSectionRef,
+    children,
+}: AccountHeaderProviderProps) => {
+    const internalBalanceSectionRef = useRef<HTMLDivElement>(null);
+    const balanceSectionRef = providedBalanceSectionRef ?? internalBalanceSectionRef;
+
+    return (
+        <AccountHeaderContext.Provider value={{ balanceSectionRef }}>
+            {children}
+        </AccountHeaderContext.Provider>
+    );
+};
+```
+
+## After
+
+### 1. Trading Detail pages
+
+```tsx
+const sendAccount = useSelector(state => selectAccountByKey(state, trade?.sendAccountKey));
+```
+
+Drop the `selectAccounts` import and `accounts` variable in all four files — none of them reads
+`accounts` for anything besides the `.find()` this replaces. Already-used pattern in this same
+feature area: `TradingFormInputCryptoAmount.tsx:186`.
+
+### 2. `tokens/index.tsx` / `nfts/index.tsx`
+
+```tsx
+useEffect(() => {
+    if (
+        selectedAccount.status === 'loaded' &&
+        !hasNetworkFeatures(selectedAccount.account, 'tokens') &&
+        routeName !== 'wallet-index'
+    ) {
+        dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+    }
+}, [
+    selectedAccount.status,
+    selectedAccount.account?.symbol,
+    selectedAccount.account?.accountType,
+    dispatch,
+    routeName,
+]);
+```
+
+(`nfts/index.tsx` analogously narrows to `selectedAccount.status`/`selectedAccount.network?.features`
+instead of the whole object.)
+
+### 3. `onboarding/index.tsx`
+
+```tsx
+useEffect(() => {
+    if (activeStepId !== STEP.ID_FIRMWARE_STEP && thpStep === 'ConfirmOnlyConnection') {
+        dispatch(goto({ routeName: 'suite-index' }));
+    }
+}, [thpStep, activeStepId, dispatch]);
+```
+
+### 4. `notifications/index.tsx`
+
+```tsx
+const { transactionNotifications, activityNotifications } = useMemo(
+    () => ({
+        transactionNotifications: notifications.filter(isTransactionNotification),
+        activityNotifications: notifications.filter(n => !isTransactionNotification(n)),
+    }),
+    [notifications],
+);
+```
+
+### 5. `useConnectPopupDesktop.tsx`
+
+```tsx
+const selectedDeviceRef = useFreshRef(selectedDevice);
+```
+
+### 6. `AccountHeaderProvider.tsx`
+
+```tsx
+export const AccountHeaderProvider = ({
+    balanceSectionRef: providedBalanceSectionRef,
+    children,
+}: AccountHeaderProviderProps) => {
+    const internalBalanceSectionRef = useRef<HTMLDivElement>(null);
+    const balanceSectionRef = providedBalanceSectionRef ?? internalBalanceSectionRef;
+    const value = useMemo(() => ({ balanceSectionRef }), [balanceSectionRef]);
+
+    return <AccountHeaderContext.Provider value={value}>{children}</AccountHeaderContext.Provider>;
+};
+```
+
+## Why it matters
+
+Six independent, low-severity instances of this skill's two cheapest-to-fix classes — wider-than-needed
+hook dependencies and missing memoization — grouped because none is costly enough alone to justify a
+standalone issue:
+
+1. **Trading Detail pages** re-scan the full accounts array on every render of a poll-driven trade
+   page; a keyed selector already used elsewhere in this feature area removes the scan entirely.
+2. **`Tokens`/`Nfts` route guards** re-run their redirect check on every account/blockchain sync tick
+   instead of only when the fields the condition reads actually change — the guarded action is
+   idempotent and rarely true, so this is wasted comparisons, not a visible bug.
+3. **`onboarding/index.tsx`'s THP redirect effect** re-evaluates and potentially redispatches
+   `goto('suite-index')` on every device-reference churn for a dependency its body never reads.
+4. **`NotificationsView`** re-filters its notification list on every render of the Activity page,
+   including tab switches that don't touch `notifications` at all.
+5. **`useConnectPopupDesktop`**'s hand-rolled ref assignment is behaviorally identical to
+   `useFreshRef` today, but a future "cleanup" could silently turn it into a stale-by-one-render
+   `useCurrentRef` shape with no lint error to catch it.
+6. **`AccountHeaderProvider`** rebuilds its Provider value on every wallet-page-header render for two
+   consumers — same defect class as sibling drafts p1-11/p1-07, at a much smaller consumer count.
+
+None of these sit on a hot, continuously-firing path — the trading pages are polling-driven, the
+route guards are idempotent, the onboarding effect's guarded action is very likely a no-op past the
+first navigation, and the notification/account-header cases have small consumer counts — which is
+why all six are P3 rather than individually filed.
+
+## Notes
+
+- Compile requirements: `useFreshRef` needs importing from `@trezor/react-utils` in
+  `useConnectPopupDesktop.tsx`; `useMemo` needs adding to `AccountHeaderProvider.tsx`'s
+  `import React, { createContext, useContext, useRef } from 'react';` and to `notifications/index.tsx`'s
+  `import { useState } from 'react';`; the four Trading Detail files swap their `selectAccounts`
+  import for `selectAccountByKey` (both from `@suite-common/wallet-core`).
+- Type nuance on finding 1: `accounts.find(...)` returns `Account | undefined`;
+  `selectAccountByKey` returns `Account | null`. Every current use of `sendAccount`/`receiveAccount`
+  across the four files is either falsy-checked or passed through an optional prop, except
+  `TradingSellDetailContent.tsx:101`'s `account={sendAccount!}` non-null assertion, which strips
+  `null` the same way it strips `undefined` — worth a per-file compile check rather than assumed, since
+  this wasn't exhaustively traced against every downstream prop type.
+- Finding 2's narrowed dependency array includes `selectedAccount.account?.accountType` alongside
+  `.symbol`, beyond a purely mechanical narrowing: `hasNetworkFeatures` resolves through
+  `getNetworkAccountFeatures({ symbol, accountType })`
+  (`suite-common/wallet-utils/src/accountUtils.ts:1036-1043`), and some networks (e.g. Bitcoin's
+  `coinjoin` account type) carry a different `features` list than the network's default.
+- Finding 5 is a pure style/consistency fix — behaviorally identical before and after, since the
+  hand-rolled version already assigns unconditionally in the render body, matching `useFreshRef`'s
+  own contract exactly.
+- Finding 6 is the same class as sibling drafts p1-11 (`ResponsiveContext`, not yet filed) and p1-07
+  (`ScrollContext`, filed), at a much smaller consumer count (2, both in the wallet-page header
+  subtree) — grouped here rather than given its own doc for that reason.
+- All six files live in `packages/suite`, which is not React-Compiler-covered — every fix above is a
+  manual dependency-array narrowing or `useMemo`/helper substitution, not something a compiler would
+  otherwise absorb.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p3-03-cleanups-suite-common-and-design-system.md
+++ b/perf-issues/react-hooks/p3-03-cleanups-suite-common-and-design-system.md
@@ -1,0 +1,214 @@
+# P3 hooks cleanups — suite-common and the design system
+
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — sections _"Keep hook dependencies referentially stable"_ and _"Relocate render-body work before memoizing it, and memoize only what pays"_. Five small, independent cleanups from the `suite-common` and design-system (`packages/components`) areas of the sweep, each too narrow on its own — a cold debug screen, a single-instance hook, or a small consumer count — to carry its own issue. Found by sweep, not named in the doc.
+
+### `suite-common/dependency-injection/src/useServices.tsx`: inline selector literal defeats `useSelectedServices`'s memo at two call sites
+
+**Where:** [`suite-common/dependency-injection/src/useServices.tsx:65-70`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/dependency-injection/src/useServices.tsx#L65-L70) (the pre-existing `eslint-disable` is at line 68 and is not itself the bug — see Notes). Misused at [`packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts:17-19`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts#L17-L19) and [`packages/suite/src/views/settings/SettingsDebug/Transport.tsx:59-61`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/views/settings/SettingsDebug/Transport.tsx#L59-L61).
+
+**Before:**
+
+```ts
+// useServices.tsx:65-70
+const useSelectedServices = (selectors: ServiceSelector<any>[]) => {
+    const services = useServicesContext();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return React.useMemo(() => selectServices(services, ...selectors), [services, ...selectors]);
+};
+```
+
+```ts
+// useOpenSuiteDesktop.ts:17-19 and Transport.tsx:59-61 — identical inline selector, fresh every render
+const { createTransports } = useServices((services): TransportsDep => ({
+    createTransports: services.createTransports,
+}));
+```
+
+**After:** hoist the selector to a module-level constant at each call site, matching the established convention used by the other ~359 `useServices` callers in the repo (e.g. `selectDesktopAnalyticsDep` in `suite/analytics/src/createAnalytics.ts`):
+
+```ts
+const selectCreateTransportsDep = (services: any): TransportsDep => ({
+    createTransports: services.createTransports,
+});
+// ...
+const { createTransports } = useServices(selectCreateTransportsDep);
+```
+
+No change needed in `useServices.tsx` itself — `[services, ...selectors]` is the correct mechanism for a variable-length selector list; it just cannot statically verify that every element is stable, which is exactly what these two call sites violate.
+
+### `suite-common/transaction-search/src/useFilteredUtxos.ts`: default parameter is a fresh array every call
+
+**Where:** [`suite-common/transaction-search/src/useFilteredUtxos.ts:8-19`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/transaction-search/src/useFilteredUtxos.ts#L8-L19). Only current consumer: [`suite-native/module-send/src/screens/SendUtxoScreen.tsx:49`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-send/src/screens/SendUtxoScreen.tsx#L49) (`useFilteredUtxos(account?.utxo ?? [], searchQuery)`).
+
+**Before:**
+
+```ts
+export const useFilteredUtxos = (
+    utxos: Utxo[] = [],
+    query: string = '',
+    outputLabels?: SearchOutputLabels,
+) =>
+    useMemo(() => {
+        if (!query.trim()) {
+            return utxos;
+        }
+
+        return utxos.filter(utxo => filterUtxos(utxo, query, outputLabels));
+    }, [utxos, query, outputLabels]);
+```
+
+**After:** module-level constant instead of a fresh `[]` default, matching the skill's own worked example:
+
+```ts
+const EMPTY_UTXOS: Utxo[] = [];
+
+export const useFilteredUtxos = (
+    utxos: Utxo[] = EMPTY_UTXOS,
+    query: string = '',
+    outputLabels?: SearchOutputLabels,
+) =>
+    // ...unchanged
+```
+
+### `suite-common/wallet-core/src/stablecoin-yield/hooks/useWrappedNativePendingTx.ts`: rescans the account's transaction history in the render body
+
+**Where:** [`suite-common/wallet-core/src/stablecoin-yield/hooks/useWrappedNativePendingTx.ts:50-56`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/wallet-core/src/stablecoin-yield/hooks/useWrappedNativePendingTx.ts#L50-L56) (`trackedTransaction`, computed inline, not memoized); the scan behind it: [`suite-common/wallet-utils/src/wrappedNativePendingTxUtils.ts:19-41`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/wallet-utils/src/wrappedNativePendingTxUtils.ts#L19-L41) (`findTrackedWrappedNativeTransaction`, up to two `Array.prototype.find` passes over `transactions`).
+
+**Before:**
+
+```ts
+const trackedTransaction = txid
+    ? findTrackedWrappedNativeTransaction({
+          transactions,
+          txid,
+          nonce: trackedNonce?.txid === txid ? trackedNonce.nonce : undefined,
+      })
+    : undefined;
+```
+
+**After:**
+
+```ts
+const trackedTransaction = useMemo(
+    () =>
+        txid
+            ? findTrackedWrappedNativeTransaction({
+                  transactions,
+                  txid,
+                  nonce: trackedNonce?.txid === txid ? trackedNonce.nonce : undefined,
+              })
+            : undefined,
+    [transactions, txid, trackedNonce],
+);
+```
+
+`transactions` (from `selectAccountTransactions`) is already a stable, weak-map-memoized reference that only changes when the account's tx list genuinely changes, so this only recomputes when `transactions`, `txid`, or `trackedNonce` actually change.
+
+### `packages/components`: compound-component `Context.Provider` values are unmemoized object literals across the design system
+
+**Where:** seven Providers, none memoized:
+
+- [`Collapsible/Collapsible.tsx:33-40`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Collapsible/Collapsible.tsx#L33-L40) → consumed at `CollapsibleContent.tsx:30`, `CollapsibleToggle.tsx:25`
+- [`Tabs/Tabs.tsx:108`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Tabs/Tabs.tsx#L108) → consumed at `TabsItem.tsx:63`
+- [`List/List.tsx:84-86`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/List/List.tsx#L84-L86) → consumed at `ListItem.tsx:62`
+- [`SubTabs/SubTabs.tsx:34`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/SubTabs/SubTabs.tsx#L34) → consumed at `SubTabsItem.tsx:50`
+- [`StepList/StepList.tsx:63-72`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/StepList/StepList.tsx#L63-L72)
+- [`Banner/Banner.tsx:140`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Banner/Banner.tsx#L140)
+- [`Modal/Modal.tsx:95`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Modal/Modal.tsx#L95), [`Modal/ModalButton.tsx:15`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Modal/ModalButton.tsx#L15), [`Modal/ModalProvider.tsx:38-43`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Modal/ModalProvider.tsx#L38-L43)
+
+**Before** (two representative examples):
+
+```tsx
+// Tabs.tsx:108 — rebuilt on every render, including the ResizeObserver-driven ones (:93-105)
+// that fire on window resize with the tab set itself unchanged
+<TabsContext.Provider value={{ activeItemId, isDisabled, size, setTabRef }}>
+```
+
+```tsx
+// Collapsible.tsx:33-40
+<CollapsibleContext.Provider
+    value={{
+        contentId,
+        isOpen: isOpen ?? uncontrolledIsOpen,
+        toggle: setUncontrolledIsOpen,
+        gap,
+    }}
+>
+```
+
+**After:** wrap each Provider's `value` in a `useMemo` keyed on its own primitive fields, e.g.:
+
+```tsx
+const tabsContextValue = useMemo(
+    () => ({ activeItemId, isDisabled, size, setTabRef }),
+    [activeItemId, isDisabled, size, setTabRef],
+);
+```
+
+Same shape at all seven sites — every field is already a primitive or a stable setter, so this is a pure win with no new dependency wrinkles.
+
+### `packages/components/src/components/Popover/Popover.tsx`: floating-ui `middleware` array is unmemoized, unlike its sibling in the same package
+
+**Where:** [`packages/components/src/components/Popover/Popover.tsx:61-75`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Popover/Popover.tsx#L61-L75); contrast with the already-correct [`packages/components/src/components/Tooltip/TooltipFloatingUi.tsx:86-95`](https://github.com/trezor/trezor-suite/blob/develop/packages/components/src/components/Tooltip/TooltipFloatingUi.tsx#L86-L95).
+
+**Before:**
+
+```tsx
+const data = useFloating({
+    placement: calculatedPlacement,
+    open,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: [
+        offset(popoverOffset),
+        flip({
+            crossAxis: calculatedPlacement.includes('-'),
+            fallbackAxisSideDirection: 'end',
+            padding: 5,
+        }),
+        shift({ padding: 5 }),
+    ],
+});
+```
+
+**After:**
+
+```tsx
+const middleware = useMemo(
+    () => [
+        offset(popoverOffset),
+        flip({
+            crossAxis: calculatedPlacement.includes('-'),
+            fallbackAxisSideDirection: 'end',
+            padding: 5,
+        }),
+        shift({ padding: 5 }),
+    ],
+    [popoverOffset, calculatedPlacement],
+);
+
+const data = useFloating({
+    placement: calculatedPlacement,
+    open,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+    middleware,
+});
+```
+
+`TooltipFloatingUi.tsx:86-95` already does exactly this for the equivalent array in the same package.
+
+## Why it matters
+
+All five are the same failure mode at different scales: a reference that could be made stable (a default parameter, a selector literal, a render-body computation, a Provider value, a middleware array) isn't, so a `useMemo` downstream — sometimes the same hook's own, sometimes a sibling's — recomputes, or a Provider re-renders its consumers, more than the underlying data requires. None is a loop and none was measured; they are grouped here because each is real but individually small: `useFilteredUtxos`'s one real caller already works around the default with its own `?? []`; `useWrappedNativePendingTx` is a single-instance hook (one active wrap/unwrap flow at a time), not a per-row one; the `useServices` misuse sits behind two cold debug/troubleshooting screens; none of the seven Provider-consuming children (`CollapsibleContent`, `TabsItem`, `ListItem`, `SubTabsItem`, etc.) is wrapped in `memo()` today, so the fix only pays off once the outer component re-renders on its own internal state while `children` is otherwise unchanged (as `Tabs` already does via its `ResizeObserver`); and `Popover` has only two call sites, neither in a per-row hot path. Each fix is a mechanical, low-risk `useMemo` or module-level constant with no new dependency wrinkles.
+
+## Notes
+
+- Compile requirement: none of the `After` snippets need anything beyond `useMemo` from `'react'`. `Tabs.tsx` already imports other hooks from `'react'` (add `useMemo` to that line); `Collapsible.tsx`, `List.tsx`, `SubTabs.tsx`, `Banner.tsx`, `Modal.tsx`, `ModalProvider.tsx`, and `Popover.tsx` already have a `'react'` import to extend. `StepList.tsx` and `Modal/ModalButton.tsx` have no `'react'` import at all today and need one added from scratch.
+- Which app: `suite-common/dependency-injection`, `suite-common/transaction-search`, and `suite-common/wallet-core` ship to both `packages/suite` (uncompiled) and `suite-native` (compiled) — per the skill, memoize regardless, since `suite-common` itself is never compiled either way. `packages/components` also ships to native, but per the skill that doesn't change the fix — memoize for the web consumer. `useFilteredUtxos`'s one real caller is itself inside `suite-native` (compiled) and never relies on the hook's own default (it always passes an explicit `account?.utxo ?? []`), so live impact there is likely nil today; the fix matters for a future web caller, or any caller that omits the argument.
+- Correct in-repo siblings, the strongest evidence for two of these fixes: `useServices`'s other ~359 call sites already use a module-level `select*Dep` constant (see `selectDesktopAnalyticsDep`); `TooltipFloatingUi.tsx:86-95` already memoizes the equivalent `middleware` array in the same package as `Popover.tsx`.
+- Honest sizing: none of these five was individually worth a standalone issue — grouped here as one PR's worth of cleanup rather than five near-empty ones, per this sweep's own severity guidance. The seven Provider-value sites are counted as one entry because they're the same mechanism repeated, not because any one of them is large.
+- Same-PR scope: all five findings are independent (different files, no shared code path) — land them together or split arbitrarily with no ordering constraint between them.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/perf-issues/react-hooks/p3-04-cleanups-suite-native.md
+++ b/perf-issues/react-hooks/p3-04-cleanups-suite-native.md
@@ -1,0 +1,348 @@
+Extracted from the `skills/performance-react-hooks/SKILL.md` audit — ten small, independent cleanups
+across `suite-native/device-authorization`, `transaction-management`, `accounts`, `module-trading`,
+`module-earn`, `module-send`, `module-accounts-management`, and `module-device-onboarding`. Each is
+low-severity and self-contained; batched into one issue because none justifies its own PR. Found by
+sweep, not named in the doc.
+
+### 1. `usePinAction.tsx`: `exhaustive-deps` suppression comment no longer matches the code
+
+**Where:** [`suite-native/device-authorization/src/hooks/usePinAction.tsx:137-144`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/device-authorization/src/hooks/usePinAction.tsx#L137-L144) (the suppressed `useFocusEffect`), whose comment refers to `handlePinAction` at [`:86-135`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/device-authorization/src/hooks/usePinAction.tsx#L86-L135).
+
+**Before:**
+
+```tsx
+// handlePinAction's only object-shaped input is already narrowed to device?.path (line 135's deps)
+const handlePinAction = useCallback(async () => {
+    // ...
+}, [analytics, type, device?.path, showSuccess, onSuccess, handleError, navigation]);
+
+useFocusEffect(
+    useCallback(() => {
+        if (!isDeviceConnectionGuardVisible) handlePinAction();
+
+        // handlePinAction is excluded as it depends on device object that could unintentionally trigger the useEffect
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isDeviceConnectionGuardVisible]),
+);
+```
+
+**After:**
+
+```tsx
+useFocusEffect(
+    useCallback(() => {
+        if (!isDeviceConnectionGuardVisible) handlePinAction();
+    }, [isDeviceConnectionGuardVisible, handlePinAction]),
+);
+```
+
+Drop the `eslint-disable` and its stale comment — `handlePinAction`'s only object-shaped input is already `device?.path`, a primitive, so nothing here can "unintentionally trigger" the effect the way the comment describes.
+
+### 2. `useMaxSpendableAmount.ts` / `useCustomFee.ts`: whole `formState` object as effect/callback dependency
+
+**Where:** [`suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts:55-98`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts#L55-L98) and [`suite-native/transaction-management/src/hooks/fees/useCustomFee.ts:98-162`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts#L98-L162) (`handleValuesChange`'s deps include `formState`, feeding the debounce effect at `:151-162`).
+
+**Before:**
+
+```tsx
+// useMaxSpendableAmount.ts:98 — formState is a whole externally-supplied object
+}, [dispatch, accountKey, tokenContract, formState, tokenBalance, enabled, symbol]);
+```
+
+```tsx
+// useCustomFee.ts:136-149 — handleValuesChange also takes formState whole, feeding a debounce effect
+}, [
+    trigger, networkType, isEip1559Fee, customFeePerUnit, formState,
+    dispatch, accountKey, customFeeLimit, customMaxPriorityFeePerGas, customMaxFeePerGas, setError, translate,
+]);
+```
+
+**After:**
+
+```tsx
+const formStateRef = useFreshRef(formState);
+
+useEffect(() => {
+    // ... unchanged body, replace `formState` reads with `formStateRef.current` ...
+}, [dispatch, accountKey, tokenContract, formStateRef, tokenBalance, enabled, symbol]);
+```
+
+Same ref-read swap in `useCustomFee.ts`'s `handleValuesChange` — read `formStateRef.current` instead of closing over `formState`, and drop `formState` from its own deps array (the debounce effect at `:151-162` already keys on the `useWatch`-sourced fee fields, not on `formState`).
+
+### 3. `AccountsListWithFilter.tsx`: prop copied into state via effect (currently inert)
+
+**Where:** [`suite-native/accounts/src/components/AccountsListWithFilter.tsx:39,48,55-57`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/accounts/src/components/AccountsListWithFilter.tsx#L39-L57).
+
+**Before:**
+
+```tsx
+const [filteredNetworks, setFilteredNetworks] = useState<NetworkSymbol[]>(networksFilter);
+// ...
+useEffect(() => {
+    setFilteredNetworks(networksFilter);
+}, [networksFilter]);
+```
+
+**After:**
+
+```tsx
+const [networksFilterOverride, setNetworksFilterOverride] = useState<NetworkSymbol[] | null>(null);
+const filteredNetworks = networksFilterOverride ?? networksFilter;
+// ... drop the useEffect entirely; handleApplyFilter/handleClearFilters now call
+// setNetworksFilterOverride(selected) / setNetworksFilterOverride([]) instead of setFilteredNetworks
+```
+
+Derive instead of duplicating: `filteredNetworks` becomes "the user's override if they've set one, else whatever the caller currently passes" — computed during render, so there is no effect left to go stale or discard an in-progress selection.
+
+### 4. `ExchangeApprovalDetails.tsx` / `ExchangeRevokeDetails.tsx`: no-op guard effect keyed on whole account
+
+**Where:** [`suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.tsx:31-35`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.tsx#L31-L35) and [`ExchangeRevokeDetails.tsx:24-28`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-trading/src/components/exchange/Approval/ExchangeRevokeDetails.tsx#L24-L28) (identical shape, different message string).
+
+**Before:**
+
+```tsx
+useEffect(() => {
+    if (!account) {
+        console.error('No account selected for exchange approval details');
+    }
+}, [account]);
+```
+
+**After:**
+
+```tsx
+useEffect(() => {
+    if (!account) {
+        console.error('No account selected for exchange approval details');
+    }
+}, [!!account]);
+```
+
+### 5. `useWatchTrade.ts`: analytics effect depends on `account` but never reads it
+
+**Where:** [`suite-native/module-trading/src/hooks/general/useWatchTrade.ts:57-69`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-trading/src/hooks/general/useWatchTrade.ts#L57-L69).
+
+**Before:**
+
+```tsx
+useEffect(() => {
+    const currentStatus = getTradeStatusStep(trade);
+    if (currentStatus !== previousStatus.current) {
+        previousStatus.current = currentStatus;
+
+        if (trade && currentStatus) {
+            analytics.report({
+                type: events.tradingStatusEvent.name,
+                payload: { type: trade.tradeType, status: currentStatus },
+            });
+        }
+    }
+}, [trade, account, previousStatus, analytics]);
+```
+
+**After:**
+
+```tsx
+}, [trade, analytics]);
+```
+
+Body unchanged — `account` and the `previousStatus` ref were never read inside it. (The file's _second_ effect, `:71-85`, legitimately needs `account`; it is separately guarded by `(!hasRefreshed || shouldReload) && shouldRefresh` so account churn alone can't cause a duplicate dispatch there — not filed.)
+
+### 6. `YieldWithdrawCompleteScreen.tsx` / `WrappedNativeTokenCompleteContent.tsx`: complete-screen memos keyed on whole account
+
+**Where:** [`suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx:117-167`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx#L117-L167) and [`suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx:58-79`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx#L58-L79).
+
+**Before:**
+
+```tsx
+// YieldWithdrawCompleteScreen.tsx — only account.symbol is read (lines 126, 131, 159)
+const rows = useMemo(() => {
+    // ...
+}, [CryptoAmountFormatter, account, isSharesInput, resolutionStatus, session, vault]);
+```
+
+```tsx
+// WrappedNativeTokenCompleteContent.tsx — only account.symbol is read (line 73)
+const rows = useMemo(() => {
+    // ...
+}, [CryptoAmountFormatter, account, amount, flowType, nativeSymbol, wrappedNative]);
+```
+
+**After:**
+
+```tsx
+}, [CryptoAmountFormatter, account?.symbol, isSharesInput, resolutionStatus, session, vault]);
+```
+
+```tsx
+}, [CryptoAmountFormatter, account?.symbol, amount, flowType, nativeSymbol, wrappedNative]);
+```
+
+Both `account`s here come from the same `useResolvedYieldFlowData`/`resolveYieldFlowData` chain as the sibling draft p1-17 (not yet filed) — this is a much smaller-consequence instance of the same "whole object where a primitive would do" pattern, on a cold completion screen rather than a live review screen.
+
+### 7. `useSendForm.tsx`: `exhaustive-deps` suppression on mount-only draft prefill
+
+**Where:** [`suite-native/module-send/src/hooks/useSendForm.tsx:291-316`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-send/src/hooks/useSendForm.tsx#L291-L316).
+
+**Before:**
+
+```tsx
+useEffect(() => {
+    const prefillValuesFromStoredDraft = async () => {
+        if (sendFormDraft?.outputs) {
+            form.reset({/* ... */});
+            if (!tokenContract) await calculateNormalFeeMaxAmount();
+            setTimeout(() => {
+                trigger();
+            }, 0);
+        }
+    };
+
+    prefillValuesFromStoredDraft();
+    // this effect should be triggered only for the first render to fill the form with the stored draft on entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+}, []);
+```
+
+**After:**
+
+```tsx
+useEffect(() => {
+    const prefillValuesFromStoredDraft = async () => {
+        if (sendFormDraft?.outputs) {
+            form.reset({/* ... */});
+            if (!tokenContract) await calculateNormalFeeMaxAmount();
+            setTimeout(() => {
+                trigger();
+            }, 0);
+        }
+    };
+
+    prefillValuesFromStoredDraft();
+    // Mount-only by design: useSendForm(accountKey, tokenContract) takes both as hook params, so a
+    // fresh account/token is always a fresh mount of this hook instance, not a param update on it.
+    void sendFormDraft;
+    void tokenContract;
+    void network;
+    void calculateNormalFeeMaxAmount;
+    void trigger;
+    void form;
+}, []);
+```
+
+Keeps today's behavior (plausibly correct — see the scan's reasoning on the navigation shape) while replacing the blanket disable with the skill's prescribed alternative, so the rule stays live if a future refactor makes any of these six values relevant.
+
+### 8. `SendUtxoScreen.tsx`: `account?.utxo ?? []` crosses the hook boundary — verify first
+
+**Where:** [`suite-native/module-send/src/screens/SendUtxoScreen.tsx:49`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-send/src/screens/SendUtxoScreen.tsx#L49), consumed by [`suite-common/transaction-search/src/useFilteredUtxos.ts:8-18`](https://github.com/trezor/trezor-suite/blob/develop/suite-common/transaction-search/src/useFilteredUtxos.ts#L8-L18).
+
+**Verify first:** confirm there is a real, reachable path where `account.utxo` is nullish while `SendUtxoScreen` is mounted (e.g. a UTXO-based account before its first `utxo` fetch resolves) before filing this as a live defect. The fallback only matters when `account.utxo` is nullish, which should be rare-to-never on a coin-control screen only reachable for UTXO-based accounts — this sweep could not find a concrete trigger, and the one downstream consumer (`filteredUtxos.length > 0 ? <UtxoList /> : ...`) only reads `.length`, not identity, so the practical impact may be zero even if the edge case does occur.
+
+**Before:**
+
+```tsx
+const filteredUtxos = useFilteredUtxos(account?.utxo ?? [], searchQuery);
+```
+
+**After:**
+
+```tsx
+// module-level, outside the component
+const EMPTY_UTXOS: Utxo[] = [];
+
+// ...
+const filteredUtxos = useFilteredUtxos(account?.utxo ?? EMPTY_UTXOS, searchQuery);
+```
+
+A module-level constant closes the gap for free even if the edge case never triggers in practice.
+
+### 9. `useDayCoinPriceChange.ts`: derived percentage computed via a second effect instead of `useMemo`
+
+**Where:** [`suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts:82-88`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.ts#L82-L88). Sole consumer: [`suite-native/module-accounts-management/src/components/AssetPriceCard.tsx:74-77`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-accounts-management/src/components/AssetPriceCard.tsx#L74-L77).
+
+**Before:**
+
+```tsx
+useEffect(() => {
+    if (isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(weekAgoValue)) {
+        setValuePercentageChange(percentageDiff(weekAgoValue, currentValue.toNumber()));
+    } else {
+        setValuePercentageChange(null);
+    }
+}, [currentValue, weekAgoValue]);
+```
+
+**After:**
+
+```tsx
+const valuePercentageChange =
+    isNotNullOrUndefined(currentValue) && isNotNullOrUndefined(weekAgoValue)
+        ? percentageDiff(weekAgoValue, currentValue.toNumber())
+        : null;
+```
+
+Drop the `valuePercentageChange`/`setValuePercentageChange` `useState` and this second effect entirely — the value is a pure function of state already in hand.
+
+### 10. `DeviceTutorialScreen.tsx`: `useFocusEffect` + empty deps array contradicts its own "first render only" comment
+
+**Where:** [`suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx:22-38`](https://github.com/trezor/trezor-suite/blob/develop/suite-native/module-device-onboarding/src/screens/DeviceTutorialScreen.tsx#L22-L38).
+
+**Before:**
+
+```tsx
+useFocusEffect(
+    useCallback(() => {
+        const showTutorial = async () => {
+            await requestPrioritizedDeviceAccess(() =>
+                TrezorConnect.showDeviceTutorial({ device }),
+            );
+            navigation.replace(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
+        };
+        showTutorial();
+
+        // This use effect should be triggered only during the first render
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []),
+);
+```
+
+**After:**
+
+```tsx
+useEffect(() => {
+    const showTutorial = async () => {
+        await requestPrioritizedDeviceAccess(() => TrezorConnect.showDeviceTutorial({ device }));
+        navigation.replace(DeviceOnboardingStackRoutes.CreateOrRecoverCrossroads);
+    };
+    showTutorial();
+}, []);
+```
+
+Swap `useFocusEffect` for a plain `useEffect` so the hook's own semantics match the comment's stated "first render only" intent, and drop the now-unnecessary disable. (If re-running on every refocus is actually wanted instead, keep `useFocusEffect` and add `device` to the inner `useCallback`'s deps — either reading is a one-line fix, but the code as written asserts both at once.)
+
+## Why it matters
+
+Ten independent, low-severity instances of this skill's cheapest-to-fix classes — wider-than-needed hook dependencies, derived state routed through an effect, and stale `eslint-disable` comments — grouped because none is costly enough alone to justify a standalone issue:
+
+1. **`usePinAction.tsx`** — a lying dependency array: the suppression comment describes code from before `device` was narrowed to `device?.path`; the next person to touch this file has no reliable signal about what's actually being protected against.
+2. **`useMaxSpendableAmount.ts`/`useCustomFee.ts`** — both drive "max spendable amount"/custom-fee-preview UI during active typing in a send flow. `useMaxSpendableAmount`'s only current caller never passes `formState` (dormant today), and `useCustomFee`'s `formState` source wasn't traced in this sweep — so treat this as hardening against a reference that _would_ restart the guarded async work on every keystroke if a future caller supplies an unstable one, not a proven hot path today.
+3. **`AccountsListWithFilter.tsx`** — not live today (all 3 callers pass a referentially stable `networksFilter`), but the component's own prop contract invites a future caller to pass an inline array literal, which would silently discard a user's in-progress filter selection on every parent re-render.
+4. **`ExchangeApprovalDetails.tsx`/`ExchangeRevokeDetails.tsx`** — cheap, bounded re-invocation of a truthiness check on every account update to the exchange's send account; harmless today, included as a clean one-character-diff example of the same "whole object" habit as this sweep's hotter findings.
+5. **`useWatchTrade.ts`** — `account` and a ref sit in a dependency array whose body never reads them; a zero-risk removal.
+6. **`YieldWithdrawCompleteScreen.tsx`/`WrappedNativeTokenCompleteContent.tsx`** — cold-path completion screens; the recomputed work is string formatting, not a network call, so this rides on the same account-chain family as sibling draft p1-17 at a much smaller consequence.
+7. **`useSendForm.tsx`'s mount-only prefill** — plausibly correct given how this screen is navigated to, but the blanket `eslint-disable` gives no signal if that navigation assumption ever changes.
+8. **`SendUtxoScreen.tsx`** — verify first: this sweep could not find a live path where `account.utxo` is nullish while the screen is mounted, so this may be a zero-impact defensive cleanup rather than an active defect.
+9. **`useDayCoinPriceChange.ts`** — a guaranteed extra render of `AssetPriceCard` on every 30-second price refresh, since the percentage is a pure function of state already in hand.
+10. **`DeviceTutorialScreen.tsx`** — `useFocusEffect` and an empty dependency array assert two different lifecycles at once; if a future navigator change ever allows refocusing this screen, `device` would be silently stale with no lint error to catch it.
+
+None of these sit on a hot, continuously re-rendering path — most are cold/one-shot screens, guarded async work, or effects whose bodies don't even read the flagged dependency — which is why all ten are P3 rather than individually filed.
+
+## Notes
+
+- Compile requirements: `useFreshRef` (from `@trezor/react-utils`) needs importing in both files for #2 (neither currently imports from that package). #10 swaps `DeviceTutorialScreen.tsx`'s `import { useCallback } from 'react';` for `import { useEffect } from 'react';` — `useCallback` becomes unused once `useFocusEffect` is dropped. #3 and #8 need no new imports (`useState`/a module-level array are already in scope).
+- **F-09-10 is genuinely low confidence** (#8 above) — flagged per the skill's exact "crosses the hook boundary" pattern match, but this sweep could not construct a realistic trigger. Verify the nullish-`utxo` path exists before filing; if it doesn't, this is optional defensive cleanliness rather than a fix.
+- All ten files are `suite-native`, compiled by React Compiler: every fix here is a dependency-array narrowing, a derive-instead-of-store rewrite, or an `eslint-disable` replacement — never a manual memo addition.
+- #6 cites sibling draft p1-17 ("Native fee-compose effects key on whole account", not yet filed) — same `useResolvedYieldFlowData` root cause, much smaller blast radius (a one-time completion screen vs. a live review screen), which is why it's batched here instead of merged into that doc.
+- #5's second effect in `useWatchTrade.ts` (`:71-85`) was checked and is _not_ included — it legitimately needs `account` and is separately guarded against duplicate dispatch.
+
+<sub>Verified against `issues/perf-react-hooks` at 9e0d5b6a45. Part of #28886.</sub>

--- a/skills/comments/SKILL.md
+++ b/skills/comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comments
-description: Comment conventions for Trezor Suite — prefer self-documenting code, and how to write and format a comment when one is actually needed. Use when writing or reviewing code comments.
+description: Comment conventions for Trezor Suite — prefer self-documenting code, extract and name logic rather than explaining it in a comment paragraph, and how to write and format a comment when one is actually needed. Use when writing or reviewing code comments, or when a block needs a comment before it makes sense.
 ---
 
 # Comments
@@ -31,6 +31,57 @@ index += 1;
 // Firmware < 2.6.0 reports the fee in a different unit, so we normalize here.
 const fee = normalizeFee(rawFee, firmwareVersion);
 ```
+
+## Give a name to logic the reader has to decode
+
+Sometimes the honest fix for a block that needs a comment is not a better comment — it is a name. Two
+concrete triggers:
+
+- **A block needs a multi-line comment before it makes sense.** Extract it into a named function and let
+  early returns replace the nesting. The long comment then hangs on the extracted unit instead of on a line
+  only someone already inside the block will ever see. `getPoolDelegation`
+  ([stakeFormCardanoActions.ts:313](../../packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts))
+  came out of exactly this.
+- **The same compound condition appears twice.** Hoist it into a named `const` — `apyAvailable`
+  ([EarnStakingAccountRow.tsx:297](../../packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx))
+  is read at two branches that previously each spelled the check out, and would have drifted the moment a
+  third status was added.
+
+A component body that assembles a `ReactNode` into a `let` through an `if / else if / else` chain is the same
+defect wearing JSX: extract it into its own component and each case returns.
+
+```tsx
+// bad - the pre-fix shape from #30255 - three layouts assembled into a `let` before the screen renders
+// anything, so the reader unwinds the chain to find the actual output
+let transactionTitle: ReactNode;
+if (isUnstakeTransaction) {
+    transactionTitle = <UnstakeTransactionDetailTitle unstakeAmount={unstakeAmount} />;
+} else if (wrapKind) {
+    transactionTitle = <WrapTransactionName transaction={transaction} kind={wrapKind} />;
+} else {
+    transactionTitle = <TransactionName transaction={transaction} isPending={isPending} />;
+}
+
+// good - TransactionDetailTitle.tsx:21 - each case returns and is then forgotten; the screen renders
+// <TransactionDetailTitle /> and the name says what it is
+export const TransactionDetailTitle = ({ transaction, isPending }: Props) => {
+    const unstakeAmount = getUnstakeTxAmount(transaction);
+    const wrapKind = getNativeWrapTxKind(transaction);
+
+    if (unstakeAmount !== undefined) {
+        return <UnstakeTransactionDetailTitle unstakeAmount={unstakeAmount} />;
+    }
+
+    if (wrapKind) {
+        return <WrapTransactionName transaction={transaction} kind={wrapKind} />;
+    }
+
+    return <TransactionName transaction={transaction} isPending={isPending} />;
+};
+```
+
+Don't extract a single-use one-liner — the triggers above are the whole rule, and a comment explaining
+genuinely non-obvious _why_ stays a comment.
 
 ## Start with an uppercase letter and end with a period
 

--- a/skills/components/SKILL.md
+++ b/skills/components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: components
-description: React component file structure and patterns for Trezor Suite. Use when creating or reviewing React components, including prop passing and component organization.
+description: React component file structure and patterns for Trezor Suite, including one component per file and where an extracted helper component or hook goes. Use when creating or reviewing React components, including prop passing and component organization.
 ---
 
 # Components
@@ -14,6 +14,43 @@ description: React component file structure and patterns for Trezor Suite. Use w
 5. 🆎 Component types
 6. 🎭 Component prop type
 7. 🍱 Component
+
+## Export one component per file, and give an extracted hook its own file
+
+A file exports exactly one React component. A helper component that only this file uses still gets its own
+file next to it — not a shared `parts.tsx` — and a hook extracted from a component goes into
+`hooks/<useHookName>.ts(x)`, named after the hook
+([useYourPositionCardYieldBadge.tsx](../../suite-native/module-accounts-management/src/hooks/useYourPositionCardYieldBadge.tsx)
+is the shape, `.tsx` because it returns JSX-bearing values).
+
+The second component in a file is reliably the part that later needs reuse or refactoring, and it is
+reachable by neither filename nor a test that renders it alone.
+
+```tsx
+// bad - two components in one file; the fee row is not findable by filename and cannot be rendered on
+// its own in a test
+const CancelTransactionFeeRow = ({ title, fee, symbol }: CancelTransactionFeeRowProps) => (
+    <TransactionDetailRow title={title}>{/* ... */}</TransactionDetailRow>
+);
+
+export const CancelEvmTransactionButton = ({ accountKey, transaction }: Props) => (
+    <CancelTransactionFeeRow title={feeTitle} fee={fee} symbol={transaction.symbol} />
+);
+
+// good - CancelEvmTransactionButton.tsx - one component, with the row and the hook each in their own file
+import { useCancelEvmTransaction } from '../hooks/useCancelEvmTransaction';
+
+import { CancelTransactionFeeRow } from './CancelTransactionFeeRow';
+
+export const CancelEvmTransactionButton = ({ accountKey, transaction }: Props) => {
+    const { fee, cancel } = useCancelEvmTransaction({ accountKey, transaction });
+
+    return <CancelTransactionFeeRow fee={fee} symbol={transaction.symbol} onPress={cancel} />;
+};
+```
+
+Counting the components in a file is a job for `react/no-multi-comp`, which is not enabled yet; what a linter
+cannot decide, and what this rule is therefore about, is _where_ the extracted unit goes.
 
 ## 🟠 Component structure
 

--- a/skills/data-fetching/SKILL.md
+++ b/skills/data-fetching/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: data-fetching
+description: TanStack Query conventions for Trezor Suite — fetching with useQuery instead of an effect that dispatches a thunk, when useMutation is the right tool, central query keys, letting callers pass queryOptions into a shared hook, and calling the narrowest hook. Use when a screen needs to load data, when writing a query hook in suite-common, or when you find yourself mirroring loading or error state into useState.
+---
+
+# Data Fetching
+
+Everything here is about `@tanstack/react-query`, which both apps use. The rules are the ones a linter cannot
+decide — [`reactQueryConfig.mjs`](../../packages/eslint/src/reactQueryConfig.mjs) already enables
+`flat/recommended-strict`, so the query's own `exhaustive-deps`, rest-destructuring and mutation property
+order are mechanized and are not restated below.
+
+## Fetch with `useQuery`, not an effect that dispatches and mirrors state
+
+Data a screen needs as soon as its inputs exist belongs in a `useQuery` keyed by those inputs, not in a
+`useEffect` that dispatches a thunk and mirrors loading, error and race state into `useState`. Query identity
+gives request de-duplication, discarding of superseded responses and an `AbortSignal` for free. The
+hand-rolled version has to re-earn each of those: miss the request-id guard and a superseded fee estimate
+overwrites the current one, miss the loading flag and the spinner never clears
+(`useComposeEarnFees.ts:93` and `:96` are both halves of that bookkeeping).
+
+The corollary is that `useMutation` is for imperative, user-triggered writes. Calling `mutate()` from a
+`useEffect` says the case was declarative all along, so make it a query and let the effect's guard clause
+become `enabled`.
+
+```tsx
+// bad - useEthereumCancelTxCompose.ts:115 - a mutation nothing user-triggered ever calls, fired from an
+// effect whose deps include the whole `account` object, so it refires after every blockchain update
+const {
+    mutate,
+    data,
+    isPending: isComposing,
+} = useMutation({
+    mutationFn: () => dispatch(composeEthereumCancelTransactionThunk({ account, tx })).unwrap(),
+});
+
+useEffect(() => {
+    if (account.networkType !== 'ethereum' || !feeInfo) return;
+
+    mutate();
+}, [account, tx, feeInfo, mutate]);
+
+// good - the preconditions become `enabled` and the effect disappears with them; add the new key to the
+// factory in suite-common/react-query rather than inlining it here
+const { data, isPending: isComposing } = useQuery({
+    queryKey: desktopQueryKeys.ethereumCancelTx(account.key, tx.txid),
+    queryFn: () => dispatch(composeEthereumCancelTransactionThunk({ account, tx })).unwrap(),
+    enabled: account.networkType === 'ethereum' && Boolean(feeInfo),
+});
+```
+
+Wrapping an existing thunk in `queryFn` is a legitimate and common shape — see
+[`useMissingRateTickersQuery`](../../suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.ts) —
+so a thunk is not a reason to keep the effect. Keys live in the factories in
+[`queryKeys.ts`](../../suite-common/react-query/src/constants/queryKeys.ts) (`commonQueryKeys` for both apps,
+`desktopQueryKeys` for `packages/suite`); never inline a `queryKey` array at the call site, because the key
+is what two callers have to agree on to share a cache entry.
+
+## Let callers pass `queryOptions` into a shared query hook, and never overwrite them
+
+A query hook in `suite-common` is consumed by both apps, whose needs differ per screen — `enabled`,
+`staleTime`, `select`. Accept a caller options object as the second parameter and type it as
+`Omit<UseQueryOptions<…>, 'queryKey'>` so no caller can break the query identity. Express the hook's own
+condition as a destructuring default, not as an assignment after the spread.
+
+```tsx
+// bad - useSolanaRewardsTotal.ts:11 - the caller's `enabled` is spread in and then overwritten, so a
+// screen that disabled the query still fires it
+return useQuery({
+    ...queryOptions,
+    enabled: account.symbol === 'sol',
+    queryKey: commonQueryKeys.solanaRewardsTotal(account.descriptor),
+    queryFn: () => getSolanaRewardsTotal({ routeParams: { address: account.descriptor } }),
+});
+
+// good - useEthereumValidatorsQueue.ts:16 - the hook's condition is only the caller's default, and
+// `queryKey` is omitted from the options type so no caller can break the cache identity
+export function useEthereumValidatorsQueue(
+    { account, timestamp }: UseEthereumValidatorsQueueProps,
+    {
+        enabled = Boolean(account),
+        ...restQueryOptions
+    }: Omit<UseQueryOptions<EthValidatorsQueue>, 'queryKey'> = {},
+) {
+    return useQuery({
+        staleTime: 60 * 1000, // 1 minute
+        ...restQueryOptions,
+        enabled,
+        queryKey: commonQueryKeys.validatorsQueue(account?.key, timestamp),
+        queryFn: () => getEthereumValidatorsQueue({ params: { timestamp } }),
+    });
+}
+```
+
+A hook local to `packages/suite` or to a `module-*` package has one consumer and needs no options parameter.
+
+## Call the narrowest query hook for what you render
+
+When a hook exists for the single record a component renders, do not call the list hook and filter
+client-side. The wide call sits in code that runs once per row, and every consumer shares the one list cache
+key, so any invalidation refetches all `YIELD_OPPORTUNITIES_DEFAULT_LIMIT` (100) records for all of them.
+Narrow the shape with the query's `select`, not with a wider fetch.
+
+```tsx
+// bad - one badge per token row, each pulling the whole 100-vault list to read one APY, and all of them
+// refetching together on any invalidation
+const { data: yieldOpportunities } = useAllYieldOpportunities();
+const vault = yieldOpportunities?.find(opportunity => opportunity.id === vaultId);
+
+// good - YieldBadge.tsx:52 - one request per vault, cached under its own key
+const { data: vault } = useYieldOpportunity(vaultId);
+```
+
+The list hook is right when the screen genuinely renders the list; the rule is about a per-item component or
+per-item hook reaching for it. `useYourPositionCardYieldBadge.tsx:18` is the case still in the tree.
+
+## Related skills
+
+- [Redux](../redux/SKILL.md) — where a thunk still belongs, and `.unwrap()` inside a `mutationFn`.
+- [React hooks](../performance-react-hooks/SKILL.md) — why an effect keyed on a whole `account` object
+  refetches unboundedly.
+- [Packages](../packages/SKILL.md) — which layer a shared query hook belongs in.

--- a/skills/defensive-programming/SKILL.md
+++ b/skills/defensive-programming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: defensive-programming
-description: Type safety practices including exhaustive checks, explicit return types, Result-based error handling, and non-mutating array methods. Use when writing TypeScript logic that handles multiple cases or error conditions, or when sorting, reversing or splicing an array you did not create.
+description: Type safety practices including exhaustive checks, explicit return types, Result-based error handling, never failing with a bare null, keeping an absent value undefined instead of '' or '0', deciding per-network behaviour from network features, checksum-agnostic EVM address comparison, and non-mutating array methods. Use when writing TypeScript logic that handles multiple cases or error conditions, when a value may be missing, when branching on a coin's capabilities, when comparing addresses, or when sorting, reversing or splicing an array you did not create.
 ---
 
 # Defensive Programming
@@ -60,6 +60,66 @@ const result: { [K in keyof Schema]: () => void } = {
 };
 ```
 
+## Do not substitute a placeholder for a missing value
+
+When a value is genuinely missing, pass `undefined` (or `null` where that is the domain type) and let the
+consumer decide what to render. `''` and `'0'` are indistinguishable from real data, so the absence stops
+being visible: an empty symbol renders as a confident blank instead of a placeholder, a `?? '0'` balance as
+a confident zero, and every reader downstream has to re-guess whether the empty value meant "absent" or
+"empty". The type-checker cannot help — the sentinel is a valid inhabitant of the declared type.
+
+Where the absence makes the surrounding computation meaningless, guard on it and let the type narrow rather
+than manufacturing a value that satisfies the compiler.
+
+```tsx
+// bad - useYieldFlow.ts:217 - the symbol is typed `string` (:80) and rendered by YieldWithdrawForm
+// (:240), so a missing token shows an empty symbol where the UI should show a placeholder
+const inputTokenSymbol = isSharesInput ? (receiptToken?.symbol ?? '') : (token?.symbol ?? '');
+
+// good - useYieldBadge.tsx:41 - the value is meaningless without a symbol, so guard and narrow;
+// `token.symbol` needs no `??` after it
+if (!networkSymbol || !token?.symbol) return [];
+```
+
+A controlled form input's `value` and string concatenation are the boundary: there `''` is the real empty
+state, not a stand-in for absence. Beware the sentinel that is not even reachable —
+`YourPositionCard.tsx:77` writes `vaultId={yieldBadge.vaultId ?? ''}` on a value its own hook already types
+as `vaultId: string`.
+
+## Decide per-network behaviour from network `features`, not a symbol list
+
+Whether a coin supports a capability is declared in the `networks` config as `features: NetworkFeature[]`
+([types.ts:99](../../suite-common/wallet-config/src/types.ts)). Read it from there: `hasNetworkFeatures`
+([accountUtils.ts:1045](../../suite-common/wallet-utils/src/accountUtils.ts)) is the default because it
+honours per-`accountType` overrides, `getNetworkFeatures(symbol)` covers a symbol-level check, and
+config-derived sets like `STAKING_SYMBOLS` / `isStakingSymbol`
+([networksConfig.ts:810](../../suite-common/wallet-config/src/networksConfig.ts),
+[stakingUtils.ts:86](../../suite-common/wallet-utils/src/stakingUtils.ts)) cover the whole-set case.
+
+Adding a network sets its `features` once, but every hardcoded symbol comparison has to be found by hand.
+Miss one and the capability silently disappears for that coin in that one view — no type error, no failing
+test, just a coin that never shows up. The exhaustiveness guidance above cannot help here: a boolean chain
+type-checks perfectly while being incomplete.
+
+```tsx
+// bad - useStakingTableData.ts:47 - a second list of staking coins that nothing keeps in sync with the
+// network config, so a fifth staking network silently skips this view
+const stakingAccounts = accounts.filter(
+    account =>
+        account.symbol === 'eth' ||
+        account.symbol === 'sol' ||
+        account.symbol === 'ada' ||
+        account.symbol === 'trx',
+);
+
+// good - useStakingListData.ts:36 - the same filter in the mobile app, derived from `features`
+const stakingAccounts = accounts.filter(account => isStakingSymbol(account.symbol));
+```
+
+A constant deliberately pinned to an external contract is the exception and must say so: `EVM_SPENDER_LABELS`
+([evm.ts](../../suite-common/suite-constants/src/evm.ts)) is a flattened copy of the firmware's
+`KNOWN_ADDRESSES` precisely so the approve flow cannot drift out of clear-signing.
+
 ## Prefer the non-mutating array methods to copy-then-mutate
 
 `[...items].sort()` and `items.slice().sort()` are workarounds for `sort` mutating in place, and they only work if you remember the copy. `toSorted`, `toReversed`, `toSpliced` and [`with`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with) return a new array, so forgetting is not an option — and forgetting matters here, because the arrays in play are usually a selector result or Redux state that something else is still holding. Nothing will catch it either: `immutableCheck` is `false` in both stores ([suite](../../packages/suite/src/reducers/store.ts), [native](../../suite-native/state/src/store.ts)), so a mutated slice surfaces later as a stale render or a wrong total, far from the `.sort()` that caused it.
@@ -71,6 +131,31 @@ const sorted = [...accounts].sort(byBalance);
 // good - one call, nothing to forget
 const sorted = accounts.toSorted(byBalance);
 ```
+
+## Compare EVM addresses with `areEvmAddressesEqual`
+
+EVM addresses reach Suite in mixed EIP-55 casing, so every equality check has to be checksum-agnostic. Use
+[`areEvmAddressesEqual`](../../suite-common/address/src/evmChecksumUtils.ts) from `@suite-common/address`
+rather than lowercasing at the call site; it handles both sides plus missing and invalid input, so there is
+nothing left to remember. Where a value is stored or passed on, normalize once at the parse boundary instead
+(`address.ts:39`) and two already-normalized values may then compare with `===`.
+
+A `.toLowerCase()` missing on one side compiles, type-checks and silently answers "not ours". Nothing fails
+loudly — the wrong boolean just propagates.
+
+```ts
+// bad - transactionUtils.ts:76 - drop either `.toLowerCase()` and this mis-attributes the signer of any
+// mixed-case address, which then feeds EVM nonce arithmetic
+vin.addresses?.some(address => address.toLowerCase() === descriptor.toLowerCase());
+
+// good - checksum-agnostic and null-safe in one call, and the name carries the intent that the
+// surrounding comment currently has to explain
+vin.addresses?.some(address => areEvmAddressesEqual(address, descriptor));
+```
+
+Two boundaries: the helper is EVM-only — it returns `false` for bech32 and base58 addresses — and it pulls
+viem in, so a consumer reachable from `build-connect` may keep a hand-rolled comparison with a comment
+saying why ([wrappedNativeToken.ts:43](../../networks/ethereum/network-ethereum/src/constants/wrappedNativeToken.ts)).
 
 ## Do not use exceptions
 
@@ -106,3 +191,39 @@ if (result.error) {
     }
 }
 ```
+
+## Never fail with a bare `null`
+
+The rule above is about _how_ to pass an expected failure, not about staying silent. A bare `null` return is
+neither a `Result` nor a `throw`: it collapses every distinct precondition into one indistinguishable value,
+and the caller is left able to render only "something went wrong". Its harness twin is logging "skipping"
+and returning.
+
+So pick one deliberately. A typed `Result` or discriminated variant for a failure the caller branches on;
+a `throw` naming the missing field for an invariant the caller cannot act on. On the signing path the
+message string is the entire diagnostic that survives, because `createThunk` serializes a thrown error down
+to `{ name, message, stack }` before it reaches the slice, the toast and Sentry.
+
+```ts
+// bad - the pre-fix shape from #27718 - one `null` for a missing fee and for an unparsable payload, so
+// the reason has to be re-derived by bisecting the helper by hand
+const getTransactionWithSelectedFee = (
+    parsedTransaction: StablecoinYieldParsedTransactionForSigning,
+    selectedFee?: EvmSelectedFee | null,
+): StablecoinYieldParsedTransactionForSigning | null => {
+    const parsedSelectedFee = parseEvmFeeHex(selectedFee);
+
+    if (!parsedSelectedFee) return null;
+
+    return { ...parsedTransaction, ...flattenEvmFees(parsedSelectedFee) };
+};
+
+// good - stablecoinYieldSigningUtils.ts:64 - the message names the missing field, and the return type
+// loses its `| null` along with it (:56)
+if (!parsedSelectedFee) {
+    throw new Error('Fee information is missing for the transaction.');
+}
+```
+
+Name the missing field (`fee`, `gasLimit`), never its value — these strings reach Sentry and user-facing
+toasts, and an amount, address or label in one is confidential data leaving the device.

--- a/skills/packages/SKILL.md
+++ b/skills/packages/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: packages
-description: How to create and structure packages in the Trezor Suite monorepo, including scopes and sizing guidance. Use when creating new packages or resolving cyclic dependencies.
+description: How to create and structure packages in the Trezor Suite monorepo, including scopes, sizing guidance, and moving logic both apps need into suite-common instead of duplicating it. Use when creating new packages, resolving cyclic dependencies, or when the same logic is about to exist in both suite and suite-native.
 ---
 
 # Packages
@@ -15,6 +15,39 @@ Use command `yarn generate-package @scope/newPackageName`. For example using nam
 | @suite-common | /suite-common | code shared between @suite and @suite native                                                            | @trezor                   |
 | @suite-native | /suite-native | mobile Suite                                                                                            | @trezor and @suite-common |
 | @suite        | /suite        | desktop & web Suite                                                                                     | @trezor and @suite-common |
+
+## Move logic both apps need into suite-common instead of duplicating it
+
+When the same derivation or hook body appears in the web/desktop app and in `suite-native`, move the
+platform-agnostic core into the shared layer — into the `@suite-common/*` hook that already returns the raw
+data, or into a `@suite-common/*` util — and leave only the platform glue in each app: navigation, native
+components, desktop analytics.
+
+Copies drift silently, and the drift is invisible at the copy site. `getPollIntervalMs` was extracted to
+[`pollingUtils.ts:5`](../../suite-common/wallet-utils/src/pollingUtils.ts), but `packages/suite` kept two
+local re-implementations, so the block-time-to-poll-interval ratio now lives in three places: change the
+shared one and mobile plus suite's wrap/unwrap flows move, while suite's Tron-stake and yield pending-tx
+screens keep the old value with nothing to indicate it.
+
+```tsx
+// bad - the pre-review shape from #28374 - each app re-derives the same value from the same raw query
+const { data } = useTronStakingStats();
+const maxApr = data?.length ? Math.max(...data.map(({ apr }) => apr)) : null;
+
+// good - useTronStakingStats.ts:17 - the shared hook derives it once and both apps just read it
+export function useTronStakingStats(queryOptions?: Partial<UseQueryOptions<TrxStats>>) {
+    const stats = useQuery({ staleTime: 5 * 60 * 1000, ...queryOptions, queryKey, queryFn });
+
+    const maxApr = stats.data?.length ? Math.max(...stats.data.map(({ apr }) => apr)) : null;
+
+    return { stats, maxApr };
+}
+```
+
+If a hook cannot be shared wholesale, extract the pure parts rather than copying the file — the platform
+specifics are the reason to split it, not a reason to duplicate it. If nothing platform-agnostic is left, keep
+the duplicate and say so in a comment. The direction is one-way and half of it is already enforced:
+`local-rules/no-suite-imports-in-suite-common` fails the build if the shared layer reaches back into an app.
 
 ## Packages size
 

--- a/skills/performance-react-hooks/SKILL.md
+++ b/skills/performance-react-hooks/SKILL.md
@@ -123,15 +123,50 @@ dependency array on a memo whose callback reads through a ref. Restructure inste
 which one. When the value is genuinely read through a stable callback and the linter therefore cannot see
 it, keep the dependency listed and reference it with a `void` statement so the rule stays live rather than
 suppressed — `useTradingBuyFormDefaultValues.ts:45` does exactly that with `void coins;`, and carries no
-`eslint-disable` at all.
-[`useFreshRef`](../../packages/react-utils/src/hooks/useFreshRef.ts) assigns during render, so `.current`
-is always the newest value; it is the only correct choice when the ref is read in render or inside a
-`useMemo`. [`useCurrentRef`](../../packages/react-utils/src/hooks/useCurrentRef.ts) assigns in an effect,
-so during render `.current` still holds the last committed value. Neither tracks the previous value — for
-that, assign a plain `useRef` at the end of the effect. And confirm the dependency is genuinely unstable
-at its declaration first: a `useCallback(…, [])` handler is already stable and belongs in the array
+`eslint-disable` at all. And confirm the dependency is genuinely unstable at its declaration first: a
+`useCallback(…, [])` handler is already stable and belongs in the array
 ([#26319](https://github.com/trezor/trezor-suite/pull/26319#discussion_r3137461927),
 [#27384](https://github.com/trezor/trezor-suite/pull/27384#discussion_r3193474335)).
+
+## Pick the ref hook by when `.current` is read
+
+Choose by the moment the value is read, not by which helper is nearest.
+[`useFreshRef`](../../packages/react-utils/src/hooks/useFreshRef.ts) assigns during render, so `.current` is
+always the newest value — the only correct choice when the ref is read in render or inside a `useMemo`.
+[`useCurrentRef`](../../packages/react-utils/src/hooks/useCurrentRef.ts) assigns in an effect keyed on the
+value, so during render `.current` still holds the last committed one. There are 33 `useCurrentRef` call sites
+in `packages/suite`, so the distinction is live rather than theoretical.
+
+Neither holds the _previous_ value, and `useCurrentRef` does not either inside a later effect, because its own
+effect is declared first and has already run. Reaching for a helper when previous-value semantics are what you
+need makes the transition condition permanently false: the branch never runs, with no lint error and no crash.
+
+```tsx
+// bad - the suggestion on #27725 - useFreshRef assigns during render, so `.current` is already the new
+// serializedTx by the time the effect runs and the transition is never detected
+const serializedTxRef = useFreshRef(serializedTx);
+
+useEffect(() => {
+    if (serializedTxRef.current && !serializedTx && isSending) {
+        setIsSending(false);
+    }
+}, [isSending, serializedTx, serializedTxRef]);
+
+// good - TransactionReviewModalBody.tsx:59 - a plain ref, read at the top and assigned on the last line,
+// is the only shape that holds the previous value
+const prevSerializedTxRef = useRef(serializedTx);
+
+useEffect(() => {
+    if (prevSerializedTxRef.current && !serializedTx && isSending) {
+        setIsSending(false);
+    }
+
+    prevSerializedTxRef.current = serializedTx;
+}, [isSending, serializedTx]);
+```
+
+That branch is what clears `isSending` after a failed push; if it never fires, the expired-transaction "Try
+again" button stays blocked and the user is stuck in the review modal.
 
 ## Related skills
 
@@ -146,3 +181,5 @@ at its declaration first: a `useCallback(…, [])` handler is already stable and
 - [DOM and CSS](../performance-dom/SKILL.md) — forced layout, observers, compositor-only animation.
 - [Long and non-essential tasks](../performance-scheduling/SKILL.md) — yielding long tasks, deferring
   background work.
+- [Data fetching](../data-fetching/SKILL.md) — the `useQuery` shape that removes the fetching effect
+  altogether.

--- a/skills/redux/SKILL.md
+++ b/skills/redux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: redux
-description: Redux Toolkit patterns including slices, selectors, thunks, and middleware conventions for Trezor Suite. Use when writing or reviewing Redux state management code.
+description: Redux Toolkit patterns including slices, selectors, thunks, handling a rejected thunk when calling .unwrap(), and middleware conventions for Trezor Suite. Use when writing or reviewing Redux state management code, or when dispatching a thunk from a component.
 ---
 
 # Redux
@@ -215,6 +215,36 @@ await TrezorConnect.init({
 
 - For async thunks, try to make use of the [lifecycle actions](https://redux-toolkit.js.org/api/createAsyncThunk#promise-lifecycle-actions) whenever it makes sense. For example, when you have an async thunk that fetches something and saves in state. If fetching was not successful, you can explicitly modify the slice state in a relevant way: add an error message, change some status or reset the state (if business logic deems no data better than not-up-to-date data)
 - When using async thunks in effects, cancel the action by calling the [abort() method](https://redux-toolkit.js.org/api/createAsyncThunk#canceling-while-running) in effect cleanup.
+
+### Only call `.unwrap()` where you handle the rejection
+
+`dispatch(thunk())` resolves with the rejected action; `.unwrap()` re-throws it instead
+([`createThunk`](../../suite-common/redux-utils/src/createThunk.ts) is RTK's `createAsyncThunk`, so those are
+its semantics). Every `.unwrap()` must therefore sit inside a `try/catch`, inside a `useMutation`
+`mutationFn`, or be returned to a caller that does one of those. If you don't need the resolved value, drop
+`.unwrap()` and read the lifecycle state from the slice.
+
+An unhandled rejection from an `onClick` gives the user a button that silently does nothing, skips every
+statement after the `await`, and surfaces as a context-free unhandled rejection in Sentry instead of the error
+state the thunk already wrote to the store.
+
+```tsx
+// bad - useTradingSellTradeActions.ts:103 - reached from onClick (TradingOfferSellBankAccount.tsx:62);
+// nothing catches the rejected thunk
+const addBankAccount = async () => {
+    if (!selectedQuote) return;
+
+    await dispatch(requestSellTradeThunk({ quote: selectedQuote })).unwrap();
+};
+
+// good - the mutation owns the rejection, and `mutation.error` is what renders it
+const addBankAccountMutation = useMutation({
+    mutationFn: (quote: SellQuote) => dispatch(requestSellTradeThunk({ quote })).unwrap(),
+});
+```
+
+A `catch {}` may be empty only with a comment naming the thunk that owns the error state — see
+`TransactionReviewModal.tsx:99`.
 
 ### State and dependency contracts
 

--- a/skills/tests/SKILL.md
+++ b/skills/tests/SKILL.md
@@ -82,9 +82,34 @@ void invalid;
 
 ### Typing
 
-All fixtures and mocks shall be typed and declaratively defined; using `as` to cast an incomplete object is only a last
-resort. This may add boilerplate, but it ensures type changes surface as type errors instead of hard-to-fix failing
-tests.
+All fixtures and mocks shall be typed and declaratively defined; `as unknown as T` — the form actually in the
+tree — is only a last resort. This may add boilerplate, but it ensures type changes surface as type errors
+instead of hard-to-fix failing tests. The double cast disables checking for every field inside, so renaming or
+retyping a field leaves the fixture compiling and the test asserting on a shape production no longer produces;
+the failure then surfaces as a mysterious assertion far from the fixture.
+
+Reach for `satisfies` instead, and for a deliberately partial fixture say which part is missing with
+`satisfies Omit<T, 'field'>[]` or `satisfies Pick<T, …>`.
+
+```ts
+// bad - useSubscribeForSolanaBlockUpdates.test.ts:20 - the double cast turns off checking for every field
+// inside, so a renamed Account field keeps compiling here
+const solanaAccount = {
+    key: 'sol-account-1',
+    symbol: 'sol',
+    networkType: 'solana',
+} as unknown as Account;
+
+// good - the fields present stay checked, and the type says what was deliberately left out
+const tokens = [{ contract, symbol: 'USDC', decimals: 6, balance: '25' }] satisfies Omit<
+    TokenInfo,
+    'standard'
+>[];
+```
+
+Two exceptions are unavoidable: a cast on a branded primitive (`'eth-account-key' as AccountKey`, since
+[`AccountKey`](../../suite-common/wallet-types/src/account.ts) is a branded template literal), and
+`} satisfies T as unknown as T` for a fixture that is structurally complete but nominally incompatible.
 
 ### Organization & Naming Convention
 

--- a/skills/typescript/SKILL.md
+++ b/skills/typescript/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typescript
-description: TypeScript-specific conventions including ts-expect-error usage, unknown vs any, const assertions, and type vs interface preferences. Use when writing TypeScript code.
+description: TypeScript-specific conventions including ts-expect-error usage, unknown vs any, what to reach for instead of an `as` cast, narrowing an account to one network type, const assertions, and type vs interface preferences. Use when writing TypeScript code, when you are about to write `as`, or when a function takes an Account but only works for one network.
 ---
 
 # TypeScript
@@ -34,6 +34,77 @@ const validateKey = (key: unknown): key is DictionaryKey => {
 ```
 
 If the above type guard marked `key` as `any`, calling `key()` would not throw.
+
+## Replace an `as` cast with `satisfies`, a guard, a parse, or a better type
+
+An `as` cast is an unchecked claim, so it is the wrong tool at exactly the places it is most tempting. It
+silences the compiler where the shape is decided, so a later field rename — or a value that was never a
+`NetworkSymbol` — keeps compiling and fails at runtime, far from the cast that caused it. Each case has a
+tool that keeps the code compiling only while it is still true:
+
+- **Constructing a value** — `satisfies`. It checks the shape without erasing what the compiler knows.
+- **Narrowing a string you did not construct** — the
+  [`isNetworkSymbol`](../../suite-common/wallet-config/src/utils.ts) guard where there is a fallback to fall
+  back to, or the sanctioned [`asNetworkSymbol`](../../suite-common/wallet-config/src/types.ts) wrapper at a
+  parse boundary where the string comes from outside and there is no alternative.
+- **An object payload from outside the type system** — parse it. `safeParse` on a schema in
+  `@suite-common/schemas`, the way [`parseEvmFeeHex`](../../suite-common/schemas/src/evm/fees/index.ts) does;
+  HTTP responses already get this from `createHttpClient`'s per-endpoint `schema`.
+- **None of the above fits** — the type is wrong. Change it instead of casting around it.
+
+```ts
+// bad - useEthereumCancelTxCompose.ts:105 - the cast is the only reason this literal type-checks, so a
+// renamed field on PrecomposedTransactionFinalCancelRbf keeps compiling here
+return {
+    composedCancelTx: {
+        ...normalLevel,
+        rbfType: 'cancel',
+        prevTxid: tx.txid,
+    } as PrecomposedTransactionFinalCancelRbf,
+    cancelFormState: formState,
+};
+
+// good - `satisfies` checks the same shape without erasing it; if it stops compiling, the type is wrong
+// and that is the thing to fix rather than assert past
+const composedCancelTx = {
+    ...normalLevel,
+    rbfType: 'cancel',
+    prevTxid: tx.txid,
+} satisfies PrecomposedTransactionFinalCancelRbf;
+```
+
+## Take `AccountWithNetworkType<T>`, not `Account`
+
+When code only makes sense for one network type, type its input as `AccountWithNetworkType<'tron'>`
+([account.ts:111](../../suite-common/wallet-types/src/account.ts)) instead of `Account` or a hand-rolled
+`Account & { networkType: 'tron' }`. Do the "is this the right account?" check once at the boundary that
+produces the account, so nothing downstream needs a guard for a case that cannot happen.
+
+Passing the wide `Account` pushes that check into every consumer, and the fallbacks it forces are what hide
+the bug: `getTronResources` returns `undefined` for every non-tron account, so an all-zero card is
+indistinguishable from a real one.
+
+```tsx
+// bad - TronResourcesCard.tsx:18 - any Account gets in, so the card re-derives the network check (:26)
+// and every read needs a `?? 0` that renders an all-zero card for a non-tron account
+interface TronResourcesCardProps {
+    account: Account;
+}
+
+const resources = getTronResources(account);
+const energyAvailable = resources?.availableEnergy ?? 0;
+
+// good - the network check happens once upstream, so the redundant call and its chain are gone
+type TronResourcesCardProps = {
+    account: AccountWithNetworkType<'tron'>;
+};
+
+const energyAvailable = account.misc.tronResources?.availableEnergy ?? 0;
+```
+
+The narrower type earns its keep by deleting impossible branches rather than handling them defensively — see
+[Defensive programming](../defensive-programming/SKILL.md). On the ethereum variant it also makes
+`misc.nonce: string` non-optional outright.
 
 ## Prefer direct type assignment to indirect
 


### PR DESCRIPTION
**This is PR for me to have documented all those findings / potential issues somewhere. I'll review it, let AI create Github issues from good findings and discard the rest.**

## Description

Repo-wide sweep against [`skills/performance-react-hooks/SKILL.md`](https://github.com/trezor/trezor-suite/blob/issues/perf-react-hooks/skills/performance-react-hooks/SKILL.md) — memoization per app (compiled native vs uncompiled web), referential stability of hook dependencies, effect refetch loops, defeated memos, ref-hook misuse.

**Docs only — no source file is touched.**

- [`perf-issues/react-hooks/`](perf-issues/react-hooks) — **43 documents (17 P1, 22 P2, 4 batched P3)**, one per proposed issue, each following the structure of #31137. Start at [`perf-issues/react-hooks/README.md`](perf-issues/react-hooks/README.md) — it carries the filing order, the overlap boundaries against the complexity/scheduling drafts, and a digest of where writers overrode the scan on evidence.
- Merged from 81 raw findings; raw scan output and per-area "checked, clean" lists in [`_scan/`](perf-issues/react-hooks/_scan).

## Notes for QA

**No QA needed — documentation only, no runtime code changes.**

Two caveats a reviewer should know: no number in these documents is a measurement (cadences are mechanism statements), and the `After` hunks were written by reading the surrounding types, not by running `tsc`. All 370 cited `file:line` anchors were mechanically verified at `9e0d5b6a45`: 0 broken.

## Related Issue

Part of #28886 (filing parent: #31374). Stacked on #31387 — this branch targets `issues/perf-scheduling`; GitHub will retarget it automatically once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)