### PR TITLE
DeFi Yield fixes for Trezor Model One

### DIFF
--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.test.ts
@@ -38,10 +38,14 @@ jest.mock('../../send/sendFormEthereumThunks', () => ({
 const OWNER_ADDRESS = '0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326';
 const VAULT_ADDRESS = '0xd63070114470f685b75B74D60EEc7c1113d33a3D';
 
+// 750000 gas at 1 Gwei is the fee every case here prices, so the balance covers it exactly.
+const DEPOSIT_FEE_WEI = '750000000000000';
+
 const account = mockWalletAccount({
     symbol: asNetworkSymbol('eth'),
     descriptor: asAccountDescriptor(OWNER_ADDRESS),
     deviceState: 'mock@device:0',
+    availableBalance: DEPOSIT_FEE_WEI,
 });
 
 const flowData = {
@@ -134,5 +138,27 @@ describe(composeYieldDepositTransactionThunk.name, () => {
             selectedAccount: account,
             fetchConfirmedNonce: true,
         });
+    });
+
+    // The deposit spends the vault's input token, but its fee comes out of the native balance —
+    // composing it anyway gets the transaction signed and only then rejected by the node.
+    it('fails with insufficient-native-balance when the native balance cannot cover the fee', async () => {
+        (estimateYieldFeeLevel as jest.Mock).mockResolvedValue({
+            success: true,
+            payload: { feeLimit: '750000' },
+        });
+
+        const poorAccount = { ...account, availableBalance: '749999999999999' };
+        const store = initStore();
+        const result = await store
+            .dispatch(
+                composeYieldDepositTransactionThunk({
+                    flowData: { ...flowData, account: poorAccount },
+                    amount: '1',
+                }),
+            )
+            .unwrap();
+
+        expect(result).toEqual({ type: 'error', reason: 'insufficient-native-balance' });
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts
@@ -25,6 +25,7 @@ import { estimateYieldFeeLevel } from '../utils/stablecoinYieldFeeEstimation';
 import {
     buildYieldDepositCalldata,
     buildYieldUnsignedTransaction,
+    canAffordYieldTransaction,
     getAllowanceSpender,
     getWithdrawRequestAmount,
 } from '../utils/stablecoinYieldUtils';
@@ -37,6 +38,7 @@ export type YieldDepositErrorReason =
     | 'vault-chain-mismatch'
     | 'missing-fee-level'
     | 'fee-estimation-failed'
+    | 'insufficient-native-balance'
     | 'compose-failed';
 
 export const getYieldDepositErrorTranslationKey = (reason: YieldDepositErrorReason) =>
@@ -167,17 +169,23 @@ export const composeYieldDepositTransactionThunk = createThunk<
             return { type: 'error', reason: 'missing-fee-level' } as const;
         }
 
-        const unsignedTransaction = JSON.stringify(
-            buildYieldUnsignedTransaction({
-                chainId: network.chainId,
-                data: calldata,
-                feeLevel: normalLevel,
-                from: account.descriptor,
-                gasLimit: estimatedFeeLevel.payload.feeLimit,
-                nonce: Number(nonce),
-                to: spender,
-            }),
-        );
+        const transaction = buildYieldUnsignedTransaction({
+            chainId: network.chainId,
+            data: calldata,
+            feeLevel: normalLevel,
+            from: account.descriptor,
+            gasLimit: estimatedFeeLevel.payload.feeLimit,
+            nonce: Number(nonce),
+            to: spender,
+        });
+
+        // The deposit moves the vault's input token, but its fee comes out of the native balance —
+        // without this the transaction gets signed on the device and only then rejected by the node.
+        if (!canAffordYieldTransaction(transaction, account.availableBalance)) {
+            return { type: 'error', reason: 'insufficient-native-balance' } as const;
+        }
+
+        const unsignedTransaction = JSON.stringify(transaction);
 
         const receiptAmount =
             getWithdrawRequestAmount({

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.test.ts
@@ -1,18 +1,43 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { deviceInitialState } from '@suite-common/device';
 import { createMockDispatch } from '@suite-common/redux-utils/mocks';
+import { configureMockStore } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { type Account, type FeeInfo, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type TokenInfo } from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
 
 import {
     type TrackWrappedNativeTokenThunkState,
+    composeYieldWrapTransactionThunk,
     trackWrappedNativeTokenThunk,
 } from './stablecoinYieldWrapThunks';
 import { accountsActions } from '../../accounts/accountsActions';
+import { accountsInitialState } from '../../accounts/accountsReducer';
+import { blockchainInitialState } from '../../blockchain/blockchainReducer';
+import { feesReducer } from '../../fees/feesReducer';
+import { transactionsInitialState } from '../../transactions/transactionsReducer';
 import { fetchWrappedNativeTokenInfo } from '../utils/fetchWrappedNativeTokenInfo';
+import { estimateYieldFeeLevel } from '../utils/stablecoinYieldFeeEstimation';
 
 jest.mock('../utils/fetchWrappedNativeTokenInfo', () => ({
     fetchWrappedNativeTokenInfo: jest.fn(),
+}));
+
+jest.mock('../utils/stablecoinYieldFeeEstimation', () => ({
+    estimateYieldFeeLevel: jest.fn(),
+}));
+
+jest.mock('../../send/sendFormEthereumThunks', () => ({
+    ethereumGetCurrentNonceThunk: jest.fn(() => () => {
+        const result = { nonce: '5', confirmedNonce: '5' };
+
+        return Object.assign(Promise.resolve(result), {
+            unwrap: () => Promise.resolve(result),
+        });
+    }),
 }));
 
 const fetchWrappedNativeTokenInfoMock = jest.mocked(fetchWrappedNativeTokenInfo);
@@ -185,5 +210,102 @@ describe('trackWrappedNativeTokenThunk', () => {
 
         expect(balance).toBe('2.5');
         expect(addTokensActions).toHaveLength(0);
+    });
+});
+
+// 1 Gwei, raw — the thunk converts it to Gwei itself.
+const ethFeeInfo: FeeInfo = {
+    blockHeight: 100,
+    blockTime: 12,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 1,
+    levels: [{ label: 'normal', feePerUnit: '1000000000', blocks: -1 }],
+};
+
+// The balance from the "insufficient funds for gas * price + value" report: wrapping all of it
+// leaves nothing for the fee, which is paid out of the very same balance.
+const WHOLE_BALANCE_WEI = '885386728109194';
+const WHOLE_BALANCE = '0.000885386728109194';
+// 60000 gas at 1 Gwei.
+const WRAP_FEE_WEI = '60000000000000';
+
+const wrapAccount: Account = {
+    ...ethereumAccount,
+    availableBalance: WHOLE_BALANCE_WEI,
+    formattedBalance: WHOLE_BALANCE,
+};
+
+const initWrapStore = () =>
+    configureMockStore({
+        reducer: combineReducers({
+            device: () => deviceInitialState,
+            wallet: combineReducers({
+                accounts: () => accountsInitialState,
+                blockchain: () => blockchainInitialState,
+                fees: feesReducer,
+                transactions: () => transactionsInitialState,
+            }),
+        }),
+        preloadedState: {
+            device: deviceInitialState,
+            wallet: {
+                accounts: accountsInitialState,
+                blockchain: blockchainInitialState,
+                fees: { eth: { status: 'loaded', data: ethFeeInfo } },
+                transactions: transactionsInitialState,
+            },
+        },
+    });
+
+const composeWrap = (wrapAmount: string) =>
+    initWrapStore()
+        .dispatch(
+            composeYieldWrapTransactionThunk({
+                account: wrapAccount,
+                token: { contractAddress: WETH_ADDRESS, decimals: 18 },
+                wrapAmount,
+            }),
+        )
+        .unwrap();
+
+describe('composeYieldWrapTransactionThunk', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (estimateYieldFeeLevel as jest.Mock).mockResolvedValue({
+            success: true,
+            payload: { feeLimit: '60000' },
+        });
+    });
+
+    it('refuses to compose a wrap of the whole balance, which cannot cover its own fee', async () => {
+        await expect(composeWrap(WHOLE_BALANCE)).resolves.toEqual({
+            type: 'error',
+            reason: 'insufficient-native-balance',
+        });
+    });
+
+    it('refuses to compose when the amount leaves less than the fee behind', async () => {
+        const justUnderTheFee = new BigNumber(WHOLE_BALANCE_WEI)
+            .minus(WRAP_FEE_WEI)
+            .plus(1)
+            .shiftedBy(-18)
+            .toFixed();
+
+        await expect(composeWrap(justUnderTheFee)).resolves.toEqual({
+            type: 'error',
+            reason: 'insufficient-native-balance',
+        });
+    });
+
+    it('composes the largest amount the balance can still fund', async () => {
+        const maxFundable = new BigNumber(WHOLE_BALANCE_WEI)
+            .minus(WRAP_FEE_WEI)
+            .shiftedBy(-18)
+            .toFixed();
+
+        const result = await composeWrap(maxFundable);
+
+        expect(result.type).toBe('action-ready');
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
@@ -28,6 +28,7 @@ import {
     buildYieldUnsignedTransaction,
     buildYieldUnwrapTransactionData,
     buildYieldWrapTransactionData,
+    getYieldTransactionNativeCost,
 } from '../utils/stablecoinYieldUtils';
 
 const YIELD_WRAP_THUNK_PREFIX = `${STABLECOIN_YIELD_PREFIX}/thunk`;
@@ -37,7 +38,8 @@ export type ComposeYieldWrapErrorReason =
     | 'not-wrapped-native'
     | 'missing-chain-id'
     | 'missing-fee-level'
-    | 'fee-estimation-failed';
+    | 'fee-estimation-failed'
+    | 'insufficient-native-balance';
 
 export type ComposeYieldWrapResult =
     | {
@@ -137,20 +139,28 @@ export const composeYieldWrapTransactionThunk = createThunk<
             return { type: 'error', reason: 'missing-fee-level' } as const;
         }
 
-        const unsignedTransaction = JSON.stringify(
-            buildYieldUnsignedTransaction({
-                chainId: network.chainId,
-                data,
-                feeLevel: normalLevel,
-                from: account.descriptor,
-                gasLimit,
-                nonce: Number(nonce),
-                to: wethAddress,
-                value,
-            }),
-        );
+        const transaction = buildYieldUnsignedTransaction({
+            chainId: network.chainId,
+            data,
+            feeLevel: normalLevel,
+            from: account.descriptor,
+            gasLimit,
+            nonce: Number(nonce),
+            to: wethAddress,
+            value,
+        });
 
-        return { type: 'action-ready', unsignedTransaction } as const;
+        // A wrap carries its amount in the transaction value, so the fee is paid out of the same
+        // balance — composing a transaction that does not fit gets it signed on the device and
+        // then rejected by the node ("insufficient funds for gas * price + value").
+        if (getYieldTransactionNativeCost(transaction).gt(account.availableBalance)) {
+            return { type: 'error', reason: 'insufficient-native-balance' } as const;
+        }
+
+        return {
+            type: 'action-ready',
+            unsignedTransaction: JSON.stringify(transaction),
+        } as const;
     },
 );
 
@@ -303,18 +313,24 @@ export const composeYieldUnwrapTransactionThunk = createThunk<
             return { type: 'error', reason: 'missing-fee-level' } as const;
         }
 
-        const unsignedTransaction = JSON.stringify(
-            buildYieldUnsignedTransaction({
-                chainId: network.chainId,
-                data,
-                feeLevel: normalLevel,
-                from: account.descriptor,
-                gasLimit: estimatedFeeLevel.payload.feeLimit,
-                nonce: Number(nonce),
-                to: wethAddress,
-            }),
-        );
+        const transaction = buildYieldUnsignedTransaction({
+            chainId: network.chainId,
+            data,
+            feeLevel: normalLevel,
+            from: account.descriptor,
+            gasLimit: estimatedFeeLevel.payload.feeLimit,
+            nonce: Number(nonce),
+            to: wethAddress,
+        });
 
-        return { type: 'action-ready', unsignedTransaction } as const;
+        // An unwrap spends the wrapped token, but its fee still comes out of the native balance.
+        if (getYieldTransactionNativeCost(transaction).gt(account.availableBalance)) {
+            return { type: 'error', reason: 'insufficient-native-balance' } as const;
+        }
+
+        return {
+            type: 'action-ready',
+            unsignedTransaction: JSON.stringify(transaction),
+        } as const;
     },
 );

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
@@ -28,7 +28,7 @@ import {
     buildYieldUnsignedTransaction,
     buildYieldUnwrapTransactionData,
     buildYieldWrapTransactionData,
-    getYieldTransactionNativeCost,
+    canAffordYieldTransaction,
 } from '../utils/stablecoinYieldUtils';
 
 const YIELD_WRAP_THUNK_PREFIX = `${STABLECOIN_YIELD_PREFIX}/thunk`;
@@ -153,7 +153,7 @@ export const composeYieldWrapTransactionThunk = createThunk<
         // A wrap carries its amount in the transaction value, so the fee is paid out of the same
         // balance — composing a transaction that does not fit gets it signed on the device and
         // then rejected by the node ("insufficient funds for gas * price + value").
-        if (getYieldTransactionNativeCost(transaction).gt(account.availableBalance)) {
+        if (!canAffordYieldTransaction(transaction, account.availableBalance)) {
             return { type: 'error', reason: 'insufficient-native-balance' } as const;
         }
 
@@ -324,7 +324,7 @@ export const composeYieldUnwrapTransactionThunk = createThunk<
         });
 
         // An unwrap spends the wrapped token, but its fee still comes out of the native balance.
-        if (getYieldTransactionNativeCost(transaction).gt(account.availableBalance)) {
+        if (!canAffordYieldTransaction(transaction, account.availableBalance)) {
             return { type: 'error', reason: 'insufficient-native-balance' } as const;
         }
 

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldFeeEstimation.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldFeeEstimation.ts
@@ -5,6 +5,12 @@ import type { BlockchainEstimatedFee } from '@trezor/connect-common/src/types/ap
 import { type Result, err, ok } from '@trezor/type-utils';
 
 export type YieldFeeEstimationError = 'fee-estimation-failed';
+/**
+ * Why a yield action transaction could not be composed for signing. `insufficient-native-balance`
+ * means the account cannot pay what the transaction spends (its value plus the whole fee
+ * allowance), which the node would reject after the device already signed it.
+ */
+export type YieldComposeError = YieldFeeEstimationError | 'insufficient-native-balance';
 export type YieldEstimatedFeeLevel = BlockchainEstimatedFee['levels'][number] & {
     feeLimit: string;
 };

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.test.ts
@@ -1,6 +1,7 @@
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
 import type { YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type FeeLevel } from '@trezor/connect';
 
 import type { YieldPendingTransactionState } from '../stablecoinYieldTypes';
 import {
@@ -12,6 +13,8 @@ import {
     buildYieldWrapTransactionData,
     getMaxWrapAmount,
     getNextYieldFlowStep,
+    getWrapFeeReserve,
+    getWrappableBalanceLimit,
     getWrappableNativeBalance,
     getYieldDepositAvailableBalance,
     getYieldDepositableBalance,
@@ -416,39 +419,91 @@ describe('stablecoinYieldUtils', () => {
         });
     });
 
+    describe('getWrapFeeReserve', () => {
+        const buildFeeInfo = (levels: Partial<FeeLevel>[]) =>
+            ({ levels }) as unknown as Parameters<typeof getWrapFeeReserve>[0];
+
+        it('prices the backup gas limit at the normal level maxFeePerGas', () => {
+            // 60000 gas * 20 Gwei = 0.0012 of the native coin.
+            expect(
+                getWrapFeeReserve(
+                    buildFeeInfo([
+                        { label: 'low', feePerUnit: '1', maxFeePerGas: '1' },
+                        { label: 'normal', feePerUnit: '30', maxFeePerGas: '20' },
+                    ]),
+                ),
+            ).toBe('0.0012');
+        });
+
+        it('falls back to feePerUnit on networks without EIP-1559 levels', () => {
+            expect(getWrapFeeReserve(buildFeeInfo([{ label: 'normal', feePerUnit: '20' }]))).toBe(
+                '0.0012',
+            );
+        });
+
+        it('returns zero when the fee levels are not loaded', () => {
+            expect(getWrapFeeReserve(null)).toBe('0');
+            expect(getWrapFeeReserve(buildFeeInfo([]))).toBe('0');
+        });
+    });
+
+    describe('getWrappableBalanceLimit', () => {
+        it('keeps the wrap fee aside', () => {
+            expect(getWrappableBalanceLimit('0.2', '0.0012')).toBe('0.1988');
+        });
+
+        it('floors at zero when the fee exceeds the balance', () => {
+            expect(getWrappableBalanceLimit('0.0005', '0.0012')).toBe('0');
+        });
+
+        it('treats an unknown fee as no reserve', () => {
+            expect(getWrappableBalanceLimit('0.2', '0')).toBe('0.2');
+        });
+    });
+
     describe('getMaxWrapAmount', () => {
+        const wrapFeeReserve = '0.0012';
+
         it('keeps the gas reserve aside when the balance covers it', () => {
-            expect(getMaxWrapAmount('0.2')).toBe('0.195');
+            expect(getMaxWrapAmount('0.2', wrapFeeReserve)).toBe('0.195');
         });
 
-        it('offers the whole balance when it does not cover the reserve', () => {
-            expect(getMaxWrapAmount('0.003')).toBe('0.003');
+        // Wrapping the whole balance can never be broadcast — the fee comes out of the same
+        // balance, so the node rejects it with "insufficient funds for gas * price + value".
+        it('keeps the wrap fee aside when the balance does not cover the gas reserve', () => {
+            expect(getMaxWrapAmount('0.003', wrapFeeReserve)).toBe('0.0018');
         });
 
-        it('offers the whole balance when it exactly matches the reserve', () => {
-            expect(getMaxWrapAmount('0.005')).toBe('0.005');
+        it('keeps the wrap fee aside when the balance exactly matches the gas reserve', () => {
+            expect(getMaxWrapAmount('0.005', wrapFeeReserve)).toBe('0.0038');
+        });
+
+        it('returns zero when the balance cannot even cover the wrap fee', () => {
+            expect(getMaxWrapAmount('0.001', wrapFeeReserve)).toBe('0');
         });
 
         // Max must offer an amount that is both usable and flagged, otherwise the button reads as
         // dead — the regression behind trezor/trezor-suite#30842.
         it('offers an amount that triggers the reserve recommendation', () => {
-            expect(shouldRecommendWrapReserve(getMaxWrapAmount('0.003'), '0.003')).toBe(true);
+            expect(
+                shouldRecommendWrapReserve(getMaxWrapAmount('0.003', wrapFeeReserve), '0.003'),
+            ).toBe(true);
         });
 
         it('treats an empty balance as zero', () => {
-            expect(getMaxWrapAmount('')).toBe('0');
+            expect(getMaxWrapAmount('', wrapFeeReserve)).toBe('0');
         });
 
         it('returns zero for a zero balance', () => {
-            expect(getMaxWrapAmount('0')).toBe('0');
+            expect(getMaxWrapAmount('0', wrapFeeReserve)).toBe('0');
         });
 
         it('returns zero for a negative balance', () => {
-            expect(getMaxWrapAmount('-1')).toBe('0');
+            expect(getMaxWrapAmount('-1', wrapFeeReserve)).toBe('0');
         });
 
         it('returns zero for non-numeric input', () => {
-            expect(getMaxWrapAmount('abc')).toBe('0');
+            expect(getMaxWrapAmount('abc', wrapFeeReserve)).toBe('0');
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.ts
@@ -330,6 +330,16 @@ export const getYieldTransactionNativeCost = (tx: YieldUnsignedTransaction): Big
     return new BigNumber(tx.value).plus(new BigNumber(tx.gasLimit).multipliedBy(gasPrice));
 };
 
+/**
+ * Whether `availableBalance` (native subunits) covers everything the transaction spends. The node
+ * checks this before it accepts a transaction, so composing one the account cannot fund only gets
+ * it signed on the device and then rejected — every yield compose has to check it up front.
+ */
+export const canAffordYieldTransaction = (
+    tx: YieldUnsignedTransaction,
+    availableBalance: string,
+): boolean => getYieldTransactionNativeCost(tx).lte(availableBalance);
+
 type BuildYieldWrapTransactionDataParams = {
     wrapAmount: string;
     decimals: number;

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.ts
@@ -1,12 +1,16 @@
 import { Calldata, type EvmAddress } from '@suite-common/calldata';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol, getNetworkByYieldXyzId } from '@suite-common/wallet-config';
-import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
-import { type AccountKey, type EvmSelectedFee } from '@suite-common/wallet-types';
+import {
+    WETH_DEPOSIT_BACKUP_GAS_LIMIT,
+    WETH_WRAP_GAS_RESERVE,
+} from '@suite-common/wallet-constants';
+import { type AccountKey, type EvmSelectedFee, type FeeInfo } from '@suite-common/wallet-types';
 import {
     asAmountUnit,
     fromGwei,
     fromIntegerString,
+    fromWei,
     getContractAddressForNetworkSymbol,
     isWrappedNativeToken,
     unitsToSubunits,
@@ -313,6 +317,19 @@ export const buildYieldUnsignedTransaction = ({
     };
 };
 
+type YieldUnsignedTransaction = ReturnType<typeof buildYieldUnsignedTransaction>;
+
+/**
+ * Native coin the transaction spends: its value plus the whole fee allowance
+ * (`gasLimit × gas price`). This is what the node checks the balance against before it accepts a
+ * transaction, so a wrap that spends more than this can never be broadcast.
+ */
+export const getYieldTransactionNativeCost = (tx: YieldUnsignedTransaction): BigNumber => {
+    const gasPrice = 'maxFeePerGas' in tx ? tx.maxFeePerGas : tx.gasPrice;
+
+    return new BigNumber(tx.value).plus(new BigNumber(tx.gasLimit).multipliedBy(gasPrice));
+};
+
 type BuildYieldWrapTransactionDataParams = {
     wrapAmount: string;
     decimals: number;
@@ -384,13 +401,60 @@ export const getWrappableNativeBalance = (nativeFormattedBalance: string): strin
     ).toString();
 
 /**
- * Amount the wrap step's "Max" button fills in: the balance minus `WETH_WRAP_GAS_RESERVE` while
- * that leaves something to wrap, otherwise the whole balance. A balance at or below the reserve
- * has nothing to keep aside, and offering `0` reads as a dead button
- * (trezor/trezor-suite#30842). Wrapping it all is allowed, and `shouldRecommendWrapReserve` then
- * surfaces the non-blocking recommendation to keep some native coin for the follow-up fees.
+ * Fee the wrap transaction itself will cost, in display units, estimated from the network's
+ * normal fee level and the `deposit()` gas backup limit. Deliberately an over-estimate — the real
+ * call is cheaper than the backup limit — because it is subtracted from the wrappable balance,
+ * where being short by a wei makes the signed transaction unbroadcastable.
+ *
+ * Returns `'0'` when the fee levels are not loaded yet; the compose thunks re-check the real cost.
  */
-export const getMaxWrapAmount = (nativeFormattedBalance: string): string => {
+export const getWrapFeeReserve = (feeInfo: FeeInfo | null | undefined): string => {
+    const level = feeInfo?.levels.find(({ label }) => label === 'normal') ?? feeInfo?.levels[0];
+    // EVM fee levels are converted to Gwei by `selectConvertedNetworkFeeInfo`.
+    const gasPriceGwei = level?.maxFeePerGas ?? level?.feePerUnit;
+
+    if (!gasPriceGwei || !new BigNumber(gasPriceGwei).isFinite()) {
+        return '0';
+    }
+
+    const feeWei = fromGwei(gasPriceGwei)
+        .toWei('bignumber')
+        .multipliedBy(WETH_DEPOSIT_BACKUP_GAS_LIMIT);
+
+    return fromWei(feeWei.toFixed(0)).toEther();
+};
+
+/**
+ * Most that can be wrapped out of the native balance: the wrap carries its amount in the
+ * transaction value, so the fee is paid out of the same balance and wrapping all of it can never
+ * be broadcast ("insufficient funds for gas * price + value").
+ */
+export const getWrappableBalanceLimit = (
+    nativeFormattedBalance: string,
+    wrapFeeReserve?: string,
+): string => {
+    const balance = new BigNumber(nativeFormattedBalance || '0');
+
+    if (!balance.isFinite() || balance.lte(0)) {
+        return '0';
+    }
+
+    return BigNumber.max(0, balance.minus(wrapFeeReserve || '0')).toString();
+};
+
+/**
+ * Amount the wrap step's "Max" button fills in: the balance minus `WETH_WRAP_GAS_RESERVE` while
+ * that leaves something to wrap, otherwise everything the balance can still fund. A balance at or
+ * below the reserve has nothing to keep aside, and offering `0` reads as a dead button
+ * (trezor/trezor-suite#30842) — but the wrap's own fee has to stay behind either way, so the
+ * fallback is the balance minus `wrapFeeReserve`, not the whole balance.
+ * `shouldRecommendWrapReserve` then surfaces the non-blocking recommendation to keep some native
+ * coin for the follow-up fees.
+ */
+export const getMaxWrapAmount = (
+    nativeFormattedBalance: string,
+    wrapFeeReserve?: string,
+): string => {
     const balance = new BigNumber(nativeFormattedBalance || '0');
 
     if (!balance.isFinite() || balance.lte(0)) {
@@ -399,7 +463,9 @@ export const getMaxWrapAmount = (nativeFormattedBalance: string): string => {
 
     const wrappableBalance = new BigNumber(getWrappableNativeBalance(nativeFormattedBalance));
 
-    return wrappableBalance.gt(0) ? wrappableBalance.toString() : balance.toString();
+    return wrappableBalance.gt(0)
+        ? wrappableBalance.toString()
+        : getWrappableBalanceLimit(nativeFormattedBalance, wrapFeeReserve);
 };
 
 /**

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import type { TokenInfo } from '@trezor/connect';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { buildApprovalTransactionData } from './ethUtils';
 import {
@@ -528,6 +529,32 @@ describe('constructTransactionReviewOutputs', () => {
         expect(outputs).not.toEqual(
             expect.arrayContaining([expect.objectContaining({ type: 'contract_intent' })]),
         );
+    });
+
+    it.each([
+        { op: 'wrap', token: undefined, transactionData: WETH_DEPOSIT_DATA },
+        { op: 'unwrap', token: wethToken, transactionData: WETH_WITHDRAW_DATA },
+    ])('mirrors the legacy device screens for a WETH $op on T1B1', ({ token, transactionData }) => {
+        const outputs = constructTransactionReviewOutputs({
+            account,
+            device: mockSuiteDevice(undefined, {
+                internal_model: DeviceModelInternal.T1B1,
+                major_version: 1,
+                minor_version: 13,
+                patch_version: 0,
+            }),
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({ transactionData }),
+            precomposedTx: buildPrecomposedTransaction({ to: WETH_MAINNET, token }),
+        });
+
+        // The legacy flow walks address → data → fee, and the review renders that fee as its own
+        // summary row. A separate 'fee' output would both desync the steps and, in the earn
+        // review, fail its output allowlist and leave the screen blank.
+        expect(outputs).toEqual([
+            { type: 'regular_legacy', value: WETH_MAINNET },
+            { type: 'data', value: transactionData },
+        ]);
     });
 
     it('keeps the raw data row for a wrapped native the firmware does not clear-sign (WBNB on BSC)', () => {

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -1,3 +1,4 @@
+import { Calldata, asEvmAddress } from '@suite-common/calldata';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
@@ -11,6 +12,7 @@ import {
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import type { TokenInfo } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { buildApprovalTransactionData } from './ethUtils';
 import {
@@ -33,6 +35,20 @@ const LIFI_SWAP_DATA = `0x5fd9ae2e${'00'.repeat(32 * 4)}`;
 
 // ERC-20 transfer (global selector a9059cbb) — works on any contract
 const ERC20_TRANSFER_DATA = `0xa9059cbb${'00'.repeat(32 * 2)}`;
+
+// Merkl rewards distributor — the earn "claim rewards" target.
+const MERKL_DISTRIBUTOR = '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae';
+const CLAIM_USER = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+const DISTRIBUTOR_CLAIM_DATA =
+    Calldata.evm.distributor.claim.encode(
+        {
+            users: [asEvmAddress(CLAIM_USER)],
+            tokens: [asEvmAddress('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')],
+            amounts: [new BigNumber(1)],
+            proofs: [[]],
+        },
+        { sender: asEvmAddress(CLAIM_USER) },
+    ).data ?? '';
 
 // Everstake staking pool
 const EVERSTAKE_POOL = '0xD523794C879D9eC028960a231F866758e405bE34';
@@ -554,6 +570,30 @@ describe('constructTransactionReviewOutputs', () => {
         expect(outputs).toEqual([
             { type: 'regular_legacy', value: WETH_MAINNET },
             { type: 'data', value: transactionData },
+        ]);
+    });
+
+    // A rewards claim takes the same legacy path on T1B1 as wrap/unwrap: the review renders the
+    // fee as its own summary row, so a separate 'fee' output would desync the steps and, in the
+    // earn claim review, fail its output allowlist — leaving the flow with a "reward details
+    // didn't match the transaction" alert instead of a review.
+    it('mirrors the legacy device screens for a rewards claim on T1B1', () => {
+        const outputs = constructTransactionReviewOutputs({
+            account,
+            device: mockSuiteDevice(undefined, {
+                internal_model: DeviceModelInternal.T1B1,
+                major_version: 1,
+                minor_version: 13,
+                patch_version: 0,
+            }),
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({ transactionData: DISTRIBUTOR_CLAIM_DATA }),
+            precomposedTx: buildPrecomposedTransaction({ to: MERKL_DISTRIBUTOR }),
+        });
+
+        expect(outputs).toEqual([
+            { type: 'regular_legacy', value: MERKL_DISTRIBUTOR },
+            { type: 'data', value: DISTRIBUTOR_CLAIM_DATA },
         ]);
     });
 

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -263,10 +263,14 @@ const constructOldFlow = ({
             ?.address,
         data: precomposedForm.transactionData,
     });
-    // Wrap/unwrap are yield operations as well: their review renders the fee in its own summary
-    // step, so the legacy flow must not emit a separate fee output for them either.
+    // Wrap/unwrap and the rewards claim are yield operations as well: their reviews render the fee
+    // in their own summary step, so the legacy flow must not emit a separate fee output for them
+    // either. The updated flow and the desktop review list draw the same line.
     const isYieldOperation =
-        isEvmYieldTxByTextSignature(evmTxType) || evmTxType === 'wrap' || evmTxType === 'unwrap';
+        isEvmYieldTxByTextSignature(evmTxType) ||
+        evmTxType === 'wrap' ||
+        evmTxType === 'unwrap' ||
+        evmTxType === 'claim';
 
     const hasDestinationTag = 'destinationTag' in precomposedForm;
 

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -35,7 +35,6 @@ import {
 import { fromGwei, fromWei } from './ethConverter';
 import {
     getEvmTransactionPurpose,
-    getEvmTransactionTextSignature,
     isEvmApprovalTx,
     isEvmYieldTxByTextSignature,
     isUnwrapNativeTx,
@@ -255,8 +254,19 @@ const constructOldFlow = ({
     const isCardano = isCardanoTx(account, precomposedTx);
     const isStellar = account.networkType === 'stellar';
     const { networkType } = account;
-    const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
-    const isYieldOperation = isEvmYieldTxByTextSignature(evmTxType);
+    // Resolved from the full context rather than the calldata alone, so that the WETH
+    // deposit()/withdraw() selectors classify as wrap/unwrap instead of 'unknown', the same way
+    // the updated flow resolves them.
+    const evmTxType = getEvmTransactionPurpose({
+        networkSymbol: account.symbol,
+        to: precomposedTx.outputs.find(o => 'address' in o && typeof o.address === 'string')
+            ?.address,
+        data: precomposedForm.transactionData,
+    });
+    // Wrap/unwrap are yield operations as well: their review renders the fee in its own summary
+    // step, so the legacy flow must not emit a separate fee output for them either.
+    const isYieldOperation =
+        isEvmYieldTxByTextSignature(evmTxType) || evmTxType === 'wrap' || evmTxType === 'unwrap';
 
     const hasDestinationTag = 'destinationTag' in precomposedForm;
 

--- a/suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts
+++ b/suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts
@@ -78,6 +78,7 @@ const composeReady = (unsignedTransaction = BASE_UNSIGNED_TX) => ({
 
 type HookProps = {
     amount: string | undefined;
+    availableBalance: string;
     composeTransaction: (amount: string) => Promise<ComposeTxResult<ComposedTxBase>>;
     formDraftKey: string;
     hasInvalidContext: boolean;
@@ -106,6 +107,7 @@ const createTestStore = () =>
 
 const createProps = (overrides: Partial<HookProps> = {}): HookProps => ({
     amount: '1',
+    availableBalance: '1000000000000000000',
     composeTransaction: jest.fn(),
     formDraftKey: FORM_DRAFT_KEY,
     hasInvalidContext: false,

--- a/suite-native/module-earn/src/hooks/usePreparedTxFees.ts
+++ b/suite-native/module-earn/src/hooks/usePreparedTxFees.ts
@@ -58,6 +58,8 @@ type BaseActionContext<TComposed extends ComposedTxBase> = {
 
 type UsePreparedTxFeesParams<TComposed extends ComposedTxBase> = {
     amount: string | undefined;
+    /** Native balance in subunits; levels that outspend it are priced as unaffordable. */
+    availableBalance: string;
     /**
      * Composes the base transaction for the debounced amount. Must not throw — map failures to
      * the `error` result. Every error is surfaced as a retryable alert; a failure that only
@@ -88,6 +90,7 @@ const getFeeInfoRevision = (feeInfo: FeeInfo | null | undefined) =>
  */
 export const usePreparedTxFees = <TComposed extends ComposedTxBase>({
     amount,
+    availableBalance,
     composeTransaction,
     formDraftKey,
     hasInvalidContext,
@@ -205,13 +208,14 @@ export const usePreparedTxFees = <TComposed extends ComposedTxBase>({
         return buildYieldDepositFeeDraftState({
             currentFormDraft: formDraft,
             amount: baseActionContext.amount,
+            availableBalance,
             feeInfo: currentFeeInfo,
             gasLimit: baseActionContext.baseFeePreview.feeLimit,
             symbol: baseActionContext.transaction.symbol,
             token: baseActionContext.transaction.token,
             unsignedTransaction: baseActionContext.transaction.unsignedTransaction,
         });
-    }, [baseActionContext, feeInfoRevision, formDraft]);
+    }, [availableBalance, baseActionContext, feeInfoRevision, formDraft]);
 
     const preparedTx = useMemo((): PreparedTx<TComposed> | null => {
         if (!baseActionContext) {

--- a/suite-native/module-earn/src/hooks/useWrapFeeReserve.ts
+++ b/suite-native/module-earn/src/hooks/useWrapFeeReserve.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type FeesRootState,
+    getWrapFeeReserve,
+    selectConvertedNetworkFeeInfo,
+    updateFeeInfoThunk,
+} from '@suite-common/wallet-core';
+
+/**
+ * Native amount the wrap form has to keep aside for the wrap transaction's own fee, in display
+ * units. There is no background fee-info sync on mobile (desktop has one), so the levels the
+ * estimate reads are fetched here — the form needs the reserve before the first compose, to fill
+ * in "Max" and to cap the entered amount.
+ */
+export const useWrapFeeReserve = (symbol: NetworkSymbol | undefined) => {
+    const dispatch = useDispatch();
+    const feeInfo = useSelector((state: FeesRootState) =>
+        selectConvertedNetworkFeeInfo(state, symbol),
+    );
+
+    useEffect(() => {
+        if (!symbol) return;
+
+        void dispatch(updateFeeInfoThunk({ networkSymbol: symbol }));
+    }, [dispatch, symbol]);
+
+    return getWrapFeeReserve(feeInfo);
+};

--- a/suite-native/module-earn/src/hooks/useWrappedNativeTokenFees.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeTokenFees.ts
@@ -110,6 +110,7 @@ export const useWrappedNativeTokenFees = ({
 
     const fees = usePreparedTxFees({
         amount,
+        availableBalance: account?.availableBalance ?? '0',
         composeTransaction,
         formDraftKey,
         hasInvalidContext,

--- a/suite-native/module-earn/src/hooks/useYieldDepositFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositFees.ts
@@ -70,6 +70,7 @@ export const useYieldDepositFees = ({
 
     const fees = usePreparedTxFees({
         amount,
+        availableBalance: flowData?.account.availableBalance ?? '0',
         composeTransaction,
         formDraftKey,
         hasInvalidContext,

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
@@ -8,11 +8,12 @@ import { getNetwork } from '@suite-common/wallet-config';
 import {
     type FeesRootState,
     type FormDraftRootState,
-    type YieldFeeEstimationError,
+    type YieldComposeError,
     type YieldWithdrawFlowType,
     buildEvmSelectedFee,
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
+    canAffordYieldTransaction,
     estimateYieldFeeLevel,
     ethereumGetCurrentNonceThunk,
     formDraftActions,
@@ -44,6 +45,7 @@ import { type Result, err, ok } from '@trezor/type-utils';
 import { EARN_MODULE_PREFIX } from '../constants';
 import { type ResolvedYieldFlowData } from './useResolvedYieldFlowData';
 import { useYieldFeeEstimationError } from './useYieldFeeEstimationError';
+import { applyYieldFeeAffordability } from '../utils/yieldFeeAffordabilityUtils';
 import { getYieldWithdrawFormDraftKey } from '../utils/yieldWithdrawUtils';
 
 type UseYieldWithdrawFeesParams = Pick<ResolvedYieldFlowData, 'flowData' | 'flowKey'> & {
@@ -92,6 +94,8 @@ type ComposeYieldWithdrawTransactionParams = {
 
 type BuildYieldWithdrawFeeLevelsParams = {
     amount: string;
+    /** Native balance in subunits; levels that outspend it are priced as unaffordable. */
+    availableBalance: string;
     feeInfo: FeeInfo;
     gasLimit: string;
     reviewToken: WithdrawFlowData['receiptToken'];
@@ -208,7 +212,7 @@ const composeYieldWithdrawTransaction = async ({
     feeInfo,
     flowData,
     flowType,
-}: ComposeYieldWithdrawTransactionParams): Promise<Result<string, YieldFeeEstimationError>> => {
+}: ComposeYieldWithdrawTransactionParams): Promise<Result<string, YieldComposeError>> => {
     const { account, receiptToken, vault } = flowData;
 
     if (account.networkType !== 'ethereum') {
@@ -264,11 +268,18 @@ const composeYieldWithdrawTransaction = async ({
         to: vaultAddress,
     });
 
+    // The withdraw moves the receipt token, but its fee comes out of the native balance — without
+    // this the transaction gets signed on the device and only then rejected by the node.
+    if (!canAffordYieldTransaction(unsignedTransaction, account.availableBalance)) {
+        return err('insufficient-native-balance');
+    }
+
     return ok(JSON.stringify(unsignedTransaction));
 };
 
 const buildYieldWithdrawFeeLevels = ({
     amount,
+    availableBalance,
     feeInfo,
     gasLimit,
     reviewToken,
@@ -287,7 +298,10 @@ const buildYieldWithdrawFeeLevels = ({
                     unsignedTransaction,
                 });
 
-                return [feeLevel.label, precomposedTransaction];
+                return [
+                    feeLevel.label,
+                    applyYieldFeeAffordability(precomposedTransaction, availableBalance),
+                ];
             }),
     );
 
@@ -410,6 +424,7 @@ export const useYieldWithdrawFees = ({
                 });
                 const withdrawFeeLevels = buildYieldWithdrawFeeLevels({
                     amount: withdrawAmount,
+                    availableBalance: withdrawFlowData.account.availableBalance,
                     feeInfo: withdrawFeeInfo,
                     gasLimit: baseFormState.feeLimit,
                     reviewToken,

--- a/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
@@ -9,6 +9,7 @@ import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import {
     type AccountsRootState,
     getMaxWrapAmount,
+    getWrappableBalanceLimit,
     selectAccountByKey,
     shouldRecommendWrapReserve,
 } from '@suite-common/wallet-core';
@@ -32,6 +33,7 @@ import { YieldTxSimulationBottomSheet } from '../components/YieldTxSimulationBot
 import { useMessageSystemWrappedNative } from '../hooks/useMessageSystemWrappedNative';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useStandaloneWrappedNativeFlow } from '../hooks/useStandaloneWrappedNativeFlow';
+import { useWrapFeeReserve } from '../hooks/useWrapFeeReserve';
 import { useWrappedNativeTokenFees } from '../hooks/useWrappedNativeTokenFees';
 import { useWrappedNativeTokenForm } from '../hooks/useWrappedNativeTokenForm';
 import { useYieldCurrencyToggleAnalytics } from '../hooks/useYieldCurrencyToggleAnalytics';
@@ -58,8 +60,15 @@ export const WrapNativeTokenScreen = () => {
         variant: wrapDisabledVariant,
     } = useMessageSystemWrappedNative('wrap');
 
+    // The wrap pays its fee out of the same native balance it wraps, so the amount is capped
+    // below the balance — wrapping all of it signs a transaction the node cannot accept.
+    const wrapFeeReserve = useWrapFeeReserve(account?.symbol);
+
     const form = useWrappedNativeTokenForm({
-        availableBalance: account?.formattedBalance ?? '0',
+        availableBalance: getWrappableBalanceLimit(
+            account?.formattedBalance ?? '0',
+            wrapFeeReserve,
+        ),
         decimals: account ? getNetwork(account.symbol).decimals : 0,
         tokenSymbol: nativeSymbol,
     });
@@ -145,7 +154,7 @@ export const WrapNativeTokenScreen = () => {
                         <WrappedNativeTokenAmountInputCard
                             amountLabel={<Translation id="earn.wrapNativeToken.amountToWrap" />}
                             balance={account.formattedBalance}
-                            maxAmount={getMaxWrapAmount(account.formattedBalance)}
+                            maxAmount={getMaxWrapAmount(account.formattedBalance, wrapFeeReserve)}
                             onCurrencyChange={reportCurrencyToggle}
                             onMaxPress={flow.reportMaxSelected}
                             symbol={account.symbol}

--- a/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
@@ -10,6 +10,7 @@ import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config
 import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import {
     getMaxWrapAmount,
+    getWrappableBalanceLimit,
     getYieldVaultContractAddress,
     shouldRecommendWrapReserve,
     stablecoinYieldActions,
@@ -43,6 +44,7 @@ import { useMessageSystemWrappedNative } from '../hooks/useMessageSystemWrappedN
 import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransactionFailureAlert';
+import { useWrapFeeReserve } from '../hooks/useWrapFeeReserve';
 import {
     type PreparedWrappedNativeTokenAction,
     useWrappedNativeTokenFees,
@@ -127,9 +129,12 @@ export const YieldDepositWrapScreen = () => {
 
     const nativeSymbol = toTokenSymbol(account ? getNetworkDisplaySymbol(account.symbol) : '');
     const nativeBalance = account?.formattedBalance ?? '0';
+    // The wrap pays its fee out of the same native balance it wraps, so the amount is capped
+    // below the balance — wrapping all of it signs a transaction the node cannot accept.
+    const wrapFeeReserve = useWrapFeeReserve(account?.symbol);
 
     const form = useWrappedNativeTokenForm({
-        availableBalance: nativeBalance,
+        availableBalance: getWrappableBalanceLimit(nativeBalance, wrapFeeReserve),
         decimals: account ? getNetwork(account.symbol).decimals : 0,
         tokenSymbol: nativeSymbol,
     });
@@ -348,7 +353,7 @@ export const YieldDepositWrapScreen = () => {
                             <WrappedNativeTokenAmountInputCard
                                 amountLabel={<Translation id="earn.wrapNativeToken.amountToWrap" />}
                                 balance={nativeBalance}
-                                maxAmount={getMaxWrapAmount(nativeBalance)}
+                                maxAmount={getMaxWrapAmount(nativeBalance, wrapFeeReserve)}
                                 onCurrencyChange={reportCurrencyToggle}
                                 onMaxPress={reportMaxSelected}
                                 symbol={account.symbol}

--- a/suite-native/module-earn/src/utils/yieldClaimFeeUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldClaimFeeUtils.ts
@@ -11,6 +11,8 @@ import { calculateTotalGasCost, fromGwei, fromIntegerString } from '@suite-commo
 import { type FeeLevel } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
+import { buildInsufficientFeeBalanceTransaction } from './yieldFeeAffordabilityUtils';
+
 type BuildYieldClaimFeeLevelsParams = {
     availableBalance: string;
     feeInfo: FeeInfo;
@@ -32,12 +34,6 @@ type YieldClaimFee = {
           maxPriorityFeePerGas?: never;
       }
 );
-
-const buildInsufficientFeeBalanceTransaction = (): PrecomposedTransaction => ({
-    type: 'error',
-    error: 'AMOUNT_IS_NOT_ENOUGH',
-    errorMessage: { id: 'AMOUNT_IS_NOT_ENOUGH' },
-});
 
 const buildYieldClaimFeeLevel = ({
     availableBalance,

--- a/suite-native/module-earn/src/utils/yieldFeeAffordabilityUtils.test.ts
+++ b/suite-native/module-earn/src/utils/yieldFeeAffordabilityUtils.test.ts
@@ -1,0 +1,60 @@
+import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { type TokenInfo } from '@trezor/blockchain-link-types';
+
+import { applyYieldFeeAffordability } from './yieldFeeAffordabilityUtils';
+
+const usdc = { contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' } as TokenInfo;
+
+const buildPrecomposedTransaction = ({
+    fee,
+    token,
+    totalSpent,
+}: {
+    fee: string;
+    token?: TokenInfo;
+    totalSpent: string;
+}): PrecomposedTransactionFinal =>
+    ({
+        type: 'final',
+        fee,
+        totalSpent,
+        token,
+    }) as PrecomposedTransactionFinal;
+
+describe('applyYieldFeeAffordability', () => {
+    // Token flows (deposit, withdraw, unwrap) spend the native coin on the fee only; `totalSpent`
+    // counts the transferred token, not the balance the fee is paid from.
+    const tokenTransaction = buildPrecomposedTransaction({
+        fee: '21000000000000',
+        token: usdc,
+        totalSpent: '1000000',
+    });
+    // A wrap moves the native coin itself, so `totalSpent` already covers amount plus fee.
+    const nativeTransaction = buildPrecomposedTransaction({
+        fee: '21000000000000',
+        totalSpent: '1021000000000000',
+    });
+
+    it('keeps a token-flow level the balance can cover', () => {
+        expect(applyYieldFeeAffordability(tokenTransaction, '21000000000000')).toBe(
+            tokenTransaction,
+        );
+    });
+
+    it('rejects a token-flow level one wei short of its fee', () => {
+        expect(applyYieldFeeAffordability(tokenTransaction, '20999999999999')).toEqual({
+            type: 'error',
+            error: 'AMOUNT_IS_NOT_ENOUGH',
+            errorMessage: { id: 'AMOUNT_IS_NOT_ENOUGH' },
+        });
+    });
+
+    it('counts the wrapped amount and the fee for a native-spending level', () => {
+        expect(applyYieldFeeAffordability(nativeTransaction, '1021000000000000')).toBe(
+            nativeTransaction,
+        );
+        expect(applyYieldFeeAffordability(nativeTransaction, '1020999999999999')).toMatchObject({
+            type: 'error',
+        });
+    });
+});

--- a/suite-native/module-earn/src/utils/yieldFeeAffordabilityUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldFeeAffordabilityUtils.ts
@@ -1,0 +1,34 @@
+import {
+    type PrecomposedTransaction,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
+
+/**
+ * Priced fee level the account cannot pay for. The fee selector turns any errored level into the
+ * "not enough <coin> to cover the transaction fee" banner and blocks the submit, which is where
+ * every yield flow has to end up — a transaction that outspends the balance would otherwise be
+ * signed on the device and only then rejected by the node.
+ */
+export const buildInsufficientFeeBalanceTransaction = (): PrecomposedTransaction => ({
+    type: 'error',
+    error: 'AMOUNT_IS_NOT_ENOUGH',
+    errorMessage: { id: 'AMOUNT_IS_NOT_ENOUGH' },
+});
+
+/**
+ * Native coin the transaction spends. `totalSpent` counts the transferred amount in the spent
+ * token's units, so it only doubles as the native spend when the transaction moves the native coin
+ * itself (a wrap); for token flows (deposit, withdraw, unwrap) the fee is the whole native cost.
+ */
+const getNativeSpend = (precomposedTransaction: PrecomposedTransactionFinal): string =>
+    precomposedTransaction.token ? precomposedTransaction.fee : precomposedTransaction.totalSpent;
+
+/** Keeps a priced fee level only while the native balance covers everything it spends. */
+export const applyYieldFeeAffordability = (
+    precomposedTransaction: PrecomposedTransactionFinal,
+    availableBalance: string,
+): PrecomposedTransaction =>
+    new BigNumber(getNativeSpend(precomposedTransaction)).gt(availableBalance)
+        ? buildInsufficientFeeBalanceTransaction()
+        : precomposedTransaction;

--- a/suite-native/module-earn/src/utils/yieldReviewOutputUtils.test.ts
+++ b/suite-native/module-earn/src/utils/yieldReviewOutputUtils.test.ts
@@ -1,0 +1,78 @@
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { WRAPPED_NATIVE, asNetworkSymbol } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { buildYieldReviewPreview } from './yieldReviewOutputUtils';
+
+const ethSymbol = asNetworkSymbol('eth');
+const WETH = WRAPPED_NATIVE.eth!;
+
+const account = mockWalletAccount({ symbol: ethSymbol }) as Account;
+
+const buildUnsignedTransaction = (data: string, value?: string) =>
+    JSON.stringify({
+        from: '0x1111111111111111111111111111111111111111',
+        to: WETH.address,
+        data,
+        chainId: 1,
+        gasLimit: '0x7530',
+        nonce: '0x1',
+        maxFeePerGas: '0x3b9aca00',
+        maxPriorityFeePerGas: '0x3b9aca00',
+        ...(value ? { value } : {}),
+    });
+
+const nativeToken = {
+    networkSymbol: ethSymbol,
+    symbol: 'ETH',
+    decimals: 18,
+    contractAddress: null,
+};
+
+const wrappedNativeToken = {
+    networkSymbol: ethSymbol,
+    symbol: WETH.symbol,
+    decimals: WETH.decimals,
+    contractAddress: WETH.address,
+};
+
+const t1b1Device = mockSuiteDevice(undefined, {
+    internal_model: DeviceModelInternal.T1B1,
+    major_version: 1,
+    minor_version: 13,
+    patch_version: 0,
+});
+
+describe('buildYieldReviewPreview', () => {
+    // T1B1 firmware is 1.x, so it always blind-signs the wrap/unwrap through the legacy review
+    // flow. Its outputs still have to stay within the types the earn review renders, otherwise
+    // the preview is discarded and the review screen renders blank.
+    it.each([
+        {
+            flowType: 'wrap' as const,
+            reviewToken: nativeToken,
+            unsignedTransaction: buildUnsignedTransaction('0xd0e30db0', '0xde0b6b3a7640000'),
+        },
+        {
+            flowType: 'unwrap' as const,
+            reviewToken: wrappedNativeToken,
+            unsignedTransaction: buildUnsignedTransaction(`0x2e1a7d4d${'00'.repeat(32)}`),
+        },
+    ])(
+        'builds a $flowType preview for a T1B1 device',
+        ({ flowType, reviewToken, unsignedTransaction }) => {
+            const preview = buildYieldReviewPreview({
+                account,
+                device: t1b1Device,
+                review: { amount: '1', unsignedTransaction },
+                reviewToken,
+                type: flowType,
+            });
+
+            expect(preview?.evmTransactionPurpose).toBe(flowType);
+            expect(preview?.outputs.map(output => output.type)).toEqual(['regular_legacy', 'data']);
+        },
+    );
+});

--- a/suite-native/module-earn/src/utils/yieldReviewOutputUtils.test.ts
+++ b/suite-native/module-earn/src/utils/yieldReviewOutputUtils.test.ts
@@ -1,8 +1,11 @@
+import { Calldata, asEvmAddress } from '@suite-common/calldata';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { WRAPPED_NATIVE, asNetworkSymbol } from '@suite-common/wallet-config';
+import { type StablecoinYieldActionReviewState } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { buildYieldReviewPreview } from './yieldReviewOutputUtils';
 
@@ -75,4 +78,54 @@ describe('buildYieldReviewPreview', () => {
             expect(preview?.outputs.map(output => output.type)).toEqual(['regular_legacy', 'data']);
         },
     );
+
+    // A claim review that cannot be built is reported to the user as "reward details didn't match
+    // the transaction", so the legacy T1B1 outputs have to stay within the rendered types too.
+    it('builds a claim preview for a T1B1 device', () => {
+        const claimUser = asEvmAddress('0x1111111111111111111111111111111111111111');
+        const rewardToken = asEvmAddress('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
+        const claimData = Calldata.evm.distributor.claim.encode(
+            {
+                users: [claimUser],
+                tokens: [rewardToken],
+                amounts: [new BigNumber(1)],
+                proofs: [[]],
+            },
+            { sender: claimUser },
+        ).data;
+        const review = {
+            type: 'claim',
+            rewards: [
+                {
+                    token: {
+                        networkSymbol: ethSymbol,
+                        symbol: 'USDC',
+                        decimals: 6,
+                        contractAddress: rewardToken,
+                    },
+                    value: '1',
+                    fiatValue: '1',
+                },
+            ],
+            unsignedTransaction: {
+                to: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
+                data: claimData,
+                chainId: 1,
+                gasLimit: '21000',
+                maxFeePerGas: '2000000000',
+                maxPriorityFeePerGas: '1000000000',
+                nonce: '10',
+            },
+        } as Extract<StablecoinYieldActionReviewState, { type: 'claim' }>;
+
+        const preview = buildYieldReviewPreview({
+            account,
+            device: t1b1Device,
+            review,
+            type: 'claim',
+        });
+
+        expect(preview?.evmTransactionPurpose).toBe('claim');
+        expect(preview?.outputs.map(output => output.type)).toEqual(['regular_legacy', 'data']);
+    });
 });

--- a/suite-native/module-earn/src/yieldDepositFeeUtils.test.ts
+++ b/suite-native/module-earn/src/yieldDepositFeeUtils.test.ts
@@ -9,6 +9,10 @@ import {
     buildYieldDepositSelectedFeeUnsignedTransaction,
 } from './yieldDepositFeeUtils';
 
+// Comfortably above every fee the fixtures price, so levels stay affordable unless a test says
+// otherwise.
+const AVAILABLE_BALANCE = '1000000000000000000';
+
 const baseUnsignedTransaction = {
     from: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
     to: '0xbEef047a543E45807105E51A8BBEFCc5950fcfBa',
@@ -132,6 +136,7 @@ describe('buildYieldDepositFeeLevels', () => {
     it('derives EIP-1559 fee levels from the base deposit transaction', () => {
         const result = buildYieldDepositFeeLevels({
             amount: '1.25',
+            availableBalance: AVAILABLE_BALANCE,
             feeInfo: eip1559FeeInfo,
             gasLimit: '21000',
             symbol: 'eth' as NetworkSymbol,
@@ -171,6 +176,65 @@ describe('buildYieldDepositFeeLevels', () => {
             maxPriorityFeePerGas: '1',
         });
         expect(result.custom).toBeUndefined();
+    });
+
+    // Fee levels the native balance cannot pay for are offered as errors so the fee selector shows
+    // the "insufficient coin for the fee" banner and blocks the submit, instead of letting the
+    // device sign a transaction the node will reject.
+    it('prices a level the native balance cannot cover as unaffordable', () => {
+        const result = buildYieldDepositFeeLevels({
+            amount: '1.25',
+            // One wei short of the normal level's 21000000000000 fee.
+            availableBalance: '20999999999999',
+            feeInfo: eip1559FeeInfo,
+            gasLimit: '21000',
+            symbol: 'eth' as NetworkSymbol,
+            token: {
+                contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+                decimals: 6,
+                symbol: 'USDC',
+            },
+            unsignedTransaction: JSON.stringify({
+                ...baseUnsignedTransaction,
+                type: 2,
+                maxFeePerGas: '0x3b9aca00',
+                maxPriorityFeePerGas: '0x1dcd6500',
+            }),
+        });
+
+        expect(result.normal).toEqual({
+            type: 'error',
+            error: 'AMOUNT_IS_NOT_ENOUGH',
+            errorMessage: { id: 'AMOUNT_IS_NOT_ENOUGH' },
+        });
+    });
+
+    // A wrap spends the native coin in the transaction value, so the balance has to cover the
+    // wrapped amount and the fee together.
+    it('counts the wrapped amount when the transaction spends the native coin', () => {
+        const buildNativeLevels = (availableBalance: string) =>
+            buildYieldDepositFeeLevels({
+                amount: '0.001',
+                availableBalance,
+                feeInfo: eip1559FeeInfo,
+                gasLimit: '21000',
+                symbol: 'eth' as NetworkSymbol,
+                token: { contractAddress: null, decimals: 18, symbol: 'ETH' },
+                unsignedTransaction: JSON.stringify({
+                    ...baseUnsignedTransaction,
+                    type: 2,
+                    maxFeePerGas: '0x3b9aca00',
+                    maxPriorityFeePerGas: '0x1dcd6500',
+                }),
+            });
+
+        // 0.001 ETH + the 21000000000000 wei fee.
+        expect(buildNativeLevels('1021000000000000')).toMatchObject({
+            normal: { type: 'final' },
+        });
+        expect(buildNativeLevels('1020999999999999')).toMatchObject({
+            normal: { type: 'error', error: 'AMOUNT_IS_NOT_ENOUGH' },
+        });
     });
 });
 
@@ -335,6 +399,7 @@ describe('buildYieldDepositFeeDraftState', () => {
     it('adds a custom fee level when the custom fee draft is complete', () => {
         const result = buildYieldDepositFeeDraftState({
             amount: '1.25',
+            availableBalance: AVAILABLE_BALANCE,
             currentFormDraft: buildFormDraft({
                 selectedFee: 'custom',
                 feePerUnit: '7',

--- a/suite-native/module-earn/src/yieldDepositFeeUtils.ts
+++ b/suite-native/module-earn/src/yieldDepositFeeUtils.ts
@@ -11,6 +11,8 @@ import {
 } from '@suite-common/wallet-types';
 import { calculateTotalGasCost, fromHex } from '@suite-common/wallet-utils';
 
+import { applyYieldFeeAffordability } from './utils/yieldFeeAffordabilityUtils';
+
 type ParsedUnsignedEvmTransaction = NonNullable<
     ReturnType<typeof parseUnsignedEvmTransactionForSigning>
 >;
@@ -23,6 +25,8 @@ export type YieldDepositFeeToken = {
 
 type BuildYieldDepositFeeLevelsParams = {
     amount: string;
+    /** Native balance in subunits; levels that outspend it are offered as unaffordable. */
+    availableBalance: string;
     feeInfo: FeeInfo;
     gasLimit: string;
     symbol: NetworkSymbol;
@@ -188,6 +192,7 @@ export const buildYieldDepositFeePreview = (
 
 export const buildYieldDepositFeeLevels = ({
     amount,
+    availableBalance,
     feeInfo,
     gasLimit,
     symbol,
@@ -206,7 +211,10 @@ export const buildYieldDepositFeeLevels = ({
                     unsignedTransaction,
                 });
 
-                return [feeLevel.label, precomposedTransaction];
+                return [
+                    feeLevel.label,
+                    applyYieldFeeAffordability(precomposedTransaction, availableBalance),
+                ];
             }),
     );
 


### PR DESCRIPTION
## Description

Fix wrap/unwrap tx review flow for Model One

## Related Issue

## Screenshots:

https://github.com/user-attachments/assets/cc46a3c4-253b-477e-a8d9-423358b24f78

https://github.com/user-attachments/assets/48fc8d2a-5305-4b63-833f-52d5361da5f9

<img width="386" height="799" alt="Screenshot 2026-08-19 at 15 32 46" src="https://github.com/user-attachments/assets/f26788aa-a6e4-4878-b087-afe6035473ea" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in suite-native/module-earn (mobile-native earn screens and hooks) and shared stablecoin-yield utilities in suite-common. The desktop E2E suite has no dedicated stablecoin-yield functional tests, so direct high-priority coverage is unavailable. The main E2E risk is that changes to shared suite-common code could break rendering or navigation of the /earn/yield/* routes; the check-links test provides a lightweight smoke check for this. All other changed files are either unit tests, mobile-native code outside the desktop E2E scope, or broad shared utilities with only transitive static coverage.

<details><summary><b>Changed files (23)</b></summary>

- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldFeeEstimation.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`
- `suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts`
- `suite-native/module-earn/src/hooks/usePreparedTxFees.ts`
- `suite-native/module-earn/src/hooks/useWrapFeeReserve.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeTokenFees.ts`
- `suite-native/module-earn/src/hooks/useYieldDepositFees.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts`
- `suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx`
- `suite-native/module-earn/src/utils/yieldClaimFeeUtils.ts`
- `suite-native/module-earn/src/utils/yieldFeeAffordabilityUtils.test.ts`
- `suite-native/module-earn/src/utils/yieldFeeAffordabilityUtils.ts`
- `suite-native/module-earn/src/utils/yieldReviewOutputUtils.test.ts`
- `suite-native/module-earn/src/yieldDepositFeeUtils.test.ts`
- `suite-native/module-earn/src/yieldDepositFeeUtils.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to all application routes including the earn/yield routes (/earn/yield/deposit, /earn/yield/withdraw, /earn/yield/claim, /earn/yield/wrap, /earn/yield/unwrap) and verifies each page loads without errors. Changes to shared stablecoin-yield utilities in suite-common/wallet-core could introduce runtime errors on these routes, so check-links acts as a smoke test for the affected feature area.

</details>

⚠️ **Changes with no test coverage (18)**
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts`
- `suite-native/module-earn/src/hooks/usePreparedTxFees.ts`
- `suite-native/module-earn/src/hooks/useWrapFeeReserve.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeTokenFees.ts`
- `suite-native/module-earn/src/hooks/useYieldDepositFees.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts`
- `suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx`
- `suite-native/module-earn/src/utils/yieldClaimFeeUtils.ts`
- `suite-native/module-earn/src/utils/yieldFeeAffordabilityUtils.test.ts`
- `suite-native/module-earn/src/utils/yieldFeeAffordabilityUtils.ts`
- `suite-native/module-earn/src/utils/yieldReviewOutputUtils.test.ts`
- `suite-native/module-earn/src/yieldDepositFeeUtils.test.ts`
- `suite-native/module-earn/src/yieldDepositFeeUtils.ts`

_Updated: 2026-08-19T14:11:13.097Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/yield-model-one&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/yield-model-one&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/yield-model-one&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T14:12:25.756Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T13:42:41.958Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/yield-model-one/web/](https://dev.suite.sldev.cz/suite-web/fix/native/yield-model-one/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->