### PR TITLE
fix(connect): `createThpSession` cancel passphrase using empty payload

### DIFF
--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -321,7 +321,7 @@ describe('THP pairing', () => {
         if (result.success) throw ERR;
         expect(result.error.message).toMatch(FW_CANCEL_ERR);
 
-        // 5. reject passphrase from host
+        // 5. reject passphrase from host using TrezorConnect.cancel()
         TrezorConnect.removeAllListeners('ui-request_passphrase');
         TrezorConnect.removeAllListeners('ui-button');
         TrezorConnect.on('ui-button', buttonRequestHandler());
@@ -337,7 +337,28 @@ describe('THP pairing', () => {
         if (result.success) throw ERR;
         expect(result.error.message).toMatch(CANCEL_ERR);
 
-        // 6. reject passphrase from Trezor
+        // 6. reject passphrase from host using empty payload
+        TrezorConnect.removeAllListeners('ui-request_passphrase');
+        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.on('ui-button', buttonRequestHandler());
+        TrezorConnect.on('ui-request_passphrase', () => {
+            // @ts-expect-error payload is missing
+            TrezorConnect.uiResponse({
+                type: 'ui-receive_passphrase',
+            });
+        });
+        result = await TrezorConnect.getAddress({
+            device: {
+                ...device,
+                instance: 1,
+            },
+            path: "m/44'/0'/0'/1/1",
+            showOnTrezor: true,
+        });
+        if (result.success) throw ERR;
+        expect(result.error.code).toMatch('Method_Cancel');
+
+        // 7. reject passphrase from Trezor
         TrezorConnect.removeAllListeners('ui-request_passphrase');
         TrezorConnect.removeAllListeners('ui-button');
         TrezorConnect.on('ui-request_passphrase', enterPassphraseOnHost('a'));

--- a/packages/connect/src/device/thp/session.ts
+++ b/packages/connect/src/device/thp/session.ts
@@ -1,3 +1,4 @@
+import { DEVICE, ERRORS } from '@trezor/connect-common';
 import type { thp as protocolThp } from '@trezor/protocol';
 
 import { thpCall } from './thpCall';
@@ -9,9 +10,9 @@ export const createThpSession = async (device: IDevice, deriveCardano: boolean) 
         passphrase = { passphrase: '' };
     } else {
         // same flow as DeviceCurrentSession PassphraseRequest
-        passphrase = await device.prompt('passphrase', {}).then(promptRes => {
+        passphrase = await device.prompt(DEVICE.PASSPHRASE, {}).then(promptRes => {
             if (!promptRes.success) {
-                return { passphrase: '' };
+                throw ERRORS.TypedError('Method_Cancel');
             }
 
             return promptRes.payload.passphraseOnDevice


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cancelled passphrase prompt (cancelled by not passing the payload - which is not used in suite and not allowed by typescript - yet still possible in runtime) is treated as empty passphrase

Except for added e2e tests could be verified using `connect-cli`

with emulator:
`yarn workspace @trezor/connect-cli udp --debug --cancel-passphrase-ui --credentials`

or real device:
`yarn workspace @trezor/connect-cli usb --debug --cancel-passphrase-ui --credentials`

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/thp-passphrase-cancel/web/](https://dev.suite.sldev.cz/suite-web/fix/thp-passphrase-cancel/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly scoped to THP session/pairing logic. Risk is concentrated in THP pairing flows during onboarding, especially for T3W1. I recommend running the dedicated connect THP pairing test plus the few suite onboarding tests that explicitly traverse THP pairing, while avoiding the large static fan-out of unrelated suite tests.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/e2e/tests/device/thpPairing.test.ts`
- `packages/connect/src/device/thp/session.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `packages/connect/e2e/tests/device/thpPairing.test.ts` — This test directly exercises the THP pairing/session logic and was itself modified, so it is the most targeted validation of the change.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The test explicitly handles the THP pairing code flow during onboarding; a regression in the THP session logic would likely prevent it from reaching the dashboard.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — It performs device pairing via THP (Trezor Host Protocol) while creating a wallet, directly depending on the changed THP session implementation.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test opens the guide panel during an onboarding flow that includes firmware checks and THP pairing, so it shares the same pairing-dependent onboarding path.
- `suite/e2e/tests/suite/initial-run.test.ts` — It verifies initial-run onboarding behavior and explicitly involves THP pairing code entry, making it sensitive to THP session changes.

</details>

_Updated: 2026-08-19T13:28:40.254Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-passphrase-cancel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-passphrase-cancel&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-passphrase-cancel&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T13:30:10.960Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T13:29:22.284Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->