### PR TITLE
feat(connect): support Soroban InvokeHostFunction Stellar operation

### DIFF
--- a/networks/stellar/network-stellar/src/runtime/transactions/transactions.test.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/transactions.test.ts
@@ -1,9 +1,79 @@
+import {
+    Account,
+    Address,
+    Networks,
+    Operation,
+    TransactionBuilder,
+    nativeToScVal,
+    xdr,
+} from '@stellar/stellar-sdk';
+
 import { BigNumber } from '@trezor/utils';
 
 import { toStroops } from '../../constants';
 import * as fixtures from './__fixtures__/transactions.fixture';
 
 import { buildSendTransaction, transformTransaction } from './index';
+
+const SOURCE = 'GBRF6PKZYP4J4WI2A3NF4CGF23SL34GRKA5LTQZCQFEUT2YJDZO2COXH';
+const CONTRACT = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+const AUTH_ADDRESS = 'GDNSSYSCSSJ76FER5WEEXME5G4MTCUBKDRQSKOYP36KUKVDB2VCMERS6';
+// A sint64 nonce above Number.MAX_SAFE_INTEGER, to prove full precision is preserved.
+const NONCE = '6216415363851494999';
+
+const buildSorobanData = () =>
+    new xdr.SorobanTransactionData({
+        ext: new xdr.SorobanTransactionDataExt(0),
+        resources: new xdr.SorobanResources({
+            footprint: new xdr.LedgerFootprint({ readOnly: [], readWrite: [] }),
+            instructions: 0,
+            diskReadBytes: 0,
+            writeBytes: 0,
+        }),
+        resourceFee: xdr.Int64.fromString('100'),
+    });
+
+const buildAuthEntry = () => {
+    const contractFn = new xdr.InvokeContractArgs({
+        contractAddress: new Address(CONTRACT).toScAddress(),
+        functionName: 'transfer',
+        args: [nativeToScVal(1000, { type: 'i128' })],
+    });
+
+    return new xdr.SorobanAuthorizationEntry({
+        credentials: xdr.SorobanCredentials.sorobanCredentialsAddressV2(
+            new xdr.SorobanAddressCredentials({
+                address: new Address(AUTH_ADDRESS).toScAddress(),
+                nonce: xdr.Int64.fromString(NONCE),
+                signatureExpirationLedger: 5000,
+                signature: xdr.ScVal.scvVoid(),
+            }),
+        ),
+        rootInvocation: new xdr.SorobanAuthorizedInvocation({
+            function:
+                xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(contractFn),
+            subInvocations: [],
+        }),
+    });
+};
+
+const buildInvokeHostFunctionTx = () => {
+    const op = Operation.invokeContractFunction({
+        contract: CONTRACT,
+        function: 'hello',
+        args: [nativeToScVal(1, { type: 'u32' }), nativeToScVal('sym', { type: 'symbol' })],
+        auth: [buildAuthEntry()],
+    });
+
+    return new TransactionBuilder(new Account(SOURCE, '1'), {
+        fee: '1000',
+        networkPassphrase: Networks.PUBLIC,
+    })
+        .addOperation(op)
+        .setSorobanData(buildSorobanData())
+        .setTimeout(0)
+        .build();
+};
 
 describe('transactions', () => {
     describe('toStroops', () => {
@@ -40,6 +110,67 @@ describe('transactions', () => {
                 });
                 expect(result).toEqual(expectedOutput);
             });
+        });
+    });
+
+    describe('transformTransaction (Soroban InvokeHostFunction)', () => {
+        const tx = buildInvokeHostFunctionTx();
+        const result = transformTransaction(tx);
+
+        it('transforms the invoke host function operation', () => {
+            expect(result.operations).toEqual([
+                {
+                    type: 'invokeHostFunction',
+                    source: undefined,
+                    function: {
+                        type: 0, // HOST_FUNCTION_TYPE_INVOKE_CONTRACT
+                        invoke_contract: {
+                            contract_address: CONTRACT,
+                            function_name: 'hello',
+                            args: [
+                                { type: 3, u32: 1 }, // SCV_U32
+                                { type: 15, symbol: 'sym' }, // SCV_SYMBOL
+                            ],
+                        },
+                    },
+                    auth: [
+                        {
+                            credentials: {
+                                type: 2, // SOROBAN_CREDENTIALS_ADDRESS_V2
+                                address_v2: {
+                                    address: AUTH_ADDRESS,
+                                    nonce: NONCE,
+                                    signature_expiration_ledger: 5000,
+                                    signature: { type: 1 }, // SCV_VOID
+                                },
+                            },
+                            root_invocation: {
+                                function: {
+                                    type: 0, // SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN
+                                    contract_fn: {
+                                        contract_address: CONTRACT,
+                                        function_name: 'transfer',
+                                        args: [{ type: 10, i128: { hi: '0', lo: '1000' } }], // SCV_I128
+                                    },
+                                },
+                                sub_invocations: [],
+                            },
+                        },
+                    ],
+                },
+            ]);
+        });
+
+        it('preserves the sint64 nonce as a full-precision string', () => {
+            const { nonce } = (result.operations[0] as any).auth[0].credentials.address_v2;
+            expect(nonce).toBe(NONCE);
+            expect(Number(nonce).toString()).not.toBe(NONCE); // would lose precision as a number
+        });
+
+        it('exposes the SorobanTransactionData as hex', () => {
+            const ext = tx.tx.ext();
+            const expected = 'sorobanData' in ext ? ext.sorobanData().toXDR('hex') : undefined;
+            expect(result.sorobanData).toBe(expected);
         });
     });
 });

--- a/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
@@ -1,6 +1,7 @@
 // Former connect-plugin-stellar
 
 import {
+    Address,
     Asset,
     Keypair,
     type Memo,
@@ -8,11 +9,211 @@ import {
     MemoID,
     MemoReturn,
     MemoText,
+    type Operation,
     type Signer,
     type Transaction,
+    type xdr,
 } from '@stellar/stellar-sdk';
 
 import { toStroops } from '../../constants';
+
+// The protobuf Soroban enums mirror the Stellar XDR enums, so the XDR discriminant
+// (`x.switch().value`) is used directly as the protobuf `type`.
+
+/**
+ * Reads an SCAddress (account or contract) into its Stellar string form (G.../C...).
+ */
+const readScAddress = (address: xdr.ScAddress) => Address.fromScAddress(address).toString();
+
+/**
+ * Reads an SCVal from XDR into the protobuf StellarSCVal shape.
+ * bytes-typed fields (bytes, string) are hex strings; 64-bit ints are decimal strings.
+ */
+const readScVal = (val: xdr.ScVal): any => {
+    const type = val.switch().value;
+
+    switch (val.switch().name) {
+        case 'scvBool':
+            return { type, b: val.b() };
+        case 'scvVoid':
+            return { type };
+        case 'scvU32':
+            return { type, u32: val.u32() };
+        case 'scvI32':
+            return { type, i32: val.i32() };
+        case 'scvU64':
+            return { type, u64: val.u64().toString() };
+        case 'scvI64':
+            return { type, i64: val.i64().toString() };
+        case 'scvTimepoint':
+            return { type, timepoint: val.timepoint().toString() };
+        case 'scvDuration':
+            return { type, duration: val.duration().toString() };
+        case 'scvU128': {
+            const parts = val.u128();
+
+            return { type, u128: { hi: parts.hi().toString(), lo: parts.lo().toString() } };
+        }
+        case 'scvI128': {
+            const parts = val.i128();
+
+            return { type, i128: { hi: parts.hi().toString(), lo: parts.lo().toString() } };
+        }
+        case 'scvU256': {
+            const parts = val.u256();
+
+            return {
+                type,
+                u256: {
+                    hi_hi: parts.hiHi().toString(),
+                    hi_lo: parts.hiLo().toString(),
+                    lo_hi: parts.loHi().toString(),
+                    lo_lo: parts.loLo().toString(),
+                },
+            };
+        }
+        case 'scvI256': {
+            const parts = val.i256();
+
+            return {
+                type,
+                i256: {
+                    hi_hi: parts.hiHi().toString(),
+                    hi_lo: parts.hiLo().toString(),
+                    lo_hi: parts.loHi().toString(),
+                    lo_lo: parts.loLo().toString(),
+                },
+            };
+        }
+        case 'scvBytes':
+            return { type, bytes: val.bytes().toString('hex') };
+        case 'scvString':
+            // The bytes in an SCString are not necessarily valid UTF-8, so keep them as hex.
+            return { type, string: val.str().toString('hex') };
+        case 'scvSymbol':
+            return { type, symbol: val.sym().toString() };
+        case 'scvVec': {
+            const vec = val.vec();
+            // A null vector is not a valid Soroban value; rejecting it avoids signing bytes
+            // that differ from the input XDR (the firmware always encodes the vector as present).
+            if (!vec) {
+                throw new Error('SCV_VEC with a null vector is not supported');
+            }
+
+            return { type, vec: vec.map(readScVal) };
+        }
+        case 'scvMap': {
+            const map = val.map();
+            if (!map) {
+                throw new Error('SCV_MAP with a null map is not supported');
+            }
+
+            return {
+                type,
+                map: map.map(entry => ({
+                    key: readScVal(entry.key()),
+                    value: readScVal(entry.val()),
+                })),
+            };
+        }
+        case 'scvAddress':
+            return { type, address: readScAddress(val.address()) };
+        default:
+            throw new Error(`Unsupported SCVal type: ${val.switch().name}`);
+    }
+};
+
+/**
+ * Reads InvokeContractArgs (contract address, function name and arguments) from XDR.
+ */
+const readInvokeContractArgs = (data: xdr.InvokeContractArgs) => ({
+    contract_address: readScAddress(data.contractAddress()),
+    function_name: data.functionName().toString(),
+    args: data.args().map(readScVal),
+});
+
+/**
+ * Reads a HostFunction from XDR. Only the invoke-contract host function is supported.
+ */
+const readHostFunction = (hostFunction: xdr.HostFunction) => {
+    if (hostFunction.switch().name !== 'hostFunctionTypeInvokeContract') {
+        throw new Error(`Unsupported host function type: ${hostFunction.switch().name}`);
+    }
+
+    return {
+        type: hostFunction.switch().value,
+        invoke_contract: readInvokeContractArgs(hostFunction.invokeContract()),
+    };
+};
+
+/**
+ * Reads a SorobanAuthorizedFunction from XDR. Only the contract-fn variant is supported.
+ */
+const readAuthorizedFunction = (fn: xdr.SorobanAuthorizedFunction) => {
+    if (fn.switch().name !== 'sorobanAuthorizedFunctionTypeContractFn') {
+        throw new Error(`Unsupported SorobanAuthorizedFunction type: ${fn.switch().name}`);
+    }
+
+    return {
+        type: fn.switch().value,
+        contract_fn: readInvokeContractArgs(fn.contractFn()),
+    };
+};
+
+/**
+ * Reads a SorobanAuthorizedInvocation tree from XDR (recurses into sub-invocations).
+ */
+const readAuthorizedInvocation = (invocation: xdr.SorobanAuthorizedInvocation): any => ({
+    function: readAuthorizedFunction(invocation.function()),
+    sub_invocations: invocation.subInvocations().map(readAuthorizedInvocation),
+});
+
+/**
+ * Reads SorobanAddressCredentials from XDR.
+ */
+const readAddressCredentials = (credentials: xdr.SorobanAddressCredentials) => ({
+    address: readScAddress(credentials.address()),
+    // Nonce is a random sint64; keep it as a string to preserve full precision.
+    nonce: credentials.nonce().toString(),
+    signature_expiration_ledger: credentials.signatureExpirationLedger(),
+    signature: readScVal(credentials.signature()),
+});
+
+/**
+ * Reads SorobanCredentials from XDR. Only source-account and address-v2 credentials are
+ * supported; the legacy (to-be-deprecated) address credentials are intentionally rejected.
+ */
+const readCredentials = (credentials: xdr.SorobanCredentials) => {
+    switch (credentials.switch().name) {
+        case 'sorobanCredentialsSourceAccount':
+            return { type: credentials.switch().value };
+        case 'sorobanCredentialsAddressV2':
+            return {
+                type: credentials.switch().value,
+                address_v2: readAddressCredentials(credentials.addressV2()),
+            };
+        default:
+            throw new Error(`Unsupported SorobanCredentials type: ${credentials.switch().name}`);
+    }
+};
+
+/**
+ * Reads a SorobanAuthorizationEntry from XDR.
+ */
+const readAuthorizationEntry = (entry: xdr.SorobanAuthorizationEntry) => ({
+    credentials: readCredentials(entry.credentials()),
+    root_invocation: readAuthorizedInvocation(entry.rootInvocation()),
+});
+
+/**
+ * Transforms an InvokeHostFunction operation into the protobuf-shaped connect operation.
+ */
+const transformInvokeHostFunction = (op: Operation.InvokeHostFunction) => ({
+    type: 'invokeHostFunction',
+    source: op.source,
+    function: readHostFunction(op.func),
+    auth: (op.auth ?? []).map(readAuthorizationEntry),
+});
 
 /**
  * Transforms Signer to TrezorConnect.StellarTransaction.Signer
@@ -108,6 +309,12 @@ export const transformTransaction = (transaction: Transaction) => {
     const assets = ['asset', 'sendAsset', 'destAsset', 'selling', 'buying', 'line'];
 
     const operations = transaction.operations.map((o, i) => {
+        // Soroban operations carry XDR structures that need bespoke handling, not the generic
+        // asset/amount field processing below.
+        if (o.type === 'invokeHostFunction') {
+            return transformInvokeHostFunction(o);
+        }
+
         const operation: any = { ...o };
 
         // stellar-sdk 16 returns null for absent optional setOptions fields; connect expects
@@ -174,6 +381,13 @@ export const transformTransaction = (transaction: Transaction) => {
         return operation;
     });
 
+    // Soroban transactions carry a transaction extension (SorobanTransactionData) that the
+    // device signs over; expose it as raw XDR (hex) for the StellarTxExt message. Only the v1
+    // envelope (TransactionExt) has it; the legacy v0 envelope never does.
+    const ext = transaction.tx.ext();
+    const sorobanData =
+        'sorobanData' in ext && ext.switch() === 1 ? ext.sorobanData().toXDR('hex') : undefined;
+
     return {
         source: transaction.source,
         fee: Number.parseInt(transaction.fee, 10),
@@ -181,5 +395,6 @@ export const transformTransaction = (transaction: Transaction) => {
         memo: transformMemo(transaction.memo),
         timebounds: transformTimebounds(transaction.timeBounds),
         operations,
+        ...(sorobanData && { sorobanData }),
     };
 };

--- a/packages/connect-common/src/types/api/stellar.type-test.ts
+++ b/packages/connect-common/src/types/api/stellar.type-test.ts
@@ -328,7 +328,46 @@ export const stellarSignTransaction = async (api: TrezorConnect) => {
                     balanceId:
                         '00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9',
                 },
+                {
+                    type: 'invokeHostFunction',
+                    function: {
+                        type: 0,
+                        invoke_contract: {
+                            contract_address:
+                                'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE',
+                            function_name: 'hello',
+                            args: [{ type: 3, u32: 1 }],
+                        },
+                    },
+                    auth: [
+                        {
+                            credentials: {
+                                type: 2,
+                                address_v2: {
+                                    address:
+                                        'GDNSSYSCSSJ76FER5WEEXME5G4MTCUBKDRQSKOYP36KUKVDB2VCMERS6',
+                                    nonce: '6216415363851494999',
+                                    signature_expiration_ledger: 5000,
+                                    signature: { type: 1 },
+                                },
+                            },
+                            root_invocation: {
+                                function: {
+                                    type: 0,
+                                    contract_fn: {
+                                        contract_address:
+                                            'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE',
+                                        function_name: 'transfer',
+                                        args: [{ type: 10, i128: { hi: '0', lo: '1000' } }],
+                                    },
+                                },
+                                sub_invocations: [],
+                            },
+                        },
+                    ],
+                },
             ],
+            sorobanData: 'deadbeef',
         },
     });
 

--- a/packages/connect-common/src/types/api/stellar/common.ts
+++ b/packages/connect-common/src/types/api/stellar/common.ts
@@ -181,6 +181,17 @@ export const StellarClaimClaimableBalanceOperation = Type.Object({
     balanceId: Type.String(), // Proto: "balance_id"
 });
 
+// Soroban smart-contract invocation. Unlike the classic operations, its payload has no
+// simpler representation than the on-wire XDR, so `function` and `auth` reuse the protobuf
+// structures directly. network-stellar walks the parsed XDR into this shape.
+export type StellarInvokeHostFunctionOperation = Static<typeof StellarInvokeHostFunctionOperation>;
+export const StellarInvokeHostFunctionOperation = Type.Object({
+    type: Type.Literal('invokeHostFunction'), // Proto: "StellarInvokeHostFunctionOp"
+    source: Type.Optional(Type.String()), // Proto: "source_account"
+    function: PROTO.StellarHostFunction, // Proto: "function"
+    auth: Type.Array(PROTO.StellarSorobanAuthorizationEntry), // Proto: "auth"
+});
+
 // [typescript-performace]: Keep this explicit type to prevent TypeScript from expanding the
 // inferred type in the emitted declaration.
 export type StellarOperation =
@@ -198,7 +209,8 @@ export type StellarOperation =
     | StellarInflationOperation
     | StellarManageDataOperation
     | StellarBumpSequenceOperation
-    | StellarClaimClaimableBalanceOperation;
+    | StellarClaimClaimableBalanceOperation
+    | StellarInvokeHostFunctionOperation;
 
 export const StellarOperation: TUnsafe<StellarOperation> = Type.Union([
     StellarCreateAccountOperation,
@@ -216,6 +228,7 @@ export const StellarOperation: TUnsafe<StellarOperation> = Type.Union([
     StellarManageDataOperation,
     StellarBumpSequenceOperation,
     StellarClaimClaimableBalanceOperation,
+    StellarInvokeHostFunctionOperation,
 ]);
 
 export type StellarTransaction = Static<typeof StellarTransaction>;
@@ -238,6 +251,9 @@ export const StellarTransaction = Type.Object({
         }),
     ),
     operations: Type.Array(StellarOperation), // Proto: calculated array length > "num_operations"
+    // Raw SorobanTransactionData XDR (hex), required for Soroban (InvokeHostFunction)
+    // transactions. Sent to the device as StellarTxExt after the operations.
+    sorobanData: Type.Optional(Type.String()), // Proto: StellarTxExt.soroban_data
 });
 
 export type StellarSignTransaction = Static<typeof StellarSignTransaction>;
@@ -298,6 +314,10 @@ export type StellarOperationMessage =
     | StellarOperationMessageOf<
           'StellarClaimClaimableBalanceOp',
           typeof PROTO.StellarClaimClaimableBalanceOp
+      >
+    | StellarOperationMessageOf<
+          'StellarInvokeHostFunctionOp',
+          typeof PROTO.StellarInvokeHostFunctionOp
       >;
 
 export const StellarOperationMessage: TUnsafe<StellarOperationMessage> = Type.Union([
@@ -384,5 +404,11 @@ export const StellarOperationMessage: TUnsafe<StellarOperationMessage> = Type.Un
             type: Type.Literal('StellarClaimClaimableBalanceOp'),
         }),
         PROTO.StellarClaimClaimableBalanceOp,
+    ]),
+    Type.Intersect([
+        Type.Object({
+            type: Type.Literal('StellarInvokeHostFunctionOp'),
+        }),
+        PROTO.StellarInvokeHostFunctionOp,
     ]),
 ]);

--- a/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
@@ -141,6 +141,12 @@ const transformOperation = (op: any) => {
     }
 };
 
+// Soroban (StellarInvokeHostFunctionOp) signing was added in firmware 2.12.4.
+const SOROBAN_MIN_FIRMWARE = '2.12.4';
+
+const isInvokeHostFunctionTest = (parameters: any) =>
+    parameters.operations?.some((op: any) => op._message_type === 'StellarInvokeHostFunctionOp');
+
 const legacyResults = [
     {
         rules: ['<2.4.3'],
@@ -185,6 +191,20 @@ const legacyResultsMap: Record<string, LegacyResult[]> = {
     ],
 };
 
+const getLegacyResults = (name: string, result: any): LegacyResult[] => {
+    if (legacyResultsMap[name]) {
+        return legacyResultsMap[name];
+    }
+    // Soroban signing (success cases) only works from firmware 2.12.4 onwards. The error
+    // cases have no `result` and already expect a failure on every firmware.
+    if (name.startsWith('StellarInvokeHostFunction') && result.signature) {
+        return [{ rules: [`<${SOROBAN_MIN_FIRMWARE}`], payload: false }];
+    }
+
+    // stellar has required update
+    return [{ rules: ['<2.3.0'], payload: false }];
+};
+
 const stellarSignTransaction: TestCase = {
     method: 'stellarSignTransaction',
     setup: {
@@ -196,42 +216,10 @@ const stellarSignTransaction: TestCase = {
                 (test: any) =>
                     !test.experimental &&
                     // payment request tests need PaymentRequest data that can't be expressed in this fixture format
-                    !test.parameters.payment_request &&
-                    // Soroban InvokeHostFunction operations are not supported by connect yet
-                    !test.parameters.operations?.some(
-                        (op: any) => op._message_type === 'StellarInvokeHostFunctionOp',
-                    ),
+                    !test.parameters.payment_request,
             )
-            .flatMap(({ name, result, parameters, skip_models }: any) => [
-                {
-                    name,
-                    description: name,
-                    skip_models,
-                    result,
-                    params: {
-                        path: parameters.address_n,
-                        networkPassphrase: parameters.network_passphrase,
-                        transaction: {
-                            source: parameters.tx.source_account,
-                            fee: parameters.tx.fee,
-                            sequence: parameters.tx.sequence_number,
-                            timebounds: {
-                                minTime: parameters.tx.timebounds_start,
-                                maxTime: parameters.tx.timebounds_end,
-                            },
-                            memo: {
-                                type: Messages.StellarMemoType[
-                                    parameters.tx.memo_type as keyof typeof Messages.StellarMemoType
-                                ],
-                                text: parameters.tx.memo_text,
-                                id: parameters.tx.memo_id,
-                                hash: parameters.tx.memo_hash,
-                            },
-                            operations: parameters.operations.flatMap(transformOperation),
-                        },
-                    },
-                },
-                {
+            .flatMap(({ name, result, parameters, skip_models }: any) => {
+                const xdrVariant = {
                     name,
                     description: `${name} (XDR)`,
                     skip_models,
@@ -242,25 +230,64 @@ const stellarSignTransaction: TestCase = {
                         testnet:
                             parameters.network_passphrase === 'Test SDF Network ; September 2015',
                     },
-                },
-            ])
+                };
+
+                // Soroban InvokeHostFunction operations carry XDR-shaped SCVal payloads (whose
+                // 64-bit integers lose precision as JSON numbers) plus a SorobanTransactionData
+                // tx extension, neither of which the simplified `transaction` object can express.
+                // Exercise them through the XDR path only, which parses the envelope faithfully.
+                if (isInvokeHostFunctionTest(parameters)) {
+                    return [xdrVariant];
+                }
+
+                return [
+                    {
+                        name,
+                        description: name,
+                        skip_models,
+                        result,
+                        params: {
+                            path: parameters.address_n,
+                            networkPassphrase: parameters.network_passphrase,
+                            transaction: {
+                                source: parameters.tx.source_account,
+                                fee: parameters.tx.fee,
+                                sequence: parameters.tx.sequence_number,
+                                timebounds: {
+                                    minTime: parameters.tx.timebounds_start,
+                                    maxTime: parameters.tx.timebounds_end,
+                                },
+                                memo: {
+                                    type: Messages.StellarMemoType[
+                                        parameters.tx
+                                            .memo_type as keyof typeof Messages.StellarMemoType
+                                    ],
+                                    text: parameters.tx.memo_text,
+                                    id: parameters.tx.memo_id,
+                                    hash: parameters.tx.memo_hash,
+                                },
+                                operations: parameters.operations.flatMap(transformOperation),
+                            },
+                        },
+                    },
+                    xdrVariant,
+                ];
+            })
             .map(({ name, description, params, result, skip_models }: any) => ({
-                skip: skip_models?.flatMap((model: string) => (model === 't1' ? '1' : [])),
+                skip: skip_models?.flatMap((model: string) =>
+                    model === 't1' || model === 't1b1' ? '1' : [],
+                ),
                 description,
                 params,
-                result: {
-                    publicKey: result.public_key,
-                    signature: Buffer.from(result.signature, 'base64').toString('hex'),
-                },
-                legacyResults: legacyResultsMap[name]
-                    ? legacyResultsMap[name]
-                    : [
-                          {
-                              // stellar has required update
-                              rules: ['<2.3.0'],
-                              payload: false,
-                          },
-                      ],
+                // Error-case fixtures (e.g. Soroban memo-not-allowed) carry `error_message`
+                // instead of a signature; omit `result` so the harness expects a failure.
+                result: result.signature
+                    ? {
+                          publicKey: result.public_key,
+                          signature: Buffer.from(result.signature, 'base64').toString('hex'),
+                      }
+                    : undefined,
+                legacyResults: getLegacyResults(name, result),
             })),
         {
             description: 'Sequence is over Number.MAX_SAFE_INTEGER and is sent as string',

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -21,6 +21,9 @@ type Params = { path: number[] } & StellarSignTransactionSchema;
 const StellarSignTransactionFeatures = Object.freeze({
     manageBuyOffer: ['1.10.4', '2.4.3'],
     pathPaymentStrictSend: ['1.10.4', '2.4.3'],
+    // Soroban is not available on T1, so a plain version string is used instead of a
+    // per-model array: T1's major version is lower and never satisfies the comparison.
+    invokeHostFunction: '2.12.4',
 });
 
 export default class StellarSignTransaction extends AbstractMethod<
@@ -89,6 +92,7 @@ export default class StellarSignTransaction extends AbstractMethod<
 
         this._ensureFirmwareSupportsOperation('manageBuyOffer', transaction.operations);
         this._ensureFirmwareSupportsOperation('pathPaymentStrictSend', transaction.operations);
+        this._ensureFirmwareSupportsOperation('invokeHostFunction', transaction.operations);
 
         const response = await helper.stellarSignTx(
             this.getDevice().getCommands().typedCall,

--- a/packages/connect/src/api/stellar/stellarSignTx.ts
+++ b/packages/connect/src/api/stellar/stellarSignTx.ts
@@ -5,7 +5,8 @@ import { StellarOperation } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
-import { isNotUndefined, throwError } from '@trezor/utils';
+import { exhaustive } from '@trezor/type-utils';
+import { throwError } from '@trezor/utils';
 
 import type { TypedCall } from '../../device/DeviceCommands';
 
@@ -40,7 +41,7 @@ const transformSignMessage = (
 };
 
 // transform incoming parameters to protobuf messages format
-const transformOperation = (op: StellarOperation): StellarOperationMessage | undefined => {
+const transformOperation = (op: StellarOperation): StellarOperationMessage => {
     Assert(StellarOperation, op);
 
     switch (op.type) {
@@ -190,7 +191,24 @@ const transformOperation = (op: StellarOperation): StellarOperationMessage | und
                 balance_id: op.balanceId,
             };
 
-        // no default
+        case 'invokeHostFunction':
+            // `function` and `auth` are already in protobuf shape (built by network-stellar).
+            return {
+                type: 'StellarInvokeHostFunctionOp',
+                source_account: op.source,
+                function: op.function,
+                auth: op.auth,
+            };
+
+        case 'inflation':
+            // There is no StellarInflationOp protobuf message, so the device cannot sign it.
+            throw ERRORS.TypedError(
+                'Method_InvalidParameter',
+                'Stellar inflation operation is not supported',
+            );
+
+        default:
+            return exhaustive(op);
     }
 };
 
@@ -202,7 +220,7 @@ export const stellarSignTx = async (
     payment_req?: PROTO.PaymentRequest,
 ) => {
     const message = transformSignMessage(tx, { address_n, network_passphrase, payment_req });
-    const operations = tx.operations.map(transformOperation).filter(isNotUndefined);
+    const operations = tx.operations.map(transformOperation);
 
     await typedCall('StellarSignTx', 'StellarTxOpRequest', message);
 
@@ -218,6 +236,29 @@ export const stellarSignTx = async (
                 `Stellar transaction doesn't include any valid operation.`,
             ),
         );
+
+    // Soroban (InvokeHostFunction) transactions carry a transaction extension
+    // (SorobanTransactionData). After the final operation the device requests it via
+    // StellarTxExtRequest and only then returns the signature.
+    const isSoroban = operations.some(o => o.type === 'StellarInvokeHostFunctionOp');
+
+    if (isSoroban) {
+        if (!tx.sorobanData) {
+            throw ERRORS.TypedError(
+                'Method_InvalidParameter',
+                'Soroban transaction is missing sorobanData (SorobanTransactionData XDR).',
+            );
+        }
+
+        await typedCall(type, 'StellarTxExtRequest', op);
+
+        const response = await typedCall('StellarTxExt', 'StellarSignedTx', {
+            v: 1,
+            soroban_data: tx.sorobanData,
+        });
+
+        return response.message;
+    }
 
     const response = await typedCall(type, 'StellarSignedTx', op);
 

--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -211,6 +211,10 @@ export const TYPE_PATCH = {
     'StellarInt256Parts.hi_lo': UINT_TYPE,
     'StellarInt256Parts.lo_hi': UINT_TYPE,
     'StellarInt256Parts.lo_lo': UINT_TYPE,
+    // Soroban authorization nonces are random sint64 values that routinely exceed
+    // Number.MAX_SAFE_INTEGER, so they must accept string bignums to sign correctly.
+    'StellarSorobanAddressCredentials.nonce': SINT_TYPE,
+    'StellarSorobanAuthorizationWithAddress.nonce': SINT_TYPE,
     'TezosContractID.tag': 'number',
     'TezosContractID.hash': 'Uint8Array',
     'TezosRevealOp.source': 'Uint8Array',

--- a/packages/protobuf/src/definitions/messages-stellar.ts
+++ b/packages/protobuf/src/definitions/messages-stellar.ts
@@ -299,7 +299,7 @@ export type StellarSorobanAddressCredentials = Static<typeof StellarSorobanAddre
 export const StellarSorobanAddressCredentials = Type.Object(
     {
         address: Type.String(),
-        nonce: Type.Number(),
+        nonce: Type.Uint({ allowNegative: true }),
         signature_expiration_ledger: Type.Number(),
         signature: StellarSCVal,
     },
@@ -463,7 +463,7 @@ export type StellarSorobanAuthorizationWithAddress = Static<
 >;
 export const StellarSorobanAuthorizationWithAddress = Type.Object(
     {
-        nonce: Type.Number(),
+        nonce: Type.Uint({ allowNegative: true }),
         signature_expiration_ledger: Type.Number(),
         address: Type.String(),
         invocation: StellarSorobanAuthorizedInvocation,

--- a/suite-common/walletconnect/src/adapters/stellar.ts
+++ b/suite-common/walletconnect/src/adapters/stellar.ts
@@ -22,26 +22,6 @@ import {
 
 const methods = ['stellar_signXDR', 'stellar_signAndSubmitXDR'];
 
-// Supported classic Stellar operation types in TrezorConnect.
-// TODO: Perhaps we can add this to `transformTransaction`
-const SUPPORTED_OPERATION_TYPES = new Set([
-    'createAccount',
-    'payment',
-    'pathPaymentStrictReceive',
-    'pathPaymentStrictSend',
-    'createPassiveSellOffer',
-    'manageSellOffer',
-    'manageBuyOffer',
-    'setOptions',
-    'changeTrust',
-    'allowTrust',
-    'accountMerge',
-    'inflation',
-    'manageData',
-    'bumpSequence',
-    'claimClaimableBalance',
-]);
-
 const resolveStellarRequestContext = (event: WalletKitTypes.SessionRequest) => {
     const { chainId } = event.params;
     const network = networksCollection.find(
@@ -80,13 +60,6 @@ const stellarSignXDR = createThunk<
         const { parseTransactionFromXDR } = await loadStellar();
 
         const transaction = parseTransactionFromXDR(xdrBase64, testnet);
-
-        // Validate all operations are supported classic types.
-        for (const op of transaction.operations) {
-            if (!SUPPORTED_OPERATION_TYPES.has(op.type)) {
-                throw new Error(`Unsupported operation: ${op.type}`);
-            }
-        }
 
         const device = selectSelectedDevice(getState());
         const accounts = selectAccounts(getState());


### PR DESCRIPTION
## Description

Adds signing support for Stellar's Soroban smart-contract invocation operation (`InvokeHostFunction`). `network-stellar` now transforms the XDR host-function call, authorization entries, and `SorobanTransactionData` transaction extension into the protobuf-shaped structures expected by the device; `connect`'s `stellarSignTx` sends the extension via a new `StellarTxExtRequest`/`StellarTxExt` round-trip after the final operation, gated on firmware 2.12.4. Also fixes the `SorobanCredentials`/`SorobanAuthorizationWithAddress` nonce fields to preserve full sint64 precision (previously lossy above `Number.MAX_SAFE_INTEGER`), and updates e2e fixtures to exercise Soroban test vectors through the XDR-transaction path.

Separately, `transformOperation` previously returned `undefined` for operations it had no case for and `stellarSignTx` filtered those out, while `num_operations` was computed from the unfiltered list — so the device was told to expect more operations than it received. This affected `inflation`, which is in the `StellarOperation` union but has no protobuf message. The switch is now closed with `exhaustive` and `inflation` raises `Method_InvalidParameter`, which makes connect the single source of truth and lets the duplicated (and already-drifted) operation allowlist in the WalletConnect Stellar adapter be removed.

## Notes for QA

Focus on Stellar Soroban `invokeHostFunction` signing (new), both via direct `stellarSignTransaction` calls and via a WalletConnect dApp using `stellar_signXDR` / `stellar_signAndSubmitXDR`; Soroban requires firmware 2.12.4+ and is unavailable on T1, where an unsupported-feature error should appear instead of a device-level failure. Regression-test the existing classic Stellar operation types over WalletConnect in particular — unsupported operations are now rejected by connect after the popup opens rather than by the adapter before it, so the error surface and timing changed.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on Stellar (network runtime transforms, Connect signing APIs, protobuf definitions, type definitions, and WalletConnect adapter). Among the 163 suite/e2e candidates, only one test explicitly exercises Stellar network enablement. The core Stellar transaction-signing logic is not covered by suite e2e tests and should be validated by the relevant Connect/unit tests. Recommended strategy: run the single Stellar network smoke test and rely on lower-level tests for signing correctness.

<details><summary><b>Changed files (10)</b></summary>

- `networks/stellar/network-stellar/src/runtime/transactions/transactions.test.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/transform.ts`
- `packages/connect-common/src/types/api/stellar.type-test.ts`
- `packages/connect-common/src/types/api/stellar/common.ts`
- `packages/connect/e2e/__fixtures__/stellarSignTransaction.ts`
- `packages/connect/src/api/stellar/api/stellarSignTransaction.ts`
- `packages/connect/src/api/stellar/stellarSignTx.ts`
- `packages/protobuf/scripts/protobuf-patches/index.ts`
- `packages/protobuf/src/definitions/messages-stellar.ts`
- `suite-common/walletconnect/src/adapters/stellar.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test explicitly enables the Stellar (XLM) network from the receive account picker during a swap flow and verifies Stellar account selection. Changes to Stellar protobuf definitions, common types, or the WalletConnect Stellar adapter could break Stellar network enablement or account discovery in this flow.

</details>

⚠️ **Changes with no test coverage (7)**
- `networks/stellar/network-stellar/src/runtime/transactions/transactions.test.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/transform.ts`
- `packages/connect-common/src/types/api/stellar.type-test.ts`
- `packages/connect/e2e/__fixtures__/stellarSignTransaction.ts`
- `packages/connect/src/api/stellar/api/stellarSignTransaction.ts`
- `packages/connect/src/api/stellar/stellarSignTx.ts`
- `packages/protobuf/scripts/protobuf-patches/index.ts`

_Updated: 2026-09-01T12:05:11.555Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/stellar-invoke-host-function-op/web/](https://dev.suite.sldev.cz/suite-web/stellar-invoke-host-function-op/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=stellar-invoke-host-function-op&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=stellar-invoke-host-function-op&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=stellar-invoke-host-function-op&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:07:41.732Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:07:57.115Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->