### PR TITLE
fix(protobuf): bump protobufjs to patch critical CVE (GHSA-xq3m-2v4x-88gg)

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/protobuf",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "license": "See LICENSE.md in repo root",
     "repository": {
         "type": "git",
@@ -36,7 +36,7 @@
     "dependencies": {
         "@trezor/schema-utils": "workspace:*",
         "long": "5.2.5",
-        "protobufjs": "7.4.0"
+        "protobufjs": "7.5.5"
     },
     "devDependencies": {
         "protobufjs-cli": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14884,7 +14884,7 @@ __metadata:
   dependencies:
     "@trezor/schema-utils": "workspace:*"
     long: "npm:5.2.5"
-    protobufjs: "npm:7.4.0"
+    protobufjs: "npm:7.5.5"
     protobufjs-cli: "npm:^1.1.3"
     tsx: "npm:^4.20.3"
   peerDependencies:
@@ -38646,9 +38646,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.4.0":
-  version: 7.4.0
-  resolution: "protobufjs@npm:7.4.0"
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -38662,7 +38662,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/408423506610f70858d7593632f4a6aa4f05796c90fd632be9b9252457c795acc71aa6d3b54bb7f48a890141728fee4ca3906723ccea6c202ad71f21b3879b8b
+  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

`@trezor/protobuf` on this branch still depends on `protobufjs@7.4.0`, which
is affected by a **critical** arbitrary code execution vulnerability,
[GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg)
(patched in `protobufjs@7.5.5`).

`@trezor/protobuf@1.5.3` was already published elsewhere with this exact fix
(`protobufjs: 7.5.5`), but that bump never landed on `connect-v9`, so this
line's `packages/protobuf/package.json` (and its lockfile entry) still
resolve to the vulnerable `7.4.0`.

This matters beyond this repo: `@trezor/connect-plugin-stellar` (used by
`@creit.tech/stellar-wallets-kit`, a popular Stellar wallet-connect library)
pulls in `@trezor/connect` → `@trezor/blockchain-link` →
`@trezor/blockchain-link-utils` / `@trezor/device-authenticity`, both of
which depend on `@trezor/protobuf` via `workspace:*`. Any consumer of
`@trezor/connect` on the 9.x line — including via `stellar-wallets-kit` —
currently pulls in the vulnerable `protobufjs@7.4.0` transitively and gets
flagged by dependency-scanning tools (e.g. Socket.dev's critical-CVE check),
even though the fix already exists upstream.

## Change

- `packages/protobuf/package.json`: `protobufjs` `7.4.0` → `7.5.5`, package
  version `1.5.2` → `1.5.3` (reusing the same version number already used
  for this fix elsewhere, for traceability).
- `yarn.lock`: regenerated the `protobufjs` resolution/checksum via
  `yarn install --mode=update-lockfile` (lockfile-only, no other changes).

No source code changes — `protobufjs` is a drop-in patch-level bump.

## Test plan

- [x] `yarn install --mode=update-lockfile` completes cleanly, touching only
      the `protobufjs` entry and `packages/protobuf`'s own metadata block.

