### PR TITLE
fix(suite-desktop-core): restrict parseCustomFeedURL to https

### DIFF
--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -47,10 +47,9 @@ export const silentlyBlockedDomains = [
     'pulse.walletconnect.org', // WalletConnect analytics
 ];
 
-// Restrict Desktop Update to these URLs. Update installation is already gated by signature verification,
-// so this is only an additional layer – no need to allow any other domains.
-export const allowedDesktopUpdateDomains = [
+// Restrict Desktop Update to these remote URLs (localhost domains are also allowed).
+// Update installation is already gated by signature verification, so this is only an additional layer.
+export const allowedDesktopUpdateRemoteDomains = [
     'trezor.io', // Production server
     'sldev.cz', // Test environment, available only with VPN
-    ...localhostDomains, // Allowed for local testing
 ];

--- a/packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts
+++ b/packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts
@@ -36,13 +36,30 @@ describe(parseCustomFeedURL.name, () => {
         },
         {
             it: 'allows a subdomain from the update domain allowlist',
-            customFeedURL: 'https://data.trezor.io/suite/releases/desktop/latest',
+            customFeedURL: 'https://data.trezor.io/update',
+            result: 'https://data.trezor.io/update',
+        },
+        {
+            it: 'falls back to the default URL when an allowed remote domain does not use https',
+            customFeedURL: 'http://trezor.io/update',
             result: defaultFeedURL,
+            shouldWarn: true,
+        },
+        {
+            it: 'falls back to the default URL when an allowed remote subdomain does not use https',
+            customFeedURL: 'http://data.trezor.io/update',
+            result: defaultFeedURL,
+            shouldWarn: true,
         },
         {
             it: 'allows localhost overrides',
             customFeedURL: 'http://127.0.0.1:8080/update',
             result: 'http://127.0.0.1:8080/update',
+        },
+        {
+            it: 'allows localhost subdomain overrides',
+            customFeedURL: 'http://dev.localhost:8080/update',
+            result: 'http://dev.localhost:8080/update',
         },
     ];
 

--- a/packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts
+++ b/packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts
@@ -1,6 +1,6 @@
 import { isUrl, isWhitelistedHost } from '@trezor/utils';
 
-import { allowedDesktopUpdateDomains } from '../config';
+import { allowedDesktopUpdateRemoteDomains, localhostDomains } from '../config';
 
 type ParseCustomFeedURLParams = {
     customFeedURL: string;
@@ -27,10 +27,22 @@ export const parseCustomFeedURL = ({
         return defaultFeedURL;
     }
 
-    const { hostname } = new URL(customFeedURL);
+    const { hostname, protocol } = new URL(customFeedURL);
 
-    if (!isWhitelistedHost(hostname, allowedDesktopUpdateDomains)) {
+    // Localhost is allowed if explicitely demanded; the user is reponsible for anything running on localhost.
+    // All protocols are allowed for localhost.
+    if (isWhitelistedHost(hostname, localhostDomains)) {
+        return customFeedURL;
+    }
+
+    // For the whitelisted remote domains, a secure protocol must be ensured to prevent MITM.
+    if (!isWhitelistedHost(hostname, allowedDesktopUpdateRemoteDomains)) {
         warn?.(`Custom desktop update URL ${customFeedURL} is from a forbidden domain.`);
+
+        return defaultFeedURL;
+    }
+    if (protocol !== 'https:') {
+        warn?.(`Custom desktop update URL ${customFeedURL} must be https.`);
 
         return defaultFeedURL;
     }


### PR DESCRIPTION
## Description

Restrict the `--updater-url` flag to allow remote domains only with https.

Http is still acceptable for localhost.

## Notes for QA

Desktop update works → shall be tested during RC.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files in `suite-desktop-core` (`config.ts`, `parseCustomFeedURL.ts`, and its unit test) are desktop auto-updater / custom feed internals. None of the 126 available E2E test descriptions reference custom update feeds, `parseCustomFeedURL`, or the desktop core config, so there is no inferred E2E coverage. The unit test `parseCustomFeedURL.test.ts` already validates the parsing logic, and no E2E test is expected to exercise this surface. Therefore no E2E tests are recommended; rely on the existing unit test and manual/desktop smoke validation.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite-desktop-core/src/config.ts`
- `packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts`
- `packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/suite-desktop-core/src/config.ts`
- `packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts`
- `packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts`

_Updated: 2026-08-20T07:58:24.944Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/parseCustomFeedURL-enforce-protocol/web/](https://dev.suite.sldev.cz/suite-web/fix/parseCustomFeedURL-enforce-protocol/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/parseCustomFeedURL-enforce-protocol&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/parseCustomFeedURL-enforce-protocol&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-20T08:00:44.280Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T08:00:17.166Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->