### PR TITLE
DeFi Yield fixes for Trezor Model One

### DIFF
--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -35,7 +35,6 @@ import {
 import { fromGwei, fromWei } from './ethConverter';
 import {
     getEvmTransactionPurpose,
-    getEvmTransactionTextSignature,
     isEvmApprovalTx,
     isEvmYieldTxByTextSignature,
     isUnwrapNativeTx,
@@ -255,8 +254,19 @@ const constructOldFlow = ({
     const isCardano = isCardanoTx(account, precomposedTx);
     const isStellar = account.networkType === 'stellar';
     const { networkType } = account;
-    const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
-    const isYieldOperation = isEvmYieldTxByTextSignature(evmTxType);
+
+    const evmTxType = getEvmTransactionPurpose({
+        networkSymbol: account.symbol,
+        to: precomposedTx.outputs.find(o => 'address' in o && typeof o.address === 'string')
+            ?.address,
+        data: precomposedForm.transactionData,
+    });
+
+    const isYieldOperation =
+        isEvmYieldTxByTextSignature(evmTxType) ||
+        evmTxType === 'wrap' ||
+        evmTxType === 'unwrap' ||
+        evmTxType === 'claim';
 
     const hasDestinationTag = 'destinationTag' in precomposedForm;
 

--- a/suite-native/module-earn/src/screens/YieldClaimCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimCompleteScreen.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { type RouteProp, useRoute } from '@react-navigation/native';
+import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
@@ -15,8 +15,9 @@ import {
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Translation } from '@suite-native/intl';
 import {
+    type StackNavigationProps,
     type YieldStackParamList,
-    type YieldStackRoutes,
+    YieldStackRoutes,
     useInterceptNativeNavigation,
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
@@ -25,9 +26,14 @@ import { YieldCompleteScreenContent } from '../components/YieldCompleteScreenCon
 import { getYieldClaimCompleteRows } from '../components/YieldCompleteScreenPresets';
 
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldClaimComplete>;
+type NavigationProps = StackNavigationProps<
+    YieldStackParamList,
+    YieldStackRoutes.YieldClaimComplete
+>;
 
 export const YieldClaimCompleteScreen = () => {
     const route = useRoute<RouteProps>();
+    const navigation = useNavigation<NavigationProps>();
     const dispatch = useDispatch();
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const { accountKey } = route.params;
@@ -62,7 +68,11 @@ export const YieldClaimCompleteScreen = () => {
 
             return;
         }
-    }, [navigateToInitialScreen, session]);
+
+        if (session.step !== 'complete') {
+            navigation.replace(YieldStackRoutes.YieldClaim, route.params);
+        }
+    }, [navigateToInitialScreen, navigation, route.params, session]);
 
     if (session?.step !== 'complete') {
         return null;

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -98,6 +98,8 @@ export const YieldClaimScreen = () => {
         waitForMerklToResolveClaim,
     } = useYieldClaimRewards({ account });
     const {
+        displayedPendingTransaction,
+        isSheetPresented,
         pendingBottomSheetRef,
         pendingModalProps,
         pendingTransaction: claimPendingTransaction,
@@ -168,10 +170,12 @@ export const YieldClaimScreen = () => {
     });
 
     useEffect(() => {
+        if (isSheetPresented) return;
+
         if (session?.step === 'complete') {
             navigation.replace(YieldStackRoutes.YieldClaimComplete, route.params);
         }
-    }, [navigation, route.params, session?.step]);
+    }, [isSheetPresented, navigation, route.params, session?.step]);
 
     const reportClaimEvent = useCallback(
         (payload: { action: 'continue' | 'cancel'; type: 'claim' | 'tx-simulation-modal' }) => {
@@ -346,13 +350,14 @@ export const YieldClaimScreen = () => {
                 </VStack>
             </Box>
 
-            {claimPendingTransaction && pendingModalProps && (
+            {displayedPendingTransaction && pendingModalProps && (
                 <YieldPendingTransactionModal
                     ref={pendingBottomSheetRef}
                     accountLabel={accountLabel}
                     accountSymbol={account.symbol}
                     fee={pendingModalProps.fee}
                     isExploreDisabled={pendingModalProps.isExploreDisabled}
+                    onDismiss={pendingModalProps.onDismiss}
                     onExplorePress={pendingModalProps.onExplorePress}
                     submittedAt={pendingModalProps.submittedAt}
                     txid={pendingModalProps.txid}


### PR DESCRIPTION
## Description

Fix wrap/unwrap and claim tx review flow for Trezor Model One.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31402
Resolve https://github.com/trezor/trezor-suite/issues/31403

## Screenshots:

<table>
<tr>
<td>

https://github.com/user-attachments/assets/1b1cf004-a39a-4264-b637-6d939476c582

</td>
<td>

https://github.com/user-attachments/assets/6eeac196-d92d-4d17-8459-e7e0f1b51439

</td>
<td>

https://github.com/user-attachments/assets/65c24804-eeca-4f24-a5fb-bf3a7c783b1a

</td>
</tr>
</table>

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies a broad shared utility (reviewTransactionUtils.ts) and two suite-native mobile yield claim screens. The mobile screens are not covered by the suite-web/desktop Playwright E2E suite and should be tested via native mobile automation instead. Because reviewTransactionUtils.ts is referenced by 135 tests, only a tightly focused set of tests that directly exercise transaction review, confirmation, and fee/amount display are recommended. Running these four high-priority tests plus one medium-priority test should catch regressions in transaction review formatting without over-extending CI.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`
- `suite-native/module-earn/src/screens/YieldClaimCompleteScreen.tsx`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests a reward claim flow with fee display, amount formatting, and device confirmation prompts. Since the change touches review transaction utilities and yield claim screens, this claim-style staking flow is the closest web analog for validating that claim transaction details are formatted correctly for review.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Validates DEX swap confirmation with send/receive amounts, network fee, slippage, minimum received, and detailed device prompts. These confirmation screens rely heavily on review transaction utilities to render amounts and fees consistently.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly exercises the core transaction review path for Ethereum, verifying gas limit, max fee per gas, max priority fee per gas, send amount, and total/maximum fee display on both the app UI and the hardware device emulator.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests the Solana send max flow with the review & send modal, verifying recipient address, send amount, transaction fee, and total sent on the device prompt. This covers non-EVM review transaction formatting that the shared utility may affect.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Covers the sell flow confirmation screen and device prompt with crypto amount, fiat amount, fee, and destination address. While it shares the transaction review infrastructure, it is less directly tied to the exact display utilities than the high-priority tests.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/module-earn/src/screens/YieldClaimCompleteScreen.tsx`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`

_Updated: 2026-08-20T12:00:29.164Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/yield-trezor-model-one/web/](https://dev.suite.sldev.cz/suite-web/fix/native/yield-trezor-model-one/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/yield-trezor-model-one&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/yield-trezor-model-one&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/yield-trezor-model-one&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T12:01:00.313Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-20T12:00:57.632Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->