### PR TITLE
31433 uselayout header rerenders

### DIFF
--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -1,4 +1,4 @@
-import { type FC, type PropsWithChildren, useEffect } from 'react';
+import { type FC, type PropsWithChildren, memo, useEffect } from 'react';
 
 import { selectShouldDisplayDeviceCompromisedOnRoute } from '@suite/authenticity-checks';
 import { useDevice } from '@suite/device';
@@ -48,7 +48,8 @@ const getFullscreenApp = (route: AppState['router']['route']): FC | undefined =>
 
 // Preloader is a top level wrapper used in _app.tsx.
 // Decides which content should be displayed basing on route and prerequisites.
-export const Preloader = ({ children }: PropsWithChildren) => {
+// Memoised so that a re-render above it (Main) does not cascade through the whole app.
+export const Preloader = memo(function Preloader({ children }: PropsWithChildren) {
     const lifecycle = useSelector(state => state.suite.lifecycle);
     const isTransportInitialized = useSelector(selectIsTransportInitialized);
     const router = useSelector(state => state.router);
@@ -151,4 +152,4 @@ export const Preloader = ({ children }: PropsWithChildren) => {
 
     // everything is set.
     return <SuiteLayout>{children}</SuiteLayout>;
-};
+});

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/LayoutPayloadProvider.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/LayoutPayloadProvider.tsx
@@ -1,0 +1,34 @@
+import { type ReactNode, memo, useState } from 'react';
+
+import {
+    type LayoutContextPayload,
+    LayoutPayloadContext,
+    LayoutSetterContext,
+} from 'src/support/suite/LayoutContext';
+
+type LayoutPayloadProviderProps = {
+    children: ReactNode;
+};
+
+/**
+ * Owns the payload that pages publish through `useLayout`. The state lives here instead of in
+ * `SuiteLayout` so that a page publishing a new header re-renders only the layout slots, not the
+ * whole app root. `children` is the very same element on every re-render, so React skips the
+ * subtree and only the slot consumers below re-render.
+ *
+ * Memoised for the same reason as `SuiteLayout`: nothing above it should be able to re-render the
+ * payload owner, which would re-render every slot consumer with it.
+ */
+export const LayoutPayloadProvider = memo(function LayoutPayloadProvider({
+    children,
+}: LayoutPayloadProviderProps) {
+    const [payload, setLayoutPayload] = useState<LayoutContextPayload>({});
+
+    return (
+        <LayoutSetterContext.Provider value={setLayoutPayload}>
+            <LayoutPayloadContext.Provider value={payload}>
+                {children}
+            </LayoutPayloadContext.Provider>
+        </LayoutSetterContext.Provider>
+    );
+});

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSlots.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSlots.tsx
@@ -1,0 +1,22 @@
+import { useContext } from 'react';
+
+import { Metadata } from 'src/components/suite/Metadata';
+import { LayoutPayloadContext } from 'src/support/suite/LayoutContext';
+
+export const LayoutMetadata = () => {
+    const { title } = useContext(LayoutPayloadContext);
+
+    return <Metadata title={title} />;
+};
+
+export const LayoutHeaderSlot = () => {
+    const { layoutHeader } = useContext(LayoutPayloadContext);
+
+    return layoutHeader;
+};
+
+export const LayoutFooterSlot = () => {
+    const { layoutFooter } = useContext(LayoutPayloadContext);
+
+    return layoutFooter;
+};

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useRef, useState } from 'react';
+import { type ReactNode, memo, useRef } from 'react';
 
 import styled from 'styled-components';
 
@@ -6,18 +6,18 @@ import { ScrollContext } from '@suite/router';
 import { Modal, variables } from '@trezor/components';
 
 import { GuideButton, GuideRouter } from 'src/components/guide';
-import { Metadata } from 'src/components/suite/Metadata';
 import { SuiteBanners } from 'src/components/suite/banners';
 import { DiscoveryProgress } from 'src/components/wallet';
 import { HEADER_HEIGHT_NUMERIC, SUBPAGE_NAV_HEIGHT_NUMERIC } from 'src/constants/suite/layout';
 import { useLayoutSize } from 'src/hooks/suite';
 import { useClearAnchorHighlightOnClick } from 'src/hooks/suite/useClearAnchorHighlightOnClick';
 import { useResetScrollOnUrl } from 'src/hooks/suite/useResetScrollOnUrl';
-import { LayoutContext, type LayoutContextPayload } from 'src/support/suite/LayoutContext';
 
 import { ContentContainer } from '../ContentContainer';
 import { AddPassphraseWalletFlow } from './AddPassphraseWalletFlow';
 import { CoinjoinBars } from './CoinjoinBars/CoinjoinBars';
+import { LayoutPayloadProvider } from './LayoutPayloadProvider';
+import { LayoutFooterSlot, LayoutHeaderSlot, LayoutMetadata } from './LayoutSlots';
 import { PowerMonitorManager } from './PowerMonitor/PowerMonitor';
 import { Sidebar } from './Sidebar/Sidebar';
 import { SwitchDeviceLayer } from './SwitchDeviceLayer';
@@ -98,10 +98,16 @@ interface SuiteLayoutProps {
     ['data-testid']?: string;
 }
 
-export const SuiteLayout = ({ children, 'data-testid': dataTest }: SuiteLayoutProps) => {
-    const [{ title, layoutHeader, layoutFooter }, setLayoutPayload] =
-        useState<LayoutContextPayload>({});
-
+/**
+ * Memoised because it is the app root of every page: `Preloader` re-renders on a long list of
+ * store subscriptions, and without this every one of those re-renders would walk the whole
+ * layout — sidebar, banners, page. `children` comes from `Preloader`'s own props, so it stays
+ * referentially stable and React can bail out here.
+ */
+export const SuiteLayout = memo(function SuiteLayout({
+    children,
+    'data-testid': dataTest,
+}: SuiteLayoutProps) {
     const { isBelowTablet } = useLayoutSize();
     const wrapperRef = useRef<HTMLDivElement>(null);
     const { scrollRef } = useResetScrollOnUrl();
@@ -114,19 +120,19 @@ export const SuiteLayout = ({ children, 'data-testid': dataTest }: SuiteLayoutPr
             <Wrapper ref={wrapperRef} data-testid="@suite-layout">
                 <PageWrapper>
                     <Modal.Provider>
-                        <Metadata title={title} />
+                        <LayoutPayloadProvider>
+                            <LayoutMetadata />
 
-                        <ModalSwitcher />
-                        <SwitchDeviceLayer />
-                        <AddPassphraseWalletFlow />
+                            <ModalSwitcher />
+                            <SwitchDeviceLayer />
+                            <AddPassphraseWalletFlow />
 
-                        <PowerMonitorManager />
+                            <PowerMonitorManager />
 
-                        {isBelowTablet && <CoinjoinBars />}
+                            {isBelowTablet && <CoinjoinBars />}
 
-                        <DiscoveryProgress />
+                            <DiscoveryProgress />
 
-                        <LayoutContext.Provider value={setLayoutPayload}>
                             <Body data-testid="@suite-layout/body">
                                 <Columns>
                                     <Sidebar />
@@ -134,7 +140,7 @@ export const SuiteLayout = ({ children, 'data-testid': dataTest }: SuiteLayoutPr
                                         {!isBelowTablet && <CoinjoinBars />}
                                         <SuiteBanners />
                                         <AppWrapper data-testid="@app" ref={scrollRef}>
-                                            {layoutHeader}
+                                            <LayoutHeaderSlot />
 
                                             <ContentContainer
                                                 data-testid={
@@ -145,13 +151,13 @@ export const SuiteLayout = ({ children, 'data-testid': dataTest }: SuiteLayoutPr
                                             >
                                                 {children}
                                             </ContentContainer>
-                                            {layoutFooter}
+                                            <LayoutFooterSlot />
                                         </AppWrapper>
                                     </MainContent>
                                 </Columns>
                             </Body>
-                        </LayoutContext.Provider>
-                        {!isBelowTablet && <GuideButton />}
+                            {!isBelowTablet && <GuideButton />}
+                        </LayoutPayloadProvider>
                     </Modal.Provider>
                 </PageWrapper>
 
@@ -159,4 +165,4 @@ export const SuiteLayout = ({ children, 'data-testid': dataTest }: SuiteLayoutPr
             </Wrapper>
         </ScrollContext.Provider>
     );
-};
+});

--- a/packages/suite/src/hooks/suite/useLayout.tsx
+++ b/packages/suite/src/hooks/suite/useLayout.tsx
@@ -1,9 +1,9 @@
 import { type ReactNode, useContext, useEffect } from 'react';
 
-import { LayoutContext } from 'src/support/suite/LayoutContext';
+import { LayoutSetterContext } from 'src/support/suite/LayoutContext';
 
 export const useLayout = (title?: string, layoutHeader?: ReactNode, layoutFooter?: ReactNode) => {
-    const setLayout = useContext(LayoutContext);
+    const setLayout = useContext(LayoutSetterContext);
 
     useEffect(() => {
         setLayout({ title, layoutHeader, layoutFooter });

--- a/packages/suite/src/support/suite/LayoutContext.ts
+++ b/packages/suite/src/support/suite/LayoutContext.ts
@@ -7,4 +7,12 @@ export type LayoutContextPayload = {
     layoutFooter?: React.ReactNode;
 };
 
-export const LayoutContext = createContext<(payload: LayoutContextPayload) => void>(() => {});
+/**
+ * Setter for the layout payload, used by the `useLayout` hook. It has to stay apart from the
+ * payload itself: pages are the ones calling `useLayout`, so reading the payload from the same
+ * context would re-render every page on every publish and feed the next element back into the
+ * effect.
+ */
+export const LayoutSetterContext = createContext<(payload: LayoutContextPayload) => void>(() => {});
+
+export const LayoutPayloadContext = createContext<LayoutContextPayload>({});

--- a/suite/e2e/performance/budgets.ts
+++ b/suite/e2e/performance/budgets.ts
@@ -3,32 +3,32 @@ import { type Baselines, type Limits } from '@trezor/perf-e2e';
 /**
  * Both maps below are keyed by measurement: `'wallet-discovery [T3W1]'` applies to that scenario on
  * that device model only, while a bare `'wallet-discovery'` is the default for every model that has
- * no entry of its own. The entries here predate the per-model split, so they are still scenario-wide;
- * the end-of-run report prints per-model numbers to replace them with.
+ * no entry of its own. The entries here are still scenario-wide; the end-of-run report prints
+ * per-model numbers to split them with once a scenario measurably differs between models.
  */
 
 /** What each scenario costs today, measured on CI. Reference only, never enforced. */
 export const BASELINES: Baselines = {
     'wallet-discovery': {
-        totalBlockingTimeMs: 453,
-        longTaskCount: 18,
-        longestTaskMs: 185,
-        reactCommitCount: 270,
-        interactionDurationMs: 7506,
+        totalBlockingTimeMs: 894,
+        longTaskCount: 26,
+        longestTaskMs: 196,
+        reactCommitCount: 214,
+        interactionDurationMs: 6894,
     },
     'account-switch': {
-        totalBlockingTimeMs: 217,
+        totalBlockingTimeMs: 282,
         longTaskCount: 1,
-        longestTaskMs: 267,
-        reactCommitCount: 43,
-        interactionDurationMs: 915,
+        longestTaskMs: 332,
+        reactCommitCount: 35,
+        interactionDurationMs: 696,
     },
     'multi-account-discovery': {
-        totalBlockingTimeMs: 4700,
-        longTaskCount: 62,
-        longestTaskMs: 543,
-        reactCommitCount: 237,
-        interactionDurationMs: 12125,
+        totalBlockingTimeMs: 2063,
+        longTaskCount: 55,
+        longestTaskMs: 333,
+        reactCommitCount: 231,
+        interactionDurationMs: 8369,
     },
 };
 


### PR DESCRIPTION
## Description

Typing one character into a trading form re-rendered the whole app — sidebar, header and page — once per keystroke.

`useLayout` wrote the element it is given into the only state `SuiteLayout` owned, and every page is `SuiteLayout`'s child. So publishing a header re-rendered the app root, which re-rendered the calling page, which built a fresh element, which fed the effect again. `memo()` on the page could not help: the re-render came from the parent, not from props.

The layout now owns the problem, so no page has to remember an invisible rule about how it passes its header:

- `LayoutPayloadProvider` holds the payload and renders `{children}`. `SuiteLayout` no longer re-renders on publish, so the `children` element stays referentially stable and React bails out on the subtree.
- `LayoutMetadata`, `LayoutHeaderSlot` and `LayoutFooterSlot` read the payload from context, so publishing a header re-renders those three slots instead of the app root.
- The setter keeps its own context. Pages are the publishers, so reading the payload from the same context would re-render every page and restore the loop.
- `SuiteLayout`, `LayoutPayloadProvider` and `Preloader` are wrapped in `memo` so a re-render above them does not cascade through the layout. `SuiteLayout` is the one that matters most here — it receives `children` from `Preloader`'s own props, so it stays stable across `Preloader`'s many store-driven re-renders.

Page headers keep the inline JSX they have on `develop`. No DOM change: same nodes, same positions, same `data-testid`s.

Out of scope: re-renders starting *above* `SuiteLayout` (`Preloader` still re-renders the sidebar and banners, though no longer the page).

## Notes for QA

The slots are new, so the risk is a **header, footer or tab title missing, stale, or one render late**:

- Navigate between pages (Dashboard, Earn, Settings, Password manager, Activity, wallet accounts, trading) — header and tab title should match the page.
- Switch accounts and devices on wallet and Earn pages; run an Earn wrap/unwrap through — the header must follow, never show the previous one.
- Activity: switch tabs, check the highlighted tab and the unseen-notification dot.
- Trading: type an amount and click the percentage buttons — header stays correct, and the sidebar/page should stop re-rendering around the form.
- Everything the layout renders beside the slots: sidebar, banners, discovery progress, modals, guide panel, coinjoin bars on a small window.

## Related Issue

Resolve #31433

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/31433-uselayout-header-rerenders/web/](https://dev.suite.sldev.cz/suite-web/31433-uselayout-header-rerenders/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=31433-uselayout-header-rerenders&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=31433-uselayout-header-rerenders&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T13:00:36.461Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-21T15:29:54.738Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are core layout/preloader infrastructure used globally across the app. The primary regression risks are: app failing to load, layout not rendering after navigation/reload, and loading indicators not hiding. The recommended tests focus on route-level layout rendering (check-links), browser-specific app loading (firefox), reload/initial-run state (initial-run, multiple-sessions), and loading indicator teardown (remembered-wallet-loading). No inferred coverage exists for LayoutPayloadProvider.tsx or LayoutSlots.tsx.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/suite/Preloader/Preloader.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/LayoutPayloadProvider.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSlots.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx`
- `packages/suite/src/hooks/suite/useLayout.tsx`
- `packages/suite/src/support/suite/LayoutContext.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to nearly every app route and explicitly asserts that the @suite-layout element is attached and the @suite/bundle-loader is hidden after each navigation. Changes to SuiteLayout, Preloader, or layout context could break these core rendering guarantees across routes.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — Verifies that the Suite application loads successfully in Firefox without showing an unsupported-browser warning. This directly exercises the Preloader/SuiteLayout initialization path in a real browser environment.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the onboarding/initial-run flow across page reloads, asserting that the analytics toggle and complete-onboarding button appear correctly and that the connected device status is shown after completion. Reload behavior is sensitive to Preloader and layout state rehydration.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Involves page reloads and verifying that the dashboard/device switcher renders correctly after reclaiming a Bridge session. This exercises how SuiteLayout and Preloader restore the main UI after reload.
- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — Explicitly asserts that the Suite loading indicator and bundle loader become hidden after reloading from a seeded IndexedDB state, which directly exercises Preloader loading-state teardown.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/layouts/SuiteLayout/LayoutPayloadProvider.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSlots.tsx`

_Updated: 2026-08-21T09:24:50.662Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->
