### PR TITLE
feat(connect): nightly fw release channel

### DIFF
--- a/packages/connect-common/src/types/firmware.ts
+++ b/packages/connect-common/src/types/firmware.ts
@@ -97,6 +97,7 @@ export type FirmwareChannel =
     | 'production-early-access'
     | 'test-unsigned'
     | 'test-unsigned-stable'
+    | 'test-unsigned-nightly'
     | 'test-signed'
     | 'localhost-unsigned'
     | 'localhost-signed';

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -23,6 +23,10 @@ const UNSIGNED_STABLE_URL_REMOTE_BASE = {
     BASE_URL: 'https://data.trezor.io',
     MIDDLE_PATH: 'dev/firmware/releases/unsigned-stable',
 };
+const UNSIGNED_NIGHTLY_URL_REMOTE_BASE = {
+    BASE_URL: 'https://data.trezor.io',
+    MIDDLE_PATH: 'dev/firmware/firmware-nightly',
+};
 const SIGNED_URL_REMOTE_BASE = {
     BASE_URL: 'https://suite.corp.sldev.cz',
     MIDDLE_PATH: 'firmware/signed',
@@ -40,6 +44,7 @@ const FIRMWARE_REMOTE_BASE_URLS: Record<FirmwareChannel, RemoteBaseInfo> = {
     'production-early-access': RELEASES_URL_REMOTE_BASE,
     'test-unsigned': UNSIGNED_URL_REMOTE_BASE,
     'test-unsigned-stable': UNSIGNED_STABLE_URL_REMOTE_BASE,
+    'test-unsigned-nightly': UNSIGNED_NIGHTLY_URL_REMOTE_BASE,
     'test-signed': SIGNED_URL_REMOTE_BASE,
     'localhost-unsigned': UNSIGNED_LOCALHOST,
     'localhost-signed': SIGNED_LOCALHOST,
@@ -88,7 +93,7 @@ const CONFIG_PATH_BY_CHANNEL: Partial<Record<FirmwareChannel, string>> = {
     'production-early-access': 'config-early-access/',
 };
 
-const fetchRemoteJws = async (firmwareChannel?: FirmwareChannel): Promise<JwsInfo> => {
+const fetchRemoteFwConfig = async (firmwareChannel?: FirmwareChannel) => {
     const {
         BASE_URL,
         MIDDLE_PATH,
@@ -112,19 +117,29 @@ const fetchRemoteJws = async (firmwareChannel?: FirmwareChannel): Promise<JwsInf
             throw new Error(`HTTP error! Status: ${response.status}`);
         }
 
-        // Assuming the response JSON has a 'jws' property.
         const data = await response.json();
-        if (typeof data.jws !== 'string') {
-            throw new Error('Invalid response format: "jws" property missing or not a string.');
-        }
 
-        return { jws: data.jws, firmwareChannel: resolvedChannel };
+        return { data, firmwareChannel: resolvedChannel };
     } catch (error) {
         throw new Error(
-            `Failed to fetch remote JWS: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to fetch remote: ${error instanceof Error ? error.message : String(error)}`,
             { cause: error },
         );
     }
+};
+
+const fetchRemoteJws = async (firmwareChannel?: FirmwareChannel): Promise<JwsInfo> => {
+    const { data, firmwareChannel: resolvedChannel } = await fetchRemoteFwConfig(firmwareChannel);
+
+    // Assuming the response JSON has a 'jws' property.
+    if (typeof data.jws !== 'string') {
+        throw new Error('Invalid response format: "jws" property missing or not a string.');
+    }
+
+    return {
+        jws: data.jws,
+        firmwareChannel: resolvedChannel,
+    };
 };
 
 const verifyAndDecodeJws = (jws: string, publicKey: string): FirmwareReleaseConfig => {
@@ -153,6 +168,13 @@ const verifyAndDecodeJws = (jws: string, publicKey: string): FirmwareReleaseConf
 
 export const getFirmwareReleaseConfig = async (firmwareChannel?: FirmwareChannel) => {
     try {
+        if (firmwareChannel === 'test-unsigned-nightly') {
+            // Nightly does not use JWS signing
+            const remoteConfig = await fetchRemoteFwConfig(firmwareChannel);
+
+            return { config: remoteConfig.data, isRemote: true };
+        }
+
         const { jws, firmwareChannel: resolvedChannel } = await fetchRemoteJws(firmwareChannel);
 
         const useProductionKey = ['test-signed', 'production-early-access', 'production'].includes(

--- a/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
@@ -20,6 +20,7 @@ export const FirmwareUpdateEnvironmentSelect = () => {
         { label: 'Production Early Access', value: 'production-early-access' },
         { label: 'Test Unsigned', value: 'test-unsigned' },
         { label: 'Test Unsigned Stable', value: 'test-unsigned-stable' },
+        { label: 'Test Unsigned Nightly', value: 'test-unsigned-nightly' },
         { label: 'Test Signed', value: 'test-signed' },
         { label: 'Localhost Signed', value: 'localhost-signed' },
         { label: 'Localhost Unsigned', value: 'localhost-unsigned' },

--- a/suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx
@@ -14,6 +14,7 @@ const options: SelectItemType<FirmwareChannel>[] = [
     { label: 'Production Early Access', value: 'production-early-access' },
     { label: 'Test Unsigned', value: 'test-unsigned' },
     { label: 'Test Unsigned Stable', value: 'test-unsigned-stable' },
+    { label: 'Test Unsigned Nightly', value: 'test-unsigned-nightly' },
     { label: 'Test Signed', value: 'test-signed' },
 ];
 


### PR DESCRIPTION
## Description

Following https://github.com/trezor/trezor-firmware/pull/7621

We now have nightly unsigned builds for FW. 
This PR now enables downloading them in Suite through the new "Test Unsigned Nightly" channel

Limitations:
- T1B1 not supported yet
- Not JWS signed, after some discussion, we will not be signing it

## Notes for QA

Switch to new "Test Unsigned Nightly" channel and try updating a device

<img width="728" height="493" alt="Screenshot 2026-08-26 at 11 02 02" src="https://github.com/user-attachments/assets/f909fbf2-8dc8-43ce-804e-c75e18563ceb" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches firmware release configuration parsing, firmware types, and debug/native firmware channel selectors. The highest risk is in firmware readiness/update flows, so run the targeted firmware installation, firmware-check, and device-settings firmware-modal tests first. The native FirmwareUpdateChannelSelect has no suite-web E2E coverage and should be verified through native/mobile testing.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect-common/src/types/firmware.ts`
- `packages/connect/src/utils/firmwareReleaseConfigUtils.ts`
- `packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx`
- `suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test installs custom firmware through the Settings > Device flow and exercises the firmware installation API and modal, which directly depend on the changed firmware types and release-config utilities. A regression here would be immediately visible in the firmware update flow.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — The test's sole purpose is to verify firmware readiness during onboarding, which relies on firmware release configuration parsing and comparison logic from the changed utils/types. It is the most targeted regression detector for firmware-release behavior.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — It opens and closes the firmware update modal from device settings, so it renders firmware update state derived from the release config. If the changed utilities/types break modal rendering or availability, this test will fail.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Like the T2T1 settings test, it opens the firmware update modal on a different device model, covering model-specific firmware release behavior affected by the changed utils/types.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — The onboarding flow disables firmware revision checks for canary firmware, which is influenced by firmware release/channel detection logic. Changes to release-config utilities could alter how canary/official builds are identified.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test explicitly navigates to Settings > Debug, where the changed FirmwareUpdateEnvironmentSelect component is rendered. It provides a shallow smoke test that the debug settings view still loads correctly, though it does not assert the selector's behavior.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx`

_Updated: 2026-09-04T09:33:14.948Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fw-nightly-channel&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fw-nightly-channel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fw-nightly-channel&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T09:34:53.532Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T09:34:21.656Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fw-nightly-channel/web/](https://dev.suite.sldev.cz/suite-web/fw-nightly-channel/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->