### PR TITLE
feat(e2e): add yield withdraw test and enhance deposit test

### DIFF
--- a/packages/e2e-utils/src/mocks/backendServer.ts
+++ b/packages/e2e-utils/src/mocks/backendServer.ts
@@ -23,6 +23,8 @@ export interface Fixture {
 
 export interface PushNotification {
     delay?: number;
+    id?: string;
+    data?: unknown;
 }
 
 export class BackendWebsocketServerMock extends WebSocketServer {

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx
@@ -31,7 +31,12 @@ export const EarnYieldYearlyRewards = ({
         />
 
         {hasDisplayableDepositedAmount && (
-            <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
+            <Paragraph
+                typographyStyle="body-sm"
+                intent="neutral"
+                priority="secondary"
+                data-testid="@earn/dashboard/deposited-amount"
+            >
                 <HiddenPlaceholder>
                     <Translation
                         id="TR_EARN_YIELD_DASHBOARD_DEPOSITED"

--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -145,7 +145,7 @@ export const YieldAmountCard = ({
         <Card paddingType="none">
             <Column gap={8} width="100%" padding={{ vertical: 16, horizontal: 20 }}>
                 <Row justifyContent="space-between" alignItems="center" gap={16}>
-                    <Text typographyStyle="body-md">
+                    <Text typographyStyle="body-md" data-testid="@yield/form/amount-label">
                         <Translation id={heading?.amountLabelTranslationId ?? 'AMOUNT'} />
                     </Text>
                     {unitSwitch ?? fiatSwitch}
@@ -176,7 +176,12 @@ export const YieldAmountCard = ({
                         maxLength={AMOUNT_INPUT_MAX_LENGTH}
                         isDisabled={isDisabled}
                         rightContent={
-                            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                            <Text
+                                typographyStyle="body-md"
+                                intent="neutral"
+                                priority="secondary"
+                                data-testid="@yield/form/amount-unit"
+                            >
                                 {tokenSymbol}
                             </Text>
                         }
@@ -186,7 +191,12 @@ export const YieldAmountCard = ({
                 {summary && (
                     <Row justifyContent="space-between" alignItems="center" gap={8} width="100%">
                         <Row alignItems="center" gap={8} minWidth={0}>
-                            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                            <Text
+                                typographyStyle="body-md"
+                                intent="neutral"
+                                priority="secondary"
+                                data-testid="@yield/form/summary-label"
+                            >
                                 <Translation id={summary.labelTranslationId} />:
                             </Text>
                             <TruncatedAmount>
@@ -194,6 +204,7 @@ export const YieldAmountCard = ({
                                     typographyStyle="body-md"
                                     intent="neutral"
                                     priority="secondary"
+                                    data-testid="@yield/form/summary-amount-with-symbol"
                                 >
                                     {summary.value}
                                 </Text>

--- a/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
@@ -129,7 +129,12 @@ export const YieldFlowComplete = ({
                 </Column>
             </Card>
 
-            <Button intent="neutral" priority="secondary" onClick={handleBackToOverview}>
+            <Button
+                intent="neutral"
+                priority="secondary"
+                data-testid="@yield/flow-complete/back-to-overview-button"
+                onClick={handleBackToOverview}
+            >
                 <Translation id="TR_EARN_YIELD_BACK_TO_OVERVIEW" />
             </Button>
 

--- a/suite/e2e/support/mocks/blockBookMock.ts
+++ b/suite/e2e/support/mocks/blockBookMock.ts
@@ -17,6 +17,7 @@ export class BlockbookMock {
     private _mockServer: BackendWebsocketServerMock | undefined;
     private accountState: any = null;
     private mockType: SupportedSymbols | null = null;
+    private readonly newBlockSubscriptionIds = new Set<string>();
 
     get mockServer() {
         if (!this._mockServer) {
@@ -52,6 +53,11 @@ export class BlockbookMock {
     @step()
     async start(mockType: SupportedSymbols, serverType: BackendType = 'blockbook') {
         this._mockServer = await BackendWebsocketServerMock.create(serverType);
+        // Remember block-subscription request ids: a pushed notification is only routed to the
+        // client's `block` event when its id matches the id the subscription was created with.
+        this.mockServer.on('blockbook_subscribeNewBlock', (request: { id: string }) => {
+            this.newBlockSubscriptionIds.add(request.id);
+        });
         this.mockType = mockType;
         const fixtures = this.selectFixture(mockType);
         this.mockServer.setFixtures(fixtures);
@@ -133,6 +139,24 @@ export class BlockbookMock {
         });
 
         this.mockServer.setFixtures(updatedFixtures);
+    }
+
+    // Pushes a new-block notification to the subscribed clients — the same way a real blockbook
+    // surfaces on-chain changes. Suite reacts with onBlockMinedThunk, which immediately re-fetches
+    // all visible accounts on the network, so a preceding `updateAccountState` reaches Redux
+    // without waiting for the periodic account sync (whose timer is not controlled by page.clock).
+    @step()
+    async sendNewBlockNotification({ height, hash }: { height: number; hash: string }) {
+        if (this.newBlockSubscriptionIds.size === 0) {
+            throw new Error('No subscribeNewBlock subscription has been captured yet');
+        }
+
+        const notifications = [...this.newBlockSubscriptionIds].map(id => ({
+            id,
+            data: { height, hash, evmData: null },
+        }));
+
+        await this.mockServer.sendNotification(notifications);
     }
 
     // Updates the `rpcCall` fixture used by ERC-20 allowance checks. `rawAmount` is the

--- a/suite/e2e/support/mocks/eth-endpoints.ts
+++ b/suite/e2e/support/mocks/eth-endpoints.ts
@@ -89,8 +89,9 @@ export const fixtures = [
         method: 'estimateFee',
         default: true,
         response: ({ params }: any) => {
-            // deposit(assets, receiver) === 0x6e553f65
-            if (params?.specific?.data?.startsWith('0x6e553f65')) {
+            // ERC-4626 vault calls: deposit === 0x6e553f65, withdraw === 0xb460af94
+            const vaultCallSelectors = ['0x6e553f65', '0xb460af94'];
+            if (vaultCallSelectors.some(selector => params?.specific?.data?.startsWith(selector))) {
                 return {
                     data: [
                         {

--- a/suite/e2e/support/mocks/yieldMock.ts
+++ b/suite/e2e/support/mocks/yieldMock.ts
@@ -26,6 +26,7 @@ export const YIELD_VAULTS = {
 
 const YIELD_API_PATTERN = /\/yieldxyz\/v2\/yields/;
 const YIELD_DETAIL_API_PATTERN = /\/yieldxyz\/v2\/yields\/(?<vaultId>[^/?]+)/;
+const VAULT_ADDRESS_API_PATTERN = /\/vaults\/v1\//;
 const MERKL_API_PATTERN = /\/merkl\/v1\/users\/rewards/;
 const BLOCKAID_API_PATTERN = /\/evm\/json-rpc\/scan/;
 
@@ -33,7 +34,51 @@ const USDC_CONTRACT = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 // Trezor Steakhouse USDC Prime Vault
 const YIELD_USDC_VAULT_ADDRESS = '0xde6c23E561F3e55846207EC45A91b777e0F7C889';
 const USDC_VAULT = YIELD_USDC_VAULT_ADDRESS.toLowerCase();
-const BLOCKAID_BENIGN_RESPONSE = {
+
+export const YIELD_USDC_VAULT_SHARE_TOKEN = {
+    type: 'ERC20',
+    standard: 'ERC20',
+    name: YIELD_VAULTS.usdcPrime.name,
+    contract: USDC_VAULT,
+    symbol: 'trSHUSDCp',
+    decimals: 18,
+    balance: '9944238455556494216',
+    transfers: 1,
+} as const;
+
+// Share token balance converted by pricePerShareState.price (1.005607422297114), as displayed
+export const YIELD_USDC_DEPOSITED_AMOUNT = '10';
+const USDC_ASSET = {
+    type: 'ERC20',
+    address: USDC_CONTRACT,
+    decimals: 6,
+    name: 'USD Coin',
+    symbol: 'USDC',
+};
+
+const USDC_VAULT_SHARE_ASSET = {
+    type: 'ERC20',
+    address: USDC_VAULT,
+    decimals: 18,
+    name: YIELD_VAULTS.usdcPrime.name,
+    symbol: 'trSHUSDCp',
+};
+
+type BlockaidTransfer = {
+    asset: typeof USDC_ASSET;
+    rawValue: string;
+    value: string;
+    usdPrice: string;
+    summary: string;
+};
+
+const createBlockaidBenignResponse = ({
+    sent,
+    received,
+}: {
+    sent: BlockaidTransfer;
+    received: BlockaidTransfer;
+}) => ({
     validation: {
         status: 'Success',
         result_type: 'Benign',
@@ -53,38 +98,26 @@ const BLOCKAID_BENIGN_RESPONSE = {
             assets_diffs: [
                 {
                     asset_type: 'ERC20',
-                    asset: {
-                        type: 'ERC20',
-                        address: USDC_CONTRACT,
-                        decimals: 6,
-                        name: 'USD Coin',
-                        symbol: 'USDC',
-                    },
+                    asset: sent.asset,
                     in: [],
                     out: [
                         {
-                            raw_value: '0x989680',
-                            value: '10.0',
-                            usd_price: '9.996549999999999159',
-                            summary: 'Sending 10 USDC',
+                            raw_value: sent.rawValue,
+                            value: sent.value,
+                            usd_price: sent.usdPrice,
+                            summary: sent.summary,
                         },
                     ],
                 },
                 {
                     asset_type: 'ERC20',
-                    asset: {
-                        type: 'ERC20',
-                        address: USDC_VAULT,
-                        decimals: 18,
-                        name: YIELD_VAULTS.usdcPrime.name,
-                        symbol: 'trSHUSDCp',
-                    },
+                    asset: received.asset,
                     in: [
                         {
-                            raw_value: '0x8a01083041395266',
-                            value: '9.944238455556494216',
-                            usd_price: '9.996535861217905605',
-                            summary: 'Receiving 9.944 trSHUSDCp',
+                            raw_value: received.rawValue,
+                            value: received.value,
+                            usd_price: received.usdPrice,
+                            summary: received.summary,
                         },
                     ],
                     out: [],
@@ -92,9 +125,9 @@ const BLOCKAID_BENIGN_RESPONSE = {
             ],
             exposures: [],
             total_usd_diff: {
-                in: '9.996535861217905605',
-                out: '9.996549999999999159',
-                total: '-0.000014138782093553',
+                in: received.usdPrice,
+                out: sent.usdPrice,
+                total: (Number(received.usdPrice) - Number(sent.usdPrice)).toString(),
             },
             total_usd_exposure: {},
             traces: [],
@@ -103,7 +136,41 @@ const BLOCKAID_BENIGN_RESPONSE = {
         addressbook_messages: [],
         error: null,
     },
-};
+});
+
+const BLOCKAID_DEPOSIT_RESPONSE = createBlockaidBenignResponse({
+    sent: {
+        asset: USDC_ASSET,
+        rawValue: '0x989680',
+        value: '10.0',
+        usdPrice: '9.996549999999999159',
+        summary: 'Sending 10 USDC',
+    },
+    received: {
+        asset: USDC_VAULT_SHARE_ASSET,
+        rawValue: '0x8a01083041395266',
+        value: '9.944238455556494216',
+        usdPrice: '9.996535861217905605',
+        summary: 'Receiving 9.944 trSHUSDCp',
+    },
+});
+
+const BLOCKAID_WITHDRAW_RESPONSE = createBlockaidBenignResponse({
+    sent: {
+        asset: USDC_VAULT_SHARE_ASSET,
+        rawValue: '0x45008418209ca967',
+        value: '4.972119227778247015',
+        usdPrice: '4.998272935608987',
+        summary: 'Sending 4.972 trSHUSDCp',
+    },
+    received: {
+        asset: USDC_ASSET,
+        rawValue: '0x4c4b40',
+        value: '5.0',
+        usdPrice: '4.998274999999999579',
+        summary: 'Receiving 5 USDC',
+    },
+});
 
 const YIELD_VAULTS_RESPONSE = {
     items: [
@@ -169,11 +236,10 @@ const YIELD_VAULTS_RESPONSE = {
                 enter: true,
                 exit: true,
             },
-            // Share price so 10 USDC converts to ~9.944 trSHUSDCp shares (matches the deposit
-            // simulation in yielddepositusdc.har): shares = amount / price.
+
             state: {
                 pricePerShareState: {
-                    price: '1.005606287729678',
+                    price: '1.005607422297114',
                     shareToken: {
                         symbol: 'trSHUSDCp',
                         name: YIELD_VAULTS.usdcPrime.name,
@@ -266,18 +332,30 @@ export class YieldMock {
             return vault ? route.fulfill({ json: vault }) : route.continue();
         });
         await this.page.route(MERKL_API_PATTERN, route => route.fulfill({ json: [] }));
+        // Vault address lookup (getYieldVault) used when composing withdraw/redeem transactions.
+        await this.page.route(VAULT_ADDRESS_API_PATTERN, route =>
+            route.fulfill({ json: { address: YIELD_USDC_VAULT_ADDRESS } }),
+        );
     }
 
     @step()
     async mockUsdcDeposit() {
         await this.page.route(BLOCKAID_API_PATTERN, route =>
-            route.fulfill({ json: BLOCKAID_BENIGN_RESPONSE }),
+            route.fulfill({ json: BLOCKAID_DEPOSIT_RESPONSE }),
+        );
+    }
+
+    @step()
+    async mockUsdcWithdraw() {
+        await this.page.route(BLOCKAID_API_PATTERN, route =>
+            route.fulfill({ json: BLOCKAID_WITHDRAW_RESPONSE }),
         );
     }
 
     @step()
     async stop() {
         await this.page.unroute(BLOCKAID_API_PATTERN);
+        await this.page.unroute(VAULT_ADDRESS_API_PATTERN);
         await this.page.unroute(MERKL_API_PATTERN);
         await this.page.unroute(YIELD_DETAIL_API_PATTERN);
         await this.page.unroute(YIELD_API_PATTERN);

--- a/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
@@ -3,27 +3,43 @@ import { type Locator, type Page } from '@playwright/test';
 export class YieldFlowSection {
     // Approve step
     readonly approvedAmount: Locator;
+    readonly amountLabel: Locator;
     readonly amountInput: Locator;
+    readonly amountUnit: Locator;
+    readonly summaryLabel: Locator;
+    readonly summaryAmount: Locator;
     readonly approveButton: Locator;
     // Continue button of the shared allowance approve modal opened by the approve step
     readonly approveModalContinueButton: Locator;
     readonly pendingTransactionLabel: Locator;
     // Deposit step
     readonly depositButton: Locator;
+    readonly depositedToast: Locator;
+    // Withdraw step
+    readonly withdrawButton: Locator;
+    readonly withdrawnToast: Locator;
     // Flow-complete screen
     readonly flowCompleteHeading: Locator;
     readonly flowCompleteStatus: Locator;
     readonly flowCompleteApy: Locator;
     readonly flowCompleteTransferInputAmount: Locator;
     readonly flowCompleteTransferOutputAmount: Locator;
+    readonly backToOverviewButton: Locator;
 
     constructor(private readonly page: Page) {
         this.approvedAmount = this.page.getByTestId('@yield/approve/approved-amount-with-symbol');
+        this.amountLabel = this.page.getByTestId('@yield/form/amount-label');
         this.amountInput = this.page.getByTestId('@yield/form/amount-input');
+        this.amountUnit = this.page.getByTestId('@yield/form/amount-unit');
+        this.summaryLabel = this.page.getByTestId('@yield/form/summary-label');
+        this.summaryAmount = this.page.getByTestId('@yield/form/summary-amount-with-symbol');
         this.approveButton = this.page.getByTestId('@yield/form/approve-button');
         this.approveModalContinueButton = this.page.getByTestId('@modal/approve/continue-button');
         this.pendingTransactionLabel = this.page.getByTestId('@pending-transaction/title');
         this.depositButton = this.page.getByTestId('@yield/form/deposit-button');
+        this.depositedToast = this.page.getByTestId('@toast/tx-yield-deposit');
+        this.withdrawButton = this.page.getByTestId('@yield/form/withdraw-button');
+        this.withdrawnToast = this.page.getByTestId('@toast/tx-yield-withdraw');
         this.flowCompleteHeading = this.page.getByTestId('@yield/flow-complete/heading');
         this.flowCompleteStatus = this.page.getByTestId('@yield/flow-complete/status');
         this.flowCompleteApy = this.page.getByTestId('@earn/dashboard/apy-percentage');
@@ -32,6 +48,9 @@ export class YieldFlowSection {
         );
         this.flowCompleteTransferOutputAmount = this.page.getByTestId(
             '@yield/flow-complete/transfer/output-with-symbol',
+        );
+        this.backToOverviewButton = this.page.getByTestId(
+            '@yield/flow-complete/back-to-overview-button',
         );
     }
 }

--- a/suite/e2e/support/pageObjects/yield/yieldSection.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldSection.ts
@@ -47,8 +47,24 @@ export class YieldSection {
         return this.row(vaultId).getByTestId('@earn/dashboard/yearly-rewards/amount');
     }
 
+    depositedAmount(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/deposited-amount');
+    }
+
     potentialRewardAmount(vaultId: string): Locator {
         return this.row(vaultId).getByTestId('@earn/dashboard/potential-rewards/amount');
+    }
+
+    withdrawButton(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/withdraw-button');
+    }
+
+    depositMoreButton(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/deposit-more-button');
+    }
+
+    depositNowButton(vaultId: string): Locator {
+        return this.row(vaultId).getByTestId('@earn/dashboard/deposit-now-button');
     }
 
     @step()

--- a/suite/e2e/tests/yield/deposit.test.ts
+++ b/suite/e2e/tests/yield/deposit.test.ts
@@ -1,7 +1,8 @@
 import ETH_BASE_TX from '../../fixtures/staking/eth-base-tx.json';
 import ETH_STAKE_CONFIRMED_TX from '../../fixtures/staking/eth-stake-confirmed-tx.json';
 import { expect, test } from '../../support/fixtures';
-import { YIELD_VAULTS } from '../../support/mocks/yieldMock';
+import { ETH_MOCKED_ACCOUNT } from '../../support/mocks/eth-endpoints';
+import { YIELD_USDC_VAULT_SHARE_TOKEN, YIELD_VAULTS } from '../../support/mocks/yieldMock';
 
 const { usdcPrime, usdtPrime } = YIELD_VAULTS;
 const YIELD_USDC_VAULT_DISPLAY_NAME = ['Trezor Steakhouse', '\n', 'USDC Prime Vault'];
@@ -219,6 +220,18 @@ test.describe('stablecoin yield', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =>
                 },
             });
             await devicePrompt.waitForFinalPromptAndConfirm();
+
+            blockbookMock.updateAllowance('0');
+            blockbookMock.updateAccountState({
+                txs: 3,
+                nonce: '2',
+                tokens: [
+                    ...ETH_MOCKED_ACCOUNT.tokens.map(token =>
+                        token.symbol === 'USDC' ? { ...token, balance: '990000000' } : token,
+                    ),
+                    YIELD_USDC_VAULT_SHARE_TOKEN,
+                ],
+            });
             await devicePrompt.sendButton.click();
             await expect(toastSection.yieldDeposit).toBeVisible();
             await expect(yieldFlowSection.flowCompleteHeading).toHaveTranslation(
@@ -232,8 +245,23 @@ test.describe('stablecoin yield', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =>
             // Output shares render at full token precision via formatCoinBalance (8 fractional
             // digits + ellipsis), not the rounded simulation preview shown earlier in the flow.
             await expect(yieldFlowSection.flowCompleteTransferOutputAmount).toHaveText(
-                '9.94424967… trSHUSDCp',
+                '9.94423845… trSHUSDCp',
             );
+
+            await blockbookMock.sendNewBlockNotification({
+                // One block above bestHeight of the getInfo fixture in eth-endpoints.
+                height: 22881954,
+                hash: '0xa07d0d92b6bb9a5f388d47a10b824b4b09e0b3aeb08d0f61c0e30a25f6c8455f',
+            });
+        });
+
+        await test.step('Returning to the dashboard shows the deposited position', async () => {
+            await yieldFlowSection.backToOverviewButton.click();
+
+            // The vault row now offers deposit-more + withdraw actions instead of "Deposit now".
+            await expect(yieldSection.withdrawButton(usdcPrime.id)).toBeVisible();
+            await expect(yieldSection.depositMoreButton(usdcPrime.id)).toBeVisible();
+            await expect(yieldSection.depositNowButton(usdcPrime.id)).toBeHidden();
         });
     });
 });

--- a/suite/e2e/tests/yield/withdrawal.test.ts
+++ b/suite/e2e/tests/yield/withdrawal.test.ts
@@ -1,0 +1,192 @@
+import ETH_BASE_TX from '../../fixtures/staking/eth-base-tx.json';
+import ETH_STAKE_CONFIRMED_TX from '../../fixtures/staking/eth-stake-confirmed-tx.json';
+import { expect, test } from '../../support/fixtures';
+import { ETH_MOCKED_ACCOUNT } from '../../support/mocks/eth-endpoints';
+import {
+    YIELD_USDC_DEPOSITED_AMOUNT,
+    YIELD_USDC_VAULT_SHARE_TOKEN,
+    YIELD_VAULTS,
+} from '../../support/mocks/yieldMock';
+
+const { usdcPrime } = YIELD_VAULTS;
+const YIELD_USDC_VAULT_DISPLAY_NAME = ['Trezor Steakhouse', '\n', 'USDC Prime Vault'];
+const WITHDRAW_AMOUNT = '5';
+const WITHDRAW_MAX_FEE = '0.00010840280031 ETH';
+const NEW_BLOCK = {
+    height: 22881954,
+    hash: '0xa07d0d92b6bb9a5f388d47a10b824b4b09e0b3aeb08d0f61c0e30a25f6c8455f',
+};
+
+const buildEthAccountTokens = ({
+    usdcBalance,
+    shareBalance,
+}: {
+    usdcBalance: string;
+    shareBalance: string;
+}) => [
+    ...ETH_MOCKED_ACCOUNT.tokens.map(token =>
+        token.symbol === 'USDC' ? { ...token, balance: usdcBalance } : token,
+    ),
+    { ...YIELD_USDC_VAULT_SHARE_TOKEN, balance: shareBalance },
+];
+
+test.describe('stablecoin yield withdrawal', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({
+        deviceSetup: {
+            mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
+        },
+    });
+
+    test.beforeEach(async ({ onboardingPage, settingsPage, blockbookMock, yieldMock }) => {
+        await onboardingPage.completeOnboarding();
+        await blockbookMock.start('eth');
+        blockbookMock.updateAccountState({
+            txs: 3,
+            nonce: '2',
+            transactions: [ETH_STAKE_CONFIRMED_TX, ETH_BASE_TX],
+            tokens: buildEthAccountTokens({
+                usdcBalance: '990000000',
+                shareBalance: YIELD_USDC_VAULT_SHARE_TOKEN.balance,
+            }),
+        });
+        await yieldMock.start();
+        await settingsPage.changeNetworks({
+            enableNetworks: [
+                { symbol: 'eth', backend: { type: 'blockbook', url: blockbookMock.url } },
+            ],
+        });
+    });
+
+    test('User can withdraw USDC from a yield vault', async ({
+        yieldSection,
+        yieldFlowSection,
+        txSimulationModal,
+        devicePrompt,
+        device,
+        blockbookMock,
+        yieldMock,
+    }) => {
+        await test.step('Deposited position is shown on the dashboard', async () => {
+            await yieldSection.earnMenuButton.click();
+
+            await expect(yieldSection.depositedAmount(usdcPrime.id)).toHaveTranslation(
+                'TR_EARN_YIELD_DASHBOARD_DEPOSITED',
+                { values: { amount: YIELD_USDC_DEPOSITED_AMOUNT, displaySymbol: 'USDC' } },
+            );
+            await expect(yieldSection.yearlyRewardAmount(usdcPrime.id)).toHaveText('0.426 USDC');
+            await expect(yieldSection.depositMoreButton(usdcPrime.id)).toBeVisible();
+            await expect(yieldSection.depositNowButton(usdcPrime.id)).toBeHidden();
+
+            await yieldSection.withdrawButton(usdcPrime.id).click();
+        });
+
+        await test.step(`Withdraw ${WITHDRAW_AMOUNT} USDC`, async () => {
+            await yieldMock.mockUsdcWithdraw();
+            await expect(yieldFlowSection.amountLabel).toHaveTranslation(
+                'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',
+            );
+            await yieldFlowSection.amountInput.fill(WITHDRAW_AMOUNT);
+
+            await expect(yieldFlowSection.amountUnit).toHaveText('USDC');
+            await expect(yieldFlowSection.summaryLabel).toContainTranslation(
+                'TR_EARN_YIELD_DEPOSITED',
+            );
+            await expect(yieldFlowSection.summaryAmount).toHaveText(
+                `${YIELD_USDC_DEPOSITED_AMOUNT} USDC`,
+            );
+            await yieldFlowSection.withdrawButton.click();
+
+            await expect(txSimulationModal.sentAsset(0)).toHaveText('Sending 4.972 trSHUSDCp');
+            await expect(txSimulationModal.sentAssetFiat(0)).toHaveText(`-$${WITHDRAW_AMOUNT}.00`);
+            await expect(txSimulationModal.receivedAsset(0)).toHaveText(
+                `Receiving ${WITHDRAW_AMOUNT} USDC`,
+            );
+            await expect(txSimulationModal.receivedAssetFiat(0)).toHaveText(
+                `+$${WITHDRAW_AMOUNT}.00`,
+            );
+            await expect(txSimulationModal.maxFeeAmount).toHaveText('0.000108403 ETH');
+            await expect(txSimulationModal.maxFeeFiat).toHaveText('≈ $0.00');
+            await txSimulationModal.confirmButton.click();
+
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Withdraw' },
+                    body: [['Review details to', '\n', 'withdraw from', '\n', 'vault.']],
+                    actions: { right_button: 'Confirm' },
+                },
+                T3T1: {
+                    body: [['Review details to', '\n', 'withdraw from vault.']],
+                },
+            });
+            await devicePrompt.waitForPromptAndClick();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Withdraw' },
+                    body: [YIELD_USDC_VAULT_DISPLAY_NAME],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    body: [['Withdraw from'], YIELD_USDC_VAULT_DISPLAY_NAME],
+                },
+            });
+            await device.pressYes();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Withdraw' },
+                    body: [
+                        ['Withdraw amount'],
+                        [`${WITHDRAW_AMOUNT} USDC`],
+                        ['Chain'],
+                        ['Ethereum'],
+                    ],
+                    actions: { right_button: 'Continue' },
+                },
+            });
+            await device.pressYes();
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(WITHDRAW_MAX_FEE);
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Withdraw' },
+                    body: [['Maximum fee'], device.wrapText(WITHDRAW_MAX_FEE, { isAmount: true })],
+                    actions: { right_button: 'Hold to sign' },
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+
+            blockbookMock.updateAccountState({
+                txs: 4,
+                nonce: '3',
+                tokens: buildEthAccountTokens({
+                    usdcBalance: '995000000',
+                    shareBalance: '4972119227778247201',
+                }),
+            });
+            await devicePrompt.sendButton.click();
+
+            await expect(yieldFlowSection.withdrawnToast).toBeVisible();
+            await expect(yieldFlowSection.flowCompleteHeading).toHaveTranslation(
+                'TR_EARN_YIELD_WITHDRAW_COMPLETE',
+            );
+            await expect(yieldFlowSection.flowCompleteStatus).toHaveTranslation(
+                'TR_EARN_YIELD_COMPLETED',
+            );
+            await expect(yieldFlowSection.flowCompleteTransferOutputAmount).toHaveText(
+                `${WITHDRAW_AMOUNT} USDC`,
+            );
+
+            await blockbookMock.sendNewBlockNotification(NEW_BLOCK);
+        });
+
+        await test.step('Dashboard shows the reduced position', async () => {
+            await yieldFlowSection.backToOverviewButton.click();
+
+            await expect(yieldSection.depositedAmount(usdcPrime.id)).toHaveTranslation(
+                'TR_EARN_YIELD_DASHBOARD_DEPOSITED',
+                { values: { amount: '5', displaySymbol: 'USDC' } },
+            );
+            await expect(yieldSection.yearlyRewardAmount(usdcPrime.id)).toHaveText('0.213 USDC');
+            await expect(yieldSection.withdrawButton(usdcPrime.id)).toBeVisible();
+        });
+    });
+});


### PR DESCRIPTION
## Description

Adds an E2E test for the DeFi yield withdrawal flow (dashboard → withdraw → tx simulation → device confirmation → updated position) and extends the deposit test.



<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-yield-withdrawal/web/](https://dev.suite.sldev.cz/suite-web/test-yield-withdrawal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-yield-withdrawal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-yield-withdrawal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T11:24:42.057Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-20T11:23:39.767Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->