### PR TITLE
Use info intent for Cardano new provider banner

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
@@ -44,7 +44,7 @@ export const NewProviderCard = ({ account }: NewProviderCardProps) => {
     return (
         <Banner
             icon
-            intent="warning"
+            intent={isStakedWithFiveBinaries ? 'warning' : 'info'}
             title={
                 <Translation
                     id={


### PR DESCRIPTION
## Description

Renders the Cardano new provider banner in blue instead of orange. The FiveBinaries variant stays orange, as it warns about near-zero rewards.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29185

## Screenshots:
<img width="1434" height="401" alt="Screenshot 2026-08-20 at 13 11 28" src="https://github.com/user-attachments/assets/18feb589-abbe-4f54-9257-e7abd841b026" />