### PR TITLE
feat(suite): show XSS warning in devtools console

### DIFF
--- a/packages/suite-web/src/MainWeb.tsx
+++ b/packages/suite-web/src/MainWeb.tsx
@@ -26,6 +26,7 @@ import { createSuiteWebCompositionRoot } from './createSuiteWebCompositionRoot';
 import { initSentry } from './sentry';
 import { usePlaywright } from './support/usePlaywright';
 import { webComponents } from './support/webComponents';
+import { logXssWarning } from './support/xssWarning';
 
 const MainWeb = () => {
     usePlaywright();
@@ -48,6 +49,8 @@ const MainWeb = () => {
 };
 
 export const init = async (container: HTMLElement) => {
+    logXssWarning();
+
     if (!window.Playwright) {
         initSentry();
     }

--- a/packages/suite-web/src/support/xssWarning.ts
+++ b/packages/suite-web/src/support/xssWarning.ts
@@ -1,0 +1,19 @@
+/* eslint-disable no-console */
+import { isCodesignBuild } from '@trezor/env-utils';
+
+const XSS_WARNING_HEADLINE = 'STOP!';
+const XSS_WARNING_HEADLINE_STYLE =
+    'color: #e00000; font-size: 40px; font-weight: 700; line-height: 1.2;';
+const XSS_WARNING_TEXT_STYLE = 'font-size: 15px;';
+const XSS_WARNING_TEXT = `This is a feature intended for developers.\nIf someone told you to copy and paste something here,\nDO NOT do so unless you fully understand the code – it may be a scam to compromise your wallet and steal your funds.`;
+
+/**
+ * Display a warning on using devtools to unsuspecting users.
+ * This intentionally lives only in Suite Web, because on Desktop, devtools are by default disabled in codesign build.
+ */
+export const logXssWarning = () => {
+    if (!isCodesignBuild()) return;
+
+    console.log(`%c${XSS_WARNING_HEADLINE}`, XSS_WARNING_HEADLINE_STYLE);
+    console.log(`%c${XSS_WARNING_TEXT}`, XSS_WARNING_TEXT_STYLE);
+};


### PR DESCRIPTION
## Description

Followup to https://github.com/trezor/trezor-suite/pull/30741: display a warning in console on Suite Web, because we can't effectively ban devtools on Web, unlike Desktop.

## Notes for QA

Shall be tested with next Suite Web RC:
- opening devtools on production Suite Web yields a warning
- no such warning on develop builds

## Related issue

Resolve https://github.com/trezor/trezor-suite/issues/31442

## Screenshots

<img width="686" height="135" alt="image" src="https://github.com/user-attachments/assets/49ff3ba8-945e-4a78-8dd0-a8ed01efbbfc" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/console-log-xss-warning/web/](https://dev.suite.sldev.cz/suite-web/feat/console-log-xss-warning/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/console-log-xss-warning&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/console-log-xss-warning&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-20T11:28:36.064Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T11:28:32.234Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->