### PR TITLE
feat(tx-simulation): simulate connect calls from every popup source

### DIFF
--- a/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModal.tsx
+++ b/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModal.tsx
@@ -9,7 +9,7 @@ export const ConnectPopupTxSimulationModal = () => {
         return null;
     }
 
-    const { action, account } = txSimulationCallWithAccount;
+    const { action, account, source } = txSimulationCallWithAccount;
 
-    return <ConnectPopupTxSimulationModalInner action={action} account={account} />;
+    return <ConnectPopupTxSimulationModalInner action={action} account={account} source={source} />;
 };

--- a/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx
+++ b/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx
@@ -9,7 +9,10 @@ import {
     TxSimulationTitle,
 } from '@suite/tx-simulation/src/common';
 import { EvmInsufficientGasWarning } from '@suite/tx-simulation/src/evm';
-import { connectPopupActions } from '@suite-common/connect-popup';
+import {
+    type ConnectCallSource as ConnectPopupSource,
+    connectPopupActions,
+} from '@suite-common/connect-popup';
 import {
     TX_METHODS_WITH_FEES,
     areTxSimulationMethods,
@@ -33,11 +36,13 @@ import { useEvmTxSimulationFeesForm } from '../common/hooks/useEvmTxSimulationFe
 interface ConnectPopupTxSimulationModalInnerProps {
     action: TxSimulationAction;
     account: Account;
+    source: ConnectPopupSource;
 }
 
 export function ConnectPopupTxSimulationModalInner({
     action,
     account,
+    source,
 }: ConnectPopupTxSimulationModalInnerProps) {
     const dispatch = useDispatch();
     const [disclaimerAccepted, setDisclaimerAccepted] = useState(false);
@@ -58,6 +63,11 @@ export function ConnectPopupTxSimulationModalInner({
             : undefined,
     });
 
+    // Only WalletConnect calls have the chosen fee written back into the payload; every other
+    // caller signs the fee it supplied, so a picker there would silently discard the choice.
+    const isFeeApplied = source.type === 'walletconnect';
+    const isFeeSelectable = areTxSimulationMethods(TX_METHODS_WITH_FEES, action) && isFeeApplied;
+
     const selectedFeeLevel = form.watch('selectedFee') || 'normal';
     const currentComposedLevel = composedLevels?.[selectedFeeLevel];
 
@@ -76,7 +86,7 @@ export function ConnectPopupTxSimulationModalInner({
     function confirm() {
         const selectedFee = getSelectedFee();
 
-        if (areTxSimulationMethods(TX_METHODS_WITH_FEES, action) && selectedFee) {
+        if (isFeeSelectable && selectedFee) {
             dispatch(
                 connectPopupActions.setSelectedFee({
                     selectedFee:
@@ -152,7 +162,7 @@ export function ConnectPopupTxSimulationModalInner({
                     <Column margin={{ left: 8 }} gap={16}>
                         <TxSimulationProvider />
 
-                        {areTxSimulationMethods(TX_METHODS_WITH_FEES, action) && (
+                        {isFeeSelectable && (
                             <FormProvider {...form}>
                                 <Card>
                                     <Fees

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -109,28 +109,25 @@ const preCallHook = async <M extends CallMethodKeys>({
             }),
         );
 
-        if (source.type !== 'desktop-ws' && source.type !== 'web') {
-            // Display simulation
-            const device = selectSelectedDevice(getState());
-            if (!device) throw new Error('No device selected');
-            const accountAddress = await TrezorConnect.ethereumGetAddress({
-                path: (payload as any).path,
-                device: {
-                    path: device.path,
-                    instance: device.instance,
-                    state: device.state,
-                    useEmptyPassphrase: device.useEmptyPassphrase,
-                },
-                showOnTrezor: false,
-            });
-            if (!accountAddress.success) throw new Error(accountAddress.error.message);
-            dispatch(
-                connectPopupActions.txSimulation({
-                    fromAddress: accountAddress.payload.address,
-                }),
-            );
-            await getPermissionDeferred(true).promise;
-        }
+        const device = selectSelectedDevice(getState());
+        if (!device) throw new Error('No device selected');
+        const accountAddress = await TrezorConnect.ethereumGetAddress({
+            path: (payload as any).path,
+            device: {
+                path: device.path,
+                instance: device.instance,
+                state: device.state,
+                useEmptyPassphrase: device.useEmptyPassphrase,
+            },
+            showOnTrezor: false,
+        });
+        if (!accountAddress.success) throw new Error(accountAddress.error.message);
+        dispatch(
+            connectPopupActions.txSimulation({
+                fromAddress: accountAddress.payload.address,
+            }),
+        );
+        await getPermissionDeferred(true).promise;
 
         // Modify payload to include selected fee, if present
         if (method === 'ethereumSignTransaction' && source.type === 'walletconnect') {

--- a/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts
@@ -24,7 +24,6 @@ const preCallHook = async <M extends CallMethodKeys>({
     getState,
     dispatch,
     txSigningPrecomposed,
-    source,
 }: PreCallHookParams<M>) => {
     try {
         if (method === 'solanaSignTransaction') {
@@ -72,28 +71,25 @@ const preCallHook = async <M extends CallMethodKeys>({
                 );
             }
 
-            if (source.type !== 'desktop-ws' && source.type !== 'web') {
-                // Display simulation
-                const device = selectSelectedDevice(getState());
-                if (!device) throw new Error('No device selected');
-                const accountAddress = await TrezorConnect.solanaGetAddress({
-                    path: typedPayload.path,
-                    device: {
-                        path: device.path,
-                        instance: device.instance,
-                        state: device.state,
-                        useEmptyPassphrase: device.useEmptyPassphrase,
-                    },
-                    showOnTrezor: false,
-                });
-                if (!accountAddress.success) throw new Error(accountAddress.error.message);
-                dispatch(
-                    connectPopupActions.txSimulation({
-                        fromAddress: accountAddress.payload.address,
-                    }),
-                );
-                await getPermissionDeferred(true).promise;
-            }
+            const device = selectSelectedDevice(getState());
+            if (!device) throw new Error('No device selected');
+            const accountAddress = await TrezorConnect.solanaGetAddress({
+                path: typedPayload.path,
+                device: {
+                    path: device.path,
+                    instance: device.instance,
+                    state: device.state,
+                    useEmptyPassphrase: device.useEmptyPassphrase,
+                },
+                showOnTrezor: false,
+            });
+            if (!accountAddress.success) throw new Error(accountAddress.error.message);
+            dispatch(
+                connectPopupActions.txSimulation({
+                    fromAddress: accountAddress.payload.address,
+                }),
+            );
+            await getPermissionDeferred(true).promise;
         }
     } catch (error) {
         // If an error occurs it's not a problem, we just fall back to generic UI

--- a/suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts
@@ -19,7 +19,6 @@ const preCallHook = async <M extends CallMethodKeys>({
     payload,
     getState,
     dispatch,
-    source,
 }: PreCallHookParams<M>) => {
     try {
         if (method !== 'stellarSignTransaction') {
@@ -55,27 +54,25 @@ const preCallHook = async <M extends CallMethodKeys>({
             }),
         );
 
-        if (source.type !== 'desktop-ws' && source.type !== 'web') {
-            const device = selectSelectedDevice(getState());
-            if (!device) throw new Error('No device selected');
-            const accountAddress = await TrezorConnect.stellarGetAddress({
-                path: typedPayload.path,
-                device: {
-                    path: device.path,
-                    instance: device.instance,
-                    state: device.state,
-                    useEmptyPassphrase: device.useEmptyPassphrase,
-                },
-                showOnTrezor: false,
-            });
-            if (!accountAddress.success) throw new Error(accountAddress.error.message);
-            dispatch(
-                connectPopupActions.txSimulation({
-                    fromAddress: accountAddress.payload.address,
-                }),
-            );
-            await getPermissionDeferred(true).promise;
-        }
+        const device = selectSelectedDevice(getState());
+        if (!device) throw new Error('No device selected');
+        const accountAddress = await TrezorConnect.stellarGetAddress({
+            path: typedPayload.path,
+            device: {
+                path: device.path,
+                instance: device.instance,
+                state: device.state,
+                useEmptyPassphrase: device.useEmptyPassphrase,
+            },
+            showOnTrezor: false,
+        });
+        if (!accountAddress.success) throw new Error(accountAddress.error.message);
+        dispatch(
+            connectPopupActions.txSimulation({
+                fromAddress: accountAddress.payload.address,
+            }),
+        );
+        await getPermissionDeferred(true).promise;
     } catch (error) {
         // If an error occurs it's not a problem, we just fall back to generic UI
         console.error(`Error in Connect Popup ${method} hook:`, error);


### PR DESCRIPTION
Stacked on #31349.

## What

Blockaid simulation skipped the `web` and `desktop-ws` Connect call sources on **every** chain, so a browser dApp or the desktop WebSocket bridge — the two flows most likely to submit a transaction the user has never seen — got no simulation, while `walletconnect`, `mcp` and `deeplink` did.

The exclusion dates back to the original EVM simulation commit (c28a4abd35) with no stated reason, no comment, and no follow-up; only that commit and this stack have ever touched it. It was not a UI limitation — `useConnectPopupModals` opens the simulation modal purely on `popupCall.state === 'tx-simulation'`, with no reference to the source, and it already renders the permission modal for these same sources.

This drops the condition in all three method hooks (`ethereumSignTransaction`, `solanaSignTransaction`, `stellarSignTransaction`).

## Fee picker

Lifting the gate exposed a pre-existing bug. The modal rendered `<Fees>` and dispatched `setSelectedFee` for any source, but the only code that writes `selectedFee` back into the payload is gated on `source.type === 'walletconnect'`. So on `mcp`/`deeplink` today a user can adjust gas and have it silently discarded — and `web`/`desktop-ws` would have joined them.

The picker is now shown only where the fee is actually applied. Elsewhere the caller signs the fee it supplied, which is also the safer default: Suite should not rewrite a dApp's gas.

## Review notes

- **Untested.** Nothing in the repo asserts the method hooks' source gating, so this behaviour change lands without test coverage. Exercising it needs `preCallHooks` with a mocked device plus TrezorConnect, which no current connect-popup test does.
- **Privacy scope.** This sends a new class of third-party transaction data plus the account address to Blockaid. Same mechanism and disclaimer as the existing sources, but a deliberate broadening — worth a conscious ack.
- Native's `TxSimulationInner` has the same unconditional `setSelectedFee`, left alone: mobile only ever sees `deeplink`/`walletconnect`, so this change adds no sources there.

## Verification

`tsc --build` (suite, connect-popup, native module-connect-popup) · `verify-project-references` · `yarn install --immutable` · `@suite-common/connect-popup` 48 tests · `packages/suite` 110 tests (tx-simulation + trading) · type-aware eslint + prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/blockaid-connect-popup-sources&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/blockaid-connect-popup-sources&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/blockaid-connect-popup-sources&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in transaction-simulation UI and logic across Trading (swap/DEX), Connect popup, and Earn stablecoin flows, with significant cross-chain and Solana/Stellar coverage. The highest regression risk lies in DEX/cross-chain swap confirmation screens and Connect popup transaction signing. I recommend running the swap tests that statically map to the changed files, plus the Ethereum sign-transaction and yield deposit tests that directly exercise Connect and Earn simulation modals. Additional swap variants and the Bitcoin sign-transaction test provide medium-confidence coverage of adjacent paths.

<details><summary><b>Changed files (73)</b></summary>

- `jest.config.native.js`
- `packages/suite/src/components/tx-simulation/common/components/TxSimulationDisclaimer.tsx`
- `packages/suite/src/components/tx-simulation/common/components/TxSimulationSuccessResult.tsx`
- `packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModal.tsx`
- `packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx`
- `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx`
- `suite-common/connect-popup/package.json`
- `suite-common/connect-popup/src/hooks/useTxSimulationPopupCall.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/index.ts`
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`
- `suite-common/connect-popup/tsconfig.json`
- `suite-common/trading/package.json`
- `suite-common/trading/src/__fixtures__/utils.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.test.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.ts`
- `suite-common/trading/src/utils/exchange/getExchangeIssue.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.ts`
- `suite-common/trading/tsconfig.json`
- `suite-common/tx-simulation/package.json`
- `suite-common/tx-simulation/src/chains.test.ts`
- `suite-common/tx-simulation/src/chains.ts`
- `suite-common/tx-simulation/src/client.ts`
- `suite-common/tx-simulation/src/constants.ts`
- `suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts`
- `suite-common/tx-simulation/src/index.ts`
- `suite-common/tx-simulation/src/jestSetup.ts`
- `suite-common/tx-simulation/src/types.ts`
- `suite-common/tx-simulation/src/utils/getAssetDiffTransferAmount.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts`
- `suite-common/tx-simulation/src/utils/index.ts`
- `suite-common/tx-simulation/tsconfig.json`
- `suite-common/wallet-types/package.json`
- `suite-common/wallet-types/src/transactionSimulation.ts`
- `suite-common/wallet-types/tsconfig.json`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-trading/package.json`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSimulationPreviewCard.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`
- `suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx`
- `suite-native/module-trading/tsconfig.json`
- `suite-native/tx-simulation/src/components/EvmTxSimulationAssetAmount.tsx`
- `suite-native/tx-simulation/src/components/EvmTxSimulationReviewContent.tsx`
- `suite-native/tx-simulation/src/components/SolanaTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/StellarTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/TxSimulationAssetRows.tsx`
- `suite-native/tx-simulation/src/components/TxSimulationCrossChainAsset.tsx`
- `suite-native/tx-simulation/src/components/index.ts`
- `suite/intl/src/messages.ts`
- `suite/tx-simulation/src/evm/components/TxSimulationCrossChainAsset/TxSimulationCrossChainAsset.tsx`
- `suite/tx-simulation/src/evm/index.ts`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationAsset/SolanaTxSimulationAsset.tsx`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationAsset/SolanaTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/solana/index.ts`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAsset.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/stellar/index.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (11)</b></summary>

- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — Cross-chain BTC-to-ETH-token swap exercises the changed TradingOfferExchange.tsx, tx-simulation risk summary/asset-diff utilities, and cross-chain EVM simulation components end-to-end.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — LI.FI DEX swap directly uses the changed composeDexTxSimulationAction.ts and sendDexTransactionThunk.ts paths, making it the most focused regression test for DEX transaction simulation.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Cross-chain ETH-to-SOL swap hits EVM tx-simulation components and the simulated receive-amount logic that were changed.
- `suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts` — Cross-chain ERC-20-to-SOL-token swap exercises the same changed EVM cross-chain simulation and trading-exchange utilities as ETH-to-SOL with token-specific asset diff handling.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BTC swap with custom fees uses the changed swap offer exchange flow and tx-simulation infrastructure while verifying fee-related composed transaction info.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — ETH swap with custom gas fees exercises the changed swap offer exchange path and EVM fee-related tx simulation rendering.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Solana-to-BTC cross-chain swap directly exercises the changed Solana tx-simulation asset components and asset-diff utilities.
- `suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts` — Solana SPL-token-to-ETH swap exercises Solana tx-simulation components and cross-chain asset diff logic that were modified.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live Solana SPL-token-to-coin swap uses the changed trading exchange issue hooks and tx-simulation risk/asset-diff utilities in a live-traffic scenario.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test directly exercises the changed ethereumSignTransaction.ts connect-popup method hook and the ConnectPopupTxSimulationModal flow, including tx simulation display for Ethereum transactions.
- `suite/e2e/tests/yield/deposit.test.ts` — Static coverage maps this test directly to the changed EarnYieldTxSimulationModalInner.tsx and TxSimulationSuccessResult.tsx components; it is the only e2e test exercising the earn-stablecoin tx-simulation success path.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — SOL-to-USDC swap shares the same Solana tx-simulation and trading-offer-exchange infrastructure as the high-priority swap tests but covers a slightly different quote/trade path.
- `suite/e2e/tests/trading/swap-coins.test.ts` — SOL-to-BTC swap overlaps with the high-priority swap-sol-to-btc test; included as a secondary path through the same changed Solana and cross-chain simulation code.
- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — LI.FI token-approval flow is closely related to the DEX swap changes (composeDexTxSimulationAction, sendDexTransactionThunk) and may surface regressions in approval-specific simulation rendering.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Solana USDT-to-BTC swap exercises the same changed Solana tx-simulation and trading-exchange code paths with a token sell side.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Swap involving Stellar (XLM) is the only candidate test likely to exercise the changed Stellar tx-simulation asset/disclaimer components.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Solana SPL-token-to-SPL-token swap covers another token-only path through the changed Solana tx-simulation and trading-exchange utilities.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Connect-popup Bitcoin sign transaction shares the changed methodHooks infrastructure and tx-simulation modal wiring, though it does not exercise the Ethereum/Solana-specific hooks.

</details>

⚠️ **Changes with no test coverage (45)**
- `jest.config.native.js`
- `packages/suite/src/components/tx-simulation/common/components/TxSimulationDisclaimer.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `suite-common/connect-popup/package.json`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`
- `suite-common/connect-popup/tsconfig.json`
- `suite-common/trading/package.json`
- `suite-common/trading/src/__fixtures__/utils.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.test.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/trading/tsconfig.json`
- `suite-common/tx-simulation/package.json`
- `suite-common/tx-simulation/src/chains.test.ts`
- `suite-common/tx-simulation/src/chains.ts`
- `suite-common/tx-simulation/src/constants.ts`
- `suite-common/tx-simulation/src/index.ts`
- `suite-common/tx-simulation/src/jestSetup.ts`
- `suite-common/tx-simulation/src/types.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts`
- `suite-common/tx-simulation/tsconfig.json`
- `suite-common/wallet-types/package.json`
- `suite-common/wallet-types/src/transactionSimulation.ts`
- `suite-common/wallet-types/tsconfig.json`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-trading/package.json`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSimulationPreviewCard.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`
- `suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx`
- `suite-native/module-trading/tsconfig.json`
- `suite-native/tx-simulation/src/components/EvmTxSimulationAssetAmount.tsx`
- `suite-native/tx-simulation/src/components/EvmTxSimulationReviewContent.tsx`
- `suite-native/tx-simulation/src/components/SolanaTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/StellarTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/TxSimulationAssetRows.tsx`
- `suite-native/tx-simulation/src/components/TxSimulationCrossChainAsset.tsx`
- `suite-native/tx-simulation/src/components/index.ts`
- `suite/intl/src/messages.ts`
- `suite/tx-simulation/src/evm/index.ts`
- `suite/tx-simulation/src/solana/index.ts`
- `suite/tx-simulation/src/stellar/index.ts`

_Updated: 2026-08-21T00:02:20.113Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/blockaid-connect-popup-sources/web/](https://dev.suite.sldev.cz/suite-web/feat/blockaid-connect-popup-sources/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T00:04:18.571Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-21T00:03:25.356Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->