### PR TITLE
fix(suite-native): correctly report actual resolved language in analytics

### DIFF
--- a/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
+++ b/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
@@ -18,7 +18,7 @@ import {
 } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { selectIsBiometricsEnabled } from '@suite-native/biometrics';
-import { selectLocale } from '@suite-native/intl';
+import { selectSupportedLanguageLocale } from '@suite-native/intl';
 import { selectIsOnboardingFinished } from '@suite-native/settings';
 import { selectIsAppReady } from '@suite-native/state';
 import { useUserColorScheme } from '@suite-native/theme';
@@ -37,7 +37,7 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
     const rememberedStandardWallets = useSelector(selectRememberedStandardWalletsCount);
     const rememberedHiddenWallets = useSelector(selectRememberedHiddenWalletsCount);
     const enabledNetworks = useSelector(selectEnabledNetworks);
-    const appLanguage = useSelector(selectLocale);
+    const appLanguage = useSelector(selectSupportedLanguageLocale);
     const deviceLanguage = useSelector(selectDeviceLanguage);
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
 

--- a/suite-native/intl/src/localeSlice.ts
+++ b/suite-native/intl/src/localeSlice.ts
@@ -58,6 +58,10 @@ export const selectAreDebugTranslationKeysDisplayed = (state: LocaleSliceRootSta
 
 const selectSystemLocaleCode = (state: LocaleSliceRootState) => state.locale.systemLocaleCode;
 
+/**
+ * Select either the locale selected in-app, or if set to system, the preferred system one.
+ * Note that this does not guarantee app language! See selectSupportedLanguageLocale
+ */
 export const selectLocale = (state: LocaleSliceRootState) => {
     const userSelectedLocaleCode = selectAppLocaleCode(state);
     const systemLocaleCode = selectSystemLocaleCode(state);
@@ -65,6 +69,10 @@ export const selectLocale = (state: LocaleSliceRootState) => {
     return userSelectedLocaleCode === 'system' ? systemLocaleCode : userSelectedLocaleCode;
 };
 
+/**
+ * Selects the actual resolved language – either explicitely selected in-app, or if set to system,
+ * resolved from preferred locale (either it is a supported language, or fallback is used).
+ */
 export const selectSupportedLanguageLocale = (state: LocaleSliceRootState): SupportedLocaleCode => {
     const locale = selectLocale(state);
     if (isOfficiallySupportedLanguage(locale)) {


### PR DESCRIPTION
## Description

Currently there is an inaccuracy in Suite Mobile analytics:
the `AppReady` event [should report "app language"](https://github.com/trezor/trezor-suite/blob/e37dc522fff0a37d3ad8ad713dab096cc1490a98/suite-native/analytics/src/events/appReadyEvent.ts#L57), but now it reports preferred locale instead of actual language.

We only have a [few supported languages](https://github.com/trezor/trezor-suite/tree/f1c0adfe381a48bcd6f38f8eae6d33d87f7dfd94/suite-native/intl/translations) and the logic is as follows:
- if language explicitely chosen in-app, use that
- if set to system, look at preferred system locale and
  - if we support it, use that
  - if we don't support it, use fallback:
    - try to find language that shares the first two chars a.k.a. ISO 639-1 and use that
    - or use English

That's why preferred locale is not necessarily the actual displayed language.

→ report the actual displayed language, as the `AppReady` event specifies.

## Notes for QA

Can't be tested, it's analytics only.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native-language-analytics-reporting&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->