### PR TITLE
fix(suite-native): remove app ready load duration analytics

### DIFF
--- a/suite-native/analytics/src/events/appReadyEvent.ts
+++ b/suite-native/analytics/src/events/appReadyEvent.ts
@@ -21,7 +21,6 @@ type Attributes = {
     osVersion: AttributeDef<string | number>;
     discreetMode: AttributeDef<boolean>;
     theme: AttributeDef<'standard' | 'dark' | 'system' | 'debug'>;
-    loadDuration: AttributeDef<number>;
     isBiometricsEnabled: AttributeDef<boolean>;
     rememberedStandardWallets: AttributeDef<number>;
     rememberedHiddenWallets: AttributeDef<number>;
@@ -46,6 +45,7 @@ export const appReadyEvent: EventDef<Attributes, EventType.AppReady> = {
             notes: 'params `appLanguage` and `deviceLanguage` finally report real data.',
         },
         { version: '26.2.1', notes: 'param `labeling` added' },
+        { version: '26.8.1', notes: 'param `loadDuration` removed' },
     ],
 
     attributes: {
@@ -108,10 +108,6 @@ export const appReadyEvent: EventDef<Attributes, EventType.AppReady> = {
         theme: {
             changelog: [{ version: '24.4.1', notes: 'added' }],
             description: 'The color theme of the app',
-        },
-        loadDuration: {
-            changelog: [{ version: '24.4.1', notes: 'added' }],
-            description: 'The duration of the app to load in milliseconds',
         },
         isBiometricsEnabled: {
             changelog: [{ version: '24.4.1', notes: 'added' }],

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -39,11 +39,6 @@ import { useReportAppInitToAnalytics } from './hooks/useReportAppInitToAnalytics
 import { RootStackNavigator } from './navigation/RootStackNavigator';
 import { disableRTL } from './rtl';
 
-// Base time to measure app loading time.
-// The constant has to be placed at the beginning of this file to be initialized as soon as possible.
-// TODO: This method of measuring app loading time is not ideal, Should be substituted by some more sophisticated solution in the future.
-const APP_STARTED_TIMESTAMP = Date.now();
-
 markStartupJsBundleEvaluated();
 
 if (__DEV__) {
@@ -74,7 +69,7 @@ const AppComponent = () => {
     const isAppReady = useSelector(selectIsAppReady);
     const shouldUserBeAuthenticated = useSelector(selectShouldUserBeAuthenticated);
 
-    useReportAppInitToAnalytics(APP_STARTED_TIMESTAMP);
+    useReportAppInitToAnalytics();
 
     useEffect(() => {
         if (!isApplicationInitDispatchedRef.current) {

--- a/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
+++ b/suite-native/app/src/hooks/useReportAppInitToAnalytics.ts
@@ -23,8 +23,7 @@ import { selectIsOnboardingFinished } from '@suite-native/settings';
 import { selectIsAppReady } from '@suite-native/state';
 import { useUserColorScheme } from '@suite-native/theme';
 
-export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
-    const [loadDuration, setLoadDuration] = useState<number | null>(null);
+export const useReportAppInitToAnalytics = () => {
     const [initWasReported, setInitWasReported] = useState(false);
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const isAppReady = useSelector(selectIsAppReady);
@@ -42,11 +41,7 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
 
     useEffect(() => {
-        if (isAppReady && !loadDuration) setLoadDuration(Date.now() - appLaunchTimestamp);
-    }, [isAppReady, appLaunchTimestamp, loadDuration]);
-
-    useEffect(() => {
-        if (isAppReady && isOnboardingFinished && loadDuration && !initWasReported) {
+        if (isAppReady && isOnboardingFinished && !initWasReported) {
             setInitWasReported(true);
             analytics.report({
                 type: events.appReadyEvent.name,
@@ -63,7 +58,6 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
                     localCurrency: currencyCode,
                     theme: userColorScheme,
                     discreetMode: isDiscreetMode,
-                    loadDuration,
                     isBiometricsEnabled: isBiometricsOptionEnabled,
                     rememberedStandardWallets,
                     rememberedHiddenWallets,
@@ -80,7 +74,6 @@ export const useReportAppInitToAnalytics = (appLaunchTimestamp: number) => {
         bitcoinUnit,
         userColorScheme,
         isDiscreetMode,
-        loadDuration,
         isBiometricsOptionEnabled,
         rememberedStandardWallets,
         rememberedHiddenWallets,


### PR DESCRIPTION
## Description

Removes `loadDuration` from the mobile `app_ready` analytics event because startup duration is now tracked in Sentry. This also removes the analytics-only launch timestamp plumbing from the native app entry point and updates the event definition changelog.

## Notes for QA

No manual QA required beyond confirming the mobile `app_ready` analytics payload no longer contains `loadDuration`.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/drop-load-duration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->