### PR TITLE
fix(suite): do not show fiat toggle when fiat rate is zero

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts
@@ -62,9 +62,7 @@ export const useYieldFiatInput = ({
     const fiatSymbol = baseCurrencyCode.toUpperCase();
 
     const currentRate = useMemo(() => {
-        if (!symbol) {
-            return undefined;
-        }
+        if (!symbol) return undefined;
 
         return getTokenFiatRate(
             currentFiatRates,
@@ -72,7 +70,7 @@ export const useYieldFiatInput = ({
         );
     }, [currentFiatRates, baseCurrencyCode, symbol, tokenAddress]);
 
-    const hasFiatRate = currentRate !== undefined;
+    const hasFiatRate = !!currentRate;
 
     const liveAmount = useWatch({ control: methods.control, name: 'amountInput' });
 


### PR DESCRIPTION
## Description

Do not show fiat toggle when fiat rate is zero.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30901

## Screenshots:

<img width="1512" height="799" alt="Screenshot 2026-08-20 at 15 19 54" src="https://github.com/user-attachments/assets/4eddf64e-c399-454d-bd4c-d1b29870a8e7" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared hook used by yield staking forms, but the static coverage map touches 135 tests, so it is effectively a broad dependency. The highest-confidence coverage comes from the dedicated staking-form test, which directly manipulates fiat/crypto input and amount calculations. Adding a representative ETH end-to-end stake test ensures the computed amount still flows correctly through to the signed transaction. Other mapped tests either do not exercise the yield input path or cover unrelated flows, so they are omitted to keep the run minimal.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly exercises the yield staking form's amount input, including crypto/fiat switching, percentage buttons, Max calculation, and validation. These are the exact responsibilities of useYieldFiatInput, so it is the most targeted regression check for this change.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This end-to-end ETH staking flow enters an amount in the yield staking form and asserts the exact staked amount propagated to the device and success toasts. A regression in the yield input hook could produce an incorrect amount before signing, so this test provides a real-transaction safety net for the staking form logic.

</details>

_Updated: 2026-08-20T13:15:07.635Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-zero-fiat-rate-input-toggle&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-zero-fiat-rate-input-toggle&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-zero-fiat-rate-input-toggle/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-zero-fiat-rate-input-toggle/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T13:17:44.048Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-20T13:17:34.969Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->