### PR TITLE
feat(suite-desktop): remove obsolete exception to tighten will-navigate

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -163,12 +163,8 @@ const init = async () => {
         contents.on('will-navigate', (event, navigationUrl) => {
             // See: https://www.electronjs.org/docs/latest/tutorial/security#13-disable-or-limit-navigation
 
-            const parsedUrl = new URL(navigationUrl);
-
-            if (parsedUrl.origin !== 'https://trezor.io') {
-                logger.error('electron', `Prevented unexpected redirect to: ${navigationUrl}`);
-                event.preventDefault();
-            }
+            logger.error('electron', `Prevented unexpected redirect to: ${navigationUrl}`);
+            event.preventDefault();
         });
     });
 


### PR DESCRIPTION
## Description

Remove a trezor.io exception in Electron Main `will-navigate` interceptor.
Apparently we were alloing the electron main renderer window to navigate to trezor.io. 

But I have found no flow in that would want to directly navigate there. All links open it in the default browser, not in electron:
- `<Button href` have `target="_blank"` by default, it's not overridden anywhere
- very few direct `<a href`, all either stay on localhost or they do have `target="_blank"` 
- programatic usages open new window as well

The exception was added in https://github.com/trezor/trezor-suite/pull/17809 with unclear reason :see_no_evil: Rumor has it, that it was done to support https://github.com/trezor/trezor-suite/pull/17710 but that doesn't make sense.

→ remove the exception 

### Notes

With the planned [In-app Browser](https://app.notion.com/p/satoshilabs/In-app-Browser-390dc526060680ae8331fb904948ecbe) (PoC draft in https://github.com/trezor/trezor-suite/pull/29013 ) there will be many more exceptions, but as I understand,  _not in the main electron window_, but in a different window with isolated scope. The In-app Browser will be responsible for whitelisting specific domains that are requested.

## Notes for QA

Test links and redirect flows that go to trezor.io, verify nothing is broken.
Test what you can think of, no need to systematically cover everything, but beware of any external link that might be broken. 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No static coverage mapping exists for packages/suite-desktop-core/src/app.ts, so recommendations are inferred from the LLM analysis. The changed file is the desktop main-process entry point, so the highest-value tests are those that launch the Electron app and exercise bridge/daemon lifecycle and main-process IPC. I recommend the two bridge-lifecycle tests plus the silent-mode test unconditionally, and one representative TrezorConnect core-mode smoke test for broader coverage. All other desktop Connect tests share the same startup path and can be covered by CI's broader suite if these pass.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-core/src/app.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test launches the Electron app in bridge-daemon mode and asserts that the node-bridge process is spawned, survives UI close, and stops with the daemon. These lifecycle behaviors are implemented in the suite-desktop-core main process entry point (app.ts).
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — The test verifies that the Electron app spawns and stops the bundled bridge on startup/close, reconnects after an external bridge restart, and shows the dashboard. This directly exercises the bridge lifecycle and app initialization code owned by app.ts.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Silent-mode behavior is driven by the main-process app/focus IPC and appIsVisible channel, which are wired up in app.ts. The test confirms that TrezorConnect calls do or do not bring Suite to the foreground based on the silent-mode setting.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This is a representative TrezorConnect suite-desktop core-mode test that relies on app.ts to initialize the desktop Connect bridge and expose the WebSocket. A regression in app startup or Connect host setup would surface here, though it does not stress the specific IPC paths tested by silentMode.

</details>

_Updated: 2026-08-20T18:46:25.412Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-obsolete-exception/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-obsolete-exception/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-obsolete-exception&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-obsolete-exception&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-20T18:48:56.027Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T18:48:42.614Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->