### PR TITLE
feat(suite-desktop): fully cover desktopIpc with validation

### DIFF
--- a/packages/connect-examples/electron-main-process/src/electron.js
+++ b/packages/connect-examples/electron-main-process/src/electron.js
@@ -1,3 +1,5 @@
+// We have restricted electron.ipcMain import to wrap it with security validation, but this is not a live app, only an example.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { BrowserWindow, app, ipcMain } from 'electron';
 import path from 'node:path';
 import url, { fileURLToPath } from 'node:url';

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -47,6 +47,16 @@ const suiteInternalPatterns = {
         '@suite-common/* and @suite-native/* packages are private to the suite apps and must not be imported by other workspace packages.',
 };
 
+/*
+ Currently only relevant in @trezor/suite-desktop-core, but if the ipcMain import is to be used elsewhere,
+ the wrapper shall be extracted and this should still be a global rule.
+*/
+const electronIpcMainRestrictedImport = {
+    name: 'electron',
+    importNames: ['ipcMain'],
+    message: 'Use the local ipcMain wrapper instead.',
+};
+
 export const restrictedImportsPatterns = [
     buildArtifactPatterns,
     suiteInternalPatterns,
@@ -71,7 +81,12 @@ export const typescriptConfig = [
             '@typescript-eslint/no-restricted-imports': [
                 'error',
                 {
-                    paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
+                    paths: [
+                        { name: '.' },
+                        { name: '..' },
+                        { name: '../..' },
+                        electronIpcMainRestrictedImport,
+                    ],
                     patterns: [
                         buildArtifactPatterns,
                         networksPackagePattern,
@@ -111,7 +126,12 @@ export const typescriptConfig = [
             '@typescript-eslint/no-restricted-imports': [
                 'error',
                 {
-                    paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
+                    paths: [
+                        { name: '.' },
+                        { name: '..' },
+                        { name: '../..' },
+                        electronIpcMainRestrictedImport,
+                    ],
                     patterns: restrictedImportsPatterns,
                 },
             ],

--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -1,7 +1,6 @@
 import { type EventEmitter } from 'events';
 
 import { type ElectronIpcMainInvokeEvent } from './types';
-import { validateIpcMessage } from './validateIpcMessage';
 
 interface EventEmitterApi {
     on: (event: any, listener: (...args: any[]) => any) => any;
@@ -43,7 +42,7 @@ interface IpcMainHandlers {
     '/create': [string, ...any[]]; // channelName, ...params of interface constructor
 }
 
-export interface ElectronIpcMainEvent {
+export interface ElectronIpcMainProxyInvokeEvent extends ElectronIpcMainInvokeEvent {
     // reply: (channel: string, response: any) => any; // in electron it's defined as `Function`
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     reply: Function; // in electron it's defined as `Function`
@@ -52,7 +51,7 @@ export interface ElectronIpcMainEvent {
 interface ElectronIpcMain<Api> {
     on<K extends keyof IpcMainEvents<any>, Key extends string>(
         channel: `${Key}${K}`,
-        listener: (event: ElectronIpcMainEvent, args: IpcMainEvents<Api>[K]) => void,
+        listener: (event: ElectronIpcMainProxyInvokeEvent, args: IpcMainEvents<Api>[K]) => void,
     ): any;
     on(channel: string, listener: (event: ElectronIpcMainInvokeEvent, ...args: any[]) => void): any; // just to type compatibility with original Electron.IpcMain
     handle<K extends keyof IpcMainHandlers, Key extends string>(
@@ -82,8 +81,6 @@ export const createIpcProxyHandler = <Api extends EventEmitterApi>(
     debug?.info(SERVICE_NAME, `Init ipc interface ${channel}`);
     // Handle creation event from proxy-generator and creates actual interface instance
     ipcMain.handle(`${channel}/create`, async (ipcEvent, [instancePrefix, constructorParams]) => {
-        validateIpcMessage({ ipcEvent });
-
         debug?.info(SERVICE_NAME, `Create ipc chanel ${instancePrefix}`);
         const { onRequest, onAddListener, onRemoveListener } = await onCreateInstance(
             ...constructorParams,

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -5,12 +5,12 @@ import path from 'path';
 
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isMacOs } from '@trezor/env-utils';
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import type { HandshakeClient } from '@trezor/suite-desktop-api';
 import { colorVariants } from '@trezor/theme';
 import { createDeferred, resolveAfter } from '@trezor/utils';
 
 import { handshakeAndHangDetect } from './handshake-and-hang-detect';
+import { ipcMain } from './ipcMain';
 import { processStatePatch, restartApp } from './libs/app-utils';
 import { isAutoStartEnabled, promptForAutoStartBeforeQuit } from './libs/auto-start';
 import { APP_NAME } from './libs/constants';
@@ -29,7 +29,6 @@ import { initBackgroundModules, initModules } from './modules';
 import { initBioAuthModule } from './modules/bioAuthModule';
 import { mainThreadEmitter } from './modules/module';
 import { init as initTorModule } from './modules/tor';
-import { ipcMain } from './typed-electron';
 
 process.traceProcessWarnings = true;
 
@@ -294,9 +293,7 @@ const init = async () => {
             }));
 
     // repeated during app lifecycle (e.g. Ctrl+R)
-    ipcMain.handle('handshake/load-modules', (ipcEvent, payload) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('handshake/load-modules', (_, payload) => {
         // one time back-wards compatibility migration from redux to electron store. this can be deleted after some time
         // storageLoadBioAuth should be removed as well
         if (
@@ -324,19 +321,13 @@ const init = async () => {
         store,
     });
 
-    ipcMain.handle('browser-window/reload', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('browser-window/reload', () => {
         mainWindowProxy.getInstance()?.webContents.reload();
     });
 
     loadBioAuthModule();
 
-    ipcMain.handle('handshake/load-tor-module', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
-        return loadTorModule();
-    });
+    ipcMain.handle('handshake/load-tor-module', () => loadTorModule());
 
     let readyToQuit = false;
     let stoppingDaemon = false;

--- a/packages/suite-desktop-core/src/handshake-and-hang-detect.ts
+++ b/packages/suite-desktop-core/src/handshake-and-hang-detect.ts
@@ -1,11 +1,9 @@
 import { type BrowserWindow, dialog } from 'electron';
 
-import { validateIpcMessage } from '@trezor/ipc-proxy';
-import { type ElectronIpcMainInvokeEvent } from '@trezor/ipc-proxy/src/types';
 import { type TimerId } from '@trezor/type-utils';
 
+import { ipcMain } from './ipcMain';
 import { loadIndex } from './libs/loadIndex';
-import { ipcMain } from './typed-electron';
 
 const HANG_WAIT = 30000;
 
@@ -36,11 +34,7 @@ export const handshakeAndHangDetect = ({
     statePatch,
 }: HandshakeAndHangDetectParams) => {
     const { logger } = global;
-    const handshakeHandler = (ipcEvent: ElectronIpcMainInvokeEvent) => {
-        validateIpcMessage({ ipcEvent });
-
-        return Promise.resolve({});
-    };
+    const handshakeHandler = () => Promise.resolve({});
     let timeout: TimerId;
 
     const handshake = new Promise<HandshakeResult>(resolve => {

--- a/packages/suite-desktop-core/src/ipcMain.test.ts
+++ b/packages/suite-desktop-core/src/ipcMain.test.ts
@@ -1,5 +1,5 @@
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
-// eslint-disable-next-line local-rules/no-electron-ipc-main-reference
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ipcMain as electronIpcMain } from 'electron';
 
 import { validateIpcMessage } from '@trezor/ipc-proxy';

--- a/packages/suite-desktop-core/src/ipcMain.test.ts
+++ b/packages/suite-desktop-core/src/ipcMain.test.ts
@@ -1,0 +1,122 @@
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
+// eslint-disable-next-line local-rules/no-electron-ipc-main-reference
+import { ipcMain as electronIpcMain } from 'electron';
+
+import { validateIpcMessage } from '@trezor/ipc-proxy';
+
+import { ipcMain } from './ipcMain';
+
+jest.mock('electron', () => ({
+    app: {},
+    ipcMain: {
+        on: jest.fn(),
+        once: jest.fn(),
+        addListener: jest.fn(),
+        handle: jest.fn(),
+        handleOnce: jest.fn(),
+    },
+    ipcRenderer: {},
+}));
+
+jest.mock('@trezor/ipc-proxy', () => ({
+    validateIpcMessage: jest.fn(),
+}));
+
+describe('typed-electron ipcMain validation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('validates sender before registering on listeners', () => {
+        const originalListener = jest.fn();
+        const ipcEvent = {
+            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
+        } as unknown as IpcMainEvent;
+
+        ipcMain.on('theme/change', originalListener);
+
+        const wrappedListener = jest.mocked(electronIpcMain.on).mock.calls[0]?.[1];
+        expect(wrappedListener).toBeDefined();
+        if (wrappedListener === undefined) {
+            throw new Error('wrappedListener is undefined');
+        }
+        wrappedListener(ipcEvent, 'dark');
+
+        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
+        expect(originalListener).toHaveBeenCalledWith(ipcEvent, 'dark');
+    });
+
+    it('validates sender before registering once listeners', () => {
+        const originalListener = jest.fn();
+        const ipcEvent = {
+            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
+        } as unknown as IpcMainEvent;
+
+        ipcMain.once('theme/change', originalListener);
+
+        const wrappedListener = jest.mocked(electronIpcMain.once).mock.calls[0]?.[1];
+        expect(wrappedListener).toBeDefined();
+        if (wrappedListener === undefined) {
+            throw new Error('wrappedListener is undefined');
+        }
+        wrappedListener(ipcEvent, 'dark');
+
+        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
+        expect(originalListener).toHaveBeenCalledWith(ipcEvent, 'dark');
+    });
+
+    it('validates sender before registering addListener listeners', () => {
+        const originalListener = jest.fn();
+        const ipcEvent = {
+            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
+        } as unknown as IpcMainEvent;
+
+        ipcMain.addListener('theme/change', originalListener);
+
+        const wrappedListener = jest.mocked(electronIpcMain.addListener).mock.calls[0]?.[1];
+        expect(wrappedListener).toBeDefined();
+        if (wrappedListener === undefined) {
+            throw new Error('wrappedListener is undefined');
+        }
+        wrappedListener(ipcEvent, 'dark');
+
+        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
+        expect(originalListener).toHaveBeenCalledWith(ipcEvent, 'dark');
+    });
+
+    it('validates sender before registering handle listeners and preserves return values', async () => {
+        const originalListener = jest.fn().mockResolvedValue('result');
+        const ipcEvent = {
+            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
+        } as unknown as IpcMainInvokeEvent;
+
+        ipcMain.handle('app/is-visible', originalListener);
+
+        const wrappedListener = jest.mocked(electronIpcMain.handle).mock.calls[0]?.[1];
+        expect(wrappedListener).toBeDefined();
+        if (wrappedListener === undefined) {
+            throw new Error('wrappedListener is undefined');
+        }
+        await expect(wrappedListener(ipcEvent)).resolves.toBe('result');
+        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
+        expect(originalListener).toHaveBeenCalledWith(ipcEvent);
+    });
+
+    it('validates sender before registering handleOnce listeners and preserves return values', async () => {
+        const originalListener = jest.fn().mockResolvedValue('result');
+        const ipcEvent = {
+            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
+        } as unknown as IpcMainInvokeEvent;
+
+        ipcMain.handleOnce('app/is-visible', originalListener);
+
+        const wrappedListener = jest.mocked(electronIpcMain.handleOnce).mock.calls[0]?.[1];
+        expect(wrappedListener).toBeDefined();
+        if (wrappedListener === undefined) {
+            throw new Error('wrappedListener is undefined');
+        }
+        await expect(wrappedListener(ipcEvent)).resolves.toBe('result');
+        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
+        expect(originalListener).toHaveBeenCalledWith(ipcEvent);
+    });
+});

--- a/packages/suite-desktop-core/src/ipcMain.ts
+++ b/packages/suite-desktop-core/src/ipcMain.ts
@@ -1,0 +1,52 @@
+// This file is the one wrapper where we shall import electron.ipcMain
+// eslint-disable-next-line local-rules/no-electron-ipc-main-reference
+import { ipcMain as baseIpcMain } from 'electron';
+
+import { validateIpcMessage } from '@trezor/ipc-proxy';
+import type * as desktopApi from '@trezor/suite-desktop-api';
+
+export type StrictIpcMain = desktopApi.StrictIpcMain<
+    Omit<Electron.IpcMain, 'handle' | 'handleOnce' | 'removeHandler'>,
+    Electron.IpcMainInvokeEvent
+>;
+
+const withValidation = <T extends (...args: any[]) => any>(fn: T): T =>
+    ((...args: any[]) => {
+        const [ipcEvent] = args;
+        validateIpcMessage({ ipcEvent });
+
+        return fn(...args);
+    }) as T;
+
+const on: Electron.IpcMain['on'] = (channel, listener) =>
+    baseIpcMain.on(channel, withValidation(listener));
+
+const once: Electron.IpcMain['once'] = (channel, listener) =>
+    baseIpcMain.once(channel, withValidation(listener));
+
+const addListener: Electron.IpcMain['addListener'] = (channel, listener) =>
+    baseIpcMain.addListener(channel, withValidation(listener));
+
+const handle: Electron.IpcMain['handle'] = (channel, handler) =>
+    baseIpcMain.handle(channel, withValidation(handler));
+
+const handleOnce: Electron.IpcMain['handleOnce'] = (channel, handler) =>
+    baseIpcMain.handleOnce(channel, withValidation(handler));
+
+/**
+ * @deprecated direct export of electron.ipcMain that does not validate sender frame.
+ * Use only in cases where you need to do validation yourself (createIpcProxyHandler).
+ */
+export const rawIpcMain = baseIpcMain;
+
+/**
+ * ipcMain with listeners wrapped in security validation.
+ * Unless specifically needed, this should be used instead of rawIpcMain.
+ */
+export const ipcMain: StrictIpcMain = Object.assign(Object.create(baseIpcMain ?? {}), baseIpcMain, {
+    on,
+    once,
+    addListener,
+    handle,
+    handleOnce,
+});

--- a/packages/suite-desktop-core/src/ipcMain.ts
+++ b/packages/suite-desktop-core/src/ipcMain.ts
@@ -1,5 +1,5 @@
-// This file is the one wrapper where we shall import electron.ipcMain
-// eslint-disable-next-line local-rules/no-electron-ipc-main-reference
+// This file is the central place to directly import electron.ipcMain and wrap it with security validation.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ipcMain as baseIpcMain } from 'electron';
 
 import { validateIpcMessage } from '@trezor/ipc-proxy';

--- a/packages/suite-desktop-core/src/ipcMain.ts
+++ b/packages/suite-desktop-core/src/ipcMain.ts
@@ -34,19 +34,23 @@ const handleOnce: Electron.IpcMain['handleOnce'] = (channel, handler) =>
     baseIpcMain.handleOnce(channel, withValidation(handler));
 
 /**
- * @deprecated direct export of electron.ipcMain that does not validate sender frame.
- * Use only in cases where you need to do validation yourself (createIpcProxyHandler).
+ * `ipcMain` with listeners wrapped in security validation, but untyped IPC channels (original electron type).
+ * Use only in cases that declare their own IPC channel API (createIpcProxyHandler).
  */
-export const rawIpcMain = baseIpcMain;
+export const looselyTypedIpcMain: Electron.IpcMain = Object.assign(
+    Object.create(baseIpcMain ?? {}),
+    baseIpcMain,
+    {
+        on,
+        once,
+        addListener,
+        handle,
+        handleOnce,
+    },
+);
 
 /**
- * ipcMain with listeners wrapped in security validation.
- * Unless specifically needed, this should be used instead of rawIpcMain.
+ * `ipcMain` with listeners wrapped in security validation, and with IPC channels typed to a strict API contract (@trezor/suite-desktop-api).
+ * This should be used in Electron Main modules.
  */
-export const ipcMain: StrictIpcMain = Object.assign(Object.create(baseIpcMain ?? {}), baseIpcMain, {
-    on,
-    once,
-    addListener,
-    handle,
-    handleOnce,
-});
+export const ipcMain: StrictIpcMain = looselyTypedIpcMain;

--- a/packages/suite-desktop-core/src/libs/auto-start.ts
+++ b/packages/suite-desktop-core/src/libs/auto-start.ts
@@ -3,10 +3,10 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { createDeferred } from '@trezor/utils';
 
-import { app, ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
+import { app } from '../typed-electron';
 import { type Store } from './store';
 
 const canUseWindowForAutoStartPrompt = (mainWindow: BrowserWindow) =>
@@ -101,12 +101,10 @@ export const promptForAutoStartBeforeQuit = async (mainWindow: BrowserWindow, st
     let modalShown = false;
     ipcMain.removeHandler('app/auto-start/popup-ack');
     ipcMain.removeHandler('app/auto-start/popup-response');
-    ipcMain.handleOnce('app/auto-start/popup-ack', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.handleOnce('app/auto-start/popup-ack', () => {
         modalShown = true;
     });
-    ipcMain.handleOnce('app/auto-start/popup-response', (ipcEvent, response) => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.handleOnce('app/auto-start/popup-response', (_, response) => {
         deferredResponse.resolve(response);
     });
 

--- a/packages/suite-desktop-core/src/libs/connect-popup-messages.ts
+++ b/packages/suite-desktop-core/src/libs/connect-popup-messages.ts
@@ -6,7 +6,7 @@
 import type { ConnectPopupResponse } from '@trezor/suite-desktop-api';
 import { type Deferred, createDeferred } from '@trezor/utils';
 
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 
 const LOG_PREFIX = 'connect-popup-messages';
 

--- a/packages/suite-desktop-core/src/modules/auto-start.ts
+++ b/packages/suite-desktop-core/src/modules/auto-start.ts
@@ -1,11 +1,9 @@
 /**
  * Auto start handler
  */
-import { validateIpcMessage } from '@trezor/ipc-proxy';
-
-import { isAutoStartEnabled, linuxAutoStart, setAutoStartEnabled } from '../libs/auto-start';
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 import type { ModuleInit } from './module';
+import { isAutoStartEnabled, linuxAutoStart, setAutoStartEnabled } from '../libs/auto-start';
 
 export const SERVICE_NAME = 'auto-start';
 
@@ -17,8 +15,7 @@ export const init: ModuleInit = () => {
         setAutoStartEnabled(enabled);
     });
 
-    ipcMain.handle('app/auto-start/is-enabled', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.handle('app/auto-start/is-enabled', () => {
         const result = isAutoStartEnabled();
 
         return { success: true, payload: result };

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -9,16 +9,16 @@ import {
 import { unlinkSync } from 'fs';
 
 import { isDevEnv, isFeatureFlagEnabled } from '@suite-common/suite-utils';
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { type HandshakeElectron } from '@trezor/suite-desktop-api';
 import { bytesToHumanReadable, serializeError } from '@trezor/utils';
 
 import { type ModuleInit, mainThreadEmitter } from './module';
+import { ipcMain } from '../ipcMain';
 import { parseCustomFeedURL } from '../libs/parseCustomFeedURL';
 import { getSwitchValue, hasSwitch } from '../libs/process-switches';
 import { getSignatureFile, verifySignature } from '../libs/update-checker';
 import { b2t } from '../libs/utils';
-import { app, ipcMain } from '../typed-electron';
+import { app } from '../typed-electron';
 
 export const SERVICE_NAME = 'auto-updater';
 
@@ -261,8 +261,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         );
     });
 
-    ipcMain.on('update/check', (ipcEvent, { isManual }) => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.on('update/check', (_, { isManual }) => {
         if (isManual === true) {
             isManualCheck = true;
         }
@@ -271,21 +270,18 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         autoUpdater.checkForUpdates();
     });
 
-    ipcMain.on('update/download', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.on('update/download', () => {
         startDownload();
     });
 
-    ipcMain.on('update/set-auto-install-on-app-quit', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.on('update/set-auto-install-on-app-quit', () => {
         // If the update is triggered manually by the button in the app, we want to force update,
         // because it may have been disabled by the user switch the automatic update off. But because the user deliberately
         // clicked the "Update on quit" button, we want to install it.
         autoUpdater.autoInstallOnAppQuit = true;
     });
 
-    ipcMain.on('update/install', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.on('update/install', () => {
         logger.info(SERVICE_NAME, 'Restart and update request');
 
         setImmediate(() => {
@@ -300,8 +296,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         });
     });
 
-    ipcMain.on('update/cancel', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.on('update/cancel', () => {
         logger.info(
             SERVICE_NAME,
             `Cancel update request (in progress: ${b2t(!!updateCancellationToken)})`,
@@ -311,8 +306,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         }
     });
 
-    ipcMain.on('update/allow-prerelease', (ipcEvent, value = true) => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.on('update/allow-prerelease', (_, value = true) => {
         logger.info(SERVICE_NAME, `${value ? 'allow' : 'disable'} prerelease!`);
         mainWindowProxy.getInstance()?.webContents.send('update/allow-prerelease', value);
         const settings = store.getUpdateSettings();
@@ -324,8 +318,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         logger.info(SERVICE_NAME, `New feed url: ${feedURL}`);
     });
 
-    ipcMain.on('update/set-automatic-update-enabled', (ipcEvent, value = true) => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.on('update/set-automatic-update-enabled', (_, value = true) => {
         logger.info(SERVICE_NAME, `set-automatic-update-enabled: ${value ? 'true' : 'false'}`);
 
         mainWindowProxy

--- a/packages/suite-desktop-core/src/modules/bioAuthModule.ts
+++ b/packages/suite-desktop-core/src/modules/bioAuthModule.ts
@@ -1,11 +1,10 @@
 import { systemPreferences } from 'electron';
 
 import { isLinux, isMacOs, isWindows } from '@trezor/env-utils';
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { createWinHelloManager } from '@trezor/suite-desktop-native';
 import { TypedEmitter, serializeError } from '@trezor/utils';
 
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 import { type Dependencies } from './module';
 
 const PROMPT_REASON = 'Trezor Suite: validation BIO authentication to access the Suite UI';
@@ -248,26 +247,21 @@ export const initBioAuthModule = ({
             return;
         }
 
-        ipcMain.handle('bio-auth/is-bio-auth-available', ipcEvent => {
-            validateIpcMessage({ ipcEvent });
-
+        ipcMain.handle('bio-auth/is-bio-auth-available', () => {
             // Necessary check for race condition: UI might ask for availability before await bioAuth.init()
             if (!bioAuth) return Promise.resolve(false);
 
             return bioAuth.isAvailable();
         });
 
-        ipcMain.handle('bio-auth/set-bio-auth-settings', (ipcEvent, params) => {
-            validateIpcMessage({ ipcEvent });
-
+        ipcMain.handle('bio-auth/set-bio-auth-settings', (_, params) => {
             store.setBioAuthSettings(params);
         });
 
-        ipcMain.handle('bio-auth/get-bio-auth-settings', ipcEvent => {
-            validateIpcMessage({ ipcEvent });
-
-            return { enabled: false, ...store.getBioAuthSettings() };
-        });
+        ipcMain.handle('bio-auth/get-bio-auth-settings', () => ({
+            enabled: false,
+            ...store.getBioAuthSettings(),
+        }));
 
         store.onBioAuthSettingsChange(newSettings => {
             if (!newSettings) return;
@@ -279,9 +273,7 @@ export const initBioAuthModule = ({
             bioAuth?.setEnabled(enabled);
         });
 
-        ipcMain.handle('bio-auth/validate-bio-auth', (ipcEvent, params) => {
-            validateIpcMessage({ ipcEvent });
-
+        ipcMain.handle('bio-auth/validate-bio-auth', (_, params) => {
             if (!bioAuth?.initialized) {
                 throw new Error('BioAuth module is not initialized (calling validate-bio-auth)');
             }
@@ -289,8 +281,7 @@ export const initBioAuthModule = ({
             return bioAuth.validate(params.message ?? PROMPT_REASON);
         });
 
-        ipcMain.handle('bio-auth/get-validation-status', ipcEvent => {
-            validateIpcMessage({ ipcEvent });
+        ipcMain.handle('bio-auth/get-validation-status', () => {
             if (!bioAuth?.initialized) {
                 throw new Error(
                     'BioAuth module is not initialized (calling get-validation-status)',

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -1,5 +1,4 @@
 import { exec } from 'child_process';
-import { ipcMain } from 'electron';
 
 import { isMacOs } from '@trezor/env-utils';
 import { type IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
@@ -13,6 +12,7 @@ import {
 import { createLazy, throwError } from '@trezor/utils';
 
 import type { ModuleInit } from './module';
+import { rawIpcMain } from '../ipcMain';
 import { BluetoothProcess } from '../libs/processes/BluetoothProcess';
 
 export const SERVICE_NAME = '@trezor/transport-bluetooth';
@@ -136,7 +136,7 @@ export const init: ModuleInit = () => {
         },
     };
 
-    const unregisterProxy = createIpcProxyHandler(ipcMain, 'Bluetooth', proxyOptions);
+    const unregisterProxy = createIpcProxyHandler(rawIpcMain, 'Bluetooth', proxyOptions);
     const onLoad = () => {
         bluetoothModuleState.getTransport = getBluetoothTransport;
     };

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -12,7 +12,7 @@ import {
 import { createLazy, throwError } from '@trezor/utils';
 
 import type { ModuleInit } from './module';
-import { rawIpcMain } from '../ipcMain';
+import { looselyTypedIpcMain } from '../ipcMain';
 import { BluetoothProcess } from '../libs/processes/BluetoothProcess';
 
 export const SERVICE_NAME = '@trezor/transport-bluetooth';
@@ -136,7 +136,7 @@ export const init: ModuleInit = () => {
         },
     };
 
-    const unregisterProxy = createIpcProxyHandler(rawIpcMain, 'Bluetooth', proxyOptions);
+    const unregisterProxy = createIpcProxyHandler(looselyTypedIpcMain, 'Bluetooth', proxyOptions);
     const onLoad = () => {
         bluetoothModuleState.getTransport = getBluetoothTransport;
     };

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -1,16 +1,15 @@
 /**
  * Bridge runner
  */
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { type InvokeResult } from '@trezor/suite-desktop-api';
 import { type TrezordNode } from '@trezor/transport-bridge';
 import { scheduleAction } from '@trezor/utils';
 
+import { ipcMain } from '../ipcMain';
+import type { Dependencies } from './module';
 import { hasSwitch } from '../libs/process-switches';
 import { ThreadProxy } from '../libs/thread-proxy';
 import { b2t } from '../libs/utils';
-import { ipcMain } from '../typed-electron';
-import type { Dependencies } from './module';
 
 // bridge node is intended for internal testing
 const bridgeTest = hasSwitch('bridge-test');
@@ -180,27 +179,20 @@ export const initBackground = ({
 };
 
 export const init = ({ store, mainWindowProxy, mainThreadEmitter }: Dependencies) => {
-    ipcMain.handle(
-        'bridge/change-settings',
-        (ipcEvent, payload: { doNotStartOnStartup: boolean }) => {
-            validateIpcMessage({ ipcEvent });
+    ipcMain.handle('bridge/change-settings', (_, payload: { doNotStartOnStartup: boolean }) => {
+        try {
+            store.setBridgeSettings(payload);
 
-            try {
-                store.setBridgeSettings(payload);
+            return { success: true };
+        } catch (error) {
+            return { success: false, error };
+        } finally {
+            const newSettings = store.getBridgeSettings();
+            mainWindowProxy?.getInstance()?.webContents.send('bridge/settings', newSettings);
+        }
+    });
 
-                return { success: true };
-            } catch (error) {
-                return { success: false, error };
-            } finally {
-                const newSettings = store.getBridgeSettings();
-                mainWindowProxy?.getInstance()?.webContents.send('bridge/settings', newSettings);
-            }
-        },
-    );
-
-    ipcMain.handle('bridge/get-settings', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('bridge/get-settings', () => {
         try {
             return { success: true, payload: store.getBridgeSettings() };
         } catch (error) {
@@ -225,9 +217,7 @@ export const init = ({ store, mainWindowProxy, mainThreadEmitter }: Dependencies
         }
     };
 
-    ipcMain.handle('bridge/toggle', async ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('bridge/toggle', async () => {
         // turning bridge on and off disables watchdog. this watchdog handles quite an edge-case anyway so trying to reconcile both functionalities
         if (watchInterval) {
             clearInterval(watchInterval);
@@ -236,9 +226,7 @@ export const init = ({ store, mainWindowProxy, mainThreadEmitter }: Dependencies
         return await toggleBridge();
     });
 
-    ipcMain.handle('bridge/get-status', async ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('bridge/get-status', async () => {
         try {
             const status = await bridge.status();
 

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -17,7 +17,7 @@ import { type InterceptedEvent } from '@trezor/request-manager';
 import { getSynchronize } from '@trezor/utils';
 
 import type { ModuleInit } from './module';
-import { ipcMain, rawIpcMain } from '../ipcMain';
+import { ipcMain, looselyTypedIpcMain } from '../ipcMain';
 import { PowerSaveBlocker } from '../libs/power-save-blocker';
 import { CoinjoinProcess } from '../libs/processes/CoinjoinProcess';
 import { ThreadProxy } from '../libs/thread-proxy';
@@ -207,13 +207,13 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
 
     const registerProxies = () => {
         const unregisterBackendProxy = createIpcProxyHandler(
-            rawIpcMain,
+            looselyTypedIpcMain,
             BACKEND_CHANNEL,
             backendProxyOptions,
         );
 
         const unregisterClientProxy = createIpcProxyHandler(
-            rawIpcMain,
+            looselyTypedIpcMain,
             CLIENT_CHANNEL,
             clientProxyOptions,
         );

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -3,7 +3,6 @@
  */
 
 import { captureMessage, withScope } from '@sentry/electron/main';
-import { ipcMain } from 'electron';
 
 import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG } from '@suite-common/sentry';
 import {
@@ -18,6 +17,7 @@ import { type InterceptedEvent } from '@trezor/request-manager';
 import { getSynchronize } from '@trezor/utils';
 
 import type { ModuleInit } from './module';
+import { ipcMain, rawIpcMain } from '../ipcMain';
 import { PowerSaveBlocker } from '../libs/power-save-blocker';
 import { CoinjoinProcess } from '../libs/processes/CoinjoinProcess';
 import { ThreadProxy } from '../libs/thread-proxy';
@@ -207,13 +207,13 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
 
     const registerProxies = () => {
         const unregisterBackendProxy = createIpcProxyHandler(
-            ipcMain,
+            rawIpcMain,
             BACKEND_CHANNEL,
             backendProxyOptions,
         );
 
         const unregisterClientProxy = createIpcProxyHandler(
-            ipcMain,
+            rawIpcMain,
             CLIENT_CHANNEL,
             clientProxyOptions,
         );

--- a/packages/suite-desktop-core/src/modules/event-logging/index.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/index.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from '../../typed-electron';
+import { ipcMain } from '../../ipcMain';
 import type { ModuleInit } from '../module';
 
 export const SERVICE_NAME = 'event-logging';

--- a/packages/suite-desktop-core/src/modules/http-receiver.ts
+++ b/packages/suite-desktop-core/src/modules/http-receiver.ts
@@ -4,14 +4,14 @@
 import { captureMessage } from '@sentry/electron/main';
 
 import { isMacOs, isWindows } from '@trezor/env-utils';
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { isArrayMember } from '@trezor/utils';
 
+import { ipcMain } from '../ipcMain';
 import { restartApp } from '../libs/app-utils';
 import { initConnectPopupResponseHandler } from '../libs/connect-popup-messages';
 import { exposeConnectWs } from '../libs/connect-ws';
 import { createHttpReceiver } from '../libs/http-receiver';
-import { app, ipcMain } from '../typed-electron';
+import { app } from '../typed-electron';
 import { type ModuleInitBackground } from './module';
 
 export const SERVICE_NAME = 'http-receiver';
@@ -77,8 +77,7 @@ export const initBackground: ModuleInitBackground = ({
         });
 
         // when httpReceiver was asked to provide current address for given pathname
-        ipcMain.handle('server/request-address', (ipcEvent, pathname) => {
-            validateIpcMessage({ ipcEvent });
+        ipcMain.handle('server/request-address', (_, pathname) => {
             try {
                 // Use deeplink URLs for trading redirects on macOS/Windows only
                 if (isArrayMember(pathname, TRADING_REDIRECT_PATHS) && (isMacOs() || isWindows())) {
@@ -98,14 +97,8 @@ export const initBackground: ModuleInitBackground = ({
             }
         });
 
-        ipcMain.handle('connect-popup/enabled', ipcEvent => {
-            validateIpcMessage({ ipcEvent });
-
-            return connectPopupEnabled();
-        });
-        ipcMain.handle('connect-popup/set-enabled', (ipcEvent, enabled: boolean) => {
-            validateIpcMessage({ ipcEvent });
-
+        ipcMain.handle('connect-popup/enabled', () => connectPopupEnabled());
+        ipcMain.handle('connect-popup/set-enabled', (_, enabled: boolean) => {
             store.setConnectSettings({ disableWs: !enabled });
             restartApp();
         });

--- a/packages/suite-desktop-core/src/modules/mcp-server.test.ts
+++ b/packages/suite-desktop-core/src/modules/mcp-server.test.ts
@@ -14,7 +14,7 @@ const getFreePort = (): Promise<number> =>
         srv.on('error', reject);
     });
 
-jest.mock('../typed-electron', () => ({
+jest.mock('../ipcMain', () => ({
     ipcMain: {
         handle: (channel: string, handler: (...args: any[]) => any) => {
             ipcHandlers[channel] = handler;

--- a/packages/suite-desktop-core/src/modules/mcp-server.ts
+++ b/packages/suite-desktop-core/src/modules/mcp-server.ts
@@ -12,13 +12,12 @@ import * as http from 'http';
 import { CALL_SOURCE_MCP, type ConnectProcessInfo } from '@suite-common/connect-popup';
 import { getNetworkOptional } from '@suite-common/wallet-config';
 import { convertAmountUnitsToSubunits, substituteBip43Path } from '@suite-common/wallet-utils';
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { findProcessFromIncomingPort } from '@trezor/node-utils';
 
+import { ipcMain } from '../ipcMain';
+import { type ModuleInit } from './module';
 import { addMessage } from '../libs/connect-popup-messages';
 import { getProcessIcon } from '../libs/process-icon';
-import { ipcMain } from '../typed-electron';
-import { type ModuleInit } from './module';
 
 export const SERVICE_NAME = 'mcp-server';
 
@@ -1377,9 +1376,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
     };
 
     // IPC handlers for controlling the MCP server from the renderer
-    ipcMain.handle('mcp/get-settings', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('mcp/get-settings', () => {
         const settings = store.getMcpSettings();
 
         return {
@@ -1390,17 +1387,14 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         };
     });
 
-    ipcMain.handle('mcp/regenerate-token', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
+    ipcMain.handle('mcp/regenerate-token', () => {
         const newToken = generateToken();
         store.setMcpSettings({ token: newToken });
 
         return { token: newToken };
     });
 
-    ipcMain.handle('mcp/set-enabled', (ipcEvent, enabled: boolean) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('mcp/set-enabled', (_, enabled: boolean) => {
         if (typeof enabled !== 'boolean') return;
 
         const currentSettings = store.getMcpSettings();

--- a/packages/suite-desktop-core/src/modules/metadata.ts
+++ b/packages/suite-desktop-core/src/modules/metadata.ts
@@ -1,11 +1,9 @@
 /**
  * Metadata feature (save/load metadata locally)
  */
-import { validateIpcMessage } from '@trezor/ipc-proxy';
-
-import { read, readDir, rename, save } from '../libs/user-data';
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 import type { ModuleInit } from './module';
+import { read, readDir, rename, save } from '../libs/user-data';
 
 const DATA_DIR = '/metadata';
 
@@ -14,36 +12,28 @@ export const SERVICE_NAME = 'metadata';
 export const init: ModuleInit = () => {
     const { logger } = global;
 
-    ipcMain.handle('metadata/write', async (ipcEvent, message) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('metadata/write', async (_, message) => {
         logger.info(SERVICE_NAME, `Writing metadata to ${DATA_DIR}/${message.file}`);
         const resp = await save(DATA_DIR, message.file, message.content, 'utf-8');
 
         return resp;
     });
 
-    ipcMain.handle('metadata/read', async (ipcEvent, message) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('metadata/read', async (_, message) => {
         logger.info(SERVICE_NAME, `Reading metadata from ${DATA_DIR}/${message.file}`);
         const resp = await read(DATA_DIR, message.file);
 
         return resp;
     });
 
-    ipcMain.handle('metadata/get-files', async ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('metadata/get-files', async () => {
         logger.info(SERVICE_NAME, `Retrieving metadata file names from ${DATA_DIR}`);
         const resp = await readDir(DATA_DIR);
 
         return resp;
     });
 
-    ipcMain.handle('metadata/rename-file', async (ipcEvent, message) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('metadata/rename-file', async (_, message) => {
         const { file, to } = message;
         logger.info(SERVICE_NAME, `Renaming metadata file ${file} name to ${to}`);
         const resp = await rename(DATA_DIR, file, to);

--- a/packages/suite-desktop-core/src/modules/safeStorage.test.ts
+++ b/packages/suite-desktop-core/src/modules/safeStorage.test.ts
@@ -16,18 +16,15 @@ jest.mock('electron', () => ({
         getSelectedStorageBackend: jest.fn(() => 'gnome_libsecret'),
         isEncryptionAvailable: jest.fn(() => true),
     },
-}));
-
-jest.mock('@trezor/ipc-proxy', () => ({
-    validateIpcMessage: jest.fn(),
-}));
-
-jest.mock('../typed-electron', () => ({
     ipcMain: {
         handle: (channel: string, handler: IpcHandler) => {
             mockIpcHandlers.set(channel, handler);
         },
     },
+}));
+
+jest.mock('@trezor/ipc-proxy', () => ({
+    validateIpcMessage: jest.fn(),
 }));
 
 const delegatedIdentityKey = '0c9d40cd155e7ddb93e7b3c7b2acd8d75e7a3ebd543a3504c8f8164fb692772b';

--- a/packages/suite-desktop-core/src/modules/safeStorage.ts
+++ b/packages/suite-desktop-core/src/modules/safeStorage.ts
@@ -2,12 +2,11 @@ import { safeStorage } from 'electron';
 
 import { DecryptionFailed, EncryptionUnavailable } from '@suite-common/platform-encryption';
 import { isLinux } from '@trezor/env-utils';
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { err, ok } from '@trezor/type-utils';
 
 import type { ModuleInit } from './module';
 import { isSafeStorageDecryptedValue } from './safeStorageValidation';
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 
 export const SERVICE_NAME = 'SAFE_STORAGE';
 
@@ -39,9 +38,7 @@ const isEncryptionAvailable = () => {
 };
 
 export const init: ModuleInit = () => {
-    ipcMain.handle('safe-storage/decrypt', (ipcEvent, params) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('safe-storage/decrypt', (_, params) => {
         const isEncryptionAvailableResult = isEncryptionAvailable();
         if (!isEncryptionAvailableResult.success) {
             return isEncryptionAvailableResult;
@@ -63,9 +60,7 @@ export const init: ModuleInit = () => {
         }
     });
 
-    ipcMain.handle('safe-storage/encrypt', (ipcEvent, params) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('safe-storage/encrypt', (_, params) => {
         const isEncryptionAvailableResult = isEncryptionAvailable();
         if (!isEncryptionAvailableResult.success) {
             return isEncryptionAvailableResult;

--- a/packages/suite-desktop-core/src/modules/store.ts
+++ b/packages/suite-desktop-core/src/modules/store.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 import type { ModuleInit } from './module';
 
 export const SERVICE_NAME = 'store';

--- a/packages/suite-desktop-core/src/modules/system-settings.ts
+++ b/packages/suite-desktop-core/src/modules/system-settings.ts
@@ -3,7 +3,7 @@ import { exec } from 'child_process';
 import { isLinux, isMacOs, isWindows } from '@trezor/env-utils';
 import { type InvokeResult } from '@trezor/suite-desktop-api';
 
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 import type { ModuleInit } from './module';
 
 export const SERVICE_NAME = 'system-settings';

--- a/packages/suite-desktop-core/src/modules/theme.ts
+++ b/packages/suite-desktop-core/src/modules/theme.ts
@@ -2,9 +2,9 @@ import { nativeTheme } from 'electron';
 
 import { type SuiteThemeVariant } from '@trezor/suite-desktop-api';
 
-import { Store } from '../libs/store';
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 import type { ModuleInit } from './module';
+import { Store } from '../libs/store';
 
 const setThemeManually = (theme: SuiteThemeVariant, store: Store) => {
     const { logger } = global;

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -7,15 +7,15 @@ import path from 'path';
 
 import { TorStatus } from '@suite/tor-types';
 import TrezorConnect from '@trezor/connect';
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { getFreePort } from '@trezor/node-utils';
 import { type BootstrapEvent } from '@trezor/request-manager';
 import { type BootstrapTorEvent, type HandshakeTorModule } from '@trezor/suite-desktop-api';
 
+import { ipcMain } from '../ipcMain';
 import { hasSwitch } from '../libs/process-switches';
 import { TorExternalProcess } from '../libs/processes/TorExternalProcess';
 import { TorProcess, type TorProcessStatus } from '../libs/processes/TorProcess';
-import { app, ipcMain } from '../typed-electron';
+import { app } from '../typed-electron';
 import type { Dependencies } from './module';
 
 const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies) => {
@@ -216,11 +216,9 @@ const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies)
     ipcMain.handle(
         'tor/change-settings',
         (
-            ipcEvent,
+            _,
             { useExternalTor, externalPort }: { useExternalTor: boolean; externalPort: number },
         ) => {
-            validateIpcMessage({ ipcEvent });
-
             try {
                 store.setTorSettings({
                     ...store.getTorSettings(),
@@ -239,9 +237,7 @@ const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies)
         },
     );
 
-    ipcMain.handle('tor/get-settings', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('tor/get-settings', () => {
         try {
             return { success: true, payload: store.getTorSettings() };
         } catch (error) {
@@ -249,9 +245,7 @@ const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies)
         }
     });
 
-    ipcMain.handle('tor/toggle', async (ipcEvent, shouldEnableTor: boolean) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('tor/toggle', async (_, shouldEnableTor: boolean) => {
         logger.info('tor', `Toggling ${shouldEnableTor ? 'ON' : 'OFF'}`);
 
         try {

--- a/packages/suite-desktop-core/src/modules/tray.ts
+++ b/packages/suite-desktop-core/src/modules/tray.ts
@@ -5,10 +5,10 @@ import { Menu, Tray } from 'electron';
 import path from 'path';
 
 import { DEVICE, type DeviceEvent } from '@trezor/connect';
-import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { type Status, type TraySettings } from '@trezor/suite-desktop-api';
 
-import { app, ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
+import { app } from '../typed-electron';
 import { type ModuleInitBackground, mainThreadEmitter } from './module';
 import { APP_NAME_BARE } from '../libs/constants';
 
@@ -131,9 +131,7 @@ export const initBackground: ModuleInitBackground = ({ store, mainWindowProxy })
         renderTray();
     });
 
-    ipcMain.handle('tray/change-settings', (ipcEvent, updatedSettings: TraySettings) => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('tray/change-settings', (_, updatedSettings: TraySettings) => {
         try {
             store.setTraySettings({
                 ...store.getTraySettings(),
@@ -148,9 +146,7 @@ export const initBackground: ModuleInitBackground = ({ store, mainWindowProxy })
         }
     });
 
-    ipcMain.handle('tray/get-settings', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('tray/get-settings', () => {
         try {
             return { success: true, payload: store.getTraySettings() };
         } catch (error) {

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -1,5 +1,3 @@
-import { ipcMain } from 'electron';
-
 import TrezorConnect, {
     type ConnectSettings,
     type ConnectSettingsTransport,
@@ -17,6 +15,7 @@ import { parseElectrumUrl } from '@trezor/utils';
 import { bluetoothModuleState } from './bluetooth';
 import { getStoredFirmwares } from './firmware';
 import { type MainThreadEmitter, type ModuleInit, type ModuleInitBackground } from './module';
+import { rawIpcMain } from '../ipcMain';
 import { APP_NAME } from '../libs/constants';
 import { getComputerName } from '../libs/info';
 import { PowerSaveBlocker } from '../libs/power-save-blocker';
@@ -196,7 +195,7 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
         }),
     };
 
-    const unregisterProxy = createIpcProxyHandler(ipcMain, 'TrezorConnect', ipcProxyOptions);
+    const unregisterProxy = createIpcProxyHandler(rawIpcMain, 'TrezorConnect', ipcProxyOptions);
 
     const onLoad = () => {
         // TODO: doing nothing for now.

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -15,7 +15,7 @@ import { parseElectrumUrl } from '@trezor/utils';
 import { bluetoothModuleState } from './bluetooth';
 import { getStoredFirmwares } from './firmware';
 import { type MainThreadEmitter, type ModuleInit, type ModuleInitBackground } from './module';
-import { rawIpcMain } from '../ipcMain';
+import { looselyTypedIpcMain } from '../ipcMain';
 import { APP_NAME } from '../libs/constants';
 import { getComputerName } from '../libs/info';
 import { PowerSaveBlocker } from '../libs/power-save-blocker';
@@ -195,7 +195,11 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
         }),
     };
 
-    const unregisterProxy = createIpcProxyHandler(rawIpcMain, 'TrezorConnect', ipcProxyOptions);
+    const unregisterProxy = createIpcProxyHandler(
+        looselyTypedIpcMain,
+        'TrezorConnect',
+        ipcProxyOptions,
+    );
 
     const onLoad = () => {
         // TODO: doing nothing for now.

--- a/packages/suite-desktop-core/src/modules/user-data.ts
+++ b/packages/suite-desktop-core/src/modules/user-data.ts
@@ -1,25 +1,19 @@
-import { validateIpcMessage } from '@trezor/ipc-proxy';
-
-import * as userData from '../libs/user-data';
-import { ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
 import type { ModuleInit } from './module';
+import * as userData from '../libs/user-data';
 
 export const SERVICE_NAME = 'user-data';
 
 export const init: ModuleInit = () => {
     const { logger } = global;
 
-    ipcMain.handle('user-data/clear', ipcEvent => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('user-data/clear', () => {
         logger.info(SERVICE_NAME, `Clearing user-data.`);
 
         return userData.clearAppData();
     });
 
-    ipcMain.handle('user-data/open', (ipcEvent, directory = '') => {
-        validateIpcMessage({ ipcEvent });
-
+    ipcMain.handle('user-data/open', (_, directory = '') => {
         logger.info(SERVICE_NAME, `Opening user-data${directory} folder.`);
 
         return userData.open(directory);

--- a/packages/suite-desktop-core/src/modules/window-controls.ts
+++ b/packages/suite-desktop-core/src/modules/window-controls.ts
@@ -3,7 +3,8 @@
  */
 import { isWindows } from '@trezor/env-utils';
 
-import { app, ipcMain } from '../typed-electron';
+import { ipcMain } from '../ipcMain';
+import { app } from '../typed-electron';
 import type { ModuleInit } from './module';
 
 export const SERVICE_NAME = 'window-control';

--- a/packages/suite-desktop-core/src/typed-electron.ts
+++ b/packages/suite-desktop-core/src/typed-electron.ts
@@ -1,24 +1,21 @@
-/* eslint-disable prefer-destructuring */
-import * as electron from 'electron';
+import {
+    type BrowserWindow,
+    type Event,
+    type IpcRenderer,
+    type WebContents,
+    app as baseElectronApp,
+    ipcRenderer as baseIpcRenderer,
+} from 'electron';
 
 import type * as desktopApi from '@trezor/suite-desktop-api';
 
-export type StrictIpcMain = desktopApi.StrictIpcMain<
-    Omit<Electron.IpcMain, 'handle' | 'handleOnce' | 'removeHandler'>,
-    Electron.IpcMainInvokeEvent
->;
-
 export type StrictIpcRenderer = desktopApi.StrictIpcRenderer<
-    Omit<electron.IpcRenderer, 'invoke' | 'send'>,
-    Electron.Event
+    Omit<IpcRenderer, 'invoke' | 'send'>,
+    Event
 >;
 
-export type StrictBrowserWindow = desktopApi.StrictBrowserWindow<
-    Electron.BrowserWindow,
-    Electron.WebContents
->;
+export type StrictBrowserWindow = desktopApi.StrictBrowserWindow<BrowserWindow, WebContents>;
 
-export const { app } = electron;
+export const app = baseElectronApp;
 
-export const ipcMain: StrictIpcMain = electron.ipcMain;
-export const ipcRenderer: StrictIpcRenderer = electron.ipcRenderer;
+export const ipcRenderer: StrictIpcRenderer = baseIpcRenderer;


### PR DESCRIPTION
## Description

In Suite Desktop Core we have many `electron.ipcMain` listeners. At most places we are calling validation to ensure that the ipc can be only invoked from our bundled UI, not any other sender, [like here](https://github.com/trezor/trezor-suite/blob/ae3881ce2418eb71c1f30b34b83a62af9af77df9/packages/suite-desktop-core/src/modules/safeStorage.ts#L41-L42).
:warning: But it's easy to forget the validation and there are some places where it's missing, [like here](https://github.com/trezor/trezor-suite/blob/ae3881ce2418eb71c1f30b34b83a62af9af77df9/packages/suite-desktop-core/src/modules/auto-start.ts#L15-L25).

:point_right: Therefore:
- centralize the validation in an `electron.ipcMain` wrapper.
- via eslint, ban direct import of `electron.ipcMain`
- use `rawIpcMain` with deprecation message to the few direct usecases, all in `createIpcProxyHandler`
  - `createIpcProxyHandler` calls validation themselves, though it is incomplete
- complete the validation in `createIpcProxyHandler` as well

To be sure, I verified with a console log that the validation is called on all cases that I tested.

## Related issues

Resolves https://github.com/trezor/trezor-suite-private/issues/225 (the main part)

## Notes for QA

Should change nothing but potentially wide blast radius.
Verify some of the Suite Desktop-only features (can be done during RC checks):
- Connect
- Tor
- Bluetooth
- FW Update
- Recalling Suite sync keys for remembered wallet 
- Suite Desktop update works, incl. toggling into EAP and out
- Resetting app
- Daemon mode
- MCP
- External links (i.e. knowledgebase, trading redirect)
- CJ discovery

I randomly tested _most of that_ myself, but more eyes will be appreciated :pray:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/desktop-IPC-tightening/web/](https://dev.suite.sldev.cz/suite-web/feat/desktop-IPC-tightening/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/desktop-IPC-tightening&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/desktop-IPC-tightening&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T12:31:06.483Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T12:31:30.862Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is almost entirely desktop Electron internals (main process, IPC, bridge, and desktop modules). The highest risk lies in the bridge lifecycle and the TrezorConnect desktop integration, so the recommended strategy focuses on the bridge spawning tests and a representative set of TrezorConnect desktop tests that exercise permissions, signing, and popup messaging. Many desktop-only modules (auto-updater, tray, tor, etc.) have no visible e2e coverage and should be verified through unit tests or manual QA.

<details><summary><b>Changed files (30)</b></summary>

- `packages/connect-examples/electron-main-process/src/electron.js`
- `packages/ipc-proxy/src/proxy-handler.ts`
- `packages/suite-desktop-core/src/app.ts`
- `packages/suite-desktop-core/src/handshake-and-hang-detect.ts`
- `packages/suite-desktop-core/src/ipcMain.test.ts`
- `packages/suite-desktop-core/src/ipcMain.ts`
- `packages/suite-desktop-core/src/libs/auto-start.ts`
- `packages/suite-desktop-core/src/libs/connect-popup-messages.ts`
- `packages/suite-desktop-core/src/modules/auto-start.ts`
- `packages/suite-desktop-core/src/modules/auto-updater.ts`
- `packages/suite-desktop-core/src/modules/bioAuthModule.ts`
- `packages/suite-desktop-core/src/modules/bluetooth.ts`
- `packages/suite-desktop-core/src/modules/bridge.ts`
- `packages/suite-desktop-core/src/modules/coinjoin.ts`
- `packages/suite-desktop-core/src/modules/event-logging/index.ts`
- `packages/suite-desktop-core/src/modules/http-receiver.ts`
- `packages/suite-desktop-core/src/modules/mcp-server.test.ts`
- `packages/suite-desktop-core/src/modules/mcp-server.ts`
- `packages/suite-desktop-core/src/modules/metadata.ts`
- `packages/suite-desktop-core/src/modules/safeStorage.test.ts`
- `packages/suite-desktop-core/src/modules/safeStorage.ts`
- `packages/suite-desktop-core/src/modules/store.ts`
- `packages/suite-desktop-core/src/modules/system-settings.ts`
- `packages/suite-desktop-core/src/modules/theme.ts`
- `packages/suite-desktop-core/src/modules/tor.ts`
- `packages/suite-desktop-core/src/modules/tray.ts`
- `packages/suite-desktop-core/src/modules/trezor-connect.ts`
- `packages/suite-desktop-core/src/modules/user-data.ts`
- `packages/suite-desktop-core/src/modules/window-controls.ts`
- `packages/suite-desktop-core/src/typed-electron.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Directly exercises the desktop bridge module (bridge.ts) and the full Electron app launch lifecycle (app.ts, ipcMain.ts, typed-electron.ts). A regression in bridge spawning or main-process IPC would be caught immediately here.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Tests the daemon-mode app lifecycle, which relies on app.ts, ipcMain.ts and the bridge module. It validates that the node-bridge process outlives the renderer window and stops with the daemon, covering desktop-specific process management.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Directly targets the desktop TrezorConnect integration (trezor-connect.ts, connect-popup-messages.ts) and the Connect settings tab. It exercises permission granting, remembering, revoking, and the connect permissions modal flow that depends on main/renderer IPC.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Validates the app/focus IPC path and silent-mode checkbox behavior in the connect permissions modal. This is a sensitive desktop-only flow that touches trezor-connect.ts, connect-popup-messages.ts, ipcMain.ts and the main-process focus handler.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — End-to-end desktop sign-transaction flow through TrezorConnect, covering connect-popup-messages.ts, trezor-connect.ts, main/renderer IPC, and on-device prompt sequencing. A regression in connect IPC or popup messaging would surface here.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Covers the core TrezorConnect.getAddress desktop flow including permissions modal, address confirmation, and verified/error badges. It shares the connect-popup-messages and trezor-connect.ts infrastructure with the changed files.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Exercises desktop Ethereum transaction signing via TrezorConnect, including permissions modal and multi-step device prompts. It relies on the same connect desktop wiring that was changed.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Tests TrezorConnect.selectAccount on desktop, including permissions modal, account selection modal, and on-device verification. It shares connect IPC and popup-message infrastructure with the changed files.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Validates the requestedPermissions desktop feature, which batches coin permissions into a single consent modal. This is a connect-specific permissions path that depends on trezor-connect.ts and connect-popup-messages.ts.

</details>

⚠️ **Changes with no test coverage (22)**
- `packages/connect-examples/electron-main-process/src/electron.js`
- `packages/ipc-proxy/src/proxy-handler.ts`
- `packages/suite-desktop-core/src/libs/auto-start.ts`
- `packages/suite-desktop-core/src/modules/auto-start.ts`
- `packages/suite-desktop-core/src/modules/auto-updater.ts`
- `packages/suite-desktop-core/src/modules/bioAuthModule.ts`
- `packages/suite-desktop-core/src/modules/bluetooth.ts`
- `packages/suite-desktop-core/src/modules/coinjoin.ts`
- `packages/suite-desktop-core/src/modules/event-logging/index.ts`
- `packages/suite-desktop-core/src/modules/http-receiver.ts`
- `packages/suite-desktop-core/src/modules/mcp-server.test.ts`
- `packages/suite-desktop-core/src/modules/mcp-server.ts`
- `packages/suite-desktop-core/src/modules/metadata.ts`
- `packages/suite-desktop-core/src/modules/safeStorage.test.ts`
- `packages/suite-desktop-core/src/modules/safeStorage.ts`
- `packages/suite-desktop-core/src/modules/store.ts`
- `packages/suite-desktop-core/src/modules/system-settings.ts`
- `packages/suite-desktop-core/src/modules/theme.ts`
- `packages/suite-desktop-core/src/modules/tor.ts`
- `packages/suite-desktop-core/src/modules/tray.ts`
- `packages/suite-desktop-core/src/modules/user-data.ts`
- `packages/suite-desktop-core/src/modules/window-controls.ts`

_Updated: 2026-08-27T12:29:37.015Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->