### PR TITLE
test(suite): add locators to device prompt headers

### DIFF
--- a/packages/product-components/src/components/FeeRate/FeeRate.tsx
+++ b/packages/product-components/src/components/FeeRate/FeeRate.tsx
@@ -32,7 +32,7 @@ export const FeeRate = ({ feeRate, networkType, preserveDecimals }: FeeRateProps
 
     return (
         <span data-testid="@fee-rate">
-            {fee}&nbsp;{getFeeUnits(networkType)}
+            <span data-testid="@fee-rate/value">{fee}</span>&nbsp;{getFeeUnits(networkType)}
         </span>
     );
 };

--- a/packages/suite/src/components/suite/ConnectCallSource.tsx
+++ b/packages/suite/src/components/suite/ConnectCallSource.tsx
@@ -7,7 +7,11 @@ import { useSelector } from 'src/hooks/suite';
 
 import { ConnectAppIcon } from './ConnectAppIcon';
 
-export const ConnectCallSource = () => {
+type ConnectCallSourceProps = {
+    'data-testid'?: string;
+};
+
+export const ConnectCallSource = ({ 'data-testid': dataTestId }: ConnectCallSourceProps = {}) => {
     const connectPopupCall = useSelector(selectConnectPopupCall);
     if (
         connectPopupCall?.state !== 'ongoing' &&
@@ -28,7 +32,12 @@ export const ConnectCallSource = () => {
                         : 'trezorConnect'
                 }
             />
-            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+            <Text
+                data-testid={dataTestId}
+                typographyStyle="body-sm"
+                intent="neutral"
+                priority="secondary"
+            >
                 <Translation id="TR_CONNECTED_TO" />
                 {': '}
                 <Text intent="neutral">

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewEthereumNotes.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewEthereumNotes.tsx
@@ -7,7 +7,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { getFee, hasEip1559MaxPriorityFee, isEip1559 } from '@suite-common/wallet-utils';
-import { Note } from '@trezor/components';
+import { Note, Text } from '@trezor/components';
 import { CheckCircleIcon, GasPumpIcon } from '@trezor/icons';
 import { FeeRate } from '@trezor/product-components';
 
@@ -50,24 +50,24 @@ export const TransactionReviewEthereumNotes = ({
     return (
         <>
             {ethereumNonce !== undefined && (
-                <Note data-testid="@modal/ethereum/nonce" icon={CheckCircleIcon}>
+                <Note data-testid="@modal/header/nonce" icon={CheckCircleIcon}>
                     <Translation id="TR_NONCE" />
                     {': '}
-                    {ethereumNonce}
+                    <Text data-testid="@modal/header/nonce/value">{ethereumNonce}</Text>
                 </Note>
             )}
-            <Note data-testid="@modal/ethereum/gas-limit" icon={GasPumpIcon}>
+            <Note data-testid="@modal/header/gas-limit" icon={GasPumpIcon}>
                 <Translation id="TR_GAS_LIMIT" />
                 {': '}
-                {tx.feeLimit}
+                <Text data-testid="@modal/header/gas-limit/value">{tx.feeLimit}</Text>
             </Note>
-            <Note data-testid="@modal/ethereum/fee" icon={GasPumpIcon}>
+            <Note data-testid="@modal/header/fee-per-gas" icon={GasPumpIcon}>
                 <Translation id={isEip1559(tx) ? 'TR_MAX_FEE_PER_GAS' : 'TR_GAS_PRICE'} />
                 {': '}
                 <FeeRate feeRate={fee} networkType={account.networkType} />
             </Note>
             {hasEip1559MaxPriorityFee(tx) && (
-                <Note data-testid="@modal/ethereum/priority-fee" icon={GasPumpIcon}>
+                <Note data-testid="@modal/header/priority-fee" icon={GasPumpIcon}>
                     <Translation id="TR_MAX_PRIORITY_FEE_PER_GAS" />
                     {': '}
                     <FeeRate feeRate={tx.maxPriorityFeePerGas} networkType={account.networkType} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputTimer.tsx
@@ -39,11 +39,12 @@ export const TransactionReviewOutputTimer = ({
                     size="small"
                     isDisabled={isSending || disabled}
                     onClick={() => handleClick(() => onTryAgain(true))}
+                    data-testid="@modal/header/try-again-button"
                 >
                     <Translation id="TR_TRY_AGAIN" />
                 </Button>
                 <Badge intent="warning">
-                    <TimerBox>
+                    <TimerBox data-testid="@modal/header/timer">
                         {isSending ? (
                             <Translation id="TR_CONFIRMING_TX" />
                         ) : (

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -88,13 +88,16 @@ export const TransactionReviewSummary = ({
                             account={account}
                             showAccountTypeBadge
                             accountTypeBadgeSize="small"
+                            data-testid="@modal/header/account-label"
                         />
                     </Row>
 
                     {estimateTime !== undefined && (
-                        <Note icon={ClockIcon}>
+                        <Note data-testid="@modal/header/estimated-time" icon={ClockIcon}>
                             {'≈ '}
-                            {formatDurationStrict(estimateTime, locale)}
+                            <Text data-testid="@modal/header/estimated-time/value">
+                                {formatDurationStrict(estimateTime, locale)}
+                            </Text>
                         </Note>
                     )}
 
@@ -103,7 +106,7 @@ export const TransactionReviewSummary = ({
                     )}
 
                     {!['ethereum', 'solana', 'tron'].includes(networkType) && (
-                        <Note icon={ReceiptIcon}>
+                        <Note data-testid="@modal/header/fee-rate" icon={ReceiptIcon}>
                             <FeeRate feeRate={fee} networkType={network.networkType} />
                         </Note>
                     )}
@@ -113,26 +116,31 @@ export const TransactionReviewSummary = ({
                     )}
 
                     {isComposedFeeRateDifferent && network.networkType === 'bitcoin' && (
-                        <Translation id="TR_FEE_RATE_CHANGED" />
+                        <Text data-testid="@modal/header/fee-rate-changed">
+                            <Translation id="TR_FEE_RATE_CHANGED" />
+                        </Text>
                     )}
 
                     {!stakeType && !broadcast && connectPopupCall?.state !== 'ongoing' && (
-                        <Note icon={BroadcastIcon}>
+                        <Note data-testid="@modal/header/broadcast" icon={BroadcastIcon}>
                             <Translation id="BROADCAST" />
                             {': '}
-                            <Text intent="critical">
+                            <Text data-testid="@modal/header/broadcast/state" intent="critical">
                                 <Translation id="TR_OFF" />
                             </Text>
                         </Note>
                     )}
 
-                    {connectPopupCall?.state === 'ongoing' && <ConnectCallSource />}
+                    {connectPopupCall?.state === 'ongoing' && (
+                        <ConnectCallSource data-testid="@modal/header/connect-source" />
+                    )}
 
                     {tx.inputs.length > 0 && (
                         // TODO: IconButton doesn't take margin even though it should
                         <Box margin={{ left: 'auto' }}>
                             <IconButton
                                 onClick={() => onDetailsClick()}
+                                data-testid="@modal/header/details-button"
                                 intent="neutral"
                                 priority="secondary"
                                 icon={InfoIcon}
@@ -148,12 +156,12 @@ export const TransactionReviewSummary = ({
             {networkType === 'solana' && isDebug && (
                 <Row margin={{ top: 8 }} gap={8}>
                     <DebugOnlyBadge />
-                    <Note icon={ComputerTowerIcon}>
+                    <Note data-testid="@modal/header/cu-limit" icon={ComputerTowerIcon}>
                         CU Limit
                         {': '}
-                        {tx.feeLimit} CU
+                        <Text data-testid="@modal/header/cu-limit/value">{tx.feeLimit}</Text> CU
                     </Note>
-                    <Note icon={ComputerTowerIcon}>
+                    <Note data-testid="@modal/header/cu-price" icon={ComputerTowerIcon}>
                         CU Price
                         {': '}
                         <FeeRate

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewTronFeeNotes.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewTronFeeNotes.tsx
@@ -44,7 +44,7 @@ export const TransactionReviewTronFeeNotes = ({
     return (
         <>
             {totalTrxBurned && !totalTrxBurned.isZero() && (
-                <Note icon={ReceiptIcon}>
+                <Note data-testid="@modal/header/tron-burned" icon={ReceiptIcon}>
                     <FormattedCryptoAmount
                         disableHiddenPlaceholder
                         value={totalTrxBurned.toString()}
@@ -53,14 +53,14 @@ export const TransactionReviewTronFeeNotes = ({
                 </Note>
             )}
             {coveredBandwidth?.gt(0) && (
-                <Note icon={ReceiptIcon}>
+                <Note data-testid="@modal/header/tron-bandwidth" icon={ReceiptIcon}>
                     {translationString('TR_TRON_FEE_BANDWIDTH', {
                         count: coveredBandwidth.toNumber(),
                     })}
                 </Note>
             )}
             {coveredEnergy?.gt(0) && (
-                <Note icon={ReceiptIcon}>
+                <Note data-testid="@modal/header/tron-energy" icon={ReceiptIcon}>
                     {translationString('TR_TRON_FEE_ENERGY', {
                         count: coveredEnergy.toNumber(),
                     })}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CurrentFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CurrentFee.tsx
@@ -41,7 +41,7 @@ export const CurrentFee = () => {
             </Text>
             <Text intent="neutral" typographyStyle="body-sm">
                 <Row alignItems="center" gap={4}>
-                    <Text>
+                    <Text data-testid="@fee-card/current-rate">
                         <FeeRate feeRate={currentFeeRate} networkType={networkType} />
                     </Text>
                     <Icon as={networkType === 'ethereum' ? GasPumpIcon : ReceiptIcon} size={20} />

--- a/suite/e2e/support/pageObjects/devicePrompt.ts
+++ b/suite/e2e/support/pageObjects/devicePrompt.ts
@@ -2,6 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 
 import { step } from '../common';
 import { DeviceFixture } from '../device';
+import { DevicePromptHeaderSection } from './devicePromptHeaderSection';
 
 export class DevicePrompt {
     readonly confirmOnDevicePrompt: Locator;
@@ -38,14 +39,9 @@ export class DevicePrompt {
     readonly assetsReceiveAddress: Locator;
     readonly reviewAmount: Locator;
     readonly sendButton: Locator;
-    readonly header: Locator;
-    readonly headerParagraph: Locator;
+    readonly header: DevicePromptHeaderSection;
     readonly acquireDeviceButton: Locator;
     readonly closeButton: Locator;
-    readonly ethereumGasLimit: Locator;
-    readonly ethereumFeeRate: Locator;
-    readonly ethereumPriorityFeeRate: Locator;
-    readonly headerFeeRate: Locator;
 
     constructor(
         private page: Page,
@@ -65,18 +61,9 @@ export class DevicePrompt {
         this.assetsReceiveAddress = page.getByTestId('@modal/assets/receive/address');
         this.reviewAmount = page.getByTestId('@modal/transaction-review/amount');
         this.sendButton = page.getByTestId('@modal/send');
-        this.header = page.getByTestId('@modal/header');
-        this.headerParagraph = page.getByTestId('@modal/header-paragraph');
+        this.header = new DevicePromptHeaderSection(page);
         this.acquireDeviceButton = this.page.getByTestId('@device-acquire');
         this.closeButton = this.page.getByTestId('@confirm-on-device/close-button');
-        this.ethereumGasLimit = this.page.getByTestId('@modal/ethereum/gas-limit');
-        this.ethereumFeeRate = this.page
-            .getByTestId('@modal/ethereum/fee')
-            .getByTestId('@fee-rate');
-        this.ethereumPriorityFeeRate = this.page
-            .getByTestId('@modal/ethereum/priority-fee')
-            .getByTestId('@fee-rate');
-        this.headerFeeRate = this.page.getByTestId('@fee-rate');
     }
 
     @step()
@@ -180,25 +167,6 @@ export class DevicePrompt {
         const removeWhitespaces = (text: string) => text.replace(/\s+/g, '');
 
         return textsArray.map(removeWhitespaces).join('');
-    }
-
-    @step()
-    async getFeeRate() {
-        // Element format is: Bitcoin #1 \n+ ≈ 10 minutes \n+ 4.00 sat/vB
-        const fullText = await this.headerParagraph.innerText();
-        const lines = fullText
-            .split('\n')
-            .map(line => line.trim())
-            .filter(line => line.length > 0);
-        const feeRateRegex = /^\d+(\.\d+)?\s+sat\/vB$/;
-        const lastLine = lines[lines.length - 1];
-        if (!lastLine || !feeRateRegex.test(lastLine)) {
-            throw new Error(
-                `Last line does not match the expected format of a decimal number followed by 'sat/vB': ${lastLine}`,
-            );
-        }
-
-        return lastLine;
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/devicePromptHeaderSection.ts
+++ b/suite/e2e/support/pageObjects/devicePromptHeaderSection.ts
@@ -1,0 +1,65 @@
+import { Locator, Page } from '@playwright/test';
+
+export class DevicePromptHeaderSection {
+    readonly container: Locator;
+    readonly accountLabel: Locator;
+    readonly estimatedTime: Locator;
+    readonly estimatedTimeValue: Locator;
+    readonly feeRate: Locator;
+    readonly feeRateValue: Locator;
+    readonly feeRateChanged: Locator;
+    readonly broadcast: Locator;
+    readonly broadcastState: Locator;
+    readonly nonce: Locator;
+    readonly nonceValue: Locator;
+    readonly gasLimit: Locator;
+    readonly gasLimitValue: Locator;
+    readonly feePerGas: Locator;
+    readonly feePerGasRate: Locator;
+    readonly feePerGasValue: Locator;
+    readonly priorityFee: Locator;
+    readonly priorityFeeRate: Locator;
+    readonly priorityFeeValue: Locator;
+    readonly tronBurned: Locator;
+    readonly tronBandwidth: Locator;
+    readonly tronEnergy: Locator;
+    readonly computeUnitLimitValue: Locator;
+    readonly computeUnitPriceValue: Locator;
+    readonly connectSource: Locator;
+    readonly timer: Locator;
+    readonly tryAgainButton: Locator;
+    readonly detailsButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.container = this.page.getByTestId('@modal/header-paragraph');
+        this.accountLabel = this.container.getByTestId('@modal/header/account-label');
+        this.estimatedTime = this.container.getByTestId('@modal/header/estimated-time');
+        this.estimatedTimeValue = this.container.getByTestId('@modal/header/estimated-time/value');
+        this.feeRate = this.container.getByTestId('@modal/header/fee-rate');
+        this.feeRateValue = this.feeRate.getByTestId('@fee-rate/value');
+        this.feeRateChanged = this.container.getByTestId('@modal/header/fee-rate-changed');
+        this.broadcast = this.container.getByTestId('@modal/header/broadcast');
+        this.broadcastState = this.container.getByTestId('@modal/header/broadcast/state');
+        this.nonce = this.container.getByTestId('@modal/header/nonce');
+        this.nonceValue = this.container.getByTestId('@modal/header/nonce/value');
+        this.gasLimit = this.container.getByTestId('@modal/header/gas-limit');
+        this.gasLimitValue = this.container.getByTestId('@modal/header/gas-limit/value');
+        this.feePerGas = this.container.getByTestId('@modal/header/fee-per-gas');
+        this.feePerGasRate = this.feePerGas.getByTestId('@fee-rate');
+        this.feePerGasValue = this.feePerGas.getByTestId('@fee-rate/value');
+        this.priorityFee = this.container.getByTestId('@modal/header/priority-fee');
+        this.priorityFeeRate = this.priorityFee.getByTestId('@fee-rate');
+        this.priorityFeeValue = this.priorityFee.getByTestId('@fee-rate/value');
+        this.tronBurned = this.container.getByTestId('@modal/header/tron-burned');
+        this.tronBandwidth = this.container.getByTestId('@modal/header/tron-bandwidth');
+        this.tronEnergy = this.container.getByTestId('@modal/header/tron-energy');
+        this.computeUnitLimitValue = this.container.getByTestId('@modal/header/cu-limit/value');
+        this.computeUnitPriceValue = this.container
+            .getByTestId('@modal/header/cu-price')
+            .getByTestId('@fee-rate/value');
+        this.connectSource = this.container.getByTestId('@modal/header/connect-source');
+        this.timer = this.container.getByTestId('@modal/header/timer');
+        this.tryAgainButton = this.container.getByTestId('@modal/header/try-again-button');
+        this.detailsButton = this.container.getByTestId('@modal/header/details-button');
+    }
+}

--- a/suite/e2e/support/pageObjects/trading/feeSection.ts
+++ b/suite/e2e/support/pageObjects/trading/feeSection.ts
@@ -15,6 +15,8 @@ export class FeeSection {
     readonly valueOnCard = (feeType: FeeTypes) =>
         this.page.getByTestId(`@fee-card/${feeType}-fiat-amount`);
     readonly rateOnCard = (feeType: FeeTypes) => this.page.getByTestId(`@fee-card/${feeType}-rate`);
+    readonly rateValueOnCard = (feeType: FeeTypes) =>
+        this.rateOnCard(feeType).getByTestId('@fee-rate/value');
     readonly collapsibleFeesToggle: Locator;
     readonly collapsibleFees: Locator;
     readonly customInput: Locator;
@@ -109,24 +111,21 @@ export class FeeSection {
 
     @step()
     async getBitcoinFeeRate(type: FeeTypes | 'custom') {
-        let feeRateText: string;
-        const nonBreakingSpace = '\u00A0';
-        const suffixForDustPreventionFee = `${nonBreakingSpace}sat/vB`;
-        const suffixForCustomFee = `.00${nonBreakingSpace}sat/vB`;
+        let feeRate: string;
 
         if (type !== 'custom') {
             await this.expectBitcoinFeeCalculated();
-            feeRateText = await this.rateOnCard(type).innerText();
+            feeRate = await this.rateValueOnCard(type).innerText();
         } else {
-            feeRateText = (await this.customInput.inputValue()) + suffixForCustomFee;
+            feeRate = new BigNumber(await this.customInput.inputValue()).toFixed(2);
         }
 
         const isDustPreventionRateApplied = await this.dustPreventionNotice.isVisible();
         if (isDustPreventionRateApplied) {
-            feeRateText = (await this.getDustPreventionFeeRate()) + suffixForDustPreventionFee;
+            feeRate = await this.getDustPreventionFeeRate();
         }
 
-        return feeRateText;
+        return feeRate;
     }
 
     calculateEthereumMaxFee({

--- a/suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts
@@ -110,7 +110,7 @@ test.describe(
 
             await test.step('Initiate send', async () => {
                 await tradingPage.confirmation.initiateSendConfirmation();
-                await expect(devicePrompt.headerParagraph).toContainText(accountLabel);
+                await expect(devicePrompt.header.accountLabel).toHaveText(accountLabel);
                 await expect(devicePrompt.outputValueOf('address')).toHaveValidAddress('sol');
 
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(

--- a/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
@@ -127,7 +127,7 @@ test.describe(
                 await tradingPage.confirmation.initiateSendConfirmation({
                     confirmAlsoToken: true,
                 });
-                await expect(devicePrompt.headerParagraph).toContainText(accountLabel);
+                await expect(devicePrompt.header.accountLabel).toHaveText(accountLabel);
                 await expect(devicePrompt.outputValueOf('address')).toHaveValidAddress('sol');
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                     formattedSendAmount,

--- a/suite/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/sell-bitcoin.test.ts
@@ -84,7 +84,7 @@ test.describe('Trading - Sell BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
 
         await test.step('Initiate send', async () => {
             await tradingPage.confirmation.initiateSendConfirmation();
-            await expect(devicePrompt.headerParagraph).toContainText('Bitcoin #1');
+            await expect(devicePrompt.header.accountLabel).toHaveText('Bitcoin #1');
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedAddress);
             await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
                 formattedCryptoAmount,

--- a/suite/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -75,7 +75,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
 
         await test.step('Initiate send', async () => {
             await tradingPage.confirmation.initiateSendConfirmation();
-            await expect(devicePrompt.headerParagraph).toContainText('Ethereum #1');
+            await expect(devicePrompt.header.accountLabel).toHaveText('Ethereum #1');
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedAddress);
             await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
                 formattedCryptoAmount,

--- a/suite/e2e/tests/trading/sell-ethereum.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum.test.ts
@@ -101,7 +101,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
 
         await test.step('Initiate send', async () => {
             await tradingPage.confirmation.openConfirmAndSendModal();
-            await expect(devicePrompt.headerParagraph).toContainText('Ethereum #1');
+            await expect(devicePrompt.header.accountLabel).toHaveText('Ethereum #1');
             await devicePrompt.waitForPromptAndClick();
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedAddress);
             await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
@@ -117,10 +117,10 @@ test.describe('Trading - Sell Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
             });
 
         await test.step('Verify fees on modal and emulator', async () => {
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(`${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`);
-            await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
-            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
-                `${maxPriorityFeePerGasRounded} Gwei`,
+            await expect(devicePrompt.header.gasLimitValue).toHaveText(gasLimit);
+            await expect(devicePrompt.header.feePerGasValue).toHaveText(`${maxFeePerGasRounded}`);
+            await expect(devicePrompt.header.priorityFeeValue).toHaveText(
+                `${maxPriorityFeePerGasRounded}`,
             );
             await expect(device).toDisplayOnEmulator({
                 T3W1: {

--- a/suite/e2e/tests/trading/sell-solana.test.ts
+++ b/suite/e2e/tests/trading/sell-solana.test.ts
@@ -103,7 +103,7 @@ test.describe('Trading - Sell Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
 
         await test.step('Initiate send', async () => {
             await tradingPage.confirmation.initiateSendConfirmation();
-            await expect(devicePrompt.headerParagraph).toContainText('Solana #1');
+            await expect(devicePrompt.header.accountLabel).toHaveText('Solana #1');
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedAddress);
             await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                 formattedCryptoAmount,

--- a/suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts
+++ b/suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts
@@ -76,7 +76,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await liveTradePromise;
             providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
-            await expect(devicePrompt.headerParagraph).toContainText(sendAccountLabel);
+            await expect(devicePrompt.header.accountLabel).toHaveText(sendAccountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
                 formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
             );

--- a/suite/e2e/tests/trading/swap-dex-lifi.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi.test.ts
@@ -1,4 +1,3 @@
-import { messages } from '@suite/intl';
 import { getCryptoId } from '@suite-common/trading';
 import { fromGwei, localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
@@ -12,8 +11,6 @@ const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
 const accountLabel = 'Ethereum #1';
 const usdcCryptoId = getCryptoId('eth', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
 const dexProvider = getCompanyNameFromList('lifi', 'swapList');
-
-const gasLimitPattern = new RegExp(`^${messages.TR_GAS_LIMIT.defaultMessage}: (\\d+)$`);
 
 // A DEX swap broadcasts the swap itself, so there is no CONFIRMING deposit phase.
 const dexStatusFlow = swapStatusFlow.filter(phase => phase.status !== 'CONFIRMING');
@@ -73,6 +70,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             });
         });
 
+        let reviewedGasLimit: string;
         let maxFeePerGas: string;
         let feeRate: string;
         let priorityFeeRate: string;
@@ -148,8 +146,6 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             await tradingPage.confirmation.openConfirmAndSendModal();
         });
 
-        let gasLimitWithLabel: string;
-
         await test.step('Confirm the DEX transaction on device', async () => {
             await devicePrompt.confirmOnDevicePromptIsShown();
 
@@ -185,6 +181,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             await expect(devicePrompt.assetsReceiveAddress).toHaveText(
                 tradingMockNew.liveTrade.receiveAddress!,
             );
+            const minimumReceivedOnDevice = `${new BigNumber(minimumReceived.toFixed(6)).toFixed()} USDC`;
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: deviceReview.contractTitle },
@@ -192,23 +189,16 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
                         [deviceReview.sendLabel],
                         device.wrapText(formattedSendAmount, { isAmount: true }),
                         [deviceReview.receiveLabel],
-                        device.wrapText(`${minimumReceived.toFixed(6)} USDC`, { isAmount: true }),
+                        device.wrapText(minimumReceivedOnDevice, { isAmount: true }),
                     ],
                     actions: { right_button: deviceReview.confirmButton },
                 },
             });
             await devicePrompt.waitForPromptAndConfirm();
 
-            await expect(devicePrompt.ethereumFeeRate).toHaveText(feeRate);
-            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(priorityFeeRate);
-
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitPattern);
-            gasLimitWithLabel = await devicePrompt.ethereumGasLimit.innerText();
-            const reviewedGasLimit = gasLimitWithLabel.match(gasLimitPattern)?.[1];
-            if (!reviewedGasLimit) {
-                throw new Error(`Unexpected gas limit format: ${gasLimitWithLabel}`);
-            }
-
+            await expect(devicePrompt.header.feePerGasRate).toHaveText(feeRate);
+            await expect(devicePrompt.header.priorityFeeRate).toHaveText(priorityFeeRate);
+            reviewedGasLimit = await devicePrompt.header.gasLimitValue.innerText();
             const maximumFeeInGwei = new BigNumber(maxFeePerGas).times(reviewedGasLimit).toFixed();
             const maximumFee = `${localizeNumber(fromGwei(maximumFeeInGwei).toEther())} ETH`;
             await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(maximumFee);
@@ -239,7 +229,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             await expect(devicePrompt.assetsReceiveAddress).toHaveText(
                 tradingMockNew.liveTrade.receiveAddress!,
             );
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitWithLabel);
+            await expect(devicePrompt.header.gasLimitValue).toHaveText(reviewedGasLimit);
         });
 
         await test.step('Send the DEX transaction (broadcast blocked by mock)', async () => {

--- a/suite/e2e/tests/trading/swap-eth-to-sol.test.ts
+++ b/suite/e2e/tests/trading/swap-eth-to-sol.test.ts
@@ -63,7 +63,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await liveTradePromise;
             providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
-            await expect(devicePrompt.headerParagraph).toContainText(sendAccountLabel);
+            await expect(devicePrompt.header.accountLabel).toHaveText(sendAccountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
                 formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
             );

--- a/suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts
+++ b/suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts
@@ -77,7 +77,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await liveTradePromise;
             providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
-            await expect(devicePrompt.headerParagraph).toContainText(sendAccountLabel);
+            await expect(devicePrompt.header.accountLabel).toHaveText(sendAccountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
                 formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
             );

--- a/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -52,7 +52,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@T3T1', '@T3W1'] }, () => 
             await tradingPage.swapBestOfferButton.click();
             await page.expectReduxObjectNotToBeEmpty('wallet.trading.composedTransactionInfo');
             await tradingPage.confirmation.openConfirmAndSendModal();
-            await expect(devicePrompt.headerParagraph).toContainText('Bitcoin #1');
+            await expect(devicePrompt.header.accountLabel).toHaveText('Bitcoin #1');
             await devicePrompt.waitForPromptAndClick();
             await devicePrompt.waitForPromptAndClick();
         });
@@ -63,7 +63,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@T3T1', '@T3W1'] }, () => 
             await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                 `${totalAmount} BTC`,
             );
-            await expect(devicePrompt.headerFeeRate).toContainText(feeRate);
+            await expect(devicePrompt.header.feeRateValue).toHaveText(feeRate);
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: 'Send' },
@@ -83,11 +83,11 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@T3T1', '@T3W1'] }, () => 
 
         await test.step('Verify Fee Info on emulator', async () => {
             await device.openFeeInfo({ buttonIndexT3W1: 2 });
-            const feeRateWithoutDecimals = feeRate.replace('.00\u00A0', ' ');
+            const feeRateOnDevice = `${new BigNumber(feeRate).toString()} sat/vB`;
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: 'Fee info' },
-                    body: [['Fee rate'], [feeRateWithoutDecimals]],
+                    body: [['Fee rate'], [feeRateOnDevice]],
                 },
                 T3T1: { footer: undefined },
             });

--- a/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -60,7 +60,7 @@ test.describe('Trading - Swap fees', { tag: ['@T3W1', '@T3T1'] }, () => {
             await tradingPage.swapBestOfferButton.click();
             await page.expectReduxObjectNotToBeEmpty('wallet.trading.composedTransactionInfo');
             await tradingPage.confirmation.openConfirmAndSendModal();
-            await expect(devicePrompt.headerParagraph).toContainText('Ethereum #1');
+            await expect(devicePrompt.header.accountLabel).toHaveText('Ethereum #1');
             await devicePrompt.waitForPromptAndClick();
         });
 
@@ -71,10 +71,10 @@ test.describe('Trading - Swap fees', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
         await test.step('Verify fees on modal and emulator', async () => {
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(`Gas limit: ${gasLimit}`);
-            await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
-            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
-                `${maxPriorityFeePerGasRounded} Gwei`,
+            await expect(devicePrompt.header.gasLimitValue).toHaveText(gasLimit);
+            await expect(devicePrompt.header.feePerGasValue).toHaveText(`${maxFeePerGasRounded}`);
+            await expect(devicePrompt.header.priorityFeeValue).toHaveText(
+                `${maxPriorityFeePerGasRounded}`,
             );
             await expect(
                 devicePrompt.cryptoAmountWithSymbolOf('fee'),

--- a/suite/e2e/tests/trading/swap-sol-to-btc.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-to-btc.test.ts
@@ -74,7 +74,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await liveTradePromise;
             providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
-            await expect(devicePrompt.headerParagraph).toContainText(accountLabel);
+            await expect(devicePrompt.header.accountLabel).toHaveText(accountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
                 formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
             );

--- a/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
@@ -73,7 +73,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await liveTradePromise;
             providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
-            await expect(devicePrompt.headerParagraph).toContainText(sendAccountLabel);
+            await expect(devicePrompt.header.accountLabel).toHaveText(sendAccountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
                 formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
             );

--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -17,7 +17,7 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
     test(`Global receive`, async ({ page, devicePrompt, tradingPage, walletPage }) => {
         await test.step('Open receive form', async () => {
             await page.getByTestId('@wallet/menu/wallet-global-receive').click();
-            await expect(devicePrompt.header).toHaveTranslation('TR_NAV_RECEIVE');
+            await expect(page.modalHeader).toHaveTranslation('TR_NAV_RECEIVE');
         });
 
         await test.step('Add ETH account', async () => {
@@ -58,7 +58,6 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
 
     test(`Global send`, async ({
         page,
-        devicePrompt,
         walletPage,
         tradingPage,
         settingsPage,
@@ -81,7 +80,7 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
 
         await test.step('Open send form', async () => {
             await page.getByTestId('@wallet/menu/wallet-global-send').click();
-            await expect(devicePrompt.header).toHaveTranslation('TR_NAV_SEND');
+            await expect(page.modalHeader).toHaveTranslation('TR_NAV_SEND');
         });
 
         await test.step('Bitcoin Regtest account selection', async () => {

--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -1,4 +1,3 @@
-import { messages } from '@suite/intl';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -75,7 +74,7 @@ test.describe(
 
             await test.step('Verify Recipient address', async () => {
                 await tradingPage.sendButton.click();
-                await expect(devicePrompt.headerParagraph).toContainText(networkName);
+                await expect(devicePrompt.header.accountLabel).toHaveText(networkName);
                 await expect(devicePrompt.outputValueOf('address')).toHaveText(
                     formattedSendAddress,
                 );
@@ -90,13 +89,12 @@ test.describe(
 
             await test.step('Verify Total including fee', async () => {
                 await devicePrompt.waitForPromptAndClick();
-                const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
-                await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
-                await expect(devicePrompt.ethereumFeeRate).toHaveText(
-                    `${maxFeePerGasRounded} Gwei`,
+                await expect(devicePrompt.header.gasLimitValue).toHaveText(gasLimit);
+                await expect(devicePrompt.header.feePerGasValue).toHaveText(
+                    `${maxFeePerGasRounded}`,
                 );
-                await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
-                    `${maxPriorityFeePerGasRounded} Gwei`,
+                await expect(devicePrompt.header.priorityFeeValue).toHaveText(
+                    `${maxPriorityFeePerGasRounded}`,
                 );
                 await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
                 await expect(
@@ -164,7 +162,7 @@ test.describe(
 
             await test.step('Verify Recipient address', async () => {
                 await tradingPage.sendButton.click();
-                await expect(devicePrompt.headerParagraph).toContainText(networkName);
+                await expect(devicePrompt.header.accountLabel).toHaveText(networkName);
                 await expect(devicePrompt.outputValueOf('address')).toHaveText(
                     formattedSendAddress,
                 );
@@ -179,13 +177,12 @@ test.describe(
 
             await test.step('Verify Total including fee', async () => {
                 await devicePrompt.waitForPromptAndClick();
-                const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
-                await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
-                await expect(devicePrompt.ethereumFeeRate).toHaveText(
-                    `${maxFeePerGasRounded} Gwei`,
+                await expect(devicePrompt.header.gasLimitValue).toHaveText(gasLimit);
+                await expect(devicePrompt.header.feePerGasValue).toHaveText(
+                    `${maxFeePerGasRounded}`,
                 );
-                await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
-                    `${maxPriorityFeePerGasRounded} Gwei`,
+                await expect(devicePrompt.header.priorityFeeValue).toHaveText(
+                    `${maxPriorityFeePerGasRounded}`,
                 );
                 await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
                 await expect(

--- a/suite/e2e/tests/wallet/send-eth.test.ts
+++ b/suite/e2e/tests/wallet/send-eth.test.ts
@@ -1,4 +1,3 @@
-import { messages } from '@suite/intl';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -59,7 +58,7 @@ test.describe('Send Eth', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         await test.step('Verify Recipient address', async () => {
             await tradingPage.sendButton.click();
-            await expect(devicePrompt.headerParagraph).toContainText('Ethereum #1');
+            await expect(devicePrompt.header.accountLabel).toHaveText('Ethereum #1');
             await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedSendAddress);
             await expect(device).toShowOnDisplay({
                 T3W1: {
@@ -76,11 +75,10 @@ test.describe('Send Eth', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         await test.step('Verify Total including fee', async () => {
             await devicePrompt.waitForPromptAndClick();
-            const gasLimitTranslation = `${messages['TR_GAS_LIMIT'].defaultMessage}: ${gasLimit}`;
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitTranslation);
-            await expect(devicePrompt.ethereumFeeRate).toHaveText(`${maxFeePerGasRounded} Gwei`);
-            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(
-                `${maxPriorityFeePerGasRounded} Gwei`,
+            await expect(devicePrompt.header.gasLimitValue).toHaveText(gasLimit);
+            await expect(devicePrompt.header.feePerGasValue).toHaveText(`${maxFeePerGasRounded}`);
+            await expect(devicePrompt.header.priorityFeeValue).toHaveText(
+                `${maxPriorityFeePerGasRounded}`,
             );
             await expect(devicePrompt.cryptoAmountOf('amount')).toHaveText(sendAmount);
             await expect(devicePrompt.cryptoAmountOf('fee'), errorMessageMaxCalculation).toHaveText(

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -86,7 +86,7 @@ test.describe('Send - Solana', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
             });
 
             await test.step('Verify Recipient Address', async () => {
-                await expect(devicePrompt.headerParagraph).toContainText('Solana #1');
+                await expect(devicePrompt.header.accountLabel).toHaveText('Solana #1');
                 await expect(devicePrompt.outputValueOf('address')).toHaveText(FORMATTED_ADDRESS);
 
                 // verify recipient address on device


### PR DESCRIPTION
update tests to rely on these better and narrower locators

## Description

### Why
Nothing in the transaction-review modal header had its own testid, so tests worked around it:
`toContainText` on the whole header paragraph to match an account label (17 sites), rebuilding
`` `${messages.TR_GAS_LIMIT.defaultMessage}: ${gasLimit}` `` because label and value share one
element (6 sites, one hardcoded in English), and an unscoped `@fee-rate` compared via
`replace('.00\u00A0', ' ')`.

### How
- `@modal/header/<item>` on every header item, plus `/value` where a test needs the bare number.
  `@modal/ethereum/*` folded into the same namespace. Items no test uses yet (tron notes, solana
  debug CU, review timer, connect source) are covered too.
- `FeeRate` wraps its value in `@fee-rate/value`, chained from the parent that identifies it
  (`@modal/header/fee-per-gas`, `@fee-card/{level}-rate`, …); `CurrentFee` gained the missing parent.
- New `DevicePromptHeaderSection` (`devicePrompt.header`), all locators scoped under
  `@modal/header-paragraph`. Dropped the dead `getFeeRate()` and the unscoped `devicePrompt.header`,
  whose only users assert the global send/receive modal and now use `page.modalHeader`.
- Tests assert values exactly: no label rebuilding, no unit stripping, no nbsp handling.
- `swap-dex-lifi`: fee assertions corrected — EVM uses the max-fee-per-gas locator, and the gas limit
  is read from the review because the DEX limit is estimated live.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/device-prompt-header/web/](https://dev.suite.sldev.cz/suite-web/device-prompt-header/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=device-prompt-header&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=device-prompt-header&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T06:40:07.824Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T06:40:10.536Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->