### PR TITLE
feat(suite): unify add account network selection

### DIFF
--- a/packages/suite/src/components/earn/dashboard/common/EarnActivateButton.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnActivateButton.tsx
@@ -46,7 +46,6 @@ export const EarnActivateButton = ({ symbol }: EarnActivateButtonProps) => {
                 type: 'add-account',
                 device,
                 symbol,
-                noRedirect: true,
                 isCoinjoinDisabled: true,
                 isBackClickDisabled: true,
             }),

--- a/packages/suite/src/components/suite/NetworkList/NetworkCard.tsx
+++ b/packages/suite/src/components/suite/NetworkList/NetworkCard.tsx
@@ -21,6 +21,7 @@ type NetworkCardProps = {
     onClick?: (symbol: NetworkSymbol, isEnabled: boolean) => void;
     onSettings?: (symbol: NetworkSymbol) => void;
     rightContent?: ReactNode;
+    showRepresentativeAssets?: boolean;
 };
 
 export const NetworkCard = ({
@@ -33,6 +34,7 @@ export const NetworkCard = ({
     onClick,
     onSettings,
     rightContent,
+    showRepresentativeAssets = true,
 }: NetworkCardProps) => {
     const isBelowMobile = useIsContentBelowBreakpoint();
 
@@ -56,7 +58,9 @@ export const NetworkCard = ({
                         </Text>
                     </Column>
                     <Row gap={12} onClick={e => e.stopPropagation()} flex="0 0 auto">
-                        {!isBelowMobile && <RepresentativeAssetIconSet symbol={symbol} />}
+                        {!isBelowMobile && showRepresentativeAssets && (
+                            <RepresentativeAssetIconSet symbol={symbol} />
+                        )}
                         {onSettings && (
                             // Make the clickable area bigger
                             <Box padding={8} margin={-8} onClick={() => onSettings(symbol)}>

--- a/packages/suite/src/components/suite/NetworkList/NetworkList.tsx
+++ b/packages/suite/src/components/suite/NetworkList/NetworkList.tsx
@@ -25,12 +25,20 @@ export type NetworkListProps = {
         isEnabled: boolean;
         onClick: () => void;
     }) => ReactNode;
+    getIsSettingsVisible?: (params: { network: Network; isEnabled: boolean }) => boolean;
+    showRepresentativeAssets?: boolean;
     /**
      * When `true`, toggles stay enabled regardless of device/UI lock state and the
      * "Loading accounts" tooltip is not shown. Intended for callers that only stage
      * changes locally and apply them explicitly.
      */
     ignoreDeviceLock?: boolean;
+    /**
+     * When `true`, toggles stay enabled regardless of device/UI lock state, like `ignoreDeviceLock`,
+     * and also regardless of running discovery, allowing queuing of multiple assets/networks.
+     * TODO maybe it could be unified in https://github.com/trezor/trezor-suite/issues/31779
+     */
+    ignoreDiscoveryLock?: boolean;
 };
 
 export const NetworkList = ({
@@ -40,14 +48,24 @@ export const NetworkList = ({
     onClick,
     onSettings,
     renderRightContent,
+    getIsSettingsVisible,
+    showRepresentativeAssets = true,
+    ignoreDiscoveryLock = false,
     ignoreDeviceLock = false,
 }: NetworkListProps) => {
     const { device, isLocked } = useDevice();
     const blockchain = useSelector(selectBlockchainState);
-    const isDeviceLocked = !ignoreDeviceLock && !!device && isLocked(true);
     const { isDiscoveryRunning } = useDiscovery();
+    const isDeviceLocked =
+        !ignoreDeviceLock &&
+        !!device &&
+        isLocked(true) &&
+        !(ignoreDiscoveryLock && isDiscoveryRunning);
     const lockedTooltip = isDeviceLocked ? 'TR_DISABLED_SWITCH_TOOLTIP' : null;
-    const discoveryTooltip = !ignoreDeviceLock && isDiscoveryRunning ? 'TR_LOADING_ACCOUNTS' : null;
+    const discoveryTooltip =
+        !ignoreDeviceLock && !ignoreDiscoveryLock && isDiscoveryRunning
+            ? 'TR_LOADING_ACCOUNTS'
+            : null;
 
     const deviceModelInternal = device?.features?.internal_model;
     const isBootloaderMode = isDeviceInBootloaderMode(device);
@@ -75,6 +93,7 @@ export const NetworkList = ({
                     : 'update-required';
 
                 const isEnabled = !!enabledNetworks?.includes(symbol);
+                const showSettings = getIsSettingsVisible?.({ network, isEnabled }) ?? true;
 
                 const isDisabled = isDeviceLocked;
                 const unavailabilityTooltip =
@@ -107,7 +126,8 @@ export const NetworkList = ({
                             isEnabled={isEnabled}
                             isCardClickable={isCardClickable}
                             onClick={onClick}
-                            onSettings={onSettings}
+                            onSettings={showSettings ? onSettings : undefined}
+                            showRepresentativeAssets={showRepresentativeAssets}
                             rightContent={renderRightContent?.({
                                 network,
                                 isEnabled,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/GlobalReceiveModal.tsx
@@ -133,7 +133,6 @@ export const GlobalReceiveModal = ({ onCancel, onSubmit }: GlobalReceiveModalPro
             </Modal>
             {accountModal.open && device && (
                 <AddAccountModal
-                    noRedirect
                     device={device}
                     onCancel={accountModal.closeModal}
                     onAddAccount={account => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
@@ -43,7 +43,7 @@ const AccountTypeSelectComponent = ({
         return (
             <Row alignItems="baseline" gap={8}>
                 {accountTypeName && <Translation id={accountTypeName} />}
-                <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
+                <Text intent="neutral" priority="secondary">
                     <Translation id={getAccountTypeTech(option.value.bip43Path)} />
                 </Text>
             </Row>
@@ -64,7 +64,11 @@ const AccountTypeSelectComponent = ({
         <Column alignItems="center" gap={16}>
             <Select
                 data-testid="@add-account-type/select"
-                labelLeft={<Translation id="TR_SELECT_TYPE" />}
+                labelLeft={
+                    <Text typographyStyle="body-sm">
+                        <Translation id="TR_SELECT_ADDRESS_TYPE" />
+                    </Text>
+                }
                 isSearchable={false}
                 isClearable={false}
                 value={value}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountBannerAboutNetworks.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountBannerAboutNetworks.tsx
@@ -1,0 +1,50 @@
+import { AnimatePresence, motion } from 'framer-motion';
+
+import { selectIsAddAccountNetworksBannerClosed, setFlag } from '@suite/flags';
+import { Translation } from '@suite/intl';
+import { Banner } from '@trezor/components';
+import { GraduationCapIcon } from '@trezor/icons';
+
+import { bannerAnimationConfig } from 'src/components/suite/modals/ReduxModal/UserContextModal/ActivateAssetsModal';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+const AddAccountBannerAboutNetworksInner = () => {
+    const dispatch = useDispatch();
+    const closeNetworkInfoBanner = () => {
+        dispatch(setFlag({ key: 'addAccountNetworksBannerClosed', value: true }));
+    };
+
+    return (
+        <Banner
+            intent="neutral"
+            margin={{ bottom: 12 }}
+            icon={GraduationCapIcon}
+            title={<Translation id="TR_ADD_ACCOUNT_NETWORKS_BANNER_TITLE" />}
+            description={<Translation id="TR_ADD_ACCOUNT_NETWORKS_BANNER_DESCRIPTION" />}
+            rightContent={
+                <Banner.Button
+                    size="small"
+                    onClick={closeNetworkInfoBanner}
+                    data-testid="@modal/account/networks-banner-dismiss"
+                >
+                    <Translation id="TR_OK_GOT_IT" />
+                </Banner.Button>
+            }
+            data-testid="@modal/account/networks-banner"
+        />
+    );
+};
+
+export const AddAccountBannerAboutNetworks = () => {
+    const isAddAccountNetworksBannerClosed = useSelector(selectIsAddAccountNetworksBannerClosed);
+
+    return (
+        <AnimatePresence>
+            {!isAddAccountNetworksBannerClosed ? (
+                <motion.div {...bannerAnimationConfig}>
+                    <AddAccountBannerAboutNetworksInner />
+                </motion.div>
+            ) : null}
+        </AnimatePresence>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddAccountButton.tsx
@@ -17,6 +17,7 @@ interface AddAccountButtonProps {
     scopedAccounts: Account[];
     onEnableAccount: (account: Account) => void;
     onAddNewAccount: () => void;
+    isLoading?: boolean;
 }
 
 const AddDefaultAccountButton = ({
@@ -25,6 +26,7 @@ const AddDefaultAccountButton = ({
     onAddNewAccount,
     network,
     selectedAccount,
+    isLoading,
 }: AddAccountButtonProps) => {
     const defaultAccount = scopedAccounts.at(-1);
     const device = useSelector(selectSelectedDevice);
@@ -52,6 +54,7 @@ const AddDefaultAccountButton = ({
             disabledMessage={disabledMessage && <Translation id={disabledMessage} />}
             networkName={network.name}
             onClick={handleClick}
+            isLoading={isLoading}
         />
     );
 };
@@ -62,6 +65,7 @@ export const AddAccountButton = ({
     scopedAccounts,
     onEnableAccount,
     onAddNewAccount,
+    isLoading,
 }: AddAccountButtonProps) => {
     switch (selectedAccount?.accountType) {
         case 'coinjoin':
@@ -74,6 +78,7 @@ export const AddAccountButton = ({
                     scopedAccounts={scopedAccounts}
                     onEnableAccount={onEnableAccount}
                     onAddNewAccount={onAddNewAccount}
+                    isLoading={isLoading}
                 />
             );
     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -47,11 +47,14 @@ import { AdvancedCoinSettingsModal } from '../AdvancedCoinSettingsModal/Advanced
 
 type AddAccountProps = {
     device: TrezorDevice;
+    // Callback when modal is closed, same as any other modal.
     onCancel: () => void;
+    // Callback when the add-account flow completed successfully enough to resume the parent flow.
     onConfirm?: () => void;
     symbol?: NetworkSymbol;
     isCoinjoinDisabled?: boolean;
     isBackClickDisabled?: boolean;
+    // Callback when the flow produced a specific single usable account (not when enabling a pinned network).
     onAddAccount?: (account: Account) => void;
 };
 
@@ -75,6 +78,11 @@ export const AddAccountModal = ({
 
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
+
+    const closeModalAndNotifyCompletion = useCallback(() => {
+        onCancel();
+        onConfirm?.();
+    }, [onCancel, onConfirm]);
 
     const resetAccountSearch = (networkSymbol: NetworkSymbol) => {
         // Reset the account search so the new account is visible in the list.
@@ -281,9 +289,8 @@ export const AddAccountModal = ({
     );
 
     function enablePinnedNetwork(network: Network) {
-        onCancel();
         dispatch(changeCoinVisibility({ symbol: network.symbol, shouldBeVisible: true }));
-        onConfirm?.();
+        closeModalAndNotifyCompletion();
     }
 
     async function enableAccount(
@@ -322,9 +329,7 @@ export const AddAccountModal = ({
                 return;
             }
 
-            onCancel();
-            onConfirm?.();
-
+            closeModalAndNotifyCompletion();
             onAddAccount?.(addedAccount);
         };
 
@@ -428,8 +433,7 @@ export const AddAccountModal = ({
                 return;
             }
 
-            onCancel();
-            onConfirm?.();
+            closeModalAndNotifyCompletion();
             onAddAccount?.(addedAccount);
         } finally {
             finishAddingAccount();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -1,11 +1,8 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 
-import { AnimatePresence, motion } from 'framer-motion';
-
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsPublic } from '@suite/coinjoin';
 import { selectIsDebugModeActive } from '@suite/debug';
-import { selectIsAddAccountNetworksBannerClosed, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { preserveModal } from '@suite/modal';
 import { selectIsTestnetNetworksEnabled } from '@suite/settings';
@@ -26,10 +23,11 @@ import {
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
 import { getAvailableAccountTypes, prepareNewAccountPayload } from '@suite-common/wallet-utils';
-import { Banner, Box, Column, Icon, Modal, Tooltip } from '@trezor/components';
+import { Box, Column, Icon, Modal, Tooltip } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
-import { GraduationCapIcon, InfoIcon } from '@trezor/icons';
+import { InfoIcon } from '@trezor/icons';
 
+import { AddAccountBannerAboutNetworks } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountBannerAboutNetworks';
 import { useAvailableNetworkSymbols } from 'src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useAccountSearch, useDispatch, useSelector } from 'src/hooks/suite';
@@ -45,7 +43,6 @@ import { SelectNetwork } from './SelectNetwork';
 import { getSortedNetworks, getVisibleAccountCounts } from './addAccountModalUtils';
 import { useNetworkActivationQueue } from './useNetworkActivationQueue';
 import { verifyAvailability } from './verifyAvailability';
-import { bannerAnimationConfig } from '../ActivateAssetsModal';
 import { AdvancedCoinSettingsModal } from '../AdvancedCoinSettingsModal/AdvancedCoinSettingsModal';
 
 type AddAccountProps = {
@@ -70,7 +67,6 @@ export const AddAccountModal = ({
     const accounts = useSelector(selectAccounts);
     const isDebug = useSelector(selectIsDebugModeActive);
     const isCoinjoinPublic = useSelector(selectIsPublic);
-    const isAddAccountNetworksBannerClosed = useSelector(selectIsAddAccountNetworksBannerClosed);
     const enabledNetworkSymbols = useSelector(selectEnabledNetworks);
     const useTestnetNetworks = useSelector(selectIsTestnetNetworksEnabled);
     const dispatch = useDispatch();
@@ -169,9 +165,6 @@ export const AddAccountModal = ({
     const finishAddingAccount = () => {
         addingAccountNetworkSymbolRef.current = undefined;
         setAddingAccountNetworkSymbol(undefined);
-    };
-    const closeNetworkInfoBanner = () => {
-        dispatch(setFlag({ key: 'addAccountNetworksBannerClosed', value: true }));
     };
 
     const availableNetworksSymbols = useAvailableNetworkSymbols();
@@ -600,33 +593,7 @@ export const AddAccountModal = ({
                               }
                           />
                           <Column>
-                              <AnimatePresence>
-                                  {!isAddAccountNetworksBannerClosed && (
-                                      <motion.div {...bannerAnimationConfig}>
-                                          <Banner
-                                              intent="neutral"
-                                              margin={{ bottom: 12 }}
-                                              icon={GraduationCapIcon}
-                                              title={
-                                                  <Translation id="TR_ADD_ACCOUNT_NETWORKS_BANNER_TITLE" />
-                                              }
-                                              description={
-                                                  <Translation id="TR_ADD_ACCOUNT_NETWORKS_BANNER_DESCRIPTION" />
-                                              }
-                                              rightContent={
-                                                  <Banner.Button
-                                                      size="small"
-                                                      onClick={closeNetworkInfoBanner}
-                                                      data-testid="@modal/account/networks-banner-dismiss"
-                                                  >
-                                                      <Translation id="TR_OK_GOT_IT" />
-                                                  </Banner.Button>
-                                              }
-                                              data-testid="@modal/account/networks-banner"
-                                          />
-                                      </motion.div>
-                                  )}
-                              </AnimatePresence>
+                              <AddAccountBannerAboutNetworks />
                               {hasNoSearchResults ? (
                                   <Box padding={{ vertical: 32 }}>
                                       <NoNetworkSearchResults dataTestId="@modal/account/no-networks-found" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -26,9 +26,9 @@ import {
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
 import { getAvailableAccountTypes, prepareNewAccountPayload } from '@suite-common/wallet-utils';
-import { Banner, Box, Column, Modal } from '@trezor/components';
+import { Banner, Box, Column, Icon, Modal, Tooltip } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
-import { GraduationCapIcon } from '@trezor/icons';
+import { GraduationCapIcon, InfoIcon } from '@trezor/icons';
 
 import { useAvailableNetworkSymbols } from 'src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
@@ -582,6 +582,22 @@ export const AddAccountModal = ({
                               onSearchChange={handleSearchChange}
                               onSearchClear={handleSearchClear}
                               dataTestId="@modal/account/network-search-input"
+                              rightContent={
+                                  <Tooltip
+                                      tooltipMaxWidth={285}
+                                      content={
+                                          <Translation id="TR_ADD_ACCOUNT_NETWORKS_BANNER_DESCRIPTION" />
+                                      }
+                                      placement="bottom"
+                                  >
+                                      <Icon
+                                          as={InfoIcon}
+                                          size={20}
+                                          intent="neutral"
+                                          priority="secondary"
+                                      />
+                                  </Tooltip>
+                              }
                           />
                           <Column>
                               <AnimatePresence>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -596,7 +596,7 @@ export const AddAccountModal = ({
                                   </Tooltip>
                               }
                           />
-                          <Column>
+                          <Column padding={{ bottom: 8 }}>
                               <AddAccountBannerAboutNetworks />
                               {hasNoSearchResults ? (
                                   <Box padding={{ vertical: 32 }}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
@@ -151,8 +151,25 @@ export const AddAccountModal = ({
     const [advancedSettingsSymbol, setAdvancedSettingsSymbol] = useState<
         NetworkSymbol | undefined
     >();
+    // TODO after this refactoring, no need to track it here, it will be a selector https://github.com/trezor/trezor-suite/issues/31779
+    const [addingAccountNetworkSymbol, setAddingAccountNetworkSymbol] = useState<NetworkSymbol>();
+    const addingAccountNetworkSymbolRef = useRef<NetworkSymbol | undefined>(undefined);
 
     const closeAdvancedSettings = () => setAdvancedSettingsSymbol(undefined);
+    const shouldStartAddingAccount = (networkSymbol: NetworkSymbol) => {
+        if (addingAccountNetworkSymbolRef.current) {
+            return false;
+        }
+
+        addingAccountNetworkSymbolRef.current = networkSymbol;
+        setAddingAccountNetworkSymbol(networkSymbol);
+
+        return true;
+    };
+    const finishAddingAccount = () => {
+        addingAccountNetworkSymbolRef.current = undefined;
+        setAddingAccountNetworkSymbol(undefined);
+    };
     const closeNetworkInfoBanner = () => {
         dispatch(setFlag({ key: 'addAccountNetworksBannerClosed', value: true }));
     };
@@ -286,6 +303,10 @@ export const AddAccountModal = ({
             accountTypes?: NetworkAccount[];
         } = {},
     ) {
+        if (addingAccountNetworkSymbolRef.current) {
+            return;
+        }
+
         if (shouldKeepModalOpen) {
             dispatch(preserveModal());
         }
@@ -321,30 +342,38 @@ export const AddAccountModal = ({
             return;
         }
 
-        const newAccount = await prepareNewAccountPayload({
-            accountType: account.accountType,
-            networkSymbol: account.symbol,
-            index: account.index + 1,
-            backendType: account.backendType != 'coinjoin' ? account.backendType : undefined,
-            selectedAccount: nextSelectedAccount,
-            accountTypes: nextAccountTypes,
-            device,
-        });
-
-        if (newAccount instanceof Error) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'discovery-error',
-                    error: newAccount.message,
-                }),
-            );
-
+        if (!shouldStartAddingAccount(account.symbol)) {
             return;
         }
 
-        const createAccountAction = accountsActions.createAccount(newAccount);
-        dispatch(createAccountAction);
-        finishEnableAccount(createAccountAction.payload);
+        try {
+            const newAccount = await prepareNewAccountPayload({
+                accountType: account.accountType,
+                networkSymbol: account.symbol,
+                index: account.index + 1,
+                backendType: account.backendType != 'coinjoin' ? account.backendType : undefined,
+                selectedAccount: nextSelectedAccount,
+                accountTypes: nextAccountTypes,
+                device,
+            });
+
+            if (newAccount instanceof Error) {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'discovery-error',
+                        error: newAccount.message,
+                    }),
+                );
+
+                return;
+            }
+
+            const createAccountAction = accountsActions.createAccount(newAccount);
+            dispatch(createAccountAction);
+            finishEnableAccount(createAccountAction.payload);
+        } finally {
+            finishAddingAccount();
+        }
     }
 
     async function addNewAccount({
@@ -356,54 +385,62 @@ export const AddAccountModal = ({
         account: NetworkAccount;
         accountTypes: NetworkAccount[];
     }) {
+        if (!shouldStartAddingAccount(network.symbol)) {
+            return;
+        }
+
         if (shouldKeepModalOpen) {
             dispatch(preserveModal());
         }
 
-        const newAccount = await prepareNewAccountPayload({
-            accountType: account.accountType,
-            networkSymbol: network.symbol,
-            index: 0,
-            backendType: account.backendType != 'coinjoin' ? account.backendType : undefined,
-            selectedAccount: account,
-            accountTypes: nextAccountTypes,
-            device,
-        });
+        try {
+            const newAccount = await prepareNewAccountPayload({
+                accountType: account.accountType,
+                networkSymbol: network.symbol,
+                index: 0,
+                backendType: account.backendType != 'coinjoin' ? account.backendType : undefined,
+                selectedAccount: account,
+                accountTypes: nextAccountTypes,
+                device,
+            });
 
-        if (newAccount instanceof Error) {
+            if (newAccount instanceof Error) {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'discovery-error',
+                        error: newAccount.message,
+                    }),
+                );
+
+                return;
+            }
+
+            const createAccountAction = accountsActions.createAccount(newAccount);
+            dispatch(createAccountAction);
+            const addedAccount = createAccountAction.payload;
+            resetAccountSearch(addedAccount.symbol);
+            reportNewAccountAnalytics(addedAccount);
+            dispatch(reportWalletBalanceThunk());
             dispatch(
                 notificationsActions.addToast({
-                    type: 'discovery-error',
-                    error: newAccount.message,
+                    type: 'account-added',
+                    networkName: getNetwork(addedAccount.symbol).name,
                 }),
             );
 
-            return;
+            if (shouldKeepModalOpen) {
+                setAccountTypeSelectionNetwork(undefined);
+                setSelectedAccount(undefined);
+
+                return;
+            }
+
+            onCancel();
+            onConfirm?.();
+            onAddAccount?.(addedAccount);
+        } finally {
+            finishAddingAccount();
         }
-
-        const createAccountAction = accountsActions.createAccount(newAccount);
-        dispatch(createAccountAction);
-        const addedAccount = createAccountAction.payload;
-        resetAccountSearch(addedAccount.symbol);
-        reportNewAccountAnalytics(addedAccount);
-        dispatch(reportWalletBalanceThunk());
-        dispatch(
-            notificationsActions.addToast({
-                type: 'account-added',
-                networkName: getNetwork(addedAccount.symbol).name,
-            }),
-        );
-
-        if (shouldKeepModalOpen) {
-            setAccountTypeSelectionNetwork(undefined);
-            setSelectedAccount(undefined);
-
-            return;
-        }
-
-        onCancel();
-        onConfirm?.();
-        onAddAccount?.(addedAccount);
     }
 
     const handleNetworkSelection = async (networkSymbol?: NetworkSymbol) => {
@@ -501,6 +538,9 @@ export const AddAccountModal = ({
                           network={accountTypeSelectionNetwork}
                           selectedAccount={selectedAccount}
                           scopedAccounts={scopedAccounts}
+                          isLoading={
+                              addingAccountNetworkSymbol === accountTypeSelectionNetwork.symbol
+                          }
                           onEnableAccount={account => {
                               void enableAccount(account, {
                                   selectedAccount,
@@ -529,6 +569,7 @@ export const AddAccountModal = ({
                               networks={visibleNetworks}
                               enabledNetworkSymbols={enabledNetworkSymbols}
                               accountCounts={accountCounts}
+                              addingAccountNetworkSymbol={addingAccountNetworkSymbol}
                               handleNetworkSelection={handleNetworkSelection}
                               onSettings={setAdvancedSettingsSymbol}
                               getAddDisabledMessage={getAddDisabledMessage}
@@ -580,6 +621,7 @@ export const AddAccountModal = ({
                                       enabledNetworkSymbols={enabledNetworkSymbols}
                                       accountCounts={accountCounts}
                                       activatingNetworkSymbols={activatingNetworkSymbols}
+                                      addingAccountNetworkSymbol={addingAccountNetworkSymbol}
                                       activationErrors={activationErrors}
                                       handleNetworkSelection={handleNetworkSelection}
                                       onSettings={setAdvancedSettingsSymbol}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
 
+import { AnimatePresence, motion } from 'framer-motion';
+
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsPublic } from '@suite/coinjoin';
 import { selectIsDebugModeActive } from '@suite/debug';
+import { selectIsAddAccountNetworksBannerClosed, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { goto, selectRouterApp } from '@suite/router';
+import { preserveModal } from '@suite/modal';
 import { selectIsTestnetNetworksEnabled } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -23,9 +26,9 @@ import {
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
 import { getAvailableAccountTypes, prepareNewAccountPayload } from '@suite-common/wallet-utils';
-import { Box, Column, Modal } from '@trezor/components';
+import { Banner, Box, Column, Modal } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
-import { arrayPartition } from '@trezor/utils';
+import { GraduationCapIcon } from '@trezor/icons';
 
 import { useAvailableNetworkSymbols } from 'src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
@@ -39,7 +42,10 @@ import { useNetworkSettingsSearch } from 'src/views/settings/SettingsCoins/useNe
 import { AccountTypeSelect } from './AccountTypeSelect/AccountTypeSelect';
 import { AddAccountButton } from './AddAccountButton/AddAccountButton';
 import { SelectNetwork } from './SelectNetwork';
+import { getSortedNetworks, getVisibleAccountCounts } from './addAccountModalUtils';
+import { useNetworkActivationQueue } from './useNetworkActivationQueue';
 import { verifyAvailability } from './verifyAvailability';
+import { bannerAnimationConfig } from '../ActivateAssetsModal';
 import { AdvancedCoinSettingsModal } from '../AdvancedCoinSettingsModal/AdvancedCoinSettingsModal';
 
 type AddAccountProps = {
@@ -47,7 +53,6 @@ type AddAccountProps = {
     onCancel: () => void;
     onConfirm?: () => void;
     symbol?: NetworkSymbol;
-    noRedirect?: boolean;
     isCoinjoinDisabled?: boolean;
     isBackClickDisabled?: boolean;
     onAddAccount?: (account: Account) => void;
@@ -58,27 +63,28 @@ export const AddAccountModal = ({
     onCancel,
     onConfirm,
     symbol,
-    noRedirect,
     onAddAccount,
     isCoinjoinDisabled,
     isBackClickDisabled,
 }: AddAccountProps) => {
     const accounts = useSelector(selectAccounts);
-    const app = useSelector(selectRouterApp);
     const isDebug = useSelector(selectIsDebugModeActive);
     const isCoinjoinPublic = useSelector(selectIsPublic);
+    const isAddAccountNetworksBannerClosed = useSelector(selectIsAddAccountNetworksBannerClosed);
     const enabledNetworkSymbols = useSelector(selectEnabledNetworks);
     const useTestnetNetworks = useSelector(selectIsTestnetNetworksEnabled);
     const dispatch = useDispatch();
+    const { activateNetwork, activatingNetworkSymbols, activationErrors } =
+        useNetworkActivationQueue(device);
 
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { setCoinFilter, setSearchString, coinFilter } = useAccountSearch();
 
-    const resetAccountSearch = (symbol: NetworkSymbol) => {
-        // reset search string in account search box so the new account is visible in the list
+    const resetAccountSearch = (networkSymbol: NetworkSymbol) => {
+        // Reset the account search so the new account is visible in the list.
         setSearchString(undefined);
-        if (coinFilter && !coinFilter.includes(symbol)) {
-            // if coinFilter is active then reset it only if added account doesn't belong to selected/filtered coin
+        if (coinFilter && !coinFilter.includes(networkSymbol)) {
+            // Reset an active filter only when it does not include the added account.
             setCoinFilter([]);
         }
     };
@@ -96,8 +102,7 @@ export const AddAccountModal = ({
         });
     };
 
-    const { showUnsupportedCoins, supportedMainnets, unsupportedMainnets, supportedTestnets } =
-        useNetworkSupport();
+    const { supportedMainnets, supportedTestnets } = useNetworkSupport();
 
     const supportedNetworks = [...supportedMainnets, ...supportedTestnets];
     const allTestnetNetworksDisabled = !supportedTestnets.some(network =>
@@ -105,10 +110,11 @@ export const AddAccountModal = ({
     );
     const isBitcoinOnlyFirmware = hasBitcoinOnlyFirmware(device);
 
-    // applied when changing account in trading exchange receive options context
+    // Applied when changing account in trading exchange receive options context.
     const networkPinned = !!symbol;
+    const shouldKeepModalOpen = !networkPinned && !onAddAccount;
     const preselectedNetwork = symbol && supportedNetworks.find(n => n.symbol === symbol);
-    // or in case of only btc is enabled on bitcoin-only firmware
+    // Applied when only BTC is enabled on bitcoin-only firmware.
     const bitcoinOnlyDefaultNetworkSelection =
         isBitcoinOnlyFirmware && supportedMainnets.length === 1 && allTestnetNetworksDisabled
             ? networks.btc
@@ -147,74 +153,44 @@ export const AddAccountModal = ({
     >();
 
     const closeAdvancedSettings = () => setAdvancedSettingsSymbol(undefined);
+    const closeNetworkInfoBanner = () => {
+        dispatch(setFlag({ key: 'addAccountNetworksBannerClosed', value: true }));
+    };
 
     const availableNetworksSymbols = useAvailableNetworkSymbols();
 
     const enabledNetworks = availableNetworksSymbols.map(networkSymbol =>
         getNetwork(networkSymbol),
     );
-    const [enabledMainnetNetworks, enabledTestnetNetworks] = useMemo(
-        () => arrayPartition(enabledNetworks, network => !network?.testnet),
-        [enabledNetworks],
-    );
     const disabledNetworks = supportedNetworks.filter(
         network => !availableNetworksSymbols.includes(network.symbol),
     );
-
-    const [disabledMainnetNetworks, disabledTestnetNetworks] = useMemo(
-        () => arrayPartition(disabledNetworks, network => !network?.testnet),
-        [disabledNetworks],
+    // `getSortedNetworks` sorts first enabled, then disabled networks. But we call it only once to maintain
+    // a stable order, so that the network rows don't jump around when networks are enabled/disabled.
+    const [stableNetworks] = useState(() =>
+        getSortedNetworks({
+            availableNetworks: [
+                ...supportedMainnets,
+                ...(useTestnetNetworks ? supportedTestnets : []),
+            ],
+            enabledNetworkSymbols: availableNetworksSymbols,
+        }),
     );
-    const testnetNetworks = useMemo(
-        () => [...enabledTestnetNetworks, ...disabledTestnetNetworks],
-        [enabledTestnetNetworks, disabledTestnetNetworks],
-    );
-
-    const allSearchableNetworks = useMemo(() => {
-        if (symbol) {
-            return [];
-        }
-
-        return [
-            ...enabledMainnetNetworks,
-            ...disabledMainnetNetworks,
-            ...(useTestnetNetworks ? testnetNetworks : []),
-            ...(showUnsupportedCoins ? unsupportedMainnets : []),
-        ];
-    }, [
-        disabledMainnetNetworks,
-        enabledMainnetNetworks,
-        showUnsupportedCoins,
-        symbol,
-        testnetNetworks,
-        unsupportedMainnets,
-        useTestnetNetworks,
-    ]);
+    const allSearchableNetworks = networkPinned ? [] : stableNetworks;
 
     const {
         searchQuery,
-        hasActiveSearch,
         hasNoSearchResults,
         filterNetworks,
         handleSearchChange,
         handleSearchClear,
     } = useNetworkSettingsSearch(allSearchableNetworks, { origin: 'add-account' });
 
-    const filteredEnabledMainnetNetworks = filterNetworks(enabledMainnetNetworks);
-    const filteredDisabledMainnetNetworks = filterNetworks(disabledMainnetNetworks);
-    const filteredTestnetNetworks = filterNetworks(testnetNetworks);
-    const filteredUnsupportedMainnets = filterNetworks(unsupportedMainnets);
-
-    const showEnabledMainnets = !hasActiveSearch || filteredEnabledMainnetNetworks.length > 0;
-    const showDisabledMainnets = !hasActiveSearch || filteredDisabledMainnetNetworks.length > 0;
-    const showTestnetsSection =
-        useTestnetNetworks &&
-        testnetNetworks.length > 0 &&
-        (!hasActiveSearch || filteredTestnetNetworks.length > 0);
-    const showUnsupportedSection =
-        showUnsupportedCoins &&
-        unsupportedMainnets.length > 0 &&
-        (!hasActiveSearch || filteredUnsupportedMainnets.length > 0);
+    const filteredNetworks = filterNetworks(stableNetworks);
+    const accountCounts = useMemo(
+        () => getVisibleAccountCounts(accounts, device.state?.staticSessionId),
+        [accounts, device.state?.staticSessionId],
+    );
 
     // Collect all empty accounts related to selected device and selected accountType
     const currentType = selectedAccount?.accountType ?? 'normal';
@@ -242,10 +218,7 @@ export const AddAccountModal = ({
     const filterNetworksBySymbol = (items: Network[], networkSymbol?: NetworkSymbol) =>
         networkSymbol ? items.filter(network => network.symbol === networkSymbol) : items;
 
-    const filteredDisabledNetworks = filterNetworksBySymbol(
-        symbol ? disabledNetworks : disabledMainnetNetworks,
-        symbol,
-    );
+    const filteredDisabledNetworks = filterNetworksBySymbol(disabledNetworks, symbol);
     const filteredEnabledNetworks = filterNetworksBySymbol(enabledNetworks, symbol);
 
     const visibleNetworks =
@@ -297,24 +270,10 @@ export const AddAccountModal = ({
         ],
     );
 
-    function enableNetwork(network: Network) {
+    function enablePinnedNetwork(network: Network) {
         onCancel();
         dispatch(changeCoinVisibility({ symbol: network.symbol, shouldBeVisible: true }));
         onConfirm?.();
-
-        if (app === 'wallet' && !noRedirect) {
-            // redirect to account only if added from "wallet" app
-            dispatch(
-                goto({
-                    routeName: 'wallet-index',
-                    params: {
-                        symbol: network.symbol,
-                        accountIndex: 0,
-                        accountType: 'normal',
-                    },
-                }),
-            );
-        }
     }
 
     async function enableAccount(
@@ -327,27 +286,32 @@ export const AddAccountModal = ({
             accountTypes?: NetworkAccount[];
         } = {},
     ) {
-        onCancel();
+        if (shouldKeepModalOpen) {
+            dispatch(preserveModal());
+        }
 
         const finishEnableAccount = (addedAccount: Account) => {
             resetAccountSearch(addedAccount.symbol);
             reportNewAccountAnalytics(addedAccount);
             dispatch(reportWalletBalanceThunk());
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'account-added',
+                    networkName: getNetwork(addedAccount.symbol).name,
+                }),
+            );
+
+            if (shouldKeepModalOpen) {
+                setAccountTypeSelectionNetwork(undefined);
+                setSelectedAccount(undefined);
+
+                return;
+            }
+
+            onCancel();
             onConfirm?.();
 
             onAddAccount?.(addedAccount);
-            if (app === 'wallet' && !noRedirect) {
-                dispatch(
-                    goto({
-                        routeName: 'wallet-index',
-                        params: {
-                            symbol: addedAccount.symbol,
-                            accountIndex: addedAccount.index,
-                            accountType: addedAccount.accountType,
-                        },
-                    }),
-                );
-            }
         };
 
         if (!account.visible) {
@@ -392,6 +356,10 @@ export const AddAccountModal = ({
         account: NetworkAccount;
         accountTypes: NetworkAccount[];
     }) {
+        if (shouldKeepModalOpen) {
+            dispatch(preserveModal());
+        }
+
         const newAccount = await prepareNewAccountPayload({
             accountType: account.accountType,
             networkSymbol: network.symbol,
@@ -413,12 +381,29 @@ export const AddAccountModal = ({
             return;
         }
 
-        onCancel();
-        dispatch(accountsActions.createAccount(newAccount));
-        resetAccountSearch(newAccount.symbol);
-        reportNewAccountAnalytics(newAccount);
+        const createAccountAction = accountsActions.createAccount(newAccount);
+        dispatch(createAccountAction);
+        const addedAccount = createAccountAction.payload;
+        resetAccountSearch(addedAccount.symbol);
+        reportNewAccountAnalytics(addedAccount);
         dispatch(reportWalletBalanceThunk());
+        dispatch(
+            notificationsActions.addToast({
+                type: 'account-added',
+                networkName: getNetwork(addedAccount.symbol).name,
+            }),
+        );
+
+        if (shouldKeepModalOpen) {
+            setAccountTypeSelectionNetwork(undefined);
+            setSelectedAccount(undefined);
+
+            return;
+        }
+
+        onCancel();
         onConfirm?.();
+        onAddAccount?.(addedAccount);
     }
 
     const handleNetworkSelection = async (networkSymbol?: NetworkSymbol) => {
@@ -434,6 +419,16 @@ export const AddAccountModal = ({
             return;
         }
 
+        if (!enabledNetworkSymbols.includes(networkToSelect.symbol)) {
+            if (networkPinned) {
+                enablePinnedNetwork(networkToSelect);
+            } else {
+                activateNetwork(networkToSelect.symbol);
+            }
+
+            return;
+        }
+
         const networkAccountTypes = getAccountTypesForNetwork(networkToSelect);
 
         if (networkAccountTypes && networkAccountTypes.length > 1) {
@@ -441,12 +436,6 @@ export const AddAccountModal = ({
                 setAccountTypeSelectionNetwork(networkToSelect);
                 setSelectedAccount(undefined);
             }
-
-            return;
-        }
-
-        if (!enabledNetworkSymbols.includes(networkToSelect.symbol)) {
-            enableNetwork(networkToSelect);
 
             return;
         }
@@ -484,12 +473,8 @@ export const AddAccountModal = ({
     const isAccountTypeSelectionStep =
         !!accountTypeSelectionNetwork && !!accountTypes && accountTypes.length > 1;
 
-    const getStepConfig = () => {
-        const isAccountActivated =
-            preselectedNetwork &&
-            enabledNetworks.some(enabledNetwork => enabledNetwork.symbol === symbol);
-
-        return isAccountTypeSelectionStep
+    const getStepConfig = () =>
+        isAccountTypeSelectionStep
             ? {
                   heading: (
                       <Translation
@@ -538,17 +523,12 @@ export const AddAccountModal = ({
               }
             : {
                   heading: <Translation id="TR_ADD_ACCOUNT" />,
-                  children: symbol ? (
+                  children: networkPinned ? (
                       <Column gap={24}>
                           <SelectNetwork
-                              heading={
-                                  isAccountActivated ? (
-                                      <Translation id="TR_ACTIVATED_COINS" />
-                                  ) : (
-                                      <Translation id="TR_INACTIVE_COINS" />
-                                  )
-                              }
                               networks={visibleNetworks}
+                              enabledNetworkSymbols={enabledNetworkSymbols}
+                              accountCounts={accountCounts}
                               handleNetworkSelection={handleNetworkSelection}
                               onSettings={setAdvancedSettingsSymbol}
                               getAddDisabledMessage={getAddDisabledMessage}
@@ -562,54 +542,54 @@ export const AddAccountModal = ({
                               onSearchClear={handleSearchClear}
                               dataTestId="@modal/account/network-search-input"
                           />
-                          {hasNoSearchResults ? (
-                              <Box padding={{ vertical: 32 }}>
-                                  <NoNetworkSearchResults dataTestId="@modal/account/no-networks-found" />
-                              </Box>
-                          ) : (
-                              <>
-                                  {showEnabledMainnets && (
-                                      <SelectNetwork
-                                          heading={<Translation id="TR_ACTIVATED_COINS" />}
-                                          networks={filteredEnabledMainnetNetworks}
-                                          handleNetworkSelection={handleNetworkSelection}
-                                          onSettings={setAdvancedSettingsSymbol}
-                                          getAddDisabledMessage={getAddDisabledMessage}
-                                      />
+                          <Column>
+                              <AnimatePresence>
+                                  {!isAddAccountNetworksBannerClosed && (
+                                      <motion.div {...bannerAnimationConfig}>
+                                          <Banner
+                                              intent="neutral"
+                                              margin={{ bottom: 12 }}
+                                              icon={GraduationCapIcon}
+                                              title={
+                                                  <Translation id="TR_ADD_ACCOUNT_NETWORKS_BANNER_TITLE" />
+                                              }
+                                              description={
+                                                  <Translation id="TR_ADD_ACCOUNT_NETWORKS_BANNER_DESCRIPTION" />
+                                              }
+                                              rightContent={
+                                                  <Banner.Button
+                                                      size="small"
+                                                      onClick={closeNetworkInfoBanner}
+                                                      data-testid="@modal/account/networks-banner-dismiss"
+                                                  >
+                                                      <Translation id="TR_OK_GOT_IT" />
+                                                  </Banner.Button>
+                                              }
+                                              data-testid="@modal/account/networks-banner"
+                                          />
+                                      </motion.div>
                                   )}
-                                  {showDisabledMainnets && (
-                                      <SelectNetwork
-                                          heading={<Translation id="TR_INACTIVE_COINS" />}
-                                          networks={filteredDisabledMainnetNetworks}
-                                          handleNetworkSelection={handleNetworkSelection}
-                                          onSettings={setAdvancedSettingsSymbol}
-                                          getAddDisabledMessage={getAddDisabledMessage}
-                                      />
-                                  )}
-                                  {showTestnetsSection && (
-                                      <SelectNetwork
-                                          heading={<Translation id="TR_TESTNET_COINS" />}
-                                          data-testid="@modal/account/activate_more_coins"
-                                          networks={filteredTestnetNetworks}
-                                          handleNetworkSelection={handleNetworkSelection}
-                                          onSettings={setAdvancedSettingsSymbol}
-                                          getAddDisabledMessage={getAddDisabledMessage}
-                                      />
-                                  )}
-                                  {showUnsupportedSection && (
-                                      <SelectNetwork
-                                          heading={<Translation id="TR_UNSUPPORTED_COINS" />}
-                                          data-testid="@modal/account/activate_more_coins"
-                                          networks={filteredUnsupportedMainnets}
-                                          onSettings={setAdvancedSettingsSymbol}
-                                      />
-                                  )}
-                              </>
-                          )}
+                              </AnimatePresence>
+                              {hasNoSearchResults ? (
+                                  <Box padding={{ vertical: 32 }}>
+                                      <NoNetworkSearchResults dataTestId="@modal/account/no-networks-found" />
+                                  </Box>
+                              ) : (
+                                  <SelectNetwork
+                                      networks={filteredNetworks}
+                                      enabledNetworkSymbols={enabledNetworkSymbols}
+                                      accountCounts={accountCounts}
+                                      activatingNetworkSymbols={activatingNetworkSymbols}
+                                      activationErrors={activationErrors}
+                                      handleNetworkSelection={handleNetworkSelection}
+                                      onSettings={setAdvancedSettingsSymbol}
+                                      getAddDisabledMessage={getAddDisabledMessage}
+                                  />
+                              )}
+                          </Column>
                       </Column>
                   ),
               };
-    };
 
     if (advancedSettingsSymbol) {
         return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -1,15 +1,15 @@
 import { Translation } from '@suite/intl';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
-import { Button, Column, H4, Row, Text, Tooltip } from '@trezor/components';
+import { Button, Column, Row, Text, Tooltip } from '@trezor/components';
 
 import { NetworkList } from 'src/components/suite/NetworkList/NetworkList';
 
 type SelectNetworkProps = {
-    heading?: React.ReactNode;
     networks: Network[];
     enabledNetworkSymbols?: NetworkSymbol[];
     accountCounts?: Partial<Record<NetworkSymbol, number>>;
     activatingNetworkSymbols?: NetworkSymbol[];
+    addingAccountNetworkSymbol?: NetworkSymbol;
     activationErrors?: Partial<Record<NetworkSymbol, string>>;
     handleNetworkSelection?: (symbol?: NetworkSymbol) => void;
     onSettings?: (symbol: NetworkSymbol) => void;
@@ -18,11 +18,11 @@ type SelectNetworkProps = {
 };
 
 export const SelectNetwork = ({
-    heading,
     networks,
     enabledNetworkSymbols,
     accountCounts,
     activatingNetworkSymbols = [],
+    addingAccountNetworkSymbol,
     activationErrors,
     handleNetworkSelection,
     onSettings,
@@ -35,11 +35,6 @@ export const SelectNetwork = ({
 
     return (
         <Column gap={12} data-testid={dataTestId}>
-            {heading !== undefined && (
-                <H4 intent="neutral" priority="secondary" typographyStyle="body-sm">
-                    {heading}
-                </H4>
-            )}
             <NetworkList
                 onClick={handleNetworkSelection}
                 networks={networks}
@@ -55,12 +50,16 @@ export const SelectNetwork = ({
                     handleNetworkSelection
                         ? ({ network, isEnabled }) => {
                               const disabledMessage = getAddDisabledMessage?.(network);
-                              const isLoading = activatingNetworkSymbols.includes(network.symbol);
+                              const isActivating = activatingNetworkSymbols.includes(
+                                  network.symbol,
+                              );
+                              const isAdding = addingAccountNetworkSymbol === network.symbol;
+                              const isLoading = isActivating || isAdding;
                               const activationError = activationErrors?.[network.symbol];
 
                               return (
                                   <Row gap={12}>
-                                      {isEnabled && !isLoading && (
+                                      {isEnabled && !isActivating && (
                                           <Text
                                               typographyStyle="body-sm"
                                               intent="neutral"
@@ -92,9 +91,9 @@ export const SelectNetwork = ({
                                           >
                                               <Translation
                                                   id={
-                                                      isEnabled && !isLoading
-                                                          ? 'TR_ADD'
-                                                          : 'TR_ENABLE'
+                                                      isActivating || !isEnabled
+                                                          ? 'TR_ENABLE'
+                                                          : 'TR_ADD'
                                                   }
                                               />
                                           </Button>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode } from 'react';
+
 import { Translation } from '@suite/intl';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
 import { Button, Column, Row, Text, Tooltip } from '@trezor/components';
@@ -6,15 +8,14 @@ import { NetworkList } from 'src/components/suite/NetworkList/NetworkList';
 
 type SelectNetworkProps = {
     networks: Network[];
-    enabledNetworkSymbols?: NetworkSymbol[];
-    accountCounts?: Partial<Record<NetworkSymbol, number>>;
+    enabledNetworkSymbols: NetworkSymbol[];
+    accountCounts: Partial<Record<NetworkSymbol, number>>;
+    addingAccountNetworkSymbol: NetworkSymbol | undefined;
+    handleNetworkSelection: (symbol?: NetworkSymbol) => void;
+    onSettings: (symbol: NetworkSymbol) => void;
+    getAddDisabledMessage: (network: Network) => ReactNode;
     activatingNetworkSymbols?: NetworkSymbol[];
-    addingAccountNetworkSymbol?: NetworkSymbol;
     activationErrors?: Partial<Record<NetworkSymbol, string>>;
-    handleNetworkSelection?: (symbol?: NetworkSymbol) => void;
-    onSettings?: (symbol: NetworkSymbol) => void;
-    getAddDisabledMessage?: (network: Network) => React.ReactNode;
-    dataTestId?: string;
 };
 
 export const SelectNetwork = ({
@@ -27,14 +28,13 @@ export const SelectNetwork = ({
     handleNetworkSelection,
     onSettings,
     getAddDisabledMessage,
-    dataTestId,
 }: SelectNetworkProps) => {
     if (!networks.length) {
         return null;
     }
 
     return (
-        <Column gap={12} data-testid={dataTestId}>
+        <Column gap={12}>
             <NetworkList
                 onClick={handleNetworkSelection}
                 networks={networks}
@@ -46,63 +46,50 @@ export const SelectNetwork = ({
                 }
                 showRepresentativeAssets={false}
                 ignoreDiscoveryLock
-                renderRightContent={
-                    handleNetworkSelection
-                        ? ({ network, isEnabled }) => {
-                              const disabledMessage = getAddDisabledMessage?.(network);
-                              const isActivating = activatingNetworkSymbols.includes(
-                                  network.symbol,
-                              );
-                              const isAdding = addingAccountNetworkSymbol === network.symbol;
-                              const isLoading = isActivating || isAdding;
-                              const activationError = activationErrors?.[network.symbol];
+                renderRightContent={({ network, isEnabled }) => {
+                    const disabledMessage = getAddDisabledMessage(network);
+                    const isActivating = activatingNetworkSymbols.includes(network.symbol);
+                    const isAdding = addingAccountNetworkSymbol === network.symbol;
+                    const isLoading = isActivating || isAdding;
+                    const activationError = activationErrors?.[network.symbol];
+                    const currentAccountCount = accountCounts[network.symbol] ?? 0;
 
-                              return (
-                                  <Row gap={12}>
-                                      {isEnabled && !isActivating && (
-                                          <Text
-                                              typographyStyle="body-sm"
-                                              intent="neutral"
-                                              priority="secondary"
-                                          >
-                                              <Translation
-                                                  id="TR_ACCOUNT_COUNT"
-                                                  values={{
-                                                      count: accountCounts?.[network.symbol] ?? 0,
-                                                  }}
-                                              />
-                                          </Text>
-                                      )}
-                                      <Tooltip
-                                          tooltipMaxWidth={285}
-                                          content={
-                                              isLoading
-                                                  ? undefined
-                                                  : (activationError ?? disabledMessage)
-                                          }
-                                      >
-                                          <Button
-                                              size="small"
-                                              intent="brand"
-                                              isLoading={isLoading}
-                                              isDisabled={!!disabledMessage || isLoading}
-                                              data-testid={`@settings/wallet/network/${network.symbol}/add-button`}
-                                              onClick={() => handleNetworkSelection(network.symbol)}
-                                          >
-                                              <Translation
-                                                  id={
-                                                      isActivating || !isEnabled
-                                                          ? 'TR_ENABLE'
-                                                          : 'TR_ADD'
-                                                  }
-                                              />
-                                          </Button>
-                                      </Tooltip>
-                                  </Row>
-                              );
-                          }
-                        : undefined
-                }
+                    return (
+                        <Row gap={12}>
+                            {isEnabled && !isActivating && (
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    <Translation
+                                        id="TR_ACCOUNT_COUNT"
+                                        values={{ count: currentAccountCount }}
+                                    />
+                                </Text>
+                            )}
+                            <Tooltip
+                                tooltipMaxWidth={285}
+                                content={
+                                    isLoading ? undefined : (activationError ?? disabledMessage)
+                                }
+                            >
+                                <Button
+                                    size="small"
+                                    intent="brand"
+                                    isLoading={isLoading}
+                                    isDisabled={!!disabledMessage || isLoading}
+                                    data-testid={`@settings/wallet/network/${network.symbol}/add-button`}
+                                    onClick={() => handleNetworkSelection(network.symbol)}
+                                >
+                                    <Translation
+                                        id={isActivating || !isEnabled ? 'TR_ENABLE' : 'TR_ADD'}
+                                    />
+                                </Button>
+                            </Tooltip>
+                        </Row>
+                    );
+                }}
             />
         </Column>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/SelectNetwork.tsx
@@ -1,12 +1,16 @@
 import { Translation } from '@suite/intl';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
-import { Button, Column, H4, Tooltip } from '@trezor/components';
+import { Button, Column, H4, Row, Text, Tooltip } from '@trezor/components';
 
 import { NetworkList } from 'src/components/suite/NetworkList/NetworkList';
 
 type SelectNetworkProps = {
-    heading: React.ReactNode;
+    heading?: React.ReactNode;
     networks: Network[];
+    enabledNetworkSymbols?: NetworkSymbol[];
+    accountCounts?: Partial<Record<NetworkSymbol, number>>;
+    activatingNetworkSymbols?: NetworkSymbol[];
+    activationErrors?: Partial<Record<NetworkSymbol, string>>;
     handleNetworkSelection?: (symbol?: NetworkSymbol) => void;
     onSettings?: (symbol: NetworkSymbol) => void;
     getAddDisabledMessage?: (network: Network) => React.ReactNode;
@@ -16,6 +20,10 @@ type SelectNetworkProps = {
 export const SelectNetwork = ({
     heading,
     networks,
+    enabledNetworkSymbols,
+    accountCounts,
+    activatingNetworkSymbols = [],
+    activationErrors,
     handleNetworkSelection,
     onSettings,
     getAddDisabledMessage,
@@ -27,31 +35,71 @@ export const SelectNetwork = ({
 
     return (
         <Column gap={12} data-testid={dataTestId}>
-            <H4 intent="neutral" priority="secondary" typographyStyle="body-sm">
-                {heading}
-            </H4>
+            {heading !== undefined && (
+                <H4 intent="neutral" priority="secondary" typographyStyle="body-sm">
+                    {heading}
+                </H4>
+            )}
             <NetworkList
                 onClick={handleNetworkSelection}
                 networks={networks}
+                enabledNetworks={enabledNetworkSymbols}
                 isCardClickable={false}
                 onSettings={onSettings}
+                getIsSettingsVisible={({ isEnabled, network }) =>
+                    !isEnabled && !activatingNetworkSymbols.includes(network.symbol)
+                }
+                showRepresentativeAssets={false}
+                ignoreDiscoveryLock
                 renderRightContent={
                     handleNetworkSelection
-                        ? ({ network }) => {
+                        ? ({ network, isEnabled }) => {
                               const disabledMessage = getAddDisabledMessage?.(network);
+                              const isLoading = activatingNetworkSymbols.includes(network.symbol);
+                              const activationError = activationErrors?.[network.symbol];
 
                               return (
-                                  <Tooltip tooltipMaxWidth={285} content={disabledMessage}>
-                                      <Button
-                                          size="small"
-                                          intent="brand"
-                                          isDisabled={!!disabledMessage}
-                                          data-testid={`@settings/wallet/network/${network.symbol}/add-button`}
-                                          onClick={() => handleNetworkSelection(network.symbol)}
+                                  <Row gap={12}>
+                                      {isEnabled && !isLoading && (
+                                          <Text
+                                              typographyStyle="body-sm"
+                                              intent="neutral"
+                                              priority="secondary"
+                                          >
+                                              <Translation
+                                                  id="TR_ACCOUNT_COUNT"
+                                                  values={{
+                                                      count: accountCounts?.[network.symbol] ?? 0,
+                                                  }}
+                                              />
+                                          </Text>
+                                      )}
+                                      <Tooltip
+                                          tooltipMaxWidth={285}
+                                          content={
+                                              isLoading
+                                                  ? undefined
+                                                  : (activationError ?? disabledMessage)
+                                          }
                                       >
-                                          <Translation id="TR_ADD" />
-                                      </Button>
-                                  </Tooltip>
+                                          <Button
+                                              size="small"
+                                              intent="brand"
+                                              isLoading={isLoading}
+                                              isDisabled={!!disabledMessage || isLoading}
+                                              data-testid={`@settings/wallet/network/${network.symbol}/add-button`}
+                                              onClick={() => handleNetworkSelection(network.symbol)}
+                                          >
+                                              <Translation
+                                                  id={
+                                                      isEnabled && !isLoading
+                                                          ? 'TR_ADD'
+                                                          : 'TR_ENABLE'
+                                                  }
+                                              />
+                                          </Button>
+                                      </Tooltip>
+                                  </Row>
                               );
                           }
                         : undefined

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/addAccountModalUtils.test.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/addAccountModalUtils.test.ts
@@ -1,0 +1,95 @@
+import { networks } from '@suite-common/wallet-config';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import {
+    enqueueNetworkActivation,
+    getNewNetworkAccounts,
+    getSortedNetworks,
+    getVisibleAccountCounts,
+} from './addAccountModalUtils';
+
+describe('addAccountModalUtils', () => {
+    describe(getSortedNetworks.name, () => {
+        it('places enabled networks first and disabled networks last.', () => {
+            const result = getSortedNetworks({
+                availableNetworks: [networks.eth, networks.btc, networks.sol, networks.ada],
+                enabledNetworkSymbols: [networks.btc.symbol, networks.ada.symbol],
+            });
+
+            expect(result).toEqual([networks.btc, networks.ada, networks.eth, networks.sol]);
+        });
+    });
+
+    describe(getVisibleAccountCounts.name, () => {
+        it('counts only visible accounts belonging to the selected device state', () => {
+            const accounts = [
+                mockWalletAccount({
+                    symbol: networks.btc.symbol,
+                    deviceState: 'state@device:0',
+                    visible: true,
+                }),
+                mockWalletAccount({
+                    symbol: networks.btc.symbol,
+                    deviceState: 'state@device:0',
+                    visible: false,
+                }),
+                mockWalletAccount({
+                    symbol: networks.eth.symbol,
+                    deviceState: 'state@device:0',
+                    visible: true,
+                }),
+                mockWalletAccount({
+                    symbol: networks.btc.symbol,
+                    deviceState: 'other@device:0',
+                    visible: true,
+                }),
+            ];
+
+            expect(getVisibleAccountCounts(accounts, 'state@device:0')).toEqual({
+                btc: 1,
+                eth: 1,
+            });
+        });
+    });
+
+    describe(enqueueNetworkActivation.name, () => {
+        it('does not enqueue a network more than once', () => {
+            expect(enqueueNetworkActivation([networks.btc.symbol], networks.btc.symbol)).toEqual([
+                networks.btc.symbol,
+            ]);
+        });
+
+        it('appends a different network without reordering the queue', () => {
+            expect(enqueueNetworkActivation([networks.btc.symbol], networks.eth.symbol)).toEqual([
+                networks.btc.symbol,
+                networks.eth.symbol,
+            ]);
+        });
+    });
+
+    describe(getNewNetworkAccounts.name, () => {
+        it('returns only accounts created for the activated network after discovery started', () => {
+            const existingAccount = mockWalletAccount({
+                descriptor: asAccountDescriptor('existingAccount'),
+                symbol: networks.btc.symbol,
+            });
+            const newBitcoinAccount = mockWalletAccount({
+                descriptor: asAccountDescriptor('newBitcoinAccount'),
+                symbol: networks.btc.symbol,
+            });
+            const newEthereumAccount = mockWalletAccount({
+                descriptor: asAccountDescriptor('newEthereumAccount'),
+                symbol: networks.eth.symbol,
+            });
+
+            expect(
+                getNewNetworkAccounts({
+                    accounts: [existingAccount, newBitcoinAccount, newEthereumAccount],
+                    existingAccountKeys: new Set([existingAccount.key]),
+                    networkSymbol: networks.btc.symbol,
+                }),
+            ).toEqual([newBitcoinAccount]);
+        });
+    });
+});

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/addAccountModalUtils.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/addAccountModalUtils.ts
@@ -1,0 +1,49 @@
+import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
+import { arrayPartition } from '@trezor/utils';
+
+export const getSortedNetworks = ({
+    availableNetworks,
+    enabledNetworkSymbols,
+}: {
+    availableNetworks: Network[];
+    enabledNetworkSymbols: NetworkSymbol[];
+}) => {
+    const [enabledNetworks, disabledNetworks] = arrayPartition(availableNetworks, network =>
+        enabledNetworkSymbols.includes(network.symbol),
+    );
+
+    return [...enabledNetworks, ...disabledNetworks];
+};
+
+export const getVisibleAccountCounts = (accounts: Account[], deviceState?: string) =>
+    accounts.reduce<Partial<Record<NetworkSymbol, number>>>((counts, account) => {
+        if (account.deviceState !== deviceState || !account.visible) {
+            return counts;
+        }
+
+        counts[account.symbol] = (counts[account.symbol] ?? 0) + 1;
+
+        return counts;
+    }, {});
+
+export const enqueueNetworkActivation = (
+    queuedNetworkSymbols: NetworkSymbol[],
+    networkSymbol: NetworkSymbol,
+) =>
+    queuedNetworkSymbols.includes(networkSymbol)
+        ? queuedNetworkSymbols
+        : [...queuedNetworkSymbols, networkSymbol];
+
+export const getNewNetworkAccounts = ({
+    accounts,
+    existingAccountKeys,
+    networkSymbol,
+}: {
+    accounts: Account[];
+    existingAccountKeys: Set<AccountKey>;
+    networkSymbol: NetworkSymbol;
+}) =>
+    accounts.filter(
+        account => account.symbol === networkSymbol && !existingAccountKeys.has(account.key),
+    );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/useNetworkActivationQueue.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/useNetworkActivationQueue.ts
@@ -1,0 +1,227 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { preserveModal } from '@suite/modal';
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import {
+    accountsActions,
+    changeCoinVisibility,
+    discoveryActions,
+    runAdditionalDiscoveryThunk,
+    selectAccounts,
+} from '@suite-common/wallet-core';
+import { type AccountKey, type DiscoveryStatus } from '@suite-common/wallet-types';
+
+import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+
+import { enqueueNetworkActivation, getNewNetworkAccounts } from './addAccountModalUtils';
+
+type ActiveNetworkActivation = {
+    networkSymbol: NetworkSymbol;
+    existingAccountKeys: Set<AccountKey>;
+};
+
+/**
+ * @deprecated Temporary PoC code, will be moved, do not create new imports!
+ * TODO https://github.com/trezor/trezor-suite/issues/31779
+ */
+export const useNetworkActivationQueue = (device: TrezorDevice) => {
+    const accounts = useSelector(selectAccounts);
+    const { discovery } = useDiscovery();
+    const dispatch = useDispatch();
+
+    const [queuedNetworkSymbols, setQueuedNetworkSymbols] = useState<NetworkSymbol[]>([]);
+    const [activeActivation, setActiveActivation] = useState<ActiveNetworkActivation>();
+    const [activationErrors, setActivationErrors] = useState<
+        Partial<Record<NetworkSymbol, string>>
+    >({});
+    const isRollingBackRef = useRef(false);
+
+    useEffect(() => {
+        const staticSessionId = device.state?.staticSessionId;
+        const nextNetworkSymbol = queuedNetworkSymbols[0];
+
+        if (activeActivation || !nextNetworkSymbol || !staticSessionId) {
+            return;
+        }
+
+        const existingAccountKeys = new Set(
+            accounts
+                .filter(
+                    account =>
+                        account.deviceState === staticSessionId &&
+                        account.symbol === nextNetworkSymbol,
+                )
+                .map(account => account.key),
+        );
+
+        setQueuedNetworkSymbols(currentQueue => currentQueue.slice(1));
+        setActiveActivation({ networkSymbol: nextNetworkSymbol, existingAccountKeys });
+
+        // Setting discovery to a running state before enabling the network prevents
+        // discoveryMiddleware from starting a duplicate discovery call.
+        dispatch(preserveModal());
+        dispatch(
+            discoveryActions.startDiscovery(device.path, {
+                isAddingHiddenWallet: false,
+                isAddingExistingWallet: false,
+            }),
+        );
+
+        void dispatch(
+            changeCoinVisibility({
+                symbol: nextNetworkSymbol,
+                shouldBeVisible: true,
+            }),
+        )
+            .then(result => {
+                if (changeCoinVisibility.rejected.match(result)) {
+                    dispatch(
+                        discoveryActions.updateDiscovery(
+                            {
+                                status: 'failed',
+                                error: result.error.message ?? 'Network activation failed',
+                            },
+                            device.path,
+                        ),
+                    );
+
+                    return;
+                }
+
+                return dispatch(runAdditionalDiscoveryThunk(staticSessionId));
+            })
+            .then(result => {
+                if (result && runAdditionalDiscoveryThunk.rejected.match(result)) {
+                    dispatch(
+                        discoveryActions.updateDiscovery(
+                            {
+                                status: 'failed',
+                                error: result.error.message ?? 'Account discovery failed',
+                            },
+                            device.path,
+                        ),
+                    );
+                }
+            });
+    }, [
+        accounts,
+        activeActivation,
+        device.path,
+        device.state?.staticSessionId,
+        dispatch,
+        queuedNetworkSymbols,
+    ]);
+
+    useEffect(() => {
+        if (!activeActivation || !discovery || isRollingBackRef.current) {
+            return;
+        }
+
+        const { networkSymbol, existingAccountKeys } = activeActivation;
+        const staticSessionId = device.state?.staticSessionId;
+
+        if (discovery.status === 'complete') {
+            const discoveredAccountCount = accounts.filter(
+                account =>
+                    account.deviceState === staticSessionId &&
+                    account.symbol === networkSymbol &&
+                    account.visible,
+            ).length;
+
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'accounts-discovered',
+                    count: discoveredAccountCount,
+                    networkName: getNetwork(networkSymbol).name,
+                }),
+            );
+            setActiveActivation(undefined);
+
+            return;
+        }
+
+        const shouldRollbackNetworkActivation = (status: DiscoveryStatus['status']) =>
+            status === 'failed' || status === 'cancelled';
+        if (!shouldRollbackNetworkActivation(discovery.status)) {
+            return;
+        }
+
+        const newNetworkAccounts = getNewNetworkAccounts({
+            accounts,
+            existingAccountKeys,
+            networkSymbol,
+        });
+        const failedStatus = discovery;
+        isRollingBackRef.current = true;
+
+        if (newNetworkAccounts.length > 0) {
+            dispatch(accountsActions.removeAccount(newNetworkAccounts));
+        }
+
+        dispatch(
+            discoveryActions.startDiscovery(device.path, {
+                isAddingHiddenWallet: false,
+                isAddingExistingWallet: false,
+            }),
+        );
+
+        void dispatch(
+            changeCoinVisibility({
+                symbol: networkSymbol,
+                shouldBeVisible: false,
+            }),
+        ).then(() => {
+            dispatch(discoveryActions.updateDiscovery(failedStatus, device.path));
+
+            if (failedStatus.status === 'failed') {
+                const error = failedStatus.error ?? 'Unknown error';
+                setActivationErrors(currentErrors => ({
+                    ...currentErrors,
+                    [networkSymbol]: error,
+                }));
+                dispatch(notificationsActions.addToast({ type: 'discovery-error', error }));
+            }
+
+            isRollingBackRef.current = false;
+            setActiveActivation(undefined);
+        });
+    }, [
+        accounts,
+        activeActivation,
+        device.path,
+        device.state?.staticSessionId,
+        discovery,
+        dispatch,
+    ]);
+
+    const activatingNetworkSymbols = useMemo(
+        () => [
+            ...(activeActivation ? [activeActivation.networkSymbol] : []),
+            ...queuedNetworkSymbols,
+        ],
+        [activeActivation, queuedNetworkSymbols],
+    );
+
+    const activateNetwork = (networkSymbol: NetworkSymbol) => {
+        if (activatingNetworkSymbols.includes(networkSymbol)) {
+            return;
+        }
+
+        setActivationErrors(currentErrors => {
+            const { [networkSymbol]: _, ...remainingErrors } = currentErrors;
+
+            return remainingErrors;
+        });
+        setQueuedNetworkSymbols(currentQueue =>
+            enqueueNetworkActivation(currentQueue, networkSymbol),
+        );
+    };
+
+    return {
+        activateNetwork,
+        activatingNetworkSymbols,
+        activationErrors,
+    };
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -75,7 +75,6 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
                 <AddAccountModal
                     device={payload.device}
                     symbol={payload.symbol}
-                    noRedirect={payload.noRedirect}
                     isCoinjoinDisabled={payload.isCoinjoinDisabled}
                     isBackClickDisabled={payload.isBackClickDisabled}
                     onCancel={payload.onCancel ?? onCancel}

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -135,6 +135,23 @@ export const NotificationRenderer = ({
                 values: { error: notification.error },
             });
 
+        case 'account-added':
+            return renderNotificationView(render, notification, {
+                variant: 'transparent',
+                message: 'TOAST_ACCOUNT_ADDED',
+                values: { networkName: notification.networkName },
+            });
+
+        case 'accounts-discovered':
+            return renderNotificationView(render, notification, {
+                variant: 'transparent',
+                message: 'TOAST_ACCOUNTS_DISCOVERED',
+                values: {
+                    count: notification.count,
+                    networkName: notification.networkName,
+                },
+            });
+
         case 'backup-failed':
             return renderNotificationView(render, notification, {
                 variant: 'error',

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
@@ -36,6 +38,7 @@ export const AccountsMenuHeader = () => {
 
     const device = useSelector(selectSelectedDevice);
     const accounts = useSelector(selectAllAccountsToList);
+    const [isHovered, setIsHovered] = useState(false);
 
     const isEmpty = accounts.length === 0;
 
@@ -71,13 +74,22 @@ export const AccountsMenuHeader = () => {
                                             />
                                         }
                                     >
-                                        <RelativeWrapper>
+                                        <RelativeWrapper
+                                            onMouseEnter={() => setIsHovered(true)}
+                                            onMouseLeave={() => setIsHovered(false)}
+                                        >
                                             {coinFilter.length > 0 && <Indicator />}
                                             <Icon
                                                 size={16}
-                                                intent={isCoinsFilterVisible ? 'brand' : 'neutral'}
+                                                intent={
+                                                    isCoinsFilterVisible && !isHovered
+                                                        ? 'brand'
+                                                        : 'neutral'
+                                                }
                                                 priority={
-                                                    isCoinsFilterVisible ? 'primary' : 'secondary'
+                                                    isCoinsFilterVisible || isHovered
+                                                        ? 'primary'
+                                                        : 'secondary'
                                                 }
                                                 as={FunnelSimpleIcon}
                                                 onClick={toggleCoinsFilter}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
+
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { Icon, Row, ShortcutBadge, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
+import { Box, Icon, Row, ShortcutBadge, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
 import { PlusIcon } from '@trezor/icons';
 
 import { useDiscovery, useDispatch } from 'src/hooks/suite';
@@ -20,6 +22,8 @@ type AddAccountButtonProps = {
 
 export const AddAccountButton = ({ device }: AddAccountButtonProps) => {
     const { isDiscoveryRunning } = useDiscovery();
+    const [isHovered, setIsHovered] = useState(false);
+
     const dispatch = useDispatch();
 
     // TODO: add more cases when adding account is not possible
@@ -50,15 +54,17 @@ export const AddAccountButton = ({ device }: AddAccountButtonProps) => {
                 </Row>
             }
         >
-            <Icon
-                onClick={device ? handleOnClick : undefined}
-                as={PlusIcon}
-                size={16}
-                {...(addAccountDisabled
-                    ? { isDisabled: true }
-                    : { intent: 'neutral', priority: 'secondary' })}
-                data-testid={dataTestId}
-            />
+            <Box onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+                <Icon
+                    onClick={device ? handleOnClick : undefined}
+                    as={PlusIcon}
+                    size={16}
+                    isDisabled={addAccountDisabled}
+                    intent="neutral"
+                    priority={isHovered ? 'primary' : 'secondary'}
+                    data-testid={dataTestId}
+                />
+            </Box>
         </Tooltip>
     );
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
@@ -136,7 +136,6 @@ const useTradingVerifyAccount = ({
                 type: 'add-account',
                 device,
                 symbol,
-                noRedirect: true,
                 isCoinjoinDisabled: true,
                 isBackClickDisabled: true,
             }),

--- a/packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx
@@ -33,7 +33,7 @@ export const NetworkSettingsSearchInput = ({
             leftContent={
                 <Icon as={MagnifyingGlassIcon} intent="neutral" priority="secondary" size={16} />
             }
-            rightContent={rightContent}
+            rightContent={searchQuery ? undefined : rightContent}
         />
     );
 };

--- a/packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/NetworkSettingsSearchInput.tsx
@@ -1,3 +1,5 @@
+import { type ReactElement } from 'react';
+
 import { useTranslation } from '@suite/intl';
 import { Icon, Input } from '@trezor/components';
 import { MagnifyingGlassIcon } from '@trezor/icons';
@@ -7,6 +9,7 @@ type NetworkSettingsSearchInputProps = {
     onSearchChange: (value: string) => void;
     onSearchClear: () => void;
     dataTestId?: string;
+    rightContent?: ReactElement;
 };
 
 export const NetworkSettingsSearchInput = ({
@@ -14,6 +17,7 @@ export const NetworkSettingsSearchInput = ({
     onSearchChange,
     onSearchClear,
     dataTestId = '@settings-coins/network-search-input',
+    rightContent,
 }: NetworkSettingsSearchInputProps) => {
     const { translationString } = useTranslation();
 
@@ -29,6 +33,7 @@ export const NetworkSettingsSearchInput = ({
             leftContent={
                 <Icon as={MagnifyingGlassIcon} intent="neutral" priority="secondary" size={16} />
             }
+            rightContent={rightContent}
         />
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountAddSuiteOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountAddSuiteOption.tsx
@@ -38,7 +38,6 @@ export const TradingReceiveAccountAddSuiteOption = () => {
                 type: 'add-account',
                 device,
                 symbol,
-                noRedirect: true,
                 isCoinjoinDisabled: true,
                 isBackClickDisabled: true,
                 onConfirm: () => {

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -36,7 +36,6 @@ export type UserContextPayload =
           type: 'add-account';
           device: TrezorDevice;
           symbol?: Account['symbol'];
-          noRedirect?: boolean;
           isCoinjoinDisabled?: boolean;
           isBackClickDisabled?: boolean;
           onCancel?: () => void;

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -121,6 +121,17 @@ type YieldClaimTransactionNotification = {
     type: 'tx-yield-claim';
 } & BaseTransactionNotificationPayload;
 
+type AccountAddedNotification = {
+    type: 'account-added';
+    networkName: string;
+};
+
+type AccountsDiscoveredNotification = {
+    type: 'accounts-discovered';
+    count: number;
+    networkName: string;
+};
+
 export type ErrorToastPayload = {
     type:
         | 'error'
@@ -250,6 +261,8 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | YieldDepositTransactionNotification
     | YieldWithdrawTransactionNotification
     | YieldClaimTransactionNotification
+    | AccountAddedNotification
+    | AccountsDiscoveredNotification
     | {
           type: 'cannot-open-bluetooth-settings-error';
       }

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -25,6 +25,7 @@ export class CoinsTab {
     readonly coinAdvanceSettingSaveButton: Locator;
     readonly modal: Locator;
     readonly activateCoinsButton: Locator;
+    readonly addAccountNetworkSearchInput: Locator;
 
     constructor(private readonly page: Page) {
         this.coinBackendSelector = this.page.getByTestId('@settings/advance/select-type/input');
@@ -32,6 +33,9 @@ export class CoinsTab {
         this.coinAdvanceSettingSaveButton = this.page.getByTestId('@settings/advance/button/save');
         this.modal = this.page.modal;
         this.activateCoinsButton = this.page.getByTestId('@settings-coins/discovery-button');
+        this.addAccountNetworkSearchInput = this.page
+            .getByTestId('@modal/account/network-search-input')
+            .getByRole('textbox');
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -25,7 +25,6 @@ export class CoinsTab {
     readonly coinAdvanceSettingSaveButton: Locator;
     readonly modal: Locator;
     readonly activateCoinsButton: Locator;
-    readonly addAccountNetworkSearchInput: Locator;
 
     constructor(private readonly page: Page) {
         this.coinBackendSelector = this.page.getByTestId('@settings/advance/select-type/input');
@@ -33,9 +32,6 @@ export class CoinsTab {
         this.coinAdvanceSettingSaveButton = this.page.getByTestId('@settings/advance/button/save');
         this.modal = this.page.modal;
         this.activateCoinsButton = this.page.getByTestId('@settings-coins/discovery-button');
-        this.addAccountNetworkSearchInput = this.page
-            .getByTestId('@modal/account/network-search-input')
-            .getByRole('textbox');
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -68,6 +68,9 @@ export class WalletPage {
     readonly topPanelBalanceWithSymbol: Locator;
     readonly addAccountButton: Locator;
     readonly addAccountConfirmButton: Locator;
+    readonly addAccountNetworkSearchInput: Locator;
+    readonly addAccountNetworkButton = (symbol: NetworkSymbol) =>
+        this.page.getByTestId(`@settings/wallet/network/${symbol}/add-button`);
     readonly filterAccountsButton: Locator;
     readonly addAccountTypeSelectInput: Locator;
     readonly addAccountTypeSelectOption = (type: string) =>
@@ -145,6 +148,9 @@ export class WalletPage {
         this.verifyAddressErrorToast = this.page.getByTestId('@toast/verify-address-error');
         this.addAccountButton = this.page.getByTestId('@account-menu/add-account');
         this.addAccountConfirmButton = this.page.getByTestId('@add-account');
+        this.addAccountNetworkSearchInput = this.page.getByTestId(
+            '@modal/account/network-search-input',
+        );
         this.filterAccountsButton = this.page.getByTestId('@account-menu/filter-accounts');
         this.addAccountTypeSelectInput = this.page.getByTestId('@add-account-type/select/input');
         this.accountNotLoaded = this.page.getByTestId('@accounts/account-not-loaded');
@@ -163,6 +169,18 @@ export class WalletPage {
             .getByTestId('@menu/switch-device')
             .getByTestId('@deviceStatus-disconnected');
         this.discoveryWarning = this.page.getByTestId('@warning/trezorDiscovery');
+    }
+
+    get addAccountModal() {
+        return this.page
+            .locator('[data-testid="@modal"]')
+            .filter({ has: this.addAccountNetworkSearchInput });
+    }
+
+    @step()
+    async closeAddAccountModal() {
+        await this.addAccountModal.getByTestId('@modal/close-button').click();
+        await expect(this.addAccountModal).toBeHidden();
     }
 
     accountButton = ({

--- a/suite/e2e/tests/metadata/legacy/account-metadata.test.ts
+++ b/suite/e2e/tests/metadata/legacy/account-metadata.test.ts
@@ -99,8 +99,17 @@ test.describe('Account metadata', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =>
             const newAccountLabelId = `m/84'/0'/${newAccountIndex}'` as AccountLabelId;
             await walletPage.openAccount();
             await walletPage.addAccountButton.click();
-            await settingsPage.coinsTab.networkAddButton('btc').click();
-            await page.getByTestId('@add-account').click();
+            await expect(walletPage.addAccountNetworkSearchInput).toBeVisible();
+            await walletPage.addAccountNetworkSearchInput.fill('btc');
+            await expect(walletPage.addAccountNetworkButton('eth')).toBeHidden();
+            await walletPage.addAccountNetworkButton('btc').click();
+            await walletPage.addAccountConfirmButton.click();
+            await walletPage.closeAddAccountModal();
+            await walletPage.openAccount({
+                symbol: 'btc',
+                type: 'normal',
+                atIndex: newAccountIndex,
+            });
             await metadataPage.account.changeLabel({
                 accountId: newAccountLabelId,
                 label: 'adding label to a newly added account. does it work?',

--- a/suite/e2e/tests/wallet/add-account-types.test.ts
+++ b/suite/e2e/tests/wallet/add-account-types.test.ts
@@ -27,7 +27,7 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1'] }, () => {
                 priority: TestPriority.Critical,
             }),
         },
-        async ({ page, dashboardPage, settingsPage, walletPage }) => {
+        async ({ dashboardPage, settingsPage, walletPage }) => {
             const accountTypes: { coin: NetworkSymbol; accounts: { type: string }[] }[] = [
                 {
                     coin: 'btc',
@@ -57,11 +57,14 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1'] }, () => {
 
                         await walletPage.addAccountButton.click();
                         await expect(settingsPage.modal).toBeVisible();
+                        await settingsPage.coinsTab.addAccountNetworkSearchInput.fill(coin);
+                        await expect(settingsPage.coinsTab.networkAddButton('eth')).toBeHidden();
                         await settingsPage.coinsTab.networkAddButton(coin).click();
                         await walletPage.addAccountTypeSelectInput.click();
-                        await page.waitForTimeout(500);
                         await walletPage.addAccountTypeSelectOption(type).click();
                         await walletPage.addAccountConfirmButton.click();
+                        await expect(settingsPage.modal).toBeVisible();
+                        await settingsPage.modalCloseButton.click();
 
                         const numberOfAccountsAfter = await walletPage.getAccountsInTypeCount(type);
 
@@ -103,7 +106,11 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1'] }, () => {
 
                 await walletPage.addAccountButton.click();
                 await expect(settingsPage.modal).toBeVisible();
+                await settingsPage.coinsTab.addAccountNetworkSearchInput.fill(coin.symbol);
+                await expect(settingsPage.coinsTab.networkAddButton('btc')).toBeHidden();
                 await settingsPage.coinsTab.networkAddButton(coin.symbol).click();
+                await expect(settingsPage.modal).toBeVisible();
+                await settingsPage.modalCloseButton.click();
 
                 const numberOfAccountsAfter = await walletPage.getAccountsForCoinInTypeCount(
                     'normal',

--- a/suite/e2e/tests/wallet/add-account-types.test.ts
+++ b/suite/e2e/tests/wallet/add-account-types.test.ts
@@ -56,15 +56,14 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1'] }, () => {
                             await walletPage.getAccountsInTypeCount(type);
 
                         await walletPage.addAccountButton.click();
-                        await expect(settingsPage.modal).toBeVisible();
-                        await settingsPage.coinsTab.addAccountNetworkSearchInput.fill(coin);
-                        await expect(settingsPage.coinsTab.networkAddButton('eth')).toBeHidden();
-                        await settingsPage.coinsTab.networkAddButton(coin).click();
+                        await expect(walletPage.addAccountNetworkSearchInput).toBeVisible();
+                        await walletPage.addAccountNetworkSearchInput.fill(coin);
+                        await expect(walletPage.addAccountNetworkButton('eth')).toBeHidden();
+                        await walletPage.addAccountNetworkButton(coin).click();
                         await walletPage.addAccountTypeSelectInput.click();
                         await walletPage.addAccountTypeSelectOption(type).click();
                         await walletPage.addAccountConfirmButton.click();
-                        await expect(settingsPage.modal).toBeVisible();
-                        await settingsPage.modalCloseButton.click();
+                        await walletPage.closeAddAccountModal();
 
                         const numberOfAccountsAfter = await walletPage.getAccountsInTypeCount(type);
 
@@ -105,12 +104,11 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1'] }, () => {
                 );
 
                 await walletPage.addAccountButton.click();
-                await expect(settingsPage.modal).toBeVisible();
-                await settingsPage.coinsTab.addAccountNetworkSearchInput.fill(coin.symbol);
-                await expect(settingsPage.coinsTab.networkAddButton('btc')).toBeHidden();
-                await settingsPage.coinsTab.networkAddButton(coin.symbol).click();
-                await expect(settingsPage.modal).toBeVisible();
-                await settingsPage.modalCloseButton.click();
+                await expect(walletPage.addAccountNetworkSearchInput).toBeVisible();
+                await walletPage.addAccountNetworkSearchInput.fill(coin.symbol);
+                await expect(walletPage.addAccountNetworkButton('btc')).toBeHidden();
+                await walletPage.addAccountNetworkButton(coin.symbol).click();
+                await walletPage.closeAddAccountModal();
 
                 const numberOfAccountsAfter = await walletPage.getAccountsForCoinInTypeCount(
                     'normal',

--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -22,8 +22,11 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
 
         await test.step('Add ETH account', async () => {
             await tradingPage.assetPicker.globalAddAccountButton.click();
+            await expect(walletPage.addAccountNetworkSearchInput).toBeVisible();
+            await walletPage.addAccountNetworkSearchInput.fill('eth');
             await tradingPage.receiveAccount.addAccountModalNetworkButton('eth').click();
             await page.discoveryShouldFinish();
+            await walletPage.closeAddAccountModal();
         });
 
         await test.step('Filter and select account', async () => {

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -25,6 +25,7 @@ export type FlagsState = {
     showOnboardingFeedbackBanner: boolean;
     showSettingsDesktopAppPromoBanner: boolean;
     activateAssetsBannerClosed: boolean;
+    addAccountNetworksBannerClosed: boolean;
     stakeEthBannerClosed: boolean;
     earnEthBannerClosed: boolean;
     stakeSolBannerClosed: boolean;
@@ -68,6 +69,7 @@ export const flagsInitialState: FlagsState = {
     showOnboardingFeedbackBanner: false,
     showSettingsDesktopAppPromoBanner: true,
     activateAssetsBannerClosed: false,
+    addAccountNetworksBannerClosed: false,
     stakeEthBannerClosed: false,
     earnEthBannerClosed: false,
     stakeSolBannerClosed: false,
@@ -149,6 +151,8 @@ export const selectIsSettingsDesktopAppPromoBannerShown = (state: FlagsRootState
     state.flags.showSettingsDesktopAppPromoBanner;
 export const selectIsActivateAssetsBannerClosed = (state: FlagsRootState) =>
     state.flags.activateAssetsBannerClosed;
+export const selectIsAddAccountNetworksBannerClosed = (state: FlagsRootState) =>
+    state.flags.addAccountNetworksBannerClosed;
 export const selectIsUnhideTokenModalShown = (state: FlagsRootState) =>
     state.flags.showUnhideTokenModal;
 export const selectIsCopyAddressModalShown = (state: FlagsRootState) =>

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -184,9 +184,30 @@ export const messages = defineMessages({
         id: 'TR_ADD',
         defaultMessage: 'Add',
     },
+    TR_ENABLE: {
+        id: 'TR_ENABLE',
+        defaultMessage: 'Enable',
+    },
     TR_ADD_ACCOUNT: {
         defaultMessage: 'Add account',
         id: 'TR_ADD_ACCOUNT',
+    },
+    TR_ACCOUNT_COUNT: {
+        defaultMessage: '{count, plural, one {# account} other {# accounts}}',
+        id: 'TR_ACCOUNT_COUNT',
+    },
+    TR_ADD_ACCOUNT_NETWORKS_BANNER_TITLE: {
+        defaultMessage: 'Networks power your accounts',
+        id: 'TR_ADD_ACCOUNT_NETWORKS_BANNER_TITLE',
+    },
+    TR_ADD_ACCOUNT_NETWORKS_BANNER_DESCRIPTION: {
+        defaultMessage:
+            "You'll only see accounts on networks you've already enabled. Enable more and your accounts will load automatically.",
+        id: 'TR_ADD_ACCOUNT_NETWORKS_BANNER_DESCRIPTION',
+    },
+    TR_OK_GOT_IT: {
+        defaultMessage: 'Ok, got it',
+        id: 'TR_OK_GOT_IT',
     },
     TR_SHOW_COINS_FILTER: {
         defaultMessage: 'Show filter',
@@ -203,6 +224,10 @@ export const messages = defineMessages({
     TR_SELECT_TYPE: {
         defaultMessage: 'Select type',
         id: 'TR_SELECT_TYPE',
+    },
+    TR_SELECT_ADDRESS_TYPE: {
+        defaultMessage: 'Select address type',
+        id: 'TR_SELECT_ADDRESS_TYPE',
     },
     TR_ADD_HIDDEN_WALLET: {
         defaultMessage: 'Passphrase wallet',
@@ -4174,6 +4199,15 @@ export const messages = defineMessages({
         id: 'TOAST_DISCOVERY_ERROR',
         defaultMessage: 'Account discovery error: {error}',
     },
+    TOAST_ACCOUNT_ADDED: {
+        id: 'TOAST_ACCOUNT_ADDED',
+        defaultMessage: 'New {networkName} account added',
+    },
+    TOAST_ACCOUNTS_DISCOVERED: {
+        id: 'TOAST_ACCOUNTS_DISCOVERED',
+        defaultMessage:
+            "We've found {count, plural, one {# account} other {# accounts}} on {networkName}",
+    },
     TOAST_BACKUP_FAILED: {
         id: 'TOAST_BACKUP_FAILED',
         defaultMessage: 'Wallet backup failed',
@@ -4701,14 +4735,6 @@ export const messages = defineMessages({
         id: 'TR_DRY_RUN_CHECK_ITEM_DESCRIPTION',
         defaultMessage:
             "This wallet backup check is precisely the same as the normal recovery process. You should only trust the information and instructions displayed on your Trezor's screen.",
-    },
-    TR_ACTIVATED_COINS: {
-        id: 'TR_ACTIVATED_COINS',
-        defaultMessage: 'Add account to active network',
-    },
-    TR_INACTIVE_COINS: {
-        id: 'TR_INACTIVE_COINS',
-        defaultMessage: 'Activate network and add account',
     },
     TR_ACTIVATION_IN_PROGRESS_BANNER: {
         id: 'TR_ACTIVATION_IN_PROGRESS_BANNER',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -221,10 +221,6 @@ export const messages = defineMessages({
         defaultMessage: 'Add {network} account',
         id: 'TR_ADD_NETWORK_ACCOUNT',
     },
-    TR_SELECT_TYPE: {
-        defaultMessage: 'Select type',
-        id: 'TR_SELECT_TYPE',
-    },
     TR_SELECT_ADDRESS_TYPE: {
         defaultMessage: 'Select address type',
         id: 'TR_SELECT_ADDRESS_TYPE',


### PR DESCRIPTION
## Notes for QA
- replace segmented Add Account sections with one searchable, stable network list showing account counts
- enable networks inline through queued discovery with rollback, retry feedback, and neutral success/error notifications
- preserve pinned and trading flows while adding an animated, per-installation dismissible guidance banner



Closes #31282

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/unified-add-account-modal/web/](https://dev.suite.sldev.cz/suite-web/feat/unified-add-account-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/unified-add-account-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/unified-add-account-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/unified-add-account-modal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T12:53:30.260Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T12:54:08.163Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->