### PR TITLE
perf(blockchain-link): improve support for direct RPC

### DIFF
--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getInfo.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getInfo.ts
@@ -2,15 +2,13 @@ import { RESPONSES } from '@trezor/blockchain-link-types';
 import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import type { Request } from '../types';
+import { getChainId } from '../utils/client';
 
 export const getInfo = async (
     request: Request<MessageTypes.GetInfo>,
 ): Promise<Responses.GetInfo> => {
     const client = await request.connect();
-    const [blockNumber, chainId] = await Promise.all([
-        client.getBlockNumber(),
-        client.getChainId(),
-    ]);
+    const [blockNumber, chainId] = await Promise.all([client.getBlockNumber(), getChainId(client)]);
 
     const block = await client.getBlock({ blockNumber, includeTransactions: false });
 

--- a/packages/blockchain-link/src/workers/evm-rpc/index.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/index.ts
@@ -15,6 +15,7 @@ import { rpcCall } from './handlers/rpcCall';
 import { cleanupSubscriptions, subscribe, unsubscribe } from './handlers/subscribe';
 import { validateRpcUrl } from './handlers/validateRpcUrl';
 import type { Request } from './types';
+import { getChainId } from './utils/client';
 import { getTransportType } from './utils/transportType';
 
 const onRequest = (request: Request<MessageTypes.Message>) => {
@@ -68,7 +69,8 @@ export class EvmRpcWorker extends BaseWorker<PublicClient> {
             transport: transportType(url),
         });
 
-        await client.getChainId();
+        // Doubles as the connectivity probe, and primes the cache the handlers read from.
+        await getChainId(client);
 
         this.post({ id: -1, type: RESPONSES.CONNECTED });
 

--- a/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.test.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.test.ts
@@ -1,0 +1,165 @@
+import { type PublicClient, encodeAbiParameters, parseAbiParameters } from 'viem';
+
+import { getStakingPoolData } from './poolData';
+
+const ADDRESS = '0x1234567890123456789012345678901234567890' as const;
+const EVERSTAKE_ACCOUNTING = '0x7a7f0b3c23C23a31cFcb0c44709be70d4D545c6e';
+const MULTICALL3 = '0xcA11bde05977b3631167028862bE2a173976CA11';
+
+const encodeUint = (value: bigint) => encodeAbiParameters(parseAbiParameters('uint256'), [value]);
+const encodeUintPair = (a: bigint, b: bigint) =>
+    encodeAbiParameters(parseAbiParameters('uint256, uint256'), [a, b]);
+
+const AGGREGATE3_RESULT = parseAbiParameters('(bool success, bytes returnData)[]');
+
+const encodeAggregate3 = (entries: { success: boolean; returnData: `0x${string}` }[]) =>
+    encodeAbiParameters(AGGREGATE3_RESULT, [entries]);
+
+const succeeded = (returnData: `0x${string}`[]) =>
+    returnData.map(data => ({ success: true, returnData: data }));
+
+type Balances = {
+    pending?: bigint;
+    pendingDeposited?: bigint;
+    deposited?: bigint;
+    withdrawTotal?: bigint;
+    claimable?: bigint;
+    restaked?: bigint;
+    autocompound?: bigint;
+};
+
+// Order matches ACCOUNTING_FUNCTIONS in poolData.ts.
+const balances = ({
+    pending = 1n,
+    pendingDeposited = 2n,
+    deposited = 3n,
+    withdrawTotal = 4n,
+    claimable = 5n,
+    restaked = 6n,
+    autocompound = 7n,
+}: Balances = {}): `0x${string}`[] => [
+    encodeUint(pending),
+    encodeUint(pendingDeposited),
+    encodeUint(deposited),
+    encodeUintPair(withdrawTotal, claimable),
+    encodeUint(restaked),
+    encodeUint(autocompound),
+];
+
+const ZERO: Balances = {
+    pending: 0n,
+    pendingDeposited: 0n,
+    deposited: 0n,
+    withdrawTotal: 0n,
+    claimable: 0n,
+    restaked: 0n,
+    autocompound: 0n,
+};
+
+const createClient = ({
+    chainId = 1,
+    multicall3Deployed = true,
+    returnData = balances(),
+}: {
+    chainId?: number;
+    multicall3Deployed?: boolean;
+    returnData?: `0x${string}`[];
+} = {}) => {
+    let individualIndex = 0;
+
+    const call = jest.fn();
+    call.mockImplementation(({ to }: { to: string }) => {
+        if (to === MULTICALL3) {
+            return Promise.resolve({ data: encodeAggregate3(succeeded(returnData)) });
+        }
+
+        const data = returnData[individualIndex];
+        individualIndex += 1;
+
+        return Promise.resolve({ data });
+    });
+
+    const client = {
+        getChainId: jest.fn().mockResolvedValue(chainId),
+        getCode: jest.fn().mockResolvedValue(multicall3Deployed ? '0x6080604052' : '0x'),
+        call,
+    };
+
+    return { client, asPublicClient: client as unknown as PublicClient };
+};
+
+describe('getStakingPoolData', () => {
+    it('reads every accounting balance in a single Multicall3 request', async () => {
+        const { client, asPublicClient } = createClient();
+
+        const pools = await getStakingPoolData(asPublicClient, ADDRESS);
+
+        expect(client.call).toHaveBeenCalledTimes(1);
+        expect(client.call.mock.calls[0]?.[0].to).toBe(MULTICALL3);
+
+        expect(pools).toEqual([
+            {
+                contract: EVERSTAKE_ACCOUNTING,
+                name: 'Everstake',
+                pendingBalance: '1',
+                pendingDepositedBalance: '2',
+                depositedBalance: '3',
+                withdrawTotalAmount: '4',
+                claimableAmount: '5',
+                restakedReward: '6',
+                autocompoundBalance: '7',
+            },
+        ]);
+    });
+
+    it('falls back to one request per balance without Multicall3', async () => {
+        const { client, asPublicClient } = createClient({ multicall3Deployed: false });
+
+        const pools = await getStakingPoolData(asPublicClient, ADDRESS);
+
+        expect(client.call).toHaveBeenCalledTimes(6);
+        expect(
+            client.call.mock.calls.every(
+                ([{ to }]: [{ to: string }]) => to === EVERSTAKE_ACCOUNTING,
+            ),
+        ).toBe(true);
+        expect(pools?.[0]?.depositedBalance).toBe('3');
+    });
+
+    it('resolves the chain id once per client', async () => {
+        const { client, asPublicClient } = createClient();
+
+        await getStakingPoolData(asPublicClient, ADDRESS);
+        await getStakingPoolData(asPublicClient, ADDRESS);
+
+        expect(client.getChainId).toHaveBeenCalledTimes(1);
+        expect(client.call).toHaveBeenCalledTimes(2);
+    });
+
+    it('makes no contract request on a chain without a known pool', async () => {
+        const { client, asPublicClient } = createClient({ chainId: 137 });
+
+        await expect(getStakingPoolData(asPublicClient, ADDRESS)).resolves.toBeUndefined();
+
+        expect(client.call).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when every balance is zero', async () => {
+        const { asPublicClient } = createClient({ returnData: balances(ZERO) });
+
+        await expect(getStakingPoolData(asPublicClient, ADDRESS)).resolves.toBeUndefined();
+    });
+
+    it('returns undefined when a batched balance reverts', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValue({
+            data: encodeAggregate3([
+                { success: false, returnData: '0x' },
+                ...succeeded(balances().slice(1)),
+            ]),
+        });
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await expect(getStakingPoolData(asPublicClient, ADDRESS)).resolves.toBeUndefined();
+    });
+});

--- a/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
@@ -4,7 +4,8 @@ import type { StakingPool } from '@trezor/blockchain-link-types';
 
 import { EVERSTAKE_ACCOUNTING_ABI } from './abi';
 import { STAKING_POOL_CONTRACTS } from './constants';
-import { type BatchCall, batchRead, getChainId } from '../utils/multicall';
+import { getChainId } from '../utils/client';
+import { type BatchCall, batchRead } from '../utils/multicall';
 
 type EverstakeAccountingFunctionName = Extract<
     (typeof EVERSTAKE_ACCOUNTING_ABI)[number],

--- a/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
@@ -4,13 +4,65 @@ import type { StakingPool } from '@trezor/blockchain-link-types';
 
 import { EVERSTAKE_ACCOUNTING_ABI } from './abi';
 import { STAKING_POOL_CONTRACTS } from './constants';
+import { type BatchCall, batchRead, getChainId } from '../utils/multicall';
+
+const ACCOUNTING_FUNCTIONS = [
+    'pendingBalanceOf',
+    'pendingDepositedBalanceOf',
+    'depositedBalanceOf',
+    'withdrawRequest',
+    'restakedRewardOf',
+    'autocompoundBalanceOf',
+] as const;
+
+const readAccountingBalances = async (
+    client: PublicClient,
+    contract: `0x${string}`,
+    address: `0x${string}`,
+) => {
+    const calls: BatchCall[] = ACCOUNTING_FUNCTIONS.map(functionName => ({
+        address: contract,
+        abi: EVERSTAKE_ACCOUNTING_ABI,
+        functionName,
+        args: [address],
+    }));
+
+    const results = await batchRead(client, calls);
+
+    const unread = ACCOUNTING_FUNCTIONS.filter((_, index) => results[index] === undefined);
+    if (unread.length > 0) {
+        throw new Error(`Could not read staking accounting: ${unread.join(', ')}`);
+    }
+
+    // Order follows ACCOUNTING_FUNCTIONS; withdrawRequest is the only tuple return.
+    const [
+        pendingBalance,
+        pendingDepositedBalance,
+        depositedBalance,
+        withdrawRequestResult,
+        restakedReward,
+        autocompoundBalance,
+    ] = results as [bigint, bigint, bigint, readonly [bigint, bigint], bigint, bigint];
+
+    const [withdrawTotalAmount, claimableAmount] = withdrawRequestResult;
+
+    return {
+        pendingBalance,
+        pendingDepositedBalance,
+        depositedBalance,
+        withdrawTotalAmount,
+        claimableAmount,
+        restakedReward,
+        autocompoundBalance,
+    };
+};
 
 export const getStakingPoolData = async (
     client: PublicClient,
     address: `0x${string}`,
 ): Promise<StakingPool[] | undefined> => {
     try {
-        const chainId = await client.getChainId();
+        const chainId = await getChainId(client);
         const poolConfig = STAKING_POOL_CONTRACTS[chainId];
 
         if (!poolConfig) {
@@ -18,64 +70,9 @@ export const getStakingPoolData = async (
         }
 
         const { contract, name } = poolConfig;
-        const [
-            pendingBalance,
-            pendingDepositedBalance,
-            depositedBalance,
-            withdrawRequestResult,
-            restakedReward,
-            autocompoundBalance,
-        ] = await Promise.all([
-            client.readContract({
-                address: contract,
-                abi: EVERSTAKE_ACCOUNTING_ABI,
-                functionName: 'pendingBalanceOf',
-                args: [address],
-            }),
-            client.readContract({
-                address: contract,
-                abi: EVERSTAKE_ACCOUNTING_ABI,
-                functionName: 'pendingDepositedBalanceOf',
-                args: [address],
-            }),
-            client.readContract({
-                address: contract,
-                abi: EVERSTAKE_ACCOUNTING_ABI,
-                functionName: 'depositedBalanceOf',
-                args: [address],
-            }),
-            client.readContract({
-                address: contract,
-                abi: EVERSTAKE_ACCOUNTING_ABI,
-                functionName: 'withdrawRequest',
-                args: [address],
-            }),
-            client.readContract({
-                address: contract,
-                abi: EVERSTAKE_ACCOUNTING_ABI,
-                functionName: 'restakedRewardOf',
-                args: [address],
-            }),
-            client.readContract({
-                address: contract,
-                abi: EVERSTAKE_ACCOUNTING_ABI,
-                functionName: 'autocompoundBalanceOf',
-                args: [address],
-            }),
-        ]);
+        const balances = await readAccountingBalances(client, contract, address);
 
-        const [withdrawTotalAmount, claimableAmount] = withdrawRequestResult;
-
-        const allZero =
-            pendingBalance === 0n &&
-            pendingDepositedBalance === 0n &&
-            depositedBalance === 0n &&
-            withdrawTotalAmount === 0n &&
-            claimableAmount === 0n &&
-            restakedReward === 0n &&
-            autocompoundBalance === 0n;
-
-        if (allZero) {
+        if (Object.values(balances).every(value => value === 0n)) {
             return undefined;
         }
 
@@ -83,13 +80,13 @@ export const getStakingPoolData = async (
             {
                 contract,
                 name,
-                pendingBalance: pendingBalance.toString(),
-                pendingDepositedBalance: pendingDepositedBalance.toString(),
-                depositedBalance: depositedBalance.toString(),
-                withdrawTotalAmount: withdrawTotalAmount.toString(),
-                claimableAmount: claimableAmount.toString(),
-                restakedReward: restakedReward.toString(),
-                autocompoundBalance: autocompoundBalance.toString(),
+                pendingBalance: balances.pendingBalance.toString(),
+                pendingDepositedBalance: balances.pendingDepositedBalance.toString(),
+                depositedBalance: balances.depositedBalance.toString(),
+                withdrawTotalAmount: balances.withdrawTotalAmount.toString(),
+                claimableAmount: balances.claimableAmount.toString(),
+                restakedReward: balances.restakedReward.toString(),
+                autocompoundBalance: balances.autocompoundBalance.toString(),
             },
         ];
     } catch (error) {

--- a/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
@@ -6,6 +6,11 @@ import { EVERSTAKE_ACCOUNTING_ABI } from './abi';
 import { STAKING_POOL_CONTRACTS } from './constants';
 import { type BatchCall, batchRead, getChainId } from '../utils/multicall';
 
+type EverstakeAccountingFunctionName = Extract<
+    (typeof EVERSTAKE_ACCOUNTING_ABI)[number],
+    { type: 'function' }
+>['name'];
+
 const ACCOUNTING_FUNCTIONS = [
     'pendingBalanceOf',
     'pendingDepositedBalanceOf',
@@ -13,7 +18,7 @@ const ACCOUNTING_FUNCTIONS = [
     'withdrawRequest',
     'restakedRewardOf',
     'autocompoundBalanceOf',
-] as const;
+] as const satisfies readonly EverstakeAccountingFunctionName[];
 
 const readAccountingBalances = async (
     client: PublicClient,

--- a/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
@@ -5,6 +5,7 @@ import type { StakingPool } from '@trezor/blockchain-link-types';
 import { EVERSTAKE_ACCOUNTING_ABI } from './abi';
 import { STAKING_POOL_CONTRACTS } from './constants';
 import { getChainId } from '../utils/client';
+import { getErrorName } from '../utils/errors';
 import { type BatchCall, batchRead } from '../utils/multicall';
 
 type EverstakeAccountingFunctionName = Extract<
@@ -96,7 +97,7 @@ export const getStakingPoolData = async (
             },
         ];
     } catch (error) {
-        console.warn('[evm-rpc] Failed to fetch staking pool data:', error);
+        console.warn('[evm-rpc] Failed to fetch staking pool data:', getErrorName(error));
 
         return undefined;
     }

--- a/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenInfo.test.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenInfo.test.ts
@@ -1,0 +1,223 @@
+import {
+    type PublicClient,
+    decodeAbiParameters,
+    encodeAbiParameters,
+    parseAbiParameters,
+} from 'viem';
+
+import { getTokenInfo } from './tokenInfo';
+
+const USER = '0x1234567890123456789012345678901234567890' as const;
+const TOKEN = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as const;
+const MULTICALL3 = '0xcA11bde05977b3631167028862bE2a173976CA11';
+
+const encodeUint = (value: bigint) => encodeAbiParameters(parseAbiParameters('uint256'), [value]);
+const encodeString = (value: string) => encodeAbiParameters(parseAbiParameters('string'), [value]);
+const encodeUint8 = (value: number) => encodeAbiParameters(parseAbiParameters('uint8'), [value]);
+const encodeBool = (value: boolean) => encodeAbiParameters(parseAbiParameters('bool'), [value]);
+
+type Entry = { success: boolean; returnData: `0x${string}` };
+
+const encodeAggregate3 = (entries: Entry[]) =>
+    encodeAbiParameters(parseAbiParameters('(bool success, bytes returnData)[]'), [entries]);
+
+const ok = (returnData: `0x${string}`): Entry => ({ success: true, returnData });
+const reverted: Entry = { success: false, returnData: '0x' };
+
+const innerCallCount = (data: `0x${string}`) => {
+    const [calls] = decodeAbiParameters(
+        parseAbiParameters('(address target, bool allowFailure, bytes callData)[]'),
+        `0x${data.slice(10)}` as `0x${string}`,
+    );
+
+    return (calls as readonly unknown[]).length;
+};
+
+// balanceOf, name, symbol, decimals, supportsInterface(ERC721), supportsInterface(ERC1155)
+const fullResponse = ({
+    balance = 500n,
+    isErc721 = false,
+    isErc1155 = false,
+}: { balance?: bigint; isErc721?: boolean; isErc1155?: boolean } = {}) =>
+    encodeAggregate3([
+        ok(encodeUint(balance)),
+        ok(encodeString('USD Coin')),
+        ok(encodeString('USDC')),
+        ok(encodeUint8(6)),
+        ok(encodeBool(isErc721)),
+        ok(encodeBool(isErc1155)),
+    ]);
+
+const createClient = () => {
+    const client = {
+        getCode: jest.fn().mockResolvedValue('0x6080604052'),
+        call: jest.fn().mockResolvedValue({ data: fullResponse() }),
+    };
+
+    return { client, asPublicClient: client as unknown as PublicClient };
+};
+
+describe('getTokenInfo', () => {
+    it('reads balance and metadata in a single Multicall3 request', async () => {
+        const { client, asPublicClient } = createClient();
+
+        const token = await getTokenInfo(asPublicClient, USER, TOKEN, true);
+
+        expect(client.call).toHaveBeenCalledTimes(1);
+
+        const [{ to, data }] = client.call.mock.calls[0];
+        expect(to).toBe(MULTICALL3);
+        expect(innerCallCount(data)).toBe(6);
+
+        expect(token).toEqual({
+            standard: 'ERC20',
+            contract: TOKEN.toLowerCase(),
+            balance: '500',
+            name: 'USD Coin',
+            symbol: 'USDC',
+            decimals: 6,
+        });
+    });
+
+    it('refetches only the balance once metadata is cached', async () => {
+        const { client, asPublicClient } = createClient();
+
+        await getTokenInfo(asPublicClient, USER, TOKEN, true);
+
+        client.call.mockResolvedValue({ data: encodeAggregate3([ok(encodeUint(900n))]) });
+
+        const token = await getTokenInfo(asPublicClient, USER, TOKEN, true);
+
+        expect(client.call).toHaveBeenCalledTimes(2);
+        expect(innerCallCount(client.call.mock.calls[1][0].data)).toBe(1);
+
+        // Balance is fresh, metadata comes from the cache.
+        expect(token).toEqual({
+            standard: 'ERC20',
+            contract: TOKEN.toLowerCase(),
+            balance: '900',
+            name: 'USD Coin',
+            symbol: 'USDC',
+            decimals: 6,
+        });
+    });
+
+    it('caches metadata per client, not globally', async () => {
+        const first = createClient();
+        const second = createClient();
+
+        await getTokenInfo(first.asPublicClient, USER, TOKEN, true);
+        await getTokenInfo(second.asPublicClient, USER, TOKEN, true);
+
+        expect(innerCallCount(second.client.call.mock.calls[0][0].data)).toBe(6);
+    });
+
+    it('detects ERC721 and ERC1155 from the batched interface queries', async () => {
+        const erc721 = createClient();
+        erc721.client.call.mockResolvedValue({ data: fullResponse({ isErc721: true }) });
+        const erc1155 = createClient();
+        erc1155.client.call.mockResolvedValue({ data: fullResponse({ isErc1155: true }) });
+
+        await expect(getTokenInfo(erc721.asPublicClient, USER, TOKEN, true)).resolves.toMatchObject(
+            { standard: 'ERC721' },
+        );
+        await expect(
+            getTokenInfo(erc1155.asPublicClient, USER, TOKEN, true),
+        ).resolves.toMatchObject({ standard: 'ERC1155' });
+    });
+
+    it('falls back to unknown metadata when those calls revert', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValue({
+            data: encodeAggregate3([
+                ok(encodeUint(1n)),
+                reverted,
+                reverted,
+                reverted,
+                reverted,
+                reverted,
+            ]),
+        });
+
+        await expect(getTokenInfo(asPublicClient, USER, TOKEN, true)).resolves.toEqual({
+            standard: 'ERC20',
+            contract: TOKEN.toLowerCase(),
+            balance: '1',
+            name: 'unknown',
+            symbol: 'unknown',
+            decimals: 0,
+        });
+    });
+
+    it('does not cache placeholder metadata when the whole batch fails to read', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValueOnce({
+            data: encodeAggregate3([reverted, reverted, reverted, reverted, reverted, reverted]),
+        });
+
+        await expect(getTokenInfo(asPublicClient, USER, TOKEN, true)).resolves.toMatchObject({
+            name: 'unknown',
+            decimals: 0,
+        });
+
+        // The next poll re-reads metadata instead of serving the placeholders forever.
+        const token = await getTokenInfo(asPublicClient, USER, TOKEN, true);
+
+        expect(innerCallCount(client.call.mock.calls[1][0].data)).toBe(6);
+        expect(token).toMatchObject({ name: 'USD Coin', symbol: 'USDC', decimals: 6 });
+    });
+
+    it('does not cache metadata when only decimals failed to read', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValueOnce({
+            data: encodeAggregate3([
+                ok(encodeUint(5n)),
+                ok(encodeString('USD Coin')),
+                ok(encodeString('USDC')),
+                reverted,
+                ok(encodeBool(false)),
+                ok(encodeBool(false)),
+            ]),
+        });
+
+        // Caching 0 here would render every amount 10^6 too large for the rest of the connection.
+        await expect(getTokenInfo(asPublicClient, USER, TOKEN, true)).resolves.toMatchObject({
+            decimals: 0,
+        });
+
+        const token = await getTokenInfo(asPublicClient, USER, TOKEN, true);
+
+        expect(innerCallCount(client.call.mock.calls[1][0].data)).toBe(6);
+        expect(token).toMatchObject({ decimals: 6 });
+    });
+
+    it('caches NFT metadata even though decimals cannot be read', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValue({
+            data: encodeAggregate3([
+                ok(encodeUint(1n)),
+                ok(encodeString('CryptoPunks')),
+                ok(encodeString('PUNK')),
+                reverted,
+                ok(encodeBool(true)),
+                ok(encodeBool(false)),
+            ]),
+        });
+
+        await getTokenInfo(asPublicClient, USER, TOKEN, true);
+        const token = await getTokenInfo(asPublicClient, USER, TOKEN, true);
+
+        expect(innerCallCount(client.call.mock.calls[1][0].data)).toBe(1);
+        expect(token).toMatchObject({ standard: 'ERC721', decimals: 0 });
+    });
+
+    it('returns null for a zero balance unless the check is skipped', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValue({ data: fullResponse({ balance: 0n }) });
+
+        await expect(getTokenInfo(asPublicClient, USER, TOKEN)).resolves.toBeNull();
+        await expect(getTokenInfo(asPublicClient, USER, TOKEN, true)).resolves.toMatchObject({
+            balance: '0',
+        });
+    });
+});

--- a/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenInfo.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenInfo.ts
@@ -3,101 +3,59 @@ import { type PublicClient, erc20Abi } from 'viem';
 import type { TokenInfo, TokenStandard } from '@trezor/blockchain-link-types';
 
 import { ERC1155_INTERFACE_ID, ERC165_ABI, ERC721_INTERFACE_ID } from './constants';
+import { type BatchCall, batchRead } from '../utils/multicall';
 
-const getTokenMetadata = async (
-    client: PublicClient,
-    address: `0x${string}`,
-): Promise<{ name: string; symbol: string; decimals: number }> => {
-    try {
-        const [name, symbol, decimals] = await Promise.all([
-            client
-                .readContract({ address, abi: erc20Abi, functionName: 'name' })
-                .catch(() => 'unknown' as const),
-            client
-                .readContract({ address, abi: erc20Abi, functionName: 'symbol' })
-                .catch(() => 'unknown' as const),
-            client
-                .readContract({ address, abi: erc20Abi, functionName: 'decimals' })
-                .catch(() => 0),
-        ]);
-
-        return { name, symbol, decimals };
-    } catch {
-        return { name: 'unknown', symbol: 'unknown', decimals: 0 };
-    }
+type TokenMetadata = {
+    name: string;
+    symbol: string;
+    decimals: number;
+    standard: TokenStandard;
 };
 
-const getTokenBalance = async (
-    client: PublicClient,
-    contractAddress: `0x${string}`,
-    userAddress: `0x${string}`,
-): Promise<string> => {
-    try {
-        const balance = await client.readContract({
-            abi: erc20Abi,
-            functionName: 'balanceOf',
-            address: contractAddress,
-            args: [userAddress],
-        });
+// Immutable per token, while account info is refetched on every mined block: cache it per
+// connection so a refresh only costs the balance read.
+const metadataCaches = new WeakMap<PublicClient, Map<string, TokenMetadata>>();
 
-        return balance.toString();
-    } catch {
-        return '0';
-    }
+const getMetadataCache = (client: PublicClient) => {
+    const existing = metadataCaches.get(client);
+    if (existing) return existing;
+
+    const cache = new Map<string, TokenMetadata>();
+    metadataCaches.set(client, cache);
+
+    return cache;
 };
 
-const supportsInterface = async (
-    client: PublicClient,
-    address: `0x${string}`,
-    interfaceId: `0x${string}`,
-): Promise<boolean> => {
-    try {
-        return await client.readContract({
-            abi: ERC165_ABI,
-            functionName: 'supportsInterface',
-            address,
-            args: [interfaceId],
-        });
-    } catch {
-        return false;
-    }
-};
+const balanceCall = (contract: `0x${string}`, userAddress: `0x${string}`): BatchCall => ({
+    address: contract,
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: [userAddress],
+});
 
-const detectTokenType = async (
-    client: PublicClient,
-    address: `0x${string}`,
-): Promise<TokenStandard> => {
-    try {
-        const [isERC721, isERC1155] = await Promise.all([
-            supportsInterface(client, address, ERC721_INTERFACE_ID),
-            supportsInterface(client, address, ERC1155_INTERFACE_ID),
-        ]);
+const metadataCalls = (contract: `0x${string}`): BatchCall[] => [
+    { address: contract, abi: erc20Abi, functionName: 'name' },
+    { address: contract, abi: erc20Abi, functionName: 'symbol' },
+    { address: contract, abi: erc20Abi, functionName: 'decimals' },
+    {
+        address: contract,
+        abi: ERC165_ABI,
+        functionName: 'supportsInterface',
+        args: [ERC721_INTERFACE_ID],
+    },
+    {
+        address: contract,
+        abi: ERC165_ABI,
+        functionName: 'supportsInterface',
+        args: [ERC1155_INTERFACE_ID],
+    },
+];
 
-        if (isERC721) {
-            return 'ERC721';
-        }
+const toStandard = (isErc721: unknown, isErc1155: unknown): TokenStandard => {
+    if (isErc721 === true) return 'ERC721';
+    if (isErc1155 === true) return 'ERC1155';
 
-        if (isERC1155) {
-            return 'ERC1155';
-        }
-
-        try {
-            await client.readContract({
-                abi: erc20Abi,
-                functionName: 'balanceOf',
-                address,
-                args: ['0x0000000000000000000000000000000000000000'],
-            });
-
-            return 'ERC20';
-        } catch {
-            // TODO: handle this better
-            return 'ERC20';
-        }
-    } catch {
-        // TODO: handle this better
-        return 'ERC20';
-    }
+    return 'ERC20';
 };
 
 export const getTokenInfo = async (
@@ -106,18 +64,43 @@ export const getTokenInfo = async (
     contractAddress: `0x${string}`,
     skipBalanceCheck = false,
 ): Promise<TokenInfo | null> => {
-    const [balance, metadata, tokenType] = await Promise.all([
-        getTokenBalance(client, contractAddress, userAddress),
-        getTokenMetadata(client, contractAddress),
-        detectTokenType(client, contractAddress),
-    ]);
+    const cache = getMetadataCache(client);
+    const cacheKey = contractAddress.toLowerCase();
+    const cached = cache.get(cacheKey);
+
+    const calls = cached
+        ? [balanceCall(contractAddress, userAddress)]
+        : [balanceCall(contractAddress, userAddress), ...metadataCalls(contractAddress)];
+
+    const [rawBalance, ...metadataResults] = await batchRead(client, calls);
+    const [name, symbol, decimals, isErc721, isErc1155] = metadataResults;
+
+    const metadata =
+        cached ??
+        ({
+            name: typeof name === 'string' ? name : 'unknown',
+            symbol: typeof symbol === 'string' ? symbol : 'unknown',
+            decimals: typeof decimals === 'number' ? decimals : 0,
+            standard: toStandard(isErc721, isErc1155),
+        } satisfies TokenMetadata);
+
+    // Caching a failed read would pin the token to 0 decimals for the whole connection and render
+    // every amount 10^decimals too large, so only cache once decimals is actually known. NFTs have
+    // no decimals to read, and a name or symbol that stays "unknown" is merely cosmetic.
+    const decimalsKnown = typeof decimals === 'number' || metadata.standard !== 'ERC20';
+
+    if (!cached && decimalsKnown) {
+        cache.set(cacheKey, metadata);
+    }
+
+    const balance = typeof rawBalance === 'bigint' ? rawBalance.toString() : '0';
 
     if (balance === '0' && !skipBalanceCheck) {
         return null;
     }
 
     return {
-        standard: tokenType,
+        standard: metadata.standard,
         contract: contractAddress.toLowerCase(),
         balance,
         name: metadata.name,

--- a/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenInfo.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/tokens/tokenInfo.ts
@@ -13,7 +13,8 @@ type TokenMetadata = {
 };
 
 // Immutable per token, while account info is refetched on every mined block: cache it per
-// connection so a refresh only costs the balance read.
+// connection so a refresh only costs the balance read. Keyed weakly, so the entries go away with
+// the client when the connection is torn down.
 const metadataCaches = new WeakMap<PublicClient, Map<string, TokenMetadata>>();
 
 const getMetadataCache = (client: PublicClient) => {

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/client.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/client.ts
@@ -1,0 +1,28 @@
+import { type PublicClient } from 'viem';
+
+/**
+ * Caches a read for the lifetime of the client. A client is created per connection, so an answer
+ * cached here only has to hold for that one connection. A failed read is not cached.
+ */
+export const cachePerClient = <T>(
+    cache: WeakMap<PublicClient, Promise<T>>,
+    client: PublicClient,
+    read: () => Promise<T>,
+) => {
+    const cached = cache.get(client);
+    if (cached) return cached;
+
+    const pending = read().catch(error => {
+        cache.delete(client);
+        throw error;
+    });
+    cache.set(client, pending);
+
+    return pending;
+};
+
+// The chain cannot change under a connection.
+const chainIds = new WeakMap<PublicClient, Promise<number>>();
+
+export const getChainId = (client: PublicClient) =>
+    cachePerClient(chainIds, client, () => client.getChainId());

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/errors.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/errors.ts
@@ -1,0 +1,7 @@
+/**
+ * Name of the error's type, e.g. `HttpRequestError`. A viem error also quotes the request it failed
+ * on, which carries the account address in its calldata and the RPC URL, so the message and the
+ * error itself must be kept out of anything that can leave the device, logs included.
+ */
+export const getErrorName = (error: unknown) =>
+    error instanceof Error ? error.name : 'unknown error';

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.test.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.test.ts
@@ -1,0 +1,251 @@
+import {
+    type PublicClient,
+    decodeAbiParameters,
+    encodeAbiParameters,
+    parseAbiParameters,
+} from 'viem';
+
+import { type BatchCall, MULTICALL3_ADDRESS, batchRead } from './multicall';
+
+const CONTRACT = '0x7a7f0b3c23C23a31cFcb0c44709be70d4D545c6e';
+const OTHER_CONTRACT = '0x1111111111111111111111111111111111111111';
+
+const TEST_ABI = [
+    {
+        name: 'balanceOf',
+        type: 'function',
+        stateMutability: 'view',
+        inputs: [{ name: 'account', type: 'address' }],
+        outputs: [{ type: 'uint256' }],
+    },
+    {
+        name: 'pair',
+        type: 'function',
+        stateMutability: 'view',
+        inputs: [],
+        outputs: [{ type: 'uint256' }, { type: 'uint256' }],
+    },
+] as const;
+
+const AGGREGATE3_RESULT = parseAbiParameters('(bool success, bytes returnData)[]');
+
+const encodeUint = (value: bigint) => encodeAbiParameters(parseAbiParameters('uint256'), [value]);
+
+const encodeAggregate3 = (entries: { success: boolean; returnData: `0x${string}` }[]) =>
+    encodeAbiParameters(AGGREGATE3_RESULT, [entries]);
+
+// Strips the 4-byte aggregate3 selector so the calls array can be inspected.
+const decodeAggregate3Input = (data: `0x${string}`) => {
+    const [calls] = decodeAbiParameters(
+        parseAbiParameters('(address target, bool allowFailure, bytes callData)[]'),
+        `0x${data.slice(10)}` as `0x${string}`,
+    );
+
+    return calls as readonly { target: string; allowFailure: boolean; callData: string }[];
+};
+
+const balanceOfCall = (address: `0x${string}`): BatchCall => ({
+    address,
+    abi: TEST_ABI as unknown as BatchCall['abi'],
+    functionName: 'balanceOf',
+    args: ['0x2222222222222222222222222222222222222222'],
+});
+
+const createClient = ({ multicall3Deployed = true }: { multicall3Deployed?: boolean } = {}) => {
+    const client = {
+        getCode: jest.fn().mockResolvedValue(multicall3Deployed ? '0x6080604052' : '0x'),
+        call: jest.fn(),
+    };
+
+    return { client, asPublicClient: client as unknown as PublicClient };
+};
+
+describe('batchRead', () => {
+    it('sends one aggregate3 request carrying every call', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValue({
+            data: encodeAggregate3([
+                { success: true, returnData: encodeUint(11n) },
+                { success: true, returnData: encodeUint(22n) },
+            ]),
+        });
+
+        const results = await batchRead(asPublicClient, [
+            balanceOfCall(CONTRACT),
+            balanceOfCall(OTHER_CONTRACT),
+        ]);
+
+        expect(client.call).toHaveBeenCalledTimes(1);
+
+        const [{ to, data }] = client.call.mock.calls[0];
+        expect(to).toBe(MULTICALL3_ADDRESS);
+
+        const inner = decodeAggregate3Input(data);
+        expect(inner).toHaveLength(2);
+        expect(inner.map(c => c.target.toLowerCase())).toEqual([
+            CONTRACT.toLowerCase(),
+            OTHER_CONTRACT.toLowerCase(),
+        ]);
+        expect(inner.every(c => c.allowFailure)).toBe(true);
+
+        expect(results).toEqual([11n, 22n]);
+    });
+
+    it('decodes multi-output functions as a tuple', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValue({
+            data: encodeAggregate3([
+                {
+                    success: true,
+                    returnData: encodeAbiParameters(parseAbiParameters('uint256, uint256'), [
+                        4n,
+                        5n,
+                    ]),
+                },
+            ]),
+        });
+
+        const [pair] = await batchRead(asPublicClient, [
+            {
+                address: CONTRACT,
+                abi: TEST_ABI as unknown as BatchCall['abi'],
+                functionName: 'pair',
+            },
+        ]);
+
+        expect(pair).toEqual([4n, 5n]);
+    });
+
+    it('maps a reverting call to undefined without losing the batch', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValue({
+            data: encodeAggregate3([
+                { success: false, returnData: '0x' },
+                { success: true, returnData: encodeUint(7n) },
+            ]),
+        });
+
+        const results = await batchRead(asPublicClient, [
+            balanceOfCall(CONTRACT),
+            balanceOfCall(OTHER_CONTRACT),
+        ]);
+
+        expect(results).toEqual([undefined, 7n]);
+    });
+
+    it('falls back to single calls when the aggregate3 request itself fails', async () => {
+        const { client, asPublicClient } = createClient();
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        client.call
+            .mockRejectedValueOnce(new Error('not an aggregate3 response'))
+            .mockResolvedValue({ data: encodeUint(8n) });
+
+        const results = await batchRead(asPublicClient, [
+            balanceOfCall(CONTRACT),
+            balanceOfCall(OTHER_CONTRACT),
+        ]);
+
+        expect(client.call).toHaveBeenCalledTimes(3);
+        expect(client.call.mock.calls.slice(1).map(([{ to }]) => to)).toEqual([
+            CONTRACT,
+            OTHER_CONTRACT,
+        ]);
+        expect(results).toEqual([8n, 8n]);
+
+        warn.mockRestore();
+    });
+
+    it('stops attempting to batch when the address does not answer as Multicall3', async () => {
+        const { client, asPublicClient } = createClient();
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        client.call.mockResolvedValue({ data: '0xdeadbeef' });
+
+        await batchRead(asPublicClient, [balanceOfCall(CONTRACT)]);
+        const afterFirstRead = client.call.mock.calls.length;
+
+        client.call.mockResolvedValue({ data: encodeUint(5n) });
+        const results = await batchRead(asPublicClient, [
+            balanceOfCall(CONTRACT),
+            balanceOfCall(OTHER_CONTRACT),
+        ]);
+
+        // Retrying the doomed batch on every read would cost more requests than never batching.
+        expect(
+            client.call.mock.calls
+                .slice(afterFirstRead)
+                .every(([{ to }]) => to !== MULTICALL3_ADDRESS),
+        ).toBe(true);
+        expect(results).toEqual([5n, 5n]);
+
+        warn.mockRestore();
+    });
+
+    it('keeps batching after a transient batch failure', async () => {
+        const { client, asPublicClient } = createClient();
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        client.call.mockRejectedValueOnce(new Error('timeout')).mockResolvedValue({
+            data: encodeAggregate3([{ success: true, returnData: encodeUint(6n) }]),
+        });
+
+        await batchRead(asPublicClient, [balanceOfCall(CONTRACT)]);
+        const afterFirstRead = client.call.mock.calls.length;
+
+        const results = await batchRead(asPublicClient, [balanceOfCall(CONTRACT)]);
+
+        expect(client.call.mock.calls[afterFirstRead]?.[0].to).toBe(MULTICALL3_ADDRESS);
+        expect(results).toEqual([6n]);
+
+        warn.mockRestore();
+    });
+
+    it('falls back to one request per call when Multicall3 is absent', async () => {
+        const { client, asPublicClient } = createClient({ multicall3Deployed: false });
+        client.call.mockResolvedValue({ data: encodeUint(9n) });
+
+        const results = await batchRead(asPublicClient, [
+            balanceOfCall(CONTRACT),
+            balanceOfCall(OTHER_CONTRACT),
+        ]);
+
+        expect(client.call).toHaveBeenCalledTimes(2);
+        expect(client.call.mock.calls.map(([{ to }]) => to)).toEqual([CONTRACT, OTHER_CONTRACT]);
+        expect(results).toEqual([9n, 9n]);
+    });
+
+    it('isolates failures in the fallback path', async () => {
+        const { client, asPublicClient } = createClient({ multicall3Deployed: false });
+        client.call
+            .mockRejectedValueOnce(new Error('reverted'))
+            .mockResolvedValueOnce({ data: encodeUint(3n) });
+
+        const results = await batchRead(asPublicClient, [
+            balanceOfCall(CONTRACT),
+            balanceOfCall(OTHER_CONTRACT),
+        ]);
+
+        expect(results).toEqual([undefined, 3n]);
+    });
+
+    it('probes Multicall3 support once per client', async () => {
+        const { client, asPublicClient } = createClient();
+        client.call.mockResolvedValue({
+            data: encodeAggregate3([{ success: true, returnData: encodeUint(1n) }]),
+        });
+
+        await batchRead(asPublicClient, [balanceOfCall(CONTRACT)]);
+        await batchRead(asPublicClient, [balanceOfCall(CONTRACT)]);
+        await batchRead(asPublicClient, [balanceOfCall(CONTRACT)]);
+
+        expect(client.getCode).toHaveBeenCalledTimes(1);
+        expect(client.call).toHaveBeenCalledTimes(3);
+    });
+
+    it('makes no request for an empty call list', async () => {
+        const { client, asPublicClient } = createClient();
+
+        await expect(batchRead(asPublicClient, [])).resolves.toEqual([]);
+
+        expect(client.getCode).not.toHaveBeenCalled();
+        expect(client.call).not.toHaveBeenCalled();
+    });
+});

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.test.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.test.ts
@@ -1,7 +1,9 @@
 import {
+    HttpRequestError,
     type PublicClient,
     decodeAbiParameters,
     encodeAbiParameters,
+    encodeFunctionData,
     parseAbiParameters,
 } from 'viem';
 
@@ -9,6 +11,7 @@ import { type BatchCall, MULTICALL3_ADDRESS, batchRead } from './multicall';
 
 const CONTRACT = '0x7a7f0b3c23C23a31cFcb0c44709be70d4D545c6e';
 const OTHER_CONTRACT = '0x1111111111111111111111111111111111111111';
+const ACCOUNT = '0x2222222222222222222222222222222222222222' as const;
 
 const TEST_ABI = [
     {
@@ -48,7 +51,7 @@ const balanceOfCall = (address: `0x${string}`): BatchCall => ({
     address,
     abi: TEST_ABI as unknown as BatchCall['abi'],
     functionName: 'balanceOf',
-    args: ['0x2222222222222222222222222222222222222222'],
+    args: [ACCOUNT],
 });
 
 const createClient = ({ multicall3Deployed = true }: { multicall3Deployed?: boolean } = {}) => {
@@ -194,6 +197,42 @@ describe('batchRead', () => {
 
         expect(client.call.mock.calls[afterFirstRead]?.[0].to).toBe(MULTICALL3_ADDRESS);
         expect(results).toEqual([6n]);
+
+        warn.mockRestore();
+    });
+
+    it('logs the failure without the request it failed on', async () => {
+        const { client, asPublicClient } = createClient();
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const rpcUrl = 'https://rpc.example/an-api-key';
+        client.call
+            .mockRejectedValueOnce(
+                new HttpRequestError({
+                    url: rpcUrl,
+                    body: {
+                        method: 'eth_call',
+                        params: [
+                            {
+                                to: MULTICALL3_ADDRESS,
+                                data: encodeFunctionData({
+                                    abi: TEST_ABI,
+                                    functionName: 'balanceOf',
+                                    args: [ACCOUNT],
+                                }),
+                            },
+                        ],
+                    },
+                }),
+            )
+            .mockResolvedValue({ data: encodeUint(1n) });
+
+        await batchRead(asPublicClient, [balanceOfCall(CONTRACT)]);
+
+        const logged = warn.mock.calls.flat().join(' ');
+        expect(logged).toContain('HttpRequestError');
+        // The account address reaches the RPC inside the calldata, so neither may be logged.
+        expect(logged).not.toContain(ACCOUNT.slice(2));
+        expect(logged).not.toContain(rpcUrl);
 
         warn.mockRestore();
     });

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.ts
@@ -1,0 +1,172 @@
+import { type Abi, type PublicClient, decodeFunctionResult, encodeFunctionData } from 'viem';
+
+// Canonical CREATE2 deployment, identical on every chain Multicall3 is deployed to.
+export const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11' as const;
+
+const AGGREGATE3_ABI = [
+    {
+        name: 'aggregate3',
+        type: 'function',
+        stateMutability: 'payable',
+        inputs: [
+            {
+                name: 'calls',
+                type: 'tuple[]',
+                components: [
+                    { name: 'target', type: 'address' },
+                    { name: 'allowFailure', type: 'bool' },
+                    { name: 'callData', type: 'bytes' },
+                ],
+            },
+        ],
+        outputs: [
+            {
+                name: 'returnData',
+                type: 'tuple[]',
+                components: [
+                    { name: 'success', type: 'bool' },
+                    { name: 'returnData', type: 'bytes' },
+                ],
+            },
+        ],
+    },
+] as const;
+
+export type BatchCall = {
+    address: `0x${string}`;
+    abi: Abi;
+    functionName: string;
+    args?: readonly unknown[];
+};
+
+const encodeCall = ({ abi, functionName, args }: BatchCall) =>
+    encodeFunctionData({ abi, functionName, args });
+
+const decodeCall = ({ abi, functionName }: BatchCall, data: `0x${string}`) => {
+    try {
+        return decodeFunctionResult({ abi, functionName, data });
+    } catch {
+        return undefined;
+    }
+};
+
+// Keyed by client because a client is created per connection, which is also the lifetime of both
+// answers: a chain cannot change under a connection, nor can Multicall3 appear on it.
+const multicall3Support = new WeakMap<PublicClient, Promise<boolean>>();
+const chainIds = new WeakMap<PublicClient, Promise<number>>();
+
+const cachePerClient = <T>(
+    cache: WeakMap<PublicClient, Promise<T>>,
+    client: PublicClient,
+    read: () => Promise<T>,
+) => {
+    const cached = cache.get(client);
+    if (cached) return cached;
+
+    const pending = read().catch(error => {
+        cache.delete(client);
+        throw error;
+    });
+    cache.set(client, pending);
+
+    return pending;
+};
+
+export const getChainId = (client: PublicClient) =>
+    cachePerClient(chainIds, client, () => client.getChainId());
+
+// Custom RPCs may point at a chain without Multicall3, so probe before relying on it.
+export const hasMulticall3 = (client: PublicClient) =>
+    cachePerClient(multicall3Support, client, async () => {
+        const code = await client.getCode({ address: MULTICALL3_ADDRESS });
+
+        return !!code && code !== '0x';
+    }).catch(() => false);
+
+// Raised when the address answers with something that is not an aggregate3 result. Unlike a
+// network error this will not fix itself, so the connection stops attempting to batch.
+class NotMulticall3Error extends Error {}
+
+const readAggregated = async (client: PublicClient, calls: readonly BatchCall[]) => {
+    const data = encodeFunctionData({
+        abi: AGGREGATE3_ABI,
+        functionName: 'aggregate3',
+        args: [
+            calls.map(call => ({
+                target: call.address,
+                allowFailure: true,
+                callData: encodeCall(call),
+            })),
+        ],
+    });
+
+    const result = await client.call({ to: MULTICALL3_ADDRESS, data });
+
+    if (!result.data) {
+        throw new NotMulticall3Error('aggregate3 returned no data');
+    }
+
+    let entries;
+    try {
+        entries = decodeFunctionResult({
+            abi: AGGREGATE3_ABI,
+            functionName: 'aggregate3',
+            data: result.data,
+        });
+    } catch {
+        throw new NotMulticall3Error('aggregate3 returned an unexpected result');
+    }
+
+    // Map over the calls, not the response, so there is one slot per requested call even if a
+    // non-conforming Multicall3 returns a different number of entries.
+    return calls.map((call, index) => {
+        const entry = entries[index];
+
+        return entry?.success ? decodeCall(call, entry.returnData) : undefined;
+    });
+};
+
+const readIndividually = (client: PublicClient, calls: readonly BatchCall[]) =>
+    Promise.all(
+        calls.map(async call => {
+            try {
+                const result = await client.call({ to: call.address, data: encodeCall(call) });
+
+                return result.data ? decodeCall(call, result.data) : undefined;
+            } catch {
+                return undefined;
+            }
+        }),
+    );
+
+/**
+ * Reads several contract functions in one Multicall3 `aggregate3` request, falling back to one
+ * request per call when Multicall3 is not deployed or the batch fails. Never rejects: a call that
+ * reverts or cannot be read yields `undefined` in its slot, and callers decide whether that is
+ * fatal or a default.
+ */
+export const batchRead = async (
+    client: PublicClient,
+    calls: readonly BatchCall[],
+): Promise<unknown[]> => {
+    if (calls.length === 0) {
+        return [];
+    }
+
+    if (await hasMulticall3(client)) {
+        try {
+            return await readAggregated(client, calls);
+        } catch (error) {
+            // Retrying unbatched keeps one bad batch from failing the whole read. When the address
+            // is not a real Multicall3 that retry would repeat on every poll, costing more requests
+            // than never batching, so stop trusting it for the rest of the connection.
+            if (error instanceof NotMulticall3Error) {
+                multicall3Support.set(client, Promise.resolve(false));
+            }
+
+            console.warn('[evm-rpc] Multicall3 batch failed, reading calls individually:', error);
+        }
+    }
+
+    return readIndividually(client, calls);
+};

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.ts
@@ -1,5 +1,7 @@
 import { type Abi, type PublicClient, decodeFunctionResult, encodeFunctionData } from 'viem';
 
+import { cachePerClient } from './client';
+
 // Canonical CREATE2 deployment, identical on every chain Multicall3 is deployed to.
 export const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11' as const;
 
@@ -50,30 +52,8 @@ const decodeCall = ({ abi, functionName }: BatchCall, data: `0x${string}`) => {
     }
 };
 
-// Keyed by client because a client is created per connection, which is also the lifetime of both
-// answers: a chain cannot change under a connection, nor can Multicall3 appear on it.
+// Multicall3 cannot appear on a chain under a running connection.
 const multicall3Support = new WeakMap<PublicClient, Promise<boolean>>();
-const chainIds = new WeakMap<PublicClient, Promise<number>>();
-
-const cachePerClient = <T>(
-    cache: WeakMap<PublicClient, Promise<T>>,
-    client: PublicClient,
-    read: () => Promise<T>,
-) => {
-    const cached = cache.get(client);
-    if (cached) return cached;
-
-    const pending = read().catch(error => {
-        cache.delete(client);
-        throw error;
-    });
-    cache.set(client, pending);
-
-    return pending;
-};
-
-export const getChainId = (client: PublicClient) =>
-    cachePerClient(chainIds, client, () => client.getChainId());
 
 // Custom RPCs may point at a chain without Multicall3, so probe before relying on it.
 export const hasMulticall3 = (client: PublicClient) =>

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/multicall.ts
@@ -1,6 +1,7 @@
 import { type Abi, type PublicClient, decodeFunctionResult, encodeFunctionData } from 'viem';
 
 import { cachePerClient } from './client';
+import { getErrorName } from './errors';
 
 // Canonical CREATE2 deployment, identical on every chain Multicall3 is deployed to.
 export const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11' as const;
@@ -65,7 +66,9 @@ export const hasMulticall3 = (client: PublicClient) =>
 
 // Raised when the address answers with something that is not an aggregate3 result. Unlike a
 // network error this will not fix itself, so the connection stops attempting to batch.
-class NotMulticall3Error extends Error {}
+class NotMulticall3Error extends Error {
+    override name = 'NotMulticall3Error';
+}
 
 const readAggregated = async (client: PublicClient, calls: readonly BatchCall[]) => {
     const data = encodeFunctionData({
@@ -144,7 +147,10 @@ export const batchRead = async (
                 multicall3Support.set(client, Promise.resolve(false));
             }
 
-            console.warn('[evm-rpc] Multicall3 batch failed, reading calls individually:', error);
+            console.warn(
+                '[evm-rpc] Multicall3 batch failed, reading calls individually:',
+                getErrorName(error),
+            );
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Utilizes multicall to improve fetching of data 

## Notes for QA

1) to test direct RPC I'd recommend an account with a lot of tokens. RPC url can be found here: https://chainlist.org/chain/1

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31470

## Screenshots:


Before:

https://github.com/user-attachments/assets/5791c650-5876-4afc-bc9e-c6e4eb400de5

After:

https://github.com/user-attachments/assets/f2344e53-255f-46e1-a1ec-d3dd9f410f69




<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/multicall-direct-rpc/web/](https://dev.suite.sldev.cz/suite-web/perf/multicall-direct-rpc/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/multicall-direct-rpc&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/multicall-direct-rpc&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T06:32:48.636Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T06:32:08.062Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->