### PR TITLE
fix(suite-native): apy dotted underline on android

### DIFF
--- a/suite-native/atoms/src/Card/TimelineDetailsCard.tsx
+++ b/suite-native/atoms/src/Card/TimelineDetailsCard.tsx
@@ -1,8 +1,7 @@
-import { type ReactNode } from 'react';
-import { Pressable } from 'react-native';
+import React, { type ReactNode, useMemo } from 'react';
 
 import { Icon, type IconName } from '@suite-native/icons';
-import { type NativeStyle, prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { Box } from '../Box';
 import { OrderedListIcon } from '../OrderedListIcon';
@@ -14,9 +13,8 @@ export type TimelineDetailsCardItem = {
     id: string;
     title: ReactNode;
     description?: ReactNode;
+    descriptionContainer?: ({ children }: { children: ReactNode }) => ReactNode;
     icon?: ReactNode;
-    style?: NativeStyle<any>;
-    onPress?: () => void;
 };
 
 type TimelineDetailsCardProps = {
@@ -67,6 +65,68 @@ const renderDefaultItemIcon = (index: number) => (
     <OrderedListIcon iconNumber={index + 1} {...defaultItemIconProps} />
 );
 
+interface TimelineDetailsCardItemComponentProps {
+    item: TimelineDetailsCardItem;
+    index: number;
+    renderItemIcon?: (params: { item: TimelineDetailsCardItem; index: number }) => ReactNode;
+}
+
+const TimelineDetailsCardItemComponent = ({
+    item,
+    index,
+    renderItemIcon,
+}: TimelineDetailsCardItemComponentProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const itemIcon = useMemo(
+        () => item.icon ?? renderItemIcon?.({ item, index }) ?? renderDefaultItemIcon(index),
+        [item, index, renderItemIcon],
+    );
+
+    const itemTitle = useMemo(
+        () => (
+            <Text variant="body-sm-strong" style={applyStyle(itemTitleStyle)}>
+                {item.title}
+            </Text>
+        ),
+        [item.title, applyStyle],
+    );
+
+    const itemDescription = useMemo(() => {
+        if (!item.description) return null;
+
+        const Container = item.descriptionContainer ?? React.Fragment;
+
+        return (
+            <Container>
+                <Text
+                    variant="body-sm"
+                    color="contentSecondary"
+                    numberOfLines={1}
+                    style={applyStyle(itemDescriptionStyle)}
+                >
+                    {item.description}
+                </Text>
+            </Container>
+        );
+    }, [item, applyStyle]);
+
+    return (
+        <HStack spacing="sp8" alignItems="flex-start" style={applyStyle(itemRowStyle)}>
+            <HStack
+                spacing="sp12"
+                alignItems="flex-start"
+                style={applyStyle(itemTitleContainerStyle)}
+            >
+                {itemIcon}
+                {itemTitle}
+            </HStack>
+
+            {itemDescription}
+        </HStack>
+    );
+};
+
 export const TimelineDetailsCard = ({
     headerTitle,
     headerIconName,
@@ -83,51 +143,23 @@ export const TimelineDetailsCard = ({
                         {headerIconName && (
                             <Icon name={headerIconName} color="contentSecondary" size={20} />
                         )}
+
                         <Text variant="body-md" color="contentSecondary">
                             {headerTitle}
                         </Text>
                     </HStack>
                 </Box>
+
                 <Box style={applyStyle(separatorStyle)} />
+
                 <VStack spacing="sp16" padding="sp16">
                     {items.map((item, index) => (
-                        <Pressable key={item.id} onPress={item.onPress}>
-                            <HStack
-                                spacing="sp8"
-                                alignItems="flex-start"
-                                style={applyStyle(itemRowStyle)}
-                            >
-                                <HStack
-                                    spacing="sp12"
-                                    alignItems="flex-start"
-                                    style={applyStyle(itemTitleContainerStyle)}
-                                >
-                                    {item.icon ??
-                                        renderItemIcon?.({ item, index }) ??
-                                        renderDefaultItemIcon(index)}
-                                    <Text
-                                        variant="body-sm-strong"
-                                        style={applyStyle(itemTitleStyle)}
-                                    >
-                                        {item.title}
-                                    </Text>
-                                </HStack>
-                                {item.description && (
-                                    <Text
-                                        variant="body-sm"
-                                        color="contentSecondary"
-                                        numberOfLines={1}
-                                        style={applyStyle(
-                                            item.style
-                                                ? [itemDescriptionStyle, item.style]
-                                                : itemDescriptionStyle,
-                                        )}
-                                    >
-                                        {item.description}
-                                    </Text>
-                                )}
-                            </HStack>
-                        </Pressable>
+                        <TimelineDetailsCardItemComponent
+                            key={item.id}
+                            item={item}
+                            index={index}
+                            renderItemIcon={renderItemIcon}
+                        />
                     ))}
                 </VStack>
             </VStack>

--- a/suite-native/module-earn/src/components/ApyDottedUnderline.tsx
+++ b/suite-native/module-earn/src/components/ApyDottedUnderline.tsx
@@ -1,0 +1,49 @@
+import { type ReactNode } from 'react';
+import { View } from 'react-native';
+
+import { PressableOpacity, VStack } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+const dottedDividerContainerStyle = prepareNativeStyle(() => ({
+    height: 1,
+    overflow: 'hidden',
+}));
+
+const dottedDividerContentStyle = prepareNativeStyle(({ colors }) => ({
+    height: 2,
+    borderWidth: 2,
+    borderStyle: 'dotted',
+    borderColor: colors.contentSecondary,
+    borderRadius: 0.1,
+    marginHorizontal: -1,
+}));
+
+const DottedDivider = () => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={applyStyle(dottedDividerContainerStyle)}>
+            <View style={applyStyle(dottedDividerContentStyle)} />
+        </View>
+    );
+};
+
+interface ApyDottedUnderlineProps {
+    children: ReactNode;
+    onPress?: () => void;
+}
+
+export const ApyDottedUnderline = ({ children, onPress }: ApyDottedUnderlineProps) => {
+    const content = (
+        <VStack spacing="sp2">
+            {children}
+            <DottedDivider />
+        </VStack>
+    );
+
+    if (onPress) {
+        return <PressableOpacity onPress={onPress}>{content}</PressableOpacity>;
+    }
+
+    return content;
+};

--- a/suite-native/module-earn/src/components/HowEarnWorks/yieldPresets.tsx
+++ b/suite-native/module-earn/src/components/HowEarnWorks/yieldPresets.tsx
@@ -1,16 +1,10 @@
 import { useMemo } from 'react';
 
 import { Translation } from '@suite-native/intl';
-import { prepareNativeStyle } from '@trezor/styles-native';
 
 import { type HowEarnWorksBenefitItem } from './HowEarnWorksBenefitsSection';
 import { type HowEarnWorksScreenPreset, type HowEarnWorksTimelineSectionPreset } from './types';
-
-const abbrStyle = prepareNativeStyle(({ colors }) => ({
-    borderStyle: 'dotted',
-    borderBottomWidth: 1,
-    borderColor: colors.contentSecondary,
-}));
+import { ApyDottedUnderline } from '../ApyDottedUnderline';
 
 type UseHowYieldWorksPresetProps = {
     tokenSymbol: string;
@@ -213,8 +207,9 @@ export const useHowYieldWorksPreset = ({
                             ) : (
                                 <Translation id="earn.notAvailableShort" />
                             ),
-                        style: abbrStyle,
-                        onPress: onApyPress,
+                        descriptionContainer: ({ children }) => (
+                            <ApyDottedUnderline onPress={onApyPress}>{children}</ApyDottedUnderline>
+                        ),
                     },
                 ],
             },

--- a/suite-native/module-earn/src/components/YieldCompleteScreenContent.tsx
+++ b/suite-native/module-earn/src/components/YieldCompleteScreenContent.tsx
@@ -1,5 +1,4 @@
 import { type ReactNode } from 'react';
-import { Pressable } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
@@ -52,7 +51,6 @@ const footerStyle = prepareNativeStyle(utils => ({
 export type YieldCompleteSummaryRow = {
     key: string;
     label: ReactNode;
-    onPress?: () => void;
 } & (
     | {
           value: ReactNode;
@@ -170,20 +168,19 @@ export const YieldCompleteScreenContent = ({
                         }
 
                         return (
-                            <Pressable onPress={row.onPress} key={row.key}>
-                                <HStack
-                                    spacing="sp16"
-                                    style={applyStyle(summaryRowStyle, {
-                                        hasBorder: index > 0,
-                                        hasContent: false,
-                                    })}
-                                >
-                                    <Text variant="body-md">{row.label}</Text>
-                                    <Box flexShrink={1} alignItems="flex-end">
-                                        {row.value}
-                                    </Box>
-                                </HStack>
-                            </Pressable>
+                            <HStack
+                                key={row.key}
+                                spacing="sp16"
+                                style={applyStyle(summaryRowStyle, {
+                                    hasBorder: index > 0,
+                                    hasContent: false,
+                                })}
+                            >
+                                <Text variant="body-md">{row.label}</Text>
+                                <Box flexShrink={1} alignItems="flex-end">
+                                    {row.value}
+                                </Box>
+                            </HStack>
                         );
                     })}
                 </Card>

--- a/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
+++ b/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
@@ -38,7 +38,6 @@ const getYieldCompleteAmountValue = ({
 type GetYieldDepositCompleteRowsParams = {
     accountSymbol: NetworkSymbol;
     apyValue: ReactNode;
-    onApyPress?: () => void;
     receivedAmount: string;
     receivedTokenContract?: string;
     sentAmount: string;
@@ -61,7 +60,6 @@ const getYieldCompleteStatusRow = (): YieldCompleteSummaryRow => ({
 export const getYieldDepositCompleteRows = ({
     accountSymbol,
     apyValue,
-    onApyPress,
     receivedAmount,
     receivedTokenContract,
     sentAmount,
@@ -72,7 +70,6 @@ export const getYieldDepositCompleteRows = ({
         key: 'apy',
         label: <Translation id="earn.yieldCompleteScreen.apy" />,
         value: apyValue,
-        onPress: onApyPress,
     },
     {
         key: 'sent',

--- a/suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositCompleteScreen.tsx
@@ -21,20 +21,14 @@ import {
     useNavigateToInitialScreen,
     useOverrideBackNavigation,
 } from '@suite-native/navigation';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { ApyDottedUnderline } from '../components/ApyDottedUnderline';
 import { ApyValue } from '../components/ApyValue';
 import { YieldCompleteScreenContent } from '../components/YieldCompleteScreenContent';
 import { getYieldDepositCompleteRows } from '../components/YieldCompleteScreenPresets';
 import { useApyBreakdownAlert } from '../hooks/useApyBreakdownAlert';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { formatEarnTokenAmount } from '../utils/earnAmountUtils';
-
-const abbrStyle = prepareNativeStyle(({ colors }) => ({
-    borderStyle: 'dotted',
-    borderBottomWidth: 1,
-    borderColor: colors.contentSecondary,
-}));
 
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldDepositComplete>;
 type NavigationProps = StackNavigationProps<
@@ -45,7 +39,6 @@ type NavigationProps = StackNavigationProps<
 export const YieldDepositCompleteScreen = () => {
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
-    const { applyStyle } = useNativeStyles();
     const dispatch = useDispatch();
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const locale = useSelector(selectSupportedLanguageLocale);
@@ -116,11 +109,12 @@ export const YieldDepositCompleteScreen = () => {
         return getYieldDepositCompleteRows({
             accountSymbol: account.symbol,
             apyValue: (
-                <Text variant="body-md" color="contentPrimary" style={applyStyle(abbrStyle)}>
-                    <ApyValue apy={apy} />
-                </Text>
+                <ApyDottedUnderline onPress={apyBreakdownAlert.onPress}>
+                    <Text variant="body-md" color="contentPrimary">
+                        <ApyValue apy={apy} />
+                    </Text>
+                </ApyDottedUnderline>
             ),
-            onApyPress: apyBreakdownAlert.onPress,
             receivedAmount,
             receivedTokenContract: flowData.receiptToken.contractAddress ?? undefined,
             sentAmount,
@@ -129,7 +123,6 @@ export const YieldDepositCompleteScreen = () => {
                 : (flowData.token.contractAddress ?? undefined),
         });
     }, [
-        applyStyle,
         apyBreakdownAlert.onPress,
         account,
         apy,

--- a/suite-native/module-earn/src/screens/YieldManagementScreenContent.tsx
+++ b/suite-native/module-earn/src/screens/YieldManagementScreenContent.tsx
@@ -17,7 +17,7 @@ import {
 } from '@suite-common/wallet-types';
 import { isApyAvailable } from '@suite-common/wallet-utils';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Box, Button, Card, HStack, PressableOpacity, Text, VStack } from '@suite-native/atoms';
+import { Box, Button, Card, HStack, Text, VStack } from '@suite-native/atoms';
 import { TokenAmountFormatter, TokenToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 import {
@@ -29,6 +29,7 @@ import {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { BigNumber } from '@trezor/utils';
 
+import { ApyDottedUnderline } from '../components/ApyDottedUnderline';
 import { useApyBreakdownAlert } from '../hooks/useApyBreakdownAlert';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { useStablecoinYieldFirmwareUpdateAlert } from '../hooks/useStablecoinYieldFirmwareUpdateAlert';
@@ -41,12 +42,6 @@ const stakedSectionStyleWithBorder = prepareNativeStyle(utils => ({
     padding: utils.spacings.sp16,
     borderBottomWidth: utils.borders.widths.small,
     borderBottomColor: utils.colors.borderNeutral,
-}));
-
-const abbrStyle = prepareNativeStyle(({ colors }) => ({
-    borderStyle: 'dotted',
-    borderBottomWidth: 1,
-    borderColor: colors.contentSecondary,
 }));
 
 type NavigationProps = StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>;
@@ -359,8 +354,8 @@ export const YieldManagementScreenContent = ({
                         style={applyStyle(stakedSectionStyleWithBorder)}
                     >
                         {apyValue ? (
-                            <PressableOpacity onPress={apyBreakdownAlert.onPress}>
-                                <Text variant="body-sm" style={applyStyle(abbrStyle)}>
+                            <ApyDottedUnderline onPress={apyBreakdownAlert.onPress}>
+                                <Text variant="body-sm">
                                     <Translation
                                         id={
                                             bonusRewardTokenSymbol
@@ -370,9 +365,9 @@ export const YieldManagementScreenContent = ({
                                         values={{ apy: apyValue }}
                                     />
                                 </Text>
-                            </PressableOpacity>
+                            </ApyDottedUnderline>
                         ) : (
-                            <Text variant="body-sm" style={applyStyle(abbrStyle)}>
+                            <Text variant="body-sm">
                                 <Translation id="earn.apyNotAvailable" />
                             </Text>
                         )}


### PR DESCRIPTION
## Description

Fix APY dotted underline on Android.

On Android, `borderStyle: 'dotted'` with `borderBottomWidth: 1` doesn't work. This PR introduces a workaround by using a custom component for the underlined APY value with dotted line created from scratch.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31313

## Screenshots:

<table>
<tr>
<td>
<img width="377" height="794" alt="Screenshot 2026-08-21 at 14 45 16" src="https://github.com/user-attachments/assets/31ed30c3-3ff0-4041-a2a9-ce474a12daf7" />
</td>
<td>
<img width="377" height="794" alt="Screenshot 2026-08-21 at 14 45 27" src="https://github.com/user-attachments/assets/f726ae6e-87c2-41f2-8e0f-d7a769451b81" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/apy-dotted-underline-android&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->