### PR TITLE
Perf/accounts list

### DIFF
--- a/packages/components/jest.setup.js
+++ b/packages/components/jest.setup.js
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom';
+
+// jsdom implements no IntersectionObserver, while components that watch the edges of their own
+// scrollable content — the scroll shadows of `useScrollShadow` — construct one as they mount.
+if (!globalThis.IntersectionObserver) {
+    globalThis.IntersectionObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+            return [];
+        }
+    };
+}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,6 +22,7 @@
         "@floating-ui/react": "^0.27.17",
         "@suite-common/flags": "workspace:*",
         "@suite-common/illustrations": "workspace:*",
+        "@tanstack/react-virtual": "^3.13.9",
         "@testing-library/jest-dom": "6.9.1",
         "@trezor/env-utils": "workspace:*",
         "@trezor/icons": "workspace:*",

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -78,7 +78,7 @@ const ModalBase = ({
     padding,
     shadowBottom = true,
 }: ModalProps) => {
-    const { scrollElementRef, onScroll, ShadowTop, ShadowBottom } = useScrollShadow({
+    const { scrollElementRef, ScrollSentinels, ShadowTop, ShadowBottom } = useScrollShadow({
         backgroundColor: 'surfaceFillModal',
     });
 
@@ -155,8 +155,12 @@ const ModalBase = ({
                         )}
                         <Box position={{ type: 'relative' }} overflow="hidden" flex="1">
                             <ShadowTop />
-                            <ScrollContainer onScroll={onScroll} ref={scrollElementRef}>
-                                <Column padding={padding ? padding : 16}>
+                            <ScrollContainer ref={scrollElementRef}>
+                                <Column
+                                    padding={padding ? padding : 16}
+                                    position={{ type: 'relative' }}
+                                >
+                                    <ScrollSentinels />
                                     {icon && (
                                         <Box
                                             margin={{

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -37,6 +37,14 @@ const ScrollContainer = styled.div`
     -webkit-overflow-scrolling: touch;
 `;
 
+// The scroll shadow sentinels are positioned against this wrapper, so it has to be as wide as
+// the table it holds — a plain block would end at the visible width and its right edge would
+// never leave the viewport, no matter how far the table overflows.
+const ScrollContent = styled.div`
+    position: relative;
+    min-width: min-content;
+`;
+
 export type TableProps = AllowedFrameProps &
     AllowedTextProps & {
         children: ReactNode;
@@ -59,7 +67,7 @@ export const Table = ({
     typographyStyle = 'body-md',
     backgroundColor = 'surfaceFillRaised',
 }: TableProps) => {
-    const { scrollElementRef, onScroll, ShadowContainer, ShadowRight, ShadowLeft } =
+    const { scrollElementRef, ScrollSentinels, ShadowContainer, ShadowRight, ShadowLeft } =
         useScrollShadow({
             backgroundColor,
         });
@@ -68,17 +76,20 @@ export const Table = ({
         <TableContext.Provider value={{ isRowHighlightedOnHover, hasBorders, typographyStyle }}>
             <ShadowContainer>
                 <ShadowLeft />
-                <ScrollContainer onScroll={onScroll} ref={scrollElementRef}>
-                    <Container {...makePropsTransient({ margin })}>
-                        {colWidths && (
-                            <colgroup>
-                                {colWidths.map((widths, index) => (
-                                    <col key={index} style={widths} />
-                                ))}
-                            </colgroup>
-                        )}
-                        {children}
-                    </Container>
+                <ScrollContainer ref={scrollElementRef}>
+                    <ScrollContent>
+                        <ScrollSentinels />
+                        <Container {...makePropsTransient({ margin })}>
+                            {colWidths && (
+                                <colgroup>
+                                    {colWidths.map((widths, index) => (
+                                        <col key={index} style={widths} />
+                                    ))}
+                                </colgroup>
+                            )}
+                            {children}
+                        </Container>
+                    </ScrollContent>
                 </ScrollContainer>
                 <ShadowRight />
             </ShadowContainer>

--- a/packages/components/src/components/VirtualizedList/VirtualizedList.stories.tsx
+++ b/packages/components/src/components/VirtualizedList/VirtualizedList.stories.tsx
@@ -26,7 +26,7 @@ const getData = (end: number) =>
     Array.from({ length: end }, (_, i) => ({
         id: i,
         content: <Item>content {i}</Item>,
-        height: heights[Math.floor(Math.random() * heights.length)],
+        height: heights[Math.floor(Math.random() * heights.length)] ?? 20,
     }));
 
 export const VirtualizedList: StoryFn = () => {
@@ -49,7 +49,7 @@ export const VirtualizedList: StoryFn = () => {
                 }}
                 listHeight={400}
                 listMinHeight={180}
-                renderItem={(_item: any, index: number) => <Item>content {index}</Item>}
+                renderItem={(_item, virtualItem) => <Item>content {virtualItem.index}</Item>}
             />
         </Container>
     );

--- a/packages/components/src/components/VirtualizedList/VirtualizedList.test.tsx
+++ b/packages/components/src/components/VirtualizedList/VirtualizedList.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { VirtualizedList } from './VirtualizedList';
 
@@ -72,6 +72,16 @@ describe('VirtualizedList', () => {
     });
 
     describe('smoke tests', () => {
+        // jsdom performs no layout, so every element reports an offsetHeight of 0. The
+        // virtualizer sizes its window from that, and would find no room for any item.
+        beforeAll(() => {
+            jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(200);
+        });
+
+        afterAll(() => {
+            jest.restoreAllMocks();
+        });
+
         it('renders without crashing with minimal props', () => {
             const mockItems = Array.from({ length: 3 }, (_, i) => ({
                 id: i,
@@ -95,6 +105,33 @@ describe('VirtualizedList', () => {
 
             // Verify the first item is rendered
             expect(screen.getByTestId('item-0')).toBeTruthy();
+            expect(screen.getByText('Test Item 0')).toBeTruthy();
+        });
+
+        it('virtualizes without being given a ref', () => {
+            const mockItems = Array.from({ length: 100 }, (_, i) => ({
+                id: i,
+                content: `Test Item ${i}`,
+                height: 40,
+            }));
+
+            render(
+                <VirtualizedList
+                    items={mockItems}
+                    listHeight={200}
+                    listMinHeight={200}
+                    renderItem={item => (
+                        <div key={item.id} data-testid="item">
+                            {item.content}
+                        </div>
+                    )}
+                />,
+            );
+
+            const renderedItems = screen.getAllByTestId('item');
+
+            expect(renderedItems.length).toBeGreaterThan(0);
+            expect(renderedItems.length).toBeLessThan(mockItems.length);
             expect(screen.getByText('Test Item 0')).toBeTruthy();
         });
 
@@ -145,6 +182,93 @@ describe('VirtualizedList', () => {
             expect(ref.current).toBeInTheDocument();
             // The container should have a specific height style
             expect(ref.current).toHaveStyle({ height: '200px' });
+        });
+    });
+    describe('paging in more items', () => {
+        const ITEM_HEIGHT = 40;
+        const LIST_HEIGHT = 200;
+
+        // jsdom performs no layout, so every element reports an offsetHeight of 0. The
+        // virtualizer sizes its window from that, and would find no room for any item.
+        beforeAll(() => {
+            jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(LIST_HEIGHT);
+        });
+
+        afterAll(() => {
+            jest.restoreAllMocks();
+        });
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        const renderList = ({
+            itemCount,
+            onScrollEnd,
+        }: {
+            itemCount: number;
+            onScrollEnd: () => void;
+        }) => {
+            const ref = React.createRef<HTMLDivElement>();
+            const items = Array.from({ length: itemCount }, (_, i) => ({
+                id: i,
+                height: ITEM_HEIGHT,
+            }));
+
+            render(
+                <VirtualizedList
+                    ref={ref}
+                    items={items}
+                    listHeight={LIST_HEIGHT}
+                    listMinHeight={LIST_HEIGHT}
+                    loadMoreBufferCount={5}
+                    onScrollEnd={onScrollEnd}
+                    renderItem={item => <div key={item.id} data-testid="item" />}
+                />,
+            );
+
+            return ref.current as HTMLDivElement;
+        };
+
+        it('asks for more items once scrolling renders the end of the list', () => {
+            const onScrollEnd = jest.fn();
+            const itemCount = 300;
+            const container = renderList({ itemCount, onScrollEnd });
+
+            expect(onScrollEnd).not.toHaveBeenCalled();
+
+            // jsdom does not scroll, so the offset the virtualizer reads has to be planted. It
+            // is planted past any possible end because the mocked offsetHeight above also
+            // reaches the measurement of the items, making their real heights meaningless here.
+            Object.defineProperty(container, 'scrollTop', {
+                value: Number.MAX_SAFE_INTEGER,
+                configurable: true,
+            });
+
+            act(() => {
+                fireEvent.scroll(container);
+            });
+
+            act(() => {
+                jest.runOnlyPendingTimers();
+            });
+
+            expect(onScrollEnd).toHaveBeenCalled();
+        });
+
+        it('does not ask for more items when the end is rendered without any scrolling', () => {
+            const onScrollEnd = jest.fn();
+            renderList({ itemCount: 3, onScrollEnd });
+
+            act(() => {
+                jest.runOnlyPendingTimers();
+            });
+
+            expect(onScrollEnd).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useRef } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { type VirtualItem, useVirtualizer } from '@tanstack/react-virtual';
 import styled from 'styled-components';
@@ -43,7 +43,10 @@ const Container = styled.div<ContainerProps>`
         typeof $minHeight === 'number' ? `${$minHeight}px` : $minHeight};
 
     width: 100%;
-    overflow-y: auto;
+
+    /* Only the vertical axis is virtualized, and leaving the horizontal one at its default would
+    compute to auto next to overflow-y: auto and let a stray scrollbar appear. */
+    overflow: hidden auto;
     position: relative;
     ${withFrameProps};
 `;
@@ -85,6 +88,21 @@ export type VirtualizedListProps<T extends BaseItemProps> = AllowedFrameProps & 
     renderItem: (item: T, virtualItem: VirtualItem) => React.ReactNode;
 
     /**
+     * Identity of an item. Worth passing for lists that measure their items, as it is what makes
+     * a measured height stay with its item when the list is filtered or reordered.
+     *
+     * @default the index of the item
+     */
+    getItemKey?: (item: T, index: number) => string | number;
+
+    /**
+     * Space between two items.
+     *
+     * @default 0
+     */
+    gap?: number;
+
+    /**
      * Items rendered above and below the visible window.
      *
      * @default 8
@@ -102,6 +120,21 @@ export type VirtualizedListProps<T extends BaseItemProps> = AllowedFrameProps & 
      * @default true
      */
     resetScrollOnItemsChange?: boolean;
+
+    /**
+     * Whether changing `items` drops the heights measured from the rendered items and falls back
+     * to their `height` again. Lists where `height` is the real height want this, lists where it
+     * is only an estimate do not — for them it would throw away every height they have measured
+     * so far on every change.
+     *
+     * @default true
+     */
+    resetItemHeightsOnItemsChange?: boolean;
+
+    /**
+     * Use ResizeObserver to measure dimensions of each item, overrides `height` property of each item.
+     */
+    measureItems?: boolean;
 };
 
 export function VirtualizedListComponent<T extends BaseItemProps>({
@@ -111,16 +144,29 @@ export function VirtualizedListComponent<T extends BaseItemProps>({
     listHeight,
     listMinHeight,
     renderItem,
+    getItemKey,
     ref,
 
+    gap,
     overscan = 8,
     loadMoreBufferCount = 100,
 
     resetScrollOnItemsChange = true,
+    resetItemHeightsOnItemsChange = true,
+    measureItems = false,
     ...rest
 }: VirtualizedListProps<T>) {
     const internalRef = useRef<HTMLDivElement | null>(null);
     const containerRef = ref ?? internalRef;
+
+    const getVirtualItemKey = useCallback(
+        (index: number) => {
+            const item = items[index];
+
+            return item && getItemKey ? getItemKey(item, index) : index;
+        },
+        [items, getItemKey],
+    );
 
     const debouncedOnScrollEnd = useMemo(() => {
         if (!onScrollEnd) return undefined;
@@ -128,11 +174,13 @@ export function VirtualizedListComponent<T extends BaseItemProps>({
         return debounce(onScrollEnd, SCROLL_END_DEBOUNCE_MS);
     }, [onScrollEnd]);
 
+    // eslint-disable-next-line react-hooks/incompatible-library
     const virtualizer = useVirtualizer({
         count: items.length,
         getScrollElement: () => containerRef.current,
-        // Item heights come from the caller, so no item ever needs to be measured.
         estimateSize: index => items[index]?.height ?? 0,
+        getItemKey: getVirtualItemKey,
+        gap,
         overscan,
         // The virtualizer tracks the scroll offset itself and reports here whenever the rendered
         // window moves. Asking for items only while it is scrolling keeps a list short enough to
@@ -156,12 +204,14 @@ export function VirtualizedListComponent<T extends BaseItemProps>({
     useEffect(() => {
         // The virtualizer caches item sizes and does not watch `estimateSize`, so it has to be
         // told to recalculate them whenever the items — and with them their heights — change.
-        virtualizer.measure();
+        if (resetItemHeightsOnItemsChange) {
+            virtualizer.measure();
+        }
 
         if (resetScrollOnItemsChange && containerRef.current) {
             containerRef.current.scrollTop = 0;
         }
-    }, [items, resetScrollOnItemsChange, virtualizer, containerRef]);
+    }, [items, resetItemHeightsOnItemsChange, resetScrollOnItemsChange, virtualizer, containerRef]);
 
     const frameProps = pickAndPrepareFrameProps(
         rest,
@@ -185,7 +235,7 @@ export function VirtualizedListComponent<T extends BaseItemProps>({
                     return (
                         <Item
                             key={virtualItem.key}
-                            ref={virtualizer.measureElement}
+                            ref={measureItems ? virtualizer.measureElement : undefined}
                             data-index={virtualItem.index}
                             style={{
                                 transform: `translateY(${virtualItem.start}px)`,

--- a/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
@@ -1,9 +1,9 @@
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useEffect, useMemo, useRef } from 'react';
 
+import { type VirtualItem, useVirtualizer } from '@tanstack/react-virtual';
 import styled from 'styled-components';
 
 import { type TimerId } from '@trezor/type-utils';
-import { getIndexOrThrow } from '@trezor/utils';
 
 import {
     type FrameProps,
@@ -50,48 +50,53 @@ const Container = styled.div<ContainerProps>`
 const Content = styled.div`
     position: relative;
     overflow: hidden;
-    will-change: contents;
+    will-change: scroll-position;
 `;
 const Item = styled.div`
     position: absolute;
     width: 100%;
     left: 0;
+    top: 0;
 `;
 
 export type BaseItemProps = {
     height: number;
 };
 
-const calculateItemHeight = <T extends BaseItemProps>(item: T): number => item.height;
+const SCROLL_END_DEBOUNCE_MS = 1000;
 
-type VirtualizedListProps<T extends BaseItemProps> = AllowedFrameProps & {
+export type VirtualizedListProps<T extends BaseItemProps> = AllowedFrameProps & {
     items: Array<T>;
-    onScroll?: (e: Event) => void;
-    onScrollEnd: () => void;
+
+    /**
+     * Rendered inside the element sized to the whole list, which is what the scroll shadow
+     * sentinels of `useScrollShadow` have to be positioned against.
+     */
+    scrollSentinels?: React.ReactNode;
+
+    /**
+     * Called while scrolling once rendering reaches `loadMoreBufferCount` items from the end.
+     * Only needed by lists that page more items in.
+     */
+    onScrollEnd?: () => void;
     listHeight: number | string;
     listMinHeight: number | string;
-    ref?: React.Ref<HTMLDivElement>;
-    renderItem: (item: T, index: number) => React.ReactNode;
+    ref?: React.RefObject<HTMLDivElement | null>;
+    renderItem: (item: T, virtualItem: VirtualItem) => React.ReactNode;
 
     /**
-     * @default 20
+     * Items rendered above and below the visible window.
+     *
+     * @default 8
      */
-    visibleItemsCount?: number;
+    overscan?: number;
 
     /**
-     * @default 100
-     */
-    beforeAfterBufferCount?: number;
-
-    /**
+     * How close to the end of the list rendering has to get before `onScrollEnd` fires.
+     *
      * @default 100
      */
     loadMoreBufferCount?: number;
-
-    /**
-     * @default 40
-     */
-    estimatedItemHeight?: number;
 
     /**
      * @default true
@@ -100,151 +105,93 @@ type VirtualizedListProps<T extends BaseItemProps> = AllowedFrameProps & {
 };
 
 export function VirtualizedListComponent<T extends BaseItemProps>({
-    items: initialItems,
-    onScroll,
+    items,
+    scrollSentinels,
     onScrollEnd,
     listHeight,
     listMinHeight,
     renderItem,
     ref,
 
-    visibleItemsCount = 20,
-    beforeAfterBufferCount = 100,
+    overscan = 8,
     loadMoreBufferCount = 100,
-    estimatedItemHeight = 40,
 
     resetScrollOnItemsChange = true,
     ...rest
 }: VirtualizedListProps<T>) {
-    const newRef = useRef<HTMLDivElement>(null);
-    const containerRef = (ref as React.RefObject<HTMLDivElement>) || newRef;
-    const [items, setItems] = useState(initialItems);
-    const [indexes, setIndexes] = useState({
-        startIndex: 0,
-        endIndex: visibleItemsCount,
-    });
-    const debouncedOnScrollEnd = useMemo(() => debounce(onScrollEnd, 1000), [onScrollEnd]);
+    const internalRef = useRef<HTMLDivElement | null>(null);
+    const containerRef = ref ?? internalRef;
 
-    const resetScroll = useCallback(() => {
-        if (!containerRef.current) return;
+    const debouncedOnScrollEnd = useMemo(() => {
+        if (!onScrollEnd) return undefined;
 
-        containerRef.current.scrollTop = 0;
-    }, [containerRef]);
+        return debounce(onScrollEnd, SCROLL_END_DEBOUNCE_MS);
+    }, [onScrollEnd]);
 
-    useEffect(() => {
-        setItems(initialItems);
-
-        if (resetScrollOnItemsChange) {
-            resetScroll();
-        }
-    }, [initialItems, resetScroll, resetScrollOnItemsChange]);
-
-    const itemHeights = useMemo(() => items.map(item => calculateItemHeight(item)), [items]);
-    const totalHeight = useMemo(
-        () => itemHeights.reduce((acc, height) => acc + height, 0),
-        [itemHeights],
-    );
-
-    // TODO: use https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API, it's more efficient
-    const handleScroll = useCallback(
-        (e: Event) => {
-            if (!containerRef.current) return;
-            const { scrollTop, clientHeight } = containerRef.current;
-            let offset = 0;
-            let newStartIndex = 0;
-
-            for (let i = 0; i < itemHeights.length; i++) {
-                // index is provably valid by loop bound
-                const height = getIndexOrThrow(itemHeights, i);
-                if (offset + height >= scrollTop) {
-                    newStartIndex = i;
-                    break;
-                }
-                offset += height;
+    const virtualizer = useVirtualizer({
+        count: items.length,
+        getScrollElement: () => containerRef.current,
+        // Item heights come from the caller, so no item ever needs to be measured.
+        estimateSize: index => items[index]?.height ?? 0,
+        overscan,
+        // The virtualizer tracks the scroll offset itself and reports here whenever the rendered
+        // window moves. Asking for items only while it is scrolling keeps a list short enough to
+        // have its own end already rendered from asking for more of them forever.
+        onChange: instance => {
+            if (!instance.isScrolling) {
+                return;
             }
 
-            newStartIndex = Math.max(0, newStartIndex - beforeAfterBufferCount);
+            const lastRenderedIndex = instance.getVirtualIndexes().at(-1);
 
-            let newEndIndex = newStartIndex;
-            let visibleHeight = 0;
-            const containerHeight = clientHeight;
-
-            while (
-                newEndIndex < items.length &&
-                visibleHeight < containerHeight + beforeAfterBufferCount * estimatedItemHeight
+            if (
+                lastRenderedIndex !== undefined &&
+                lastRenderedIndex >= instance.options.count - loadMoreBufferCount
             ) {
-                // newEndIndex is provably valid (parallel arrays: items.length === itemHeights.length)
-                const height = getIndexOrThrow(itemHeights, newEndIndex);
-                visibleHeight += height;
-                newEndIndex++;
+                debouncedOnScrollEnd?.();
             }
-            newEndIndex = Math.min(items.length, newEndIndex + beforeAfterBufferCount);
-
-            setIndexes({
-                startIndex: newStartIndex,
-                endIndex: newEndIndex,
-            });
-
-            if (newEndIndex >= items.length - loadMoreBufferCount) {
-                debouncedOnScrollEnd();
-            }
-            onScroll?.(e);
         },
-        [
-            beforeAfterBufferCount,
-            containerRef,
-            debouncedOnScrollEnd,
-            estimatedItemHeight,
-            itemHeights,
-            items.length,
-            loadMoreBufferCount,
-            onScroll,
-        ],
-    );
+    });
 
     useEffect(() => {
-        const container = containerRef.current;
-        if (container) {
-            container.addEventListener('scroll', handleScroll, { passive: true });
+        // The virtualizer caches item sizes and does not watch `estimateSize`, so it has to be
+        // told to recalculate them whenever the items — and with them their heights — change.
+        virtualizer.measure();
 
-            return () => container.removeEventListener('scroll', handleScroll);
+        if (resetScrollOnItemsChange && containerRef.current) {
+            containerRef.current.scrollTop = 0;
         }
-    }, [containerRef, handleScroll]);
+    }, [items, resetScrollOnItemsChange, virtualizer, containerRef]);
 
     const frameProps = pickAndPrepareFrameProps(
         rest,
         allowedVirtualizedListFrameProps,
     ) as TransientProps<AllowedFrameProps>;
 
-    const firstItemTop = useMemo(
-        () => itemHeights.slice(0, indexes.startIndex).reduce((acc, h) => acc + h, 0),
-        [itemHeights, indexes.startIndex],
-    );
-
     return (
-        <Container ref={ref} $height={listHeight} $minHeight={listMinHeight} {...frameProps}>
-            <Content style={{ height: `${totalHeight}px` }}>
-                {/* TODO: use https://react-window.vercel.app/list/variable-row-height or something that's already optimized */}
-                {itemHeights.slice(indexes.startIndex, indexes.endIndex).map((height, index) => {
-                    const itemIndex = indexes.startIndex + index;
+        <Container
+            ref={containerRef}
+            $height={listHeight}
+            $minHeight={listMinHeight}
+            {...frameProps}
+        >
+            <Content style={{ height: `${virtualizer.getTotalSize()}px` }}>
+                {scrollSentinels}
+                {virtualizer.getVirtualItems().map(virtualItem => {
+                    const item = items[virtualItem.index];
 
-                    if (!items[itemIndex]) return null;
-
-                    const itemTop =
-                        firstItemTop +
-                        itemHeights
-                            .slice(indexes.startIndex, itemIndex)
-                            .reduce((acc, h) => acc + h, 0);
+                    if (!item) return null;
 
                     return (
                         <Item
-                            key={itemIndex}
+                            key={virtualItem.key}
+                            ref={virtualizer.measureElement}
+                            data-index={virtualItem.index}
                             style={{
-                                transform: `translateY(${itemTop}px)`,
-                                height,
+                                transform: `translateY(${virtualItem.start}px)`,
                             }}
                         >
-                            {renderItem(items[itemIndex], itemIndex)}
+                            {renderItem(item, virtualItem)}
                         </Item>
                     );
                 })}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -133,7 +133,11 @@ export type { BannerIntent } from './components/Banner/types';
 export { Table, type TableProps } from './components/Table/Table';
 export { Tabs, type TabsProps } from './components/Tabs/Tabs';
 export { SubTabs, type SubTabsProps } from './components/SubTabs/SubTabs';
-export { VirtualizedList, type BaseItemProps } from './components/VirtualizedList/VirtualizedList';
+export {
+    VirtualizedList,
+    type BaseItemProps,
+    type VirtualizedListProps,
+} from './components/VirtualizedList/VirtualizedList';
 export { List, type ListProps } from './components/List/List';
 export { StoryColumn, StoryWrapper } from './support/Story';
 export {

--- a/packages/components/src/utils/useScrollShadow.tsx
+++ b/packages/components/src/utils/useScrollShadow.tsx
@@ -4,18 +4,24 @@ import styled, { type DefaultTheme } from 'styled-components';
 
 import { type Color } from '@trezor/theme';
 
-type GradientDirection = 'bottom' | 'top' | 'right' | 'left';
+type ScrollEdge = 'bottom' | 'top' | 'right' | 'left';
 
-interface GradientProps {
+type GradientProps = {
     $isVisible: boolean;
     $backgroundColor?: Color;
-    $direction: GradientDirection;
-}
+    $direction: ScrollEdge;
+};
 
 type MapArgs = {
-    $direction: GradientDirection;
+    $direction: ScrollEdge;
     $backgroundColor?: Color;
     theme: DefaultTheme;
+};
+
+type EdgeSentinelProps = {
+    edge: ScrollEdge;
+    rootRef: RefObject<HTMLDivElement | null>;
+    onReachedChange: (edge: ScrollEdge, isReached: boolean) => void;
 };
 
 type UseScrollShadowProps = {
@@ -29,7 +35,7 @@ export const mapDirectionToGradient = ({
     theme,
 }: MapArgs): string => {
     const gradientColor = $backgroundColor ? theme[$backgroundColor] : theme.surfaceFillRaised;
-    const gradientMap: Record<GradientDirection, GradientDirection> = {
+    const gradientMap: Record<ScrollEdge, ScrollEdge> = {
         top: 'bottom',
         bottom: 'top',
         left: 'right',
@@ -61,92 +67,151 @@ const Gradient = styled.div<GradientProps>`
         mapDirectionToGradient({ $direction, $backgroundColor, theme })};
 `;
 
+// Kept out of flow so it cannot grow the scrollable area, and 1px thick rather than empty so
+// that it stays a reliably observable target.
+const Sentinel = styled.div<{ $edge: ScrollEdge }>`
+    position: absolute;
+    ${({ $edge }) => `${$edge}: 0;`}
+    ${({ $edge }) =>
+        $edge === 'left' || $edge === 'right'
+            ? 'top: 0; bottom: 0; width: 1px;'
+            : 'left: 0; right: 0; height: 1px;'}
+    pointer-events: none;
+`;
+
+const SCROLL_EDGES = ['top', 'bottom', 'left', 'right'] as const satisfies ScrollEdge[];
+
+const ALL_EDGES_REACHED: Record<ScrollEdge, boolean> = {
+    top: true,
+    bottom: true,
+    left: true,
+    right: true,
+};
+
+// A probe pinned to one edge of the scrolled content. The observer reports it as intersecting
+// exactly while that edge is inside the viewport of the scroll container, which is what the
+// shadow on the opposite side of the container needs to know.
+const EdgeSentinel = ({ edge, rootRef, onReachedChange }: EdgeSentinelProps) => {
+    const sentinelRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const root = rootRef.current;
+        const sentinel = sentinelRef.current;
+
+        if (!root || !sentinel) {
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            entries => {
+                const latestEntry = entries.at(-1);
+
+                if (latestEntry) {
+                    onReachedChange(edge, latestEntry.isIntersecting);
+                }
+            },
+            { root },
+        );
+
+        observer.observe(sentinel);
+
+        return () => {
+            observer.disconnect();
+            // With nothing left to observe there is nothing to shade either, so the edge counts
+            // as reached instead of keeping the last known state around.
+            onReachedChange(edge, true);
+        };
+    }, [edge, rootRef, onReachedChange]);
+
+    return <Sentinel ref={sentinelRef} $edge={edge} />;
+};
+
+/**
+ * Gradients that fade out the content still hidden beyond an edge of a scroll container.
+ *
+ * Which edges are reached is resolved by an `IntersectionObserver` watching sentinels placed at
+ * the edges of the content, so scrolling neither runs a handler nor reads layout properties such
+ * as `scrollTop` — reading those forces a synchronous reflow on every scroll event.
+ *
+ * `ScrollSentinels` therefore has to be rendered inside the scroll container, in an element that
+ * is `position: relative` and spans the whole scrollable content; the sentinels are positioned
+ * against that element.
+ */
 export const useScrollShadow = ({ externalRef, backgroundColor }: UseScrollShadowProps = {}) => {
     const internalRef = useRef<HTMLDivElement | null>(null);
     const scrollElementRef = externalRef || internalRef;
 
-    const [isScrolledToTop, setIsScrolledToTop] = useState(true);
-    const [isScrolledToBottom, setIsScrolledToBottom] = useState(true);
-    const [isScrolledToLeft, setIsScrolledToLeft] = useState(true);
-    const [isScrolledToRight, setIsScrolledToRight] = useState(true);
+    const [reachedEdges, setReachedEdges] = useState(ALL_EDGES_REACHED);
 
-    const setShadows = useCallback(() => {
-        if (scrollElementRef?.current) {
-            const { scrollTop, scrollHeight, clientHeight, scrollLeft, scrollWidth, clientWidth } =
-                scrollElementRef.current;
+    const handleReachedChange = useCallback((edge: ScrollEdge, isReached: boolean) => {
+        setReachedEdges(previous =>
+            previous[edge] === isReached ? previous : { ...previous, [edge]: isReached },
+        );
+    }, []);
 
-            setIsScrolledToTop(scrollTop === 0);
-            setIsScrolledToBottom(Math.ceil(scrollTop + clientHeight) >= scrollHeight);
-            setIsScrolledToLeft(scrollLeft === 0);
-            setIsScrolledToRight(Math.ceil(scrollLeft + clientWidth) >= scrollWidth);
-        }
-    }, [scrollElementRef]);
-
-    useEffect(() => {
-        setShadows();
-
-        const observer = new ResizeObserver(() => {
-            setShadows();
-        });
-
-        if (scrollElementRef?.current) {
-            observer.observe(scrollElementRef.current);
-        }
-
-        return () => {
-            observer.disconnect();
-        };
-    }, [scrollElementRef, setShadows]);
-
-    const onScroll = useCallback(setShadows, [setShadows]);
+    const ScrollSentinels = useCallback(
+        () => (
+            <>
+                {SCROLL_EDGES.map(edge => (
+                    <EdgeSentinel
+                        key={edge}
+                        edge={edge}
+                        rootRef={scrollElementRef}
+                        onReachedChange={handleReachedChange}
+                    />
+                ))}
+            </>
+        ),
+        [scrollElementRef, handleReachedChange],
+    );
 
     const ShadowTop = useCallback(
         () => (
             <Gradient
                 $backgroundColor={backgroundColor}
-                $isVisible={!isScrolledToTop}
+                $isVisible={!reachedEdges.top}
                 $direction="top"
             />
         ),
-        [backgroundColor, isScrolledToTop],
+        [backgroundColor, reachedEdges.top],
     );
 
     const ShadowBottom = useCallback(
         () => (
             <Gradient
                 $backgroundColor={backgroundColor}
-                $isVisible={!isScrolledToBottom}
+                $isVisible={!reachedEdges.bottom}
                 $direction="bottom"
             />
         ),
-        [backgroundColor, isScrolledToBottom],
+        [backgroundColor, reachedEdges.bottom],
     );
 
     const ShadowLeft = useCallback(
         () => (
             <Gradient
                 $backgroundColor={backgroundColor}
-                $isVisible={!isScrolledToLeft}
+                $isVisible={!reachedEdges.left}
                 $direction="left"
             />
         ),
-        [backgroundColor, isScrolledToLeft],
+        [backgroundColor, reachedEdges.left],
     );
 
     const ShadowRight = useCallback(
         () => (
             <Gradient
                 $backgroundColor={backgroundColor}
-                $isVisible={!isScrolledToRight}
+                $isVisible={!reachedEdges.right}
                 $direction="right"
             />
         ),
-        [backgroundColor, isScrolledToRight],
+        [backgroundColor, reachedEdges.right],
     );
 
     return {
         scrollElementRef,
-        onScroll,
+        ScrollSentinels,
         ShadowContainer,
         ShadowTop,
         ShadowBottom,

--- a/packages/suite/jest.setup.js
+++ b/packages/suite/jest.setup.js
@@ -36,3 +36,16 @@ Object.defineProperty(window, 'matchMedia', {
         dispatchEvent: jest.fn(),
     })),
 });
+
+// jsdom implements no IntersectionObserver, while components that watch the edges of their own
+// scrollable content — the scroll shadows of `useScrollShadow` — construct one as they mount.
+if (!globalThis.IntersectionObserver) {
+    globalThis.IntersectionObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+            return [];
+        }
+    };
+}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetsList/AssetsList.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetsList/AssetsList.tsx
@@ -1,12 +1,17 @@
-import { type ReactNode, type RefObject, memo, useCallback, useState } from 'react';
+import { type RefObject, memo, useMemo } from 'react';
 
-import { type BaseItemProps, VirtualizedList, useScrollShadow } from '@trezor/components';
+import {
+    type BaseItemProps,
+    VirtualizedList,
+    type VirtualizedListProps,
+    useScrollShadow,
+} from '@trezor/components';
 
-export interface AssetsListProps<T> {
+export interface AssetsListProps<T extends BaseItemProps> {
     items: T[];
-    renderItem: (item: T, index: number) => ReactNode;
-    height: string | number;
-    minHeight?: string | number;
+    renderItem: VirtualizedListProps<T>['renderItem'];
+    height: VirtualizedListProps<T>['listHeight'];
+    minHeight?: VirtualizedListProps<T>['listMinHeight'];
     ref?: RefObject<HTMLDivElement | null>;
 }
 
@@ -19,13 +24,15 @@ function AssetsListInner<T extends BaseItemProps>({
     minHeight = LIST_MIN_HEIGHT,
     ref,
 }: AssetsListProps<T>) {
-    const { onScroll, ShadowTop, ShadowBottom, ShadowContainer } = useScrollShadow({
-        externalRef: ref,
-        backgroundColor: 'surfaceFillModal',
-    });
+    const { scrollElementRef, ScrollSentinels, ShadowTop, ShadowBottom, ShadowContainer } =
+        useScrollShadow({
+            externalRef: ref,
+            backgroundColor: 'surfaceFillModal',
+        });
 
-    const [end, setEnd] = useState(items.length);
-    const onScrollEnd = useCallback(() => setEnd(end + 1000), [end]);
+    // Kept referentially stable so that the shadows switching on and off cannot re-render the
+    // list itself.
+    const scrollSentinels = useMemo(() => <ScrollSentinels />, [ScrollSentinels]);
 
     return (
         <ShadowContainer>
@@ -33,15 +40,11 @@ function AssetsListInner<T extends BaseItemProps>({
             <VirtualizedList
                 items={items}
                 padding={8}
-                ref={ref}
-                onScroll={onScroll}
+                ref={scrollElementRef}
+                scrollSentinels={scrollSentinels}
                 renderItem={renderItem}
-                onScrollEnd={onScrollEnd}
                 listHeight={height}
                 listMinHeight={minHeight}
-                visibleItemsCount={20}
-                beforeAfterBufferCount={30}
-                loadMoreBufferCount={5}
                 resetScrollOnItemsChange={false}
             />
             <ShadowBottom />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx
@@ -21,16 +21,11 @@ import {
 
 import { useApplicationLogs } from 'src/utils/suite/logsUtils';
 
+// The height sits on the scrolling element rather than on the log, so that the log spans the
+// whole scrollable content and the scroll shadow sentinels inside it land on its very edges.
 const ScrollContainer = styled.div`
     overflow: auto;
-`;
-
-const LogWrapper = styled.pre`
-    padding: 16px;
     height: 350px;
-    width: 100%;
-    text-align: left;
-    word-break: break-all;
 
     ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
         height: 320px;
@@ -41,13 +36,21 @@ const LogWrapper = styled.pre`
     }
 `;
 
+const LogWrapper = styled.pre`
+    position: relative;
+    padding: 16px;
+    width: 100%;
+    text-align: left;
+    word-break: break-all;
+`;
+
 type ApplicationLogModalProps = { onCancel: () => void };
 
 export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [hideSensitiveInfo, setHideSensitiveInfo] = useState(false);
     const applicationLogs = useApplicationLogs({ hideSensitiveInfo });
-    const { ShadowTop, ShadowBottom, ShadowContainer, onScroll, scrollElementRef } =
+    const { ShadowTop, ShadowBottom, ShadowContainer, ScrollSentinels, scrollElementRef } =
         useScrollShadow();
 
     const download = () => {
@@ -93,8 +96,9 @@ export const ApplicationLogModal = ({ onCancel }: ApplicationLogModalProps) => {
             <Card paddingType="none" margin={{ top: 12 }} overflow="hidden">
                 <ShadowContainer>
                     <ShadowTop />
-                    <ScrollContainer onScroll={onScroll} ref={scrollElementRef}>
+                    <ScrollContainer ref={scrollElementRef}>
                         <LogWrapper data-testid="@log/content">
+                            <ScrollSentinels />
                             <Text typographyStyle="body-xs">{applicationLogs}</Text>
                         </LogWrapper>
                     </ScrollContainer>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -2,6 +2,7 @@ import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
+import { Row } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -32,14 +33,16 @@ export const AccountSection = ({ account, tokens, selected }: AccountSectionProp
             dataTestKey={dataTestKey}
         />
     ) : (
-        <AccountItem
-            type="coin"
-            key={`${descriptor}-${symbol}`}
-            account={account}
-            isSelected={selected}
-            formattedBalance={formattedBalance}
-            tokens={tokens}
-            dataTestKey={dataTestKey}
-        />
+        <Row>
+            <AccountItem
+                type="coin"
+                key={`${descriptor}-${symbol}`}
+                account={account}
+                isSelected={selected}
+                formattedBalance={formattedBalance}
+                tokens={tokens}
+                dataTestKey={dataTestKey}
+            />
+        </Row>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -1,77 +1,44 @@
-import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
+import { type TokenInfo } from '@trezor/blockchain-link-types';
 
 import { useSelector } from 'src/hooks/suite';
-import { type AccountItemType } from 'src/types/wallet';
-import { getTokens } from 'src/utils/wallet/tokenUtils';
 
 import { AccountItem } from './AccountItem/AccountItem';
 import { AccountItemsGroup } from './AccountItemsGroup';
 
 interface AccountSectionProps {
     account: Account;
-    forceOnlyItemClick?: boolean;
-    hideStaking?: boolean;
+    tokens: TokenInfo[];
     selected: boolean;
-    onItemClick?: (account: Account, type: AccountItemType) => void;
 }
 
-export const AccountSection = ({
-    account,
-    forceOnlyItemClick,
-    hideStaking,
-    selected,
-    onItemClick,
-}: AccountSectionProps) => {
-    const {
-        symbol,
-        accountType,
-        index,
-        descriptor,
-        formattedBalance,
-        tokens: accountTokens = [],
-    } = account;
-
-    const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
+export const AccountSection = ({ account, tokens, selected }: AccountSectionProps) => {
+    const { symbol, accountType, index, descriptor, formattedBalance } = account;
 
     const showGroup = hasNetworkFeatures(account, 'tokens');
 
-    const isStakeShownStored = useSelector(state =>
-        selectAccountIsStakingActive(state, account.key),
-    );
-    const isStakeShown = !hideStaking && isStakeShownStored;
-
-    const tokens = getTokens({
-        tokens: accountTokens,
-        symbol: account.symbol,
-        tokenDefinitions: coinDefinitions,
-    });
-
+    const isStakeShown = useSelector(state => selectAccountIsStakingActive(state, account.key));
     const dataTestKey = `@account-menu/${symbol}/${accountType}/${index}`;
 
-    return showGroup && (isStakeShown || tokens.shownWithBalance.length) ? (
+    return showGroup && (isStakeShown || tokens.length) ? (
         <AccountItemsGroup
             key={`${descriptor}-${symbol}`}
-            forceOnlyItemClick={forceOnlyItemClick}
             account={account}
             selected={selected}
             showStaking={isStakeShown}
-            tokens={tokens.shownWithBalance}
+            tokens={tokens}
             dataTestKey={dataTestKey}
-            onItemClick={onItemClick}
         />
     ) : (
         <AccountItem
             type="coin"
             key={`${descriptor}-${symbol}`}
-            forceOnlyItemClick={forceOnlyItemClick}
             account={account}
             isSelected={selected}
-            onClick={onItemClick}
             formattedBalance={formattedBalance}
-            tokens={tokens.shownWithBalance}
+            tokens={tokens}
             dataTestKey={dataTestKey}
         />
     );

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -24,7 +24,7 @@ import { AccountSection } from './AccountSection';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
 
 const SECTION_GAP = 4;
-const OVERSCAN_SECTION_COUNT = 15;
+const OVERSCAN_SECTION_COUNT = 8;
 
 // The list is bled into by the negative margins of grouped sections, so it carries the
 // horizontal padding they need to bleed into.

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { type ReactNode, type RefObject, memo, useCallback, useMemo } from 'react';
 
 import { getDefaultAccountLabel } from '@suite/account';
 import { selectCoinjoinIsPreloading } from '@suite/coinjoin';
@@ -8,15 +8,12 @@ import { type RouteParams, selectRouterParams } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
 import { selectTokenDefinitions } from '@suite-common/token-definitions';
-import {
-    type GetTokensOutputType,
-    getTokens,
-    selectAllAccountsToList,
-} from '@suite-common/wallet-core';
+import { getTokens, selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { accountSearchFn, getAccountTypeName } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
-import { Column } from '@trezor/components';
+import { type BaseItemProps, VirtualizedList } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
 
 import { useAccountSearch, useSelector } from 'src/hooks/suite';
 import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
@@ -26,38 +23,35 @@ import { AccountItemSkeleton } from './AccountItemSkeleton';
 import { AccountSection } from './AccountSection';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
 
-type AccountsProps = {
-    accountsWithTokens: {
-        account: Account;
-        tokens: GetTokensOutputType<TokenInfo>;
-    }[];
+const SECTION_GAP = 4;
+const OVERSCAN_SECTION_COUNT = 15;
+
+// The list is bled into by the negative margins of grouped sections, so it carries the
+// horizontal padding they need to bleed into.
+const LIST_PADDING = { horizontal: 8, bottom: 20 } as const;
+
+// Every section is measured once it mounts; this is only the starting guess used to size the
+// scrollbar for sections that have not been rendered yet. A plain account row is 58px tall.
+const ESTIMATED_SECTION_HEIGHT = 58;
+
+const SKELETON_ITEM_KEY = 'coinjoin-preloading-skeleton';
+
+type AccountsListItem = BaseItemProps &
+    (
+        | {
+              kind: 'account';
+              account: Account;
+              tokens: TokenInfo[];
+          }
+        | { kind: 'skeleton' }
+    );
+
+type AccountsListProps = {
+    scrollElementRef: RefObject<HTMLDivElement | null>;
+    scrollSentinels: ReactNode;
 };
 
-const Accounts = memo(({ accountsWithTokens }: AccountsProps) => {
-    const params = useSelector(selectRouterParams) as RouteParams;
-
-    return (
-        <>
-            {accountsWithTokens.map(({ account, tokens }) => {
-                const selected =
-                    account.symbol === params?.symbol &&
-                    account.accountType === params.accountType &&
-                    account.index === params.accountIndex;
-
-                return (
-                    <AccountSection
-                        key={account.key}
-                        account={account}
-                        tokens={tokens.shownWithBalance}
-                        selected={selected}
-                    />
-                );
-            })}
-        </>
-    );
-});
-
-export const AccountsList = memo(() => {
+export const AccountsList = memo(({ scrollElementRef, scrollSentinels }: AccountsListProps) => {
     const device = useSelector(selectSelectedDevice);
     const baseAccounts = useSelector(selectAllAccountsToList);
 
@@ -71,6 +65,7 @@ export const AccountsList = memo(() => {
             device?.state?.staticSessionId ?? null,
         ),
     );
+    const params = useSelector(selectRouterParams) as RouteParams;
 
     const { translationString } = useTranslation();
     const { isSidebarCollapsed } = useResponsiveContext();
@@ -134,16 +129,74 @@ export const AccountsList = memo(() => {
         ],
     );
 
+    const isPreloadingSkeletonShown = coinjoinIsPreloading && !searchString && !coinFilter;
+
+    const items = useMemo((): AccountsListItem[] => {
+        const accountItems = filteredAccounts.map(({ account, tokens }): AccountsListItem => ({
+            kind: 'account',
+            account,
+            tokens: tokens.shownWithBalance,
+            height: ESTIMATED_SECTION_HEIGHT,
+        }));
+
+        if (isPreloadingSkeletonShown) {
+            return [...accountItems, { kind: 'skeleton', height: ESTIMATED_SECTION_HEIGHT }];
+        }
+
+        return accountItems;
+    }, [filteredAccounts, isPreloadingSkeletonShown]);
+
+    // Keying by account makes a measured section height survive searching and reordering.
+    const getItemKey = useCallback(
+        (item: AccountsListItem) =>
+            item.kind === 'account' ? item.account.key : SKELETON_ITEM_KEY,
+        [],
+    );
+
+    const renderItem = useCallback(
+        (item: AccountsListItem) => {
+            switch (item.kind) {
+                case 'account': {
+                    const { account, tokens } = item;
+                    const selected =
+                        account.symbol === params?.symbol &&
+                        account.accountType === params.accountType &&
+                        account.index === params.accountIndex;
+
+                    return <AccountSection account={account} tokens={tokens} selected={selected} />;
+                }
+                case 'skeleton':
+                    return <AccountItemSkeleton />;
+                default:
+                    return exhaustive(item);
+            }
+        },
+        [params],
+    );
+
     if (!device) {
         return null;
     }
 
-    if (filteredAccounts.length > 0) {
+    if (items.length > 0) {
         return (
-            <Column gap={4} margin={{ bottom: 20, left: 8, right: 8 }}>
-                <Accounts accountsWithTokens={filteredAccounts} />
-                {coinjoinIsPreloading && !searchString && !coinFilter && <AccountItemSkeleton />}
-            </Column>
+            <VirtualizedList
+                ref={scrollElementRef}
+                items={items}
+                renderItem={renderItem}
+                getItemKey={getItemKey}
+                scrollSentinels={scrollSentinels}
+                listHeight="100%"
+                listMinHeight={0}
+                padding={LIST_PADDING}
+                gap={SECTION_GAP}
+                overscan={OVERSCAN_SECTION_COUNT}
+                // A section is measured rather than sized, and both its height and the scroll
+                // position have to survive the list changing under an open sidebar.
+                resetItemHeightsOnItemsChange={false}
+                resetScrollOnItemsChange={false}
+                measureItems
+            />
         );
     }
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -1,3 +1,5 @@
+import { memo, useMemo } from 'react';
+
 import { getDefaultAccountLabel } from '@suite/account';
 import { selectCoinjoinIsPreloading } from '@suite/coinjoin';
 import { Translation, useTranslation } from '@suite/intl';
@@ -6,40 +8,37 @@ import { type RouteParams, selectRouterParams } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
 import { selectTokenDefinitions } from '@suite-common/token-definitions';
-import { getTokens, selectAllAccountsToList } from '@suite-common/wallet-core';
+import {
+    type GetTokensOutputType,
+    getTokens,
+    selectAllAccountsToList,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { accountSearchFn, getAccountTypeName } from '@suite-common/wallet-utils';
+import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { Column } from '@trezor/components';
 
 import { useAccountSearch, useSelector } from 'src/hooks/suite';
 import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
-import { type AccountItemType } from 'src/types/wallet';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
 import { AccountItemSkeleton } from './AccountItemSkeleton';
 import { AccountSection } from './AccountSection';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
 
-interface AccountListProps {
-    forceOnlyItemClick?: boolean;
-    hideStaking?: boolean;
-    onItemClick?: (account: Account, type: AccountItemType) => void;
-}
-
 type AccountsProps = {
-    accounts: Account[];
-    hideStaking?: boolean;
-    // NOTE: this is to disable completely default click behavior of the item
-    forceOnlyItemClick?: boolean;
-    onItemClick?: (account: Account, type: AccountItemType) => void;
+    accountsWithTokens: {
+        account: Account;
+        tokens: GetTokensOutputType<TokenInfo>;
+    }[];
 };
 
-const Accounts = ({ accounts, forceOnlyItemClick, hideStaking, onItemClick }: AccountsProps) => {
+const Accounts = memo(({ accountsWithTokens }: AccountsProps) => {
     const params = useSelector(selectRouterParams) as RouteParams;
 
     return (
         <>
-            {accounts.map(account => {
+            {accountsWithTokens.map(({ account, tokens }) => {
                 const selected =
                     account.symbol === params?.symbol &&
                     account.accountType === params.accountType &&
@@ -48,23 +47,17 @@ const Accounts = ({ accounts, forceOnlyItemClick, hideStaking, onItemClick }: Ac
                 return (
                     <AccountSection
                         key={account.key}
-                        forceOnlyItemClick={forceOnlyItemClick}
-                        hideStaking={hideStaking}
                         account={account}
+                        tokens={tokens.shownWithBalance}
                         selected={selected}
-                        onItemClick={onItemClick}
                     />
                 );
             })}
         </>
     );
-};
+});
 
-export const AccountsList = ({
-    forceOnlyItemClick,
-    hideStaking,
-    onItemClick,
-}: AccountListProps) => {
+export const AccountsList = memo(() => {
     const device = useSelector(selectSelectedDevice);
     const baseAccounts = useSelector(selectAllAccountsToList);
 
@@ -86,58 +79,69 @@ export const AccountsList = ({
     const discoveryInProgress = discoveryStatus?.status === 'loading';
     const tokenDefinitions = useSelector(selectTokenDefinitions);
 
+    const filteredAccounts = useMemo(
+        () =>
+            accounts
+                .map(account => {
+                    const tokens = getTokens({
+                        tokens: account.tokens ?? [],
+                        symbol: account.symbol,
+                        tokenDefinitions: tokenDefinitions[account.symbol]?.coin,
+                    });
+
+                    return { account, tokens };
+                })
+                .filter(({ account, tokens }) => {
+                    const { key } = account;
+
+                    if (!searchString && !coinFilter) {
+                        return true;
+                    }
+
+                    const accountLabel =
+                        account.label ??
+                        (Object.hasOwn(accountLegacyLabels, key)
+                            ? accountLegacyLabels[key]
+                            : getDefaultAccountLabel(translationString, account)) ??
+                        '';
+
+                    // Mirror the account type badge, which is hidden for normal accounts.
+                    const accountTypeTranslationId =
+                        account.accountType === 'normal'
+                            ? null
+                            : getAccountTypeName({
+                                  path: account.path,
+                                  accountType: account.accountType,
+                                  networkType: account.networkType,
+                              });
+
+                    return accountSearchFn(account, searchString, {
+                        coinsFilter: coinFilter,
+                        accountLabel,
+                        searchableTokens: tokens.shownWithBalance,
+                        accountTypeName: accountTypeTranslationId
+                            ? translationString(accountTypeTranslationId)
+                            : undefined,
+                    });
+                }),
+        [
+            accounts,
+            searchString,
+            coinFilter,
+            accountLegacyLabels,
+            tokenDefinitions,
+            translationString,
+        ],
+    );
+
     if (!device) {
         return null;
     }
 
-    const filteredAccounts =
-        searchString || coinFilter
-            ? accounts.filter(account => {
-                  const { key } = account;
-
-                  const accountLabel =
-                      account.label ??
-                      (Object.prototype.hasOwnProperty.call(accountLegacyLabels, key)
-                          ? accountLegacyLabels[key]
-                          : getDefaultAccountLabel(translationString, account)) ??
-                      '';
-
-                  const { shownWithBalance } = getTokens({
-                      tokens: account.tokens ?? [],
-                      symbol: account.symbol,
-                      tokenDefinitions: tokenDefinitions[account.symbol]?.coin,
-                  });
-
-                  // Mirror the account type badge, which is hidden for normal accounts.
-                  const accountTypeTranslationId =
-                      account.accountType === 'normal'
-                          ? null
-                          : getAccountTypeName({
-                                path: account.path,
-                                accountType: account.accountType,
-                                networkType: account.networkType,
-                            });
-
-                  return accountSearchFn(account, searchString, {
-                      coinsFilter: coinFilter,
-                      accountLabel,
-                      searchableTokens: shownWithBalance,
-                      accountTypeName: accountTypeTranslationId
-                          ? translationString(accountTypeTranslationId)
-                          : undefined,
-                  });
-              })
-            : accounts;
-
     if (filteredAccounts.length > 0) {
         return (
             <Column gap={4} margin={{ bottom: 20, left: 8, right: 8 }}>
-                <Accounts
-                    accounts={filteredAccounts}
-                    hideStaking={hideStaking}
-                    forceOnlyItemClick={forceOnlyItemClick}
-                    onItemClick={onItemClick}
-                />
+                <Accounts accountsWithTokens={filteredAccounts} />
                 {coinjoinIsPreloading && !searchString && !coinFilter && <AccountItemSkeleton />}
             </Column>
         );
@@ -156,4 +160,4 @@ export const AccountsList = ({
             <Translation id="TR_ACCOUNT_SEARCH_NO_RESULTS" />
         </AccountsMenuNotice>
     );
-};
+});

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from 'react';
 
-import styled from 'styled-components';
-
 import { Translation } from '@suite/intl';
 import { selectSelectedDevice } from '@suite-common/device';
-import { useScrollShadow } from '@trezor/components';
+import { Column, useScrollShadow } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 import { ReduxAccountSearchProvider } from 'src/hooks/suite/useAccountSearch';
@@ -14,15 +12,6 @@ import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOv
 import { AccountsList } from './AccountsList';
 import { AccountsMenuHeader } from './AccountsMenuHeader';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
-
-// The account list scrolls itself and positions its sections against its own height, so the
-// area it lives in has to be definite rather than growing with the content.
-const ListArea = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
-`;
 
 export const AccountsMenu = () => {
     const device = useSelector(selectSelectedDevice);
@@ -56,7 +45,7 @@ export const AccountsMenu = () => {
     return (
         <ReduxAccountSearchProvider>
             <AccountsMenuHeader />
-            <ListArea>
+            <Column minHeight={0}>
                 <ShadowContainer>
                     <ShadowTop />
                     <AccountsList
@@ -65,7 +54,7 @@ export const AccountsMenu = () => {
                     />
                     <ShadowBottom />
                 </ShadowContainer>
-            </ListArea>
+            </Column>
         </ReduxAccountSearchProvider>
     );
 };

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
@@ -13,19 +15,27 @@ import { AccountsList } from './AccountsList';
 import { AccountsMenuHeader } from './AccountsMenuHeader';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
 
-const ScrollContainer = styled.div`
-    height: auto;
-    overflow: hidden auto;
+// The account list scrolls itself and positions its sections against its own height, so the
+// area it lives in has to be definite rather than growing with the content.
+const ListArea = styled.div`
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
 `;
 
 export const AccountsMenu = () => {
     const device = useSelector(selectSelectedDevice);
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const { scrollElementRef, onScroll, ShadowTop, ShadowBottom, ShadowContainer } =
+    const { scrollElementRef, ScrollSentinels, ShadowTop, ShadowBottom, ShadowContainer } =
         useScrollShadow({
             backgroundColor: 'surfaceFillSunken',
         });
     const { isSidebarCollapsed } = useResponsiveContext();
+
+    // Kept referentially stable so that the shadows switching on and off cannot re-render the
+    // list itself.
+    const scrollSentinels = useMemo(() => <ScrollSentinels />, [ScrollSentinels]);
 
     const isDiscoveryEmpty = discoveryStatus?.type === 'discovery-empty';
 
@@ -46,13 +56,16 @@ export const AccountsMenu = () => {
     return (
         <ReduxAccountSearchProvider>
             <AccountsMenuHeader />
-            <ShadowContainer>
-                <ShadowTop />
-                <ScrollContainer ref={scrollElementRef} onScroll={onScroll}>
-                    <AccountsList />
-                </ScrollContainer>
-                <ShadowBottom />
-            </ShadowContainer>
+            <ListArea>
+                <ShadowContainer>
+                    <ShadowTop />
+                    <AccountsList
+                        scrollElementRef={scrollElementRef}
+                        scrollSentinels={scrollSentinels}
+                    />
+                    <ShadowBottom />
+                </ShadowContainer>
+            </ListArea>
         </ReduxAccountSearchProvider>
     );
 };

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -62,3 +62,4 @@ viem
 @tanstack/eslint-plugin-query
 orval
 up-fetch
+@tanstack/react-virtual

--- a/yarn.lock
+++ b/yarn.lock
@@ -16604,6 +16604,7 @@ __metadata:
     "@storybook/react-webpack5": "npm:^10.3.4"
     "@suite-common/flags": "workspace:*"
     "@suite-common/illustrations": "workspace:*"
+    "@tanstack/react-virtual": "npm:^3.13.9"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.3.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- I went to a rabbit whole while doing profiling during CR and I detected several perf issues.
- I recored several times that the 1st render of `AccountsMenu` (the sidebar with accounts) takes over 170ms, now it's down to ~40ms.

Before:
<img width="1649" height="1179" alt="Snímek obrazovky 2026-08-21 v 11 07 38" src="https://github.com/user-attachments/assets/5d2327a6-2974-4ef0-8360-a63d16d60af5" />

After:
<img width="1435" height="1559" alt="Snímek obrazovky 2026-08-21 v 14 06 21" src="https://github.com/user-attachments/assets/f2faf8bd-de24-4589-a7c5-54797c3f73ff" />

---

<img width="839" height="527" alt="Snímek obrazovky 2026-08-24 v 12 10 11" src="https://github.com/user-attachments/assets/9c03bae0-e453-44a0-9323-49443263b0fb" />

## Changes
- memoize mapping/filterring accounts in `AccountsMenu`
- replace slow measurement methods with obseversers
- use better performant SDK for virtualization
- also virtualize accounts in the sidebar
 

## Notes for QA

Please test that list renders correctly: asset pickers, accounts in sidebar. 

## Related Issue

Resolve #31476

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set focuses on shared UI components (Modal, Table, VirtualizedList, scroll shadows), the asset picker list, the application log modal, and the accounts menu. Because the broad shared components are imported by most tests, I selected a small set of representative tests that directly exercise the affected surfaces: asset picker navigation, account search/add, application log modal, and long transaction/swap-history lists. These cover the highest-risk rendering and interaction paths without running the full suite.

<details><summary><b>Changed files (13)</b></summary>

- `packages/components/package.json`
- `packages/components/src/components/Modal/Modal.tsx`
- `packages/components/src/components/Table/Table.tsx`
- `packages/components/src/components/VirtualizedList/VirtualizedList.stories.tsx`
- `packages/components/src/components/VirtualizedList/VirtualizedList.test.tsx`
- `packages/components/src/components/VirtualizedList/VirtualizedList.tsx`
- `packages/components/src/index.ts`
- `packages/components/src/utils/useScrollShadow.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetsList/AssetsList.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ApplicationLogModal.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/settings/application-log.test.ts` — This test directly opens and asserts the ApplicationLogModal, which is one of the changed files, and relies on the Modal component to render and export logs correctly.
- `suite/e2e/tests/trading/navigation.test.ts` — Exercises the asset picker (AssetsList) repeatedly for buy, sell, and swap flows across coins and tokens, so changes to AssetsList would be immediately visible here.
- `suite/e2e/tests/wallet/account-search.test.ts` — Directly tests account search and filtering in the left sidebar, which is rendered by the changed AccountsMenu, AccountsList, and AccountSection components.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Adds multiple account types and verifies the account list updates correctly, directly exercising the AccountsList/AccountSection rendering logic.
- `suite/e2e/tests/wallet/pagination.test.ts` — Navigates a long paginated transaction list, which is the primary code path for the changed VirtualizedList, Table, and useScrollShadow utilities.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Toggles between grid and table views of assets; Table changes could affect the table layout or rendering of asset rows.
- `suite/e2e/tests/general/suite-guide.test.ts` — Opens the Guide panel over an existing modal and exercises modal overlay behavior, so Modal changes could break guide interactions.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Edits account labels and searches accounts in the sidebar, relying on AccountsMenu/AccountsList to render and update labels correctly.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Uses the asset picker (AssetsList) to select Ethereum and proceeds through trade preview/confirmation modals, covering both asset picker and modal changes.
- `suite/e2e/tests/trading/swap-history.test.ts` — Displays a long list of past swap trades, which likely uses VirtualizedList/Table and could be affected by list or scroll-shadow changes.
- `suite/e2e/tests/wallet/discovery.test.ts` — Discovers many coins and renders the resulting accounts and balances, exercising the AccountsMenu with a populated account list.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Uses the global asset picker (AssetsList) and account picker in receive/send flows, so both asset list and account menu changes could regress.
- `suite/e2e/tests/wallet/transactions.test.ts` — Interacts with the transaction list table and summary, which uses Table/VirtualizedList rendering paths.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/components/package.json`
- `packages/components/src/components/VirtualizedList/VirtualizedList.stories.tsx`
- `packages/components/src/components/VirtualizedList/VirtualizedList.test.tsx`
- `packages/components/src/index.ts`

_Updated: 2026-08-21T13:20:06.201Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/accounts-list/web/](https://dev.suite.sldev.cz/suite-web/perf/accounts-list/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/accounts-list&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/accounts-list&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-25T07:26:35.284Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-25T07:26:43.742Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->