### PR TITLE
chore(suite-desktop): cleanup unused options on logger desktopApi

### DIFF
--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -81,18 +81,9 @@ export type HandshakeElectron = {
     };
 };
 
-interface LoggerOptions {
-    colors?: boolean;
-    writeToConsole?: boolean;
-    writeToDisk?: boolean;
-    outputFile?: string;
-    outputPath?: string;
-    logFormat?: string;
-}
-
 export interface LoggerConfig {
     level?: 'mute' | 'error' | 'warn' | 'info' | 'debug';
-    options?: LoggerOptions;
+    writeToDisk?: boolean;
 }
 
 export interface UpdateInfo {

--- a/packages/suite-desktop-core/src/modules/event-logging/index.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/index.ts
@@ -6,9 +6,8 @@ export const SERVICE_NAME = 'event-logging';
 export const init: ModuleInit = () => {
     const { logger } = global;
 
-    ipcMain.on('logger/config', (_, { level, options }) => {
+    ipcMain.on('logger/config', (_, { level, writeToDisk }) => {
         logger.level = level;
-
-        logger.config = options;
+        logger.config.writeToDisk = writeToDisk === true;
     });
 };

--- a/packages/suite-desktop-ui/src/MainDesktop.tsx
+++ b/packages/suite-desktop-ui/src/MainDesktop.tsx
@@ -78,9 +78,7 @@ export const init = async (container: HTMLElement) => {
     if (preloadAction?.type === STORAGE.LOAD && preloadAction.payload.debug?.showDebugMenu) {
         desktopApi.configLogger({
             level: 'debug',
-            options: {
-                writeToDisk: true,
-            },
+            writeToDisk: true,
         });
     }
 

--- a/suite/debug/src/useDebugModeActivator.ts
+++ b/suite/debug/src/useDebugModeActivator.ts
@@ -24,9 +24,7 @@ export const useToggleDebugMode = () => {
                 shouldEnableDebugMode
                     ? {
                           level: 'debug',
-                          options: {
-                              writeToDisk: true,
-                          },
+                          writeToDisk: true,
                       }
                     : {},
             );


### PR DESCRIPTION
## Description

Electron Main IPC `'logger/config'` has unnecessarily generous options interface but most options are unused, only `writeToDisk true/false` is needed by Renderer.
Notably, the unused options include `outputFile` and `outputPath` which present an opportunity for abuse.

→ simplify to only what is needed

## Related issues

Part of https://github.com/trezor/trezor-suite-private/issues/225

## Notes for QA

See that:
- activating debug mode starts logging into file
- deactivating debug mode stops logging into file

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/cleanup-unused-options-on-logger-desktopApi/web/](https://dev.suite.sldev.cz/suite-web/chore/cleanup-unused-options-on-logger-desktopApi/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all desktop-specific infrastructure: the desktop API message contract, the core event-logging module, the desktop UI shell, and a debug-mode activation hook. There is no static coverage mapping, so recommendations are inferred from the LLM analysis. The highest-value test is the Trezor Connect silent-mode spec because it directly asserts desktop IPC events and focus behavior. Bridge spawn tests and the offline onboarding test add confidence around desktop app startup and lifecycle. The debug-mode activator hook is not directly exercised by any identified test.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite-desktop-api/src/messages.ts`
- `packages/suite-desktop-core/src/modules/event-logging/index.ts`
- `packages/suite-desktop-ui/src/MainDesktop.tsx`
- `suite/debug/src/useDebugModeActivator.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test directly exercises the desktop API IPC layer it checks `app/focus` and `appIsVisible` events, connect permissions, and the connect settings tab, all of which depend on the desktop message contract (`messages.ts`), desktop core event logging (`event-logging/index.ts`), and the desktop UI shell (`MainDesktop.tsx`). A regression in any of those files would likely surface here.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Validates Electron desktop app launch in daemon mode and the bridge lifecycle, which relies on the desktop core initializing correctly and emitting the right internal events. Changes to `MainDesktop.tsx` or desktop core event logging could break app startup or bridge state reporting.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Covers normal Electron app launch, bundled bridge spawning, and app initialization. This exercises the desktop UI entry point and core modules that wire up bridge status, so it is a good sanity check for `MainDesktop.tsx` and related desktop infrastructure.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Runs the full desktop onboarding flow in offline mode, including the no-connection banner and app initialization. This provides end-to-end coverage of `MainDesktop.tsx` and desktop-specific startup behavior that the bridge tests do not touch.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/debug/src/useDebugModeActivator.ts`

_Updated: 2026-08-21T16:31:09.301Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/cleanup-unused-options-on-logger-desktopApi&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/cleanup-unused-options-on-logger-desktopApi&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-21T16:31:58.608Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T16:31:36.759Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->