### PR TITLE
chore(network-stellar): upgrade @stellar/stellar-sdk to v17

### DIFF
--- a/networks/stellar/network-stellar/package.json
+++ b/networks/stellar/network-stellar/package.json
@@ -49,7 +49,7 @@
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../../scripts/publish/replace-imports.sh ./lib"
     },
     "dependencies": {
-        "@stellar/stellar-sdk": "16.1.0",
+        "@stellar/stellar-sdk": "17.0.0",
         "@trezor/utils": "workspace:*"
     }
 }

--- a/networks/stellar/network-stellar/src/runtime/transactions/identify.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/identify.ts
@@ -24,17 +24,26 @@ const isoToTimestamp = (isoDate: string): number => {
 };
 
 const convertMemo = (memo: Memo): string | undefined => {
+    // Memo<T>'s `value` getter type is keyed by T, but T isn't narrowed by switching on
+    // `memo.type` here (it's a generic class, not a discriminated union), so `.value`'s static
+    // type is still the full union across all memo types (including null, for MemoNone). The
+    // case-specific `as` casts below reflect the real runtime type for each memo type (see
+    // stellar-sdk's own memo.d.ts); `== null` covers both undefined and null defensively.
     switch (memo.type) {
         // Memo.id's value is already a decimal string, not bytes; toString() is a no-op here
         case 'id':
-            return memo.value?.toString();
+            return memo.value == null ? undefined : (memo.value as string);
         // Memo.value is a Uint8Array for text/hash/return; Buffer.from() is required so
         // toString(encoding) decodes it correctly instead of silently returning garbage
         case 'text':
-            return memo.value === undefined ? undefined : Buffer.from(memo.value).toString('utf-8');
+            return memo.value == null
+                ? undefined
+                : Buffer.from(memo.value as Uint8Array).toString('utf-8');
         case 'hash':
         case 'return':
-            return memo.value === undefined ? undefined : Buffer.from(memo.value).toString('hex');
+            return memo.value == null
+                ? undefined
+                : Buffer.from(memo.value as Uint8Array).toString('hex');
         default:
             return undefined;
     }

--- a/networks/stellar/network-stellar/src/runtime/transactions/identify.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/identify.ts
@@ -25,12 +25,16 @@ const isoToTimestamp = (isoDate: string): number => {
 
 const convertMemo = (memo: Memo): string | undefined => {
     switch (memo.type) {
-        case 'text':
+        // Memo.id's value is already a decimal string, not bytes; toString() is a no-op here
         case 'id':
             return memo.value?.toString();
+        // Memo.value is a Uint8Array for text/hash/return; Buffer.from() is required so
+        // toString(encoding) decodes it correctly instead of silently returning garbage
+        case 'text':
+            return memo.value === undefined ? undefined : Buffer.from(memo.value).toString('utf-8');
         case 'hash':
         case 'return':
-            return memo.value?.toString('hex');
+            return memo.value === undefined ? undefined : Buffer.from(memo.value).toString('hex');
         default:
             return undefined;
     }
@@ -45,7 +49,7 @@ export const identifyTransaction = (rawTx: Horizon.ServerApi.TransactionRecord) 
 
     let parsedTx: Transaction;
     try {
-        const envelope = TransactionBuilder.fromXDR(rawTx.envelope_xdr, Networks.PUBLIC);
+        const envelope = TransactionBuilder.fromXdr(rawTx.envelope_xdr, Networks.PUBLIC);
         parsedTx = envelope instanceof FeeBumpTransaction ? envelope.innerTransaction : envelope;
     } catch {
         // A single unparseable record must not fail the whole account history

--- a/networks/stellar/network-stellar/src/runtime/transactions/parse.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/parse.ts
@@ -8,7 +8,7 @@ import {
 export const parseTransactionFromXDR = (xdrBase64: string, isTestnet: boolean) => {
     let parsed;
     try {
-        parsed = TransactionBuilder.fromXDR(
+        parsed = TransactionBuilder.fromXdr(
             xdrBase64,
             isTestnet ? Networks.TESTNET : Networks.PUBLIC,
         );

--- a/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
@@ -22,7 +22,7 @@ const transformSigner = (signer: Signer) => {
 
     if ('ed25519PublicKey' in signer) {
         const keyPair = Keypair.fromPublicKey(signer.ed25519PublicKey);
-        const key = keyPair.rawPublicKey().toString('hex');
+        const key = Buffer.from(keyPair.rawPublicKey()).toString('hex');
 
         return { type: 0, key, weight };
     }
@@ -64,15 +64,16 @@ const transformAsset = (asset: Asset) => {
 const transformMemo = (memo: Memo) => {
     switch (memo.type) {
         case MemoText:
-            return { type: 1, text: memo.value!.toString('utf-8') };
+            return { type: 1, text: Buffer.from(memo.value!).toString('utf-8') };
         case MemoID:
+            // Memo.id's value is already a decimal string, not bytes
             return { type: 2, id: memo.value!.toString('utf-8') };
         case MemoHash:
             // stringify is not necessary, Buffer is also accepted
-            return { type: 3, hash: memo.value!.toString('hex') };
+            return { type: 3, hash: Buffer.from(memo.value!).toString('hex') };
         case MemoReturn:
             // stringify is not necessary, Buffer is also accepted
-            return { type: 4, hash: memo.value!.toString('hex') };
+            return { type: 4, hash: Buffer.from(memo.value!).toString('hex') };
         default:
             return { type: 0 };
     }
@@ -131,12 +132,14 @@ export const transformTransaction = (transaction: Transaction) => {
         }
 
         // transform "price" field to { n: number, d: number }
+        // Note: @stellar/stellar-sdk 17 rebuilt the xdr namespace so union/struct fields
+        // (body, value, price, n, d) are plain readonly properties, not accessor methods
         if (typeof operation.price === 'string') {
-            const xdrOperationBody = transaction.tx.operations()[i]?.body().value();
+            const xdrOperationBody = transaction.tx.operations[i]?.body?.value;
             if (xdrOperationBody && 'price' in xdrOperationBody) {
                 operation.price = {
-                    n: xdrOperationBody.price().n(),
-                    d: xdrOperationBody.price().d(),
+                    n: xdrOperationBody.price.n,
+                    d: xdrOperationBody.price.d,
                 };
             }
         }
@@ -163,7 +166,7 @@ export const transformTransaction = (transaction: Transaction) => {
 
         if (operation.type === 'manageData' && operation.value) {
             // stringify is not necessary, Buffer is also accepted
-            operation.value = operation.value.toString('hex');
+            operation.value = Buffer.from(operation.value).toString('hex');
         }
         if (operation.type === 'manageBuyOffer') {
             operation.amount = operation.buyAmount;

--- a/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
@@ -62,18 +62,23 @@ const transformAsset = (asset: Asset) => {
  * Transforms Memo to TrezorConnect.StellarTransaction.Memo
  */
 const transformMemo = (memo: Memo) => {
+    // Memo<T>'s `value` getter type is keyed by T, but T isn't narrowed by switching on
+    // `memo.type` here (it's a generic class, not a discriminated union), so `.value`'s static
+    // type is still the full union across all memo types. Buffer.from()'s overloads don't accept
+    // that union directly; the case-specific `as` casts below reflect the real runtime type for
+    // each memo type (see stellar-sdk's own memo.d.ts).
     switch (memo.type) {
         case MemoText:
-            return { type: 1, text: Buffer.from(memo.value!).toString('utf-8') };
+            return { type: 1, text: Buffer.from(memo.value! as Uint8Array).toString('utf-8') };
         case MemoID:
             // Memo.id's value is already a decimal string, not bytes
-            return { type: 2, id: memo.value!.toString('utf-8') };
+            return { type: 2, id: memo.value! as string };
         case MemoHash:
             // stringify is not necessary, Buffer is also accepted
-            return { type: 3, hash: Buffer.from(memo.value!).toString('hex') };
+            return { type: 3, hash: Buffer.from(memo.value! as Uint8Array).toString('hex') };
         case MemoReturn:
             // stringify is not necessary, Buffer is also accepted
-            return { type: 4, hash: Buffer.from(memo.value!).toString('hex') };
+            return { type: 4, hash: Buffer.from(memo.value! as Uint8Array).toString('hex') };
         default:
             return { type: 0 };
     }
@@ -164,9 +169,12 @@ export const transformTransaction = (transaction: Transaction) => {
             operation.assetType = transformAsset(allowTrustAsset).type;
         }
 
-        if (operation.type === 'manageData' && operation.value) {
+        if (operation.type === 'manageData') {
+            // stellar-sdk 17 returns undefined here for a "remove data" operation (no value =
+            // delete the entry), where 16 returned null; normalize back to null so the
+            // null-means-removal contract noted above (re: setOptions) still holds.
             // stringify is not necessary, Buffer is also accepted
-            operation.value = Buffer.from(operation.value).toString('hex');
+            operation.value = operation.value ? Buffer.from(operation.value).toString('hex') : null;
         }
         if (operation.type === 'manageBuyOffer') {
             operation.amount = operation.buyAmount;

--- a/packages/connect-plugin-stellar/README.md
+++ b/packages/connect-plugin-stellar/README.md
@@ -36,7 +36,7 @@ const tx = new Transaction(..., Networks.TESTNET);
 await TrezorConnect.stellarSignTransaction({
     device,
     path,
-    xdrBase64: tx.toXDR(),
+    xdrBase64: tx.toXdr(),
     testnet: true,
 });
 ```

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -335,7 +335,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                 isTestnet: testnet,
             });
 
-            const xdrBase64 = transaction.toXDR();
+            const xdrBase64 = transaction.toXdr();
 
             response = await TrezorConnect.stellarSignTransaction({
                 device: {
@@ -354,7 +354,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                 const signature = Buffer.from(response.payload.signature, 'hex').toString('base64');
                 transaction.addSignature(selectedAccount.descriptor, signature);
 
-                return { serializedTx: transaction.toEnvelope().toXDR('hex') };
+                return { serializedTx: transaction.toEnvelope().toXdr('hex') };
             }
         } else {
             return rejectWithValue({

--- a/suite-common/wallet-core/src/token/stellarTokenThunks.ts
+++ b/suite-common/wallet-core/src/token/stellarTokenThunks.ts
@@ -85,7 +85,7 @@ const manageTrustline = async (
         asset,
         isTestnet: testnet,
     });
-    const xdrBase64 = transaction.toXDR();
+    const xdrBase64 = transaction.toXdr();
 
     const response = await TrezorConnect.stellarSignTransaction({
         device: {
@@ -108,7 +108,7 @@ const manageTrustline = async (
 
     const signature = Buffer.from(response.payload.signature, 'hex').toString('base64');
     transaction.addSignature(account.descriptor, signature);
-    const serializedTx = transaction.toEnvelope().toXDR('hex');
+    const serializedTx = transaction.toEnvelope().toXdr('hex');
 
     // Submit transaction to the network
     const pushResponse = await TrezorConnect.pushTransaction({

--- a/suite-common/walletconnect/src/adapters/stellar.ts
+++ b/suite-common/walletconnect/src/adapters/stellar.ts
@@ -126,7 +126,7 @@ const stellarSignXDR = createThunk<
         transaction.addSignature(account.descriptor, signature);
 
         return {
-            signedXDR: transaction.toEnvelope().toXDR('base64'),
+            signedXDR: transaction.toEnvelope().toXdr('base64'),
         };
     },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,6 +3342,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@exodus/bytes@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "@exodus/bytes@npm:1.15.1"
+  peerDependencies:
+    "@noble/hashes": ^1.8.0 || ^2.0.0
+  peerDependenciesMeta:
+    "@noble/hashes":
+      optional: true
+  checksum: 10/7dde00ae8040ec032ba3c287d210d7d555986caaf81a1215311c180422697d739a1952eb9d91e841132b18a19a910cdd02e4914136db3cc87baaa0fdd84b1e87
+  languageName: node
+  linkType: hard
+
 "@exodus/patch-broken-hermes-typed-arrays@npm:^1.0.0-alpha.1":
   version: 1.0.0-alpha.1
   resolution: "@exodus/patch-broken-hermes-typed-arrays@npm:1.0.0-alpha.1"
@@ -9941,24 +9953,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stellar/js-xdr@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@stellar/js-xdr@npm:4.0.0"
-  checksum: 10/d300c723e18f9d99c666499f8744a31981390ef8d780b2a321e019cbd23436a2de5b3d999e7af5e9ed334b14801497c0a19ad86ab052aff420415f2d89785a7b
+"@stellar/js-xdr@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@stellar/js-xdr@npm:5.0.0"
+  checksum: 10/90dcb6b98f5d2c1a95b5030dc78b77a6a81e78953a5d70d3cc3cf5dadcc285af4cb678136600b903a810e25e383520a1bf034b9f0def0456b71288d16149eec0
   languageName: node
   linkType: hard
 
-"@stellar/stellar-sdk@npm:16.1.0":
-  version: 16.1.0
-  resolution: "@stellar/stellar-sdk@npm:16.1.0"
+"@stellar/stellar-sdk@npm:17.0.0":
+  version: 17.0.0
+  resolution: "@stellar/stellar-sdk@npm:17.0.0"
   dependencies:
+    "@exodus/bytes": "npm:^1.15.1"
     "@noble/ed25519": "npm:^3.1.0"
     "@noble/hashes": "npm:^2.2.0"
-    "@stellar/js-xdr": "npm:4.0.0"
+    "@stellar/js-xdr": "npm:^5.0.0"
+    "@types/json-schema": "npm:^7.0.15"
     axios: "npm:1.18.0"
-    base32.js: "npm:^0.1.0"
     bignumber.js: "npm:^11.1.4"
-    buffer: "npm:^6.0.3"
     commander: "npm:^14.0.3"
     eventsource: "npm:^4.1.0"
     feaxios: "npm:^0.0.23"
@@ -9966,7 +9978,7 @@ __metadata:
     uint8array-extras: "npm:^1.5.0"
   bin:
     stellar-js: bin/stellar-js
-  checksum: 10/ebe5506ca704ebc5e10ba835a9ad6bf5dba036f397379512082d2743c63edcd73898a1ebf10534fd59c028da42e694fbe63403b6ccbe132a29f5448c599df754
+  checksum: 10/bd07c847f63538685af45ee086cb183eb0406c9328d1f9cd24925042d7820ecb8072a20779096a740123521c94fde868e3382ab8b77e94eb5542fe8f047a8b93
   languageName: node
   linkType: hard
 
@@ -17175,7 +17187,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/network-stellar@workspace:networks/stellar/network-stellar"
   dependencies:
-    "@stellar/stellar-sdk": "npm:16.1.0"
+    "@stellar/stellar-sdk": "npm:17.0.0"
     "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
@@ -22106,13 +22118,6 @@ __metadata:
   version: 5.0.1
   resolution: "base-x@npm:5.0.1"
   checksum: 10/6e4f847ef842e0a71c6b6020a6ec482a2a5e727f5a98534dbfd5d5a4e8afbc0d1bdf1fd57174b3f0455d107f10a932c3c7710bec07e2878f80178607f8f605c8
-  languageName: node
-  linkType: hard
-
-"base32.js@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "base32.js@npm:0.1.0"
-  checksum: 10/7d7401a8f5c4ec45336ff72c97ee554b9bc22c2153b301acf657e6f9e25928a6205b2cfc55731072ba5686515e4903e2d3e462bea49db5f1515bbd01da1276ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Upgrades `@stellar/stellar-sdk` from `16.1.0` to `17.0.0` in `networks/stellar/network-stellar` and updates all call sites for the SDK's renamed/changed APIs:

- `TransactionBuilder.fromXDR` → `TransactionBuilder.fromXdr`
- `Transaction#toXDR()` / `Envelope#toXDR()` → `.toXdr()`
- `Memo.value` and `Keypair.rawPublicKey()` now return `Uint8Array` instead of `Buffer`; call sites wrap them in `Buffer.from(...)` before calling `.toString(encoding)` so text/hash memos decode correctly instead of silently returning garbage
- The SDK's rebuilt `xdr` namespace now exposes union/struct fields (`body`, `value`, `price`, `n`, `d`) as plain readonly properties rather than accessor methods — updated the manage-offer `price` extraction in `transform.ts` accordingly

A follow-up commit fixes two further issues found once the SDK could actually be installed and tested:

- **manageData "remove data" regression**: v17 returns `undefined` for `operation.value` where v16 returned `null`. This codebase treats `null` as a meaningful "delete this entry" signal (distinct from `undefined`, see the comment in `transform.ts`), and that value flows straight into the `StellarManageDataOp` sent to the device for signing — normalized back to `null`.
- **`yarn type-check` failures**: `Memo<T>`'s `value` getter type isn't narrowed by switching on `memo.type` (it's a generic class, not a discriminated union), so `.value`'s static type still includes the full union in every branch, which `Buffer.from()`'s overloads reject. Added case-specific casts reflecting the real runtime type per memo type, and dropped `.toString()`'s now-invalid extra argument for `MemoID` (v17 types its value as a plain `string`).

Affected files:
- `networks/stellar/network-stellar/package.json` — bump dependency to `17.0.0`
- `networks/stellar/network-stellar/src/runtime/transactions/{identify,parse,transform}.ts` — API renames + `Uint8Array`/`Buffer` handling + xdr field access + the manageData/type-check fixes above
- `packages/connect-plugin-stellar/README.md` — update example to `toXdr()`
- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`, `suite-common/wallet-core/src/token/stellarTokenThunks.ts`, `suite-common/walletconnect/src/adapters/stellar.ts` — update `toXDR()`/`toEnvelope().toXDR()` call sites to `toXdr()`
- `yarn.lock` — pin the resolved `@stellar/stellar-sdk@17.0.0` / `@stellar/js-xdr@5.0.0`

No functional/behavioral changes are intended beyond the memo-decoding fix (converting `Uint8Array` to `Buffer` before `.toString()`) and the manageData null-normalization fix above, both required to preserve existing behavior under the new SDK's return types.

## Notes for QA

- Focus on Stellar transaction flows: sending XLM/tokens, trustline management, and WalletConnect transaction signing (`stellarSignXDR` adapter).
- Verify transaction memos of each type (text, id, hash, return) still round-trip correctly, since memo value decoding changed (`Uint8Array` → `Buffer` conversion).
- Verify manage-offer transactions display the correct price (`n`/`d`) in transaction details, since the XDR price field access pattern changed.
- Verify a "remove data" manageData operation (e.g. deleting a data entry) still signs/displays correctly — this is the regression fixed in the follow-up commit.
- Verify existing Stellar unit tests pass: `yarn workspace @trezor/network-stellar test:unit` (and any `wallet-core`/`walletconnect` Stellar-related suites). Already confirmed locally: `@trezor/network-stellar` 42/42 tests + type-check pass; `@suite-common/wallet-core` 463/463 tests pass.

## Related Issue

Resolve #31615

## Screenshots:

N/A (backend/SDK upgrade, no UI changes)
