### PR TITLE
fix(suite): handle walletconnect auth without ethereum

### DIFF
--- a/suite-common/walletconnect/jest.config.js
+++ b/suite-common/walletconnect/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+    roots: ['<rootDir>/src', '<rootDir>/../test-utils/__mocks__'],
+};

--- a/suite-common/walletconnect/package.json
+++ b/suite-common/walletconnect/package.json
@@ -7,6 +7,7 @@
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },

--- a/suite-common/walletconnect/src/adapters/index.ts
+++ b/suite-common/walletconnect/src/adapters/index.ts
@@ -22,6 +22,7 @@ import { type TronRequestThunkDeps, type TronRequestThunkState, tronAdapter } fr
 import {
     type PendingConnectionProposalNetwork,
     type WalletConnectAdapter,
+    type WalletConnectNamespace,
 } from '../walletConnectTypes';
 
 export type WalletConnectRequestThunkState = BitcoinRequestThunkState &
@@ -49,7 +50,7 @@ export const getAdapterByMethod = (method: string) =>
 export const getAdapterByNetwork = (networkType: string) =>
     adapters.find(adapter => adapter.networkType === networkType);
 
-export const getNamespaces = (accounts: Account[]) => {
+export const getNamespaces = (accounts: Account[]): Record<string, WalletConnectNamespace> => {
     const accountsDeduped: Account[] = [];
     accounts.forEach(account => {
         if (

--- a/suite-common/walletconnect/src/walletConnectAuthUtils.test.ts
+++ b/suite-common/walletconnect/src/walletConnectAuthUtils.test.ts
@@ -1,0 +1,33 @@
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import {
+    ethereumAccountRequiredError,
+    getSessionAuthenticateContext,
+} from './walletConnectAuthUtils';
+
+describe(getSessionAuthenticateContext.name, () => {
+    it.each([
+        ['no accounts', []],
+        ['only a Bitcoin account', [mockWalletAccount({ symbol: 'btc' })]],
+        ['only a hidden Ethereum account', [mockWalletAccount({ symbol: 'eth', visible: false })]],
+    ])('returns an explicit error for %s', (_, accounts) => {
+        expect(getSessionAuthenticateContext(accounts)).toEqual({
+            success: false,
+            error: ethereumAccountRequiredError,
+        });
+    });
+
+    it('returns the Ethereum account and namespace used for authentication', () => {
+        const ethereumAccount = mockWalletAccount({ symbol: 'eth' });
+
+        expect(getSessionAuthenticateContext([ethereumAccount])).toEqual({
+            success: true,
+            payload: {
+                account: ethereumAccount,
+                namespace: expect.objectContaining({
+                    chains: ['eip155:1'],
+                }),
+            },
+        });
+    });
+});

--- a/suite-common/walletconnect/src/walletConnectAuthUtils.ts
+++ b/suite-common/walletconnect/src/walletConnectAuthUtils.ts
@@ -1,0 +1,30 @@
+import { type Account } from '@suite-common/wallet-types';
+import { type Result, err, ok } from '@trezor/type-utils';
+
+import { getNamespaces } from './adapters';
+import { type WalletConnectNamespace } from './walletConnectTypes';
+
+export const ethereumAccountRequiredError = {
+    type: 'ethereum-account-required',
+    message: 'An Ethereum account is required for WalletConnect authentication.',
+} as const;
+
+type SessionAuthenticateContext = {
+    account: Account;
+    namespace: WalletConnectNamespace;
+};
+
+type SessionAuthenticateContextError = typeof ethereumAccountRequiredError;
+
+export const getSessionAuthenticateContext = (
+    accounts: Account[],
+): Result<SessionAuthenticateContext, SessionAuthenticateContextError> => {
+    const namespace = getNamespaces(accounts).eip155;
+    const ethereumAccount = accounts.find(account => account.symbol === 'eth' && account.visible);
+
+    if (!namespace || !ethereumAccount) {
+        return err(ethereumAccountRequiredError);
+    }
+
+    return ok({ account: ethereumAccount, namespace });
+};

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -32,6 +32,7 @@ import {
     processNamespaces,
 } from './adapters';
 import { walletConnectActions } from './walletConnectActions';
+import { getSessionAuthenticateContext } from './walletConnectAuthUtils';
 import { PROJECT_ID, WALLETCONNECT_METADATA, WALLETCONNECT_MODULE } from './walletConnectConstants';
 import { type WalletConnectStateRootState, selectPendingProposal } from './walletConnectReducer';
 import { type PendingConnectionProposalNetwork } from './walletConnectTypes';
@@ -51,22 +52,31 @@ const sessionAuthenticateThunk = createThunk<
     },
     { state: SessionAuthenticateThunkState; extra: SessionAuthenticateThunkDeps }
 >(`${WALLETCONNECT_MODULE}/sessionAuthenticateThunk`, async ({ event }, { getState, dispatch }) => {
-    // Support for Sign-In with Ethereum (SIWE) message, enhanced by ReCaps (ReCap Capabilities)
+    // Support for Sign-In with Ethereum (SIWE) message, enhanced by ReCaps (ReCap Capabilities).
     try {
         const accounts = selectAllSuccessfulAccountsToList(getState());
-        const supportedNamespaces = getNamespaces(accounts);
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const eip155Namespace: (typeof supportedNamespaces)[keyof typeof supportedNamespaces] =
-            supportedNamespaces.eip155;
+        const contextResult = getSessionAuthenticateContext(accounts);
+        if (!contextResult.success) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: contextResult.error.message,
+                }),
+            );
+            await walletKit.rejectSessionAuthenticate({
+                id: event.id,
+                reason: getSdkError('UNSUPPORTED_CHAINS'),
+            });
+
+            return;
+        }
+
+        const { account: ethAccount, namespace: eip155Namespace } = contextResult.payload;
         const authPayload = populateAuthPayload({
             authPayload: event.params.authPayload,
             chains: eip155Namespace.chains,
             methods: eip155Namespace.methods,
         });
-        const ethAccount = accounts.find(a => a.symbol === 'eth');
-        if (!ethAccount) {
-            throw new Error('No ETH account');
-        }
         const iss = `eip155:1:${ethAccount.descriptor}`;
         const message = walletKit.formatAuthMessage({
             request: authPayload,


### PR DESCRIPTION
## Description

Suite's wc_sessionAuthenticate handler builds supported WalletConnect namespaces from visible, successfully discovered accounts. When no Ethereum account was available, getNamespaces omitted eip155, but the handler unconditionally read eip155.chains, causing the runtime exception; the fix validates the authentication context first, shows a clear error, and rejects the request with UNSUPPORTED_CHAINS.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/walletconnect-auth-without-ethereum&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->