### PR TITLE
feat(suite-common): enable MEV protection on Robinhood Chain

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -283,7 +283,16 @@ export const networks = {
         decimals: 18,
         testnet: false,
         explorer: getExplorerUrls('https://robinscan.io', 'ethereum'),
-        features: ['rbf', 'sign-verify', 'tokens', 'nfts', 'coin-definitions', 'eip1559', 'graph'],
+        features: [
+            'rbf',
+            'sign-verify',
+            'tokens',
+            'nfts',
+            'coin-definitions',
+            'eip1559',
+            'mev-protection',
+            'graph',
+        ],
         backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {

--- a/suite-common/wallet-config/src/utils.test.ts
+++ b/suite-common/wallet-config/src/utils.test.ts
@@ -113,7 +113,7 @@ describe(isNetworkUsingExternalBackend.name, () => {
 describe(getNetworksWithMevProtection.name, () => {
     it('returns string with all networks with MEV protection', () => {
         expect(getNetworksWithMevProtection()).toEqual(
-            'Ethereum, BNB Smart Chain, Arbitrum One, Base',
+            'Ethereum, BNB Smart Chain, Arbitrum One, Base, Robinhood Chain',
         );
     });
 });


### PR DESCRIPTION
## Description

Adds the `mev-protection` feature to the Robinhood Chain (`rhc`) network in `networksConfig.ts` — Blinklabs now supports MEV protection on Robinhood.

The Blockbook side is intentionally not part of this PR; it is being handled separately with the backend team.

## Notes for QA

- Settings → MEV protection: the list of supported networks now includes Robinhood Chain.
- with MEV on, tx used Blinklabs, with MEV off, tx did not use Blinklabs
- should work the same for both Desktop and mobile

## Related Issue

Resolve #31473

## Screenshots

<img width="558" height="229" alt="Screenshot 2026-08-23 at 8 44 45" src="https://github.com/user-attachments/assets/8cdb6f1f-46c8-4945-9ba9-213d1b34c7a1" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** networksConfig.ts is a global dependency referenced by 133 tests, so the strategy targets only tests that directly exercise network enablement, backend configuration, account types, and multi-coin discovery. The selected high-priority tests cover the most user-visible regression surfaces. utils.test.ts is a unit test file with no static E2E coverage and no concrete evidence of E2E impact, so it is left uncovered.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`
- `suite-common/wallet-config/src/utils.test.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly exercises per-network custom backend configuration (Blockbook URLs) and discovery success/failure for BTC and ETH, which are core capabilities defined in networksConfig.ts. A regression in backend or network enablement metadata would be caught immediately.
- `suite/e2e/tests/settings/coins.test.ts` — Validates network enable/disable behavior, testnet visibility toggles, the Activate Assets modal, and the custom backend indicator for ETH. These flows read network definitions and feature flags directly from networksConfig.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Tests adding accounts across multiple networks (BTC, LTC, ETH, Base, ADA) and verifies correct network symbols, derivation paths, and account types in analytics events. This directly depends on networksConfig for coin definitions and account type metadata.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates eight different coins and verifies multi-network discovery completes and recovers after reload. If network definitions or discovery metadata changed, this test would fail across multiple coins.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Covers enabling a new asset (ETH) via the Activate Assets modal and verifying it appears in dashboard views. Shares the network activation flow with the changed configuration but is less focused on backend or account metadata.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — Enables multiple networks (BTC, ETH, POL, BSC, ARB) through the Activate Assets modal after onboarding. A regression in default network availability or activation would surface here.
- `suite/e2e/tests/settings/electrum.test.ts` — Configures a custom Electrum backend for regtest and verifies discovery. Complements the Blockbook backend tests by covering an alternative backend type defined in network configuration.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Verifies discovery works with custom Blockbook backends for BTC and LTC. Tests the same backend configuration path as settings/coins-custom-backend but through the wallet discovery flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-config/src/utils.test.ts`

_Updated: 2026-08-23T06:27:18.142Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/mev-protection-robinhood&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/mev-protection-robinhood&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/mev-protection-robinhood&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-23T06:29:06.580Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-23T06:27:52.328Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/mev-protection-robinhood/web/](https://dev.suite.sldev.cz/suite-web/feat/mev-protection-robinhood/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->