### PR TITLE
fix(suite-native): hide earn buy CTAs when trading is unavailable

### DIFF
--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -67,6 +67,7 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/tokens": "workspace:*",
+        "@suite-native/trading-state": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",
         "@suite-native/transactions": "workspace:*",
         "@suite-native/tx-simulation": "workspace:*",

--- a/suite-native/module-earn/src/components/EarnInsufficientBalanceBanner.tsx
+++ b/suite-native/module-earn/src/components/EarnInsufficientBalanceBanner.tsx
@@ -15,6 +15,7 @@ import {
     type StackNavigationProps,
     TradingStackRoutes,
 } from '@suite-native/navigation';
+import { selectIsTradingEnabled } from '@suite-native/trading-state';
 
 import { isBalanceBelowStakingMinimum } from '../utils/isBalanceBelowStakingMinimum';
 
@@ -31,6 +32,7 @@ export const EarnInsufficientBalanceBanner = ({
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
+    const isTradingEnabled = useSelector(selectIsTradingEnabled);
 
     const limits = account ? getStakingLimitsByNetworkSymbol(account.symbol) : null;
 
@@ -48,19 +50,25 @@ export const EarnInsufficientBalanceBanner = ({
         });
     };
 
+    const title = (
+        <Translation
+            id="earn.earnFormScreen.insufficientBalanceBanner"
+            values={{
+                minAmount: limits.MIN_AMOUNT_FOR_STAKING.toString(),
+                displaySymbol,
+            }}
+        />
+    );
+
+    if (!isTradingEnabled) {
+        return <BannerInline marginTop="sp16" intent="warning" title={title} />;
+    }
+
     return (
         <BannerInline
             marginTop="sp16"
             intent="warning"
-            title={
-                <Translation
-                    id="earn.earnFormScreen.insufficientBalanceBanner"
-                    values={{
-                        minAmount: limits.MIN_AMOUNT_FOR_STAKING.toString(),
-                        displaySymbol,
-                    }}
-                />
-            }
+            title={title}
             buttonLabel={
                 <Translation
                     id="earn.earnFormScreen.insufficientBalanceBannerButton"

--- a/suite-native/module-earn/src/components/EarnInsufficientBalanceContent.tsx
+++ b/suite-native/module-earn/src/components/EarnInsufficientBalanceContent.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react';
+import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
@@ -11,6 +12,7 @@ import {
     type StackNavigationProps,
     TradingStackRoutes,
 } from '@suite-native/navigation';
+import { selectIsTradingEnabled } from '@suite-native/trading-state';
 
 type EarnInsufficientBalanceContentProps = {
     title: ReactNode;
@@ -28,6 +30,7 @@ export const EarnInsufficientBalanceContent = ({
     onPrimaryButtonPress,
 }: EarnInsufficientBalanceContentProps) => {
     const navigation = useNavigation<NavigationProp>();
+    const isTradingEnabled = useSelector(selectIsTradingEnabled);
 
     const handleGetCoin = () => {
         onPrimaryButtonPress?.();
@@ -60,7 +63,9 @@ export const EarnInsufficientBalanceContent = ({
                 </VStack>
             </Box>
             <VStack spacing="sp12">
-                <Button onPress={handleGetCoin}>{primaryButtonContent}</Button>
+                {isTradingEnabled && (
+                    <Button onPress={handleGetCoin}>{primaryButtonContent}</Button>
+                )}
                 <Button intent="neutral" priority="secondary" onPress={handleCancel}>
                     <Translation id="generic.buttons.cancel" />
                 </Button>

--- a/suite-native/module-earn/tsconfig.json
+++ b/suite-native/module-earn/tsconfig.json
@@ -89,6 +89,7 @@
         { "path": "../test-utils" },
         { "path": "../test-utils-store" },
         { "path": "../tokens" },
+        { "path": "../trading-state" },
         { "path": "../transaction-management" },
         { "path": "../transactions" },
         { "path": "../tx-simulation" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13376,6 +13376,7 @@ __metadata:
     "@suite-native/test-utils": "workspace:*"
     "@suite-native/test-utils-store": "workspace:*"
     "@suite-native/tokens": "workspace:*"
+    "@suite-native/trading-state": "workspace:*"
     "@suite-native/transaction-management": "workspace:*"
     "@suite-native/transactions": "workspace:*"
     "@suite-native/tx-simulation": "workspace:*"


### PR DESCRIPTION
## Description

Buy/Get-coin CTAs in the Earn flows were offered even when trading is unavailable to the user (residence country not confirmed or not whitelisted, or trading disabled remotely). In that state the Trade tab is not even registered in `AppTabNavigator`, so the buttons navigated into a dead end.

Both CTAs are now gated on `selectIsTradingEnabled` — the same selector that gates the Trade tab:

- `EarnInsufficientBalanceBanner` (staking form): renders the "Not enough {coin}…" banner without the **Buy {coin}** button.
- `EarnInsufficientBalanceContent` (`YieldInsufficientBalanceScreen`): hides the primary **Get more {token}** button; the informational copy and **Cancel** stay.

`@suite-native/module-earn` gains a workspace dependency on `@suite-native/trading-state`.

## Notes for QA

- With trading available (whitelisted country confirmed, trading features on): both CTAs behave as before.
- With trading unavailable (e.g. residence check enabled and no confirmed whitelisted country): the staking form still shows the insufficient-balance warning but without **Buy {coin}**; the yield insufficient-balance screen shows only **Cancel**.
- The follow-up redesign of the yield insufficient-balance screen (should lead to *How yield works* + in-form banner) is tracked in #31299 and is not part of this fix.

## Related Issue

Resolve #31631

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files live in suite-native/module-earn (mobile-specific React Native components and package/tsconfig), while the available E2E test catalog covers only suite-web/desktop Playwright tests. There is no static coverage mapping and no evidence in the LLM analysis that any suite/e2e test exercises EarnInsufficientBalanceBanner or EarnInsufficientBalanceContent. Therefore no web E2E tests are recommended; the change should be validated with native/mobile testing or by adding coverage in the suite-native test suite.

<details><summary><b>Changed files (4)</b></summary>

- `suite-native/module-earn/package.json`
- `suite-native/module-earn/src/components/EarnInsufficientBalanceBanner.tsx`
- `suite-native/module-earn/src/components/EarnInsufficientBalanceContent.tsx`
- `suite-native/module-earn/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-native/module-earn/package.json`
- `suite-native/module-earn/src/components/EarnInsufficientBalanceBanner.tsx`
- `suite-native/module-earn/src/components/EarnInsufficientBalanceContent.tsx`
- `suite-native/module-earn/tsconfig.json`

_Updated: 2026-08-23T15:36:44.335Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31631-earn-buy-cta-trading-gate/web/](https://dev.suite.sldev.cz/suite-web/fix/31631-earn-buy-cta-trading-gate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31631-earn-buy-cta-trading-gate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31631-earn-buy-cta-trading-gate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31631-earn-buy-cta-trading-gate&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-23T15:39:51.611Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-23T15:39:25.164Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->