### PR TITLE
fix(suite-native): refine earn active-positions bottom sheets

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2957,8 +2957,8 @@ export const messages = {
                 incompleteFiatTotal: 'Some fiat rates couldn’t load. Total may be incomplete.',
             },
             activeSheet: {
-                stakingTitle: 'Your stakes',
-                stablecoinYieldTitle: 'Your yields',
+                stakingPositionsTitle: 'Your staking positions',
+                yieldPositionsTitle: 'Your yield positions',
             },
             stablecoinYieldLoadError: {
                 title: 'Unable to load yield opportunities',

--- a/suite-native/module-earn/src/components/EarnActiveItemsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/EarnActiveItemsBottomSheet.tsx
@@ -48,9 +48,9 @@ export const EarnActiveItemsBottomSheet = ({
     const title = useMemo(
         () =>
             type === 'staking' ? (
-                <Translation id="earn.earnScreen.activeSheet.stakingTitle" />
+                <Translation id="earn.earnScreen.activeSheet.stakingPositionsTitle" />
             ) : (
-                <Translation id="earn.earnScreen.activeSheet.stablecoinYieldTitle" />
+                <Translation id="earn.earnScreen.activeSheet.yieldPositionsTitle" />
             ),
         [type],
     );

--- a/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx
@@ -31,7 +31,7 @@ export const StablecoinYieldClaimRewardsBottomSheet = ({
     return (
         <BottomSheetModal
             ref={ref}
-            title={<Translation id="earn.earnScreen.activeSheet.stablecoinYieldTitle" />}
+            title={<Translation id="earn.earnScreen.activeSheet.yieldPositionsTitle" />}
             isCloseDisplayed
             onClose={onClose}
         >

--- a/suite-native/module-earn/src/hooks/useEarnDepositsCardData.ts
+++ b/suite-native/module-earn/src/hooks/useEarnDepositsCardData.ts
@@ -9,7 +9,6 @@ import {
     selectCurrentFiatRates,
     useMissingRateTickersQuery,
 } from '@suite-common/wallet-core';
-import { compareEarnByAmountDesc } from '@suite-common/wallet-utils';
 import { useTranslate } from '@suite-native/intl';
 
 import {
@@ -107,22 +106,18 @@ export const useEarnDepositsCardData = ({
 
     const stakingRows = useMemo(
         () =>
-            calculatedStakingDeposits
-                .map(
-                    ({ deposit, balance, fiatAmount }) =>
-                        ({
-                            id: deposit.id,
-                            type: 'staking',
-                            title:
-                                deposit.accountLabel ?? getNetworkDisplaySymbolName(deposit.symbol),
-                            symbol: deposit.symbol,
-                            accountKey: deposit.accountKey,
-                            balance,
-                            fiatAmount,
-                        }) satisfies EarnDepositsCardActiveItem,
-                )
-                // Active positions are ordered by fiat value, highest first (matches desktop).
-                .sort(compareEarnByAmountDesc(row => row.fiatAmount)),
+            calculatedStakingDeposits.map(
+                ({ deposit, balance, fiatAmount }) =>
+                    ({
+                        id: deposit.id,
+                        type: 'staking',
+                        title: deposit.accountLabel ?? getNetworkDisplaySymbolName(deposit.symbol),
+                        symbol: deposit.symbol,
+                        accountKey: deposit.accountKey,
+                        balance,
+                        fiatAmount,
+                    }) satisfies EarnDepositsCardActiveItem,
+            ),
         [calculatedStakingDeposits],
     );
 

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
@@ -8,11 +8,7 @@ import {
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { toTokenAddress, toTokenSymbol } from '@suite-common/wallet-types';
-import {
-    compareEarnByAmountDesc,
-    compareEarnByApyDesc,
-    compareEarnByNetwork,
-} from '@suite-common/wallet-utils';
+import { compareEarnByApyDesc, compareEarnByNetworkTokenOrder } from '@suite-common/wallet-utils';
 
 import {
     type EarnPromoListDataItem,
@@ -170,10 +166,21 @@ export const useStablecoinYieldListData = () => {
         // without an APY are pushed to the end.
         const sortedPromoItems = [...promoItems].sort(compareEarnByApyDesc(item => item.apy));
 
-        // Active positions are grouped by network (canonical coin order), highest balance first.
-        const sortedActiveItems = [...activeItems]
-            .sort(compareEarnByAmountDesc(item => item.tokenBalance ?? '0'))
-            .sort(compareEarnByNetwork(item => item.networkSymbol));
+        // Active positions follow the account order used across the app (network → token →
+        // account type → account index), matching the desktop DeFi table.
+        const accountByKey = new Map(accounts.map(account => [account.key, account]));
+        const sortedActiveItems = [...activeItems].sort(
+            compareEarnByNetworkTokenOrder(item => {
+                const account = item.accountKey ? accountByKey.get(item.accountKey) : undefined;
+
+                return {
+                    symbol: item.networkSymbol,
+                    tokenSymbol: item.tokenSymbol,
+                    accountType: account?.accountType,
+                    index: account?.index,
+                };
+            }),
+        );
 
         const promoListData: EarnPromoListDataItem[] = [
             ...DEFAULT_STABLECOIN_YIELD_PROMO_LIST_DATA,

--- a/suite-native/module-earn/src/hooks/useStakingListData.ts
+++ b/suite-native/module-earn/src/hooks/useStakingListData.ts
@@ -8,6 +8,7 @@ import {
     getAccountTotalStakingBalance,
     isCardanoStakedWithFiveBinaries,
     isStakingSymbol,
+    sortByCoin,
 } from '@suite-common/wallet-utils';
 import { selectAreTestnetsEnabled } from '@suite-native/settings';
 
@@ -34,7 +35,7 @@ export const useStakingListData = () => {
     const areTestnetsEnabled = useSelector(selectAreTestnetsEnabled);
 
     return useMemo<UseStakingListDataReturn>(() => {
-        const stakingAccounts = accounts.filter(acc => isStakingSymbol(acc.symbol));
+        const stakingAccounts = sortByCoin(accounts.filter(acc => isStakingSymbol(acc.symbol)));
         const stakingSymbols = areTestnetsEnabled ? STAKING_SYMBOLS : PROD_STAKING_SYMBOLS;
 
         const accountStakedWithFiveBinaries = stakingAccounts.find(

--- a/suite-native/module-earn/src/utils/earnAmountUtils.test.ts
+++ b/suite-native/module-earn/src/utils/earnAmountUtils.test.ts
@@ -14,14 +14,18 @@ const ethSymbol = asNetworkSymbol('eth');
 const accountKey = mockAccountKey();
 const fiatAmount = asBaseCurrencyAmount(new BigNumber(0));
 
-const stablecoinYieldItem = (balance: string, tokenSymbol: string): EarnDepositsCardActiveItem => ({
+const stablecoinYieldItem = (
+    balance: string,
+    tokenSymbol: string,
+    tokenContractAddress = toTokenAddress('0x2'),
+): EarnDepositsCardActiveItem => ({
     id: 'stablecoin-yield-item',
     type: 'stablecoin-yield',
     title: 'Vault',
     networkSymbol: ethSymbol,
     tokenSymbol: toTokenSymbol(tokenSymbol),
     contractAddress: toTokenAddress('0x1'),
-    tokenContractAddress: toTokenAddress('0x2'),
+    tokenContractAddress,
     accountKey,
     balance,
     fiatAmount,
@@ -105,6 +109,19 @@ describe(formatEarnActiveItemBalance.name, () => {
                 locale: 'en-US',
             }),
         ).toBe('0.000000000123456789 WETH');
+    });
+
+    it('displays a wrapped-native vault balance in the native coin, regardless of address casing', () => {
+        expect(
+            formatEarnActiveItemBalance({
+                item: stablecoinYieldItem(
+                    '0.01000077',
+                    'WETH',
+                    toTokenAddress('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'),
+                ),
+                locale: 'en-US',
+            }),
+        ).toBe('0.01000077 ETH');
     });
 
     it('caps a staking balance to CRYPTO_BALANCE_DECIMALS and upper-cases the symbol', () => {

--- a/suite-native/module-earn/src/utils/earnAmountUtils.ts
+++ b/suite-native/module-earn/src/utils/earnAmountUtils.ts
@@ -1,4 +1,5 @@
 import { type Locale } from '@suite-common/suite-types';
+import { getNetworkDisplaySymbol, isWrappedNativeToken } from '@suite-common/wallet-config';
 import { formatCoinBalance, localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -49,5 +50,10 @@ export const formatEarnActiveItemBalance = ({
         return `${balance} ${item.symbol.toUpperCase()}`;
     }
 
-    return formatEarnTokenAmount({ amount: item.balance, locale, symbol: item.tokenSymbol });
+    // Wrapped-native vaults are communicated in the native coin (ETH, not WETH) across the app.
+    const symbol = isWrappedNativeToken(item.networkSymbol, item.tokenContractAddress)
+        ? getNetworkDisplaySymbol(item.networkSymbol)
+        : item.tokenSymbol;
+
+    return formatEarnTokenAmount({ amount: item.balance, locale, symbol });
 };


### PR DESCRIPTION
## Description

Three refinements to the Earn active-positions bottom sheets:

- **Sorting by account order instead of value.** Staking positions dropped the fiat-desc sort (`useEarnDepositsCardData`) and now follow `sortByCoin` order from `useStakingListData`. Yield positions replaced the amount-desc-within-network sort with `compareEarnByNetworkTokenOrder` (network → token → account type → account index) — the same comparator and key shape the desktop DeFi table uses.
- **Titles renamed** to "Your staking positions" / "Your yield positions". New translation keys (`stakingPositionsTitle`, `stablecoinYieldPositionsTitle`) replace the old ones so the change shows immediately despite the Crowdin en-US overlay; the yield title is shared with the claim-rewards sheet, both usages updated.
- **Wrapped-native vault balances display the native coin** — the ETH vault row now shows `… ETH` instead of `… WETH` (`isWrappedNativeToken` → network display symbol in `formatEarnActiveItemBalance`), with a regression test covering address-casing.

## Notes for QA

- Open Earn → deposits card → Staking / DeFi Yield rows: positions in both sheets are listed in the same order as the accounts list (account type, then index), not by amount.
- The ETH vault ("Trezor Steakhouse ETH Prime") balance in the yields sheet reads ETH, not WETH; USDT vaults unchanged.
- The claim-rewards bottom sheet title also reads "Your yield positions".

## Related Issue

Resolve #31633

## Screenshots:

<img width="400"  alt="Simulator Screenshot - iPhone 17e - 2026-08-23 at 18 02 00" src="https://github.com/user-attachments/assets/f70c188d-fef8-4d6b-a61d-33d1bdff51ef" />
<img width="400"  alt="Simulator Screenshot - iPhone 17e - 2026-08-23 at 18 01 56" src="https://github.com/user-attachments/assets/66b3f299-0453-4488-9131-451f2c5209ec" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31633-earn-active-sheets&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->