### PR TITLE
fix(suite): keep yield flow session when tx is pending

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -22,6 +22,7 @@ import {
     handleYieldApproveCancelThunk,
     handleYieldApproveSuccessTxidThunk,
     initYieldAllowanceThunk,
+    isStablecoinYieldSessionResumable,
     isYieldWithdrawFlow,
     selectStablecoinYieldSession,
     stablecoinYieldActions,
@@ -30,7 +31,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { isWrappedNativeToken } from '@suite-common/wallet-utils';
-import { useCurrentRef } from '@trezor/react-utils';
+import { useCurrentRef, useFreshRef } from '@trezor/react-utils';
 
 import {
     submitYieldDepositThunk,
@@ -164,7 +165,9 @@ export const useYieldFlow = ({
 
     const ensureDeviceSession = useEnsureYieldDeviceSession({ flowType, flowKey });
     const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
-    const sessionRef = useCurrentRef(session);
+    // Fresh rather than commit-lagging: the entry effect below reads the session to decide whether
+    // the flow resumes, and a value one commit behind would restart a session it should keep.
+    const sessionRef = useFreshRef(session);
 
     const isWrappedNativeVault = isWrappedNativeToken(account.symbol, vault.token.address);
     const hasWrappedTokenBalance = isAmountGreaterThan({
@@ -221,44 +224,34 @@ export const useYieldFlow = ({
         : (receiptToken?.symbol ?? '');
 
     useEffect(() => {
-        if (!flowKey) {
-            return;
-        }
+        if (!flowKey) return;
 
-        // A session left with an pending transaction survives disposal (see `disposeSession`),
-        // so re-entering the flow rehydrates it: keep its step and pending state so tracking can
-        // resume/reconcile the transaction, instead of starting the flow over.
-        const preservedPendingTransaction = sessionRef.current.action.pendingTransaction;
+        // A session that is mid-flow survives disposal (see `isStablecoinYieldSessionResumable`),
+        // so re-entering the flow resumes it — step, approval and pending state included — instead
+        // of starting over. `enterSession` makes that call on the live state, including the wrap
+        // step a fresh wrapped-native deposit can open past.
+        const resumedSession = isStablecoinYieldSessionResumable(sessionRef.current)
+            ? sessionRef.current
+            : null;
 
-        dispatch(stablecoinYieldActions.initSession({ flowType, flowKey, isWrappedNativeVault }));
+        dispatch(
+            stablecoinYieldActions.enterSession({
+                flowType,
+                flowKey,
+                isWrappedNativeVault,
+                hasWrappedTokenBalance: hasWrappedTokenBalanceRef.current,
+            }),
+        );
 
-        if (preservedPendingTransaction) {
-            // The amount card is disabled while a transaction is pending — show its amount.
-            methodsRef.current.reset({
-                amountInput: preservedPendingTransaction.amount,
-                fiatInput: '',
-            });
-        } else {
-            dispatch(
-                stablecoinYieldActions.resetSession({ flowType, flowKey, isWrappedNativeVault }),
-            );
-
-            if (
-                flowType === 'deposit' &&
-                isWrappedNativeVault &&
-                hasWrappedTokenBalanceRef.current
-            ) {
-                dispatch(
-                    stablecoinYieldActions.resolveWrappedNativeStep({
-                        flowType,
-                        flowKey,
-                        step: 'wrap',
-                    }),
-                );
-            }
-
-            methodsRef.current.reset({ amountInput: '', fiatInput: '' });
-        }
+        // A resumed flow shows the amount it was left with: the one locked by the transaction in
+        // flight, or the one its confirmed transaction moved on to the next step.
+        resetAmountsRef.current(
+            resumedSession
+                ? (resumedSession.action.pendingTransaction?.amount ??
+                      resumedSession.action.amount ??
+                      '')
+                : '',
+        );
 
         return () => {
             dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
@@ -269,7 +262,7 @@ export const useYieldFlow = ({
         dispatch,
         isWrappedNativeVault,
         hasWrappedTokenBalanceRef,
-        methodsRef,
+        resetAmountsRef,
         sessionRef,
     ]);
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
@@ -28,6 +28,24 @@ const initSession = (flowType: YieldFlowType, isWrappedNativeVault?: boolean) =>
         }),
     );
 
+/** A deposit session on the action step, its approve transaction broadcast and confirmed. */
+const approveConfirmed = () =>
+    stablecoinYieldReducer(
+        stablecoinYieldReducer(
+            initSession('deposit'),
+            stablecoinYieldActions.setPendingTx({
+                flowType: 'deposit',
+                flowKey: FLOW_KEY,
+                tx: { type: 'approve', txid: '0xapprovetxid', amount: '100' },
+            }),
+        ),
+        stablecoinYieldActions.completeApproval({
+            flowType: 'deposit',
+            flowKey: FLOW_KEY,
+            amount: '100',
+        }),
+    );
+
 describe('stablecoinYieldReducer', () => {
     describe('step machine', () => {
         it('starts deposit at the approve step', () => {
@@ -488,6 +506,133 @@ describe('stablecoinYieldReducer', () => {
             );
 
             expect(getSession(state, 'deposit')?.action.pendingTransaction).toBeNull();
+        });
+
+        it('keeps a session whose approval already confirmed when disposed', () => {
+            const approved = approveConfirmed();
+
+            expect(getSession(approved, 'deposit')?.action.pendingTransaction).toBeNull();
+
+            const state = stablecoinYieldReducer(
+                approved,
+                stablecoinYieldActions.disposeSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('action');
+            expect(getSession(state, 'deposit')?.action.amount).toBe('100');
+        });
+
+        it('disposes a session whose flow completed', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    stablecoinYieldReducer(
+                        approveConfirmed(),
+                        stablecoinYieldActions.setPendingTx({
+                            flowType: 'deposit',
+                            flowKey: FLOW_KEY,
+                            tx: { type: 'deposit', txid: '0xdeposittxid', amount: '100' },
+                        }),
+                    ),
+                    stablecoinYieldActions.completeAction({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                        amount: '100',
+                    }),
+                ),
+                stablecoinYieldActions.disposeSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')).toBeUndefined();
+        });
+
+        it('resumes a mid-flow session when the flow is entered again', () => {
+            const state = stablecoinYieldReducer(
+                approveConfirmed(),
+                stablecoinYieldActions.enterSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('action');
+            expect(getSession(state, 'deposit')?.action.amount).toBe('100');
+        });
+
+        it('resumes a session whose transaction is still pending when the flow is entered again', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    initSession('deposit'),
+                    stablecoinYieldActions.setPendingTx({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                        tx: { type: 'deposit', txid: '0xpendingtxid', amount: '100' },
+                    }),
+                ),
+                stablecoinYieldActions.enterSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.action.pendingTransaction).toEqual({
+                type: 'deposit',
+                txid: '0xpendingtxid',
+                amount: '100',
+            });
+        });
+
+        it('starts a session that never broadcast anything over when the flow is entered again', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    initSession('deposit'),
+                    stablecoinYieldActions.enterModifyMode({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                        amount: '100',
+                    }),
+                ),
+                stablecoinYieldActions.enterSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+            expect(getSession(state, 'deposit')?.action.amount).toBeNull();
+            expect(getSession(state, 'deposit')?.approval.isModifyMode).toBe(false);
+        });
+
+        it('opens a fresh wrapped-native deposit past the wrap step when the wrapped token is held', () => {
+            const state = stablecoinYieldReducer(
+                initialStablecoinYieldState,
+                stablecoinYieldActions.enterSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    isWrappedNativeVault: true,
+                    hasWrappedTokenBalance: true,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it('opens a fresh wrapped-native deposit on the wrap step without a wrapped balance', () => {
+            const state = stablecoinYieldReducer(
+                initialStablecoinYieldState,
+                stablecoinYieldActions.enterSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    isWrappedNativeVault: true,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('wrap');
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -86,6 +86,13 @@ export type StablecoinYieldTxReviewState = {
 export type StablecoinYieldSessionState = {
     step: YieldFlowStepId;
     isWrappedNativeVault: boolean;
+    /**
+     * Set once the session broadcasts a transaction and never cleared while the flow runs.
+     * `action.pendingTransaction` only marks a transaction still in flight — every resolution
+     * (`completeApproval`, `resolveWrappedNativeStep`, `completeAction`, …) clears it — so this is
+     * what tells a session that already moved on-chain apart from an untouched one.
+     */
+    hasBroadcastTransaction: boolean;
     error: StablecoinYieldTranslationKey | null;
     approval: {
         allowanceAmount: string | null;
@@ -131,6 +138,7 @@ type StablecoinYieldSessionActionPayload = {
 export const initialStablecoinYieldSessionState: StablecoinYieldSessionState = {
     step: 'approve',
     isWrappedNativeVault: false,
+    hasBroadcastTransaction: false,
     error: null,
     approval: {
         allowanceAmount: null,
@@ -193,6 +201,24 @@ const createInitialStablecoinYieldSessionState = (
 
 export const getStablecoinYieldSessionKey = (flowKey: string) => `yield-session:${flowKey}`;
 
+/**
+ * Whether re-entering the flow should pick this session up instead of starting it over.
+ *
+ * A session becomes resumable the moment it broadcasts a transaction and stays that way until the
+ * flow completes: leaving the page must not throw away on-chain progress the user cannot redo (a
+ * granted approval, a finished wrap, an amount already withdrawn and waiting to be unwrapped), and
+ * a transaction still in flight has to stay tracked — the pending panel, the duplicate-submit
+ * guard, the completion into the next step and `replaceTransaction` following an RBF all read it.
+ */
+export const isStablecoinYieldSessionResumable = (
+    session: StablecoinYieldSessionState | undefined,
+): boolean => {
+    if (!session) return false;
+    if (session.action.pendingTransaction) return true;
+
+    return session.hasBroadcastTransaction && session.step !== 'complete';
+};
+
 const withSession = (
     state: StablecoinYieldState,
     { flowType, flowKey }: StablecoinYieldSessionActionPayload,
@@ -236,6 +262,42 @@ const stablecoinYieldSlice = createSlice({
                 );
             }
         },
+        /** Opens the flow: resumes a session that is still mid-flow, otherwise starts a fresh one. */
+        enterSession(
+            state: StablecoinYieldState,
+            action: PayloadAction<
+                StablecoinYieldSessionActionPayload & {
+                    isWrappedNativeVault?: boolean;
+                    hasWrappedTokenBalance?: boolean;
+                }
+            >,
+        ) {
+            const { flowType, flowKey, isWrappedNativeVault, hasWrappedTokenBalance } =
+                action.payload;
+
+            if (!isSafeObjectKey(flowKey)) {
+                return;
+            }
+
+            const sessionKey = getStablecoinYieldSessionKey(flowKey);
+
+            if (isStablecoinYieldSessionResumable(state[flowType][sessionKey])) {
+                return;
+            }
+
+            const session = createInitialStablecoinYieldSessionState(
+                flowType,
+                isWrappedNativeVault,
+            );
+
+            // Only a wrapped-native deposit opens on the wrap step, and there is nothing to wrap
+            // when the wrapped token is already held — mirrors `resolveWrappedNativeStep`.
+            if (session.step === 'wrap' && hasWrappedTokenBalance) {
+                session.step = getNextYieldFlowStep(flowType, 'wrap', session.isWrappedNativeVault);
+            }
+
+            state[flowType][sessionKey] = session;
+        },
         disposeSession(
             state: StablecoinYieldState,
             action: PayloadAction<StablecoinYieldSessionActionPayload>,
@@ -248,11 +310,10 @@ const stablecoinYieldSlice = createSlice({
 
             const sessionKey = getStablecoinYieldSessionKey(flowKey);
 
-            // A session tracking a pending transaction must survive its page unmounting:
-            // re-entering the flow resumes/reconciles it (pending panel, duplicate-submit guard,
-            // completion into the next step), and the `replaceTransaction` extraReducer needs it
-            // to follow an RBF. It is dropped once the transaction resolves.
-            if (state[flowType][sessionKey]?.action.pendingTransaction) {
+            // A session that is mid-flow must survive its page unmounting so re-entering the flow
+            // resumes it (see `isStablecoinYieldSessionResumable`); it is dropped once the flow
+            // completes, or never stored beyond the page when nothing was broadcast.
+            if (isStablecoinYieldSessionResumable(state[flowType][sessionKey])) {
                 return;
             }
 
@@ -613,6 +674,7 @@ const stablecoinYieldSlice = createSlice({
             >,
         ) {
             withSession(state, action.payload, session => {
+                session.hasBroadcastTransaction = true;
                 session.action.pendingTransaction = action.payload.tx;
                 session.action.pendingReceiptAmount =
                     action.payload.receiptAmount ?? session.action.pendingReceiptAmount;


### PR DESCRIPTION
## Description

Restore yield flow session with pending tx when going from e.g. deposit -> withdraw -> deposit (this should restore deposit session).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30883

## Screenshots:

https://github.com/user-attachments/assets/81ab0e66-495c-47c9-8fef-6e6baa332650

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly scoped to the stablecoin yield (Earn/Yield) flow: a hook and its reducer. The only E2E test that directly covers this user path is yield/withdrawal.test.ts, which should be run unconditionally. Other tests in the broad static coverage lists are generic wallet-core consumers and are unlikely to be affected by these yield-specific changes. The unit test file has no E2E coverage.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/yield/withdrawal.test.ts` — This test exercises the stablecoin yield withdrawal end-to-end flow, including the yield flow UI, transaction simulation, and device confirmation. Changes to useYieldFlow.ts and stablecoinYieldReducer.ts directly affect the state management and hooks driving this flow, so a regression would likely be visible here.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`

_Updated: 2026-08-23T17:22:20.326Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-keep-pending-tx-session/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-keep-pending-tx-session/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-keep-pending-tx-session&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-keep-pending-tx-session&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-keep-pending-tx-session&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-23T17:25:06.082Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-23T17:24:36.197Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->