### PR TITLE
[CI] Add timeout to staking batch request (#31237)

### DIFF
--- a/suite-common/earn-staking-api/src/staking/services/index.ts
+++ b/suite-common/earn-staking-api/src/staking/services/index.ts
@@ -41,6 +41,7 @@ export const getStakingBatch: (
 ) => Promise<StakingBatch> = earnHttpClient('/', {
     method: 'GET',
     schema: stakingBatchResponse,
+    timeout: 60_000,
 });
 
 export const getStakingStats: (


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW** — throwaway CI mirror of #31237 (CI does not run on external-contributor PRs). Will be closed once checks finish.

## Description

Mirror of everstake PR #31237, rebased onto develop `31cac156f61`.

## Notes for QA

CI-only mirror, no QA needed here — QA happens on #31237.

## Related Issue

Related to #31237

## Screenshots:

n/a

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared staking API service that the static mapper flags as a broad dependency across 136 tests. However, the concrete usage points are the ETH staking flows that call the Staking API. I recommend running the ETH initial-stake and stake-more tests unconditionally, plus the ETH unstake test as a related staking regression check, while skipping the long tail of tests that merely transitively import the module.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/earn-staking-api/src/staking/services/index.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test directly exercises the ETH staking flow and asserts on the Staking API endpoint (/staking/v1) and @suite-common/earn-staking-api types, so a change in suite-common/earn-staking-api/src/staking/services/index.ts is very likely to affect its behavior.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The test explicitly depends on the Staking API endpoint and validators queue from @suite-common/earn-staking-api when staking additional ETH, making it a direct coverage target for changes in the staking service.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — It is part of the same ETH staking feature and shares account state, pool contract data, and staking UI flows; a regression in the staking service could surface here even though it does not explicitly reference the API types.

</details>

_Updated: 2026-08-24T07:00:32.199Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/pr-31237/web/](https://dev.suite.sldev.cz/suite-web/ci/pr-31237/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/pr-31237&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/pr-31237&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/pr-31237&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T07:03:09.055Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T07:02:11.288Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->