### PR TITLE
[CI] Poll signature status instead of kit's abort-based confirmation (#30940)

### DIFF
--- a/networks/solana/network-solana/src/runtime/connect.test.ts
+++ b/networks/solana/network-solana/src/runtime/connect.test.ts
@@ -1,3 +1,6 @@
+import { SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED, isSolanaError } from '@solana/kit';
+import type { Signature } from '@solana/kit';
+
 import { fixtures } from './__fixtures__/connect.fixture';
 import {
     buildCreateAssociatedTokenAccountInstruction,
@@ -6,7 +9,23 @@ import {
     buildTransferTransaction,
     getLamportsFromSol,
     getMinimumRequiredTokenAccountsForTransfer,
+    waitForSignatureConfirmation,
 } from './connect';
+import type { SolanaAPI } from '../types/common';
+
+const mockSignature = 'mock-signature' as Signature;
+
+const mockApi = (send: jest.Mock, epochInfoSend?: jest.Mock) =>
+    ({
+        rpc: {
+            getSignatureStatuses: jest.fn().mockReturnValue({ send }),
+            getEpochInfo: jest.fn().mockReturnValue({
+                send: epochInfoSend ?? jest.fn().mockResolvedValue({ blockHeight: 0n }),
+            }),
+        },
+    }) as unknown as SolanaAPI;
+
+const mockLastValidBlockHeight = 100n;
 
 describe('solana utils', () => {
     describe('getMinimumRequiredTokenAccountsForTransfer', () => {
@@ -110,5 +129,128 @@ describe('solana utils', () => {
     it('getLamportsFromSol', () => {
         expect(getLamportsFromSol('1')).toEqual(1000000000n);
         expect(getLamportsFromSol('0.000000001')).toEqual(1n);
+    });
+
+    describe('waitForSignatureConfirmation', () => {
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('resolves once the signature is confirmed', async () => {
+            const send = jest.fn().mockResolvedValue({
+                value: [{ confirmationStatus: 'confirmed', err: null }],
+            });
+
+            await expect(
+                waitForSignatureConfirmation(
+                    mockSignature,
+                    mockLastValidBlockHeight,
+                    mockApi(send),
+                ),
+            ).resolves.toBeUndefined();
+        });
+
+        it('throws a SolanaError when the transaction fails on-chain', async () => {
+            const send = jest.fn().mockResolvedValue({
+                value: [
+                    { confirmationStatus: null, err: { InstructionError: [0, 'GenericError'] } },
+                ],
+            });
+
+            const error = await waitForSignatureConfirmation(
+                mockSignature,
+                mockLastValidBlockHeight,
+                mockApi(send),
+            ).catch(caught => caught);
+
+            expect(isSolanaError(error)).toBe(true);
+        });
+
+        it('recovers from a transient RPC error and still confirms on the next poll', async () => {
+            jest.useFakeTimers();
+            const send = jest
+                .fn()
+                .mockRejectedValueOnce(new Error('network blip'))
+                .mockResolvedValue({ value: [{ confirmationStatus: 'confirmed', err: null }] });
+
+            const resultPromise = waitForSignatureConfirmation(
+                mockSignature,
+                mockLastValidBlockHeight,
+                mockApi(send),
+            );
+
+            await jest.advanceTimersByTimeAsync(2_000);
+
+            await expect(resultPromise).resolves.toBeUndefined();
+            expect(send).toHaveBeenCalledTimes(2);
+        });
+
+        it('rejects with a timeout once the deadline elapses without confirmation or block height exceedance', async () => {
+            jest.useFakeTimers();
+            const send = jest.fn().mockResolvedValue({
+                value: [{ confirmationStatus: 'processed', err: null }],
+            });
+            const epochInfoSend = jest.fn().mockResolvedValue({ blockHeight: 0n });
+
+            const resultPromise = waitForSignatureConfirmation(
+                mockSignature,
+                mockLastValidBlockHeight,
+                mockApi(send, epochInfoSend),
+            );
+            resultPromise.catch(() => {
+                // Prevent an unhandled rejection warning before the assertion below attaches.
+            });
+
+            await jest.advanceTimersByTimeAsync(300_000);
+
+            await expect(resultPromise).rejects.toThrow(
+                'Timeout while waiting for the transaction to be confirmed.',
+            );
+        });
+
+        it('resolves when the transaction confirms between the block-height check and the final poll', async () => {
+            const send = jest
+                .fn()
+                .mockResolvedValueOnce({
+                    value: [{ confirmationStatus: 'processed', err: null }],
+                })
+                .mockResolvedValue({ value: [{ confirmationStatus: 'confirmed', err: null }] });
+            const epochInfoSend = jest
+                .fn()
+                .mockResolvedValue({ blockHeight: mockLastValidBlockHeight + 1n });
+
+            await expect(
+                waitForSignatureConfirmation(
+                    mockSignature,
+                    mockLastValidBlockHeight,
+                    mockApi(send, epochInfoSend),
+                ),
+            ).resolves.toBeUndefined();
+            expect(send).toHaveBeenCalledTimes(2);
+        });
+
+        it('rejects with a SolanaError once the block height is exceeded without confirmation', async () => {
+            jest.useFakeTimers();
+            const send = jest.fn().mockResolvedValue({
+                value: [{ confirmationStatus: 'processed', err: null }],
+            });
+            const epochInfoSend = jest
+                .fn()
+                .mockResolvedValue({ blockHeight: mockLastValidBlockHeight + 1n });
+
+            const resultPromise = waitForSignatureConfirmation(
+                mockSignature,
+                mockLastValidBlockHeight,
+                mockApi(send, epochInfoSend),
+            );
+            resultPromise.catch(() => {
+                // Prevent an unhandled rejection warning before the assertion below attaches.
+            });
+
+            await jest.advanceTimersByTimeAsync(60_000);
+
+            const error = await resultPromise.catch(caught => caught);
+            expect(isSolanaError(error, SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED)).toBe(true);
+        });
     });
 });

--- a/networks/solana/network-solana/src/runtime/connect.ts
+++ b/networks/solana/network-solana/src/runtime/connect.ts
@@ -5,6 +5,7 @@ import {
     SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_FAILED_TO_CONNECT,
     SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR,
     SOLANA_ERROR__TRANSACTION_ERROR__BLOCKHASH_NOT_FOUND,
+    SolanaError,
     address,
     appendTransactionMessageInstruction,
     appendTransactionMessageInstructions,
@@ -16,12 +17,13 @@ import {
     getBase16Encoder,
     getCompiledTransactionMessageDecoder,
     getSignatureFromTransaction,
+    getSolanaErrorFromTransactionError,
     getTransactionDecoder,
     isSolanaError,
     isTransactionMessageWithDurableNonceLifetime,
     lamports,
     prependTransactionMessageInstructions,
-    sendAndConfirmTransactionFactory,
+    sendTransactionWithoutConfirmingFactory,
     setTransactionMessageFeePayer,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
@@ -398,13 +400,88 @@ const getSendErrorMessage = (error: any) => {
     }
 };
 
+// Backstop only — confirmation normally ends with the blockhash expiry below.
+const SIGNATURE_CONFIRMATION_TIMEOUT_MS = 300_000;
+const SIGNATURE_CONFIRMATION_POLL_INTERVAL_MS = 2_000;
+
+const isConfirmed = (status?: { confirmationStatus: string | null } | null) =>
+    status?.confirmationStatus === 'confirmed' || status?.confirmationStatus === 'finalized';
+
+// `@solana/kit`'s confirmation throws on React Native/Hermes, so poll instead.
+export const waitForSignatureConfirmation = async (
+    signature: ReturnType<typeof getSignatureFromTransaction>,
+    lastValidBlockHeight: bigint,
+    api: SolanaAPI,
+) => {
+    const deadline = Date.now() + SIGNATURE_CONFIRMATION_TIMEOUT_MS;
+
+    // A transient RPC error (timeout, 429, connection blip) is treated as "no status yet"
+    // rather than failing confirmation outright, since the tx may still land on-chain.
+    const getStatus = () =>
+        api.rpc
+            .getSignatureStatuses([signature])
+            .send()
+            .then(
+                ({ value }) => value[0],
+                () => undefined,
+            );
+
+    while (Date.now() < deadline) {
+        const status = await getStatus();
+
+        if (status?.err) {
+            throw getSolanaErrorFromTransactionError(status.err);
+        }
+        if (isConfirmed(status)) {
+            return;
+        }
+
+        // The transaction cannot land anymore once its blockhash expires — the same rule
+        // kit's confirmation applies. Reporting a timeout while the blockhash is still valid
+        // would read as a failure for a transaction that may yet confirm.
+        const currentBlockHeight = await api.rpc
+            .getEpochInfo({ commitment: 'confirmed' })
+            .send()
+            .then(
+                ({ blockHeight }) => blockHeight,
+                () => undefined,
+            );
+
+        if (currentBlockHeight !== undefined && currentBlockHeight > lastValidBlockHeight) {
+            // The tx could have confirmed between the two RPC calls above.
+            const finalStatus = await getStatus();
+
+            if (finalStatus?.err) {
+                throw getSolanaErrorFromTransactionError(finalStatus.err);
+            }
+            if (isConfirmed(finalStatus)) {
+                return;
+            }
+
+            throw new SolanaError(SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED, {
+                currentBlockHeight,
+                lastValidBlockHeight,
+            });
+        }
+
+        await new Promise(resolve => setTimeout(resolve, SIGNATURE_CONFIRMATION_POLL_INTERVAL_MS));
+    }
+
+    throw new Error('Timeout while waiting for the transaction to be confirmed.');
+};
+
 export const sendAndConfirmTransaction = async (rawTx: string, api: SolanaAPI) => {
     const transaction = await preparePushTransaction(rawTx, api);
 
     try {
         const signature = getSignatureFromTransaction(transaction);
-        const send = sendAndConfirmTransactionFactory(api);
+        const send = sendTransactionWithoutConfirmingFactory({ rpc: api.rpc });
         await send(transaction, { commitment: 'confirmed', skipPreflight: false });
+        await waitForSignatureConfirmation(
+            signature,
+            transaction.lifetimeConstraint.lastValidBlockHeight,
+            api,
+        );
 
         return signature;
     } catch (error) {


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW** — throwaway CI mirror of #30940 (CI does not run on external-contributor PRs). Will be closed once checks finish.

## Description

Mirror of everstake PR #30940, rebased onto develop `31cac156f61`.

## Notes for QA

CI-only mirror, no QA needed here — QA happens on #30940.

## Related Issue

Related to #30940

## Screenshots:

n/a

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/pr-30940/web/](https://dev.suite.sldev.cz/suite-web/ci/pr-30940/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are in the Solana network runtime connection layer, which is foundational for all Solana operations in Suite. No static E2E coverage mapping was available, so recommendations are inferred from the LLM analysis and focus on Solana-specific end-to-end flows. A small representative set covering send, staking, and trading is recommended to catch regressions in connectivity, account discovery, and transaction broadcasting without running the full Solana suite.

<details><summary><b>Changed files (2)</b></summary>

- `networks/solana/network-solana/src/runtime/connect.test.ts`
- `networks/solana/network-solana/src/runtime/connect.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — This test exercises the core SOL send flow end-to-end, including account discovery, fee calculation, and transaction submission, all of which depend on the Solana network runtime connection implemented in connect.ts. Inferred from LLM analysis; no static mapping was available.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Initial SOL staking relies on the Solana runtime to fetch stake accounts, epochs, and fees, and to construct and broadcast staking transactions. A regression in connect.ts would likely surface here. Inferred from LLM analysis; no static mapping was available.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swapping SOL to BTC exercises Solana transaction construction, fee estimation, and broadcasting through the trading flow, making it a strong representative test for Solana runtime connectivity. Inferred from LLM analysis; no static mapping was available.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — The SOL sell flow shares the same Solana runtime infrastructure for balance fetching, fee calculation, and transaction submission; it complements the high-priority swap test by covering a different trading path. Inferred from LLM analysis; no static mapping was available.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstaking uses the same staking network runtime path as initial staking and verifies the lifecycle continues to work after connect.ts changes. Inferred from LLM analysis; no static mapping was available.

</details>

_Updated: 2026-08-24T07:01:49.894Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/pr-30940&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/pr-30940&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T07:02:34.165Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T07:02:00.153Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->