### PR TITLE
feat(suite): Earn mobile responsiveness

### DIFF
--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -2,6 +2,8 @@ import { type ReactNode } from 'react';
 
 import styled from 'styled-components';
 
+import { type SpacingValue } from '@trezor/theme';
+
 import { BannerButton } from './BannerButton';
 import { BannerContext } from './BannerContext';
 import { BannerIconButton } from './BannerIconButton';
@@ -27,16 +29,17 @@ import { Paragraph } from '../typography/Paragraph/Paragraph';
 
 const CONTAINER_BREAKPOINT = '440px';
 
-const Layout = styled.div`
+const Layout = styled.div<{ $contentGap: SpacingValue }>`
     container-type: inline-size;
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
+    row-gap: ${({ $contentGap }) => $contentGap}px;
     align-items: center;
 `;
 
-const IconCell = styled.div`
+const IconCell = styled.div<{ $isVerticallyCentered: boolean }>`
     grid-column: 1;
-    grid-row: 1;
+    grid-row: ${({ $isVerticallyCentered }) => ($isVerticallyCentered ? '1 / span 2' : '1')};
     margin-right: 12px;
 `;
 
@@ -71,6 +74,8 @@ export type BannerProps = AllowedFrameProps & {
     icon?: IconComponent | true;
     'data-testid'?: string;
     isLoading?: boolean;
+    isIconVerticallyCentered?: boolean;
+    contentGap?: SpacingValue;
 } & ({ title: ReactNode; description?: ReactNode } | { title?: ReactNode; description: ReactNode });
 
 export const Banner = ({
@@ -81,6 +86,8 @@ export const Banner = ({
     rightContent,
     'data-testid': dataTest,
     isLoading = false,
+    isIconVerticallyCentered = false,
+    contentGap = 0,
     width = '100%',
     ...rest
 }: BannerProps) => {
@@ -101,9 +108,9 @@ export const Banner = ({
             {...frameProps}
             width={width}
         >
-            <Layout>
+            <Layout $contentGap={contentGap}>
                 {(isLoading || withIcon) && (
-                    <IconCell>
+                    <IconCell $isVerticallyCentered={isIconVerticallyCentered}>
                         {isLoading && <Spinner size={20} isDisabled={true} />}
                         {!isLoading && withIcon && (
                             <Icon

--- a/packages/components/src/components/StepList/StepList.tsx
+++ b/packages/components/src/components/StepList/StepList.tsx
@@ -38,6 +38,7 @@ export type StepListProps = AllowedFrameProps & {
     bulletGap?: SpacingValue;
     titleGap?: SpacingValue;
     isOrdered?: boolean;
+    isContentFullWidth?: boolean;
     bulletSize?: BulletSize;
     lineWidth?: StepLineWidth;
     direction?: StepListDirection;
@@ -50,6 +51,7 @@ export const StepList = ({
     bulletGap = 24,
     titleGap = 8,
     isOrdered = false,
+    isContentFullWidth = false,
     bulletSize = 'large',
     lineWidth = 2,
     direction = 'vertical',
@@ -66,6 +68,7 @@ export const StepList = ({
                 bulletGap,
                 titleGap,
                 isOrdered,
+                isContentFullWidth,
                 bulletSize,
                 lineWidth,
                 direction,

--- a/packages/components/src/components/StepList/StepListContext.ts
+++ b/packages/components/src/components/StepList/StepListContext.ts
@@ -11,6 +11,7 @@ type StepListContextValue = {
     bulletSize: BulletSize;
     lineWidth: StepLineWidth;
     isOrdered: boolean;
+    isContentFullWidth: boolean;
     direction: StepListDirection;
 };
 
@@ -20,6 +21,7 @@ export const StepListContext = createContext<StepListContextValue>({
     bulletGap: 24,
     bulletSize: 'large',
     isOrdered: false,
+    isContentFullWidth: false,
     lineWidth: 2,
     direction: 'vertical',
 });

--- a/packages/components/src/components/StepList/StepListItem.tsx
+++ b/packages/components/src/components/StepList/StepListItem.tsx
@@ -155,6 +155,12 @@ const Line = styled.div<{
     $bulletGap: SpacingValue;
     $lineWidth: StepLineWidth;
 }>`
+    ${({ $lineWidth }) =>
+        $lineWidth === 0 &&
+        css`
+            display: none;
+        `}
+
     ${({ $direction, $bulletGap, $lineWidth }) =>
         $direction === 'horizontal'
             ? css`
@@ -181,7 +187,17 @@ const Line = styled.div<{
               `}
 `;
 
-const Content = styled.div<{ $itemGap: SpacingValue; $titleGap: SpacingValue }>`
+const Content = styled.div<{
+    $itemGap: SpacingValue;
+    $titleGap: SpacingValue;
+    $isFullWidth: boolean;
+}>`
+    ${({ $isFullWidth }) =>
+        $isFullWidth &&
+        css`
+            grid-column: 1 / -1;
+        `}
+
     padding-bottom: ${({ $itemGap }) => `${$itemGap}px`};
 
     &:not(:empty) {
@@ -208,8 +224,16 @@ export const StepListItem = ({
     'data-testid': dataTestId,
     children,
 }: StepListItemProps) => {
-    const { itemGap, bulletGap, titleGap, bulletSize, isOrdered, direction, lineWidth } =
-        useStepList();
+    const {
+        itemGap,
+        bulletGap,
+        titleGap,
+        bulletSize,
+        isOrdered,
+        isContentFullWidth,
+        direction,
+        lineWidth,
+    } = useStepList();
     const isClickable = !!onClick;
 
     const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -270,7 +294,11 @@ export const StepListItem = ({
                 </Title>
                 <Line $direction={direction} $bulletGap={bulletGap} $lineWidth={lineWidth} />
                 {direction === 'vertical' && (
-                    <Content $itemGap={itemGap} $titleGap={titleGap}>
+                    <Content
+                        $itemGap={itemGap}
+                        $titleGap={titleGap}
+                        $isFullWidth={isContentFullWidth}
+                    >
                         {children && (
                             <Text as="div" typographyStyle="body-sm">
                                 {children}

--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -2439,7 +2439,7 @@
   "TR_STAKE_RESTAKED_BADGE": "Restaked",
   "TR_STAKE_RETURNED_TO_ACCOUNT_WHEN_UNSTAKE": "Returned to account when you unstake",
   "TR_STAKE_REWARDS": "Rewards",
-  "TR_STAKE_REWARDS_BADGE": "Epoch number {count}",
+  "TR_STAKE_REWARDS_BADGE": "{count} Epoch",
   "TR_STAKE_SEND_SWAP_SPEND_ANYTIME": "Send, swap, or spend your {symbol} whenever you want—even while staking.",
   "TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT": "Due to recent Solana blockchain changes, this amount can't be unstaked. Try {higher} {symbol}{higherFiat}, or {lower} {symbol}{lowerFiat}.",
   "TR_STAKE_SOL_INVALID_UNSTAKE_AMOUNT_HIGHER_ONLY": "Due to recent Solana blockchain changes, this amount can't be unstaked. Try {higher} {symbol}{higherFiat}.",

--- a/packages/suite/src/components/dashboard/DashboardSection.tsx
+++ b/packages/suite/src/components/dashboard/DashboardSection.tsx
@@ -16,6 +16,7 @@ type DashboardSectionProps = HTMLAttributes<HTMLDivElement> & {
     heading?: ReactElement;
     subheading?: ReactElement;
     actions?: ReactElement;
+    areActionsBelowSubheading?: boolean;
     collapsible?: boolean;
     defaultCollapsed?: boolean;
     onCollapseChange?: (collapsed: boolean) => void;
@@ -28,6 +29,7 @@ export const DashboardSection = forwardRef(
             heading,
             subheading,
             actions,
+            areActionsBelowSubheading = false,
             collapsible = false,
             defaultCollapsed = false,
             onCollapseChange,
@@ -45,6 +47,7 @@ export const DashboardSection = forwardRef(
         }, [collapseChangeRef, collapsed]);
 
         const renderHeader = heading || subheading || actions || collapsible;
+        const actionsNode = actions ? <div>{actions}</div> : null;
 
         return (
             <div ref={ref} {...rest}>
@@ -70,7 +73,7 @@ export const DashboardSection = forwardRef(
                                     )}
 
                                     <Row gap={8}>
-                                        {actions && <div>{actions}</div>}
+                                        {!areActionsBelowSubheading && actionsNode}
                                         {collapsible && (
                                             <Collapsible.Toggle
                                                 onClick={() => setCollapsed(prev => !prev)}
@@ -100,6 +103,7 @@ export const DashboardSection = forwardRef(
                                         {subheading}
                                     </Text>
                                 )}
+                                {areActionsBelowSubheading && actionsNode}
                             </Column>
                         )}
                         <Collapsible.Content overflow="unset">{children}</Collapsible.Content>

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
@@ -40,8 +40,11 @@ export const EarnStakingTable = () => {
                     heading={<Translation id="TR_EARN_STAKING_DASHBOARD_TITLE" />}
                     subheading={<Translation id="TR_EARN_STAKING_DASHBOARD_TEXT" />}
                     actions={
-                        <EarnProviderInfoBadge messageId="TR_EARN_STAKING_OPERATED_BY_PROVIDERS" />
+                        <Column margin={isCardLayout ? { top: 8 } : undefined}>
+                            <EarnProviderInfoBadge messageId="TR_EARN_STAKING_OPERATED_BY_PROVIDERS" />
+                        </Column>
                     }
+                    areActionsBelowSubheading={isCardLayout}
                     ref={anchorRef}
                 >
                     <Column gap={16} alignItems="center">

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -1,3 +1,5 @@
+import styled from 'styled-components';
+
 import { Translation, type TranslationKey } from '@suite/intl';
 import {
     type RewardDtoV2,
@@ -6,9 +8,49 @@ import {
 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { getApyPercent, isWrappedNativeToken } from '@suite-common/wallet-utils';
-import { Column, Icon, Row, Text } from '@trezor/components';
+import { Column, Divider, Icon, Row, Text } from '@trezor/components';
 import { ChartLineIcon } from '@trezor/icons';
 import { TokenIcon } from '@trezor/product-components';
+import { belowBreakpoint, breakpoints } from '@trezor/theme';
+
+const RewardList = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    @media ${belowBreakpoint(breakpoints.mobile)} {
+        gap: 0;
+
+        & > *:not(:first-child) {
+            border-top: 1px solid ${({ theme }) => theme.borderNeutral};
+            padding-top: 16px;
+        }
+
+        & > *:not(:last-child) {
+            padding-bottom: 16px;
+        }
+    }
+`;
+
+const RewardRow = styled.div`
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: center;
+
+    @media ${belowBreakpoint(breakpoints.mobile)} {
+        grid-template-columns: auto minmax(0, 1fr);
+        align-items: start;
+    }
+`;
+
+const RewardRate = styled.div`
+    white-space: nowrap;
+
+    @media ${belowBreakpoint(breakpoints.mobile)} {
+        grid-column: 2;
+    }
+`;
 
 type EarnYieldApyBreakdownProps = {
     rewards: RewardDtoV2[];
@@ -68,69 +110,74 @@ export const EarnYieldApyBreakdown = ({
 
     return (
         <Column gap={16} padding={{ vertical: 10, horizontal: 8 }}>
-            {sortedRewards.map((reward, index) => {
-                const ratePercent = getApyPercent(reward.rate);
-                const hasRatePercent = ratePercent !== null && ratePercent > 0;
-                const descriptionId = getYieldSourceDescriptionId(reward.yieldSource);
-                const rateTranslationId = getRateTranslationId(reward.yieldSource);
-                // A wrapped-native reward (e.g. WETH in an ETH vault) is presented as its native
-                // asset (#29881), matching how the vault itself is labelled across the earn UI.
-                const displaySymbol = isWrappedNativeToken(networkSymbol, reward.token.address)
-                    ? getNetworkDisplaySymbol(networkSymbol)
-                    : reward.token.symbol;
+            <RewardList>
+                {sortedRewards.map((reward, index) => {
+                    const ratePercent = getApyPercent(reward.rate);
+                    const hasRatePercent = ratePercent !== null && ratePercent > 0;
+                    const descriptionId = getYieldSourceDescriptionId(reward.yieldSource);
+                    const rateTranslationId = getRateTranslationId(reward.yieldSource);
+                    // A wrapped-native reward (e.g. WETH in an ETH vault) is presented as its native
+                    // asset (#29881), matching how the vault itself is labelled across the earn UI.
+                    const displaySymbol = isWrappedNativeToken(networkSymbol, reward.token.address)
+                        ? getNetworkDisplaySymbol(networkSymbol)
+                        : reward.token.symbol;
 
-                let rateNode;
-                if (!hasRatePercent) {
-                    rateNode = <Translation id="TR_EARN_APY_N_A" />;
-                } else if (rateTranslationId) {
-                    rateNode = (
-                        <Translation id={rateTranslationId} values={{ rate: ratePercent }} />
-                    );
-                } else {
-                    rateNode = <>+{ratePercent}%</>;
-                }
+                    let rateNode;
+                    if (!hasRatePercent) {
+                        rateNode = <Translation id="TR_EARN_APY_N_A" />;
+                    } else if (rateTranslationId) {
+                        rateNode = (
+                            <Translation id={rateTranslationId} values={{ rate: ratePercent }} />
+                        );
+                    } else {
+                        rateNode = <>+{ratePercent}%</>;
+                    }
 
-                return (
-                    <Row key={index} gap={8} alignItems="center">
-                        <TokenIcon
-                            placeholder={displaySymbol || reward.token.name || 'token'}
-                            symbol={networkSymbol}
-                            contractAddress={reward.token.address}
-                            showNetworkIcon
-                            wrappedTokenIcon="network"
-                            size={20}
-                            isBordered={false}
-                        />
-                        <Column flex="1">
-                            <Text
-                                data-testid="@earn/dashboard/apy-breakdown/symbol"
-                                typographyStyle="body-sm"
-                            >
-                                {displaySymbol}
-                            </Text>
-                            {descriptionId && (
+                    return (
+                        <RewardRow key={index}>
+                            <TokenIcon
+                                placeholder={displaySymbol || reward.token.name || 'token'}
+                                symbol={networkSymbol}
+                                contractAddress={reward.token.address}
+                                showNetworkIcon
+                                wrappedTokenIcon="network"
+                                size={20}
+                                isBordered={false}
+                            />
+                            <Column flex="1">
+                                <Text
+                                    data-testid="@earn/dashboard/apy-breakdown/symbol"
+                                    typographyStyle="body-sm"
+                                >
+                                    {displaySymbol}
+                                </Text>
+                                {descriptionId && (
+                                    <Text
+                                        typographyStyle="body-sm"
+                                        intent="neutral"
+                                        priority="secondary"
+                                        data-testid="@earn/dashboard/apy-breakdown/description"
+                                    >
+                                        <Translation id={descriptionId} />
+                                    </Text>
+                                )}
+                            </Column>
+                            <RewardRate>
                                 <Text
                                     typographyStyle="body-sm"
-                                    intent="neutral"
-                                    priority="secondary"
-                                    data-testid="@earn/dashboard/apy-breakdown/description"
+                                    intent={hasRatePercent ? 'brand' : 'neutral'}
+                                    priority={hasRatePercent ? 'primary' : 'secondary'}
+                                    data-testid="@earn/dashboard/apy-breakdown/rate-percent"
                                 >
-                                    <Translation id={descriptionId} />
+                                    {rateNode}
                                 </Text>
-                            )}
-                        </Column>
-                        <Text
-                            typographyStyle="body-sm"
-                            intent={hasRatePercent ? 'brand' : 'neutral'}
-                            priority={hasRatePercent ? 'primary' : 'secondary'}
-                            data-testid="@earn/dashboard/apy-breakdown/rate-percent"
-                        >
-                            {rateNode}
-                        </Text>
-                    </Row>
-                );
-            })}
-            <Row gap={4} alignItems="center" margin={{ top: 4 }}>
+                            </RewardRate>
+                        </RewardRow>
+                    );
+                })}
+            </RewardList>
+            <Divider margin={0} />
+            <Row gap={4} alignItems="center">
                 <Icon as={ChartLineIcon} size={14} intent="neutral" priority="secondary" />
                 <Text
                     data-testid="@earn/dashboard/apy-breakdown/footer"

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -88,7 +88,7 @@ export const EarnYieldApyTooltip = ({
                     underlyingToken={vault.token}
                 />
             }
-            maxWidth={600}
+            tooltipMaxWidth={600}
             placement="top"
         >
             <Text typographyStyle="body-sm-strong" intent="neutral" priority="primary">

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
@@ -17,6 +17,7 @@ import { type useMerklRewards } from '../../yield/claim/hooks';
 
 type EarnYieldClaimRewardsBannerProps = {
     rewards: ReturnType<typeof useMerklRewards>['merklRewardsQuery'];
+    isFiatRateLoading?: boolean;
     isClaimDisabled?: boolean;
     claimDisabledTooltip?: React.ReactNode;
     onClaim?: () => void;
@@ -24,6 +25,7 @@ type EarnYieldClaimRewardsBannerProps = {
 
 export const EarnYieldClaimRewardsBanner = ({
     rewards,
+    isFiatRateLoading,
     isClaimDisabled,
     claimDisabledTooltip,
     onClaim,
@@ -37,6 +39,7 @@ export const EarnYieldClaimRewardsBanner = ({
     const { isLoading } = rewards;
 
     const { accountRewards, tokenRewards } = useYieldClaimRewardsData({ rewards });
+    const areRewardsLoading = isLoading || isFiatRateLoading || isDiscoveryRunning;
 
     const handleOnClaim = () => {
         analytics.report({
@@ -55,42 +58,44 @@ export const EarnYieldClaimRewardsBanner = ({
         <Banner
             intent="neutral"
             icon={HandCoinsIcon}
-            description={
-                <Row gap={12} alignItems="center">
+            isIconVerticallyCentered
+            contentGap={8}
+            title={
+                <Row gap={8} flexWrap="wrap">
                     <Text intent="neutral" priority="secondary">
-                        <Translation id="TR_EARN_CLAIM_REWARDS_LABEL" />:
+                        <Translation id="TR_EARN_CLAIM_REWARDS_LABEL" />
                     </Text>
 
-                    {isLoading || isDiscoveryRunning ? (
+                    {areRewardsLoading ? (
                         <Skeleton width={50} height={16} animate />
                     ) : (
-                        <>
-                            <HiddenPlaceholder>
-                                <Text typographyStyle="body-sm-strong">
-                                    {!isClaimDisabled && '≈ '}
-                                    <BaseCurrencyAmountFormatter
-                                        value={value}
-                                        currency={currency}
-                                    />
-                                </Text>
-                            </HiddenPlaceholder>
-
-                            {tokenRewards.length > 0 && (
-                                <EarnYieldClaimRewardsBannerTokensTooltip
-                                    rewards={tokenRewards}
-                                    currency={currency}
-                                />
-                            )}
-
-                            {accountRewards.length > 1 && (
-                                <EarnYieldClaimRewardsBannerAccountsTooltip
-                                    rewards={accountRewards}
-                                    currency={currency}
-                                />
-                            )}
-                        </>
+                        <HiddenPlaceholder>
+                            <Text typographyStyle="body-md-strong">
+                                {!isClaimDisabled && '≈ '}
+                                <BaseCurrencyAmountFormatter value={value} currency={currency} />
+                            </Text>
+                        </HiddenPlaceholder>
                     )}
                 </Row>
+            }
+            description={
+                !areRewardsLoading && (
+                    <Row gap={16} alignItems="center" flexWrap="wrap">
+                        {tokenRewards.length > 1 && (
+                            <EarnYieldClaimRewardsBannerTokensTooltip
+                                rewards={tokenRewards}
+                                currency={currency}
+                            />
+                        )}
+
+                        {accountRewards.length > 1 && (
+                            <EarnYieldClaimRewardsBannerAccountsTooltip
+                                rewards={accountRewards}
+                                currency={currency}
+                            />
+                        )}
+                    </Row>
+                )
             }
             rightContent={
                 <Tooltip content={claimDisabledTooltip}>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx
@@ -1,12 +1,23 @@
+import { Fragment } from 'react';
+
+import styled from 'styled-components';
+
 import { AccountLabel } from '@suite/account';
 import { HiddenPlaceholder } from '@suite/discreet-mode';
 import { Translation } from '@suite/intl';
 import { useFormatters } from '@suite-common/formatters';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { Grid, Text, Tooltip } from '@trezor/components';
+import { Grid, Icon, Row, Text, Tooltip } from '@trezor/components';
+import { WalletIcon } from '@trezor/icons';
 
 import { type AccountRewards } from './hooks/useYieldClaimRewardsData';
+
+const TooltipLabel = styled.span`
+    text-decoration: underline dotted ${({ theme }) => theme.contentSecondary};
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+`;
 
 interface EarnYieldClaimRewardsBannerAccountsTooltipProps {
     rewards: AccountRewards;
@@ -19,7 +30,7 @@ export const EarnYieldClaimRewardsBannerAccountsTooltip = ({
 }: EarnYieldClaimRewardsBannerAccountsTooltipProps) => {
     const { BaseCurrencyAmountFormatter } = useFormatters();
 
-    if (rewards.length < 2) return null;
+    if (rewards.length === 0) return null;
 
     return (
         <Tooltip
@@ -27,7 +38,7 @@ export const EarnYieldClaimRewardsBannerAccountsTooltip = ({
             content={
                 <Grid columns="auto auto" rowGap={4} columnGap={24}>
                     {rewards.map(({ account, fiat }) => (
-                        <>
+                        <Fragment key={account.key}>
                             <Text>
                                 <AccountLabel account={account} showAccountTypeBadge />
                             </Text>
@@ -40,19 +51,24 @@ export const EarnYieldClaimRewardsBannerAccountsTooltip = ({
                                     />
                                 </Text>
                             </HiddenPlaceholder>
-                        </>
+                        </Fragment>
                     ))}
                 </Grid>
             }
         >
-            <Text cursor="default">
-                <Translation
-                    id="TR_EARN_CLAIM_REWARDS_ACCOUNTS_LABEL"
-                    values={{
-                        accounts: rewards.length,
-                    }}
-                />
-            </Text>
+            <Row gap={6} cursor="help">
+                <Icon as={WalletIcon} size={16} intent="neutral" priority="secondary" />
+                <TooltipLabel>
+                    <Text intent="neutral" priority="secondary">
+                        <Translation
+                            id="TR_EARN_CLAIM_REWARDS_ACCOUNTS_LABEL"
+                            values={{
+                                accounts: rewards.length,
+                            }}
+                        />
+                    </Text>
+                </TooltipLabel>
+            </Row>
         </Tooltip>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx
@@ -1,12 +1,23 @@
+import { Fragment } from 'react';
+
+import styled from 'styled-components';
+
 import { Translation } from '@suite/intl';
 import { useFormatters } from '@suite-common/formatters';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { Grid, Text, Tooltip } from '@trezor/components';
+import { Grid, Row, Text, Tooltip } from '@trezor/components';
+import { TokenIconSet } from '@trezor/product-components';
 
 import { FormattedCryptoAmount, HiddenPlaceholder } from 'src/components/suite';
 
 import { type TokenRewards } from './hooks/useYieldClaimRewardsData';
+
+const TooltipLabel = styled.span`
+    text-decoration: underline dotted ${({ theme }) => theme.contentSecondary};
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+`;
 
 interface EarnYieldClaimRewardsBannerTokensTooltipProps {
     rewards: TokenRewards;
@@ -21,13 +32,15 @@ export const EarnYieldClaimRewardsBannerTokensTooltip = ({
 
     if (rewards.length === 0) return null;
 
+    const networkSymbols = [...new Set(rewards.map(({ networkSymbol }) => networkSymbol))];
+
     return (
         <Tooltip
             width="auto"
             content={
                 <Grid columns="auto auto" rowGap={4} columnGap={24}>
-                    {rewards.map(({ symbol, crypto, fiat }) => (
-                        <>
+                    {rewards.map(({ symbol, networkSymbol, contractAddress, crypto, fiat }) => (
+                        <Fragment key={`${networkSymbol}-${contractAddress}`}>
                             <Text>
                                 <FormattedCryptoAmount value={crypto.toString()} symbol={symbol} />
                             </Text>
@@ -40,24 +53,37 @@ export const EarnYieldClaimRewardsBannerTokensTooltip = ({
                                     />
                                 </Text>
                             </HiddenPlaceholder>
-                        </>
+                        </Fragment>
                     ))}
                 </Grid>
             }
         >
-            <Text cursor="default">
-                {rewards.length === 1 ? (
-                    <Translation
-                        id="TR_EARN_CLAIM_REWARDS_TOKEN_LABEL"
-                        values={{ symbol: rewards[0]!.symbol }}
-                    />
-                ) : (
-                    <Translation
-                        id="TR_EARN_CLAIM_REWARDS_TOKENS_LABEL"
-                        values={{ tokens: rewards.length }}
-                    />
-                )}
-            </Text>
+            <Row gap={6} cursor="help">
+                <Row gap={2}>
+                    {networkSymbols.map(networkSymbol => (
+                        <TokenIconSet
+                            key={networkSymbol}
+                            symbol={networkSymbol}
+                            tokens={rewards
+                                .filter(reward => reward.networkSymbol === networkSymbol)
+                                .map(({ symbol, contractAddress }) => ({
+                                    symbol,
+                                    contract: contractAddress,
+                                }))}
+                            size={20}
+                            gap={14}
+                        />
+                    ))}
+                </Row>
+                <TooltipLabel>
+                    <Text intent="neutral" priority="secondary">
+                        <Translation
+                            id="TR_EARN_CLAIM_REWARDS_TOKENS_LABEL"
+                            values={{ tokens: rewards.length }}
+                        />
+                    </Text>
+                </TooltipLabel>
+            </Row>
         </Tooltip>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -185,6 +185,7 @@ export const EarnYieldTable = () => {
                         <>
                             <EarnYieldClaimRewardsBanner
                                 rewards={merklRewardsQuery}
+                                isFiatRateLoading={missingRateTickersQuery.isLoading}
                                 isClaimDisabled={isClaimDisabled}
                                 claimDisabledTooltip={
                                     claimMessageSystem.isDisabled

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -177,6 +177,7 @@ export const EarnYieldTable = () => {
                 heading={<Translation id="TR_EARN_DEFI_YIELD_TITLE" />}
                 subheading={<Translation id="TR_EARN_DEFI_YIELD_DASHBOARD_TEXT" />}
                 actions={<PoweredByBadge provider="morpho" />}
+                areActionsBelowSubheading={isCardLayout}
                 ref={anchorRef}
             >
                 <Column gap={16} alignItems="center">

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts
@@ -87,11 +87,15 @@ const renderUseYieldClaimRewardsData = (accountsRewards: AccountsRewards) => {
             accountKey: account.key,
             fiat: fiat.toString(),
         })),
-        tokenRewards: result.current.tokenRewards.map(({ symbol, crypto, fiat }) => ({
-            symbol,
-            crypto: crypto.toString(),
-            fiat: fiat.toString(),
-        })),
+        tokenRewards: result.current.tokenRewards.map(
+            ({ symbol, networkSymbol, contractAddress, crypto, fiat }) => ({
+                symbol,
+                networkSymbol,
+                contractAddress,
+                crypto: crypto.toString(),
+                fiat: fiat.toString(),
+            }),
+        ),
     };
 };
 
@@ -113,7 +117,15 @@ describe(useYieldClaimRewardsData.name, () => {
         ]);
 
         expect(accountRewards).toEqual([{ accountKey: account.key, fiat: '12.5' }]);
-        expect(tokenRewards).toEqual([{ symbol: 'USDC', crypto: '12.5', fiat: '12.5' }]);
+        expect(tokenRewards).toEqual([
+            {
+                symbol: 'USDC',
+                networkSymbol: 'eth',
+                contractAddress: USDC.address,
+                crypto: '12.5',
+                fiat: '12.5',
+            },
+        ]);
     });
 
     it('sums rewards of the same token of a single account and keeps other tokens separate', () => {
@@ -133,8 +145,20 @@ describe(useYieldClaimRewardsData.name, () => {
 
         expect(accountRewards).toEqual([{ accountKey: account.key, fiat: '1512.5' }]);
         expect(tokenRewards).toEqual([
-            { symbol: 'USDC', crypto: '12.5', fiat: '12.5' },
-            { symbol: 'WETH', crypto: '0.5', fiat: '1500' },
+            {
+                symbol: 'USDC',
+                networkSymbol: 'eth',
+                contractAddress: USDC.address,
+                crypto: '12.5',
+                fiat: '12.5',
+            },
+            {
+                symbol: 'WETH',
+                networkSymbol: 'eth',
+                contractAddress: WETH.address,
+                crypto: '0.5',
+                fiat: '1500',
+            },
         ]);
     });
 
@@ -149,7 +173,15 @@ describe(useYieldClaimRewardsData.name, () => {
         ]);
 
         expect(accountRewards).toEqual([{ accountKey: account.key, fiat: '10' }]);
-        expect(tokenRewards).toEqual([{ symbol: 'USDC', crypto: '12.5', fiat: '10' }]);
+        expect(tokenRewards).toEqual([
+            {
+                symbol: 'USDC',
+                networkSymbol: 'eth',
+                contractAddress: USDC.address,
+                crypto: '12.5',
+                fiat: '10',
+            },
+        ]);
     });
 
     it('sums rewards per token across accounts and keeps the fiat total per account', () => {
@@ -180,8 +212,20 @@ describe(useYieldClaimRewardsData.name, () => {
             { accountKey: secondAccount.key, fiat: '755' },
         ]);
         expect(tokenRewards).toEqual([
-            { symbol: 'USDC', crypto: '15', fiat: '15' },
-            { symbol: 'WETH', crypto: '0.75', fiat: '2250' },
+            {
+                symbol: 'USDC',
+                networkSymbol: 'eth',
+                contractAddress: USDC.address,
+                crypto: '15',
+                fiat: '15',
+            },
+            {
+                symbol: 'WETH',
+                networkSymbol: 'eth',
+                contractAddress: WETH.address,
+                crypto: '0.75',
+                fiat: '2250',
+            },
         ]);
     });
 });

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountWithNetworkType,
     type BaseCurrencyAmount,
@@ -28,6 +29,8 @@ export type AccountRewards = AccountReward[];
 
 interface TokenReward {
     symbol: string;
+    networkSymbol: NetworkSymbol;
+    contractAddress: string;
     crypto: AmountUnit;
     fiat: BaseCurrencyAmount;
 }
@@ -35,14 +38,24 @@ interface TokenReward {
 export type TokenRewards = TokenReward[];
 
 type TokenMap = {
-    [key: string]: { symbol: string; decimals: number; crypto: BigNumber; fiat: BigNumber };
+    [key: string]: {
+        symbol: string;
+        networkSymbol: NetworkSymbol;
+        contractAddress: string;
+        decimals: number;
+        crypto: BigNumber;
+        fiat: BigNumber;
+    };
 };
 
 export const useYieldClaimRewardsData = ({
     rewards,
 }: UseYieldClaimRewardsDataProps): UseYieldClaimRewardsDataResult => {
     const allRewards = useMemo(
-        () => rewards.data.accountsRewards.flatMap(accountRewards => accountRewards.rewards),
+        () =>
+            rewards.data.accountsRewards.flatMap(({ account, rewards: accountRewards }) =>
+                accountRewards.map(reward => ({ reward, networkSymbol: account.symbol })),
+            ),
         [rewards.data.accountsRewards],
     );
 
@@ -58,9 +71,13 @@ export const useYieldClaimRewardsData = ({
     const tokenRewards = useMemo(() => {
         const tokenMap: TokenMap = {};
 
-        for (const reward of allRewards) {
-            const entry = tokenMap[reward.token.address] ?? {
+        for (const { reward, networkSymbol } of allRewards) {
+            const contractAddress = reward.token.address;
+            const tokenKey = `${networkSymbol}-${contractAddress.toLowerCase()}`;
+            const entry = tokenMap[tokenKey] ?? {
                 symbol: reward.token.symbol,
+                networkSymbol,
+                contractAddress,
                 decimals: reward.token.decimals,
                 crypto: new BigNumber(0),
                 fiat: new BigNumber(0),
@@ -69,18 +86,18 @@ export const useYieldClaimRewardsData = ({
             entry.crypto = entry.crypto.plus(reward.claimable);
             entry.fiat = entry.fiat.plus(reward.fiat.claimable ?? '0');
 
-            tokenMap[reward.token.address] = { ...entry };
+            tokenMap[tokenKey] = { ...entry };
         }
 
-        return Object.entries(tokenMap).map(([_, { symbol, decimals, ...entry }]) => {
+        return Object.values(tokenMap).map(({ decimals, crypto: cryptoSubunits, ...entry }) => {
             const crypto = subunitsToUnits({
-                value: asAmountSubunit(entry.crypto),
+                value: asAmountSubunit(cryptoSubunits),
                 decimals,
             });
 
             const fiat = asBaseCurrencyAmount(entry.fiat);
 
-            return { symbol, crypto, fiat };
+            return { ...entry, crypto, fiat };
         }) satisfies TokenRewards;
     }, [allRewards]);
 

--- a/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
@@ -12,6 +12,7 @@ import { TokenIcon } from '@trezor/product-components';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { BasicName } from 'src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName';
 import { useDispatch } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 
 type YieldClaimPageHeaderProps = {
     account?: Account;
@@ -20,6 +21,7 @@ type YieldClaimPageHeaderProps = {
 export const YieldClaimPageHeader = ({ account }: YieldClaimPageHeaderProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const { isBelowMobile } = useLayoutSize();
 
     const onBackClick = () => {
         analytics.report({
@@ -37,24 +39,29 @@ export const YieldClaimPageHeader = ({ account }: YieldClaimPageHeaderProps) => 
 
     return (
         <PageHeader>
-            <Row width="100%" gap={16} alignItems="center">
+            <Row width="100%" gap={isBelowMobile ? 12 : 16} alignItems="center">
                 <IconButton
                     icon={CaretLeftIcon}
                     intent="neutral"
                     priority="secondary"
-                    size="large"
+                    size={isBelowMobile ? 'medium' : 'large'}
                     onClick={onBackClick}
                     data-testid="@account-subpage/back"
                     tooltip={{ content: <Translation id="TR_BACK" /> }}
                 />
                 {account ? (
-                    <Row gap={12} alignItems="center" flex="1" overflow="hidden">
-                        <TokenIcon symbol={account.symbol} size={32} />
+                    <Row
+                        gap={isBelowMobile ? 8 : 12}
+                        alignItems="center"
+                        flex="1"
+                        overflow="hidden"
+                    >
+                        <TokenIcon symbol={account.symbol} size={isBelowMobile ? 24 : 32} />
                         <AccountLabel
                             account={account}
                             showAccountTypeBadge
                             accountTypeBadgeSize="small"
-                            typographyStyle="headline-md"
+                            typographyStyle={isBelowMobile ? 'headline-sm' : 'headline-md'}
                             rowProps={{ flex: '1', overflow: 'hidden' }}
                         />
                     </Row>

--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -12,6 +12,7 @@ import { NumberInput } from '@trezor/product-components';
 
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { useSelector } from 'src/hooks/suite';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { validateDecimals } from 'src/utils/suite/validation';
 
 import { TruncatedAmount } from './TruncatedAmount';
@@ -74,6 +75,7 @@ export const YieldAmountCard = ({
 }: YieldAmountCardProps) => {
     const locale = useSelector(selectLanguage);
     const { translationString } = useTranslation();
+    const { isBelowMobile } = useLayoutSize();
     const {
         control,
         formState: { errors },
@@ -192,7 +194,7 @@ export const YieldAmountCard = ({
                     <Row justifyContent="space-between" alignItems="center" gap={8} width="100%">
                         <Row alignItems="center" gap={8} minWidth={0}>
                             <Text
-                                typographyStyle="body-md"
+                                typographyStyle={isBelowMobile ? 'body-sm' : 'body-md'}
                                 intent="neutral"
                                 priority="secondary"
                                 data-testid="@yield/form/summary-label"
@@ -201,7 +203,8 @@ export const YieldAmountCard = ({
                             </Text>
                             <TruncatedAmount>
                                 <Text
-                                    typographyStyle="body-md"
+                                    typographyStyle={isBelowMobile ? 'body-sm' : 'body-md'}
+                                    textWrap="nowrap"
                                     intent="neutral"
                                     priority="secondary"
                                     data-testid="@yield/form/summary-amount-with-symbol"

--- a/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
@@ -7,6 +7,8 @@ import { type YieldFlowStepId } from '@suite-common/wallet-core';
 import { Column, IconCircle, Row, StepList, Text } from '@trezor/components';
 import { CaretLeftIcon } from '@trezor/icons';
 
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
+
 import { type YieldFlowStepView, getYieldFlowSteps } from '../yieldFlowUtils';
 
 const EditableTitle = styled.span`
@@ -65,6 +67,8 @@ export const YieldFlowStepList = <TSequence extends readonly YieldFlowStepId[]>(
     steps,
     hasStepList = false,
 }: YieldFlowStepListProps<TSequence>) => {
+    const { isBelowMobile } = useLayoutSize();
+
     // Widened — the prop is keyed by the flow's own steps, but we index it with generic step ids.
     const stepDefinitions: Partial<Record<YieldFlowStepId, YieldFlowStepDefinition>> = steps;
     const listSteps = sequence.filter(stepId => stepDefinitions[stepId]?.isListItem !== false);
@@ -93,7 +97,15 @@ export const YieldFlowStepList = <TSequence extends readonly YieldFlowStepId[]>(
     }
 
     return (
-        <StepList isOrdered bulletSize="large" bulletGap={12} gap={24} titleGap={16}>
+        <StepList
+            isOrdered
+            isContentFullWidth={isBelowMobile}
+            bulletSize="large"
+            bulletGap={12}
+            gap={24}
+            titleGap={16}
+            lineWidth={isBelowMobile ? 0 : 2}
+        >
             {listSteps.map(stepId => {
                 const view = views[stepId];
                 const definition = stepDefinitions[stepId];

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -1,3 +1,5 @@
+import styled from 'styled-components';
+
 import { AccountLabel } from '@suite/account';
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
@@ -13,14 +15,79 @@ import {
 } from '@suite-common/suite-types/src/staking';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { Box, Button, Column, IconButton, Row, Text } from '@trezor/components';
+import { Button, IconButton, Row, Text } from '@trezor/components';
 import { CaretLeftIcon, InfoIcon } from '@trezor/icons';
 import { TokenIcon } from '@trezor/product-components';
+import { belowBreakpoint, breakpoints } from '@trezor/theme';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { useDispatch } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
+
+const HeaderLayout = styled.div`
+    display: grid;
+    grid-template-columns: auto auto minmax(0, 1fr) auto;
+    gap: 2px 12px;
+    align-items: center;
+    width: 100%;
+    min-width: 0;
+
+    @media ${belowBreakpoint(breakpoints.mobile)} {
+        row-gap: 8px;
+    }
+`;
+
+const Navigation = styled.div`
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    margin-right: 4px;
+
+    @media ${belowBreakpoint(breakpoints.mobile)} {
+        grid-row: 1;
+    }
+`;
+
+const IdentityIcon = styled.div`
+    grid-column: 2;
+    grid-row: 1 / span 2;
+
+    @media ${belowBreakpoint(breakpoints.mobile)} {
+        grid-row: 1;
+    }
+`;
+
+const IdentityTitle = styled.div`
+    grid-column: 3;
+    grid-row: 1;
+    min-width: 0;
+`;
+
+const IdentityMeta = styled.div`
+    grid-column: 3;
+    grid-row: 2;
+    min-width: 0;
+    overflow: hidden;
+
+    @media ${belowBreakpoint(breakpoints.mobile)} {
+        grid-column: 1 / -1;
+    }
+`;
+
+const MetaValue = styled.div`
+    min-width: 0;
+    overflow: hidden;
+`;
+
+const Actions = styled.div`
+    grid-column: 4;
+    grid-row: 1 / span 2;
+    margin-left: auto;
+
+    @media ${belowBreakpoint(breakpoints.mobile)} {
+        grid-row: 1;
+    }
+`;
 
 interface YieldPageHeaderProps {
     analyticsStep: Extract<EarnAnalyticsStep, 'yield-deposit' | 'yield-withdraw'>;
@@ -46,6 +113,7 @@ export const YieldPageHeader = ({
     const vaultName = vault?.metadata.name;
     const networkSymbol = account?.symbol;
     const isHowItWorksVisible = !isInvalid;
+    const hasVaultIdentity = !isInvalid && !!account && !!vaultName;
 
     const onBackClick = () => {
         analytics.report({
@@ -101,40 +169,64 @@ export const YieldPageHeader = ({
         );
     };
 
+    const identityIconNode = (() => {
+        if (hasVaultIdentity && networkSymbol) {
+            return (
+                <IdentityIcon>
+                    <TokenIcon
+                        placeholder={vault?.token?.symbol || vault?.token?.name || ''}
+                        symbol={networkSymbol}
+                        contractAddress={vault?.token?.address}
+                        showNetworkIcon
+                        size={32}
+                        isBordered={false}
+                        wrappedTokenIcon="network"
+                    />
+                </IdentityIcon>
+            );
+        }
+
+        if (!hasVaultIdentity && routeParams?.symbol) {
+            return (
+                <IdentityIcon>
+                    <TokenIcon symbol={routeParams.symbol} size={32} isBordered={false} />
+                </IdentityIcon>
+            );
+        }
+
+        return null;
+    })();
+
     return (
         <PageHeader expandable>
-            <Row width="100%" gap={16} alignItems="center">
-                <IconButton
-                    icon={CaretLeftIcon}
-                    intent="neutral"
-                    priority="secondary"
-                    size="large"
-                    onClick={onBackClick}
-                    data-testid="@account-subpage/back"
-                    tooltip={{ content: <Translation id="TR_BACK" /> }}
-                />
+            <HeaderLayout>
+                <Navigation>
+                    <IconButton
+                        icon={CaretLeftIcon}
+                        intent="neutral"
+                        priority="secondary"
+                        size="large"
+                        onClick={onBackClick}
+                        data-testid="@account-subpage/back"
+                        tooltip={{ content: <Translation id="TR_BACK" /> }}
+                    />
+                </Navigation>
 
-                {!isInvalid && account && vaultName ? (
-                    <Row alignItems="center" gap={12} overflow="hidden">
-                        {networkSymbol && (
-                            <TokenIcon
-                                placeholder={vault?.token?.symbol || vault?.token?.name || ''}
-                                symbol={networkSymbol}
-                                contractAddress={vault?.token?.address}
-                                showNetworkIcon
-                                size={32}
-                                isBordered={false}
-                                wrappedTokenIcon="network"
-                            />
-                        )}
-                        <Column gap={2} overflow="hidden">
-                            <Text
-                                typographyStyle="body-md-strong"
-                                ellipsisLineCount={isBelowMobile ? 0 : 1}
-                            >
-                                {vaultName}
-                            </Text>
-                            <Row justifyContent="space-between" alignItems="center" gap={24}>
+                {identityIconNode}
+
+                <IdentityTitle>
+                    <Text
+                        typographyStyle="body-md-strong"
+                        ellipsisLineCount={isBelowMobile ? 2 : 1}
+                    >
+                        {hasVaultIdentity ? vaultName : <Translation id={fallbackTitleId} />}
+                    </Text>
+                </IdentityTitle>
+
+                {hasVaultIdentity && (
+                    <IdentityMeta>
+                        <Row alignItems="center" gap={isBelowMobile ? 8 : 24} overflow="hidden">
+                            <MetaValue>
                                 <AccountLabel
                                     account={account}
                                     showAccountTypeBadge
@@ -143,10 +235,18 @@ export const YieldPageHeader = ({
                                     priority="secondary"
                                     typographyStyle="body-sm"
                                 />
+                            </MetaValue>
+                            {isBelowMobile && (
+                                <Text intent="neutral" priority="secondary">
+                                    •
+                                </Text>
+                            )}
+                            <MetaValue>
                                 <Text
                                     typographyStyle="body-sm"
                                     intent="neutral"
                                     priority="secondary"
+                                    ellipsisLineCount={1}
                                 >
                                     <FormattedCryptoAmount
                                         value={account.formattedBalance}
@@ -155,22 +255,13 @@ export const YieldPageHeader = ({
                                         data-testid="@yield/page-header/balance"
                                     />
                                 </Text>
-                            </Row>
-                        </Column>
-                    </Row>
-                ) : (
-                    <Row alignItems="center" gap={12}>
-                        {routeParams?.symbol && (
-                            <TokenIcon symbol={routeParams.symbol} size={32} isBordered={false} />
-                        )}
-                        <Text typographyStyle="body-md-strong">
-                            <Translation id={fallbackTitleId} />
-                        </Text>
-                    </Row>
+                            </MetaValue>
+                        </Row>
+                    </IdentityMeta>
                 )}
 
                 {isHowItWorksVisible && (
-                    <Box margin={{ left: 'auto' }}>
+                    <Actions>
                         {isBelowMobile ? (
                             <IconButton
                                 icon={InfoIcon}
@@ -192,9 +283,9 @@ export const YieldPageHeader = ({
                                 <Translation id="TR_EARN_HOW_IT_WORKS" />
                             </Button>
                         )}
-                    </Box>
+                    </Actions>
                 )}
-            </Row>
+            </HeaderLayout>
         </PageHeader>
     );
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -27,6 +27,7 @@ const Container = styled.div<{ $expandable?: boolean }>`
     position: sticky;
     top: 0;
     display: flex;
+    flex-shrink: 0;
     align-items: center;
     justify-content: space-between;
     width: 100%;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -8879,23 +8879,19 @@ export const messages = defineMessages({
     },
     TR_EARN_CLAIM_REWARDS_LABEL: {
         id: 'TR_EARN_CLAIM_REWARDS_LABEL',
-        defaultMessage: 'Available bonus rewards',
+        defaultMessage: 'Bonus rewards to claim',
     },
     TR_EARN_CLAIM_REWARDS_BUTTON: {
         id: 'TR_EARN_CLAIM_REWARDS_BUTTON',
         defaultMessage: 'Claim',
     },
-    TR_EARN_CLAIM_REWARDS_TOKEN_LABEL: {
-        id: 'TR_EARN_CLAIM_REWARDS_TOKEN_LABEL',
-        defaultMessage: 'in {symbol}',
-    },
     TR_EARN_CLAIM_REWARDS_TOKENS_LABEL: {
         id: 'TR_EARN_CLAIM_REWARDS_TOKENS_LABEL',
-        defaultMessage: 'in {tokens} tokens',
+        defaultMessage: '{tokens, plural, one {# token} other {# tokens}}',
     },
     TR_EARN_CLAIM_REWARDS_ACCOUNTS_LABEL: {
         id: 'TR_EARN_CLAIM_REWARDS_ACCOUNTS_LABEL',
-        defaultMessage: 'on {accounts} accounts',
+        defaultMessage: '{accounts, plural, one {# account} other {# accounts}}',
     },
     TR_EARN_ENTER_AMOUNT_IN: {
         id: 'TR_EARN_ENTER_AMOUNT_IN',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10811,7 +10811,7 @@ export const messages = defineMessages({
     },
     TR_STAKE_REWARDS_BADGE: {
         id: 'TR_STAKE_REWARDS_BADGE',
-        defaultMessage: 'Epoch number {count}',
+        defaultMessage: '{count} Epoch',
     },
     TR_EARN_REWARDS_ARE_EMPTY: {
         id: 'TR_EARN_REWARDS_ARE_EMPTY',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improves the responsiveness of the Earn dashboard and DeFi Yield flow, especially on mobile and card-based layouts.

### Changes

- Improved the responsive APY/APR breakdown layout.
- Moved staking and DeFi provider information below the description in card layouts.
- Redesigned the bonus rewards banner:
  - added token icons,
  - improved token and account tooltips,
  - adjusted spacing and icon alignment.
- Simplified the mobile yield flow stepper.
- Reworked the mobile vault header into separate identity and account-detail rows.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31316

## Screenshots:

<img width="350" height="248" alt="image" src="https://github.com/user-attachments/assets/19b694b7-2e04-4c9b-8a8e-6af561b5ec23" />

<img width="358" height="517" alt="image" src="https://github.com/user-attachments/assets/9cbe69eb-0d41-4878-b5e1-d2253b392e85" />

<img width="376" height="463" alt="image" src="https://github.com/user-attachments/assets/5378ee63-e274-4cfc-afe8-02835e9f1227" />

<img width="423" height="802" alt="image" src="https://github.com/user-attachments/assets/b7af3948-bc59-4477-821b-ba3b3d15f15c" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/earn-mobile-responsiveness/web/](https://dev.suite.sldev.cz/suite-web/feat/earn-mobile-responsiveness/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in the earn/yield dashboard UI and the generic Banner/StepList components. The highest-risk path is the yield withdrawal flow, which is covered by the yield/withdrawal end-to-end test. Because Banner is a shared primitive, the safety-checks warning test provides a focused check on banner behavior. No other changed files have specific end-to-end behavioral coverage; broad static mappings are transitive and should not drive test selection.

<details><summary><b>Changed files (21)</b></summary>

- `packages/components/src/components/Banner/Banner.tsx`
- `packages/components/src/components/StepList/StepList.tsx`
- `packages/components/src/components/StepList/StepListContext.ts`
- `packages/components/src/components/StepList/StepListItem.tsx`
- `packages/suite-data/files/translations/en-US.json`
- `packages/suite/src/components/dashboard/DashboardSection.tsx`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts`
- `packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx`
- `packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx`
- `packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx`
- `packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/yield/withdrawal.test.ts` — This is the only end-to-end test that exercises the earn/yield dashboard and withdrawal flow. It renders the changed earn dashboard components (EarnYieldTable, EarnYieldClaimRewardsBanner, useYieldClaimRewardsData, YieldAmountCard, YieldFlowStepList, YieldPageHeader, YieldClaimPageHeader), the changed DashboardSection, and the generic Banner and StepList components used by the yield UI. It also relies on the updated earn-related translation strings.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/safety-checks-warning.test.ts` — The safety-checks warning banner is built on the generic Banner component, which was changed. This test directly verifies banner visibility, CTA behavior, and dismiss behavior, so a regression in the Banner layout or interaction pattern would be caught here.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts`
- `packages/suite-data/files/translations/en-US.json`
- `suite/intl/src/messages.ts`

_Updated: 2026-08-24T17:02:00.968Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T17:02:43.581Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH USDC token to SOL USDT token | 🤖 auto |
| Trading - Swap > Swap ETH to SOL | 🤖 auto |

</details>

_Updated: 2026-08-24T17:03:31.190Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-mobile-responsiveness&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-mobile-responsiveness&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->