### PR TITLE
refactor(connect): add getBitcoinNetworkOrThrow and dedupe Method_UnknownCoin throws

### DIFF
--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -3,7 +3,6 @@
 import {
     type BitcoinNetworkInfo,
     DEFAULT_SORTING_STRATEGY,
-    ERRORS,
     type PermissionRequest,
     type PrecomposeParams,
     type PrecomposedResult,
@@ -12,7 +11,7 @@ import type { ComposeOutput } from '@trezor/utxo-lib';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getBitcoinNetwork } from '../data/coinInfo';
+import { getBitcoinNetworkOrThrow } from '../data/coinInfo';
 import * as pathUtils from '../utils/pathUtils';
 import { createComposer } from './bitcoin/TransactionComposer';
 import { inputToTrezor } from './bitcoin/inputs';
@@ -38,10 +37,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             { name: 'sortingStrategy', type: 'string' },
         ]);
 
-        const coinInfo = getBitcoinNetwork(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getBitcoinNetworkOrThrow(payload.coin);
 
         // validate each output and transform into @trezor/utxo-lib/compose format
         const outputs = payload.outputs.map(out => validateHDOutput(out, coinInfo));

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -14,7 +14,12 @@ import { Assert } from '@trezor/schema-utils';
 import { bundlify, validateCoinPath } from './common/paramsValidator';
 import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { fixCoinInfoNetwork, getBitcoinNetwork, getUniqueNetworks } from '../data/coinInfo';
+import {
+    fixCoinInfoNetwork,
+    getBitcoinNetwork,
+    getBitcoinNetworkOrThrow,
+    getUniqueNetworks,
+} from '../data/coinInfo';
 import { getLabel, getSerializedPath, validatePath } from '../utils/pathUtils';
 
 type Params = {
@@ -52,11 +57,8 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
             if (coinInfo && !batch.crossChain) {
                 validateCoinPath(path, coinInfo);
             } else if (!coinInfo) {
-                coinInfo = getBitcoinNetwork(path);
-            }
-
-            if (!coinInfo) {
-                throw ERRORS.TypedError('Method_UnknownCoin');
+                // coin not provided (or not bitcoin-like), derive the network from the path
+                coinInfo = getBitcoinNetworkOrThrow(path);
             }
 
             // fix coinInfo network values (segwit/legacy)

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -7,13 +7,12 @@ import {
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getBitcoinNetwork } from '../data/coinInfo';
+import { getBitcoinNetwork, getBitcoinNetworkOrThrow } from '../data/coinInfo';
 import { bundlify, validateCoinPath } from './common/paramsValidator';
 import { getPublicKeyLabel } from '../utils/accountUtils';
 import { validatePath } from '../utils/pathUtils';
@@ -42,16 +41,13 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
             if (coinInfo && !batch.crossChain) {
                 validateCoinPath(address_n, coinInfo);
             } else if (!coinInfo) {
-                // coin not provided (or not bitcoin-like), try to derive network from the path
-                coinInfo = getBitcoinNetwork(address_n);
-            }
-
-            if (!coinInfo) {
+                // If coin is omitted or does not resolve to a bitcoin-like network,
+                // derive the network from the path.
                 // Non-bitcoin-like networks (e.g. "eth") used to be silently accepted here and
                 // fall back to btc for backward compatibility. Since connect 10 getPublicKey only
                 // supports bitcoin-like coins, so a network that resolves via neither the coin nor
                 // the path is rejected.
-                throw ERRORS.TypedError('Method_UnknownCoin');
+                coinInfo = getBitcoinNetworkOrThrow(address_n);
             }
 
             const proto = {

--- a/packages/connect/src/api/sendTransaction.ts
+++ b/packages/connect/src/api/sendTransaction.ts
@@ -23,7 +23,7 @@ import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLin
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { requestExistingAccounts } from './common/requestExistingAccounts';
-import { fixCoinInfoNetwork, getBitcoinNetwork } from '../data/coinInfo';
+import { fixCoinInfoNetwork, getBitcoinNetworkOrThrow } from '../data/coinInfo';
 import { formatAmount } from '../utils/formatUtils';
 import { createComposer } from './bitcoin/TransactionComposer';
 import { enhanceSignTx } from './bitcoin/enhanceSignTx';
@@ -64,10 +64,7 @@ export default class SendTransaction extends AbstractMethod<'sendTransaction', P
             { name: 'sortingStrategy', type: 'string' },
         ]);
 
-        const coinInfo = getBitcoinNetwork(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getBitcoinNetworkOrThrow(payload.coin);
         // validate backend
         assertBackendSupported(coinInfo);
 

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -2,14 +2,13 @@
 
 import type { BitcoinNetworkInfo, PermissionRequest } from '@trezor/connect-common';
 import { SignMessage as SignMessageSchema } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateCoinPath } from './common/paramsValidator';
-import { getBitcoinNetwork } from '../data/coinInfo';
+import { getBitcoinNetwork, getBitcoinNetworkOrThrow } from '../data/coinInfo';
 import { validateModelOneMessageSize } from '../device/validateMessageSize';
 import { hexToText, messageToHex } from '../utils/formatUtils';
 import { getLabel, getScriptType, getSerializedPath, validatePath } from '../utils/pathUtils';
@@ -26,10 +25,7 @@ export default class SignMessage extends AbstractMethod<'signMessage', Params> {
         const path = validatePath(payload.path);
         let coinInfo;
         if (payload.coin) {
-            coinInfo = getBitcoinNetwork(payload.coin);
-            if (!coinInfo) {
-                throw ERRORS.TypedError('Method_UnknownCoin');
-            }
+            coinInfo = getBitcoinNetworkOrThrow(payload.coin);
             validateCoinPath(path, coinInfo);
         } else {
             coinInfo = getBitcoinNetwork(path);

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -33,7 +33,7 @@ import type { Blockchain } from '../backend/BlockchainLink';
 import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getBitcoinNetwork } from '../data/coinInfo';
+import { getBitcoinNetworkOrThrow } from '../data/coinInfo';
 import { getLabel } from '../utils/pathUtils';
 import { PAYMENT_REQUEST_AMOUNT_BYTES, encodePaymentRequestAmount } from '../utils/paymentRequest';
 import { getTransactionVbytes } from './bitcoin/transactionBytes';
@@ -89,10 +89,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             ]);
         }
 
-        const coinInfo = getBitcoinNetwork(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getBitcoinNetworkOrThrow(payload.coin);
 
         const inputs = validateTrezorInputs(payload.inputs, coinInfo);
         const outputs = validateTrezorOutputs(payload.outputs, coinInfo);

--- a/packages/connect/src/api/verifyMessage.ts
+++ b/packages/connect/src/api/verifyMessage.ts
@@ -2,12 +2,11 @@
 
 import { VerifyMessage as VerifyMessageSchema } from '@trezor/connect-common';
 import type { CoinInfo, PROTO, PermissionRequest } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getBitcoinNetwork } from '../data/coinInfo';
+import { getBitcoinNetworkOrThrow } from '../data/coinInfo';
 import { validateModelOneMessageSize } from '../device/validateMessageSize';
 import { messageToHex } from '../utils/formatUtils';
 import { getLabel } from '../utils/pathUtils';
@@ -24,10 +23,7 @@ export default class VerifyMessage extends AbstractMethod<'verifyMessage', Param
         // validate incoming parameters for each batch
         Assert(VerifyMessageSchema, payload);
 
-        const coinInfo = getBitcoinNetwork(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getBitcoinNetworkOrThrow(payload.coin);
         const messageHex = payload.hex
             ? messageToHex(payload.message)
             : Buffer.from(payload.message, 'utf8').toString('hex');

--- a/packages/connect/src/data/coinInfo.test.ts
+++ b/packages/connect/src/data/coinInfo.test.ts
@@ -1,6 +1,13 @@
 import type { CoinSymbol } from '@trezor/connect-common/src/types/coinInfo';
+import { toHardenedPathPart } from '@trezor/crypto-utils';
 
-import { getAllNetworks, getCoinInfoOrThrow, getMiscNetwork, getUniqueNetworks } from './coinInfo';
+import {
+    getAllNetworks,
+    getBitcoinNetworkOrThrow,
+    getCoinInfoOrThrow,
+    getMiscNetwork,
+    getUniqueNetworks,
+} from './coinInfo';
 
 describe('data/coinInfo', () => {
     it('resolves a coin string by shortcut only (network name / label no longer accepted)', () => {
@@ -24,6 +31,21 @@ describe('data/coinInfo', () => {
         expect(() => getCoinInfoOrThrow('bitcoin')).toThrow('Coin not found');
         expect(() => getCoinInfoOrThrow('Bitcoin Cash')).toThrow('Coin not found');
         expect(() => getCoinInfoOrThrow('cardano')).toThrow('Coin not found');
+    });
+
+    it('getBitcoinNetworkOrThrow resolves bitcoin networks and rejects everything else', () => {
+        // resolves a bitcoin-family shortcut
+        expect(getBitcoinNetworkOrThrow('btc').shortcut).toBe('BTC');
+        expect(getBitcoinNetworkOrThrow('ltc').shortcut).toBe('LTC');
+
+        // resolves by BIP32 path via slip44 ([44', 0'] -> slip44 0 -> BTC)
+        expect(
+            getBitcoinNetworkOrThrow([toHardenedPathPart(44), toHardenedPathPart(0)]).shortcut,
+        ).toBe('BTC');
+
+        // eth/misc symbols resolve via getCoinInfoOrThrow but are rejected here (bitcoin-only guard)
+        expect(() => getBitcoinNetworkOrThrow('eth')).toThrow('Coin not found');
+        expect(() => getBitcoinNetworkOrThrow('ada')).toThrow('Coin not found');
     });
 
     it('uses the production Robinhood Blockbook', () => {

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -34,6 +34,20 @@ export const getBitcoinNetwork = (
     return bitcoinNetworks.find(n => n.slip44 === slip44);
 };
 
+// Bitcoin-family variant of `getCoinInfoOrThrow`: keeps the search scoped to bitcoin
+// networks (rejecting eth/misc symbols) and preserves the `CoinSymbol | number[]` input,
+// so it can replace the repeated `getBitcoinNetwork(x)` + manual `Method_UnknownCoin` throw.
+export const getBitcoinNetworkOrThrow = (
+    symbolOrPath: CoinSymbol | number[],
+): Readonly<BitcoinNetworkInfo> => {
+    const coinInfo = getBitcoinNetwork(symbolOrPath);
+    if (!coinInfo) {
+        throw ERRORS.TypedError('Method_UnknownCoin');
+    }
+
+    return coinInfo;
+};
+
 export const getEthereumNetwork = (
     symbolOrPath: CoinSymbol | number[],
 ): Readonly<EthereumNetworkInfo> | undefined => {


### PR DESCRIPTION
## What

Introduces a bitcoin-family `getBitcoinNetworkOrThrow` helper — the counterpart to the existing all-coin `getCoinInfoOrThrow` — and uses it to remove the repeated `getBitcoinNetwork(x)` + manual `Method_UnknownCoin` throw scattered across the bitcoin-only api methods.

```ts
export const getBitcoinNetworkOrThrow = (
    symbolOrPath: CoinSymbol | number[],
): Readonly<BitcoinNetworkInfo> => {
    const coinInfo = getBitcoinNetwork(symbolOrPath);
    if (!coinInfo) {
        throw ERRORS.TypedError('Method_UnknownCoin');
    }

    return coinInfo;
};
```

## Why not just reuse `getCoinInfoOrThrow`?

`getCoinInfoOrThrow` is only correct where a method handles **all** coin families. It is **not** a drop-in for the bitcoin-only methods, for three reasons:

1. **Scope / guard** — `getCoinInfoOrThrow` resolves `getBitcoinNetwork || getEthereumNetwork || getMiscNetwork`, so it would silently *accept* eth/misc symbols that these bitcoin-only methods deliberately reject.
2. **Return type** — it returns the wider `CoinInfo` union; the call sites use the result as `BitcoinNetworkInfo` (`validateTrezorInputs`, `fixCoinInfoNetwork`, `createComposer`, `cmd.getHDNode`, `network`/`dustLimit`/`segwit`…), which would break typing.
3. **Argument** — it only accepts a `string`; several call sites pass a BIP32 `number[]` path.

`getBitcoinNetworkOrThrow` keeps the bitcoin-only scope, the `BitcoinNetworkInfo` return type, and the `CoinSymbol | number[]` signature, so it is a true drop-in.

## Applied to

- **Exact pattern (1:1):** `signTransaction`, `sendTransaction`, `composeTransaction`, `verifyMessage`
- **Branched resolution where the throw is the guard:** `signMessage` (coin branch), `getAddress` + `getPublicKey` (path fallback)

## Deliberately left as-is

- `getOwnershipId` / `getOwnershipProof` — the throw is **conditional** (`if (batch.coin && !coinInfo)`) and `undefined` is a valid result on the coin-less path, so an unconditional `*OrThrow` would be wrong.
- **eth / misc families** — they have no lookup-then-throw sites (`getEthereumNetwork(path)` and `getMiscNetwork('…')` both tolerate `undefined` by design), so no `getEthereumNetworkOrThrow` / `getMiscNetworkOrThrow` was needed.

## Notes for QA

No behavior change: for a valid bitcoin coin symbol or path the resolved network is identical; the only difference is the throw is now centralized in the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor-getcoininfoorthrow/web/](https://dev.suite.sldev.cz/suite-web/refactor-getcoininfoorthrow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-getcoininfoorthrow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-getcoininfoorthrow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-getcoininfoorthrow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T09:18:48.698Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T09:17:02.794Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The PR modifies core TrezorConnect APIs used by every device operation, so the highest-risk regressions are in address export, public keys, message signing/verification, transaction composition/signing/broadcast, and coin metadata. Run the focused connect e2e tests plus representative Suite end-to-end flows across BTC, EVM, and altcoin transactions; avoid the broad coinInfo blanket list except where specific network/address behavior is validated. sendTransaction.ts and the connect e2e tests are not in the static coverage map but are inferred from their direct API usage.

<details><summary><b>Changed files (9)</b></summary>

- `packages/connect/src/api/composeTransaction.ts`
- `packages/connect/src/api/getAddress.ts`
- `packages/connect/src/api/getPublicKey.ts`
- `packages/connect/src/api/sendTransaction.ts`
- `packages/connect/src/api/signMessage.ts`
- `packages/connect/src/api/signTransaction.ts`
- `packages/connect/src/api/verifyMessage.ts`
- `packages/connect/src/data/coinInfo.test.ts`
- `packages/connect/src/data/coinInfo.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly calls TrezorConnect.ethereumSignTransaction, making it the most focused E2E regression test for the EVM signing path in signTransaction.ts; it is inferred because the static coverage map did not link connect e2e tests.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly exercises TrezorConnect.getAddress for single, bundled, and forced on-device confirmations, covering the changed getAddress.ts implementation; inferred from the test's direct API usage.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly calls TrezorConnect.signTransaction for Bitcoin and asserts the multi-step device signing flow, giving focused coverage of signTransaction.ts; inferred from direct API usage.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — Broadcasts a signed cross-chain swap transaction, exercising composeTransaction.ts, signTransaction.ts, and the inferred sendTransaction.ts broadcast path in a user-facing trading flow.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Verifies XPUBs for BTC, LTC, and ADA on the device, directly using getPublicKey.ts and relying on coinInfo.ts for coin metadata.
- `suite/e2e/tests/wallet/receive.test.ts` — Verifies receive addresses for BTC, ETH, SOL, and TRX on the device, directly using getAddress.ts and validating coinInfo.ts address formats and network config.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Builds, signs, and broadcasts a Bitcoin transaction with locktime and OP_RETURN outputs, covering composeTransaction.ts, signTransaction.ts, and the inferred sendTransaction.ts broadcast path.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Signs and verifies Bitcoin messages end-to-end, directly invoking signMessage.ts and verifyMessage.ts.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase.test.ts` — Adds hidden wallets and verifies receive addresses, exercising getAddress.ts with passphrase-derived accounts and the associated device-switching flow.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates and discovers eight different coins, so it is sensitive to coinInfo.ts changes for network definitions, symbols, and discovery metadata.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Triggers a sign-transaction error for Doge amounts exceeding MAX_SAFE_INTEGER, covering signTransaction.ts and Doge-specific limits from coinInfo.ts.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Initiates an ETH send with custom gas fees and verifies EVM signing prompts on the device, exercising signTransaction.ts for Ethereum and the inferred sendTransaction.ts send flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/data/coinInfo.test.ts`

_Updated: 2026-08-24T09:23:05.715Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->