### PR TITLE
fix(suite-desktop): validate safe storage decryption

### DIFF
--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -16,9 +16,11 @@
     "dependencies": {
         "@sentry/electron": "^7.16.0",
         "@suite-common/connect-popup": "workspace:*",
+        "@suite-common/delegated-identity-key": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-constants": "workspace:^",
+        "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",

--- a/packages/suite-desktop-core/src/modules/safeStorage.test.ts
+++ b/packages/suite-desktop-core/src/modules/safeStorage.test.ts
@@ -1,0 +1,68 @@
+import { safeStorage } from 'electron';
+
+import { DecryptionFailed } from '@suite-common/platform-encryption';
+import { ok } from '@trezor/type-utils';
+
+import { init } from './safeStorage';
+
+type IpcHandler = (ipcEvent: never, params: { value: string }) => unknown;
+
+const mockIpcHandlers = new Map<string, IpcHandler>();
+
+jest.mock('electron', () => ({
+    safeStorage: {
+        decryptString: jest.fn(),
+        encryptString: jest.fn(),
+        getSelectedStorageBackend: jest.fn(() => 'gnome_libsecret'),
+        isEncryptionAvailable: jest.fn(() => true),
+    },
+}));
+
+jest.mock('@trezor/ipc-proxy', () => ({
+    validateIpcMessage: jest.fn(),
+}));
+
+jest.mock('../typed-electron', () => ({
+    ipcMain: {
+        handle: (channel: string, handler: IpcHandler) => {
+            mockIpcHandlers.set(channel, handler);
+        },
+    },
+}));
+
+const delegatedIdentityKey = '0c9d40cd155e7ddb93e7b3c7b2acd8d75e7a3ebd543a3504c8f8164fb692772b';
+
+describe('safeStorage', () => {
+    beforeAll(() => {
+        init({} as never);
+    });
+
+    const getDecryptHandler = () => {
+        const registeredHandler = mockIpcHandlers.get('safe-storage/decrypt');
+
+        if (registeredHandler === undefined) {
+            throw new Error('safe-storage/decrypt handler was not registered');
+        }
+
+        return registeredHandler;
+    };
+
+    it('returns a supported decrypted value', async () => {
+        jest.mocked(safeStorage.decryptString).mockReturnValue(delegatedIdentityKey);
+
+        const result = await getDecryptHandler()({} as never, { value: '00' });
+
+        // Restricting the oracle must not make persisted Suite secrets undecryptable.
+        expect(result).toEqual(ok(delegatedIdentityKey));
+    });
+
+    it('rejects an unsupported decrypted value', async () => {
+        jest.mocked(safeStorage.decryptString).mockReturnValue('arbitrary plaintext');
+
+        const result = await getDecryptHandler()({} as never, { value: '00' });
+
+        // The renderer can call this IPC directly, so this assertion prevents the handler from
+        // becoming an unrestricted safeStorage decryption oracle.
+        expect(result).toEqual({ success: false, error: DecryptionFailed() });
+    });
+});

--- a/packages/suite-desktop-core/src/modules/safeStorage.ts
+++ b/packages/suite-desktop-core/src/modules/safeStorage.ts
@@ -6,6 +6,7 @@ import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { err, ok } from '@trezor/type-utils';
 
 import type { ModuleInit } from './module';
+import { isSafeStorageDecryptedValue } from './safeStorageValidation';
 import { ipcMain } from '../typed-electron';
 
 export const SERVICE_NAME = 'SAFE_STORAGE';
@@ -49,6 +50,12 @@ export const init: ModuleInit = () => {
         try {
             const buffer = Buffer.from(params.value, 'hex');
             const decrypted = safeStorage.decryptString(buffer);
+
+            // Renderer code can invoke this handler directly, so restrict returned plaintext to
+            // known Suite values instead of exposing safeStorage as an unrestricted decrypt oracle.
+            if (!isSafeStorageDecryptedValue(decrypted)) {
+                return Promise.resolve(err(DecryptionFailed()));
+            }
 
             return Promise.resolve(ok(decrypted));
         } catch {

--- a/packages/suite-desktop-core/src/modules/safeStorageValidation.test.ts
+++ b/packages/suite-desktop-core/src/modules/safeStorageValidation.test.ts
@@ -1,0 +1,28 @@
+import {
+    asSuiteSyncOwnerId,
+    asSuiteSyncOwnerSecretHex,
+    serializeSuiteSyncOwner,
+} from '@suite-common/suite-sync-storage';
+
+import { isSafeStorageDecryptedValue } from './safeStorageValidation';
+
+const delegatedIdentityKey = '0c9d40cd155e7ddb93e7b3c7b2acd8d75e7a3ebd543a3504c8f8164fb692772b';
+const suiteSyncOwner = serializeSuiteSyncOwner({
+    ownerId: asSuiteSyncOwnerId('yg0UgROParTpm60ltI3hDw'),
+    ownerSecret: asSuiteSyncOwnerSecretHex(
+        'e17818d7c458f171885280eeef2d70078c6842b51e18ec6f2f8c9f44d3d171fd0f49a3aeff32a560d7f823321fcd24f8d8773ffa59855c6447b11af88a2fd7b5',
+    ),
+});
+
+describe(isSafeStorageDecryptedValue.name, () => {
+    it.each([delegatedIdentityKey, delegatedIdentityKey.toUpperCase(), suiteSyncOwner])(
+        'accepts a supported value',
+        value => {
+            expect(isSafeStorageDecryptedValue(value)).toBe(true);
+        },
+    );
+
+    it('rejects a value unsupported by all validators', () => {
+        expect(isSafeStorageDecryptedValue('arbitrary plaintext')).toBe(false);
+    });
+});

--- a/packages/suite-desktop-core/src/modules/safeStorageValidation.ts
+++ b/packages/suite-desktop-core/src/modules/safeStorageValidation.ts
@@ -1,0 +1,9 @@
+import { isDelegatedIdentityKey } from '@suite-common/delegated-identity-key';
+import { isSuiteSyncOwner } from '@suite-common/suite-sync-storage';
+
+type AllowedValueValidator = (value: string) => boolean;
+
+const allowedValueValidators: AllowedValueValidator[] = [isDelegatedIdentityKey, isSuiteSyncOwner];
+
+export const isSafeStorageDecryptedValue = (value: string): boolean =>
+    allowedValueValidators.some(validator => validator(value));

--- a/packages/suite-desktop-core/tsconfig.json
+++ b/packages/suite-desktop-core/tsconfig.json
@@ -7,11 +7,17 @@
             "path": "../../suite-common/connect-popup"
         },
         {
+            "path": "../../suite-common/delegated-identity-key"
+        },
+        {
             "path": "../../suite-common/platform-encryption"
         },
         { "path": "../../suite-common/sentry" },
         {
             "path": "../../suite-common/suite-constants"
+        },
+        {
+            "path": "../../suite-common/suite-sync-storage"
         },
         {
             "path": "../../suite-common/suite-utils"

--- a/packages/suite/src/views/settings/SettingsDebug/PlatformEncryption.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/PlatformEncryption.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { asEncryptedHex, selectPlatformEncryptionDep } from '@suite-common/platform-encryption';
-import { Button, ButtonGroup, Column, Textarea } from '@trezor/components';
+import { Banner, Button, ButtonGroup, Column, Textarea } from '@trezor/components';
 import { SectionItem, SettingsSection } from '@trezor/product-components';
 import { breakpoints } from '@trezor/theme';
 import { type Branded } from '@trezor/type-utils';
@@ -43,6 +43,10 @@ export const PlatformEncryption = () => {
         <SettingsSection hasVerticalLayout={isBelowLaptop} title="Platform Encryption">
             <SectionItem>
                 <Column gap={16} flex="1">
+                    <Banner
+                        intent="info"
+                        description="Decryption is supported only for validated data types: serialized Suite Sync owner data and delegated identity keys."
+                    />
                     <Textarea
                         label="Plaintext"
                         value={plaintext}

--- a/suite-common/delegated-identity-key/src/index.ts
+++ b/suite-common/delegated-identity-key/src/index.ts
@@ -1,3 +1,4 @@
 export { delegatedIdentityKeyCompositionRoot } from './delegatedIdentityKeyCompositionRoot';
 export { getProofOfDelegatedIdentity } from './getProofOfDelegatedIdentity';
 export { getPublicIdentityKeyFromDelegatedKey } from './getPublicIdentityKeyFromDeletegatedKey';
+export { isDelegatedIdentityKey } from './isDelegatedIdentityKey';

--- a/suite-common/delegated-identity-key/src/isDelegatedIdentityKey.test.ts
+++ b/suite-common/delegated-identity-key/src/isDelegatedIdentityKey.test.ts
@@ -1,0 +1,19 @@
+import { isDelegatedIdentityKey } from './isDelegatedIdentityKey';
+
+const delegatedIdentityKey = '0c9d40cd155e7ddb93e7b3c7b2acd8d75e7a3ebd543a3504c8f8164fb692772b';
+
+describe(isDelegatedIdentityKey.name, () => {
+    it.each([delegatedIdentityKey, delegatedIdentityKey.toUpperCase()])(
+        'accepts a delegated identity key',
+        value => {
+            expect(isDelegatedIdentityKey(value)).toBe(true);
+        },
+    );
+
+    it.each(['', delegatedIdentityKey.slice(2), `${delegatedIdentityKey.slice(0, -1)}z`])(
+        'rejects an invalid delegated identity key',
+        value => {
+            expect(isDelegatedIdentityKey(value)).toBe(false);
+        },
+    );
+});

--- a/suite-common/delegated-identity-key/src/isDelegatedIdentityKey.ts
+++ b/suite-common/delegated-identity-key/src/isDelegatedIdentityKey.ts
@@ -1,0 +1,4 @@
+const DELEGATED_IDENTITY_KEY_PATTERN = /^[0-9a-f]{64}$/i;
+
+export const isDelegatedIdentityKey = (value: string): boolean =>
+    DELEGATED_IDENTITY_KEY_PATTERN.test(value);

--- a/suite-common/suite-sync-storage/jest.config.js
+++ b/suite-common/suite-sync-storage/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/suite-sync-storage/package.json
+++ b/suite-common/suite-sync-storage/package.json
@@ -7,6 +7,7 @@
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
@@ -14,6 +15,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/device-utils": "workspace:*",
-        "@trezor/type-utils": "workspace:*"
+        "@trezor/type-utils": "workspace:*",
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-common/suite-sync-storage/src/index.ts
+++ b/suite-common/suite-sync-storage/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './owner/suiteSyncOwner';
 export type { CreateSuiteSyncOwner, CreateSuiteSyncOwnerDep } from './Owner';
 export { CreateSuiteSyncOwnerError } from './Owner';
+export { isSuiteSyncOwner } from './owner/isSuiteSyncOwner';
 export type {
     EntityListener,
     SuiteSyncTable,

--- a/suite-common/suite-sync-storage/src/owner/isSuiteSyncOwner.test.ts
+++ b/suite-common/suite-sync-storage/src/owner/isSuiteSyncOwner.test.ts
@@ -1,0 +1,34 @@
+import { isSuiteSyncOwner } from './isSuiteSyncOwner';
+import {
+    type SuiteSyncOwner,
+    asSuiteSyncOwnerId,
+    asSuiteSyncOwnerSecretHex,
+    serializeSuiteSyncOwner,
+} from './suiteSyncOwner';
+
+const suiteSyncOwner: SuiteSyncOwner = {
+    ownerId: asSuiteSyncOwnerId('yg0UgROParTpm60ltI3hDw'),
+    ownerSecret: asSuiteSyncOwnerSecretHex(
+        'e17818d7c458f171885280eeef2d70078c6842b51e18ec6f2f8c9f44d3d171fd0f49a3aeff32a560d7f823321fcd24f8d8773ffa59855c6447b11af88a2fd7b5',
+    ),
+};
+
+describe(isSuiteSyncOwner.name, () => {
+    it('accepts a serialized Suite Sync owner', () => {
+        expect(isSuiteSyncOwner(serializeSuiteSyncOwner(suiteSyncOwner))).toBe(true);
+    });
+
+    it.each([
+        '',
+        'arbitrary plaintext',
+        'null',
+        '[]',
+        '{}',
+        JSON.stringify({ ownerId: suiteSyncOwner.ownerId }),
+        JSON.stringify({ ...suiteSyncOwner, ownerSecret: 'not-hex' }),
+        JSON.stringify({ ...suiteSyncOwner, ownerId: 'not-an-owner-id' }),
+        JSON.stringify({ ...suiteSyncOwner, unexpected: true }),
+    ])('rejects an invalid serialized Suite Sync owner', value => {
+        expect(isSuiteSyncOwner(value)).toBe(false);
+    });
+});

--- a/suite-common/suite-sync-storage/src/owner/isSuiteSyncOwner.ts
+++ b/suite-common/suite-sync-storage/src/owner/isSuiteSyncOwner.ts
@@ -1,12 +1,9 @@
-import { typedObjectKeys } from '@trezor/utils';
+import { hasProp, typedObjectKeys } from '@trezor/utils';
 
 import { type SuiteSyncOwnerSerialized } from './suiteSyncOwner';
 
 const SUITE_SYNC_OWNER_ID_PATTERN = /^[A-Za-z0-9_-]{22}$/;
 const SUITE_SYNC_OWNER_SECRET_PATTERN = /^[0-9a-f]{128}$/i;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-    typeof value === 'object' && value !== null && !Array.isArray(value);
 
 export const isSuiteSyncOwner = (value: string): value is SuiteSyncOwnerSerialized => {
     let parsedValue: unknown;
@@ -17,12 +14,12 @@ export const isSuiteSyncOwner = (value: string): value is SuiteSyncOwnerSerializ
         return false;
     }
 
-    if (!isRecord(parsedValue)) {
+    if (!hasProp(parsedValue, 'ownerId') || !hasProp(parsedValue, 'ownerSecret')) {
         return false;
     }
 
     const keys = typedObjectKeys(parsedValue);
-    if (keys.length !== 2 || !keys.includes('ownerId') || !keys.includes('ownerSecret')) {
+    if (keys.length !== 2) {
         return false;
     }
 

--- a/suite-common/suite-sync-storage/src/owner/isSuiteSyncOwner.ts
+++ b/suite-common/suite-sync-storage/src/owner/isSuiteSyncOwner.ts
@@ -1,0 +1,35 @@
+import { typedObjectKeys } from '@trezor/utils';
+
+import { type SuiteSyncOwnerSerialized } from './suiteSyncOwner';
+
+const SUITE_SYNC_OWNER_ID_PATTERN = /^[A-Za-z0-9_-]{22}$/;
+const SUITE_SYNC_OWNER_SECRET_PATTERN = /^[0-9a-f]{128}$/i;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const isSuiteSyncOwner = (value: string): value is SuiteSyncOwnerSerialized => {
+    let parsedValue: unknown;
+
+    try {
+        parsedValue = JSON.parse(value);
+    } catch {
+        return false;
+    }
+
+    if (!isRecord(parsedValue)) {
+        return false;
+    }
+
+    const keys = typedObjectKeys(parsedValue);
+    if (keys.length !== 2 || !keys.includes('ownerId') || !keys.includes('ownerSecret')) {
+        return false;
+    }
+
+    return (
+        typeof parsedValue.ownerId === 'string' &&
+        SUITE_SYNC_OWNER_ID_PATTERN.test(parsedValue.ownerId) &&
+        typeof parsedValue.ownerSecret === 'string' &&
+        SUITE_SYNC_OWNER_SECRET_PATTERN.test(parsedValue.ownerSecret)
+    );
+};

--- a/suite-common/suite-sync-storage/tsconfig.json
+++ b/suite-common/suite-sync-storage/tsconfig.json
@@ -5,6 +5,7 @@
         { "path": "../wallet-config" },
         { "path": "../wallet-types" },
         { "path": "../../packages/device-utils" },
-        { "path": "../../packages/type-utils" }
+        { "path": "../../packages/type-utils" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11142,6 +11142,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -17493,9 +17494,11 @@ __metadata:
     "@sentry/electron": "npm:^7.16.0"
     "@sentry/webpack-plugin": "npm:^5.4.0"
     "@suite-common/connect-popup": "workspace:*"
+    "@suite-common/delegated-identity-key": "workspace:*"
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-constants": "workspace:^"
+    "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"


### PR DESCRIPTION
## Description

Restrict Electron safeStorage decryption results to allowlisted type guards colocated with the delegated identity key and Suite Sync storage domains. Reject decrypted values that do not match an allowed runtime shape without changing the stored representation.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches secure storage in the desktop core, Suite Sync storage/owner validation, and a debug encryption UI. The highest risk surface is the Suite Sync data flow, so the top priority is a focused set of Suite Sync e2e tests that create, update, remove, migrate, and read labels across wallets. Desktop safeStorage and the new delegated-identity-key validation have no direct e2e coverage in the provided analysis and should rely on unit tests plus targeted desktop QA.

<details><summary><b>Changed files (15)</b></summary>

- `packages/suite-desktop-core/package.json`
- `packages/suite-desktop-core/src/modules/safeStorage.test.ts`
- `packages/suite-desktop-core/src/modules/safeStorage.ts`
- `packages/suite-desktop-core/src/modules/safeStorageValidation.test.ts`
- `packages/suite-desktop-core/src/modules/safeStorageValidation.ts`
- `packages/suite-desktop-core/tsconfig.json`
- `packages/suite/src/views/settings/SettingsDebug/PlatformEncryption.tsx`
- `suite-common/delegated-identity-key/src/index.ts`
- `suite-common/delegated-identity-key/src/isDelegatedIdentityKey.test.ts`
- `suite-common/delegated-identity-key/src/isDelegatedIdentityKey.ts`
- `suite-common/suite-sync-storage/package.json`
- `suite-common/suite-sync-storage/src/index.ts`
- `suite-common/suite-sync-storage/src/owner/isSuiteSyncOwner.test.ts`
- `suite-common/suite-sync-storage/src/owner/isSuiteSyncOwner.ts`
- `suite-common/suite-sync-storage/tsconfig.json`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates account, wallet, address, and output labels and asserts they sync to the Evolu relay, directly exercising the Suite Sync write path that depends on suite-sync-storage and the surrounding encryption/identity stack.
- `suite/e2e/tests/metadata/suite-sync/legacy-to-suiteSync-migration.test.ts` — It migrates local labels into Suite Sync and verifies relay synchronization, which is a direct end-to-end test of the Suite Sync storage backend and migration logic.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — The test's source hints explicitly reference @suite-common/suite-sync-storage (asSuiteSyncOwnerSecretHex) and cover Suite Sync across multiple passphrase wallets, making it a strong proxy for owner-secret storage changes.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — It removes every label type and asserts the relay reflects null values, validating delete/update semantics in the Suite Sync storage layer.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test seeds labels in the Evolu relay and asserts they are downloaded and displayed correctly, covering the Suite Sync read path that relies on storage and identity validation.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — It updates existing labels and removes them, asserting both UI and relay state change correctly, which stresses the full Suite Sync CRUD cycle.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — The test enables Suite Sync and then verifies unsupported-device banner behavior across wallet switching and navigation, sharing the Suite Sync initialization path but with a UI-focused assertion set.

</details>

⚠️ **Changes with no test coverage (11)**
- `packages/suite-desktop-core/package.json`
- `packages/suite-desktop-core/src/modules/safeStorage.test.ts`
- `packages/suite-desktop-core/src/modules/safeStorage.ts`
- `packages/suite-desktop-core/src/modules/safeStorageValidation.test.ts`
- `packages/suite-desktop-core/src/modules/safeStorageValidation.ts`
- `packages/suite-desktop-core/tsconfig.json`
- `suite-common/delegated-identity-key/src/index.ts`
- `suite-common/delegated-identity-key/src/isDelegatedIdentityKey.test.ts`
- `suite-common/delegated-identity-key/src/isDelegatedIdentityKey.ts`
- `suite-common/suite-sync-storage/package.json`
- `suite-common/suite-sync-storage/tsconfig.json`

_Updated: 2026-08-24T11:20:53.469Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/safe-storage-decryption-validation/web/](https://dev.suite.sldev.cz/suite-web/fix/safe-storage-decryption-validation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/safe-storage-decryption-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/safe-storage-decryption-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/safe-storage-decryption-validation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T11:22:36.438Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T11:23:10.309Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->