### PR TITLE
fix(suite): do not lowercase token symbol in add-token analytics event

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -106,7 +106,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
                 payload: {
                     networkSymbol: account.symbol,
                     addedNth: account.tokens ? account.tokens.length + 1 : 0,
-                    token: tokenInfo[0]?.symbol?.toLowerCase() || '',
+                    token: tokenInfo[0]?.symbol || '',
                 },
             });
         }

--- a/suite/analytics/src/events/addTokenEvent.ts
+++ b/suite/analytics/src/events/addTokenEvent.ts
@@ -28,7 +28,13 @@ export const addTokenEvent: EventDef<Attributes, EventType.AddToken> = {
         token: {
             description:
                 'Identifier of the token being added (token symbol for EVM networks, contract address for Stellar)',
-            changelog: [{ version: '1.9.0', notes: 'added' }],
+            changelog: [
+                { version: '1.9.0', notes: 'added' },
+                {
+                    version: '26.9.0',
+                    notes: 'no longer lowercased, reports the exact casing returned by the blockchain backend',
+                },
+            ],
         },
     },
 };


### PR DESCRIPTION
## Description

The `add-token` analytics event lowercased the token symbol before reporting, destroying the on-chain casing returned by the blockchain backend. Differently-cased symbols can be different tokens (e.g. `USDt` is the legitimate bridged-Tether ticker on Avalanche, while lowercase `usdt` is a common fake-Tether airdrop symbol), so the manufactured lowercase variant could not be correlated with other events that report the faithful casing.

The `.toLowerCase()` is removed — the event now reports the symbol exactly as returned by the backend. The semantics change is documented in the `token` attribute changelog in `addTokenEvent.ts` (26.9.0).

## Notes for QA

- Analytics payload only, no user-facing behavior change.
- Add a custom token to an EVM account (Accounts → select account → ⋯ → Add token): the reported `add-token` event's `token` value now keeps the contract's exact symbol casing (e.g. `USDT` instead of `usdt`).
- Data note: historical events carry lowercase symbols; reporting on this field will see a casing cutover at this release.
- Preview: https://dev.suite.sldev.cz/suite-web/fix/add-token-analytics-symbol-casing/web

## Related Issue

No GitHub issue — internal Slack discussion: https://satoshilabs.slack.com/archives/G019WLX2P7B/p1787565739258459

## Screenshots:

N/A (analytics payload change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Neither changed file has identifiable behavioral test coverage in the available suite. AddTokenModal.tsx maps to 136 tests statically, indicating it is a broad, transitively-imported dependency (likely via a shared modal registry or page object); the LLM analysis of those tests shows no evidence that any of them exercise the add-token modal flow itself. The new analytics event file addTokenEvent.ts has no static coverage and none of the described analytics tests mention addToken events, so no inference is possible. Therefore no E2E tests are recommended for this change set; consider adding or manually verifying the add-token flow and its analytics event.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx`
- `suite/analytics/src/events/addTokenEvent.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx`
- `suite/analytics/src/events/addTokenEvent.ts`

_Updated: 2026-08-24T11:37:22.369Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/add-token-analytics-symbol-casing/web/](https://dev.suite.sldev.cz/suite-web/fix/add-token-analytics-symbol-casing/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/add-token-analytics-symbol-casing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/add-token-analytics-symbol-casing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T11:40:17.528Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T11:40:05.744Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->