### PR TITLE
feat(suite): Mark Chinese simplified and Indonesian as official langu…

### DIFF
--- a/suite-common/suite-types/src/languages.ts
+++ b/suite-common/suite-types/src/languages.ts
@@ -16,7 +16,7 @@ export const LANGUAGES = {
     'de-DE': { icon: '🇩🇪', name: 'Deutsch', en: 'German', type: 'official' },
     'fr-FR': { icon: '🇫🇷', name: 'Français', en: 'French', type: 'official' },
     'hu-HU': { icon: '🇭🇺', name: 'Magyar', en: 'Hungarian', type: 'community' },
-    'id-ID': { icon: '🇮🇩', name: 'Bahasa Indonesia', en: 'Indonesian', type: 'community' },
+    'id-ID': { icon: '🇮🇩', name: 'Bahasa Indonesia', en: 'Indonesian', type: 'official' },
     'it-IT': { icon: '🇮🇹', name: 'Italiano', en: 'Italian', type: 'community' },
     'ja-JP': { icon: '🇯🇵', name: '日本語', en: 'Japanese', type: 'official' },
     'ko-KR': { icon: '🇰🇷', name: '한국어', en: 'Korean', type: 'official' },
@@ -28,7 +28,7 @@ export const LANGUAGES = {
         icon: '简',
         name: '中文(简体)',
         en: 'Chinese Simplified',
-        type: 'community',
+        type: 'official',
         nameInOsStartsWith: 'zh-Hans',
     },
     'zh-TW': {


### PR DESCRIPTION
…ages

<!--- Provide a general summary of your changes in the Title above -->

## Description

Chinese simplified and Indonesian languages are now official.

## Notes for QA

- check languages in settings if they are official ones

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31472

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-new-official-language/web/](https://dev.suite.sldev.cz/suite-web/add-new-official-language/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-new-official-language&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-new-official-language&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=add-new-official-language&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T11:51:46.362Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T11:50:41.981Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->