### PR TITLE
refactor(analytics): remove typed analytics adapters

### DIFF
--- a/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
@@ -1,11 +1,6 @@
 import { type JSX, useCallback, useEffect } from 'react';
 
-import {
-    AppUpdateEventStatus,
-    asTypedDesktopAnalytics,
-    events,
-    selectDesktopAnalyticsDep,
-} from '@suite/analytics';
+import { AppUpdateEventStatus, events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import {
     UpdateState,
     availableThunk,
@@ -99,7 +94,7 @@ export const DesktopUpdater = () => {
             updateInfo: desktopUpdate.latest,
         });
 
-        asTypedDesktopAnalytics(analytics).report({
+        analytics.report({
             type: events.appUpdateEvent.name,
             payload,
         });

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, asTypedDesktopAnalytics } from '@suite/analytics';
+import { type DesktopAnalyticsDep } from '@suite/analytics';
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
@@ -106,7 +106,7 @@ export const claimMerklRewardsThunk = createThunk<
         }
 
         const reportSubmitError = (errorMessage = 'submit-failed') =>
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.yieldClaimEvent.name,
                 payload: {
                     type: 'error',
@@ -183,7 +183,7 @@ export const claimMerklRewardsThunk = createThunk<
                 }),
             );
 
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.yieldClaimEvent.name,
                 payload: {
                     type: 'tx-simulation-modal',

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, asTypedDesktopAnalytics } from '@suite/analytics';
+import { type DesktopAnalyticsDep } from '@suite/analytics';
 import { openDeferredModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin';
@@ -95,7 +95,7 @@ export const submitYieldDepositThunk = createThunk<
                 }),
             );
 
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.yieldDepositEvent.name,
                 payload: {
                     type: 'tx-simulation-modal',
@@ -126,7 +126,7 @@ export const submitYieldDepositThunk = createThunk<
             userAcceptedTxSimulation?.resolve();
 
             if (!sendResult) {
-                asTypedDesktopAnalytics(extra.services.analytics).report({
+                extra.services.analytics.report({
                     type: events.yieldDepositEvent.name,
                     payload: {
                         type: 'error',
@@ -163,7 +163,7 @@ export const submitYieldDepositThunk = createThunk<
             );
         } catch (error) {
             console.error(error);
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.yieldDepositEvent.name,
                 payload: {
                     type: 'error',

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -1,4 +1,4 @@
-import { type DesktopAnalyticsDep, asTypedDesktopAnalytics } from '@suite/analytics';
+import { type DesktopAnalyticsDep } from '@suite/analytics';
 import { openDeferredModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin';
@@ -43,7 +43,7 @@ export const submitYieldWithdrawThunk = createThunk<
     `${STABLECOIN_YIELD_PREFIX}/thunk/submitWithdraw`,
     async ({ flowKey, flowData, amount, flowType }, { dispatch, getState, extra }) => {
         const reportSubmitError = (errorMessage = 'submit-failed') =>
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.yieldWithdrawEvent.name,
                 payload: {
                     type: 'error',
@@ -98,7 +98,7 @@ export const submitYieldWithdrawThunk = createThunk<
                 }),
             );
 
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.yieldWithdrawEvent.name,
                 payload: {
                     type: 'tx-simulation-modal',
@@ -131,7 +131,7 @@ export const submitYieldWithdrawThunk = createThunk<
             userAcceptedTxSimulation?.resolve();
 
             if (!result) {
-                asTypedDesktopAnalytics(extra.services.analytics).report({
+                extra.services.analytics.report({
                     type: events.yieldWithdrawEvent.name,
                     payload: {
                         type: 'error',

--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -1,6 +1,6 @@
 import { type BuyTrade } from 'invity-api';
 
-import { type DesktopAnalyticsDep, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
 import {
@@ -52,7 +52,7 @@ export const selectBuyQuoteThunk = createThunk<
         quotesRequest.receiveCurrency,
     )?.name;
 
-    asTypedDesktopAnalytics(extra.services.analytics).report({
+    extra.services.analytics.report({
         type: events.tradeBuyEvent.name,
         payload: {
             action: 'continue',

--- a/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
@@ -1,6 +1,6 @@
 import { type ExchangeTrade } from 'invity-api';
 
-import { type DesktopAnalyticsDep, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
 import {
@@ -47,7 +47,7 @@ export const selectExchangeQuoteThunk = createThunk<
             contractAddress: receiveCryptoContractAddress,
         } = cryptoIdToNetworkSymbolAndContractAddress(quotesRequest.receive);
 
-        asTypedDesktopAnalytics(extra.services.analytics).report({
+        extra.services.analytics.report({
             type: events.tradeExchangeEvent.name,
             payload: {
                 action: 'continue',

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
@@ -1,6 +1,6 @@
 import { type SellFiatTrade } from 'invity-api';
 
-import { type DesktopAnalyticsDep, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
 import {
@@ -43,7 +43,7 @@ export const selectSellQuoteThunk = createThunk<
             quotesRequest.cryptoCurrency,
         );
 
-        asTypedDesktopAnalytics(extra.services.analytics).report({
+        extra.services.analytics.report({
             type: events.tradeSellEvent.name,
             payload: {
                 action: 'continue',

--- a/suite-native/analytics-redux/src/analyticsThunks.ts
+++ b/suite-native/analytics-redux/src/analyticsThunks.ts
@@ -9,7 +9,7 @@ import {
     selectLoggerEnabled,
 } from '@suite-common/analytics-redux';
 import { createThunk } from '@suite-common/redux-utils';
-import { type NativeAnalyticsDep, asTypedNativeAnalytics, events } from '@suite-native/analytics';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { isProduction } from '@suite-native/config';
 import { allowSentryReport, setSentryUser } from '@suite-native/sentry';
 import { type InitOptions, getTrackingRandomId } from '@trezor/analytics-uploader';
@@ -24,7 +24,7 @@ const enableAnalyticsThunk = createThunk<
     void,
     { state: void; extra: EnableAnalyticsThunkDeps }
 >(`${ACTION_PREFIX}/enableAnalyticsThunk`, (_, { dispatch, extra }) => {
-    asTypedNativeAnalytics(extra.services.analytics).report({
+    extra.services.analytics.report({
         type: events.settingsDataPermissionEvent.name,
         payload: { analyticsPermission: true },
     });
@@ -39,7 +39,7 @@ const disableAnalyticsThunk = createThunk<
     void,
     { state: void; extra: DisableAnalyticsThunkDeps }
 >(`${ACTION_PREFIX}/disableAnalyticsThunk`, (_, { dispatch, extra }) => {
-    asTypedNativeAnalytics(extra.services.analytics).report(
+    extra.services.analytics.report(
         {
             type: events.settingsDataPermissionEvent.name,
             payload: { analyticsPermission: false },

--- a/suite-native/analytics/src/asTypedNativeAnalytics.ts
+++ b/suite-native/analytics/src/asTypedNativeAnalytics.ts
@@ -1,8 +1,0 @@
-import { type AnalyticsSharedEvents } from '@suite-common/analytics';
-import { type Analytics } from '@trezor/analytics-uploader';
-
-import { type AnalyticsNativeEvents } from './analyticsEvents';
-
-// @TODO: we have to type dispatch correctly in desktop/native/common
-export const asTypedNativeAnalytics = (analytics: Analytics<AnalyticsSharedEvents>) =>
-    analytics as unknown as Analytics<AnalyticsNativeEvents>;

--- a/suite-native/analytics/src/index.ts
+++ b/suite-native/analytics/src/index.ts
@@ -31,7 +31,6 @@ export { type DeviceSetupInfoLocation } from './events/deviceSetupInfoEvent';
 export type { AutoEjectModalValue } from './events/autoEjectModalEvent';
 export type { DemoAccountQuestionnaireLinkKey } from './events/demoAccountQuestionnaireLinksEvent';
 export { analytics, type NativeAnalyticsDep, selectNativeAnalyticsDep } from './createAnalytics';
-export { asTypedNativeAnalytics } from './asTypedNativeAnalytics';
 export type { AnalyticsNativeEvents } from './analyticsEvents';
 
 export * as events from './events';

--- a/suite-native/biometrics/src/biometricsThunks.ts
+++ b/suite-native/biometrics/src/biometricsThunks.ts
@@ -5,7 +5,7 @@ import * as LocalAuthentication from 'expo-local-authentication';
 import type { LocalAuthenticationResult } from 'expo-local-authentication';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { type NativeAnalyticsDep, asTypedNativeAnalytics, events } from '@suite-native/analytics';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 
 import {
     selectGoneToBackgroundAtTimestamp,
@@ -90,7 +90,7 @@ export const toggleBiometricsSettingsThunk = createThunk<
         const isBiometricsEnabled = selectIsBiometricsEnabled(getState());
 
         if (isBiometricsEnabled) {
-            asTypedNativeAnalytics(services.analytics).report({
+            services.analytics.report({
                 type: events.biometricsChangeEvent.name,
                 payload: { enabled: false, origin: 'settingsToggle' },
             });
@@ -98,7 +98,7 @@ export const toggleBiometricsSettingsThunk = createThunk<
             return BiometricsToggleResult.Disabled;
         }
 
-        asTypedNativeAnalytics(services.analytics).report({
+        services.analytics.report({
             type: events.biometricsChangeEvent.name,
             payload: { enabled: true, origin: 'settingsToggle' },
         });

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -14,7 +14,7 @@ import {
     selectAccountsByDeviceState,
     selectDiscoveryByDevicePath,
 } from '@suite-common/wallet-core';
-import { type NativeAnalyticsDep, asTypedNativeAnalytics } from '@suite-native/analytics';
+import { type NativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type NativeBluetoothRootState,
     selectIsBluetoothDeviceOsUnpairingRequired,
@@ -85,10 +85,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps<
 
     switch (action.type) {
         case DEVICE.CONNECT: {
-            reportDeviceConnectionAnalytics(
-                action.payload.device,
-                asTypedNativeAnalytics(extra.services.analytics),
-            );
+            reportDeviceConnectionAnalytics(action.payload.device, extra.services.analytics);
             break;
         }
         case DEVICE.DISCONNECT:

--- a/suite-native/module-receive/src/receiveThunks.ts
+++ b/suite-native/module-receive/src/receiveThunks.ts
@@ -2,7 +2,7 @@ import { getReceiveAddressForFlowEntry, getReceiveAddressToAdd } from '@suite-co
 import { receiveActions, selectCurrentFreshAddress } from '@suite-common/receive';
 import { createThunk } from '@suite-common/redux-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type NativeAnalyticsDep, asTypedNativeAnalytics, events } from '@suite-native/analytics';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 
 import {
     type ReceiveAddressListRootState,
@@ -94,7 +94,7 @@ export const addReceiveAddressThunk = createThunk<
         }),
     );
 
-    asTypedNativeAnalytics(extra.services.analytics).report({
+    extra.services.analytics.report({
         type: events.receiveAddAddressEvent.name,
     });
 });

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -33,7 +33,7 @@ import {
     type TokenAddress,
 } from '@suite-common/wallet-types';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
-import { type NativeAnalyticsDep, asTypedNativeAnalytics, events } from '@suite-native/analytics';
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { type TokensRootState, selectAccountTokenSymbol } from '@suite-native/tokens';
 import {
@@ -263,7 +263,7 @@ export const sendTransactionThunk = createThunk<
                 tokenContract,
             );
 
-            asTypedNativeAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.sendTransactionDispatchedEvent.name,
                 payload: {
                     symbol: selectedAccount.symbol,

--- a/suite/analytics/src/asTypedDesktopAnalytics.ts
+++ b/suite/analytics/src/asTypedDesktopAnalytics.ts
@@ -1,8 +1,0 @@
-import { type AnalyticsSharedEvents } from '@suite-common/analytics';
-import { type Analytics } from '@trezor/analytics-uploader';
-
-import { type AnalyticsDesktopEvents } from './analyticsEvents';
-
-// @TODO: we have to type dispatch correctly in desktop/native/common
-export const asTypedDesktopAnalytics = (analytics: Analytics<AnalyticsSharedEvents>) =>
-    analytics as unknown as Analytics<AnalyticsDesktopEvents>;

--- a/suite/analytics/src/index.ts
+++ b/suite/analytics/src/index.ts
@@ -9,7 +9,6 @@ export {
     type FirmwareSource,
     AppUpdateEventStatus,
 } from './definitions';
-export { asTypedDesktopAnalytics } from './asTypedDesktopAnalytics';
 export type {
     AnalyticsDesktopEvents,
     StakingCardanoPoolDelegationPayload,

--- a/suite/metadata-migration/package.json
+++ b/suite/metadata-migration/package.json
@@ -17,7 +17,6 @@
         "@suite-common/device": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
-        "@suite-common/redux-extra-dependencies": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-sync-storage": "workspace:*",

--- a/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
+++ b/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
@@ -7,6 +7,7 @@ import { Translation } from '@suite/intl';
 import {
     MetadataProviderSelectionModal,
     type MetadataRootState,
+    type MetadataThunkDeps,
     connectProvider,
     metadataActions,
     metadataLabelingActions,
@@ -15,7 +16,6 @@ import {
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type MetadataProviderType } from '@suite-common/metadata-types';
-import { type ExtraDependencies } from '@suite-common/redux-extra-dependencies';
 import { type AnyAction } from '@suite-common/redux-utils';
 import { selectEnsureWalletSuiteSyncOnDep } from '@suite-common/suite-sync-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -35,7 +35,7 @@ type LegacyLabelingMigrationModalProps = {
     }) => void;
 };
 
-type MetadataDispatch = ThunkDispatch<MetadataRootState, ExtraDependencies, AnyAction>;
+type MetadataDispatch = ThunkDispatch<MetadataRootState, MetadataThunkDeps, AnyAction>;
 
 export const LegacyLabelingMigrationModal = ({
     onCancel,

--- a/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
+++ b/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
@@ -5,9 +5,10 @@ import type { ThunkDispatch } from 'redux-thunk';
 
 import { Translation } from '@suite/intl';
 import {
+    type ConnectProviderDeps,
+    type InitMetadataDeps,
     MetadataProviderSelectionModal,
     type MetadataRootState,
-    type MetadataThunkDeps,
     connectProvider,
     metadataActions,
     metadataLabelingActions,
@@ -35,7 +36,8 @@ type LegacyLabelingMigrationModalProps = {
     }) => void;
 };
 
-type MetadataDispatch = ThunkDispatch<MetadataRootState, MetadataThunkDeps, AnyAction>;
+type MetadataDispatchDeps = ConnectProviderDeps & InitMetadataDeps;
+type MetadataDispatch = ThunkDispatch<MetadataRootState, MetadataDispatchDeps, AnyAction>;
 
 export const LegacyLabelingMigrationModal = ({
     onCancel,

--- a/suite/metadata-migration/tsconfig.json
+++ b/suite/metadata-migration/tsconfig.json
@@ -13,9 +13,6 @@
             "path": "../../suite-common/metadata-types"
         },
         {
-            "path": "../../suite-common/redux-extra-dependencies"
-        },
-        {
             "path": "../../suite-common/redux-utils"
         },
         {

--- a/suite/metadata/package.json
+++ b/suite/metadata/package.json
@@ -18,7 +18,6 @@
         "@suite-common/device": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
-        "@suite-common/redux-extra-dependencies": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-rbf-labels-migrations-types": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",

--- a/suite/metadata/src/index.ts
+++ b/suite/metadata/src/index.ts
@@ -4,6 +4,7 @@ export * as metadataThunks from './metadataThunks';
 export { default as GoogleClient } from './google';
 export * from './metadataProviderThunks';
 export * as metadataLabelingActions from './metadataLabelingActions';
+export { type InitMetadataDeps } from './metadataLabelingActions';
 export * as metadataLabelingConstants from './metadataLabelingConstants';
 export * as METADATA from './metadataConstants';
 export {

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -1,6 +1,6 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { events } from '@suite/analytics';
 import {
     selectDeviceByStaticSessionId,
     selectDevices,
@@ -15,7 +15,6 @@ import {
     ProviderErrorAction,
     type WalletLabels,
 } from '@suite-common/metadata-types';
-import { type ExtraDependencies } from '@suite-common/redux-extra-dependencies';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type Account } from '@suite-common/wallet-types';
 import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
@@ -573,7 +572,11 @@ export const addMetadata =
  */
 export const init =
     (force: boolean, deviceStateArg?: StaticSessionId) =>
-    async (dispatch: Dispatch, getState: () => MetadataRootState, extra: ExtraDependencies) => {
+    async (
+        dispatch: Dispatch,
+        getState: () => MetadataRootState,
+        extra: metadataProviderActions.MetadataThunkDeps,
+    ) => {
         let device = deviceStateArg
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
             : selectSelectedDevice(getState());
@@ -642,7 +645,7 @@ export const init =
         if (!selectSelectedProviderForLabels(getState())) {
             const providerResult = await dispatch(metadataProviderActions.initProvider());
             if (!providerResult) {
-                asTypedDesktopAnalytics(extra.services.analytics).report({
+                extra.services.analytics.report({
                     type: events.settingsGeneralLabelingProviderEvent.name,
                     payload: {
                         provider: 'missing-provider',

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -1,6 +1,6 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
-import { events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import {
     selectDeviceByStaticSessionId,
     selectDevices,
@@ -561,6 +561,8 @@ export const addMetadata =
         return result.success;
     };
 
+export type InitMetadataDeps = { services: DesktopAnalyticsDep };
+
 /**
  * init - prepare everything needed to load + decrypt and upload + decrypt metadata. Note that this method
  * consists of number of steps of which not all have to necessarily happen. For example
@@ -572,11 +574,7 @@ export const addMetadata =
  */
 export const init =
     (force: boolean, deviceStateArg?: StaticSessionId) =>
-    async (
-        dispatch: Dispatch,
-        getState: () => MetadataRootState,
-        extra: metadataProviderActions.MetadataThunkDeps,
-    ) => {
+    async (dispatch: Dispatch, getState: () => MetadataRootState, extra: InitMetadataDeps) => {
         let device = deviceStateArg
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
             : selectSelectedDevice(getState());

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -99,11 +99,15 @@ type DisconnectProviderParams = {
     removeMetadata?: boolean;
 };
 
-export type MetadataThunkDeps = { services: DesktopAnalyticsDep };
+type DisconnectProviderDeps = { services: DesktopAnalyticsDep };
 
 export const disconnectProvider =
     ({ clientId, dataType, removeMetadata = true }: DisconnectProviderParams) =>
-    async (dispatch: Dispatch, _getState: () => MetadataRootState, extra: MetadataThunkDeps) => {
+    async (
+        dispatch: Dispatch,
+        _getState: () => MetadataRootState,
+        extra: DisconnectProviderDeps,
+    ) => {
         typedObjectKeys(fetchIntervals).forEach((id: FetchIntervalTrackingId) => {
             const [trackedDataType, trackedClientId] = id.split('-');
             if (trackedDataType === dataType && trackedClientId === clientId) {
@@ -238,9 +242,11 @@ type ConnectProviderParams = {
     clientId?: string;
 };
 
+export type ConnectProviderDeps = { services: DesktopAnalyticsDep };
+
 export const connectProvider =
     ({ type, dataType = 'labels', clientId }: ConnectProviderParams) =>
-    async (dispatch: Dispatch, getState: () => MetadataRootState, extra: MetadataThunkDeps) => {
+    async (dispatch: Dispatch, getState: () => MetadataRootState, extra: ConnectProviderDeps) => {
         const providerInstance = createProviderInstance(
             type,
             {},

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -1,6 +1,6 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
-import { type DesktopAnalyticsDep, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { selectOAuthServerEnvironment } from '@suite/settings';
 import {
     type DataType,
@@ -11,7 +11,6 @@ import {
     ProviderErrorAction,
     type Tokens,
 } from '@suite-common/metadata-types';
-import { type ExtraDependencies } from '@suite-common/redux-extra-dependencies';
 import { triggerWebDownloadFile } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { exhaustive } from '@trezor/type-utils';
@@ -100,15 +99,11 @@ type DisconnectProviderParams = {
     removeMetadata?: boolean;
 };
 
-type DisconnectProviderDeps = { services: DesktopAnalyticsDep };
+export type MetadataThunkDeps = { services: DesktopAnalyticsDep };
 
 export const disconnectProvider =
     ({ clientId, dataType, removeMetadata = true }: DisconnectProviderParams) =>
-    async (
-        dispatch: Dispatch,
-        _getState: () => MetadataRootState,
-        extra: DisconnectProviderDeps,
-    ) => {
+    async (dispatch: Dispatch, _getState: () => MetadataRootState, extra: MetadataThunkDeps) => {
         typedObjectKeys(fetchIntervals).forEach((id: FetchIntervalTrackingId) => {
             const [trackedDataType, trackedClientId] = id.split('-');
             if (trackedDataType === dataType && trackedClientId === clientId) {
@@ -245,7 +240,7 @@ type ConnectProviderParams = {
 
 export const connectProvider =
     ({ type, dataType = 'labels', clientId }: ConnectProviderParams) =>
-    async (dispatch: Dispatch, getState: () => MetadataRootState, extra: ExtraDependencies) => {
+    async (dispatch: Dispatch, getState: () => MetadataRootState, extra: MetadataThunkDeps) => {
         const providerInstance = createProviderInstance(
             type,
             {},
@@ -282,7 +277,7 @@ export const connectProvider =
             },
         });
 
-        asTypedDesktopAnalytics(extra.services.analytics).report({
+        extra.services.analytics.report({
             type: events.settingsGeneralLabelingProviderEvent.name,
             payload: {
                 provider: providerDetails.payload.type,

--- a/suite/metadata/tsconfig.json
+++ b/suite/metadata/tsconfig.json
@@ -18,9 +18,6 @@
             "path": "../../suite-common/metadata-types"
         },
         {
-            "path": "../../suite-common/redux-extra-dependencies"
-        },
-        {
             "path": "../../suite-common/redux-utils"
         },
         {

--- a/suite/tor-desktop/package.json
+++ b/suite/tor-desktop/package.json
@@ -13,7 +13,6 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
-        "@suite-common/redux-extra-dependencies": "workspace:*",
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite/tor-desktop/src/toggleTorThunk.ts
+++ b/suite/tor-desktop/src/toggleTorThunk.ts
@@ -1,26 +1,26 @@
 import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
 
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type ModalRootState, openDeferredModal, selectModalType } from '@suite/modal';
 import { type RouterRootState, selectRouterUrl } from '@suite/router';
 import { type TorRootState, isOnionUrl, selectTorBootstrap, torActions } from '@suite/tor';
 import { TorStatus } from '@suite/tor-types';
-import { type ExtraDependencies } from '@suite-common/redux-extra-dependencies';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type BlockchainRootState, selectBlockchainState } from '@suite-common/wallet-core';
 import { getCustomBackends } from '@suite-common/wallet-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 type ToggleTorRootState = TorRootState & ModalRootState & RouterRootState & BlockchainRootState;
+type ToggleTorDeps = { services: DesktopAnalyticsDep };
 
-export type ToggleTorDispatch = ThunkDispatch<ToggleTorRootState, ExtraDependencies, UnknownAction>;
+export type ToggleTorDispatch = ThunkDispatch<ToggleTorRootState, ToggleTorDeps, UnknownAction>;
 
 export const toggleTor =
     (shouldEnable: boolean) =>
     async (
         dispatch: ToggleTorDispatch,
         getState: () => ToggleTorRootState,
-        extra: ExtraDependencies,
+        extra: ToggleTorDeps,
     ) => {
         const modal = selectModalType(getState());
         const torBootstrap = selectTorBootstrap(getState());
@@ -51,7 +51,7 @@ export const toggleTor =
         const ipcResponse = await desktopApi.toggleTor(shouldEnable);
 
         if (ipcResponse.success) {
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.settingsTorEvent.name,
                 payload: {
                     value: shouldEnable,

--- a/suite/tor-desktop/tsconfig.json
+++ b/suite/tor-desktop/tsconfig.json
@@ -3,9 +3,6 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
-            "path": "../../suite-common/redux-extra-dependencies"
-        },
-        {
             "path": "../../suite-common/suite-config"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15425,7 +15425,6 @@ __metadata:
     "@suite-common/device": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
-    "@suite-common/redux-extra-dependencies": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-rbf-labels-migrations-types": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
@@ -15757,7 +15756,6 @@ __metadata:
   resolution: "@suite/tor-desktop@workspace:suite/tor-desktop"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
-    "@suite-common/redux-extra-dependencies": "workspace:*"
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15390,7 +15390,6 @@ __metadata:
     "@suite-common/device": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
-    "@suite-common/redux-extra-dependencies": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-sync-storage": "workspace:*"


### PR DESCRIPTION
## Description

Remove the obsolete Native and desktop analytics type-cast adapters now that thunk, middleware, service, and dispatch dependencies expose platform-specific analytics contracts directly. Narrow the remaining Tor and metadata dependency types so analytics events are checked without casts.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies core trading quote selection (buy/sell/swap), yield deposit/withdraw/claim thunks, and metadata labeling/migration infrastructure, with additional typing/config-only changes in analytics, native, and desktop packages. The recommended suite focuses on representative high-impact trading and yield flows plus the metadata migration path, supported by medium-coverage tests for alternate asset types and analytics payload behavior. Native, desktop-updater, tor, and some metadata config files have no E2E coverage in the provided candidate set.

<details><summary><b>Changed files (27)</b></summary>

- `packages/suite-desktop-ui/src/support/DesktopUpdater.tsx`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts`
- `packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts`
- `packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts`
- `suite-native/analytics-redux/src/analyticsThunks.ts`
- `suite-native/analytics/src/asTypedNativeAnalytics.ts`
- `suite-native/analytics/src/index.ts`
- `suite-native/biometrics/src/biometricsThunks.ts`
- `suite-native/device/src/middlewares/deviceMiddleware.ts`
- `suite-native/module-receive/src/receiveThunks.ts`
- `suite-native/send/src/sendFormThunks.ts`
- `suite/analytics/src/asTypedDesktopAnalytics.ts`
- `suite/analytics/src/index.ts`
- `suite/metadata-migration/package.json`
- `suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx`
- `suite/metadata-migration/tsconfig.json`
- `suite/metadata/package.json`
- `suite/metadata/src/index.ts`
- `suite/metadata/src/metadataLabelingActions.ts`
- `suite/metadata/src/metadataProviderThunks.ts`
- `suite/metadata/tsconfig.json`
- `suite/tor-desktop/package.json`
- `suite/tor-desktop/src/toggleTorThunk.ts`
- `suite/tor-desktop/tsconfig.json`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Directly exercises the changed LegacyLabelingMigrationModal component and the metadataLabelingActions/metadataProviderThunks paths during a legacy-to-Suite Sync label migration, including account/output/address labels and Evolu sync verification.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Directly invokes selectBuyQuoteThunk when the user requests buy quotes, compares offers, and confirms the best offer; a regression here would break best-offer selection and the buy trade payload.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Directly invokes selectSellQuoteThunk when selecting and confirming the best sell offer; covers the sell quote selection and trade-request payload path.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — Directly invokes selectExchangeQuoteThunk during the swap best-offer selection and confirm-and-send flow; covers cross-chain/token exchange quote selection.
- `suite/e2e/tests/yield/withdrawal.test.ts` — Directly exercises submitYieldWithdrawThunk and the USDC yield vault withdrawal flow, including transaction simulation and on-device confirmation; the only yield-specific test in the candidate set.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Inferred coverage for the suite/analytics typing changes: it verifies many analytics event payloads (SuiteReady, settings, device, transport), which could be affected by asTypedDesktopAnalytics/index modifications.
- `suite/e2e/tests/analytics/toggle.test.ts` — Inferred coverage for analytics typing changes: it checks analytics enable/disable events, session/instance IDs, and related event payloads that rely on the analytics module shape.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Exercises metadataLabelingActions and metadataProviderThunks through the legacy Dropbox account-label CRUD flow, including provider connection and label persistence.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Exercises metadataLabelingActions for Suite Sync account/wallet/address/output label updates and removals, plus Evolu relay sync; catches regressions in the labeling thunk paths.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Extends buy quote selection coverage to a Solana SPL token flow, exercising selectBuyQuoteThunk with tokens, network filtering, and receive-account selection.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Extends sell quote selection coverage to the Solana coin flow, exercising selectSellQuoteThunk with offers, provider selection, and watch-status updates.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Covers DEX-specific exchange quote selection via LI.FI, a distinct path from CEX swaps, exercising selectExchangeQuoteThunk with slippage, minimum received, and token-approval concerns.

</details>

⚠️ **Changes with no test coverage (15)**
- `packages/suite-desktop-ui/src/support/DesktopUpdater.tsx`
- `suite-native/analytics-redux/src/analyticsThunks.ts`
- `suite-native/analytics/src/asTypedNativeAnalytics.ts`
- `suite-native/analytics/src/index.ts`
- `suite-native/biometrics/src/biometricsThunks.ts`
- `suite-native/device/src/middlewares/deviceMiddleware.ts`
- `suite-native/module-receive/src/receiveThunks.ts`
- `suite-native/send/src/sendFormThunks.ts`
- `suite/metadata-migration/package.json`
- `suite/metadata-migration/tsconfig.json`
- `suite/metadata/package.json`
- `suite/metadata/tsconfig.json`
- `suite/tor-desktop/package.json`
- `suite/tor-desktop/src/toggleTorThunk.ts`
- `suite/tor-desktop/tsconfig.json`

_Updated: 2026-08-24T13:55:39.136Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/remove-typed-analytics-adapters&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/remove-typed-analytics-adapters&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/remove-typed-analytics-adapters&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T13:57:59.146Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T13:57:23.741Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/remove-typed-analytics-adapters/web/](https://dev.suite.sldev.cz/suite-web/refactor/remove-typed-analytics-adapters/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->