### PR TITLE
fix(suite): retain claim rewards snapshot

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -22,6 +22,7 @@ import {
     type WalletSettingsRootState,
     type YieldEstimatedFeeLevel,
     estimateYieldFeeLevel,
+    getStablecoinYieldClaimRewardsSnapshot,
     selectAddressDisplayType,
     selectIsMevProtectionEnabled,
     stablecoinYieldActions,
@@ -203,6 +204,22 @@ export const claimMerklRewardsThunk = createThunk<
                     selectedFee: userAcceptedTxSimulation?.selectedFee,
                     rewards,
                 });
+
+            // The completion screen renders this snapshot instead of the live Merkl query: Merkl
+            // stops returning the rewards once it has processed the claim. It is built from the
+            // same frozen rewards the calldata was built from, so it cannot diverge from the
+            // signed transaction when Merkl data refreshes in the background.
+            dispatch(
+                stablecoinYieldActions.storeActionReviewData({
+                    flowType: 'claim',
+                    flowKey,
+                    rewards: getStablecoinYieldClaimRewardsSnapshot({
+                        networkSymbol: account.symbol,
+                        rewards,
+                    }),
+                    unsignedTransaction: unsignedClaimTx,
+                }),
+            );
 
             dispatch(
                 stablecoinYieldActions.storePrecomposedTransaction({

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -66,8 +66,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         merklRewardsQuery.data?.accountsRewards[0];
     const isRewardsLoading = merklRewardsQuery.isLoading || missingRateTickersQuery.isLoading;
 
-    // Completion shows the claimed-rewards snapshot; until it is available, keep the claim screen.
-    const currentStep = claimSession.step === 'complete' && accountRewards ? 'complete' : 'action';
+    const currentStep = claimSession.step === 'complete' ? 'complete' : 'action';
 
     useEffect(() => {
         dispatch(stablecoinYieldActions.initSession({ flowType: 'claim', flowKey }));
@@ -245,10 +244,11 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                             },
                             complete: {
                                 isListItem: false,
-                                content: () =>
-                                    accountRewards ? (
-                                        <YieldFlowCompleteClaim accountRewards={accountRewards} />
-                                    ) : null,
+                                content: () => (
+                                    <YieldFlowCompleteClaim
+                                        rewards={claimSession.result.completedRewards}
+                                    />
+                                ),
                             },
                         }}
                     />

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteClaim.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteClaim.tsx
@@ -1,8 +1,7 @@
 import { Translation } from '@suite/intl';
-import { type YieldAccountRewards } from '@suite-common/earn-stablecoin-api';
 import { useFormatters } from '@suite-common/formatters';
+import { type YieldFlowCompleteRewardItem } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount, toTokenSymbol } from '@suite-common/wallet-types';
-import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
@@ -10,10 +9,10 @@ import { YieldFlowComplete } from './YieldFlowComplete';
 import { YieldRewardItem } from './YieldRewardItem';
 
 type YieldFlowCompleteClaimProps = {
-    accountRewards: YieldAccountRewards;
+    rewards: YieldFlowCompleteRewardItem[];
 };
 
-export const YieldFlowCompleteClaim = ({ accountRewards }: YieldFlowCompleteClaimProps) => {
+export const YieldFlowCompleteClaim = ({ rewards }: YieldFlowCompleteClaimProps) => {
     const { BaseCurrencyAmountFormatter, CryptoAmountFormatter } = useFormatters();
 
     return (
@@ -28,35 +27,28 @@ export const YieldFlowCompleteClaim = ({ accountRewards }: YieldFlowCompleteClai
                 </Text>
 
                 <Column gap={16}>
-                    {accountRewards.rewards.map((reward, index) => {
-                        const claimableUnits = subunitsToUnits({
-                            value: asAmountSubunit(new BigNumber(reward.claimable)),
-                            decimals: reward.token.decimals,
+                    {rewards.map((reward, index) => {
+                        const formattedAmount = CryptoAmountFormatter.format(reward.value, {
+                            symbol: toTokenSymbol(reward.token.symbol),
+                            withSymbol: false,
+                            isBalance: true,
+                            maxDisplayedDecimals: reward.token.decimals,
+                            isEllipsisAppended: false,
                         });
-                        const formattedAmount = CryptoAmountFormatter.format(
-                            claimableUnits.toString(),
-                            {
-                                symbol: toTokenSymbol(reward.token.symbol),
-                                withSymbol: false,
-                                isBalance: true,
-                                maxDisplayedDecimals: reward.token.decimals,
-                                isEllipsisAppended: false,
-                            },
-                        );
-                        const formattedFiatAmount = reward.fiat.claimable
+                        const formattedFiatAmount = reward.fiatValue
                             ? BaseCurrencyAmountFormatter.format(
-                                  asBaseCurrencyAmount(new BigNumber(reward.fiat.claimable)),
+                                  asBaseCurrencyAmount(new BigNumber(reward.fiatValue)),
                               )
                             : null;
 
                         return (
                             <YieldRewardItem
-                                key={`${reward.token.address}:${index}`}
+                                key={`${reward.token.contractAddress}:${index}`}
                                 formattedAmount={formattedAmount}
                                 formattedFiatAmount={formattedFiatAmount}
                                 tokenSymbol={reward.token.symbol}
-                                tokenAddress={reward.token.address}
-                                networkSymbol={accountRewards.account.symbol}
+                                tokenAddress={reward.token.contractAddress}
+                                networkSymbol={reward.token.networkSymbol}
                             />
                         );
                     })}

--- a/packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx
@@ -7,7 +7,7 @@ type YieldRewardItemProps = {
     formattedAmount: string;
     formattedFiatAmount: string | null;
     tokenSymbol: string;
-    tokenAddress: string;
+    tokenAddress?: string | null;
     networkSymbol: NetworkSymbol;
 };
 

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -73,6 +73,7 @@ export * from './stablecoin-yield/stablecoinYieldReducer';
 export * from './stablecoin-yield/stablecoinYieldSelectors';
 export * from './stablecoin-yield/utils/fetchWrappedNativeTokenInfo';
 export * from './stablecoin-yield/utils/stablecoinYieldApprovalActionUtils';
+export * from './stablecoin-yield/utils/stablecoinYieldClaimRewards';
 export * from './stablecoin-yield/thunks/stablecoinYieldApprovalThunks';
 export * from './stablecoin-yield/stablecoinYieldConstants';
 export * from './stablecoin-yield/thunks/stablecoinYieldDepositThunks';

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldClaimRewards.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldClaimRewards.test.ts
@@ -1,0 +1,58 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
+
+import { getStablecoinYieldClaimRewardsSnapshot } from './stablecoinYieldClaimRewards';
+
+const ethSymbol = asNetworkSymbol('eth');
+
+const createReward = ({
+    claimable,
+    fiatClaimable,
+}: {
+    claimable: string;
+    fiatClaimable: string | null;
+}) => ({
+    token: {
+        address: '0x0000000000000000000000000000000000000001',
+        symbol: 'USDC',
+        decimals: 6,
+    },
+    claimable: asBaseCurrencyAmount(new BigNumber(claimable)),
+    fiat: {
+        claimable:
+            fiatClaimable === null ? null : asBaseCurrencyAmount(new BigNumber(fiatClaimable)),
+    },
+});
+
+describe('getStablecoinYieldClaimRewardsSnapshot', () => {
+    it('converts claimable subunits to display units and keeps the fiat value', () => {
+        expect(
+            getStablecoinYieldClaimRewardsSnapshot({
+                networkSymbol: ethSymbol,
+                rewards: [createReward({ claimable: '1000000', fiatClaimable: '1.25' })],
+            }),
+        ).toEqual([
+            {
+                token: {
+                    networkSymbol: ethSymbol,
+                    symbol: 'USDC',
+                    decimals: 6,
+                    contractAddress: '0x0000000000000000000000000000000000000001',
+                },
+                value: '1',
+                fiatValue: '1.25',
+            },
+        ]);
+    });
+
+    it('keeps the reward without a fiat value when its rate is missing', () => {
+        const rewards = getStablecoinYieldClaimRewardsSnapshot({
+            networkSymbol: ethSymbol,
+            rewards: [createReward({ claimable: '2500000', fiatClaimable: null })],
+        });
+
+        expect(rewards[0]?.value).toBe('2.5');
+        expect(rewards[0]?.fiatValue).toBeNull();
+    });
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldClaimRewards.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldClaimRewards.ts
@@ -1,0 +1,41 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { toTokenAddress } from '@suite-common/wallet-types';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { type YieldFlowCompleteRewardItem } from '../stablecoinYieldTypes';
+
+interface YieldClaimableReward {
+    token: {
+        address: string;
+        symbol: string;
+        decimals: number;
+    };
+    claimable: BigNumber | string;
+    fiat: {
+        claimable: BigNumber | null;
+    };
+}
+
+interface GetStablecoinYieldClaimRewardsSnapshotParams {
+    networkSymbol: NetworkSymbol;
+    rewards: YieldClaimableReward[];
+}
+
+export const getStablecoinYieldClaimRewardsSnapshot = ({
+    networkSymbol,
+    rewards,
+}: GetStablecoinYieldClaimRewardsSnapshotParams): YieldFlowCompleteRewardItem[] =>
+    rewards.map(reward => ({
+        token: {
+            networkSymbol,
+            symbol: reward.token.symbol,
+            decimals: reward.token.decimals,
+            contractAddress: toTokenAddress(reward.token.address),
+        },
+        value: subunitsToUnits({
+            value: asAmountSubunit(new BigNumber(reward.claimable)),
+            decimals: reward.token.decimals,
+        }).toString(),
+        fiatValue: reward.fiat.claimable?.toString() ?? null,
+    }));

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -9,6 +9,7 @@ import { Context } from '@suite-common/message-system';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
+    getStablecoinYieldClaimRewardsSnapshot,
     selectAccountByKey,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
@@ -42,7 +43,6 @@ import { useYieldClaimRewards } from '../hooks/useYieldClaimRewards';
 import { useYieldPendingTransaction } from '../hooks/useYieldPendingTransaction';
 import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
 import { useYieldSession } from '../hooks/useYieldSession';
-import { getStablecoinYieldClaimRewardsSnapshot } from '../utils/stablecoinYieldClaimSummaryUtils';
 import { getClaimFeeWarning } from '../utils/yieldClaimFeeWarningUtils';
 
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldClaim>;
@@ -215,7 +215,7 @@ export const YieldClaimScreen = () => {
         // calldata was built from, so the review cannot diverge from the
         // signed transaction when Merkl data refreshes in the background.
         const rewardsSnapshot = getStablecoinYieldClaimRewardsSnapshot({
-            account,
+            networkSymbol: account.symbol,
             rewards: simulationPreparedAction.rewards,
         });
 

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
@@ -14,7 +14,6 @@ import {
     buildStablecoinYieldClaimItems,
     buildStablecoinYieldClaimSummaries,
     getStablecoinYieldAccountRewards,
-    getStablecoinYieldClaimRewardsSnapshot,
     getTotalFiatClaimableAmount,
 } from './stablecoinYieldClaimSummaryUtils';
 import { type StablecoinYieldPositionItem } from '../types';
@@ -182,35 +181,6 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
         expect(accountRewards?.totalFiatClaimableAmount?.toString()).toBe('3.75');
         expect(accountRewards?.rewards).toHaveLength(2);
         expect(getTotalFiatClaimableAmount(summaries)?.toString()).toBe('3.75');
-    });
-
-    it('builds stable claim reward snapshots with token and fiat values', () => {
-        const accountRewards = getStablecoinYieldAccountRewards({
-            account: ethereumAccount,
-            chainsRewardsWithFiat: [
-                createChainRewards({
-                    account: ethereumAccount,
-                    rewards: [createReward({ claimable: '1000000', fiatClaimable: '1.25' })],
-                }),
-            ],
-        });
-
-        if (!accountRewards) {
-            throw new Error('Expected claimable account rewards.');
-        }
-
-        expect(getStablecoinYieldClaimRewardsSnapshot(accountRewards)).toEqual([
-            {
-                token: {
-                    networkSymbol: 'eth',
-                    symbol: 'USDC',
-                    decimals: 6,
-                    contractAddress: '0x0000000000000000000000000000000000000001',
-                },
-                value: '1',
-                fiatValue: '1.25',
-            },
-        ]);
     });
 
     describe('buildStablecoinYieldClaimItems', () => {

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
@@ -3,15 +3,12 @@ import {
     type MerklRewardsParams,
 } from '@suite-common/earn-stablecoin-api';
 import { getNetwork } from '@suite-common/wallet-config';
-import { type YieldFlowCompleteRewardItem } from '@suite-common/wallet-core';
 import {
     type Account,
     type AccountKey,
     type BaseCurrencyAmount,
     asBaseCurrencyAmount,
-    toTokenAddress,
 } from '@suite-common/wallet-types';
-import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { type YieldClaimVaultParams } from '@suite-native/navigation';
 import { BigNumber } from '@trezor/utils';
 
@@ -124,24 +121,6 @@ export const getStablecoinYieldAccountRewards = ({
         account,
         getChainsRewardsByAccountKey(chainsRewardsWithFiat),
     );
-
-export const getStablecoinYieldClaimRewardsSnapshot = ({
-    account,
-    rewards,
-}: Pick<StablecoinYieldAccountRewards, 'account' | 'rewards'>): YieldFlowCompleteRewardItem[] =>
-    rewards.map(reward => ({
-        token: {
-            networkSymbol: account.symbol,
-            symbol: reward.token.symbol,
-            decimals: reward.token.decimals,
-            contractAddress: toTokenAddress(reward.token.address),
-        },
-        value: subunitsToUnits({
-            value: asAmountSubunit(new BigNumber(reward.claimable)),
-            decimals: reward.token.decimals,
-        }).toString(),
-        fiatValue: reward.fiat.claimable?.toString() ?? null,
-    }));
 
 export const buildStablecoinYieldClaimSummaries = ({
     accounts,


### PR DESCRIPTION
## Description

Retain claim rewards complete screen snapshot and don't rely on query data.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30889

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly focused on stablecoin-yield claim rewards logic and UI components, but there is no existing E2E test that directly covers the claim flow. The only relevant E2E coverage is the yield/withdrawal test, which exercises the same earn/yield UI surface and shared reward components. Rely primarily on the included unit tests for the changed utility and thunk logic, and run the withdrawal E2E as a medium-priority regression check for the yield UI.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/components/earn/yield/claim/YieldClaim.tsx`
- `packages/suite/src/components/earn/yield/common/YieldFlowCompleteClaim.tsx`
- `packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldClaimRewards.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldClaimRewards.ts`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/yield/withdrawal.test.ts` — This is the only E2E test in the suite that exercises the earn/yield feature area. It navigates the yield dashboard, validates reward/position display, and interacts with yield flow components, so it provides a useful sanity check that shared yield UI components (including reward display) still render and function correctly after the claim-related changes.

</details>

⚠️ **Changes with no test coverage (8)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/components/earn/yield/claim/YieldClaim.tsx`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldClaimRewards.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldClaimRewards.ts`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts`

_Updated: 2026-08-25T06:17:53.623Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-claim-rewards-snapshot&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-claim-rewards-snapshot&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-claim-rewards-snapshot&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-25T06:19:24.476Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-25T06:19:25.945Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-claim-rewards-snapshot/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-claim-rewards-snapshot/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->