### PR TITLE
refactor(redux-utils): remove global dependency fallback

### DIFF
--- a/suite-common/redux-extra-dependencies/README.md
+++ b/suite-common/redux-extra-dependencies/README.md
@@ -2,8 +2,8 @@
 
 Suite-specific Redux extra-dependency contracts shared by the desktop and mobile composition roots.
 
-This package owns the legacy `ExtraDependencies` and `CustomThunkAPI` types. New thunks should
-declare their state and dependency requirements explicitly instead of depending on the global type.
+This package owns the legacy `ExtraDependencies` composition-root contract. Thunks declare their
+state and dependency requirements explicitly instead of depending on this global type.
 
 ## Extra dependencies concept
 

--- a/suite-common/redux-extra-dependencies/src/extraDependenciesType.ts
+++ b/suite-common/redux-extra-dependencies/src/extraDependenciesType.ts
@@ -158,16 +158,6 @@ export type ExtraDependenciesStatic = {
 
 export type ExtraDependencies = ExtraDependenciesStatic & { services: CommonServices };
 
-export type ExtraDependenciesForReducer = Pick<
-    ExtraDependencies,
-    'actionTypes' | 'actions' | 'reducers'
->;
-
 export type ExtraDependenciesPartial = {
     [K in keyof ExtraDependencies]?: Partial<ExtraDependencies[K]>;
-};
-
-export type CustomThunkAPI = {
-    state: any;
-    extra: ExtraDependencies;
 };

--- a/suite-common/redux-utils/README.md
+++ b/suite-common/redux-utils/README.md
@@ -3,31 +3,33 @@
 Shared Redux and Redux Toolkit utilities such as `createThunk`, reducer helpers, middleware helpers,
 and selector utilities.
 
-This package temporarily depends on `@suite-common/redux-extra-dependencies` because `createThunk`
-still uses the legacy `CustomThunkAPI` default. Once every thunk declares its own dependencies,
-`CustomThunkAPI` and this temporary dependency can be removed.
-
 ## createThunk
 
 This function has the same signature as `createAsyncThunk`, but it injects extra dependencies as the
-`extra` parameter. It also has predefined recommended types, so it should be used instead of
-`createAsyncThunk` from Redux Toolkit.
+`extra` parameter. A thunk can access only the state and dependencies declared in its third generic.
+Omitting that generic gives it no state or injected dependencies.
 
 ```typescript
-export const exportTransactionsToFileThunk = createThunk(
-    'exportAccountsToFileThunk',
-    (payload: string, { dispatch, extra }) => {
-        const fileName = payload;
-        const {
-            services: { getTransactions },
-            utils: { saveFile },
-        } = extra;
+type ExportTransactionsToFileThunkDeps = {
+    services: { getTransactions: () => unknown };
+    utils: { saveFile: (content: string, fileName: string) => void };
+};
 
-        const transactions = getTransactions();
+export const exportTransactionsToFileThunk = createThunk<
+    void,
+    string,
+    { extra: ExportTransactionsToFileThunkDeps }
+>('exportAccountsToFileThunk', (payload, { extra }) => {
+    const fileName = payload;
+    const {
+        services: { getTransactions },
+        utils: { saveFile },
+    } = extra;
 
-        return saveFile(JSON.stringify(transactions), fileName);
-    },
-);
+    const transactions = getTransactions();
+
+    return saveFile(JSON.stringify(transactions), fileName);
+});
 ```
 
 ## createReducerWithExtraDeps

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -13,7 +13,6 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
-        "@suite-common/redux-extra-dependencies": "workspace:*",
         "lodash": "^4.18.1",
         "react": "19.2.3",
         "react-redux": "9.3.0",

--- a/suite-common/redux-utils/src/createThunk.ts
+++ b/suite-common/redux-utils/src/createThunk.ts
@@ -8,40 +8,32 @@ import {
     createAsyncThunk as createAsyncThunkReduxToolkit,
 } from '@reduxjs/toolkit';
 
-// TODO: This dependency on the global ExtraDependencies type is bad, temporary, terrible, and
-// disastrous. Remove it in follow-ups tracked by https://github.com/trezor/trezor-suite/issues/30770.
-import { type CustomThunkAPI } from '@suite-common/redux-extra-dependencies';
-
-type DefaultThunkAPI = { readonly __defaultThunkAPI: unique symbol };
 type CreateThunkDispatch = ThunkDispatch<any, any, UnknownAction>;
 
 /**
- * Resolves the thunk API while thunks are migrated away from the global `CustomThunkAPI`:
- * - omitted config keeps the complete global API;
- * - `void` provides unknown state and no extra dependencies;
- * - config with `state` opts into selective state and either explicit or no extra dependencies;
- * - config without `state` overrides only its declared fields and keeps the remaining global API.
+ * Turns the small config declared by a thunk into the complete config Redux Toolkit needs.
  *
- * Dispatch is always replaced with a broad thunk dispatch so selectively typed parent and child
- * thunks remain composable during the migration.
+ * `void` means the thunk declared no state or injected dependencies. State becomes `unknown`, so it
+ * cannot be passed to a selector, and `extra` becomes an object with no known keys. An omitted third
+ * generic uses this same safe default.
+ *
+ * A supplied config keeps the fields the thunk declared. We replace `dispatch` with a broad thunk
+ * dispatch so a parent can dispatch child thunks with their own state and dependency contracts. We
+ * also make a missing `extra` explicitly empty instead of silently giving the thunk global tools.
  */
-type ResolveThunkAPI<TThunkAPI> = [TThunkAPI] extends [DefaultThunkAPI]
-    ? CustomThunkAPI & { dispatch: CreateThunkDispatch }
-    : [TThunkAPI] extends [void]
-      ? { state: unknown; extra: Record<never, never>; dispatch: CreateThunkDispatch }
-      : TThunkAPI extends { state: unknown }
-        ? Omit<CustomThunkAPI, keyof TThunkAPI | 'dispatch' | 'extra'> &
-              TThunkAPI & {
-                  extra: TThunkAPI extends { extra: infer TExtra } ? TExtra : Record<never, never>;
-                  dispatch: CreateThunkDispatch;
-              }
-        : Omit<CustomThunkAPI, keyof TThunkAPI | 'dispatch'> &
-              TThunkAPI & { dispatch: CreateThunkDispatch };
+type ResolveThunkAPI<TThunkAPI> = [TThunkAPI] extends [void]
+    ? { state: unknown; extra: Record<never, never>; dispatch: CreateThunkDispatch }
+    : TThunkAPI extends AsyncThunkConfig
+      ? Omit<TThunkAPI, 'dispatch' | 'extra'> & {
+            extra: TThunkAPI extends { extra: infer TExtra } ? TExtra : Record<never, never>;
+            dispatch: CreateThunkDispatch;
+        }
+      : never;
 
 type CreateThunk = <
     TReturned = void,
     TThunkArg = void,
-    TThunkAPI extends AsyncThunkConfig | void | DefaultThunkAPI = DefaultThunkAPI,
+    TThunkAPI extends AsyncThunkConfig | void = void,
 >(
     typePrefix: string,
     thunk: AsyncThunkPayloadCreator<TReturned, TThunkArg, ResolveThunkAPI<TThunkAPI>>,

--- a/suite-common/redux-utils/src/createThunk.type-test.ts
+++ b/suite-common/redux-utils/src/createThunk.type-test.ts
@@ -41,13 +41,21 @@ createThunk<void, void, { state: SelectedState }>(
     },
 );
 
-createThunk('test/defaultDependencies', (_, { extra }) => {
+createThunk('test/omittedConfigHasNoDependencies', (_, { extra, getState }) => {
+    // @ts-expect-error An omitted config does not grant access to state.
+    selectSelectedValue(getState());
+
+    // @ts-expect-error An omitted config does not grant access to extra dependencies.
     void extra.services.analytics;
 });
 
 createThunk<void, void, { rejectValue: string }>(
-    'test/defaultDependenciesWithThunkConfig',
-    (_, { extra }) => {
+    'test/configWithoutStateOrDependencies',
+    (_, { extra, getState }) => {
+        // @ts-expect-error The config does not declare a state dependency.
+        selectSelectedValue(getState());
+
+        // @ts-expect-error The config does not declare extra dependencies.
         void extra.services.analytics;
     },
 );

--- a/suite-common/redux-utils/tsconfig.json
+++ b/suite-common/redux-utils/tsconfig.json
@@ -1,7 +1,5 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": [
-        { "path": "../redux-extra-dependencies" }
-    ]
+    "references": []
 }

--- a/suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts
+++ b/suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts
@@ -10,10 +10,13 @@ import {
 } from '@suite-common/wallet-types';
 import { isCardanoTx } from '@suite-common/wallet-utils';
 
-import { selectConvertedNetworkFeeInfo } from '../../fees/feesReducer';
+import { type FeesRootState, selectConvertedNetworkFeeInfo } from '../../fees/feesReducer';
 import { SEND_MODULE_PREFIX } from '../sendFormConstants';
 import { getEthereumRbfFeeInfo } from '../sendFormEthereumThunks';
-import { composeSendFormTransactionFeeLevelsThunk } from '../sendFormThunks';
+import {
+    type ComposeSendFormTransactionFeeLevelsThunkState,
+    composeSendFormTransactionFeeLevelsThunk,
+} from '../sendFormThunks';
 import { type ComposeFeeLevelsError } from '../sendFormTypes';
 
 export type ComposeEthereumCancelTransactionThunkParams = {
@@ -26,6 +29,9 @@ export type ComposedEthereumCancelTransaction = {
     cancelFormState: FormState;
 };
 
+type ComposeEthereumCancelTransactionThunkState = FeesRootState &
+    ComposeSendFormTransactionFeeLevelsThunkState;
+
 /**
  * Composes an EVM cancel transaction: a 0-value transfer to the account's own address reusing the
  * original tx's nonce (via `rbfParams`, applied at signing time) with a fee bumped above the
@@ -34,7 +40,7 @@ export type ComposedEthereumCancelTransaction = {
 export const composeEthereumCancelTransactionThunk = createThunk<
     ComposedEthereumCancelTransaction,
     ComposeEthereumCancelTransactionThunkParams,
-    { rejectValue: ComposeFeeLevelsError }
+    { state: ComposeEthereumCancelTransactionThunkState; rejectValue: ComposeFeeLevelsError }
 >(
     `${SEND_MODULE_PREFIX}/composeEthereumCancelTransactionThunk`,
     async ({ account, tx }, { dispatch, getState, rejectWithValue }) => {

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -149,16 +149,19 @@ export const recoverWalletThunk = createThunk<
 /**
  * Connect call to rerun FW authenticity checks (getFeatures used as the most basic no-op device call).
  */
-export const rerunFwAuthenticityChecksThunk = createThunk(
-    `${NATIVE_DEVICE_MODULE_PREFIX}/rerunFwAuthenticityChecksThunk`,
-    (_, { getState }) => {
-        const device = selectSelectedDevice(getState());
-        if (device === undefined) return;
-        // refrain from scheduling multiple tasks (since this runs in a loop)
-        if (deviceAccessMutex.taskQueue.length === 0) {
-            void requestDeviceAccess(() =>
-                TrezorConnect.getFeatures({ device: { path: device.path } }),
-            );
-        }
-    },
-);
+type RerunFwAuthenticityChecksThunkState = DeviceRootState;
+
+export const rerunFwAuthenticityChecksThunk = createThunk<
+    void,
+    void,
+    { state: RerunFwAuthenticityChecksThunkState }
+>(`${NATIVE_DEVICE_MODULE_PREFIX}/rerunFwAuthenticityChecksThunk`, (_, { getState }) => {
+    const device = selectSelectedDevice(getState());
+    if (device === undefined) return;
+    // refrain from scheduling multiple tasks (since this runs in a loop)
+    if (deviceAccessMutex.taskQueue.length === 0) {
+        void requestDeviceAccess(() =>
+            TrezorConnect.getFeatures({ device: { path: device.path } }),
+        );
+    }
+});

--- a/suite-native/send/src/cancelTransactionThunks.ts
+++ b/suite-native/send/src/cancelTransactionThunks.ts
@@ -1,11 +1,18 @@
 import { isRejected } from '@reduxjs/toolkit';
 
-import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
+import {
+    type MevProtectionRootState,
+    selectIsMevProtectionFeatureEnabled,
+} from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import {
+    type AccountsRootState,
+    type PushSendFormTransactionThunkDeps,
+    type PushSendFormTransactionThunkState,
     type PushTransactionError,
     type SignTransactionError,
     type SignTransactionTimeoutError,
+    type WalletSettingsRootState,
     pushSendFormTransactionThunk,
     selectAccountByKey,
     selectIsMevProtectionEnabled,
@@ -18,7 +25,12 @@ import {
 import { type Ok } from '@trezor/type-utils';
 
 import { SEND_MODULE_PREFIX } from './constants';
-import { cleanupSendFormThunk, signTransactionNativeThunk } from './sendFormThunks';
+import {
+    type CleanupSendFormThunkState,
+    type SignTransactionNativeThunkState,
+    cleanupSendFormThunk,
+    signTransactionNativeThunk,
+} from './sendFormThunks';
 
 type SignAndPushEvmCancelTransactionThunkParams = {
     accountKey: AccountKey;
@@ -29,6 +41,14 @@ type SignAndPushEvmCancelTransactionThunkParams = {
 export type SignAndPushEvmCancelTransactionError =
     SignTransactionError | SignTransactionTimeoutError | PushTransactionError | undefined;
 
+type SignAndPushEvmCancelTransactionThunkState = AccountsRootState &
+    WalletSettingsRootState &
+    MevProtectionRootState &
+    SignTransactionNativeThunkState &
+    PushSendFormTransactionThunkState &
+    CleanupSendFormThunkState;
+type SignAndPushEvmCancelTransactionThunkDeps = PushSendFormTransactionThunkDeps;
+
 /**
  * Signs and broadcasts a composed EVM cancel transaction (see
  * composeEthereumCancelTransactionThunk) through the regular native signing pipeline; the send
@@ -37,7 +57,11 @@ export type SignAndPushEvmCancelTransactionError =
 export const signAndPushEvmCancelTransactionThunk = createThunk<
     Ok<{ txid: string }>,
     SignAndPushEvmCancelTransactionThunkParams,
-    { rejectValue: SignAndPushEvmCancelTransactionError }
+    {
+        rejectValue: SignAndPushEvmCancelTransactionError;
+        state: SignAndPushEvmCancelTransactionThunkState;
+        extra: SignAndPushEvmCancelTransactionThunkDeps;
+    }
 >(
     `${SEND_MODULE_PREFIX}/signAndPushEvmCancelTransactionThunk`,
     async (

--- a/suite/device/src/deviceThunks.ts
+++ b/suite/device/src/deviceThunks.ts
@@ -1,4 +1,4 @@
-import { selectIsDeviceLocked } from '@suite/locks';
+import { type LocksRootState, selectIsDeviceLocked } from '@suite/locks';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import type { TrezorDevice } from '@suite-common/suite-types';
@@ -25,12 +25,15 @@ export const disconnectDeviceThunk = createThunk<
 /**
  * Connect call to rerun FW authenticity checks (getFeatures used as the most basic no-op device call).
  */
-export const rerunFwAuthenticityChecksThunk = createThunk(
-    `${DEVICE_MODULE_PREFIX}/rerunFwAuthenticityChecksThunk`,
-    (_, { getState }) => {
-        const device = selectSelectedDevice(getState());
-        if (device === undefined) return;
-        if (selectIsDeviceLocked(getState())) return;
-        void TrezorConnect.getFeatures({ device: { path: device.path } });
-    },
-);
+type RerunFwAuthenticityChecksThunkState = DeviceRootState & LocksRootState;
+
+export const rerunFwAuthenticityChecksThunk = createThunk<
+    void,
+    void,
+    { state: RerunFwAuthenticityChecksThunkState }
+>(`${DEVICE_MODULE_PREFIX}/rerunFwAuthenticityChecksThunk`, (_, { getState }) => {
+    const device = selectSelectedDevice(getState());
+    if (device === undefined) return;
+    if (selectIsDeviceLocked(getState())) return;
+    void TrezorConnect.getFeatures({ device: { path: device.path } });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11002,7 +11002,6 @@ __metadata:
   resolution: "@suite-common/redux-utils@workspace:suite-common/redux-utils"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
-    "@suite-common/redux-extra-dependencies": "workspace:*"
     lodash: "npm:^4.18.1"
     react: "npm:19.2.3"
     react-redux: "npm:9.3.0"


### PR DESCRIPTION
## Description

Make createThunk dependency-free by default and remove redux-utils' dependency on the global ExtraDependencies package. Add type coverage for the safe default and declare the minimal contracts on the remaining thunks exposed by the stricter typing.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches core thunk infrastructure (createThunk), Ethereum cancel-transaction logic, and device thunks in both suite and native. Suite web/desktop e2e tests can realistically cover suite/device thunks and EVM send/cancel adjacent flows, but the native thunk files and type/build config changes have no e2e coverage. A focused run of device-session, passphrase, and EVM send tests provides the highest confidence for the shared runtime paths.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/redux-extra-dependencies/src/extraDependenciesType.ts`
- `suite-common/redux-utils/package.json`
- `suite-common/redux-utils/src/createThunk.ts`
- `suite-common/redux-utils/src/createThunk.type-test.ts`
- `suite-common/redux-utils/tsconfig.json`
- `suite-common/wallet-core/src/send/composeCancelTransaction/composeEthereumCancelTransactionThunk.ts`
- `suite-native/device/src/deviceThunks.ts`
- `suite-native/send/src/cancelTransactionThunks.ts`
- `suite/device/src/deviceThunks.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Directly exercises device disconnect/reconnect flows and passphrase wallet caching, which rely on device thunk state transitions and session persistence. No static mapping existed for suite/device/src/deviceThunks.ts, so this is inferred coverage from the LLM analysis.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session stealing and reclaiming across browser tabs, covering device session lifecycle and device-status thunks that are likely defined in suite/device/src/deviceThunks.ts.
- `suite/e2e/tests/wallet/send-base.test.ts` — Sends transactions on Base, an EVM network, exercising the shared EVM transaction composition path adjacent to the Ethereum cancel transaction thunk. Strong candidate for catching regressions in thunk-based send/cancel flows.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly exercises the Ethereum send flow, device prompts, and fee composition—the closest suite e2e path to the Ethereum cancel transaction thunk and its underlying createThunk infrastructure.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery after device operations uses device authorization and discovery thunks; a regression in createThunk or device thunks could interrupt discovery completion.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Device authenticity check during onboarding triggers device authorization and state transitions that flow through device thunks.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Hidden wallet creation, switching, and address verification exercise device instance management and authorization thunks created via createThunk.
- `suite/e2e/tests/settings/forget-device.test.ts` — Forgetting and unpairing a device directly exercises device lifecycle thunks and would catch regressions in device state removal logic.

</details>

⚠️ **Changes with no test coverage (6)**
- `suite-common/redux-extra-dependencies/src/extraDependenciesType.ts`
- `suite-common/redux-utils/package.json`
- `suite-common/redux-utils/src/createThunk.type-test.ts`
- `suite-common/redux-utils/tsconfig.json`
- `suite-native/device/src/deviceThunks.ts`
- `suite-native/send/src/cancelTransactionThunks.ts`

_Updated: 2026-08-24T14:18:30.373Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/decouple-redux-utils-extra-dependencies/web/](https://dev.suite.sldev.cz/suite-web/refactor/decouple-redux-utils-extra-dependencies/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/decouple-redux-utils-extra-dependencies&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/decouple-redux-utils-extra-dependencies&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/decouple-redux-utils-extra-dependencies&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T14:19:25.049Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T14:19:18.976Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->