### PR TITLE
refactor(metadata): use shared compatible thunk type

### DIFF
--- a/suite-common/metadata-types/package.json
+++ b/suite-common/metadata-types/package.json
@@ -11,7 +11,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@reduxjs/toolkit": "2.12.0",
+        "@suite-common/redux-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*"
     }
 }

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -1,15 +1,8 @@
-import { type AnyAction, type AsyncThunk, type ThunkAction } from '@reduxjs/toolkit';
-
+import { type SuiteCompatibleThunk } from '@suite-common/redux-utils';
 import type { StaticSessionId, WalletDescriptor } from '@trezor/device-utils';
 
-// TODO: Replace with a generic shared `Thunk` type from @suite-common/redux-utils after
-// https://github.com/trezor/trezor-suite/issues/30770 is completed.
-type MetadataThunk<TPayload> =
-    | AsyncThunk<void, TPayload, Record<never, never>>
-    | ((payload: TPayload) => ThunkAction<void, any, any, AnyAction>);
-
 export type FetchAndSaveMetadataDep = {
-    fetchAndSaveMetadata: MetadataThunk<StaticSessionId>;
+    fetchAndSaveMetadata: SuiteCompatibleThunk<StaticSessionId>;
 };
 
 export interface LabelableEntityKeys {

--- a/suite-common/metadata-types/tsconfig.json
+++ b/suite-common/metadata-types/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../redux-utils" },
         { "path": "../../packages/device-utils" }
     ]
 }

--- a/suite-common/redux-extra-dependencies/.depcheckrc.json
+++ b/suite-common/redux-extra-dependencies/.depcheckrc.json
@@ -1,4 +1,0 @@
-{
-    "ignore-patterns": ["libDev", "lib"],
-    "ignores": ["@suite-common/connect-init", "@suite-common/thp"]
-}

--- a/suite-common/redux-extra-dependencies/mocks/extraDependenciesCommonMock.ts
+++ b/suite-common/redux-extra-dependencies/mocks/extraDependenciesCommonMock.ts
@@ -1,7 +1,6 @@
 import type { AddressValidator } from '@suite-common/address';
 import type { AnalyticsSharedEvents } from '@suite-common/analytics';
 import { type Bip329 } from '@suite-common/bip329-types';
-import { type ConnectInitSettings } from '@suite-common/connect-init';
 import type { NetworkModuleRepository, NetworkSymbol } from '@suite-common/networks';
 import {
     mockFindNetworkSymbolForProtocol,
@@ -14,7 +13,11 @@ import {
     asEncryptedHex,
 } from '@suite-common/platform-encryption';
 import type { SuiteSync } from '@suite-common/suite-sync-types';
-import { type ReportSecurityCheckParams, asDelegatedIdentityKey } from '@suite-common/suite-types';
+import {
+    type ConnectInitSettings,
+    type ReportSecurityCheckParams,
+    asDelegatedIdentityKey,
+} from '@suite-common/suite-types';
 import { type SelectedAccountLoaded, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { mockAnalytics } from '@trezor/analytics-uploader/mocks';

--- a/suite-common/redux-extra-dependencies/package.json
+++ b/suite-common/redux-extra-dependencies/package.json
@@ -20,6 +20,7 @@
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/networks": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-rbf-labels-migrations-types": "workspace:*",
         "@suite-common/suite-sync-types": "workspace:*",
         "@suite-common/suite-types": "workspace:*",

--- a/suite-common/redux-extra-dependencies/src/extraDependenciesType.ts
+++ b/suite-common/redux-extra-dependencies/src/extraDependenciesType.ts
@@ -1,9 +1,4 @@
-import {
-    type Action,
-    type ActionCreatorWithPreparedPayload,
-    type AsyncThunk,
-    type ThunkAction,
-} from '@reduxjs/toolkit';
+import { type ActionCreatorWithPreparedPayload } from '@reduxjs/toolkit';
 
 import type { AddressValidatorDep } from '@suite-common/address';
 import type { AnalyticsDep } from '@suite-common/analytics';
@@ -20,6 +15,7 @@ import type {
     NetworkModuleRepositoryDep,
 } from '@suite-common/networks';
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
+import { type SuiteCompatibleThunk } from '@suite-common/redux-utils';
 import { type MigrateSuiteSyncLabelsForRbfTransactionDep } from '@suite-common/suite-rbf-labels-migrations-types';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import {
@@ -45,23 +41,6 @@ import {
     type SelectedAccountStatus,
 } from '@suite-common/wallet-types';
 import { type BluetoothDeviceId, type CreateLoggerDep, type ThpSettings } from '@trezor/connect';
-
-// TODO: Replace with a generic shared `Thunk` type from @suite-common/redux-utils after
-// https://github.com/trezor/trezor-suite/issues/30770 is completed.
-interface AnyAction extends Action {
-    [extraProps: string]: any;
-}
-
-// TODO: Replace with a generic shared `Thunk` type from @suite-common/redux-utils after
-// https://github.com/trezor/trezor-suite/issues/30770 is completed.
-type OriginalReduxThunk<TPayload, TReturn = void> = (
-    payload: TPayload,
-) => ThunkAction<TReturn, any, any, AnyAction>;
-
-// TODO: Replace with a generic shared `Thunk` type from @suite-common/redux-utils after
-// https://github.com/trezor/trezor-suite/issues/30770 is completed.
-type SuiteCompatibleThunk<TPayload, TReturn = void> =
-    AsyncThunk<TReturn, TPayload, Record<never, never>> | OriginalReduxThunk<TPayload, TReturn>;
 
 type BaseReducer = (state: any, action: { type: any; payload: any }) => void;
 type StorageLoadReducer = (state: any, action: { type: any; payload: any }) => void;

--- a/suite-common/redux-extra-dependencies/tsconfig.json
+++ b/suite-common/redux-extra-dependencies/tsconfig.json
@@ -12,6 +12,7 @@
         { "path": "../metadata-types" },
         { "path": "../networks" },
         { "path": "../platform-encryption" },
+        { "path": "../redux-utils" },
         {
             "path": "../suite-rbf-labels-migrations-types"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10899,7 +10899,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/metadata-types@workspace:suite-common/metadata-types"
   dependencies:
-    "@reduxjs/toolkit": "npm:2.12.0"
+    "@suite-common/redux-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"
   languageName: unknown
   linkType: soft
@@ -10986,6 +10986,7 @@ __metadata:
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/networks": "workspace:*"
     "@suite-common/platform-encryption": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-rbf-labels-migrations-types": "workspace:*"
     "@suite-common/suite-sync-types": "workspace:*"
     "@suite-common/suite-types": "workspace:*"


### PR DESCRIPTION
## Description

Replace the private metadata and global dependency thunk unions with SuiteCompatibleThunk from redux-utils. Reverse the package edge, remove the temporary depcheck exceptions, and import the shared Connect settings type from its owning package.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/share-metadata-thunk-type/web/](https://dev.suite.sldev.cz/suite-web/refactor/share-metadata-thunk-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/share-metadata-thunk-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/share-metadata-thunk-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/share-metadata-thunk-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T14:41:41.520Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T14:42:43.894Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are primarily shared type definitions, mocks, and package configuration, so runtime risk is low. E2E coverage should focus on a representative sample of legacy metadata tests that exercise the metadata type system end-to-end, with metadata-lifecycle providing the broadest coverage and account/wallet label tests covering the two main label surfaces.

<details><summary><b>Changed files (8)</b></summary>

- `suite-common/metadata-types/package.json`
- `suite-common/metadata-types/src/metadataTypes.ts`
- `suite-common/metadata-types/tsconfig.json`
- `suite-common/redux-extra-dependencies/.depcheckrc.json`
- `suite-common/redux-extra-dependencies/mocks/extraDependenciesCommonMock.ts`
- `suite-common/redux-extra-dependencies/package.json`
- `suite-common/redux-extra-dependencies/src/extraDependenciesType.ts`
- `suite-common/redux-extra-dependencies/tsconfig.json`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This is the most comprehensive legacy metadata test, exercising enable/disable of labeling, provider selection, label persistence across device resets, and wallet lifecycle flows. These flows depend directly on the metadata type definitions and Redux state shapes defined in metadataTypes.ts.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Covers the core account label CRUD and search flow, which directly consumes AccountLabelId and metadata label types from metadataTypes.ts. A representative smoke test for basic metadata behavior.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — Exercises wallet-level label persistence via the metadata provider, covering another facet of the metadata type system and ensuring wallet label state remains intact after reload.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite-common/metadata-types/package.json`
- `suite-common/metadata-types/tsconfig.json`
- `suite-common/redux-extra-dependencies/.depcheckrc.json`
- `suite-common/redux-extra-dependencies/mocks/extraDependenciesCommonMock.ts`
- `suite-common/redux-extra-dependencies/package.json`
- `suite-common/redux-extra-dependencies/src/extraDependenciesType.ts`
- `suite-common/redux-extra-dependencies/tsconfig.json`

_Updated: 2026-08-24T14:41:03.055Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->