### PR TITLE
test(redux-utils): cover parent thunk contracts

### DIFF
--- a/suite-common/redux-utils/src/createThunk.type-test.ts
+++ b/suite-common/redux-utils/src/createThunk.type-test.ts
@@ -80,6 +80,8 @@ createThunk<void, void, { state: SelectedState; extra: SelectedExtraDependencies
     },
 );
 
+// A dispatched child thunk does not inherit the parent's permissions. Giving it a separate state
+// and dependency contract lets these tests verify that the parent covers the entire dispatch chain.
 type ChildThunkState = {
     child: {
         value: number;
@@ -104,6 +106,8 @@ const childThunk = createThunk<void, void, { state: ChildThunkState; extra: Chil
     },
 );
 
+// The parent can execute the child, so its public contract must contain everything required by both
+// thunks. These intersections describe that combined contract.
 type ParentThunkState = SelectedState & ChildThunkState;
 type ParentThunkDeps = SelectedExtraDependencies & ChildThunkDeps;
 
@@ -121,9 +125,12 @@ const parentThunk = createThunk<void, void, { state: ParentThunkState; extra: Pa
     },
 );
 
+// A store satisfying the complete parent-and-child contract must be able to dispatch the parent.
 declare const compatibleDispatch: ThunkDispatch<ParentThunkState, ParentThunkDeps, UnknownAction>;
 compatibleDispatch(parentThunk());
 
+// Conversely, dispatching the parent must fail when the store is missing either part of the
+// child's contract, even though the missing requirement is used only by the nested child thunk.
 declare const dispatchWithoutChildState: ThunkDispatch<
     SelectedState,
     ParentThunkDeps,

--- a/suite-common/redux-utils/src/createThunk.type-test.ts
+++ b/suite-common/redux-utils/src/createThunk.type-test.ts
@@ -1,3 +1,5 @@
+import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
+
 import { createThunk } from './createThunk';
 
 type SelectedExtraDependencies = {
@@ -77,3 +79,63 @@ createThunk<void, void, { state: SelectedState; extra: SelectedExtraDependencies
         void unselectedAnalytics;
     },
 );
+
+type ChildThunkState = {
+    child: {
+        value: number;
+    };
+};
+
+type ChildThunkDeps = {
+    services: {
+        childDependency: () => void;
+    };
+};
+
+const selectChildValue = (state: ChildThunkState) => state.child.value;
+
+const childThunk = createThunk<void, void, { state: ChildThunkState; extra: ChildThunkDeps }>(
+    'test/child',
+    (_, { extra, getState }) => {
+        const childValue: number = selectChildValue(getState());
+        extra.services.childDependency();
+
+        void childValue;
+    },
+);
+
+type ParentThunkState = SelectedState & ChildThunkState;
+type ParentThunkDeps = SelectedExtraDependencies & ChildThunkDeps;
+
+const parentThunk = createThunk<void, void, { state: ParentThunkState; extra: ParentThunkDeps }>(
+    'test/parent',
+    (_, { dispatch, extra, getState }) => {
+        const selectedValue: string = selectSelectedValue(getState());
+        const childValue: number = selectChildValue(getState());
+        extra.services.selectedDependency();
+        extra.services.childDependency();
+        dispatch(childThunk());
+
+        void selectedValue;
+        void childValue;
+    },
+);
+
+declare const compatibleDispatch: ThunkDispatch<ParentThunkState, ParentThunkDeps, UnknownAction>;
+compatibleDispatch(parentThunk());
+
+declare const dispatchWithoutChildState: ThunkDispatch<
+    SelectedState,
+    ParentThunkDeps,
+    UnknownAction
+>;
+// @ts-expect-error The store does not contain the state required by the dispatched child thunk.
+dispatchWithoutChildState(parentThunk());
+
+declare const dispatchWithoutChildDependencies: ThunkDispatch<
+    ParentThunkState,
+    SelectedExtraDependencies,
+    UnknownAction
+>;
+// @ts-expect-error The store does not provide the dependency required by the dispatched child thunk.
+dispatchWithoutChildDependencies(parentThunk());


### PR DESCRIPTION
## Description

Complete the createThunk contract type coverage with a parent and child that compose selective state and dependencies. Verify compatible dispatch succeeds while stores missing the child state or dependency are rejected.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a TypeScript type-test for the createThunk utility (`suite-common/redux-utils/src/createThunk.type-test.ts`). It exercises compile-time type constraints and does not alter runtime behavior, Redux thunk infrastructure, or any UI flows. Consequently, Playwright E2E tests are not an effective way to validate this change. The appropriate validation is the TypeScript/type-check and any unit tests for `createThunk`, not the E2E suite.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/redux-utils/src/createThunk.type-test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/redux-utils/src/createThunk.type-test.ts`

_Updated: 2026-08-24T14:57:17.109Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/create-thunk-contracts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/create-thunk-contracts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/create-thunk-contracts&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T14:59:42.041Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T15:00:17.689Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/create-thunk-contracts/web/](https://dev.suite.sldev.cz/suite-web/test/create-thunk-contracts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->