### PR TITLE
chore(redux-utils): enforce domain dependency boundary

### DIFF
--- a/packages/requirements/src/requirements/forbidden-deps/forbiddenDepsTypes.ts
+++ b/packages/requirements/src/requirements/forbidden-deps/forbiddenDepsTypes.ts
@@ -1,7 +1,18 @@
-export type ForbiddenDependency = {
-    readonly packageName: string;
+type ForbiddenDependencyBase = {
     readonly reason: string;
 };
+
+type ExactForbiddenDependency = ForbiddenDependencyBase & {
+    readonly packageName: string;
+    readonly packageNamePrefix?: never;
+};
+
+type PrefixForbiddenDependency = ForbiddenDependencyBase & {
+    readonly packageName?: never;
+    readonly packageNamePrefix: string;
+};
+
+export type ForbiddenDependency = ExactForbiddenDependency | PrefixForbiddenDependency;
 
 export type AllowedOnlyInRule = {
     readonly packages: ReadonlyArray<string>;

--- a/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.test.ts
+++ b/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.test.ts
@@ -1,0 +1,49 @@
+import { getForbiddenDependencyErrors } from './requireForbiddenDeps';
+
+describe(getForbiddenDependencyErrors.name, () => {
+    it('rejects an exact forbidden dependency', () => {
+        expect(
+            getForbiddenDependencyErrors({
+                dependencyOccurrences: [
+                    {
+                        field: 'dependencies',
+                        name: '@suite-common/redux-extra-dependencies',
+                    },
+                ],
+                dependencyRule: {
+                    'forbidden-deps': [
+                        {
+                            packageName: '@suite-common/redux-extra-dependencies',
+                            reason: 'Redux utilities must stay domain-independent.',
+                        },
+                    ],
+                },
+                workspaceName: '@suite-common/redux-utils',
+            }),
+        ).toEqual([
+            '@suite-common/redux-utils: "@suite-common/redux-extra-dependencies" is forbidden in dependencies. Reason: Redux utilities must stay domain-independent.',
+        ]);
+    });
+
+    it('rejects dependencies matching a forbidden package-name prefix', () => {
+        expect(
+            getForbiddenDependencyErrors({
+                dependencyOccurrences: [
+                    { field: 'dependencies', name: '@suite-common/wallet-core' },
+                    { field: 'dependencies', name: '@trezor/utils' },
+                ],
+                dependencyRule: {
+                    'forbidden-deps': [
+                        {
+                            packageNamePrefix: '@suite-common/',
+                            reason: 'Redux utilities must stay domain-independent.',
+                        },
+                    ],
+                },
+                workspaceName: '@suite-common/redux-utils',
+            }),
+        ).toEqual([
+            '@suite-common/redux-utils: "@suite-common/wallet-core" is forbidden in dependencies. Reason: Redux utilities must stay domain-independent.',
+        ]);
+    });
+});

--- a/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts
+++ b/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts
@@ -57,10 +57,18 @@ const createForbiddenDepsMap = (
     forbiddenDeps: NonNullable<ForbiddenDepsConfig['forbidden-deps']>,
 ) =>
     new Map(
-        forbiddenDeps.map(forbiddenDependency => [
-            forbiddenDependency.packageName,
-            forbiddenDependency,
-        ]),
+        forbiddenDeps.flatMap(forbiddenDependency =>
+            forbiddenDependency.packageName === undefined
+                ? []
+                : [[forbiddenDependency.packageName, forbiddenDependency] as const],
+        ),
+    );
+
+const getForbiddenDependencyPrefixes = (
+    forbiddenDeps: NonNullable<ForbiddenDepsConfig['forbidden-deps']>,
+) =>
+    forbiddenDeps.flatMap(forbiddenDependency =>
+        forbiddenDependency.packageNamePrefix === undefined ? [] : [forbiddenDependency],
     );
 
 const formatAllowedOnlyInPackages = (allowedOnlyInRule: AllowedOnlyInRule) =>
@@ -101,6 +109,10 @@ const getInvalidConfiguredPackagesErrors = ({
     const errors: string[] = [];
 
     for (const forbiddenDependency of dependencyRule?.['forbidden-deps'] ?? []) {
+        if (forbiddenDependency.packageName === undefined) {
+            continue;
+        }
+
         if (workspaceDirectories.has(forbiddenDependency.packageName)) {
             continue;
         }
@@ -129,15 +141,22 @@ type ForbiddenDependencyErrorsParams = {
     readonly workspaceName: string;
 };
 
-const getForbiddenDependencyErrors = ({
+export const getForbiddenDependencyErrors = ({
     dependencyOccurrences,
     dependencyRule,
     workspaceName,
 }: ForbiddenDependencyErrorsParams): ReadonlyArray<string> => {
     const forbiddenDepsMap = createForbiddenDepsMap(dependencyRule?.['forbidden-deps'] ?? []);
+    const forbiddenDependencyPrefixes = getForbiddenDependencyPrefixes(
+        dependencyRule?.['forbidden-deps'] ?? [],
+    );
 
     return dependencyOccurrences.flatMap(dependencyOccurrence => {
-        const forbiddenDependency = forbiddenDepsMap.get(dependencyOccurrence.name);
+        const forbiddenDependency =
+            forbiddenDepsMap.get(dependencyOccurrence.name) ??
+            forbiddenDependencyPrefixes.find(({ packageNamePrefix }) =>
+                dependencyOccurrence.name.startsWith(packageNamePrefix),
+            );
 
         if (forbiddenDependency === undefined) {
             return [];

--- a/suite-common/redux-utils/forbiddenDeps.config.ts
+++ b/suite-common/redux-utils/forbiddenDeps.config.ts
@@ -1,0 +1,13 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-deps': [
+        {
+            packageNamePrefix: '@suite-common/',
+            reason:
+                'Redux utilities are domain-independent infrastructure. Depending on a Suite ' +
+                'Common business package would reintroduce application contracts and dependency ' +
+                'cycles into this foundation package.',
+        },
+    ],
+};

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -19,5 +19,8 @@
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
         "reselect": "5.2.0"
+    },
+    "devDependencies": {
+        "@trezor/requirements": "workspace:*"
     }
 }

--- a/suite-common/redux-utils/tsconfig.json
+++ b/suite-common/redux-utils/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": []
+    "references": [
+        { "path": "../../packages/requirements" }
+    ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11003,6 +11003,7 @@ __metadata:
   resolution: "@suite-common/redux-utils@workspace:suite-common/redux-utils"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@trezor/requirements": "workspace:*"
     lodash: "npm:^4.18.1"
     react: "npm:19.2.3"
     react-redux: "npm:9.3.0"


### PR DESCRIPTION
## Description

Extend forbidden dependency rules with package-name prefixes and prohibit redux-utils from depending on any Suite Common business-domain package, preventing the removed global dependency cycle from returning.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/enforce-redux-utils-domain-boundary/web/](https://dev.suite.sldev.cz/suite-web/chore/enforce-redux-utils-domain-boundary/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/enforce-redux-utils-domain-boundary&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/enforce-redux-utils-domain-boundary&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/enforce-redux-utils-domain-boundary&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are build-time tooling, lint rules, and package configuration (forbidden-deps requirement checker and redux-utils package/tsconfig), with no direct or indirect impact on user-facing application behavior exercised by the E2E suite. The natural verification is the included unit test (requireForbiddenDeps.test.ts), not E2E tests. No E2E tests should be run based on these changes.

<details><summary><b>Changed files (5)</b></summary>

- `packages/requirements/src/requirements/forbidden-deps/forbiddenDepsTypes.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.test.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts`
- `suite-common/redux-utils/package.json`
- `suite-common/redux-utils/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `packages/requirements/src/requirements/forbidden-deps/forbiddenDepsTypes.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.test.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts`
- `suite-common/redux-utils/package.json`
- `suite-common/redux-utils/tsconfig.json`

_Updated: 2026-08-24T15:23:16.432Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T15:25:08.942Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T15:25:32.713Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->