### PR TITLE
Fix(suite-desktop-core): coinjoin coordinator url whitelisting

### DIFF
--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -64,6 +64,11 @@ export type InterceptedEvent =
           domains: string[];
       }
     | {
+          type: 'SET_WHITELISTED_DOMAIN_FOR_COINJOIN_COORDINATOR';
+          coin: string;
+          domain: string | null;
+      }
+    | {
           type: 'ADD_WHITELISTED_DOMAIN';
           domain: string;
       };

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -9,6 +9,7 @@ import {
     type CoinjoinBackend,
     type CoinjoinBackendSettings,
     CoinjoinClient,
+    type CoinjoinClientSettings,
     type LogEvent,
 } from '@trezor/coinjoin';
 import { type IpcProxyHandlerOptions, createIpcProxyHandler } from '@trezor/ipc-proxy';
@@ -65,6 +66,22 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
     const powerSaveBlocker = new PowerSaveBlocker();
 
     logger.debug(SERVICE_NAME, `Starting service`);
+
+    const emitWhitelistedCoinjoinCoordinatorDomain = ({
+        coin,
+        coordinatorUrl,
+    }: {
+        coin: CoinjoinClientSettings['network'];
+        coordinatorUrl: string | null;
+    }) => {
+        const domain = coordinatorUrl === null ? null : new URL(coordinatorUrl).hostname;
+
+        mainThreadEmitter.emit('module/request-interceptor', {
+            type: 'SET_WHITELISTED_DOMAIN_FOR_COINJOIN_COORDINATOR',
+            coin,
+            domain,
+        });
+    };
 
     const backendProxyOptions: IpcProxyHandlerOptions<CoinjoinBackend> = {
         onCreateInstance: async (settings: CoinjoinBackendSettings) => {
@@ -123,12 +140,10 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
     };
 
     const clientProxyOptions: IpcProxyHandlerOptions<CoinjoinClient> = {
-        onCreateInstance: async (settings: ConstructorParameters<typeof CoinjoinClient>[0]) => {
-            const urlObj = new URL(settings.coordinatorUrl);
-
-            mainThreadEmitter.emit('module/request-interceptor', {
-                type: 'ADD_WHITELISTED_DOMAIN',
-                domain: urlObj.hostname ?? urlObj.host,
+        onCreateInstance: async (settings: CoinjoinClientSettings) => {
+            emitWhitelistedCoinjoinCoordinatorDomain({
+                coin: settings.network,
+                coordinatorUrl: settings.coordinatorUrl,
             });
 
             const coinjoinMiddleware = await synchronize(getCoinjoinProcess);

--- a/packages/suite-desktop-core/src/modules/coinjoin.ts
+++ b/packages/suite-desktop-core/src/modules/coinjoin.ts
@@ -180,6 +180,16 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
                             clients.splice(clientIndex, 1);
                         }
 
+                        // There should be only one client per network (expected `undefined`), but duplicates are only
+                        // guarded by the Renderer process (CoinjoinService), not Main process, so let's be defensive:
+                        const sameNetworkClient = clients.find(
+                            otherClient => otherClient.settings.network === client.settings.network,
+                        );
+                        emitWhitelistedCoinjoinCoordinatorDomain({
+                            coin: client.settings.network,
+                            coordinatorUrl: sameNetworkClient?.settings.coordinatorUrl ?? null,
+                        });
+
                         if (clients.length === 0) {
                             logger.debug(SERVICE_NAME, `${CLIENT_CHANNEL} binary stop`);
                             synchronize(killCoinjoinProcess);

--- a/packages/suite-desktop-core/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop-core/src/modules/request-interceptor.ts
@@ -21,13 +21,24 @@ import {
 
 export const SERVICE_NAME = 'request-interceptor';
 
+const warn = (message: string) => logger.warn(SERVICE_NAME, message);
+
+type CustomBackendsPerNetworkSymbol = Record<string, string[]>;
+type CoinjoinCoordinatorPerNetworkSymbol = Record<string, string | undefined>;
+type MainThreadAllowedDomain = {
+    general: string[];
+    customBackends: CustomBackendsPerNetworkSymbol;
+    coinjoinCoordinatorDomains: CoinjoinCoordinatorPerNetworkSymbol;
+};
+
 /**
  * Main reason for this whitelist is to mitigate potential dependency attack,
  * where malicious dependency could send requests and potentially spy on the user, etc...
  */
-const mainThreadAllowedDomain = {
+const mainThreadAllowedDomain: MainThreadAllowedDomain = {
     general: [...allowedDomains],
-    customBackends: {} as Record<string, string[]>,
+    customBackends: {},
+    coinjoinCoordinatorDomains: {},
 };
 
 /**
@@ -73,17 +84,28 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
             case 'SET_WHITELISTED_DOMAINS_FOR_CUSTOM_BACKENDS': {
                 mainThreadAllowedDomain.customBackends[event.coin] = validateWhitelistedHostnames({
                     hostnames: event.domains,
-                    warn: message => logger.warn(SERVICE_NAME, message),
+                    warn,
                 });
 
                 return;
             }
 
+            case 'SET_WHITELISTED_DOMAIN_FOR_COINJOIN_COORDINATOR': {
+                const hostname = event.domain;
+                if (hostname === null) {
+                    delete mainThreadAllowedDomain.coinjoinCoordinatorDomains[event.coin];
+
+                    return;
+                }
+                const validatedHostname = validateWhitelistedHostname({ hostname, warn });
+                mainThreadAllowedDomain.coinjoinCoordinatorDomains[event.coin] = validatedHostname;
+
+                return;
+            }
+
             case 'ADD_WHITELISTED_DOMAIN': {
-                const validatedHostname = validateWhitelistedHostname({
-                    hostname: event.domain,
-                    warn: message => logger.warn(SERVICE_NAME, message),
-                });
+                const hostname = event.domain;
+                const validatedHostname = validateWhitelistedHostname({ hostname, warn });
 
                 if (validatedHostname !== undefined) {
                     mainThreadAllowedDomain.general.push(validatedHostname);
@@ -100,7 +122,8 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
     // handle event sent from modules/coinjoin (background thread)
     mainThreadEmitter.on('module/request-interceptor', requestInterceptorEventHandler);
 
-    // Allow only the configured list of domains (static config), plus custom backends (variable config by user).
+    // Allow only the configured list of domains (static config), plus variable custom backends and
+    // active coinjoin coordinator domains.
     // In offline mode, block all requests from Electron Main process (except localhost).
     const getWhitelistedDomains = () => {
         if (hasSwitch('offline-mode')) return localhostDomains;
@@ -108,6 +131,9 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
         return [
             ...mainThreadAllowedDomain.general,
             ...Object.values(mainThreadAllowedDomain.customBackends).flat(),
+            ...Object.values(mainThreadAllowedDomain.coinjoinCoordinatorDomains).filter(
+                (domain): domain is string => domain !== undefined,
+            ),
         ];
     };
 


### PR DESCRIPTION
## Description

After #31240, the hostnames for `request-interceptor` are properly validated.

But there is still a mess: the CJ coordinator URLs are appended to the general list, while [this relevant property is unused](https://github.com/trezor/trezor-suite/blob/ca39b487882f4f4c6ce732133d4b2814757d26a1/packages/suite-desktop-core/src/modules/request-interceptor.ts#L27).

Therefore:
- add them instead to a record per network
  - which can be really be [only btc, testnet or regtes](https://github.com/trezor/trezor-suite/blob/47c184a8592e12f72d3d8f037c7aa18587262359/packages/coinjoin/src/types/index.ts#L5), but suite-desktop-core should not care about that
- ~remove the event listener that adds to the general list (now unused)~ nevermind that, it became used in the meantime in 477cb20f

Functionally this remains the same, it just semantically doesn't make sense to add to the general list.

But one change in behavior:
- remove the coordinator URL when disabling the client, instead of keeping it whitelisted until end of app session 

## Notes for QA

CJ works:
- adding a new clients for BTC, TEST, REGTEST
- removing some of them
- the remaining still work

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are internal desktop/main-process modules (request-manager types, request-interceptor, and coinjoin) that are not directly exercised by any of the 109 candidate E2E tests. No static coverage mapping was found, and the LLM analysis does not surface any candidate test whose code path plausibly depends on these modules. Therefore the recommended E2E test set is empty for this change; confidence should come from lower-level unit/integration tests or manual verification of CoinJoin and network-request interception behavior.

<details><summary><b>Changed files (3)</b></summary>

- `packages/request-manager/src/types.ts`
- `packages/suite-desktop-core/src/modules/coinjoin.ts`
- `packages/suite-desktop-core/src/modules/request-interceptor.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/request-manager/src/types.ts`
- `packages/suite-desktop-core/src/modules/coinjoin.ts`
- `packages/suite-desktop-core/src/modules/request-interceptor.ts`

_Updated: 2026-09-11T10:46:07.474Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/coinjoin-coordinator-url-whitelisting/web/](https://dev.suite.sldev.cz/suite-web/fix/coinjoin-coordinator-url-whitelisting/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/coinjoin-coordinator-url-whitelisting&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/coinjoin-coordinator-url-whitelisting&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T10:47:41.288Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T10:48:21.407Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->