### PR TITLE
chore(intl): add commentary on list of supported languages

### DIFF
--- a/suite-common/suite-types/src/languages.ts
+++ b/suite-common/suite-types/src/languages.ts
@@ -8,7 +8,13 @@ export type LocaleInfo = {
     nameInOsStartsWith?: string;
 };
 
-// If you are adding language, add it to suite/package.json translations:download script too
+/**
+ * Source of truth for available languages in Suite Web/Desktop.
+ * Note that Suite Native does not yet have full parity, so it has its own list: suite-native/intl/src/languages.ts
+ * Meanwhile, Firmware is sourced remotely, and so are its lists of available languages (see trezor/data repository).
+ *
+ * If you are adding language, add it to suite/intl/package.json translations:download script too
+ */
 export const LANGUAGES = {
     'en-US': { icon: '🇬🇧', name: 'English', en: 'English', type: 'official' },
     'es-ES': { icon: '🇪🇸', name: 'Español', en: 'Spanish', type: 'official' },


### PR DESCRIPTION
## Description

Just code comentary to clarify what does this language list affect.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/supported-languages-commentary/web/](https://dev.suite.sldev.cz/suite-web/chore/supported-languages-commentary/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/supported-languages-commentary&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/supported-languages-commentary&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/supported-languages-commentary&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T15:40:40.217Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T15:40:33.352Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a broad, globally-imported language/locale type definition, so most of its 136 statically-mapped tests are only transitively related. The focused risk is to language selection, locale autodetection, language analytics payloads, and cross-version language persistence. Running the four directly language-affected tests above provides high confidence while avoiding unnecessary broad coverage.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/suite-types/src/languages.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — Directly exercises browser locale detection and language display in the onboarding analytics section; asserts the heading renders correct translated text for English and Spanish configurations, which depends on the language definitions in languages.ts.
- `suite/e2e/tests/settings/general.test.ts` — Directly changes the application language from English to Spanish and asserts the analytics event contains specific language codes ('es-ES', 'en-US') and autodetect flags; changes to language constants or types would break these assertions.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Asserts the SuiteReady analytics event reflects language-related settings and autodetectLanguage values after user changes; language type definitions feed into these event payloads.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Validates that a Spanish language preference persists across Suite version migrations and uses language selection components; changes to language definitions could affect migration compatibility or locale resolution.

</details>

_Updated: 2026-08-24T15:41:14.275Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->