### PR TITLE
fix(suite-common): construct DelegatedIdentityKey from string only

### DIFF
--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -43,9 +43,8 @@ export type ButtonRequest = Omit<DeviceEvent['payload'], 'device' | 'code'> & {
  * some signing capabilities to the Suite (for example the Suite Sync).
  */
 export type DelegatedIdentityKey = string & Branded<'DelegatedIdentityKey'>; // hex-encoded P-256 private key string
-export const asDelegatedIdentityKey = (
-    privateKey: Uint8Array<ArrayBufferLike> | string,
-): DelegatedIdentityKey => String(privateKey) as DelegatedIdentityKey;
+export const asDelegatedIdentityKey = (privateKey: string): DelegatedIdentityKey =>
+    privateKey as DelegatedIdentityKey;
 
 export interface ExtendedDevice {
     useEmptyPassphrase?: boolean;


### PR DESCRIPTION
## Description

Using `String(privateKey)` on a `privateKey` of type `Uint8Array<ArrayBufferLike>` does not produce (expected) hex-encoded string. As the `Unit8Array` is never used, it is easier to remove it instead of adding a more complex parsing.

## Notes for QA

Nothing to be tested.


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/m1nd3r/delegatedIdentityKey-privateKey-type/web/](https://dev.suite.sldev.cz/suite-web/fix/m1nd3r/delegatedIdentityKey-privateKey-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/m1nd3r/delegatedIdentityKey-privateKey-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/m1nd3r/delegatedIdentityKey-privateKey-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/m1nd3r/delegatedIdentityKey-privateKey-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-26T10:42:56.329Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-26T10:44:19.699Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a broadly-shared device type definition, so the main risk is type-level regressions in device model detection, feature metadata, and device state. I recommend a small, targeted run focused on tests that directly assert device model-specific behavior (analytics device events, onboarding authenticity, device settings, and forget-device flows) rather than the full 136-test static list.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/suite-types/src/device.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test asserts the DeviceConnect analytics event payload, including device model (T3T1), backup type, pin/passphrase protection, and optiga_sec. A change in suite-common device types can directly break the shape or values of that event.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — The authenticity check flow is model-aware (T3B1/T3T1) and uses device feature/type metadata. Type changes could affect how the app recognizes the device or reports the check result.
- `suite/e2e/tests/settings/forget-device.test.ts` — This test exercises device-specific forget flows for TS7 and TS5 models, including disconnected/connected states and Bluetooth pairing. It relies on device type definitions for model detection and state handling.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Covers device-name changes, display rotation, firmware update modal, homescreen, and wipe on a T2T1. These flows consume device model and feature types, so a type regression could manifest here.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Validates T3B1-specific device settings (name, background, firmware modal, wipe). Model-specific UI paths depend on the device type definitions.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Onboarding firmware readiness detection uses device feature/metadata types. A change in device.ts could alter how firmware state is interpreted during onboarding.
- `suite/e2e/tests/suite/initial-run.test.ts` — Covers the initial onboarding flow including THP pairing and device-connected status after onboarding. Device type/pairing state types are directly involved.

</details>

_Updated: 2026-08-26T10:41:10.900Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->