### PR TITLE
fix(suite): open transaction inputs and outputs in the explorer of their own network

### DIFF
--- a/packages/suite/src/components/suite/FormattedNftAmount.test.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.test.tsx
@@ -22,29 +22,30 @@ const ethereumAccount = mockWalletAccount({
     descriptor: asAccountDescriptor('ethDescriptor'),
 });
 
-const nftTransfer = {
+const nftTransfer: TokenTransfer = {
     type: 'sent',
     standard: 'ERC721',
     contract: '0xnftcontract',
+    from: '0xsender',
+    to: '0xrecipient',
     amount: '1234',
     symbol: 'NFT',
     decimals: 0,
-} as TokenTransfer;
+};
 
-const getInitialState = (): AppState =>
-    ({
-        ...mockInitialAppState,
-        wallet: {
-            ...mockInitialAppState.wallet,
-            accounts: [ethereumAccount],
-            explorer: explorerInitialState,
-            selectedAccount: {
-                status: 'loaded',
-                account: ethereumAccount,
-                network: getNetwork(ethereumAccount.symbol),
-            },
+const getInitialState = (): AppState => ({
+    ...mockInitialAppState,
+    wallet: {
+        ...mockInitialAppState.wallet,
+        explorer: explorerInitialState,
+        selectedAccount: {
+            status: 'loaded',
+            account: ethereumAccount,
+            network: getNetwork(ethereumAccount.symbol),
+            params: undefined,
         },
-    }) as AppState;
+    },
+});
 
 describe('FormattedNftAmount', () => {
     it('opens a token in the explorer of its own network, not of the selected account', () => {

--- a/packages/suite/src/components/suite/FormattedNftAmount.test.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.test.tsx
@@ -31,8 +31,6 @@ const nftTransfer = {
     decimals: 0,
 } as TokenTransfer;
 
-// An account of another network is selected, as it is when the transaction detail is opened from
-// the trade history of a swap.
 const getInitialState = (): AppState =>
     ({
         ...mockInitialAppState,

--- a/packages/suite/src/components/suite/FormattedNftAmount.test.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.test.tsx
@@ -1,0 +1,70 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { screen } from '@testing-library/react';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import { getNetwork } from '@suite-common/wallet-config';
+import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
+import { explorerInitialState } from '@suite-common/wallet-core';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type TokenTransfer } from '@trezor/connect';
+
+import { type AppState } from 'src/reducers/store';
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { FormattedNftAmount } from './FormattedNftAmount';
+import { extraDependenciesDesktopMock } from '../../../mocks/extraDependenciesDesktopMock';
+import { mockInitialAppState } from '../../../mocks/mockInitialAppState';
+
+const ethereumAccount = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('ethDescriptor'),
+});
+
+const nftTransfer = {
+    type: 'sent',
+    standard: 'ERC721',
+    contract: '0xnftcontract',
+    amount: '1234',
+    symbol: 'NFT',
+    decimals: 0,
+} as TokenTransfer;
+
+// An account of another network is selected, as it is when the transaction detail is opened from
+// the trade history of a swap.
+const getInitialState = (): AppState =>
+    ({
+        ...mockInitialAppState,
+        wallet: {
+            ...mockInitialAppState.wallet,
+            accounts: [ethereumAccount],
+            explorer: explorerInitialState,
+            selectedAccount: {
+                status: 'loaded',
+                account: ethereumAccount,
+                network: getNetwork(ethereumAccount.symbol),
+            },
+        },
+    }) as AppState;
+
+describe('FormattedNftAmount', () => {
+    it('opens a token in the explorer of its own network, not of the selected account', () => {
+        const store = configureMockStore({ preloadedState: getInitialState() });
+
+        renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <FormattedNftAmount transfer={nftTransfer} networkSymbol="pol" isWithLink />,
+        );
+
+        const polygonNftUrl = getExplorerUrl(explorerInitialState.pol.default, 'nft');
+        const ethereumNftUrl = getExplorerUrl(explorerInitialState.eth.default, 'nft');
+
+        expect(polygonNftUrl).not.toBe(ethereumNftUrl);
+        expect(screen.getByRole('link')).toHaveAttribute(
+            'href',
+            `${polygonNftUrl}${nftTransfer.contract}/${nftTransfer.amount}`,
+        );
+    });
+});

--- a/packages/suite/src/components/suite/FormattedNftAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.tsx
@@ -2,7 +2,7 @@ import { RedactNumericalValue } from '@suite/discreet-mode';
 import { TrezorLink } from '@suite/external-links';
 import { Translation, useTranslation } from '@suite/intl';
 import { type SignValue } from '@suite-common/suite-types';
-import { type NetworkSymbol, getExplorerUrl, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getExplorerUrl, getNetworkType } from '@suite-common/wallet-config';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { isNftMultitokenTransfer } from '@suite-common/wallet-utils';
 import { Box, Column, Row, Text } from '@trezor/components';
@@ -33,7 +33,7 @@ export const FormattedNftAmount = ({
     linkTypographyStyle,
 }: FormattedNftAmountProps) => {
     const { translationString } = useTranslation();
-    const network = getNetwork(networkSymbol);
+    const networkType = getNetworkType(networkSymbol);
     const explorer = useSelector(state => selectExplorer(state, networkSymbol));
 
     const symbolComponent = transfer.symbol ? (
@@ -69,7 +69,7 @@ export const FormattedNftAmount = ({
                                 </Row>
                             )}
                         </Row>
-                        {isWithLink && network.networkType === 'ethereum' ? (
+                        {isWithLink && networkType === 'ethereum' ? (
                             <TrezorLink
                                 href={`${getExplorerUrl(explorer, 'nft')}${transfer.contract}/${token.id}`}
                                 typographyStyle={linkTypographyStyle}
@@ -98,7 +98,7 @@ export const FormattedNftAmount = ({
             {isWithLink ? (
                 <TrezorLink
                     href={
-                        network.networkType === 'ethereum'
+                        networkType === 'ethereum'
                             ? `${getExplorerUrl(explorer, 'nft')}${transfer.contract}/${transfer.amount}`
                             : undefined
                     }

--- a/packages/suite/src/components/suite/FormattedNftAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.tsx
@@ -15,7 +15,6 @@ import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
 export interface FormattedNftAmountProps {
     transfer: TokenTransfer;
-    /** Network of the transfer, which decides the explorer the token is opened in. */
     networkSymbol: NetworkSymbol;
     signValue?: SignValue;
     signGrayscale?: boolean;

--- a/packages/suite/src/components/suite/FormattedNftAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedNftAmount.tsx
@@ -2,7 +2,7 @@ import { RedactNumericalValue } from '@suite/discreet-mode';
 import { TrezorLink } from '@suite/external-links';
 import { Translation, useTranslation } from '@suite/intl';
 import { type SignValue } from '@suite-common/suite-types';
-import { getExplorerUrl } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getExplorerUrl, getNetwork } from '@suite-common/wallet-config';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { isNftMultitokenTransfer } from '@suite-common/wallet-utils';
 import { Box, Column, Row, Text } from '@trezor/components';
@@ -15,6 +15,8 @@ import { BlurUrls } from 'src/views/wallet/tokens/common/BlurUrls';
 
 export interface FormattedNftAmountProps {
     transfer: TokenTransfer;
+    /** Network of the transfer, which decides the explorer the token is opened in. */
+    networkSymbol: NetworkSymbol;
     signValue?: SignValue;
     signGrayscale?: boolean;
     isWithLink?: boolean;
@@ -24,6 +26,7 @@ export interface FormattedNftAmountProps {
 
 export const FormattedNftAmount = ({
     transfer,
+    networkSymbol,
     signValue,
     signGrayscale,
     isWithLink,
@@ -31,9 +34,8 @@ export const FormattedNftAmount = ({
     linkTypographyStyle,
 }: FormattedNftAmountProps) => {
     const { translationString } = useTranslation();
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const { network } = selectedAccount;
-    const explorer = useSelector(state => selectExplorer(state, network?.symbol));
+    const network = getNetwork(networkSymbol);
+    const explorer = useSelector(state => selectExplorer(state, networkSymbol));
 
     const symbolComponent = transfer.symbol ? (
         <Text ellipsisLineCount={1}>
@@ -68,7 +70,7 @@ export const FormattedNftAmount = ({
                                 </Row>
                             )}
                         </Row>
-                        {isWithLink && network?.networkType === 'ethereum' ? (
+                        {isWithLink && network.networkType === 'ethereum' ? (
                             <TrezorLink
                                 href={`${getExplorerUrl(explorer, 'nft')}${transfer.contract}/${token.id}`}
                                 typographyStyle={linkTypographyStyle}
@@ -97,7 +99,7 @@ export const FormattedNftAmount = ({
             {isWithLink ? (
                 <TrezorLink
                     href={
-                        network?.networkType === 'ethereum'
+                        network.networkType === 'ethereum'
                             ? `${getExplorerUrl(explorer, 'nft')}${transfer.contract}/${transfer.amount}`
                             : undefined
                     }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -49,7 +49,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
     const amount = new BigNumber(formatNetworkAmount(tx.amount, tx.symbol));
     const cardanoWithdrawal = formatCardanoWithdrawal(tx);
     const cardanoDeposit = formatCardanoDeposit(tx);
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     const txSignature = tx.ethereumSpecific?.parsedData?.methodId;
     const isStakeType = isStakeTypeTx(txSignature) || tx?.solanaSpecific?.stakeOperation?.type; // ethereum or solana staking tx
@@ -218,6 +217,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                     <Text intent="neutral">
                                         <AmountComponent
                                             transfer={transfer}
+                                            networkSymbol={tx.symbol}
                                             withLink={true}
                                             withSign={true}
                                             alignMultitoken="flex-start"
@@ -226,34 +226,30 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                     </Text>
                                 </Table.Cell>
                                 <Table.Cell align="end">
-                                    {selectedAccount.account && (
-                                        <Text intent="neutral">
-                                            <BaseCurrencyValue
-                                                amount={convertAmountSubunitsToUnits(
-                                                    transfer.amount,
-                                                    transfer.decimals,
-                                                )}
-                                                symbol={selectedAccount.account?.symbol}
-                                                tokenAddress={transfer.contract as TokenAddress}
-                                                historicRate={historicTokenRate}
-                                                useHistoricRate
-                                            />
-                                        </Text>
-                                    )}
+                                    <Text intent="neutral">
+                                        <BaseCurrencyValue
+                                            amount={convertAmountSubunitsToUnits(
+                                                transfer.amount,
+                                                transfer.decimals,
+                                            )}
+                                            symbol={tx.symbol}
+                                            tokenAddress={transfer.contract as TokenAddress}
+                                            historicRate={historicTokenRate}
+                                            useHistoricRate
+                                        />
+                                    </Text>
                                 </Table.Cell>
                                 <Table.Cell align="end">
-                                    {selectedAccount.account && (
-                                        <Text intent="neutral">
-                                            <BaseCurrencyValue
-                                                amount={convertAmountSubunitsToUnits(
-                                                    transfer.amount,
-                                                    transfer.decimals,
-                                                )}
-                                                symbol={selectedAccount.account.symbol}
-                                                tokenAddress={transfer.contract as TokenAddress}
-                                            />
-                                        </Text>
-                                    )}
+                                    <Text intent="neutral">
+                                        <BaseCurrencyValue
+                                            amount={convertAmountSubunitsToUnits(
+                                                transfer.amount,
+                                                transfer.decimals,
+                                            )}
+                                            symbol={tx.symbol}
+                                            tokenAddress={transfer.contract as TokenAddress}
+                                        />
+                                    </Text>
                                 </Table.Cell>
                                 <Table.Cell align="end">
                                     {tx.blockTime && (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -1,6 +1,5 @@
 import { Translation } from '@suite/intl';
-import { getNetwork } from '@suite-common/wallet-config';
-import { selectIsPhishingTransaction } from '@suite-common/wallet-core';
+import { selectAccountNetworkType, selectIsPhishingTransaction } from '@suite-common/wallet-core';
 import { type WalletAccountTransaction, createAccountKey } from '@suite-common/wallet-types';
 import { Column, Divider } from '@trezor/components';
 
@@ -15,18 +14,18 @@ type IODetailsProps = {
 };
 
 export const IODetails = ({ tx }: IODetailsProps) => {
-    const network = getNetwork(tx.symbol);
     const accountKey = createAccountKey({
         accountDescriptor: tx.descriptor,
         networkSymbol: tx.symbol,
         deviceStaticSessionId: tx.deviceState,
     });
+    const networkType = useSelector(state => selectAccountNetworkType(state, accountKey));
     const { isPhishing: isPhishingTransaction } = useSelector(state =>
         selectIsPhishingTransaction(state, tx.txid, accountKey),
     );
 
     const getContent = () => {
-        if (network.networkType === 'ethereum' || network.networkType === 'tron') {
+        if (networkType === 'ethereum' || networkType === 'tron') {
             return (
                 <>
                     <IOGroup
@@ -41,7 +40,7 @@ export const IODetails = ({ tx }: IODetailsProps) => {
                     />
                 </>
             );
-        } else if (network.networkType === 'solana' || network.networkType === 'stellar') {
+        } else if (networkType === 'solana' || networkType === 'stellar') {
             return (
                 <>
                     <IOGroup
@@ -77,7 +76,7 @@ export const IODetails = ({ tx }: IODetailsProps) => {
                     />
                 </>
             );
-        } else if (network.networkType === 'cardano') {
+        } else if (networkType === 'cardano') {
             return (
                 <>
                     <IOGroup

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -15,8 +15,6 @@ type IODetailsProps = {
 };
 
 export const IODetails = ({ tx }: IODetailsProps) => {
-    // The transaction's own network, which is not necessarily the one of the selected account: the
-    // transaction detail is opened from places such as the trade history as well.
     const network = getNetwork(tx.symbol);
     const accountKey = createAccountKey({
         accountDescriptor: tx.descriptor,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { getNetwork } from '@suite-common/wallet-config';
 import { selectIsPhishingTransaction } from '@suite-common/wallet-core';
 import { type WalletAccountTransaction, createAccountKey } from '@suite-common/wallet-types';
 import { Column, Divider } from '@trezor/components';
@@ -14,7 +15,9 @@ type IODetailsProps = {
 };
 
 export const IODetails = ({ tx }: IODetailsProps) => {
-    const network = useSelector(state => state.wallet.selectedAccount.network);
+    // The transaction's own network, which is not necessarily the one of the selected account: the
+    // transaction detail is opened from places such as the trade history as well.
+    const network = getNetwork(tx.symbol);
     const accountKey = createAccountKey({
         accountDescriptor: tx.descriptor,
         networkSymbol: tx.symbol,
@@ -25,7 +28,7 @@ export const IODetails = ({ tx }: IODetailsProps) => {
     );
 
     const getContent = () => {
-        if (network?.networkType === 'ethereum' || network?.networkType === 'tron') {
+        if (network.networkType === 'ethereum' || network.networkType === 'tron') {
             return (
                 <>
                     <IOGroup
@@ -40,7 +43,7 @@ export const IODetails = ({ tx }: IODetailsProps) => {
                     />
                 </>
             );
-        } else if (network?.networkType === 'solana' || network?.networkType === 'stellar') {
+        } else if (network.networkType === 'solana' || network.networkType === 'stellar') {
             return (
                 <>
                     <IOGroup
@@ -76,7 +79,7 @@ export const IODetails = ({ tx }: IODetailsProps) => {
                     />
                 </>
             );
-        } else if (network?.networkType === 'cardano') {
+        } else if (network.networkType === 'cardano') {
             return (
                 <>
                     <IOGroup

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.test.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.test.tsx
@@ -36,20 +36,20 @@ const bitcoinTransaction = {
 const inputAddress = 'bc1qtestinputaddress';
 const inputs: IODetailsType[] = [{ addresses: [inputAddress] } as IODetailsType];
 
-const getInitialState = (): AppState =>
-    ({
-        ...mockInitialAppState,
-        wallet: {
-            ...mockInitialAppState.wallet,
-            accounts: [bitcoinAccount, ethereumAccount],
-            explorer: explorerInitialState,
-            selectedAccount: {
-                status: 'loaded',
-                account: ethereumAccount,
-                network: getNetwork(ethereumAccount.symbol),
-            },
+const getInitialState = (): AppState => ({
+    ...mockInitialAppState,
+    wallet: {
+        ...mockInitialAppState.wallet,
+        accounts: [bitcoinAccount, ethereumAccount],
+        explorer: explorerInitialState,
+        selectedAccount: {
+            status: 'loaded',
+            account: ethereumAccount,
+            network: getNetwork(ethereumAccount.symbol),
+            params: undefined,
         },
-    }) as AppState;
+    },
+});
 
 describe('IOGroup', () => {
     it('opens an address in the explorer of the transaction network, not of the selected account', () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.test.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.test.tsx
@@ -36,8 +36,6 @@ const bitcoinTransaction = {
 const inputAddress = 'bc1qtestinputaddress';
 const inputs: IODetailsType[] = [{ addresses: [inputAddress] } as IODetailsType];
 
-// An account of another network is selected, as it is when the transaction detail is opened from
-// the trade history of a swap.
 const getInitialState = (): AppState =>
     ({
         ...mockInitialAppState,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.test.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.test.tsx
@@ -1,0 +1,75 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { screen } from '@testing-library/react';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import { getNetwork } from '@suite-common/wallet-config';
+import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
+import { explorerInitialState } from '@suite-common/wallet-core';
+import { type WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { type AppState } from 'src/reducers/store';
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { type IODetailsType } from './IODetailsType';
+import { IOGroup } from './IOGroup';
+import { extraDependenciesDesktopMock } from '../../../../../../../../../../mocks/extraDependenciesDesktopMock';
+import { mockInitialAppState } from '../../../../../../../../../../mocks/mockInitialAppState';
+
+const bitcoinAccount = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('btcDescriptor'),
+});
+const ethereumAccount = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('ethDescriptor'),
+});
+
+const bitcoinTransaction = {
+    symbol: bitcoinAccount.symbol,
+    descriptor: bitcoinAccount.descriptor,
+    deviceState: bitcoinAccount.deviceState,
+    txid: 'bitcoin-txid',
+} as WalletAccountTransaction;
+
+const inputAddress = 'bc1qtestinputaddress';
+const inputs: IODetailsType[] = [{ addresses: [inputAddress] } as IODetailsType];
+
+// An account of another network is selected, as it is when the transaction detail is opened from
+// the trade history of a swap.
+const getInitialState = (): AppState =>
+    ({
+        ...mockInitialAppState,
+        wallet: {
+            ...mockInitialAppState.wallet,
+            accounts: [bitcoinAccount, ethereumAccount],
+            explorer: explorerInitialState,
+            selectedAccount: {
+                status: 'loaded',
+                account: ethereumAccount,
+                network: getNetwork(ethereumAccount.symbol),
+            },
+        },
+    }) as AppState;
+
+describe('IOGroup', () => {
+    it('opens an address in the explorer of the transaction network, not of the selected account', () => {
+        const store = configureMockStore({ preloadedState: getInitialState() });
+
+        renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <IOGroup tx={bitcoinTransaction} inputs={inputs} outputs={[]} />,
+        );
+
+        const bitcoinAddressUrl = getExplorerUrl(explorerInitialState.btc.default, 'address');
+        const ethereumAddressUrl = getExplorerUrl(explorerInitialState.eth.default, 'address');
+
+        expect(bitcoinAddressUrl).not.toBe(ethereumAddressUrl);
+        expect(screen.getByRole('link')).toHaveAttribute(
+            'href',
+            `${bitcoinAddressUrl}${inputAddress}`,
+        );
+    });
+});

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
@@ -14,7 +14,6 @@ import { type AddressOwnership, IOItem } from './IOItem';
 
 export type IOGroupProps = {
     tx: WalletAccountTransaction;
-    /** Symbol the amounts are displayed in; the addresses still use the transaction's network. */
     tokenSymbol?: NetworkSymbolExtended;
     contractAddress?: string;
     inputs: IODetailsType[];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
@@ -42,6 +42,7 @@ export const IOGroup = ({
     const account = useSelector(state => selectAccountByKey(state, accountKey));
     const accountAddresses = account?.addresses;
     const accountDescriptor = account?.descriptor;
+
     const displaySymbol = tokenSymbol ?? tx.symbol;
 
     const ownershipByAddress = useMemo(() => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
@@ -14,10 +14,7 @@ import { type AddressOwnership, IOItem } from './IOItem';
 
 export type IOGroupProps = {
     tx: WalletAccountTransaction;
-    /**
-     * Symbol the amounts are displayed in, set for a token transfer. The transaction keeps its own
-     * network symbol, which is what the addresses are looked up in the explorer with.
-     */
+    /** Symbol the amounts are displayed in; the addresses still use the transaction's network. */
     tokenSymbol?: NetworkSymbolExtended;
     contractAddress?: string;
     inputs: IODetailsType[];
@@ -37,8 +34,6 @@ export const IOGroup = ({
     isUtxoBased = false,
     isPhishingTransaction,
 }: IOGroupProps) => {
-    // The account the transaction belongs to, which is not necessarily the selected one: the
-    // transaction detail is opened from places such as the trade history as well.
     const accountKey = createAccountKey({
         accountDescriptor: tx.descriptor,
         networkSymbol: tx.symbol,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 
-import { selectFullSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { type NetworkSymbolExtended } from '@suite-common/wallet-config';
-import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+import { selectAccountByKey } from '@suite-common/wallet-core';
+import { type WalletAccountTransaction, createAccountKey } from '@suite-common/wallet-types';
 import { Column, Icon, InfoSegments, Row, Text } from '@trezor/components';
 import { ArrowRightIcon } from '@trezor/icons';
 
@@ -13,10 +13,12 @@ import { type IODetailsType } from './IODetailsType';
 import { type AddressOwnership, IOItem } from './IOItem';
 
 export type IOGroupProps = {
+    tx: WalletAccountTransaction;
     /**
-     * Transaction details can be passed also token's details so NetworkSymbolExtended is necessary
+     * Symbol the amounts are displayed in, set for a token transfer. The transaction keeps its own
+     * network symbol, which is what the addresses are looked up in the explorer with.
      */
-    tx: Omit<WalletAccountTransaction, 'symbol'> & { symbol: NetworkSymbolExtended };
+    tokenSymbol?: NetworkSymbolExtended;
     contractAddress?: string;
     inputs: IODetailsType[];
     outputs: IODetailsType[];
@@ -27,6 +29,7 @@ export type IOGroupProps = {
 
 export const IOGroup = ({
     tx,
+    tokenSymbol,
     contractAddress,
     inputs,
     outputs,
@@ -34,9 +37,17 @@ export const IOGroup = ({
     isUtxoBased = false,
     isPhishingTransaction,
 }: IOGroupProps) => {
-    const selectedAccount = useSelector(selectFullSelectedAccount);
-    const accountAddresses = selectedAccount?.account?.addresses;
-    const accountDescriptor = selectedAccount?.account?.descriptor;
+    // The account the transaction belongs to, which is not necessarily the selected one: the
+    // transaction detail is opened from places such as the trade history as well.
+    const accountKey = createAccountKey({
+        accountDescriptor: tx.descriptor,
+        networkSymbol: tx.symbol,
+        deviceStaticSessionId: tx.deviceState,
+    });
+    const account = useSelector(state => selectAccountByKey(state, accountKey));
+    const accountAddresses = account?.addresses;
+    const accountDescriptor = account?.descriptor;
+    const displaySymbol = tokenSymbol ?? tx.symbol;
 
     const ownershipByAddress = useMemo(() => {
         if (!accountAddresses) return undefined;
@@ -90,7 +101,8 @@ export const IOGroup = ({
                         <IOItem
                             key={`input-${input.n}`}
                             anonymitySet={anonymitySet}
-                            symbol={tx.symbol}
+                            networkSymbol={tx.symbol}
+                            symbol={displaySymbol}
                             contractAddress={contractAddress}
                             value={input.addresses?.[0]}
                             amount={input.value}
@@ -123,7 +135,8 @@ export const IOGroup = ({
                         <IOItem
                             key={`output-${output.n}`}
                             anonymitySet={anonymitySet}
-                            symbol={tx.symbol}
+                            networkSymbol={tx.symbol}
+                            symbol={displaySymbol}
                             contractAddress={contractAddress}
                             value={output.addresses?.[0]}
                             amount={output.value}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
@@ -30,9 +30,7 @@ export type AddressOwnership = keyof typeof ownershipIcon;
 
 type IOItem = {
     anonymitySet?: AnonymitySet;
-    /** Network of the transaction, which decides the explorer the address is opened in. */
     networkSymbol: NetworkSymbol;
-    /** Symbol the amount is displayed in, a token symbol for a token transfer. */
     symbol?: NetworkSymbolExtended;
     contractAddress?: string;
     value?: string;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
@@ -1,10 +1,13 @@
 import { type ReactNode } from 'react';
 
-import { selectFullSelectedAccount } from '@suite/account';
 import { Address } from '@suite/address';
 import { useExternalLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { type NetworkSymbolExtended, isNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    type NetworkSymbolExtended,
+    isNetworkSymbol,
+} from '@suite-common/wallet-config';
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
@@ -27,6 +30,9 @@ export type AddressOwnership = keyof typeof ownershipIcon;
 
 type IOItem = {
     anonymitySet?: AnonymitySet;
+    /** Network of the transaction, which decides the explorer the address is opened in. */
+    networkSymbol: NetworkSymbol;
+    /** Symbol the amount is displayed in, a token symbol for a token transfer. */
     symbol?: NetworkSymbolExtended;
     contractAddress?: string;
     value?: string;
@@ -38,14 +44,14 @@ type IOItem = {
 export const IOItem = ({
     anonymitySet,
     value,
+    networkSymbol,
     symbol,
     contractAddress,
     amount,
     isPhishingTransaction,
     ownership,
 }: IOItem) => {
-    const { network } = useSelector(selectFullSelectedAccount);
-    const explorer = useSelector(state => selectExplorer(state, network?.symbol));
+    const explorer = useSelector(state => selectExplorer(state, networkSymbol));
     const explorerUrl = getExplorerUrl(explorer, 'address');
     const explorerLink = useExternalLink(`${explorerUrl}${value}${explorer?.queryString ?? ''}`);
     const anonymity = value && anonymitySet?.[value];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
@@ -28,7 +28,7 @@ const ownershipIcon = {
 
 export type AddressOwnership = keyof typeof ownershipIcon;
 
-type IOItem = {
+type IOItemProps = {
     anonymitySet?: AnonymitySet;
     networkSymbol: NetworkSymbol;
     symbol?: NetworkSymbolExtended;
@@ -48,7 +48,7 @@ export const IOItem = ({
     amount,
     isPhishingTransaction,
     ownership,
-}: IOItem) => {
+}: IOItemProps) => {
     const explorer = useSelector(state => selectExplorer(state, networkSymbol));
     const explorerUrl = getExplorerUrl(explorer, 'address');
     const explorerLink = useExternalLink(`${explorerUrl}${value}${explorer?.queryString ?? ''}`);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
@@ -96,8 +96,6 @@ export const TokenSpecificBalanceDetailsRow = ({
                                 <IOGroup
                                     key={index}
                                     tx={tx}
-                                    // Empty, not undefined: undefined falls back to the network
-                                    // symbol and would convert this amount a second time.
                                     tokenSymbol={transfer.symbol || ''}
                                     contractAddress={transfer.contract}
                                     inputs={

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
@@ -96,9 +96,8 @@ export const TokenSpecificBalanceDetailsRow = ({
                                 <IOGroup
                                     key={index}
                                     tx={tx}
-                                    // Empty rather than undefined on purpose: undefined falls back
-                                    // to the network symbol, which would format this already
-                                    // converted amount as network units a second time.
+                                    // Empty, not undefined: undefined falls back to the network
+                                    // symbol and would convert this amount a second time.
                                     tokenSymbol={transfer.symbol || ''}
                                     contractAddress={transfer.contract}
                                     inputs={

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
@@ -95,6 +95,9 @@ export const TokenSpecificBalanceDetailsRow = ({
                                 <IOGroup
                                     key={index}
                                     tx={tx}
+                                    // Empty rather than undefined on purpose: undefined falls back
+                                    // to the network symbol, which would format this already
+                                    // converted amount as network units a second time.
                                     tokenSymbol={transfer.symbol || ''}
                                     contractAddress={transfer.contract}
                                     inputs={

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
@@ -94,7 +94,8 @@ export const TokenSpecificBalanceDetailsRow = ({
                             return (
                                 <IOGroup
                                     key={index}
-                                    tx={{ ...tx, symbol: transfer.symbol || '' }}
+                                    tx={tx}
+                                    tokenSymbol={transfer.symbol || ''}
                                     contractAddress={transfer.contract}
                                     inputs={
                                         [{ addresses: [transfer.from], value }] as IODetailsType[]

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
@@ -83,6 +83,7 @@ export const TokenSpecificBalanceDetailsRow = ({
                             const value = isNftTokenTransfer(transfer) ? (
                                 <FormattedNftAmount
                                     transfer={transfer}
+                                    networkSymbol={tx.symbol}
                                     isWithLink
                                     alignMultitoken="flex-start"
                                     linkTypographyStyle="body-xs"

--- a/packages/suite/src/components/wallet/AmountComponent.tsx
+++ b/packages/suite/src/components/wallet/AmountComponent.tsx
@@ -1,3 +1,4 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     convertAmountSubunitsToUnits,
     getTxOperation,
@@ -11,6 +12,7 @@ import { FormattedNftAmount } from 'src/components/suite/FormattedNftAmount';
 
 type AmountComponentProps = {
     transfer: TokenTransfer;
+    networkSymbol: NetworkSymbol;
     withLink?: boolean;
     withSign?: boolean;
     signGrayscale?: boolean;
@@ -20,6 +22,7 @@ type AmountComponentProps = {
 
 export const AmountComponent = ({
     transfer,
+    networkSymbol,
     withLink = false,
     withSign = false,
     signGrayscale,
@@ -32,6 +35,7 @@ export const AmountComponent = ({
         return (
             <FormattedNftAmount
                 transfer={transfer}
+                networkSymbol={networkSymbol}
                 isWithLink={withLink}
                 signValue={withSign ? operation : null}
                 signGrayscale={signGrayscale}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -121,6 +121,7 @@ export const TransactionTarget = ({
                 return (
                     <AmountComponent
                         transfer={payload}
+                        networkSymbol={transaction.symbol}
                         withLink={false}
                         withSign
                         alignMultitoken="flex-end"

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
@@ -4,6 +4,7 @@ import type {
     TradingProviderInfo as TradingProviderInfoType,
     TradingTradeType,
 } from '@suite-common/trading';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Button, Column, InfoItem, Row, Text } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
 
@@ -15,7 +16,7 @@ import { TradingProviderInfo } from '../TradingProviderInfo';
 
 type TradingDetailProviderInfoProps = {
     account?: Account;
-    receiveAccount?: Account;
+    receiveAccountKey?: AccountKey;
     estimatedTime?: string;
     orderId?: string;
     provider: TradingProviderInfoType;
@@ -25,7 +26,7 @@ type TradingDetailProviderInfoProps = {
 
 export const TradingDetailProviderInfo = ({
     account,
-    receiveAccount,
+    receiveAccountKey,
     estimatedTime,
     orderId,
     provider,
@@ -54,7 +55,7 @@ export const TradingDetailProviderInfo = ({
                         <TradingDetailTxId
                             value={txId}
                             account={account}
-                            receiveAccount={receiveAccount}
+                            receiveAccountKey={receiveAccountKey}
                         />
                     </InfoItem>
                 )}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
@@ -15,6 +15,7 @@ import { TradingProviderInfo } from '../TradingProviderInfo';
 
 type TradingDetailProviderInfoProps = {
     account?: Account;
+    receiveAccount?: Account;
     estimatedTime?: string;
     orderId?: string;
     provider: TradingProviderInfoType;
@@ -24,6 +25,7 @@ type TradingDetailProviderInfoProps = {
 
 export const TradingDetailProviderInfo = ({
     account,
+    receiveAccount,
     estimatedTime,
     orderId,
     provider,
@@ -49,7 +51,11 @@ export const TradingDetailProviderInfo = ({
                 )}
                 {account && txId && (
                     <InfoItem label={<Translation id="TR_TXID" />} direction="row">
-                        <TradingDetailTxId value={txId} account={account} />
+                        <TradingDetailTxId
+                            value={txId}
+                            account={account}
+                            receiveAccount={receiveAccount}
+                        />
                     </InfoItem>
                 )}
                 <InfoItem label={<Translation id="TR_BUY_PROVIDER" />} direction="row">

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
@@ -4,7 +4,8 @@ import userEvent from '@testing-library/user-event';
 
 import { openModal } from '@suite/modal';
 import { configureMockStore } from '@suite-common/test-utils';
-import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { transactionsInitialState } from '@suite-common/wallet-core';
+import { type WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { type AppState } from 'src/reducers/store';
@@ -25,20 +26,22 @@ const receiveAccount = mockWalletAccount({
 
 const payoutTxid = 'payoutTxid';
 
-const getInitialState = (): AppState =>
-    ({
-        ...mockInitialAppState,
-        wallet: {
-            ...mockInitialAppState.wallet,
-            accounts: [sendAccount, receiveAccount],
+const getInitialState = (): AppState => ({
+    ...mockInitialAppState,
+    wallet: {
+        ...mockInitialAppState.wallet,
+        accounts: [sendAccount, receiveAccount],
+        transactions: {
+            ...transactionsInitialState,
             transactions: {
-                transactions: {
-                    [receiveAccount.key]: [{ txid: payoutTxid, symbol: receiveAccount.symbol }],
-                    [sendAccount.key]: [],
-                },
+                [receiveAccount.key]: [
+                    { txid: payoutTxid, symbol: receiveAccount.symbol } as WalletAccountTransaction,
+                ],
+                [sendAccount.key]: [],
             },
         },
-    }) as AppState;
+    },
+});
 
 describe('TradingDetailTxId', () => {
     it('opens the transaction detail of the account holding the transaction', async () => {

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
@@ -25,7 +25,6 @@ const receiveAccount = mockWalletAccount({
 
 const payoutTxid = 'payoutTxid';
 
-// The provider's payout lands on the receive account, which is the only account holding it.
 const getInitialState = (): AppState =>
     ({
         ...mockInitialAppState,

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
@@ -1,0 +1,104 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import userEvent from '@testing-library/user-event';
+
+import { openModal } from '@suite/modal';
+import { configureMockStore } from '@suite-common/test-utils';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { type AppState } from 'src/reducers/store';
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { TradingDetailTxId } from './TradingDetailTxId';
+import { extraDependenciesDesktopMock } from '../../../../../../mocks/extraDependenciesDesktopMock';
+import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
+
+const sendAccount = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('btcDescriptor'),
+});
+const receiveAccount = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('ethDescriptor'),
+});
+
+const payoutTxid = 'payoutTxid';
+
+// The provider's payout lands on the receive account, which is the only account holding it.
+const getInitialState = (): AppState =>
+    ({
+        ...mockInitialAppState,
+        wallet: {
+            ...mockInitialAppState.wallet,
+            accounts: [sendAccount, receiveAccount],
+            transactions: {
+                transactions: {
+                    [receiveAccount.key]: [{ txid: payoutTxid, symbol: receiveAccount.symbol }],
+                    [sendAccount.key]: [],
+                },
+            },
+        },
+    }) as AppState;
+
+describe('TradingDetailTxId', () => {
+    it('opens the transaction detail of the account holding the transaction', async () => {
+        const store = configureMockStore({ preloadedState: getInitialState() });
+
+        const { container } = renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingDetailTxId
+                value={payoutTxid}
+                account={sendAccount}
+                receiveAccount={receiveAccount}
+            />,
+        );
+
+        const link = container.querySelector('a');
+        if (!link) throw new Error('The transaction ID is not rendered as a link.');
+
+        await userEvent.click(link);
+
+        expect(store.getActions()).toContainEqual(
+            openModal({
+                type: 'transaction-detail',
+                txid: payoutTxid,
+                descriptor: receiveAccount.descriptor,
+                symbol: receiveAccount.symbol,
+                deviceState: receiveAccount.deviceState,
+                flow: 'detail',
+            }),
+        );
+    });
+
+    it('falls back to the send account when the transaction is not on the receive account', async () => {
+        const store = configureMockStore({ preloadedState: getInitialState() });
+
+        const { container } = renderWithProviders(
+            store,
+            extraDependenciesDesktopMock.services,
+            <TradingDetailTxId
+                value="signedSendTxid"
+                account={sendAccount}
+                receiveAccount={receiveAccount}
+            />,
+        );
+
+        const link = container.querySelector('a');
+        if (!link) throw new Error('The transaction ID is not rendered as a link.');
+
+        await userEvent.click(link);
+
+        expect(store.getActions()).toContainEqual(
+            openModal({
+                type: 'transaction-detail',
+                txid: 'signedSendTxid',
+                descriptor: sendAccount.descriptor,
+                symbol: sendAccount.symbol,
+                deviceState: sendAccount.deviceState,
+                flow: 'detail',
+            }),
+        );
+    });
+});

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
@@ -50,7 +50,7 @@ describe('TradingDetailTxId', () => {
             <TradingDetailTxId
                 value={payoutTxid}
                 account={sendAccount}
-                receiveAccount={receiveAccount}
+                receiveAccountKey={receiveAccount.key}
             />,
         );
 
@@ -80,7 +80,7 @@ describe('TradingDetailTxId', () => {
             <TradingDetailTxId
                 value="signedSendTxid"
                 account={sendAccount}
-                receiveAccount={receiveAccount}
+                receiveAccountKey={receiveAccount.key}
             />,
         );
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
@@ -15,11 +15,6 @@ import { type Account } from 'src/types/wallet';
 type TradingDetailTxIdProps = {
     value: string;
     account: Account;
-    /**
-     * The other side of a swap. `receiveTxHash` holds the signed send transaction until a status
-     * refresh replaces it with the provider's payout on the receive network, so only the store says
-     * which account the transaction belongs to.
-     */
     receiveAccountKey?: AccountKey;
     intent?: TextProps['intent'];
     priority?: TextProps['priority'];

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
@@ -2,7 +2,11 @@ import { useDispatch } from 'react-redux';
 
 import { Address } from '@suite/address';
 import { openModal } from '@suite/modal';
-import { selectTransactionByAccountKeyAndTxid } from '@suite-common/wallet-core';
+import {
+    selectAccountByKey,
+    selectTransactionByAccountKeyAndTxid,
+} from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Link, type TextProps } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
@@ -16,7 +20,7 @@ type TradingDetailTxIdProps = {
      * refresh replaces it with the provider's payout on the receive network, so only the store says
      * which account the transaction belongs to.
      */
-    receiveAccount?: Account;
+    receiveAccountKey?: AccountKey;
     intent?: TextProps['intent'];
     priority?: TextProps['priority'];
     isDisabled?: TextProps['isDisabled'];
@@ -25,18 +29,19 @@ type TradingDetailTxIdProps = {
 export const TradingDetailTxId = ({
     value,
     account,
-    receiveAccount,
+    receiveAccountKey,
     intent,
     priority,
     isDisabled,
 }: TradingDetailTxIdProps) => {
     const dispatch = useDispatch();
-    const isTxOnReceiveAccount = useSelector(state =>
-        receiveAccount
-            ? !!selectTransactionByAccountKeyAndTxid(state, receiveAccount.key, value)
-            : false,
+
+    const payoutAccount = useSelector(state =>
+        receiveAccountKey && selectTransactionByAccountKeyAndTxid(state, receiveAccountKey, value)
+            ? selectAccountByKey(state, receiveAccountKey)
+            : null,
     );
-    const txAccount = isTxOnReceiveAccount && receiveAccount ? receiveAccount : account;
+    const txAccount = payoutAccount ?? account;
 
     return (
         <Link

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
@@ -12,9 +12,9 @@ type TradingDetailTxIdProps = {
     value: string;
     account: Account;
     /**
-     * The other side of a swap. `receiveTxHash` holds the signed send transaction until the trade
-     * status is refreshed, after which the provider replaces it with its payout transaction on the
-     * receive network — so which account the transaction belongs to is only known from the store.
+     * The other side of a swap. `receiveTxHash` holds the signed send transaction until a status
+     * refresh replaces it with the provider's payout on the receive network, so only the store says
+     * which account the transaction belongs to.
      */
     receiveAccount?: Account;
     intent?: TextProps['intent'];

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
@@ -2,13 +2,21 @@ import { useDispatch } from 'react-redux';
 
 import { Address } from '@suite/address';
 import { openModal } from '@suite/modal';
+import { selectTransactionByAccountKeyAndTxid } from '@suite-common/wallet-core';
 import { Link, type TextProps } from '@trezor/components';
 
+import { useSelector } from 'src/hooks/suite';
 import { type Account } from 'src/types/wallet';
 
 type TradingDetailTxIdProps = {
     value: string;
     account: Account;
+    /**
+     * The other side of a swap. `receiveTxHash` holds the signed send transaction until the trade
+     * status is refreshed, after which the provider replaces it with its payout transaction on the
+     * receive network — so which account the transaction belongs to is only known from the store.
+     */
+    receiveAccount?: Account;
     intent?: TextProps['intent'];
     priority?: TextProps['priority'];
     isDisabled?: TextProps['isDisabled'];
@@ -17,11 +25,18 @@ type TradingDetailTxIdProps = {
 export const TradingDetailTxId = ({
     value,
     account,
+    receiveAccount,
     intent,
     priority,
     isDisabled,
 }: TradingDetailTxIdProps) => {
     const dispatch = useDispatch();
+    const isTxOnReceiveAccount = useSelector(state =>
+        receiveAccount
+            ? !!selectTransactionByAccountKeyAndTxid(state, receiveAccount.key, value)
+            : false,
+    );
+    const txAccount = isTxOnReceiveAccount && receiveAccount ? receiveAccount : account;
 
     return (
         <Link
@@ -30,9 +45,9 @@ export const TradingDetailTxId = ({
                     openModal({
                         type: 'transaction-detail',
                         txid: value,
-                        descriptor: account.descriptor,
-                        symbol: account.symbol,
-                        deviceState: account.deviceState,
+                        descriptor: txAccount.descriptor,
+                        symbol: txAccount.symbol,
+                        deviceState: txAccount.deviceState,
                         flow: 'detail',
                     }),
                 )

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx
@@ -115,7 +115,7 @@ export const TradingExchangeDetailContent = () => {
                     <TradingExchangeDetailPaymentSuccessful
                         trade={trade.data}
                         account={sendAccount}
-                        receiveAccount={receiveAccount}
+                        receiveAccountKey={trade.receiveAccountKey}
                         provider={provider}
                     />
                 );
@@ -124,7 +124,7 @@ export const TradingExchangeDetailContent = () => {
                     <TradingExchangeDetailPaymentFailed
                         trade={trade.data}
                         account={sendAccount}
-                        receiveAccount={receiveAccount}
+                        receiveAccountKey={trade.receiveAccountKey}
                         provider={provider}
                     />
                 );
@@ -133,7 +133,7 @@ export const TradingExchangeDetailContent = () => {
                     <TradingExchangeDetailPaymentKYC
                         trade={trade.data}
                         account={sendAccount}
-                        receiveAccount={receiveAccount}
+                        receiveAccountKey={trade.receiveAccountKey}
                         provider={provider}
                         supportUrl={provider?.supportUrl}
                     />
@@ -152,7 +152,7 @@ export const TradingExchangeDetailContent = () => {
                                     <TradingExchangeDetailPaymentSending
                                         trade={trade.data}
                                         account={sendAccount}
-                                        receiveAccount={receiveAccount}
+                                        receiveAccountKey={trade.receiveAccountKey}
                                         composedTransaction={composedTransaction}
                                     />
                                 )}
@@ -160,7 +160,7 @@ export const TradingExchangeDetailContent = () => {
                                     trade={trade.data}
                                     provider={provider}
                                     account={trade.data.isDex ? sendAccount : undefined}
-                                    receiveAccount={receiveAccount}
+                                    receiveAccountKey={trade.receiveAccountKey}
                                     isDex={trade.data.isDex}
                                 />
                                 <StepList.Item

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx
@@ -115,6 +115,7 @@ export const TradingExchangeDetailContent = () => {
                     <TradingExchangeDetailPaymentSuccessful
                         trade={trade.data}
                         account={sendAccount}
+                        receiveAccount={receiveAccount}
                         provider={provider}
                     />
                 );
@@ -123,6 +124,7 @@ export const TradingExchangeDetailContent = () => {
                     <TradingExchangeDetailPaymentFailed
                         trade={trade.data}
                         account={sendAccount}
+                        receiveAccount={receiveAccount}
                         provider={provider}
                     />
                 );
@@ -131,6 +133,7 @@ export const TradingExchangeDetailContent = () => {
                     <TradingExchangeDetailPaymentKYC
                         trade={trade.data}
                         account={sendAccount}
+                        receiveAccount={receiveAccount}
                         provider={provider}
                         supportUrl={provider?.supportUrl}
                     />
@@ -149,6 +152,7 @@ export const TradingExchangeDetailContent = () => {
                                     <TradingExchangeDetailPaymentSending
                                         trade={trade.data}
                                         account={sendAccount}
+                                        receiveAccount={receiveAccount}
                                         composedTransaction={composedTransaction}
                                     />
                                 )}
@@ -156,6 +160,7 @@ export const TradingExchangeDetailContent = () => {
                                     trade={trade.data}
                                     provider={provider}
                                     account={trade.data.isDex ? sendAccount : undefined}
+                                    receiveAccount={receiveAccount}
                                     isDex={trade.data.isDex}
                                 />
                                 <StepList.Item

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentConverting.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentConverting.tsx
@@ -23,6 +23,7 @@ type TradingExchangeDetailPaymentConvertingProps = {
     trade: ExchangeTrade;
     provider?: ExchangeProviderInfo;
     account?: Account;
+    receiveAccount?: Account;
     isDex?: boolean;
 };
 
@@ -30,6 +31,7 @@ export const TradingExchangeDetailPaymentConverting = ({
     trade,
     provider,
     account,
+    receiveAccount,
     isDex,
 }: TradingExchangeDetailPaymentConvertingProps) => {
     const { translationString } = useTranslation();
@@ -54,6 +56,7 @@ export const TradingExchangeDetailPaymentConverting = ({
                     {provider && (
                         <TradingDetailProviderInfo
                             account={account}
+                            receiveAccount={receiveAccount}
                             orderId={trade.orderId}
                             provider={provider}
                             trade={trade}

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentConverting.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentConverting.tsx
@@ -1,6 +1,7 @@
 import { type ExchangeProviderInfo, type ExchangeTrade } from 'invity-api';
 
 import { Translation, useTranslation } from '@suite/intl';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Card, Column, type StepListItemState } from '@trezor/components';
 
 import { type Account } from 'src/types/wallet';
@@ -23,7 +24,7 @@ type TradingExchangeDetailPaymentConvertingProps = {
     trade: ExchangeTrade;
     provider?: ExchangeProviderInfo;
     account?: Account;
-    receiveAccount?: Account;
+    receiveAccountKey?: AccountKey;
     isDex?: boolean;
 };
 
@@ -31,7 +32,7 @@ export const TradingExchangeDetailPaymentConverting = ({
     trade,
     provider,
     account,
-    receiveAccount,
+    receiveAccountKey,
     isDex,
 }: TradingExchangeDetailPaymentConvertingProps) => {
     const { translationString } = useTranslation();
@@ -56,7 +57,7 @@ export const TradingExchangeDetailPaymentConverting = ({
                     {provider && (
                         <TradingDetailProviderInfo
                             account={account}
-                            receiveAccount={receiveAccount}
+                            receiveAccountKey={receiveAccountKey}
                             orderId={trade.orderId}
                             provider={provider}
                             trade={trade}

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentFailed.tsx
@@ -2,6 +2,7 @@ import { type ExchangeProviderInfo, type ExchangeTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Button, Card, Column, H3, IconCircle, Paragraph } from '@trezor/components';
 import { XIcon } from '@trezor/icons';
 
@@ -13,7 +14,7 @@ import { TradingDetailSupportBanner } from 'src/views/wallet/trading/common/Trad
 type TradingExchangeDetailPaymentFailedProps = {
     trade: ExchangeTrade;
     account?: Account;
-    receiveAccount?: Account;
+    receiveAccountKey?: AccountKey;
     provider?: ExchangeProviderInfo;
 };
 
@@ -21,7 +22,7 @@ export const TradingExchangeDetailPaymentFailed = ({
     trade,
     provider,
     account,
-    receiveAccount,
+    receiveAccountKey,
 }: TradingExchangeDetailPaymentFailedProps) => {
     const dispatch = useDispatch();
 
@@ -46,7 +47,7 @@ export const TradingExchangeDetailPaymentFailed = ({
                     {provider && (
                         <TradingDetailProviderInfo
                             account={account}
-                            receiveAccount={receiveAccount}
+                            receiveAccountKey={receiveAccountKey}
                             orderId={trade.orderId}
                             provider={provider}
                             trade={trade}

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentFailed.tsx
@@ -13,6 +13,7 @@ import { TradingDetailSupportBanner } from 'src/views/wallet/trading/common/Trad
 type TradingExchangeDetailPaymentFailedProps = {
     trade: ExchangeTrade;
     account?: Account;
+    receiveAccount?: Account;
     provider?: ExchangeProviderInfo;
 };
 
@@ -20,6 +21,7 @@ export const TradingExchangeDetailPaymentFailed = ({
     trade,
     provider,
     account,
+    receiveAccount,
 }: TradingExchangeDetailPaymentFailedProps) => {
     const dispatch = useDispatch();
 
@@ -44,6 +46,7 @@ export const TradingExchangeDetailPaymentFailed = ({
                     {provider && (
                         <TradingDetailProviderInfo
                             account={account}
+                            receiveAccount={receiveAccount}
                             orderId={trade.orderId}
                             provider={provider}
                             trade={trade}

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentKYC.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentKYC.tsx
@@ -1,6 +1,7 @@
 import { type ExchangeProviderInfo, type ExchangeTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Button, Card, Column, H3, IconCircle, Paragraph } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
 
@@ -10,7 +11,7 @@ import { TradingDetailProviderInfo } from 'src/views/wallet/trading/common/Tradi
 type TradingExchangeDetailPaymentKYCProps = {
     trade: ExchangeTrade;
     account?: Account;
-    receiveAccount?: Account;
+    receiveAccountKey?: AccountKey;
     provider?: ExchangeProviderInfo;
     supportUrl?: string;
 };
@@ -18,7 +19,7 @@ type TradingExchangeDetailPaymentKYCProps = {
 export const TradingExchangeDetailPaymentKYC = ({
     trade,
     account,
-    receiveAccount,
+    receiveAccountKey,
     provider,
     supportUrl,
 }: TradingExchangeDetailPaymentKYCProps) => (
@@ -46,7 +47,7 @@ export const TradingExchangeDetailPaymentKYC = ({
             {provider && (
                 <TradingDetailProviderInfo
                     account={account}
-                    receiveAccount={receiveAccount}
+                    receiveAccountKey={receiveAccountKey}
                     orderId={trade.orderId}
                     provider={provider}
                     trade={trade}

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentKYC.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentKYC.tsx
@@ -10,6 +10,7 @@ import { TradingDetailProviderInfo } from 'src/views/wallet/trading/common/Tradi
 type TradingExchangeDetailPaymentKYCProps = {
     trade: ExchangeTrade;
     account?: Account;
+    receiveAccount?: Account;
     provider?: ExchangeProviderInfo;
     supportUrl?: string;
 };
@@ -17,6 +18,7 @@ type TradingExchangeDetailPaymentKYCProps = {
 export const TradingExchangeDetailPaymentKYC = ({
     trade,
     account,
+    receiveAccount,
     provider,
     supportUrl,
 }: TradingExchangeDetailPaymentKYCProps) => (
@@ -44,6 +46,7 @@ export const TradingExchangeDetailPaymentKYC = ({
             {provider && (
                 <TradingDetailProviderInfo
                     account={account}
+                    receiveAccount={receiveAccount}
                     orderId={trade.orderId}
                     provider={provider}
                     trade={trade}

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSending.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSending.tsx
@@ -14,7 +14,7 @@ import { TradingDetailStep } from 'src/views/wallet/trading/common/TradingDetail
 import { TradingDetailTxId } from 'src/views/wallet/trading/common/TradingDetail/TradingDetailTxId';
 import { getTxEstimatedTimeSeconds } from 'src/views/wallet/trading/common/TradingDetail/utils';
 
-const getState = (trade: ExchangeTrade): StepListItemState => {
+const getStepState = (trade: ExchangeTrade): StepListItemState => {
     switch (trade.status) {
         case 'CONVERTING':
         case 'SUCCESS':
@@ -36,12 +36,14 @@ const getTitleId = (state: StepListItemState): TranslationKey => {
 type TradingExchangeDetailPaymentSendingProps = {
     trade: ExchangeTrade;
     account?: Account;
+    receiveAccount?: Account;
     composedTransaction?: TradingComposedTransactionInfo;
 };
 
 export const TradingExchangeDetailPaymentSending = ({
     trade,
     account,
+    receiveAccount,
     composedTransaction,
 }: TradingExchangeDetailPaymentSendingProps) => {
     const locale = useLocales();
@@ -49,7 +51,7 @@ export const TradingExchangeDetailPaymentSending = ({
         account ? selectRawNetworkFeeInfo(state, account.symbol) : undefined,
     );
 
-    const state = getState(trade);
+    const stepState = getStepState(trade);
     const networkType = account ? networks[account.symbol]?.networkType : undefined;
     const estimatedTimeSeconds = getTxEstimatedTimeSeconds(
         networkType,
@@ -64,17 +66,18 @@ export const TradingExchangeDetailPaymentSending = ({
         trade.receiveTxHash && account ? (
             <TradingDetailTxId
                 intent="neutral"
-                priority={state === 'done' ? 'secondary' : 'primary'}
+                priority={stepState === 'done' ? 'secondary' : 'primary'}
                 value={trade.receiveTxHash}
                 account={account}
+                receiveAccount={receiveAccount}
             />
         ) : null;
 
     return (
         <TradingDetailStep
             doneContent={txId}
-            state={state}
-            title={<Translation id={getTitleId(state)} />}
+            state={stepState}
+            title={<Translation id={getTitleId(stepState)} />}
         >
             {txId || estimatedTime ? (
                 <Card>

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSending.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSending.tsx
@@ -5,6 +5,7 @@ import { formatDurationStrict } from '@suite-common/suite-utils';
 import { type TradingComposedTransactionInfo } from '@suite-common/trading';
 import { networks } from '@suite-common/wallet-config';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Card, Column, InfoItem, type StepListItemState } from '@trezor/components';
 
 import { useLocales } from 'src/hooks/suite';
@@ -36,14 +37,14 @@ const getTitleId = (state: StepListItemState): TranslationKey => {
 type TradingExchangeDetailPaymentSendingProps = {
     trade: ExchangeTrade;
     account?: Account;
-    receiveAccount?: Account;
+    receiveAccountKey?: AccountKey;
     composedTransaction?: TradingComposedTransactionInfo;
 };
 
 export const TradingExchangeDetailPaymentSending = ({
     trade,
     account,
-    receiveAccount,
+    receiveAccountKey,
     composedTransaction,
 }: TradingExchangeDetailPaymentSendingProps) => {
     const locale = useLocales();
@@ -69,7 +70,7 @@ export const TradingExchangeDetailPaymentSending = ({
                 priority={stepState === 'done' ? 'secondary' : 'primary'}
                 value={trade.receiveTxHash}
                 account={account}
-                receiveAccount={receiveAccount}
+                receiveAccountKey={receiveAccountKey}
             />
         ) : null;
 

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSuccessful.tsx
@@ -2,6 +2,7 @@ import { type ExchangeProviderInfo, type ExchangeTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Button, Card, Column, H3, IconCircle, Paragraph } from '@trezor/components';
 import { CheckIcon } from '@trezor/icons';
 
@@ -12,14 +13,14 @@ import { TradingDetailProviderInfo } from 'src/views/wallet/trading/common/Tradi
 type TradingExchangeDetailPaymentSuccessfulProps = {
     trade: ExchangeTrade;
     account?: Account;
-    receiveAccount?: Account;
+    receiveAccountKey?: AccountKey;
     provider?: ExchangeProviderInfo;
 };
 
 export const TradingExchangeDetailPaymentSuccessful = ({
     trade,
     account,
-    receiveAccount,
+    receiveAccountKey,
     provider,
 }: TradingExchangeDetailPaymentSuccessfulProps) => {
     const dispatch = useDispatch();
@@ -44,7 +45,7 @@ export const TradingExchangeDetailPaymentSuccessful = ({
                 <Card>
                     <TradingDetailProviderInfo
                         account={account}
-                        receiveAccount={receiveAccount}
+                        receiveAccountKey={receiveAccountKey}
                         orderId={trade.orderId}
                         provider={provider}
                         trade={trade}

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSuccessful.tsx
@@ -12,12 +12,14 @@ import { TradingDetailProviderInfo } from 'src/views/wallet/trading/common/Tradi
 type TradingExchangeDetailPaymentSuccessfulProps = {
     trade: ExchangeTrade;
     account?: Account;
+    receiveAccount?: Account;
     provider?: ExchangeProviderInfo;
 };
 
 export const TradingExchangeDetailPaymentSuccessful = ({
     trade,
     account,
+    receiveAccount,
     provider,
 }: TradingExchangeDetailPaymentSuccessfulProps) => {
     const dispatch = useDispatch();
@@ -42,6 +44,7 @@ export const TradingExchangeDetailPaymentSuccessful = ({
                 <Card>
                     <TradingDetailProviderInfo
                         account={account}
+                        receiveAccount={receiveAccount}
                         orderId={trade.orderId}
                         provider={provider}
                         trade={trade}


### PR DESCRIPTION
## Description

The transaction detail read the **selected account** where it should have read the transaction's own. Trade history is device-wide, so opening a trade of another network leaves the two disagreeing: a BTC address in Inputs/Outputs opened on etherscan, or on an explorer with no `address` URL, giving a link starting with `undefined`. The same wrong read sat in the IO layout choice, the own/change address marks, `FormattedNftAmount` (explorer plus its EVM link gate) and the Amount tab's token fiat.

Separately, a cross-chain swap could not open its transaction at all: the exchange detail paired `trade.receiveTxHash` with the send account, but that field holds the signed send tx until a status refresh replaces it with the provider's payout on the *receive* network — so the modal said "Transaction not found".

Everything now resolves from the transaction: `getNetwork(tx.symbol)`, `tx.symbol`, and `selectAccountByKey` on the transaction's own key. `FormattedNftAmount`/`AmountComponent` take the network as a prop, so no shared component reaches for the selected account. `TradingDetailTxId` picks whichever of the trade's accounts holds the txid, falling back to the send account. A token transfer no longer fakes a transaction with the token symbol in place of the network one — that spread is what hid the network symbol; the display symbol travels as `tokenSymbol`.

## Notes for QA

The bug needs the selected account and the transaction to be on **different networks**, so please test from the trade history rather than from a coin's own transaction list:

1. With trades on at least two networks (e.g. a BTC sell and an ETH swap), open the trading page of **one** account and click a trade of the **other** network in the trade history.
2. Click the Tx ID, go to Inputs/Outputs and click any address — it must open the same explorer as the Tx ID link, i.e. the transaction's network.
3. Repeat for BTC, ETH and TRON, and for a token transfer (Inputs/Outputs → token rows) and an NFT transfer, whose token-id link must also open the transaction's explorer.
4. Amount tab: token rows show fiat values (previously empty when no account was selected).
5. Cross-chain swap (e.g. BTC → ETH), completed some time ago so its status has refreshed: its Tx ID must open the transaction detail instead of "Transaction not found".

Known gap, unchanged: a swap paying out to an address outside Suite has no account holding that transaction, so its Tx ID still shows "Transaction not found".

Covered by unit tests (each verified to fail before the fix), but **not** manually run against a device or a real swap.

## Related Issue

Resolve #30976

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily affects trading exchange detail UI (status-specific payment views, provider info, txid) and transaction detail modal sub-components (I/O details, amount details, transaction target). The highest-risk regressions would appear on swap detail pages and in the transaction detail modal. Run a targeted set of swap detail/history tests plus buy/sell detail tests and a pending-transactions test for the modal; the NFT amount component has no direct E2E coverage.

<details><summary><b>Changed files (19)</b></summary>

- `packages/suite/src/components/suite/FormattedNftAmount.test.tsx`
- `packages/suite/src/components/suite/FormattedNftAmount.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.test.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx`
- `packages/suite/src/components/wallet/AmountComponent.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx`
- `packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx`
- `packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentConverting.tsx`
- `packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentFailed.tsx`
- `packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentKYC.tsx`
- `packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSending.tsx`
- `packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSuccessful.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — This test completes a full cross-chain swap flow and verifies the transaction detail view, including send/receive amounts, provider name, and status transitions. It directly exercises the changed TradingExchangeDetail content and payment status components.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test covers a DEX swap end-to-end and asserts on the confirmation screen and final transaction detail view, including provider, slippage, minimum received, send/receive amounts, and account labels. It directly exercises TradingDetailProviderInfo and TradingExchangeDetailContent.
- `suite/e2e/tests/trading/swap-history.test.ts` — This test seeds multiple swap trades and opens the detailed view for each, verifying status labels (Success, Error, Confirming/Pending), provider, order ID, amounts, and send/receive accounts. It is the most direct coverage of the changed exchange detail payment status and content components.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test navigates to the buy transaction detail page after trade confirmation and watches status updates, exercising the common TradingDetailTxId and TradingDetailProviderInfo components used across trading detail views.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test verifies the sell transaction detail page with status transitions and provider information, exercising TradingDetailTxId and TradingDetailProviderInfo in a non-swap trading flow.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test opens the transaction detail modal for pending transactions and verifies txid and status labels. It is the most relevant E2E coverage for the changed TxDetailModal sub-components (AmountDetails, IODetails, IOGroup, IOItem, TokenSpecificBalanceDetailsRow) and transaction target rendering.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/suite/FormattedNftAmount.tsx`

_Updated: 2026-08-26T07:58:29.579Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tx-detail-io-explorer&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tx-detail-io-explorer&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-25T12:00:51.603Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-26T07:56:30.447Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tx-detail-io-explorer/web/](https://dev.suite.sldev.cz/suite-web/fix/tx-detail-io-explorer/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->