### PR TITLE
fix(suite): Delete "Create a new wallet" button from recovery flow

### DIFF
--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -1,4 +1,3 @@
-import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { TrezorLink } from '@suite/external-links';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { selectRecoveryWordRequestInputType } from '@suite/modal';
@@ -12,22 +11,14 @@ import {
     selectRecoveryStatus,
     selectWordsCount,
 } from '@suite/recovery';
-import { events } from '@suite-common/analytics';
-import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { isDeviceWithButtonOnlyNoTouchscreen } from '@suite-common/suite-utils';
 import { Badge, Banner, Column } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
 
-import {
-    addPath,
-    goToNextStep,
-    goToPreviousStep,
-    updateAnalytics,
-} from 'src/actions/onboarding/onboardingActions';
+import { goToNextStep, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
 import { SelectRecoveryType, SelectRecoveryWord, SelectWordCount } from 'src/components/recovery';
-import * as STEP from 'src/constants/onboarding/steps';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import RecoveryStepBox from './RecoveryStepBox';
@@ -38,7 +29,6 @@ export const RecoveryStep = () => {
     const error = useSelector(selectRecoveryError);
     const wordsCount = useSelector(selectWordsCount);
     const recoveryWordRequestInputType = useSelector(selectRecoveryWordRequestInputType);
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
 
     if (!device?.features) {
@@ -49,17 +39,6 @@ export const RecoveryStep = () => {
     const subheadingKey: TranslationKey = isDeviceWithButtonOnlyNoTouchscreen(deviceModelInternal)
         ? 'TR_RECOVER_SUBHEADING_BUTTONS'
         : 'TR_RECOVER_SUBHEADING_TOUCH';
-
-    const handleCreateWallet = () => {
-        analytics.report({
-            type: events.onboardingRecoveryWarningCreateNewWalletEvent.name,
-            payload: { platform: 'desktop' },
-        });
-        dispatch(goToPreviousStep());
-        dispatch(addPath(STEP.PATH_CREATE));
-        dispatch(goToNextStep());
-        dispatch(updateAnalytics({ seed: 'create' }));
-    };
 
     if (status === 'initial') {
         // 1. step where users chooses number of words in case of T1B1.
@@ -126,14 +105,6 @@ export const RecoveryStep = () => {
                     icon
                     title={<Translation id="TR_RECOVERY_SOURCE_WARNING_TITLE" />}
                     description={<Translation id="TR_RECOVERY_SOURCE_WARNING_DESCRIPTION" />}
-                    rightContent={
-                        <Banner.Button
-                            data-testid="@onboarding/recovery/create-wallet-button"
-                            onClick={handleCreateWallet}
-                        >
-                            <Translation id="TR_NEW_WALLET" />
-                        </Banner.Button>
-                    }
                 />
             </RecoveryStepBox>
         );

--- a/suite-common/analytics/src/events/onboardingRecoveryWarningCreateNewWalletEvent.ts
+++ b/suite-common/analytics/src/events/onboardingRecoveryWarningCreateNewWalletEvent.ts
@@ -12,7 +12,10 @@ export const onboardingRecoveryWarningCreateNewWalletEvent: EventDef<
     name: EventType.OnboardingRecoveryWarningCreateNewWallet,
     descriptionTrigger:
         'User clicks Create a new wallet in the onboarding recovery source warning. Emitted by both desktop and mobile app.',
-    changelog: [{ version: '26.8.0', notes: 'added' }],
+    changelog: [
+        { version: '26.8.0', notes: 'added' },
+        { version: '26.9.0', notes: 'no longer called anywhere' },
+    ],
 
     attributes: {
         platform: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- There shouldn't be ą button "create a new wallet" while recovery flow.
- analytics event remains for having history persistence, even though it's not used anymore (changelog updated)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31678

## Screenshots:

before

<img width="2880" height="2048" alt="image" src="https://github.com/user-attachments/assets/4a9ab441-a50d-479d-ab17-0fadff8c3d24" />



after

<img width="1082" height="839" alt="image" src="https://github.com/user-attachments/assets/4a1f2bf0-5ef1-434f-9142-2d8dccc6a7d0" />



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is localized to the onboarding RecoveryStep view and a related recovery-warning analytics event. The highest-risk regressions are in the device-specific onboarding recovery flows, so I recommend running all T1B1 and T2T1 recovery tests. These tests directly traverse the RecoveryStep UI and will indirectly exercise the new analytics event. No other tests have specific evidence of being affected, and the broad static mappings reflect shared imports rather than real coverage.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx`
- `suite-common/analytics/src/events/onboardingRecoveryWarningCreateNewWalletEvent.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Directly exercises the onboarding recovery flow on T1B1, including word-count selection, advanced recovery input, and disconnect/retry paths, all of which are rendered and controlled by the RecoveryStep component.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Covers the recovery fail/retry path in onboarding for T1B1, where the RecoveryStep warning and create-new-wallet analytics event could be triggered after a failed/disconnected recovery.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Validates the full successful recovery onboarding flow on T1B1, passing through the RecoveryStep UI and any associated recovery warnings/analytics.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests device disconnection and retry behavior during the T2T1 onboarding recovery flow, directly exercising RecoveryStep error/warning handling.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Validates recovery state persistence across reloads and reconnects during onboarding recovery, which relies on the RecoveryStep component and its state transitions.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Covers the successful 12-word recovery onboarding flow on T2T1, which traverses the RecoveryStep view and any recovery warnings/analytics.

</details>

_Updated: 2026-08-27T07:48:14.563Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=delete-create-new-wallet-from-recovery-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=delete-create-new-wallet-from-recovery-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=delete-create-new-wallet-from-recovery-flow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T07:49:22.906Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T07:48:43.579Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/delete-create-new-wallet-from-recovery-flow/web/](https://dev.suite.sldev.cz/suite-web/delete-create-new-wallet-from-recovery-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->