### PR TITLE
feat(suite): Split crowdin strings for modal titles

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx
@@ -43,7 +43,7 @@ export const DeviceAuthenticityOptOutModal = ({ onCancel }: DeviceAuthenticityOp
             intent="warning"
         >
             <H3>
-                <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_TITLE" />
+                <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_TITLE" />
             </H3>
             <Paragraph intent="neutral" priority="secondary" typographyStyle="body-sm">
                 <Translation id="TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_DESCRIPTION_3" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx
@@ -43,7 +43,7 @@ export const FirmwareRevisionOptOutModal = ({ onCancel }: DeviceAuthenticityOptO
             intent="warning"
         >
             <H3>
-                <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_TITLE" />
+                <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_TITLE" />
             </H3>
             <Paragraph intent="neutral" priority="secondary" typographyStyle="body-sm">
                 <Translation id="TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_DESCRIPTION_3" />

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -8524,6 +8524,10 @@ export const messages = defineMessages({
         id: 'TR_DEVICE_AUTHENTICITY_OPT_OUT_BUTTON_DISABLED',
         defaultMessage: 'Turn on',
     },
+    TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_TITLE: {
+        id: 'TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_TITLE',
+        defaultMessage: 'Device authenticity check',
+    },
     TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_BUTTON: {
         id: 'TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_BUTTON',
         defaultMessage: 'Turn off',
@@ -8572,6 +8576,10 @@ export const messages = defineMessages({
     TR_DEVICE_FIRMWARE_REVISION_CHECK_BUTTON_DISABLED: {
         id: 'TR_DEVICE_FIRMWARE_REVISION_CHECK_BUTTON_DISABLED',
         defaultMessage: 'Turn on',
+    },
+    TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_TITLE: {
+        id: 'TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_TITLE',
+        defaultMessage: 'Firmware authenticity check',
     },
     TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_BUTTON: {
         id: 'TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_BUTTON',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- split setting and modal titles

desktop:

Device authenticity — Settings | TR_DEVICE_AUTHENTICITY_OPT_OUT_TITLE (no change)
-- | --
Device authenticity — modal | TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_TITLE (new)
Firmware authenticity — Settings | TR_DEVICE_FIRMWARE_REVISION_CHECK_TITLE (no change)
Firmware authenticity — modal | TR_DEVICE_FIRMWARE_REVISION_CHECK_MODAL_TITLE (new)



## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29711

## Screenshots:

after



<img width="1592" height="1009" alt="Screenshot 2026-08-25 at 12 02 41" src="https://github.com/user-attachments/assets/44b8cadf-f5d5-4bcc-a45c-d6db244dd7e7" />

<img width="765" height="718" alt="Screenshot 2026-08-25 at 12 03 17" src="https://github.com/user-attachments/assets/a0489a3d-836d-48d0-9253-2c71bd217125" />

<img width="693" height="660" alt="Screenshot 2026-08-25 at 12 03 36" src="https://github.com/user-attachments/assets/1a3c384c-ab93-4a7a-ba05-25108265847e" />


(to see it without `defaultMessage` you need this change: https://github.com/trezor/trezor-suite/pull/31711)


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/split-crowdin-strings-for-modal-titles/web/](https://dev.suite.sldev.cz/suite-web/split-crowdin-strings-for-modal-titles/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly scoped to two onboarding opt-out modals for device authenticity and firmware revision checks, plus their intl messages. The main regression risk is in onboarding flows that trigger these opt-out dialogs. The static coverage mappings are inflated because the modals are part of a shared modal context, so I selected the tests that actually exercise the relevant security-check opt-out paths. Running the authenticity test plus the two firmware/revision-related onboarding tests gives targeted coverage without resorting to the full 136-test list.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DeviceAuthenticityOptOutModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/FirmwareRevisionOptOutModal.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This test directly walks through device authenticity checks and explicitly disables/opts out of firmware hash and firmware revision checks during onboarding, which is exactly the code path rendered by DeviceAuthenticityOptOutModal and FirmwareRevisionOptOutModal. If either modal's rendering, copy, or button behavior regressed, this flow would fail.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — The test verifies firmware readiness after disabling unnecessary firmware checks, which is the natural point where the FirmwareRevisionOptOutModal can be presented. A regression in the opt-out modal's confirmation logic could prevent reaching the expected firmware-ready state.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This offline onboarding flow references the firmware revision check error path (TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR), which is closely related to the FirmwareRevisionOptOutModal. Changes to that modal or its intl copy could alter how the offline create-wallet flow handles a revision-check failure.

</details>

_Updated: 2026-08-27T07:59:11.203Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=split-crowdin-strings-for-modal-titles&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=split-crowdin-strings-for-modal-titles&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T08:00:45.734Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T07:59:40.359Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->