### PR TITLE
fix(suite): Show crowdin keys for not downloaded strings

### DIFF
--- a/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
+++ b/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { IntlProvider } from 'react-intl';
 
+import { messages as definedMessages } from '@suite/intl';
 import { selectLanguage, selectShowTranslationKeys } from '@suite/settings';
 import type { Locale } from '@suite-common/suite-types';
 import { isDevEnv } from '@suite-common/suite-utils';
@@ -9,6 +10,8 @@ import enMessages from '@trezor/suite-data/files/translations/en-US.json';
 import { useSelector } from 'src/hooks/suite/useSelector';
 
 import { getEffectiveIntlMessages } from './getEffectiveIntlMessages';
+
+const DEFINED_MESSAGE_IDS = Object.keys(definedMessages);
 
 const useFetchMessages = (locale: Locale) => {
     const [messages, setMessages] = useState<{ [key: string]: any }>({});
@@ -46,7 +49,12 @@ export const ConnectedIntlProvider = ({ children }: ConnectedIntlProviderProps) 
     const showTranslationKeys = useSelector(selectShowTranslationKeys);
     const messages = useFetchMessages(locale);
     const effectiveMessages = useMemo(
-        () => getEffectiveIntlMessages(messages, showTranslationKeys),
+        () =>
+            getEffectiveIntlMessages({
+                localizedMessages: messages,
+                definedMessageIds: DEFINED_MESSAGE_IDS,
+                showTranslationKeys,
+            }),
         [messages, showTranslationKeys],
     );
 

--- a/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
+++ b/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
@@ -8,6 +8,8 @@ import enMessages from '@trezor/suite-data/files/translations/en-US.json';
 
 import { useSelector } from 'src/hooks/suite/useSelector';
 
+import { getEffectiveIntlMessages } from './getEffectiveIntlMessages';
+
 const useFetchMessages = (locale: Locale) => {
     const [messages, setMessages] = useState<{ [key: string]: any }>({});
 
@@ -43,11 +45,10 @@ export const ConnectedIntlProvider = ({ children }: ConnectedIntlProviderProps) 
     const locale = useSelector(selectLanguage);
     const showTranslationKeys = useSelector(selectShowTranslationKeys);
     const messages = useFetchMessages(locale);
-    const effectiveMessages = useMemo(() => {
-        if (!showTranslationKeys) return messages;
-
-        return Object.fromEntries(Object.keys(messages).map(id => [id, id]));
-    }, [messages, showTranslationKeys]);
+    const effectiveMessages = useMemo(
+        () => getEffectiveIntlMessages(messages, showTranslationKeys),
+        [messages, showTranslationKeys],
+    );
 
     return (
         <IntlProvider

--- a/packages/suite/src/support/suite/getEffectiveIntlMessages.test.ts
+++ b/packages/suite/src/support/suite/getEffectiveIntlMessages.test.ts
@@ -1,0 +1,23 @@
+import { getEffectiveIntlMessages } from './getEffectiveIntlMessages';
+
+describe(getEffectiveIntlMessages.name, () => {
+    it('returns downloaded translations unchanged when overlay is off', () => {
+        const localizedMessages = { TR_CANCEL: 'Cancel' };
+
+        expect(getEffectiveIntlMessages(localizedMessages, false)).toBe(localizedMessages);
+    });
+
+    it('shows downloaded translation ids when overlay is on', () => {
+        const result = getEffectiveIntlMessages({ TR_CANCEL: 'Cancel' }, true);
+
+        expect(result.TR_CANCEL).toBe('TR_CANCEL');
+    });
+
+    it('shows messages.ts ids that are missing from downloaded translations', () => {
+        const result = getEffectiveIntlMessages({}, true);
+
+        expect(result.TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_TITLE).toBe(
+            'TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_TITLE',
+        );
+    });
+});

--- a/packages/suite/src/support/suite/getEffectiveIntlMessages.test.ts
+++ b/packages/suite/src/support/suite/getEffectiveIntlMessages.test.ts
@@ -1,23 +1,27 @@
 import { getEffectiveIntlMessages } from './getEffectiveIntlMessages';
 
 describe(getEffectiveIntlMessages.name, () => {
+    const localizedMessages = { TR_CANCEL: 'Cancel' };
+    const definedMessageIds = ['TR_CANCEL', 'TR_ONLY_IN_SOURCE'];
+
     it('returns downloaded translations unchanged when overlay is off', () => {
-        const localizedMessages = { TR_CANCEL: 'Cancel' };
-
-        expect(getEffectiveIntlMessages(localizedMessages, false)).toBe(localizedMessages);
+        expect(
+            getEffectiveIntlMessages({
+                localizedMessages,
+                definedMessageIds,
+                showTranslationKeys: false,
+            }),
+        ).toBe(localizedMessages);
     });
 
-    it('shows downloaded translation ids when overlay is on', () => {
-        const result = getEffectiveIntlMessages({ TR_CANCEL: 'Cancel' }, true);
+    it('shows source message ids when overlay is on', () => {
+        const result = getEffectiveIntlMessages({
+            localizedMessages,
+            definedMessageIds,
+            showTranslationKeys: true,
+        });
 
-        expect(result.TR_CANCEL).toBe('TR_CANCEL');
-    });
-
-    it('shows messages.ts ids that are missing from downloaded translations', () => {
-        const result = getEffectiveIntlMessages({}, true);
-
-        expect(result.TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_TITLE).toBe(
-            'TR_DEVICE_AUTHENTICITY_OPT_OUT_MODAL_TITLE',
-        );
+        expect(Object.keys(result)).toStrictEqual(definedMessageIds);
+        expect(Object.values(result)).toStrictEqual(definedMessageIds);
     });
 });

--- a/packages/suite/src/support/suite/getEffectiveIntlMessages.ts
+++ b/packages/suite/src/support/suite/getEffectiveIntlMessages.ts
@@ -1,0 +1,17 @@
+import { messages as definedMessages } from '@suite/intl';
+
+export const getEffectiveIntlMessages = (
+    localizedMessages: Record<string, string>,
+    showTranslationKeys: boolean,
+): Record<string, string> => {
+    if (!showTranslationKeys) {
+        return localizedMessages;
+    }
+
+    // Ctrl+F12 remaps catalog values to their ids. Downloaded JSON files lag behind
+    // messages.ts until the next Crowdin sync, so union both sources or new keys
+    // would keep showing defaultMessage instead of the id.
+    const ids = new Set([...Object.keys(localizedMessages), ...Object.keys(definedMessages)]);
+
+    return Object.fromEntries([...ids].map(id => [id, id]));
+};

--- a/packages/suite/src/support/suite/getEffectiveIntlMessages.ts
+++ b/packages/suite/src/support/suite/getEffectiveIntlMessages.ts
@@ -1,17 +1,20 @@
-import { messages as definedMessages } from '@suite/intl';
+type GetEffectiveIntlMessagesParams = {
+    localizedMessages: Record<string, string>;
+    definedMessageIds: readonly string[];
+    showTranslationKeys: boolean;
+};
 
-export const getEffectiveIntlMessages = (
-    localizedMessages: Record<string, string>,
-    showTranslationKeys: boolean,
-): Record<string, string> => {
+export const getEffectiveIntlMessages = ({
+    localizedMessages,
+    definedMessageIds,
+    showTranslationKeys,
+}: GetEffectiveIntlMessagesParams): Record<string, string> => {
     if (!showTranslationKeys) {
         return localizedMessages;
     }
 
-    // Ctrl+F12 remaps catalog values to their ids. Downloaded JSON files lag behind
-    // messages.ts until the next Crowdin sync, so union both sources or new keys
-    // would keep showing defaultMessage instead of the id.
-    const ids = new Set([...Object.keys(localizedMessages), ...Object.keys(definedMessages)]);
-
-    return Object.fromEntries([...ids].map(id => [id, id]));
+    // Ctrl+F12 remaps catalog values to their ids. The file `messages.ts` is the source of truth
+    // for keys used within codebase, while downloaded JSON files lag behind until the next Crowdin sync,
+    // so use `messages.ts` keys, otherwise it would keep showing defaultMessage instead of the id.
+    return Object.fromEntries(definedMessageIds.map(id => [id, id]));
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ctrl+F12 (FN + Control + F12) remaps catalog values to their ids. Downloaded JSON files lag behind `messages.ts` until the next Crowdin sync, so union both sources or new keys would keep showing `defaultMessage` instead of the `id`.

## Notes for QA

translations should work the same, this is dev only feature that shouldn't change anything

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before

<img width="692" height="692" alt="Screenshot 2026-08-25 at 12 10 01" src="https://github.com/user-attachments/assets/5dcb1c96-d966-43aa-8dec-714f0443b19b" />


after

<img width="680" height="634" alt="Screenshot 2026-08-25 at 12 09 39" src="https://github.com/user-attachments/assets/b7f45bcb-2825-4d33-bacc-67179eebdf6b" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect locale message resolution and provisioning. The highest risk is incorrect or missing translations for non-default locales and autodetected languages. A small set of language/autodetect-related E2E tests covers the most user-visible surface; broad translation-dependent smoke tests are unnecessary unless these fail. The new getEffectiveIntlMessages.ts implementation has no dedicated E2E coverage, so confidence depends on these indirect tests plus its own unit tests.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/support/suite/ConnectedIntlProvider.tsx`
- `packages/suite/src/support/suite/getEffectiveIntlMessages.test.ts`
- `packages/suite/src/support/suite/getEffectiveIntlMessages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — Directly asserts that Suite renders the correct translated text for English and Spanish locales and adapts to the browser locale, which is exactly the behavior implemented by ConnectedIntlProvider and getEffectiveIntlMessages.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — Changes the application language from English to Spanish and relies on the intl provider to load and apply the Spanish message catalog without breaking the settings/dashboard UI.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Verifies that a Spanish language preference set in an older Suite version is preserved and displayed after migration, exercising locale/message loading across app restarts.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/support/suite/getEffectiveIntlMessages.ts`

_Updated: 2026-08-27T07:33:58.190Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=show-crowdin-keys-for-not-downloaded-strings&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=show-crowdin-keys-for-not-downloaded-strings&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T07:35:23.412Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T07:35:42.751Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/show-crowdin-keys-for-not-downloaded-strings/web/](https://dev.suite.sldev.cz/suite-web/show-crowdin-keys-for-not-downloaded-strings/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->