### PR TITLE
fix(suite): Split crowdin keys in guide

### DIFF
--- a/packages/suite/src/components/guide/Guide.tsx
+++ b/packages/suite/src/components/guide/Guide.tsx
@@ -61,7 +61,7 @@ export const Guide = () => {
                                             />
                                         }
                                     >
-                                        <Translation id="TR_GUIDE_SUPPORT_AND_FEEDBACK" />
+                                        <Translation id="TR_GUIDE_HELP_AND_FEEDBACK" />
                                     </GuideItem>
                                 </Column>
                             </Box>

--- a/packages/suite/src/components/guide/GuideButton.tsx
+++ b/packages/suite/src/components/guide/GuideButton.tsx
@@ -91,7 +91,7 @@ export const GuideButton = memo(function GuideButton() {
                 <Tooltip
                     content={
                         <Row gap={8}>
-                            <Translation id="TR_GUIDE_SUPPORT_AND_FEEDBACK" />
+                            <Translation id="TR_GUIDE_HELP_AND_SUPPORT" />
                             <ShortcutBadge shortcut={['F1']} />
                         </Row>
                     }
@@ -103,7 +103,7 @@ export const GuideButton = memo(function GuideButton() {
                         data-testid="@guide/button-open"
                         onClick={openGuide}
                         onMouseEnter={handleMouseEnter}
-                        aria-label={translationString('TR_GUIDE_SUPPORT_AND_FEEDBACK')}
+                        aria-label={translationString('TR_GUIDE_HELP_AND_SUPPORT')}
                     >
                         <LottieAnimation
                             type="MASCOT"

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -7984,9 +7984,15 @@ export const messages = defineMessages({
         id: 'TR_GUIDE_FORUM',
         defaultMessage: 'Trezor Forum',
     },
-    TR_GUIDE_SUPPORT_AND_FEEDBACK: {
-        id: 'TR_GUIDE_SUPPORT_AND_FEEDBACK',
+    TR_GUIDE_HELP_AND_SUPPORT: {
+        id: 'TR_GUIDE_HELP_AND_SUPPORT',
         defaultMessage: 'Help & Support',
+        description: 'Tooltip and aria-label of the Guide icon in the bottom-right corner.',
+    },
+    TR_GUIDE_HELP_AND_FEEDBACK: {
+        id: 'TR_GUIDE_HELP_AND_FEEDBACK',
+        defaultMessage: 'Help & Feedback',
+        description: 'Title of the card inside the Guide panel that opens support and feedback.',
     },
     TR_GUIDE_SEARCH_MIN_QUERY_LENGTH: {
         id: 'TR_GUIDE_SEARCH_MIN_QUERY_LENGTH',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Split reused crowdin strings.

TR_GUIDE_HELP_AND_SUPPORT - guide icon
TR_GUIDE_HELP_AND_FEEDBACK - guide panel
TR_GUIDE_SUPPORT_AND_FEEDBACK - deleted

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29706

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are focused on the Guide panel components (Guide.tsx, GuideButton.tsx) and the messages file. Although the changed components are statically referenced by many tests, only a handful specifically validate Guide behavior. The recommended strategy is to run the two comprehensive Guide panel tests at high priority and the bug-report-form test at medium priority to catch user-visible regressions in guide navigation, search, and feedback flows. The messages.ts change is inferred to be guide-related based on the co-located component changes and is covered by the translation assertions in these tests.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/guide/Guide.tsx`
- `packages/suite/src/components/guide/GuideButton.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — Comprehensive test of the Suite Guide panel including opening/closing, article search, category navigation, feedback and bug report submission, and guide closure. It directly exercises the Guide.tsx and GuideButton.tsx components and validates guide-related translation keys, so a regression here would be immediately user-visible.
- `suite/e2e/tests/suite/guide.test.ts` — Directly validates Guide panel behavior across multiple scenarios: open/close, guide node navigation, feedback submission, search with and without results, opening the guide over a modal, and guide access during onboarding. This is the most targeted test for the changed Guide components.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — Tests the bug report form reached through the Guide panel's Support and Feedback section. It shares Guide panel infrastructure with the changed components and would catch regressions in guide navigation or rendering of the feedback form.

</details>

_Updated: 2026-08-25T10:49:39.573Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/split-crowdin-keys-in-guide/web/](https://dev.suite.sldev.cz/suite-web/split-crowdin-keys-in-guide/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=split-crowdin-keys-in-guide&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=split-crowdin-keys-in-guide&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |

</details>

_Updated: 2026-08-25T10:52:07.607Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-25T10:51:59.641Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->