### PR TITLE
Perf/main store subscriptions

### DIFF
--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -3,6 +3,13 @@ import { type FC, type PropsWithChildren, memo, useEffect } from 'react';
 import { selectShouldDisplayDeviceCompromisedOnRoute } from '@suite/authenticity-checks';
 import { useDevice } from '@suite/device';
 import { KillswitchMessageScreen } from '@suite/message-system';
+import {
+    type RouterAppWithParams,
+    selectHasRoute,
+    selectIsForegroundApp,
+    selectRouterApp,
+    selectRouterLoaded,
+} from '@suite/router';
 import { selectIsAnalyticsConfirmed } from '@suite-common/analytics-redux';
 import {
     useReportDeviceCompromised,
@@ -20,7 +27,6 @@ import {
     selectIsTransportInitialized,
     selectPrerequisite,
 } from 'src/selectors/suite/suiteSelectors';
-import type { AppState } from 'src/types/suite';
 import { Onboarding } from 'src/views/onboarding';
 import { AnalyticsConsentScreen } from 'src/views/start/AnalyticsConsentScreen';
 import { SuiteStart } from 'src/views/start/SuiteStart';
@@ -35,8 +41,8 @@ import { useDeviceCompromisedNotification } from '../SecurityCheck/useDeviceComp
 import { SuiteLayout } from '../layouts/SuiteLayout/SuiteLayout';
 import { WelcomeLayout } from '../layouts/WelcomeLayout/WelcomeLayout';
 
-const getFullscreenApp = (route: AppState['router']['route']): FC | undefined => {
-    switch (route?.app) {
+const getFullscreenApp = (app: RouterAppWithParams['app']): FC | undefined => {
+    switch (app) {
         case 'start':
             return SuiteStart;
         case 'onboarding':
@@ -52,7 +58,12 @@ const getFullscreenApp = (route: AppState['router']['route']): FC | undefined =>
 export const Preloader = memo(function Preloader({ children }: PropsWithChildren) {
     const lifecycle = useSelector(state => state.suite.lifecycle);
     const isTransportInitialized = useSelector(selectIsTransportInitialized);
-    const router = useSelector(state => state.router);
+    // Only the flags the render needs, so that navigating within the same app does not re-render
+    // this component and with it the layout below it.
+    const isRouterLoaded = useSelector(selectRouterLoaded);
+    const routerApp = useSelector(selectRouterApp);
+    const isForegroundApp = useSelector(selectIsForegroundApp);
+    const hasRoute = useSelector(selectHasRoute);
     const prerequisite = useSelector(selectPrerequisite);
     const shouldDisplayDeviceCompromisedOnRoute = useSelector(
         selectShouldDisplayDeviceCompromisedOnRoute,
@@ -111,7 +122,7 @@ export const Preloader = memo(function Preloader({ children }: PropsWithChildren
 
     // @trezor/connect was initialized, but didn't emit "TRANSPORT" event yet (it could take a while)
     // display Loader as full page view
-    if (lifecycle.status !== 'ready' || !router.loaded || !isTransportInitialized) {
+    if (lifecycle.status !== 'ready' || !isRouterLoaded || !isTransportInitialized) {
         // TODO: multiplied by 5, temporarily. Now initActions incorrectly awaits altcoin specific logic which can trigger this timeout easily for bigger accounts
         return <InitialLoading timeout={90 * 5} />;
     }
@@ -123,12 +134,12 @@ export const Preloader = memo(function Preloader({ children }: PropsWithChildren
     // TODO: murder the fullscreen app logic, there must be a better way
     // i don't like how it's not clear which layout is used
     // and that the prerequisite screen is handled multiple times
-    const FullscreenApp = getFullscreenApp(router.route);
+    const FullscreenApp = getFullscreenApp(routerApp);
     if (FullscreenApp !== undefined) {
         return <FullscreenApp />;
     }
 
-    if (router.route?.isForegroundApp) {
+    if (isForegroundApp) {
         return <SuiteLayout>{children}</SuiteLayout>;
     }
 
@@ -146,7 +157,7 @@ export const Preloader = memo(function Preloader({ children }: PropsWithChildren
 
     // route does not exist, display error page in fullscreen mode
     // because if it is handled by Router it is wrapped in SuiteLayout
-    if (!router.route) {
+    if (!hasRoute) {
         return <ErrorPage />;
     }
 

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -58,8 +58,6 @@ const getFullscreenApp = (app: RouterAppWithParams['app']): FC | undefined => {
 export const Preloader = memo(function Preloader({ children }: PropsWithChildren) {
     const lifecycle = useSelector(state => state.suite.lifecycle);
     const isTransportInitialized = useSelector(selectIsTransportInitialized);
-    // Only the flags the render needs, so that navigating within the same app does not re-render
-    // this component and with it the layout below it.
     const isRouterLoaded = useSelector(selectRouterLoaded);
     const routerApp = useSelector(selectRouterApp);
     const isForegroundApp = useSelector(selectIsForegroundApp);

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/AnchorHighlightHandler.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/AnchorHighlightHandler.tsx
@@ -6,8 +6,6 @@ interface AnchorHighlightHandlerProps {
     elementRef: RefObject<HTMLElement | null>;
 }
 
-// The hook subscribes to the anchor. Kept in a memoized component that renders nothing so that
-// the subscription does not re-render the layout around it.
 export const AnchorHighlightHandler = memo(({ elementRef }: AnchorHighlightHandlerProps) => {
     useClearAnchorHighlightOnClick(elementRef);
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/AnchorHighlightHandler.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/AnchorHighlightHandler.tsx
@@ -1,0 +1,17 @@
+import { type RefObject, memo } from 'react';
+
+import { useClearAnchorHighlightOnClick } from 'src/hooks/suite/useClearAnchorHighlightOnClick';
+
+interface AnchorHighlightHandlerProps {
+    elementRef: RefObject<HTMLElement | null>;
+}
+
+// The hook subscribes to the anchor. Kept in a memoized component that renders nothing so that
+// the subscription does not re-render the layout around it.
+export const AnchorHighlightHandler = memo(({ elementRef }: AnchorHighlightHandlerProps) => {
+    useClearAnchorHighlightOnClick(elementRef);
+
+    return null;
+});
+
+AnchorHighlightHandler.displayName = 'AnchorHighlightHandler';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSizeOnly.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSizeOnly.tsx
@@ -1,0 +1,25 @@
+import { type ReactNode, memo } from 'react';
+
+import { useLayoutSize } from 'src/hooks/suite';
+
+interface LayoutSizeOnlyProps {
+    children: ReactNode;
+}
+
+// The breakpoints are read here rather than in the layout, so that crossing one re-renders only
+// these two components instead of everything the layout renders.
+export const BelowTabletOnly = memo(({ children }: LayoutSizeOnlyProps) => {
+    const { isBelowTablet } = useLayoutSize();
+
+    return isBelowTablet ? children : null;
+});
+
+BelowTabletOnly.displayName = 'BelowTabletOnly';
+
+export const AboveTabletOnly = memo(({ children }: LayoutSizeOnlyProps) => {
+    const { isBelowTablet } = useLayoutSize();
+
+    return isBelowTablet ? null : children;
+});
+
+AboveTabletOnly.displayName = 'AboveTabletOnly';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSizeOnly.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSizeOnly.tsx
@@ -6,8 +6,6 @@ interface LayoutSizeOnlyProps {
     children: ReactNode;
 }
 
-// The breakpoints are read here rather than in the layout, so that crossing one re-renders only
-// these two components instead of everything the layout renders.
 export const BelowTabletOnly = memo(({ children }: LayoutSizeOnlyProps) => {
     const { isBelowTablet } = useLayoutSize();
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
@@ -8,8 +8,6 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useGoToWithAnalytics = (account?: Account) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
-    // Only the symbol is reported, so the fallback selects it instead of the whole account: the
-    // sidebar renders this hook once per row and the account object would re-render them all.
     const selectedAccountSymbol = useSelector(selectSelectedAccountSymbol);
     const symbol = account?.symbol ?? selectedAccountSymbol;
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
@@ -1,4 +1,4 @@
-import { selectSelectedAccount } from '@suite/account';
+import { selectSelectedAccountSymbol } from '@suite/account';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
@@ -8,15 +8,17 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useGoToWithAnalytics = (account?: Account) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const selectedAccount = useSelector(selectSelectedAccount);
-    const accountToUse = account ?? selectedAccount;
+    // Only the symbol is reported, so the fallback selects it instead of the whole account: the
+    // sidebar renders this hook once per row and the account object would re-render them all.
+    const selectedAccountSymbol = useSelector(selectSelectedAccountSymbol);
+    const symbol = account?.symbol ?? selectedAccountSymbol;
     const dispatch = useDispatch();
 
     return (...[payload]: Parameters<typeof goto>) => {
-        if (accountToUse?.symbol) {
+        if (symbol) {
             analytics.report({
                 type: events.accountsActionsEvent.name,
-                payload: { symbol: accountToUse.symbol, action: payload.routeName },
+                payload: { symbol, action: payload.routeName },
             });
         }
         dispatch(goto(payload));

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/ScrollProvider.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/ScrollProvider.tsx
@@ -1,0 +1,29 @@
+import { type ReactNode, type RefObject, memo, useMemo } from 'react';
+
+import { ScrollContext } from '@suite/router';
+
+import { HEADER_HEIGHT_NUMERIC, SUBPAGE_NAV_HEIGHT_NUMERIC } from 'src/constants/suite/layout';
+import { useResetScrollOnUrl } from 'src/hooks/suite/useResetScrollOnUrl';
+
+const ANCHOR_SCROLL_OFFSET = 30;
+const TOP_OFFSET = HEADER_HEIGHT_NUMERIC + SUBPAGE_NAV_HEIGHT_NUMERIC + ANCHOR_SCROLL_OFFSET;
+
+interface ScrollProviderProps {
+    scrollRef: RefObject<HTMLDivElement | null>;
+    children: ReactNode;
+}
+
+/**
+ * Resetting the scroll requires subscribing to the route. That subscription lives here rather than
+ * in `SuiteLayout` so that a navigation re-renders only this component: the context value stays the
+ * same and `children` is the very same element, so React bails out of the layout below it.
+ */
+export const ScrollProvider = memo(({ scrollRef, children }: ScrollProviderProps) => {
+    useResetScrollOnUrl(scrollRef);
+
+    const value = useMemo(() => ({ scrollRef, topOffset: TOP_OFFSET }), [scrollRef]);
+
+    return <ScrollContext.Provider value={value}>{children}</ScrollContext.Provider>;
+});
+
+ScrollProvider.displayName = 'ScrollProvider';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/ScrollProvider.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/ScrollProvider.tsx
@@ -13,11 +13,6 @@ interface ScrollProviderProps {
     children: ReactNode;
 }
 
-/**
- * Resetting the scroll requires subscribing to the route. That subscription lives here rather than
- * in `SuiteLayout` so that a navigation re-renders only this component: the context value stays the
- * same and `children` is the very same element, so React bails out of the layout below it.
- */
 export const ScrollProvider = memo(({ scrollRef, children }: ScrollProviderProps) => {
     useResetScrollOnUrl(scrollRef);
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx
@@ -2,23 +2,21 @@ import { type ReactNode, memo, useRef } from 'react';
 
 import styled from 'styled-components';
 
-import { ScrollContext } from '@suite/router';
 import { Modal, variables } from '@trezor/components';
 
 import { GuideButton, GuideRouter } from 'src/components/guide';
 import { SuiteBanners } from 'src/components/suite/banners';
 import { DiscoveryProgress } from 'src/components/wallet';
-import { HEADER_HEIGHT_NUMERIC, SUBPAGE_NAV_HEIGHT_NUMERIC } from 'src/constants/suite/layout';
-import { useLayoutSize } from 'src/hooks/suite';
-import { useClearAnchorHighlightOnClick } from 'src/hooks/suite/useClearAnchorHighlightOnClick';
-import { useResetScrollOnUrl } from 'src/hooks/suite/useResetScrollOnUrl';
 
 import { ContentContainer } from '../ContentContainer';
 import { AddPassphraseWalletFlow } from './AddPassphraseWalletFlow';
+import { AnchorHighlightHandler } from './AnchorHighlightHandler';
 import { CoinjoinBars } from './CoinjoinBars/CoinjoinBars';
 import { LayoutPayloadProvider } from './LayoutPayloadProvider';
+import { AboveTabletOnly, BelowTabletOnly } from './LayoutSizeOnly';
 import { LayoutFooterSlot, LayoutHeaderSlot, LayoutMetadata } from './LayoutSlots';
 import { PowerMonitorManager } from './PowerMonitor/PowerMonitor';
+import { ScrollProvider } from './ScrollProvider';
 import { Sidebar } from './Sidebar/Sidebar';
 import { SwitchDeviceLayer } from './SwitchDeviceLayer';
 import { useResponsiveContextOnChange } from './useResponsiveContextOnChange';
@@ -83,8 +81,6 @@ type MainContentProps = {
     children: ReactNode;
 };
 
-const ANCHOR_SCROLL_OFFSET = 30;
-
 export const MainContent = ({ children }: MainContentProps) => {
     const ref = useRef<HTMLDivElement>(null);
 
@@ -104,20 +100,14 @@ interface SuiteLayoutProps {
  * layout — sidebar, banners, page. `children` comes from `Preloader`'s own props, so it stays
  * referentially stable and React can bail out here.
  */
-export const SuiteLayout = memo(function SuiteLayout({
-    children,
-    'data-testid': dataTest,
-}: SuiteLayoutProps) {
-    const { isBelowTablet } = useLayoutSize();
+export const SuiteLayout = memo(({ children, 'data-testid': dataTest }: SuiteLayoutProps) => {
     const wrapperRef = useRef<HTMLDivElement>(null);
-    const { scrollRef } = useResetScrollOnUrl();
-    const topOffset = HEADER_HEIGHT_NUMERIC + SUBPAGE_NAV_HEIGHT_NUMERIC + ANCHOR_SCROLL_OFFSET;
-
-    useClearAnchorHighlightOnClick(wrapperRef);
+    const scrollRef = useRef<HTMLDivElement>(null);
 
     return (
-        <ScrollContext.Provider value={{ scrollRef, topOffset }}>
+        <ScrollProvider scrollRef={scrollRef}>
             <Wrapper ref={wrapperRef} data-testid="@suite-layout">
+                <AnchorHighlightHandler elementRef={wrapperRef} />
                 <PageWrapper>
                     <Modal.Provider>
                         <LayoutPayloadProvider>
@@ -129,7 +119,9 @@ export const SuiteLayout = memo(function SuiteLayout({
 
                             <PowerMonitorManager />
 
-                            {isBelowTablet && <CoinjoinBars />}
+                            <BelowTabletOnly>
+                                <CoinjoinBars />
+                            </BelowTabletOnly>
 
                             <DiscoveryProgress />
 
@@ -137,7 +129,9 @@ export const SuiteLayout = memo(function SuiteLayout({
                                 <Columns>
                                     <Sidebar />
                                     <MainContent>
-                                        {!isBelowTablet && <CoinjoinBars />}
+                                        <AboveTabletOnly>
+                                            <CoinjoinBars />
+                                        </AboveTabletOnly>
                                         <SuiteBanners />
                                         <AppWrapper data-testid="@app" ref={scrollRef}>
                                             <LayoutHeaderSlot />
@@ -156,13 +150,17 @@ export const SuiteLayout = memo(function SuiteLayout({
                                     </MainContent>
                                 </Columns>
                             </Body>
-                            {!isBelowTablet && <GuideButton />}
+                            <AboveTabletOnly>
+                                <GuideButton />
+                            </AboveTabletOnly>
                         </LayoutPayloadProvider>
                     </Modal.Provider>
                 </PageWrapper>
 
                 <GuideRouter />
             </Wrapper>
-        </ScrollContext.Provider>
+        </ScrollProvider>
     );
 });
+
+SuiteLayout.displayName = 'SuiteLayout';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
@@ -39,89 +41,93 @@ export interface AccountItemProps {
     onClick?: (account: Account, type: AccountItemType) => void;
 }
 
-export const AccountItem = ({
-    account,
-    forceOnlyItemClick,
-    type,
-    isSelected,
-    formattedBalance,
-    customFiatValue,
-    dataTestKey,
-    isFiatLoading,
-    onClick,
-}: AccountItemProps) => {
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const { accountType, index, symbol } = account;
+export const AccountItem = memo(
+    ({
+        account,
+        forceOnlyItemClick,
+        type,
+        isSelected,
+        formattedBalance,
+        customFiatValue,
+        dataTestKey,
+        isFiatLoading,
+        onClick,
+    }: AccountItemProps) => {
+        const { analytics } = useServices(selectDesktopAnalyticsDep);
+        const { accountType, index, symbol } = account;
 
-    const goToWithAnalytics = useGoToWithAnalytics(account);
+        const goToWithAnalytics = useGoToWithAnalytics(account);
 
-    const handleHeaderClick = () => {
-        onClick?.(account, type);
+        const handleHeaderClick = () => {
+            onClick?.(account, type);
 
-        // NOTE: disable default behavior useful eg in global send modal - when picking account
-        // from which to send
-        if (forceOnlyItemClick) {
-            return;
-        }
+            // NOTE: disable default behavior useful eg in global send modal - when picking account
+            // from which to send
+            if (forceOnlyItemClick) {
+                return;
+            }
 
-        goToWithAnalytics({
-            routeName: getRoute(type),
-            params: {
-                symbol,
-                accountIndex: index,
-                accountType,
-            },
-        });
-
-        if (type === 'staking') {
-            analytics.report({
-                type: events.stakingNavigateEvent.name,
-                payload: {
-                    action: 'navigate',
-                    from: 'sidebar',
-                    networkSymbol: symbol,
+            goToWithAnalytics({
+                routeName: getRoute(type),
+                params: {
+                    symbol,
+                    accountIndex: index,
+                    accountType,
                 },
             });
-        }
-    };
 
-    const commonProps = {
-        isFiatLoading: Boolean(isFiatLoading),
-        formattedBalance,
-        dataTestKey,
-        type,
-        account,
-        customFiatValue,
-    };
+            if (type === 'staking') {
+                analytics.report({
+                    type: events.stakingNavigateEvent.name,
+                    payload: {
+                        action: 'navigate',
+                        from: 'sidebar',
+                        networkSymbol: symbol,
+                    },
+                });
+            }
+        };
 
-    return (
-        <>
-            <ExpandedSidebarOnly>
-                <AccountRow
-                    {...commonProps}
-                    isSelected={isSelected}
-                    handleHeaderClick={handleHeaderClick}
-                />
-            </ExpandedSidebarOnly>
-            <CollapsedSidebarOnly>
-                <Tooltip
-                    delayShow={TOOLTIP_DELAY_NORMAL}
-                    cursor="pointer"
-                    content={
-                        <Box padding={4}>
-                            <AccountItemContent {...commonProps} showAccountTypeBadge />
-                        </Box>
-                    }
-                    placement="right"
-                >
+        const commonProps = {
+            isFiatLoading: Boolean(isFiatLoading),
+            formattedBalance,
+            dataTestKey,
+            type,
+            account,
+            customFiatValue,
+        };
+
+        return (
+            <>
+                <ExpandedSidebarOnly>
                     <AccountRow
                         {...commonProps}
                         isSelected={isSelected}
                         handleHeaderClick={handleHeaderClick}
-                        isCollapsed
                     />
-                </Tooltip>
-            </CollapsedSidebarOnly>
-        </>
-    );
-};
+                </ExpandedSidebarOnly>
+                <CollapsedSidebarOnly>
+                    <Tooltip
+                        delayShow={TOOLTIP_DELAY_NORMAL}
+                        cursor="pointer"
+                        content={
+                            <Box padding={4}>
+                                <AccountItemContent {...commonProps} showAccountTypeBadge />
+                            </Box>
+                        }
+                        placement="right"
+                    >
+                        <AccountRow
+                            {...commonProps}
+                            isSelected={isSelected}
+                            handleHeaderClick={handleHeaderClick}
+                            isCollapsed
+                        />
+                    </Tooltip>
+                </CollapsedSidebarOnly>
+            </>
+        );
+    },
+);
+
+AccountItem.displayName = 'AccountItem';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -68,8 +68,6 @@ export const AccountItemsGroup = ({
     const rates = useSelector(selectCurrentFiatRates);
 
     const isFiatLoading = areTokenFiatRatesLoading(account, baseCurrencyCode, rates ?? {});
-    // Memoized because it is a new BigNumber every time, which would keep the memoized tokens row
-    // re-rendering with the rest of the sidebar.
     const tokensFiatBalance = useMemo(
         () =>
             isFiatLoading

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import styled from 'styled-components';
 
 import { selectRouteName } from '@suite/router';
@@ -66,9 +68,15 @@ export const AccountItemsGroup = ({
     const rates = useSelector(selectCurrentFiatRates);
 
     const isFiatLoading = areTokenFiatRatesLoading(account, baseCurrencyCode, rates ?? {});
-    const tokensFiatBalance = isFiatLoading
-        ? BASE_CURRENCY_ZERO
-        : getAccountTokensFiatBalance(account, baseCurrencyCode, rates, tokens);
+    // Memoized because it is a new BigNumber every time, which would keep the memoized tokens row
+    // re-rendering with the rest of the sidebar.
+    const tokensFiatBalance = useMemo(
+        () =>
+            isFiatLoading
+                ? BASE_CURRENCY_ZERO
+                : getAccountTokensFiatBalance(account, baseCurrencyCode, rates, tokens),
+        [isFiatLoading, account, baseCurrencyCode, rates, tokens],
+    );
 
     const tokensRoutes = [
         'wallet-tokens',

--- a/packages/suite/src/hooks/suite/useFormattersConfig.ts
+++ b/packages/suite/src/hooks/suite/useFormattersConfig.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { selectLanguage } from '@suite/settings';
 import { type FormatterProviderConfig } from '@suite-common/formatters';
 import { selectBaseCurrency, selectBitcoinAmountUnit } from '@suite-common/wallet-core';
@@ -9,10 +11,14 @@ export const useFormattersConfig = (): FormatterProviderConfig => {
     const bitcoinAmountUnit = useSelector(selectBitcoinAmountUnit);
     const baseCurrency = useSelector(selectBaseCurrency);
 
-    return {
-        locale,
-        baseCurrency,
-        bitcoinAmountUnit,
-        is24HourFormat: true,
-    };
+    // FormatterProvider rebuilds every formatter whenever the config identity changes.
+    return useMemo(
+        () => ({
+            locale,
+            baseCurrency,
+            bitcoinAmountUnit,
+            is24HourFormat: true,
+        }),
+        [locale, baseCurrency, bitcoinAmountUnit],
+    );
 };

--- a/packages/suite/src/hooks/suite/useFormattersConfig.ts
+++ b/packages/suite/src/hooks/suite/useFormattersConfig.ts
@@ -11,7 +11,6 @@ export const useFormattersConfig = (): FormatterProviderConfig => {
     const bitcoinAmountUnit = useSelector(selectBitcoinAmountUnit);
     const baseCurrency = useSelector(selectBaseCurrency);
 
-    // FormatterProvider rebuilds every formatter whenever the config identity changes.
     return useMemo(
         () => ({
             locale,

--- a/packages/suite/src/hooks/suite/useLayoutSize.ts
+++ b/packages/suite/src/hooks/suite/useLayoutSize.ts
@@ -1,5 +1,8 @@
-import { useSelector } from 'src/hooks/suite';
+import { useSelectorDeepComparison } from '@suite-common/redux-utils';
+
 import { selectBreakpointFlags } from 'src/reducers/suite/windowReducer';
 
-// This hook provides information about breakpoints using media queries
-export const useLayoutSize = () => useSelector(selectBreakpointFlags);
+// This hook provides information about breakpoints using media queries.
+// The flags are compared by value because the selector builds a new object: comparing by identity
+// would re-render every consumer on every action, and on every window blur.
+export const useLayoutSize = () => useSelectorDeepComparison(selectBreakpointFlags);

--- a/packages/suite/src/hooks/suite/useLayoutSize.ts
+++ b/packages/suite/src/hooks/suite/useLayoutSize.ts
@@ -2,7 +2,5 @@ import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 
 import { selectBreakpointFlags } from 'src/reducers/suite/windowReducer';
 
-// This hook provides information about breakpoints using media queries.
-// The flags are compared by value because the selector builds a new object: comparing by identity
-// would re-render every consumer on every action, and on every window blur.
+// This hook provides information about breakpoints using media queries
 export const useLayoutSize = () => useSelectorDeepComparison(selectBreakpointFlags);

--- a/packages/suite/src/hooks/suite/useLayoutSize.ts
+++ b/packages/suite/src/hooks/suite/useLayoutSize.ts
@@ -1,6 +1,6 @@
-import { useSelectorDeepComparison } from '@suite-common/redux-utils';
-
 import { selectBreakpointFlags } from 'src/reducers/suite/windowReducer';
 
+import { useSelector } from './useSelector';
+
 // This hook provides information about breakpoints using media queries
-export const useLayoutSize = () => useSelectorDeepComparison(selectBreakpointFlags);
+export const useLayoutSize = () => useSelector(selectBreakpointFlags);

--- a/packages/suite/src/hooks/suite/usePreferredModal.test.tsx
+++ b/packages/suite/src/hooks/suite/usePreferredModal.test.tsx
@@ -92,7 +92,6 @@ describe('usePreferredModal', () => {
     it('passes the route params through and reads cancelable out of them', () => {
         expect(renderPreferredModal({ pathname: '/firmware', hash: '#/false' })).toEqual({
             type: 'foreground-app',
-            // an unset param out of a non-empty hash parses to an empty string, not to its default
             payload: { cancelable: false, variant: '', app: 'firmware' },
         });
     });

--- a/packages/suite/src/hooks/suite/usePreferredModal.test.tsx
+++ b/packages/suite/src/hooks/suite/usePreferredModal.test.tsx
@@ -1,0 +1,111 @@
+import { Provider } from 'react-redux';
+
+import { render } from '@testing-library/react';
+
+import { MODAL_CONTEXT_NONE, MODAL_CONTEXT_USER, type State as ModalState } from '@suite/modal';
+import { type PathString, getAppWithParams } from '@suite/router';
+import { configureMockStore } from '@suite-common/test-utils';
+
+import { usePreferredModal } from './usePreferredModal';
+
+type Result = ReturnType<typeof usePreferredModal>;
+
+const NO_MODAL: ModalState = { context: MODAL_CONTEXT_NONE };
+const USER_MODAL = {
+    context: MODAL_CONTEXT_USER,
+    payload: { type: 'application-log' },
+} as ModalState;
+
+const DEFAULT_MODAL_APP_PARAMS = { cancelable: true, variant: undefined };
+
+const renderPreferredModal = ({
+    pathname,
+    hash = '',
+    modal = NO_MODAL,
+}: {
+    pathname: PathString;
+    hash?: '' | `#${string}`;
+    modal?: ModalState;
+}) => {
+    const store = configureMockStore({
+        preloadedState: {
+            router: { loaded: true, ...getAppWithParams({ pathname, hash }) },
+            modal,
+        },
+    });
+
+    let result: Result | undefined;
+
+    const Component = () => {
+        result = usePreferredModal();
+
+        return null;
+    };
+
+    const { unmount } = render(
+        <Provider store={store}>
+            <Component />
+        </Provider>,
+    );
+    unmount();
+
+    return result;
+};
+
+describe('usePreferredModal', () => {
+    it('prefers nothing on a regular route without a redux modal', () => {
+        expect(renderPreferredModal({ pathname: '/settings' })).toEqual({ type: 'none' });
+    });
+
+    it('prefers the redux modal on a regular route', () => {
+        expect(renderPreferredModal({ pathname: '/settings', modal: USER_MODAL })).toEqual({
+            type: 'redux-modal',
+            payload: USER_MODAL,
+        });
+    });
+
+    it('prefers a prioritized foreground app over the redux modal', () => {
+        expect(renderPreferredModal({ pathname: '/firmware', modal: USER_MODAL })).toEqual({
+            type: 'foreground-app',
+            payload: { ...DEFAULT_MODAL_APP_PARAMS, app: 'firmware', cancelable: true },
+        });
+    });
+
+    it('prefers the redux modal over a foreground app without priority', () => {
+        expect(renderPreferredModal({ pathname: '/switch-device', modal: USER_MODAL })).toEqual({
+            type: 'redux-modal',
+            payload: USER_MODAL,
+        });
+        expect(renderPreferredModal({ pathname: '/backup', modal: USER_MODAL })).toEqual({
+            type: 'redux-modal',
+            payload: USER_MODAL,
+        });
+    });
+
+    it('prefers a foreground app without priority when there is no redux modal', () => {
+        expect(renderPreferredModal({ pathname: '/switch-device' })).toEqual({
+            type: 'foreground-app',
+            payload: { ...DEFAULT_MODAL_APP_PARAMS, app: 'switch-device', cancelable: true },
+        });
+    });
+
+    it('passes the route params through and reads cancelable out of them', () => {
+        expect(renderPreferredModal({ pathname: '/firmware', hash: '#/false' })).toEqual({
+            type: 'foreground-app',
+            // an unset param out of a non-empty hash parses to an empty string, not to its default
+            payload: { cancelable: false, variant: '', app: 'firmware' },
+        });
+    });
+
+    it('ignores an app that is both foreground and fullscreen', () => {
+        expect(renderPreferredModal({ pathname: '/start' })).toEqual({ type: 'none' });
+        expect(renderPreferredModal({ pathname: '/onboarding', modal: USER_MODAL })).toEqual({
+            type: 'redux-modal',
+            payload: USER_MODAL,
+        });
+    });
+
+    it('prefers nothing when the route does not exist', () => {
+        expect(renderPreferredModal({ pathname: '/does-not-exist' })).toEqual({ type: 'none' });
+    });
+});

--- a/packages/suite/src/hooks/suite/usePreferredModal.test.tsx
+++ b/packages/suite/src/hooks/suite/usePreferredModal.test.tsx
@@ -28,6 +28,7 @@ const renderPreferredModal = ({
     modal?: ModalState;
 }) => {
     const store = configureMockStore({
+        extra: undefined,
         preloadedState: {
             router: { loaded: true, ...getAppWithParams({ pathname, hash }) },
             modal,

--- a/packages/suite/src/hooks/suite/usePreferredModal.ts
+++ b/packages/suite/src/hooks/suite/usePreferredModal.ts
@@ -1,55 +1,67 @@
 import { MODAL_CONTEXT_NONE } from '@suite/modal';
-import { type ModalAppParams, type Route, selectRoute, selectRouterParams } from '@suite/router';
+import {
+    type ModalAppParams,
+    type RouterAppWithParams,
+    selectForegroundAppParams,
+    selectIsForegroundApp,
+    selectIsFullscreenApp,
+    selectRouterApp,
+} from '@suite/router';
 
 import { useSelector } from 'src/hooks/suite';
 import type { ForegroundAppRoute } from 'src/types/suite';
 
-const isForegroundApp = (route: Route): route is ForegroundAppRoute =>
-    !route.isFullscreenApp && !!route.isForegroundApp;
+const HAS_PRIORITY_OVER_REDUX_MODAL: Record<ForegroundAppRoute['app'], boolean> = {
+    // Firmware, FirmwareCustom, Bridge, Udev, Version, Create New Multi-share Backup - always beats redux modals
+    firmware: true,
+    'firmware-type': true,
+    'firmware-custom': true,
+    bridge: true,
+    'bridge-requested': true,
+    'bridge-deprecated': true,
+    udev: true,
+    version: true,
+    'create-multi-share-backup': true,
+    'create-wallet-backup': true,
 
-const hasPriority = (route: ForegroundAppRoute) => {
-    const map: Record<ForegroundAppRoute['app'], boolean> = {
-        // Firmware, FirmwareCustom, Bridge, Udev, Version, Create New Multi-share Backup - always beats redux modals
-        firmware: true,
-        'firmware-type': true,
-        'firmware-custom': true,
-        bridge: true,
-        'bridge-requested': true,
-        'bridge-deprecated': true,
-        udev: true,
-        version: true,
-        'create-multi-share-backup': true,
-        'create-wallet-backup': true,
+    // Recovery - beats redux modals with some exceptions (raw-rendered)
+    recovery: true,
 
-        // Recovery - beats redux modals with some exceptions (raw-rendered)
-        recovery: true,
-
-        // Backup, SwitchDevice - always get beaten by redux modals
-        'switch-device': false,
-        backup: false,
-    };
-
-    return map[route.app];
+    // Backup, SwitchDevice - always get beaten by redux modals
+    'switch-device': false,
+    backup: false,
 };
 
-const getForegroundAppAction = (route: ForegroundAppRoute, params: Partial<ModalAppParams>) =>
+const isForegroundApp = (app: RouterAppWithParams['app']): app is ForegroundAppRoute['app'] =>
+    app in HAS_PRIORITY_OVER_REDUX_MODAL;
+
+const getForegroundAppAction = (app: ForegroundAppRoute['app'], params: Partial<ModalAppParams>) =>
     ({
         type: 'foreground-app',
         payload: {
             ...params,
-            app: route.app,
+            app,
             // params are undefined when the user goes directly to the URL
             cancelable: !!params?.cancelable,
         },
     }) as const;
 
 export const usePreferredModal = () => {
-    const route = useSelector(selectRoute);
-    const params = useSelector(selectRouterParams) as Partial<ModalAppParams>;
+    // Only the flags the decision needs, so that navigating between regular routes does not
+    // re-render every consumer of this hook.
+    const routerApp = useSelector(selectRouterApp);
+    const isForegroundAppRoute = useSelector(selectIsForegroundApp);
+    const isFullscreenAppRoute = useSelector(selectIsFullscreenApp);
+    const params = useSelector(selectForegroundAppParams) as Partial<ModalAppParams>;
     const modal = useSelector(state => state.modal);
 
-    if (route && isForegroundApp(route) && hasPriority(route)) {
-        return getForegroundAppAction(route, params);
+    const foregroundApp =
+        isForegroundAppRoute && !isFullscreenAppRoute && isForegroundApp(routerApp)
+            ? routerApp
+            : undefined;
+
+    if (foregroundApp !== undefined && HAS_PRIORITY_OVER_REDUX_MODAL[foregroundApp]) {
+        return getForegroundAppAction(foregroundApp, params);
     }
 
     if (modal.context !== MODAL_CONTEXT_NONE) {
@@ -59,8 +71,8 @@ export const usePreferredModal = () => {
         } as const;
     }
 
-    if (route && isForegroundApp(route)) {
-        return getForegroundAppAction(route, params);
+    if (foregroundApp !== undefined) {
+        return getForegroundAppAction(foregroundApp, params);
     }
 
     return {

--- a/packages/suite/src/hooks/suite/usePreferredModal.ts
+++ b/packages/suite/src/hooks/suite/usePreferredModal.ts
@@ -47,8 +47,6 @@ const getForegroundAppAction = (app: ForegroundAppRoute['app'], params: Partial<
     }) as const;
 
 export const usePreferredModal = () => {
-    // Only the flags the decision needs, so that navigating between regular routes does not
-    // re-render every consumer of this hook.
     const routerApp = useSelector(selectRouterApp);
     const isForegroundAppRoute = useSelector(selectIsForegroundApp);
     const isFullscreenAppRoute = useSelector(selectIsFullscreenApp);

--- a/packages/suite/src/hooks/suite/useResetScrollOnUrl.ts
+++ b/packages/suite/src/hooks/suite/useResetScrollOnUrl.ts
@@ -1,14 +1,13 @@
-import { useLayoutEffect, useRef } from 'react';
+import { type RefObject, useLayoutEffect, useRef } from 'react';
 
 import { selectRoute, selectRouterUrl } from '@suite/router';
 
 import { useSelector } from './useSelector';
 
-export const useResetScrollOnUrl = () => {
+export const useResetScrollOnUrl = (scrollRef: RefObject<HTMLDivElement | null>) => {
     const url = useSelector(selectRouterUrl);
     const route = useSelector(selectRoute);
 
-    const scrollRef = useRef<HTMLDivElement>(null);
     const lastNonForegroundUrl = useRef<string | null>(null);
 
     // Reset scroll position on url change.
@@ -26,7 +25,5 @@ export const useResetScrollOnUrl = () => {
 
         lastNonForegroundUrl.current = url;
         current.scrollTop = 0; // reset scroll position on url change
-    }, [url, route]);
-
-    return { scrollRef };
+    }, [scrollRef, url, route]);
 };

--- a/packages/suite/src/reducers/suite/windowReducer.ts
+++ b/packages/suite/src/reducers/suite/windowReducer.ts
@@ -31,7 +31,6 @@ export default windowReducer;
 
 export const selectIsWindowVisible = (state: WindowRootState) => state.window.isVisible;
 
-// Builds a new object on every call, so read it through `useLayoutSize`, which compares by value.
 export const selectBreakpointFlags = (state: WindowRootState): BreakpointFlags => {
     const { isVisible, ...breakpointFlags } = state.window;
 

--- a/packages/suite/src/reducers/suite/windowReducer.ts
+++ b/packages/suite/src/reducers/suite/windowReducer.ts
@@ -1,6 +1,7 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 import { produce } from 'immer';
 
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { type BreakpointFlags, initialBreakpointFlags } from '@trezor/theme';
 
 import { updateBreakpoints, updateWindowVisibility } from 'src/actions/suite/windowActions';
@@ -29,10 +30,13 @@ const windowReducer = (state: WindowState = initialState, action: UnknownAction)
 
 export default windowReducer;
 
+const createMemoizedSelector = createWeakMapSelector.withTypes<WindowRootState>();
+
 export const selectIsWindowVisible = (state: WindowRootState) => state.window.isVisible;
 
-export const selectBreakpointFlags = (state: WindowRootState): BreakpointFlags => {
-    const { isVisible, ...breakpointFlags } = state.window;
-
-    return breakpointFlags;
-};
+// Memoized because it builds a new object: without it every consumer would re-render on every
+// action instead of only when a breakpoint is actually crossed.
+export const selectBreakpointFlags = createMemoizedSelector(
+    [state => state.window],
+    ({ isVisible, ...breakpointFlags }): BreakpointFlags => breakpointFlags,
+);

--- a/packages/suite/src/reducers/suite/windowReducer.ts
+++ b/packages/suite/src/reducers/suite/windowReducer.ts
@@ -1,6 +1,7 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 import { produce } from 'immer';
 
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { type BreakpointFlags, initialBreakpointFlags } from '@trezor/theme';
 
 import { updateBreakpoints, updateWindowVisibility } from 'src/actions/suite/windowActions';
@@ -31,8 +32,9 @@ export default windowReducer;
 
 export const selectIsWindowVisible = (state: WindowRootState) => state.window.isVisible;
 
-export const selectBreakpointFlags = (state: WindowRootState): BreakpointFlags => {
-    const { isVisible, ...breakpointFlags } = state.window;
+const createMemoizedSelector = createWeakMapSelector.withTypes<WindowRootState>();
 
-    return breakpointFlags;
-};
+export const selectBreakpointFlags = createMemoizedSelector(
+    [(state: WindowRootState) => state.window],
+    ({ isVisible, ...breakpointFlags }): BreakpointFlags => breakpointFlags,
+);

--- a/packages/suite/src/reducers/suite/windowReducer.ts
+++ b/packages/suite/src/reducers/suite/windowReducer.ts
@@ -1,7 +1,6 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 import { produce } from 'immer';
 
-import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { type BreakpointFlags, initialBreakpointFlags } from '@trezor/theme';
 
 import { updateBreakpoints, updateWindowVisibility } from 'src/actions/suite/windowActions';
@@ -30,13 +29,11 @@ const windowReducer = (state: WindowState = initialState, action: UnknownAction)
 
 export default windowReducer;
 
-const createMemoizedSelector = createWeakMapSelector.withTypes<WindowRootState>();
-
 export const selectIsWindowVisible = (state: WindowRootState) => state.window.isVisible;
 
-// Memoized because it builds a new object: without it every consumer would re-render on every
-// action instead of only when a breakpoint is actually crossed.
-export const selectBreakpointFlags = createMemoizedSelector(
-    [state => state.window],
-    ({ isVisible, ...breakpointFlags }): BreakpointFlags => breakpointFlags,
-);
+// Builds a new object on every call, so read it through `useLayoutSize`, which compares by value.
+export const selectBreakpointFlags = (state: WindowRootState): BreakpointFlags => {
+    const { isVisible, ...breakpointFlags } = state.window;
+
+    return breakpointFlags;
+};

--- a/packages/suite/src/support/suite/ConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/ConnectPopupModals.tsx
@@ -1,0 +1,13 @@
+import { memo } from 'react';
+
+import { useConnectPopupModals } from './useConnectPopupModals';
+
+// The hook subscribes to the route and the modal state. Kept in a memoized leaf that renders
+// nothing so that those changes re-render only this component instead of the whole app through Main.
+export const ConnectPopupModals = memo(() => {
+    useConnectPopupModals();
+
+    return null;
+});
+
+ConnectPopupModals.displayName = 'ConnectPopupModals';

--- a/packages/suite/src/support/suite/ConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/ConnectPopupModals.tsx
@@ -2,8 +2,6 @@ import { memo } from 'react';
 
 import { useConnectPopupModals } from './useConnectPopupModals';
 
-// The hook subscribes to the route and the modal state. Kept in a memoized leaf that renders
-// nothing so that those changes re-render only this component instead of the whole app through Main.
 export const ConnectPopupModals = memo(() => {
     useConnectPopupModals();
 

--- a/packages/suite/src/support/suite/ConnectedFormatterProvider.tsx
+++ b/packages/suite/src/support/suite/ConnectedFormatterProvider.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode, memo } from 'react';
+
+import { FormatterProvider } from '@suite-common/formatters';
+
+import { useFormattersConfig } from 'src/hooks/suite';
+
+interface ConnectedFormatterProviderProps {
+    children: ReactNode;
+}
+
+// The config is read from the store here rather than in Main, so that a settings change re-renders
+// only this component instead of the whole app.
+export const ConnectedFormatterProvider = memo(({ children }: ConnectedFormatterProviderProps) => {
+    const formattersConfig = useFormattersConfig();
+
+    return <FormatterProvider config={formattersConfig}>{children}</FormatterProvider>;
+});
+
+ConnectedFormatterProvider.displayName = 'ConnectedFormatterProvider';

--- a/packages/suite/src/support/suite/ConnectedFormatterProvider.tsx
+++ b/packages/suite/src/support/suite/ConnectedFormatterProvider.tsx
@@ -8,8 +8,6 @@ interface ConnectedFormatterProviderProps {
     children: ReactNode;
 }
 
-// The config is read from the store here rather than in Main, so that a settings change re-renders
-// only this component instead of the whole app.
 export const ConnectedFormatterProvider = memo(({ children }: ConnectedFormatterProviderProps) => {
     const formattersConfig = useFormattersConfig();
 

--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -27,6 +27,9 @@ export const Main = ({
     // <StrictMode>
     <HelmetProvider>
         {trafficLightOffset ?? null}
+        {/* Outside the ErrorBoundary: a caught render error must not unmount the connect popup
+            state machine, or a pending Connect call would never be cancelled. */}
+        <ConnectPopupModals />
         <ConnectedThemeProvider>
             <ResponsiveContextProvider>
                 <ErrorBoundary>
@@ -36,7 +39,6 @@ export const Main = ({
                         <Protocol />
                         <OnlineStatus />
                         <RouterHandler />
-                        <ConnectPopupModals />
                         <ConnectedIntlProvider>
                             <SelectCacheProvider>
                                 <ConnectedFormatterProvider>{children}</ConnectedFormatterProvider>

--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -27,8 +27,6 @@ export const Main = ({
     // <StrictMode>
     <HelmetProvider>
         {trafficLightOffset ?? null}
-        {/* Outside the ErrorBoundary: a caught render error must not unmount the connect popup
-            state machine, or a pending Connect call would never be cancelled. */}
         <ConnectPopupModals />
         <ConnectedThemeProvider>
             <ResponsiveContextProvider>

--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -1,10 +1,8 @@
 import { HelmetProvider } from 'react-helmet-async';
 
-import { FormatterProvider } from '@suite-common/formatters';
 import { ReactQueryProvider } from '@suite-common/react-query/src/components/ReactQueryProvider';
 import { SelectCacheProvider } from '@trezor/components';
 
-import { useFormattersConfig } from 'src/hooks/suite';
 import Autodetect from 'src/support/suite/Autodetect';
 import { ConnectedIntlProvider } from 'src/support/suite/ConnectedIntlProvider';
 import { ConnectedThemeProvider } from 'src/support/suite/ConnectedThemeProvider';
@@ -14,8 +12,9 @@ import Protocol from 'src/support/suite/Protocol';
 import Resize from 'src/support/suite/Resize';
 import { ResponsiveContextProvider } from 'src/support/suite/ResponsiveContext';
 
+import { ConnectPopupModals } from './ConnectPopupModals';
+import { ConnectedFormatterProvider } from './ConnectedFormatterProvider';
 import { RouterHandler } from './RouterHandler';
-import { useConnectPopupModals } from './useConnectPopupModals';
 
 export const Main = ({
     trafficLightOffset,
@@ -23,36 +22,30 @@ export const Main = ({
 }: {
     trafficLightOffset?: React.ReactNode;
     children: React.ReactNode;
-}) => {
-    useConnectPopupModals();
-    const formattersConfig = useFormattersConfig();
-
-    return (
-        // Todo: Enable when issues are fixed (ReactTruncate & BumpFee)
-        // <StrictMode>
-        <HelmetProvider>
-            {trafficLightOffset ?? null}
-            <ConnectedThemeProvider>
-                <ResponsiveContextProvider>
-                    <ErrorBoundary>
-                        <ReactQueryProvider>
-                            <Autodetect />
-                            <Resize />
-                            <Protocol />
-                            <OnlineStatus />
-                            <RouterHandler />
-                            <ConnectedIntlProvider>
-                                <SelectCacheProvider>
-                                    <FormatterProvider config={formattersConfig}>
-                                        {children}
-                                    </FormatterProvider>
-                                </SelectCacheProvider>
-                            </ConnectedIntlProvider>
-                        </ReactQueryProvider>
-                    </ErrorBoundary>
-                </ResponsiveContextProvider>
-            </ConnectedThemeProvider>
-        </HelmetProvider>
-        // </StrictMode>
-    );
-};
+}) => (
+    // Todo: Enable when issues are fixed (ReactTruncate & BumpFee)
+    // <StrictMode>
+    <HelmetProvider>
+        {trafficLightOffset ?? null}
+        <ConnectedThemeProvider>
+            <ResponsiveContextProvider>
+                <ErrorBoundary>
+                    <ReactQueryProvider>
+                        <Autodetect />
+                        <Resize />
+                        <Protocol />
+                        <OnlineStatus />
+                        <RouterHandler />
+                        <ConnectPopupModals />
+                        <ConnectedIntlProvider>
+                            <SelectCacheProvider>
+                                <ConnectedFormatterProvider>{children}</ConnectedFormatterProvider>
+                            </SelectCacheProvider>
+                        </ConnectedIntlProvider>
+                    </ReactQueryProvider>
+                </ErrorBoundary>
+            </ResponsiveContextProvider>
+        </ConnectedThemeProvider>
+    </HelmetProvider>
+    // </StrictMode>
+);

--- a/suite/account/src/index.ts
+++ b/suite/account/src/index.ts
@@ -6,6 +6,7 @@ export {
     selectSelectedAccount,
     selectSelectedAccountKey,
     selectSelectedAccountStatus,
+    selectSelectedAccountSymbol,
     selectedAccountReducer,
     type SelectedAccountRootState,
     type SelectedAccountRootStateWithTrading,

--- a/suite/account/src/selectedAccountReducer.ts
+++ b/suite/account/src/selectedAccountReducer.ts
@@ -53,6 +53,9 @@ export const selectSelectedAccount = (state: SelectedAccountRootState) =>
 export const selectSelectedAccountKey = (state: SelectedAccountRootState) =>
     state.wallet.selectedAccount.account?.key;
 
+export const selectSelectedAccountSymbol = (state: SelectedAccountRootState) =>
+    state.wallet.selectedAccount.account?.symbol;
+
 export const selectSelectedAccountStatus = (state: SelectedAccountRootState) =>
     state.wallet.selectedAccount.status;
 

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -108,6 +108,9 @@ export const selectIsAccountTabPage = (state: RouterRootState) =>
     isAccountTabRoute(selectRouteName(state));
 
 export const selectRouterApp = (state: RouterRootState) => state.router.app;
+export const selectHasRoute = (state: RouterRootState) => state.router.route !== undefined;
+export const selectIsForegroundApp = (state: RouterRootState) =>
+    state.router.route?.isForegroundApp === true;
 
 export const selectCanNavigate = (state: LocksRootState & ModalRootState) =>
     !selectIsRouterOrUiLocked(state) && !selectHasActiveModal(state);

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -111,6 +111,12 @@ export const selectRouterApp = (state: RouterRootState) => state.router.app;
 export const selectHasRoute = (state: RouterRootState) => state.router.route !== undefined;
 export const selectIsForegroundApp = (state: RouterRootState) =>
     state.router.route?.isForegroundApp === true;
+export const selectIsFullscreenApp = (state: RouterRootState) =>
+    state.router.route?.isFullscreenApp === true;
+// The params are only ever read by the modal apps, so they are hidden from everyone else to keep
+// their identity stable while navigating between regular routes.
+export const selectForegroundAppParams = (state: RouterRootState) =>
+    state.router.route?.isForegroundApp === true ? state.router.params : undefined;
 
 export const selectCanNavigate = (state: LocksRootState & ModalRootState) =>
     !selectIsRouterOrUiLocked(state) && !selectHasActiveModal(state);

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -113,8 +113,6 @@ export const selectIsForegroundApp = (state: RouterRootState) =>
     state.router.route?.isForegroundApp === true;
 export const selectIsFullscreenApp = (state: RouterRootState) =>
     state.router.route?.isFullscreenApp === true;
-// The params are only ever read by the modal apps, so they are hidden from everyone else to keep
-// their identity stable while navigating between regular routes.
 export const selectForegroundAppParams = (state: RouterRootState) =>
     state.router.route?.isForegroundApp === true ? state.router.params : undefined;
 


### PR DESCRIPTION
## Description

Clicking between the tabs of one account re-rendered the whole app: ~107 ms per click, ~70 ms of it
the sidebar accounts list. Nothing subscribed to the route on purpose — `Main`, `Preloader` and
`SuiteLayout` did it through hooks. Each subscription now lives in a memoized component, and the
selectors return primitives instead of objects.

- `Main`: `useConnectPopupModals` → `ConnectPopupModals`, formatter config → `ConnectedFormatterProvider`.
  It was handing styled-components a new theme object on every navigation (`GlobalStyle` alone: 38 ms).
- `SuiteLayout`: scroll → `ScrollProvider`, anchor → `AnchorHighlightHandler`, breakpoints →
  `BelowTabletOnly` / `AboveTabletOnly`. No subscription left in it.
- `Preloader` + `usePreferredModal`: the whole route object → primitive flags.
- `useLayoutSize`: breakpoint flags compared by value — the selector built a new object on *every*
  action, and ~50 files read it.
- `useGoToWithAnalytics`: the selected account object → its symbol, which is all it reports.
- `AccountItem` memoized, plus the two things that stopped the memo holding (a fresh `BigNumber` per
  render, and every row subscribing to the selected account).
- New test: `usePreferredModal.test.tsx`, 8 cases — they pass against the old implementation too.

## Notes for QA

No behaviour change intended. Worth checking where a subscription changed scope:

- **Scroll**: switch account/tab → page scrolls to top. Open a foreground modal (firmware, bridge,
  recovery, switch device, backup) over a scrolled page and close it → scroll position kept.
- **Anchor**: open a transaction anchor link → transaction highlighted; click anywhere → highlight gone.
- **Resize across tablet width**: Coinjoin bars swap position, guide button hidden below tablet.
- **Modal priority**: firmware/bridge/recovery take over from a redux modal; switch-device/backup
  lose to one.
- **Connect popup**: start a Connect call from a third-party page, navigate away → call cancelled.
- **Sidebar**: coin/tokens/staking rows highlight the selected one and navigate on click, fiat values
  keep updating.

<img width="277" height="233" alt="Screenshot 2026-08-25 at 12 06 55 PM" src="https://github.com/user-attachments/assets/419356e8-2119-4906-be7d-164a1f2b666f" />

<img width="313" height="208" alt="Screenshot 2026-08-25 at 12 14 21 PM" src="https://github.com/user-attachments/assets/6614c8cf-1892-4bee-ac67-fcc68c56978f" />
<img width="1313" height="779" alt="Screenshot 2026-08-25 at 12 07 10 PM" src="https://github.com/user-attachments/assets/2a4f9b99-0402-4c00-a2c7-732c76b82b6d" />


Resolves #31714


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is a mix of global shell/layout code (Preloader, SuiteLayout, Main) and more focused account/routing/modal/formatter logic. Global files are imported by virtually every test, so this recommendation targets tests that directly exercise the higher-risk areas: account sidebar rendering, route navigation, Connect modals, and analytics/layout loading. A small suite of high and medium priority tests should catch regressions without running the full catalog.

<details><summary><b>Changed files (20)</b></summary>

- `packages/suite/src/components/suite/Preloader/Preloader.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/AnchorHighlightHandler.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSizeOnly.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/ScrollProvider.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/SuiteLayout.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx`
- `packages/suite/src/hooks/suite/useFormattersConfig.ts`
- `packages/suite/src/hooks/suite/useLayoutSize.ts`
- `packages/suite/src/hooks/suite/usePreferredModal.test.tsx`
- `packages/suite/src/hooks/suite/usePreferredModal.ts`
- `packages/suite/src/hooks/suite/useResetScrollOnUrl.ts`
- `packages/suite/src/reducers/suite/windowReducer.ts`
- `packages/suite/src/support/suite/ConnectPopupModals.tsx`
- `packages/suite/src/support/suite/ConnectedFormatterProvider.tsx`
- `packages/suite/src/support/suite/Main.tsx`
- `suite/account/src/index.ts`
- `suite/account/src/selectedAccountReducer.ts`
- `suite/router/src/routerReducer.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Directly exercises window dimensions (windowReducer), routing analytics (routerReducer/useGoToWithAnalytics), and the main app layout paths that load Preloader/SuiteLayout. A regression here would be immediately visible in core SuiteReady and navigation events.
- `suite/e2e/tests/general/check-links.test.ts` — Navigates every major Suite route and verifies page load, layout attachment, and bundle-loader hiding. This is the broadest coverage for routerReducer, SuiteLayout, Preloader, scroll behavior, and anchor/URL handling changes.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Exercises the Connect popup modal lifecycle, permissions modals, and address confirmation modals, which directly map to ConnectPopupModals and usePreferredModal changes. Regressions would break third-party connect integrations.
- `suite/e2e/tests/wallet/account-search.test.ts` — Directly tests account sidebar filtering and visibility, exercising AccountItem/AccountItemsGroup rendering and selected account state. A regression would be immediately visible in wallet navigation.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Validates adding accounts and the resulting account list rendering, including account counts and account type display. Directly depends on AccountItem/AccountItemsGroup and selected account state.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Covers initial app load, onboarding routing, analytics modal flow, and post-onboarding navigation to wallet. Shares Preloader, SuiteLayout, and modal infrastructure with the changed files.
- `suite/e2e/tests/settings/general.test.ts` — Tests fiat currency, theme, and language changes that rely on formatters and layout state. ConnectedFormatterProvider and useFormattersConfig are directly involved in how values and dates render after these changes.
- `suite/e2e/tests/suite/initial-run.test.ts` — Verifies onboarding persistence, page reload behavior, and the transition from initial run to dashboard. Exercises Preloader, SuiteLayout, and routing state across reloads.
- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin discovery completes and renders account balances in the wallet sidebar. AccountItem/AccountItemsGroup and selected account state are exercised once accounts are discovered and displayed.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/layouts/SuiteLayout/LayoutSizeOnly.tsx`
- `packages/suite/src/hooks/suite/usePreferredModal.test.tsx`

_Updated: 2026-08-31T10:08:25.912Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/main-store-subscriptions/web/](https://dev.suite.sldev.cz/suite-web/perf/main-store-subscriptions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/main-store-subscriptions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/main-store-subscriptions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T10:08:48.755Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T10:09:52.415Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->