### PR TITLE
Fix connect popup cancel behavior

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -1097,10 +1097,7 @@ export const connectPopupCancelThunk = createThunk<void, { error?: string; callI
         // todo: probably not needed to call explicitly anymore
         dispatch(deviceActions.removeButtonRequests({}));
 
-        const cancelError = TypedError('Method_Interrupted');
-        // Show the cancellation error modal immediately so the user sees
-        // feedback in the Suite popup ("Request was canceled by the user").
-        dispatch(connectPopupActions.setError(serializeError(cancelError)));
+        dispatch(connectPopupActions.finishCall());
 
         // Resolve the popup-call deferred directly so the cancel response
         // reaches the caller immediately.  Without this, the response
@@ -1112,7 +1109,7 @@ export const connectPopupCancelThunk = createThunk<void, { error?: string; callI
         // before RESPONSE_EVENT is sent).
         getPopupCallDeferred().resolve({
             success: false,
-            error: serializeError(cancelError),
+            error: serializeError(TypedError('Method_Interrupted')),
         });
     },
 );

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -221,11 +221,6 @@ test.describe('TrezorConnect popup web', { tag: ['@T3T1', '@webOnly'] }, () => {
             const response = page.getByTestId('@response');
             await expect(response).toHaveText(/success: false/);
             await expect(response).toHaveText(/Method_Interrupted/);
-
-            // The popup (suite window) should show a cancellation message.
-            await expect(suite.getByText('Request was canceled by the user')).toBeVisible({
-                timeout: 15_000,
-            });
         },
     );
 

--- a/suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts
@@ -245,7 +245,7 @@ test.describe('TrezorConnect webextension -> Suite Web', { tag: ['@T3T1', '@webO
             }),
         },
         async ({ model, device, context: defaultContext }) => {
-            const { context, page, suite } = await setupWebextensionTest(
+            const { context, page } = await setupWebextensionTest(
                 model,
                 device,
                 defaultContext,
@@ -262,11 +262,6 @@ test.describe('TrezorConnect webextension -> Suite Web', { tag: ['@T3T1', '@webO
                 const response = page.getByTestId('@response');
                 await expect(response).toHaveText(/success: false/);
                 await expect(response).toHaveText(/Method_Interrupted/);
-
-                // The popup (suite tab) should show a cancellation message.
-                await expect(suite.getByText('Request was canceled by the user')).toBeVisible({
-                    timeout: 15_000,
-                });
             } finally {
                 await context.close();
             }


### PR DESCRIPTION
## Description

This pull request streamlines the handling of cancellation in the Connect popup flow by removing the explicit display of a cancellation error modal and updating related test expectations. The cancellation process now finishes the call without showing a separate error message to the user.

**Connect popup cancellation flow:**

* The thunk `connectPopupCancelThunk` now calls `connectPopupActions.finishCall()` instead of explicitly setting an error modal when a request is canceled by the user.

**Test updates:**

* The E2E test `connectPopupWeb.test.ts` no longer expects the cancellation message ("Request was canceled by the user") to be visible in the popup, reflecting the updated UI behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is tightly scoped to Connect popup thunks and their two directly associated E2E tests. The broad static coverage mapping of connectPopupThunks.ts to 136 tests is almost certainly transitive, so only the two tests that explicitly target the web and webextension Connect popup flows are recommended. Running these provides high confidence that the thunk changes work correctly for the supported Connect entry points.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts`
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the web-based Trezor Connect popup flow, including permissions, address export, cancellation, and popup lifecycle behaviors that are implemented by suite-common/connect-popup/src/connectPopupThunks.ts. It was also modified in the same change set, so it is the primary regression target.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test directly exercises the webextension-based Trezor Connect popup flow, including permissions and address confirmation flows that depend on connectPopupThunks.ts. It was also modified in the same change set, making it essential to run.

</details>

_Updated: 2026-08-27T08:54:43.394Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/e2e-connect-popup-cancel/web/](https://dev.suite.sldev.cz/suite-web/test/e2e-connect-popup-cancel/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/e2e-connect-popup-cancel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/e2e-connect-popup-cancel&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/e2e-connect-popup-cancel&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T08:56:10.151Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T08:56:26.939Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->