### PR TITLE
feat(e2e): post the performance report as a PR comment

### DIFF
--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -198,10 +198,11 @@ jobs:
           GH_BRANCH: ${{ env.branch }} # Used by Currents reporter
           PASSPHRASE: ${{ secrets.e2e-passphrase }}
           PASSPHRASE_LIVE: ${{ secrets.e2e-passphrase-live }}
-          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token || secrets.github-token }}
+          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token || secrets.github-token || github.token }}
           RELEASE_BUILD: ${{ inputs.release-build }}
           RUN_GITHUB_REPORTER: ${{ inputs.run-reporter }} # Read by playwright-base.config.ts to enable the GitHub reporter
           ELECTRON_DISABLE_SANDBOX: 1
+          PERF_REPORT_LABEL: "${{ inputs.target }} / group ${{ inputs.test-group }}"
           COLLECT_COVERAGE_MAP: ${{ inputs.enable-coverage == 'true' && 'true' || '' }}
           COVERAGE_MAP_DIR: ${{ github.workspace }}/coverage-map
         run: |

--- a/packages/e2e-utils/src/gitHub/prComment.ts
+++ b/packages/e2e-utils/src/gitHub/prComment.ts
@@ -1,0 +1,107 @@
+import * as fs from 'node:fs';
+
+type PullRequestEvent = { pull_request?: { number?: number }; number?: number };
+
+export const resolvePullRequestNumber = (): number | null => {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath || !fs.existsSync(eventPath)) {
+        return null;
+    }
+
+    try {
+        const event = JSON.parse(fs.readFileSync(eventPath, 'utf8')) as PullRequestEvent;
+        const number = event.pull_request?.number ?? event.number;
+
+        return typeof number === 'number' ? number : null;
+    } catch {
+        return null;
+    }
+};
+
+const resolveRepository = () => {
+    const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '').split('/');
+
+    return owner && repo ? { owner, repo } : null;
+};
+
+export const resolveRunUrl = (): string | undefined => {
+    const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT } = process.env;
+    if (!GITHUB_REPOSITORY || !GITHUB_RUN_ID) {
+        return undefined;
+    }
+
+    const server = GITHUB_SERVER_URL ?? 'https://github.com';
+    const run = `${server}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+
+    return GITHUB_RUN_ATTEMPT ? `${run}/attempts/${GITHUB_RUN_ATTEMPT}` : run;
+};
+
+type UpsertStickyPrComment = {
+    marker: string;
+    buildBody: (existingBody: string | undefined) => string;
+    holdsOwnContent?: (body: string) => boolean;
+    attempts?: number;
+};
+
+export type StickyPrCommentResult = 'created' | 'updated' | 'skipped';
+
+export const upsertStickyPrComment = async ({
+    marker,
+    buildBody,
+    holdsOwnContent,
+    attempts = 3,
+}: UpsertStickyPrComment): Promise<StickyPrCommentResult> => {
+    const token = process.env.GITHUB_TOKEN;
+    const repository = resolveRepository();
+    const issueNumber = resolvePullRequestNumber();
+
+    if (!token || !repository || issueNumber === null) {
+        return 'skipped';
+    }
+
+    const { Octokit } = await import('@octokit/rest');
+    const octokit = new Octokit({ auth: token });
+
+    const findPrevious = async () => {
+        const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+            ...repository,
+            issue_number: issueNumber,
+            per_page: 100,
+        });
+
+        return comments.find(comment => comment.body?.includes(marker));
+    };
+
+    let result: StickyPrCommentResult = 'skipped';
+
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        const previous = await findPrevious();
+
+        if (previous) {
+            await octokit.rest.issues.updateComment({
+                ...repository,
+                comment_id: previous.id,
+                body: buildBody(previous.body),
+            });
+            result = 'updated';
+        } else {
+            await octokit.rest.issues.createComment({
+                ...repository,
+                issue_number: issueNumber,
+                body: buildBody(undefined),
+            });
+            result = 'created';
+        }
+
+        if (!holdsOwnContent) {
+            return result;
+        }
+
+        const written = await findPrevious();
+        if (written?.body && holdsOwnContent(written.body)) {
+            return result;
+        }
+    }
+
+    return result;
+};

--- a/packages/e2e-utils/src/index.ts
+++ b/packages/e2e-utils/src/index.ts
@@ -21,5 +21,7 @@ export {
 export { TestReportProviderBase, createTestAnnotation } from './githubReporter/annotationBase';
 export type { TestDetailsAnnotation, TestMetadataInput } from './githubReporter/types';
 export type * from './githubReporter/types';
+export { resolvePullRequestNumber, resolveRunUrl, upsertStickyPrComment } from './gitHub/prComment';
+export type { StickyPrCommentResult } from './gitHub/prComment';
 export * from './enums/testAnnotations';
 export * from './grepUtils';

--- a/packages/perf-e2e/src/index.ts
+++ b/packages/perf-e2e/src/index.ts
@@ -4,5 +4,6 @@ export * from './compare';
 export * from './measurement';
 export * from './aggregate';
 export * from './report';
+export * from './markdown';
 export * from './suggestLimits';
 export * from './instrumentation';

--- a/packages/perf-e2e/src/markdown.test.ts
+++ b/packages/perf-e2e/src/markdown.test.ts
@@ -1,0 +1,254 @@
+import { compareScenario } from './compare';
+import {
+    PERF_REPORT_MARKER,
+    formatMarkdownReport,
+    perfReportComment,
+    perfReportSection,
+} from './markdown';
+import { buildJsonReport } from './report';
+import { type PerfMetrics } from './types';
+
+const metrics = (overrides: Partial<PerfMetrics> = {}): PerfMetrics => ({
+    totalBlockingTimeMs: 0,
+    longTaskCount: 0,
+    longestTaskMs: 0,
+    reactCommitCount: 0,
+    interactionDurationMs: 0,
+    ...overrides,
+});
+
+const measurement = ({
+    key,
+    runs = 1,
+    current,
+    baseline,
+    limits,
+}: {
+    key: string;
+    runs?: number;
+    current: Partial<PerfMetrics>;
+    baseline?: Parameters<typeof compareScenario>[2];
+    limits?: Parameters<typeof compareScenario>[3];
+}) => ({
+    key,
+    runs,
+    report: buildJsonReport(compareScenario(key, metrics(current), baseline, limits)),
+});
+
+describe('perfReportComment', () => {
+    it('starts a report with the marker the next job looks the comment up by', () => {
+        const body = perfReportComment({ label: 'web / group 1', section: 'WEB' });
+
+        expect(body).toContain(PERF_REPORT_MARKER);
+        expect(body).toContain('## ⚡ Performance report');
+        expect(body).toContain('<!-- PERF-E2E-SECTION:web / group 1:START -->\nWEB');
+    });
+
+    it('adds a second job to the report the first one started, keeping both', () => {
+        const first = perfReportComment({ label: 'web / group 1', section: 'WEB' });
+        const both = perfReportComment({
+            existingBody: first,
+            label: 'desktop / group 3',
+            section: 'DESKTOP',
+        });
+
+        expect(both).toContain('WEB');
+        expect(both).toContain('DESKTOP');
+        expect(both.match(new RegExp(PERF_REPORT_MARKER, 'g'))).toHaveLength(1);
+    });
+
+    it('replaces only its own part when a job reports twice', () => {
+        const first = perfReportComment({ label: 'web / group 1', section: 'WEB' });
+        const both = perfReportComment({
+            existingBody: first,
+            label: 'desktop / group 3',
+            section: 'DESKTOP',
+        });
+        const rerun = perfReportComment({
+            existingBody: both,
+            label: 'web / group 1',
+            section: 'WEB AGAIN',
+        });
+
+        expect(rerun).toContain('WEB AGAIN');
+        expect(rerun).not.toContain('\nWEB\n');
+        expect(rerun).toContain('DESKTOP');
+    });
+
+    it('embeds the section block verbatim', () => {
+        const body = perfReportComment({ label: 'web / group 1', section: 'WEB' });
+
+        expect(body).toContain(perfReportSection({ label: 'web / group 1', section: 'WEB' }));
+    });
+
+    it('drops characters that would break out of the section marker', () => {
+        const body = perfReportComment({ label: 'web <!-- -->', section: 'WEB' });
+
+        expect(body).toContain('<!-- PERF-E2E-SECTION:web - -:START -->');
+    });
+});
+
+describe('formatMarkdownReport', () => {
+    it('names every measurement that went over its limit in the summary line', () => {
+        const report = formatMarkdownReport([
+            measurement({
+                key: 'account-switch [T3W1]',
+                current: { totalBlockingTimeMs: 900 },
+                limits: { totalBlockingTimeMs: 700 },
+            }),
+            measurement({
+                key: 'wallet-discovery [T3W1]',
+                current: { totalBlockingTimeMs: 100 },
+                limits: { totalBlockingTimeMs: 700 },
+            }),
+        ]);
+
+        expect(report).toContain('🔴 **Over limit:** `account-switch [T3W1]`');
+        expect(report).not.toContain('`wallet-discovery [T3W1]`, ');
+        expect(report).toContain('the run is not failed');
+    });
+
+    it('reports a passing run as within limits', () => {
+        const report = formatMarkdownReport([
+            measurement({
+                key: 'account-switch',
+                current: { totalBlockingTimeMs: 100 },
+                limits: { totalBlockingTimeMs: 700 },
+            }),
+        ]);
+
+        expect(report).toContain('🟢 **Within limits.**');
+        expect(report).not.toContain('Over limit');
+    });
+
+    it('unfolds a breached measurement and leaves a passing one folded', () => {
+        const report = formatMarkdownReport([
+            measurement({
+                key: 'over',
+                current: { totalBlockingTimeMs: 900 },
+                limits: { totalBlockingTimeMs: 700 },
+            }),
+            measurement({
+                key: 'under',
+                current: { totalBlockingTimeMs: 100 },
+                limits: { totalBlockingTimeMs: 700 },
+            }),
+        ]);
+
+        expect(report).toContain('<details open>\n<summary><code>over</code> — 🔴 over limit');
+        expect(report).toContain('<details>\n<summary><code>under</code> — 🟢 within limits');
+    });
+
+    it('marks a scenario with no limits as measured against nothing', () => {
+        const report = formatMarkdownReport([
+            measurement({ key: 'unlimited', current: { totalBlockingTimeMs: 100 } }),
+        ]);
+
+        expect(report).toContain('⚪ no limits set');
+    });
+
+    it('writes one table row per metric, flagging the ones over their limit', () => {
+        const report = formatMarkdownReport([
+            measurement({
+                key: 'account-switch',
+                current: { totalBlockingTimeMs: 900, longTaskCount: 2 },
+                limits: { totalBlockingTimeMs: 700 },
+            }),
+        ]);
+
+        expect(report).toContain('| Total Blocking Time ⚠️ | 900 ms | 700 ms | 129% | n/a | n/a |');
+        expect(report).toContain('| Long tasks (>50ms) | 2 | n/a | n/a | n/a | n/a |');
+    });
+
+    it('emphasises the share of the baseline only when the run came in under it', () => {
+        const report = formatMarkdownReport([
+            measurement({
+                key: 'account-switch',
+                current: { totalBlockingTimeMs: 500, longTaskCount: 12 },
+                baseline: { totalBlockingTimeMs: 1000, longTaskCount: 10 },
+            }),
+        ]);
+
+        expect(report).toContain(
+            '| Total Blocking Time | 500 ms | n/a | n/a | 1000 ms | **50%** |',
+        );
+        expect(report).toContain('| Long tasks (>50ms) | 12 | n/a | n/a | 10 | 120% |');
+    });
+
+    it('recommends lowering a baseline the run came in clearly under', () => {
+        const report = formatMarkdownReport([
+            measurement({
+                key: 'account-switch',
+                current: { totalBlockingTimeMs: 500 },
+                baseline: { totalBlockingTimeMs: 1000 },
+            }),
+        ]);
+
+        expect(report).toContain(
+            '🔵 **Under baseline:** `account-switch` (Total Blocking Time −50%)',
+        );
+        expect(report).toContain('the baseline is stale');
+    });
+
+    it('says nothing about a baseline the run only just came in under', () => {
+        const report = formatMarkdownReport([
+            measurement({
+                key: 'account-switch',
+                current: { totalBlockingTimeMs: 950 },
+                baseline: { totalBlockingTimeMs: 1000 },
+            }),
+        ]);
+
+        expect(report).not.toContain('Under baseline');
+    });
+
+    it('escapes a pipe and the backslash that would cancel that escape', () => {
+        const report = formatMarkdownReport([
+            measurement({ key: 'a|b', current: {} }),
+            measurement({ key: 'c\\|d', current: {} }),
+        ]);
+
+        expect(report).toContain('<code>a\\|b</code>');
+        expect(report).toContain('<code>c\\\\\\|d</code>');
+    });
+
+    it('says how many samples the medians came from', () => {
+        const single = formatMarkdownReport([
+            measurement({ key: 'account-switch', runs: 1, current: {} }),
+        ]);
+        const retried = formatMarkdownReport([
+            measurement({ key: 'account-switch', runs: 3, current: {} }),
+        ]);
+
+        expect(single).toContain('median of 1 run<');
+        expect(retried).toContain('median of 3 runs<');
+    });
+
+    it('links the run and labels the job the numbers come from', () => {
+        const report = formatMarkdownReport([measurement({ key: 'account-switch', current: {} })], {
+            label: 'desktop / group 3',
+            runUrl: 'https://github.com/o/r/actions/runs/1',
+        });
+
+        expect(report).toContain('### desktop / group 3');
+        expect(report).toContain('Measured in [this run](https://github.com/o/r/actions/runs/1).');
+    });
+
+    it('offers the budgets paste when the reporter supplies one', () => {
+        const report = formatMarkdownReport([measurement({ key: 'account-switch', current: {} })], {
+            budgetsSnippet: {
+                path: 'suite/e2e/performance/budgets.ts',
+                contents: 'export const X = 1;',
+            },
+        });
+
+        expect(report).toContain("cat > suite/e2e/performance/budgets.ts <<'TS'");
+        expect(report).toContain('export const X = 1;');
+    });
+
+    it('leaves the paste out when there is none, so the comment stays short', () => {
+        const report = formatMarkdownReport([measurement({ key: 'account-switch', current: {} })]);
+
+        expect(report).not.toContain('Record this run');
+    });
+});

--- a/packages/perf-e2e/src/markdown.ts
+++ b/packages/perf-e2e/src/markdown.ts
@@ -1,0 +1,188 @@
+import { type PerfJsonReport, formatMetricValue } from './report';
+
+export type ReportedMeasurement = {
+    key: string;
+    runs: number;
+    report: PerfJsonReport;
+};
+
+export type MarkdownReportContext = {
+    label?: string;
+    runUrl?: string;
+    budgetsSnippet?: { path: string; contents: string };
+};
+
+export const PERF_REPORT_MARKER = '<!-- PERF-E2E-REPORT -->';
+
+const PERF_REPORT_HEADING = '## ⚡ Performance report';
+
+const safeLabel = (label: string) => label.replace(/[^a-zA-Z0-9._/ -]/g, '').replace(/-{2,}/g, '-');
+
+const sectionMarkers = (label: string) => ({
+    start: `<!-- PERF-E2E-SECTION:${safeLabel(label)}:START -->`,
+    end: `<!-- PERF-E2E-SECTION:${safeLabel(label)}:END -->`,
+});
+
+const escapeCell = (value: string) => value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+
+type Metric = PerfJsonReport['metrics'][number];
+
+const ratioToLimit = (metric: Metric) =>
+    metric.ratioToLimit === null ? 'n/a' : `${Math.round(metric.ratioToLimit * 100)}%`;
+
+const ratioToBaseline = ({ baseline, current }: Metric) => {
+    if (baseline === null || baseline <= 0 || current === null) {
+        return 'n/a';
+    }
+
+    const percentage = Math.round((current / baseline) * 100);
+
+    return percentage < 100 ? `**${percentage}%**` : `${percentage}%`;
+};
+
+const verdict = (report: PerfJsonReport) => {
+    if (report.overLimit) {
+        return '🔴 over limit';
+    }
+
+    return report.unlimited ? '⚪ no limits set' : '🟢 within limits';
+};
+
+const measurementSection = ({ key, runs, report }: ReportedMeasurement) =>
+    [
+        `<details${report.overLimit ? ' open' : ''}>`,
+        `<summary><code>${escapeCell(key)}</code> — ${verdict(report)} — median of ${runs} run${runs === 1 ? '' : 's'}</summary>`,
+        '',
+        '| Metric | Current | Limit | % of limit | Baseline | % of baseline |',
+        '| --- | --: | --: | --: | --: | --: |',
+        ...report.metrics.map(metric => {
+            const cells = [
+                escapeCell(metric.label) + (metric.exceededLimit ? ' ⚠️' : ''),
+                formatMetricValue(metric.current, metric.unit),
+                formatMetricValue(metric.limit, metric.unit),
+                ratioToLimit(metric),
+                formatMetricValue(metric.baseline, metric.unit),
+                ratioToBaseline(metric),
+            ];
+
+            return `| ${cells.join(' | ')} |`;
+        }),
+        '',
+        '</details>',
+    ].join('\n');
+
+const STALE_BASELINE_RATIO = 0.9;
+
+const belowBaselineDrops = ({ report }: ReportedMeasurement) =>
+    report.metrics.flatMap(({ label, baseline, current }) => {
+        if (baseline === null || baseline <= 0 || current === null) {
+            return [];
+        }
+
+        const ratio = current / baseline;
+
+        return ratio < STALE_BASELINE_RATIO ? [`${label} −${Math.round((1 - ratio) * 100)}%`] : [];
+    });
+
+const belowBaselineNote = (measurements: readonly ReportedMeasurement[]) => {
+    const improved = measurements
+        .map(measurement => ({ key: measurement.key, drops: belowBaselineDrops(measurement) }))
+        .filter(entry => entry.drops.length > 0);
+
+    if (improved.length === 0) {
+        return [];
+    }
+
+    const listed = improved.map(entry => `\`${entry.key}\` (${entry.drops.join(', ')})`);
+
+    return [
+        '',
+        `🔵 **Under baseline:** ${listed.join('; ')} — the baseline is stale, record this run's numbers below to lower it.`,
+    ];
+};
+
+export const formatMarkdownReport = (
+    measurements: readonly ReportedMeasurement[],
+    { label, runUrl, budgetsSnippet }: MarkdownReportContext = {},
+): string => {
+    const overLimit = measurements.filter(measurement => measurement.report.overLimit);
+    const heading = label ? `### ${label}` : '### e2e';
+
+    const summary =
+        overLimit.length > 0
+            ? `🔴 **Over limit:** ${overLimit.map(measurement => `\`${measurement.key}\``).join(', ')} — reported only, the run is not failed.`
+            : '🟢 **Within limits.**';
+
+    const lines = [
+        heading,
+        '',
+        summary,
+        ...belowBaselineNote(measurements),
+        '',
+        ...measurements.map(measurementSection),
+    ];
+
+    if (budgetsSnippet) {
+        lines.push(
+            '',
+            `<details>`,
+            `<summary>Record this run's numbers</summary>`,
+            '',
+            `Run from the repo root, then commit. The baseline is reference only; a raised limit says the app may cost more.`,
+            '',
+            '```bash',
+            `cat > ${budgetsSnippet.path} <<'TS'`,
+            budgetsSnippet.contents,
+            'TS',
+            '```',
+            '',
+            '</details>',
+        );
+    }
+
+    if (runUrl) {
+        lines.push('', `Measured in [this run](${runUrl}).`);
+    }
+
+    return lines.join('\n');
+};
+
+export const perfReportSection = ({
+    label,
+    section,
+}: {
+    label: string;
+    section: string;
+}): string => {
+    const { start, end } = sectionMarkers(label);
+
+    return `${start}\n${section}\n${end}`;
+};
+
+export const perfReportComment = ({
+    existingBody = '',
+    label,
+    section,
+}: {
+    existingBody?: string;
+    label: string;
+    section: string;
+}): string => {
+    const { start, end } = sectionMarkers(label);
+    const block = perfReportSection({ label, section });
+
+    const startIndex = existingBody.indexOf(start);
+    const endIndex = existingBody.indexOf(end);
+
+    if (startIndex !== -1 && endIndex > startIndex) {
+        return (
+            existingBody.slice(0, startIndex) + block + existingBody.slice(endIndex + end.length)
+        );
+    }
+
+    const base = existingBody.includes(PERF_REPORT_MARKER)
+        ? existingBody.trimEnd()
+        : `${PERF_REPORT_MARKER}\n${PERF_REPORT_HEADING}`;
+
+    return `${base}\n\n${block}`;
+};

--- a/suite/e2e/performance/perfReportPublisher.ts
+++ b/suite/e2e/performance/perfReportPublisher.ts
@@ -1,0 +1,53 @@
+import * as fs from 'node:fs';
+
+import { resolveRunUrl, upsertStickyPrComment } from '@trezor/e2e-utils';
+import {
+    PERF_REPORT_MARKER,
+    type ReportedMeasurement,
+    formatMarkdownReport,
+    perfReportComment,
+    perfReportSection,
+} from '@trezor/perf-e2e';
+
+const runLabel = () => process.env.PERF_REPORT_LABEL || process.env.GITHUB_JOB || 'e2e';
+
+const writeStepSummary = (markdown: string) => {
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    if (!summaryPath) {
+        return;
+    }
+
+    fs.appendFileSync(summaryPath, `${markdown}\n\n`);
+};
+
+type PublishArgs = {
+    measurements: readonly ReportedMeasurement[];
+    budgetsSnippet: { path: string; contents: string };
+    log: (message: string) => void;
+};
+
+export const publishPerfReport = async ({ measurements, budgetsSnippet, log }: PublishArgs) => {
+    const label = runLabel();
+    const section = formatMarkdownReport(measurements, {
+        label,
+        runUrl: resolveRunUrl(),
+        budgetsSnippet,
+    });
+
+    try {
+        writeStepSummary(section);
+    } catch (error) {
+        log(`Failed to write the performance report to the run summary: ${error}`);
+    }
+
+    try {
+        const result = await upsertStickyPrComment({
+            marker: PERF_REPORT_MARKER,
+            buildBody: existingBody => perfReportComment({ existingBody, label, section }),
+            holdsOwnContent: body => body.includes(perfReportSection({ label, section })),
+        });
+        log(`Performance report pull request comment: ${result}.`);
+    } catch (error) {
+        log(`Failed to comment the performance report on the pull request: ${error}`);
+    }
+};

--- a/suite/e2e/performance/perfReporter.ts
+++ b/suite/e2e/performance/perfReporter.ts
@@ -16,6 +16,7 @@ import {
 } from '@trezor/perf-e2e';
 
 import { BASELINES, LIMITS } from './budgets';
+import { publishPerfReport } from './perfReportPublisher';
 
 const BUDGETS_MODULE_PATH = 'suite/e2e/performance/budgets.ts';
 
@@ -105,7 +106,7 @@ class PerfReporter implements Reporter {
         this.reports.push(...runs);
     }
 
-    onEnd(_result: FullResult) {
+    async onEnd(_result: FullResult) {
         if (this.reports.length === 0) {
             return;
         }
@@ -227,6 +228,22 @@ class PerfReporter implements Reporter {
         console.log(lines.join('\n'));
 
         annotateOverLimit(overLimit.map(entry => measurementKey(entry.scenario, entry.project)));
+
+        await publishPerfReport({
+            measurements: measured.map(entry => ({
+                key: entry.key,
+                runs: entry.runs,
+                report: entry.report,
+            })),
+            budgetsSnippet: {
+                path: BUDGETS_MODULE_PATH,
+                contents: formatBudgetsModule(updatedBaselines, updatedLimits),
+            },
+            log: message => {
+                // eslint-disable-next-line no-console
+                console.log(message);
+            },
+        });
     }
 }
 


### PR DESCRIPTION
## Description

The perf e2e report only lived at the bottom of one job's log — easy to miss, hard to find.

- Every measuring e2e job now writes its numbers into **one** sticky PR comment (`<!-- PERF-E2E-REPORT -->`), each job owning its own delimited section: one report per PR, not one per matrix entry.
- Section per job: verdict line, metrics table (auto-unfolded only when over limit), `budgets.ts` paste block, link to the exact run/attempt.
- Same markdown also goes to `GITHUB_STEP_SUMMARY`, so nightly/canary runs (no PR) get it on the run summary page.
- Concurrency: the comment is read back after writing and the section re-applied if a parallel job clobbered it (3 attempts).
- Best effort — publishing failures are logged, never thrown, so they cannot fail a measured run. Console output and the `::error` annotation are unchanged.

New: `formatMarkdownReport`/`perfReportComment` in `@trezor/perf-e2e` (14 unit tests), `upsertStickyPrComment` in `@trezor/e2e-utils`, `PERF_REPORT_LABEL` + `github.token` fallback in `template-suite-run-e2e.yml`.

## Notes for QA

Nothing to test manually — CI reporting only, no app code touched. The comment appears on this PR once a perf-tagged e2e job finishes.

## Related Issue

Resolve #31719

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/31719-profiling-report-pr-comment/web/](https://dev.suite.sldev.cz/suite-web/31719-profiling-report-pr-comment/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=31719-profiling-report-pr-comment&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=31719-profiling-report-pr-comment&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-26T08:04:36.005Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-26T08:03:54.974Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->