### PR TITLE
feat(suite-common): evaluate isBeta in selectSupportedDeviceLanguages using translation metadata

### DIFF
--- a/packages/connect-common/src/types/device.ts
+++ b/packages/connect-common/src/types/device.ts
@@ -1,4 +1,9 @@
-import type { FeaturesNarrowing, FirmwareType, StaticSessionId } from '@trezor/device-utils';
+import {
+    type FeaturesNarrowing,
+    type FirmwareType,
+    type StaticSessionId,
+    type TranslationMetadata,
+} from '@trezor/device-utils';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { ThpStateSerialized } from '@trezor/protocol';
 import type { Descriptor } from '@trezor/transport-common';
@@ -151,7 +156,7 @@ export type KnownDevice = BaseDevice & {
     features: PROTO.Features;
     thp?: DeviceThpState;
     unavailableCapabilities: UnavailableCapabilities;
-    availableTranslations: Record<string, string>;
+    availableTranslations: Record<string, TranslationMetadata>;
     authenticityChecks: {
         firmwareRevision: FirmwareRevisionCheckResult | null;
         firmwareHash: FirmwareHashCheckResult | null;

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -17,7 +17,7 @@ import type {
 } from '@trezor/connect-common';
 import { DEVICE, ERRORS, FIRMWARE, UI_REQUEST } from '@trezor/connect-common';
 import type { CreateLogger } from '@trezor/connect-common/src/types/settings';
-import type { FirmwareRelease } from '@trezor/device-utils';
+import type { FirmwareRelease, TranslationMetadata } from '@trezor/device-utils';
 import {
     DeviceModelInternal,
     getFirmwareOrBootloaderVersionArray,
@@ -168,7 +168,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
     private color?: string;
 
-    private availableTranslations: Record<string, string> = {};
+    private availableTranslations: Record<string, TranslationMetadata> = {};
 
     private authenticityChecks: KnownDevice['authenticityChecks'] = {
         firmwareRevision: null,
@@ -778,9 +778,8 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
             return;
         }
 
-        const release = await getReleaseByVersion(feat, firmwareVersion, newFirmwareType);
-        this._currentRelease = release;
-        this.availableTranslations = this._currentRelease?.translations ?? {};
+        this._currentRelease = await getReleaseByVersion(feat, firmwareVersion, newFirmwareType);
+        this.updateAvailableTranslations();
     }
 
     private _updateFeatures(feat: Features) {
@@ -828,7 +827,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                     newVersion,
                     getFirmwareType(feat),
                 );
-                this.availableTranslations = this._currentRelease?.translations ?? {};
+                this.updateAvailableTranslations();
             }
         }
 
@@ -887,6 +886,15 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                 device: this.toMessageObject(),
             });
         }
+    }
+
+    private updateAvailableTranslations() {
+        this.availableTranslations = Object.fromEntries(
+            Object.keys(this._currentRelease?.translations ?? {}).map(locale => [
+                locale,
+                this._currentRelease?.translations_metadata?.[locale] ?? { status: 'beta' },
+            ]),
+        );
     }
 
     private updateNameAndColor() {

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -86,6 +86,10 @@ export type PartialDevice = {
 
 export type FirmwareSource = 'official' | 'unknown' | 'NA - bootloader';
 
+export type TranslationMetadata = {
+    status: 'production' | 'beta';
+};
+
 // Type `FirmwareRelease` is the original in releases.json probably we should get rid of it once this is replaced by the new FirmwareReleaseConfig
 export type FirmwareRelease = {
     required: boolean;
@@ -95,6 +99,7 @@ export type FirmwareRelease = {
     min_firmware_version: VersionArray;
     min_bootloader_version: VersionArray;
     translations: Record<string, string>;
+    translations_metadata?: Record<string, TranslationMetadata>;
     firmware_revision?: string;
     bootloader_hash?: string;
     fingerprint: string;

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -168,7 +168,7 @@ export const selectSupportedDeviceLanguages = createMemoizedSelector(
                 value: code as Locale,
                 icon,
                 label: name,
-                isBeta: true, // TODO: This will need tweaking in the future.
+                isBeta: availableDeviceTranslations[code]?.status === 'beta',
             }))
             .sort((a, b) => a.label.localeCompare(b.label));
 

--- a/suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts
+++ b/suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts
@@ -245,12 +245,12 @@ export const btcDiscoveryFinishedStateT3T1: PreloadedState = {
                     evolu: 'update-required',
                 },
                 availableTranslations: {
-                    'cs-CZ': 'firmware/translations/t3t1/translation-T3T1-cs-CZ-2.9.0.bin',
-                    'de-DE': 'firmware/translations/t3t1/translation-T3T1-de-DE-2.9.0.bin',
-                    'es-ES': 'firmware/translations/t3t1/translation-T3T1-es-ES-2.9.0.bin',
-                    'fr-FR': 'firmware/translations/t3t1/translation-T3T1-fr-FR-2.9.0.bin',
-                    'it-IT': 'firmware/translations/t3t1/translation-T3T1-it-IT-2.9.0.bin',
-                    'pt-BR': 'firmware/translations/t3t1/translation-T3T1-pt-BR-2.9.0.bin',
+                    'cs-CZ': { status: 'beta' },
+                    'de-DE': { status: 'beta' },
+                    'es-ES': { status: 'beta' },
+                    'fr-FR': { status: 'beta' },
+                    'it-IT': { status: 'beta' },
+                    'pt-BR': { status: 'beta' },
                 },
                 authenticityChecks: {
                     firmwareRevision: {

--- a/suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3T1.ts
+++ b/suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3T1.ts
@@ -261,12 +261,12 @@ export const regtestDiscoveryFinishedStateT3T1: PreloadedState = {
                     evolu: 'update-required',
                 },
                 availableTranslations: {
-                    'cs-CZ': 'firmware/translations/t3t1/translation-T3T1-cs-CZ-2.9.0.bin',
-                    'de-DE': 'firmware/translations/t3t1/translation-T3T1-de-DE-2.9.0.bin',
-                    'es-ES': 'firmware/translations/t3t1/translation-T3T1-es-ES-2.9.0.bin',
-                    'fr-FR': 'firmware/translations/t3t1/translation-T3T1-fr-FR-2.9.0.bin',
-                    'it-IT': 'firmware/translations/t3t1/translation-T3T1-it-IT-2.9.0.bin',
-                    'pt-BR': 'firmware/translations/t3t1/translation-T3T1-pt-BR-2.9.0.bin',
+                    'cs-CZ': { status: 'beta' },
+                    'de-DE': { status: 'beta' },
+                    'es-ES': { status: 'beta' },
+                    'fr-FR': { status: 'beta' },
+                    'it-IT': { status: 'beta' },
+                    'pt-BR': { status: 'beta' },
                 },
                 authenticityChecks: {
                     firmwareRevision: {


### PR DESCRIPTION
## Description

* FW translation metadata stored in `KnownDevice.availableTranslations`.
  * The URI values were not used at all thus it was possible to modify the structure.
  * In case the URI values are ever needed, we may easily add them as another `uri` field next to `status`.
* e2e tests adapted to changes of `KnownDevice.availableTranslations`.
* `isBeta` in `selectSupportedDeviceLanguages` evaluated using the translation metadata.

## Notes for QA

It's necessary to change the `Firmware source` for testing.

## Related Issue

Resolve #23767

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches core device types, the Device class, and Redux device selectors—broad infrastructure that many tests transitively import. The highest-risk regressions are in device status reporting, session management, and device-derived metadata. The recommended tests focus narrowly on those areas rather than the full 136-test static mapping. The two suite-native fixture files have no web/electron E2E coverage in the provided candidate set and should be validated separately in the native test pipeline.

<details><summary><b>Changed files (6)</b></summary>

- `packages/connect-common/src/types/device.ts`
- `packages/connect/src/device/Device.ts`
- `packages/device-utils/src/types.ts`
- `suite-common/device/src/deviceSelectors.ts`
- `suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts`
- `suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3T1.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Directly asserts the DeviceConnect analytics payload contains device metadata (model, pin/passphrase protection, backup type, optiga_sec) that is derived from the Device class and device types. A change in packages/connect/src/device/Device.ts or packages/connect-common/src/types/device.ts would likely surface here first.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Exercises device session state transitions and the device status indicators (TR_USE_HERE / TR_CONNECTED) that rely on device selectors and the bridge/Device layer. Changes to device state handling or session enumeration would be immediately visible.
- `suite/e2e/tests/wallet/without-device.test.ts` — Validates disconnected-device behavior: device disconnected status, the connection modal, and the disconnected banner. This is a direct regression test for device state/selectors after changes to Device.ts or deviceSelectors.ts.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Covers the device switcher flow (eject wallet, add standard wallet) and multi-coin discovery, both of which depend on accurate device state and selector-derived wallet lists.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests device power-off/power-on reconnection and whether passphrase wallets remain cached and selectable in the device switcher after reconnect. This exercises device state persistence and selector behavior.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Simulates bridge stop/start (device disconnect/reconnect) during a recovery dry run and verifies the flow reinitializes correctly. Relevant to Device.ts bridge/session handling.
- `suite/e2e/tests/settings/forget-device.test.ts` — Covers the forget-device flow for both connected and disconnected devices, including Bluetooth state. This depends on device state, device model detection, and related selectors.
- `suite/e2e/tests/wallet/remembered-wallet-loading.test.ts` — Verifies that a remembered wallet loads and renders correctly without a connected device, including device-disconnected status. Changes to device selectors or remembered-device state could break this.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-native/app/e2e/fixtures/btcDiscoveryFinishedStateT3T1.ts`
- `suite-native/app/e2e/fixtures/regtestDiscoveryFinishedStateT3T1.ts`
- `packages/device-utils/src/types.ts`

_Updated: 2026-08-27T08:04:24.954Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/fw-translation-metadata/web/](https://dev.suite.sldev.cz/suite-web/feat/fw-translation-metadata/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T08:04:27.924Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T08:04:45.930Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fw-translation-metadata&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fw-translation-metadata&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fw-translation-metadata&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->