### PR TITLE
fix (suite): change Eth displayablePublicKey to hex instead of xpub

### DIFF
--- a/packages/connect-common/src/types/params.ts
+++ b/packages/connect-common/src/types/params.ts
@@ -119,7 +119,7 @@ export const PublicKey = Type.Object({
      * Canonical user-facing representation of the public key for the given coin.
      * - Bitcoin: `xpubSegwit ?? xpub` (SLIP-132 form matching the requested
      *   scriptType, e.g. ypub/zpub for SegWit, `tr(...)` descriptor for Taproot)
-     * - Ethereum: `xpub`
+     * - Ethereum: hex-encoded compressed public key (same value as `publicKey`)
      * - Cardano: extended public key (xpub)
      * - Solana: base58-encoded address (same value as `publicKeyBase58`)
      * - Tezos: base58check-encoded public key, `edpk…` (same value as `publicKey`)
@@ -139,11 +139,8 @@ export const PublicKey = Type.Object({
      *   while this field is the BIP-389 multipath descriptor with `'`-notation
      *   and trailing `/<0;1>/*` used to derive both external and change
      *   addresses (e.g. `tr([fp/86'/0'/0']xpub…/<0;1>/*)`).
-     * - Ethereum: firmware shows the raw compressed public key (`publicKey`,
-     *   33 bytes hex); this field is the `xpub` because that's the more useful
-     *   identifier in host-side UIs. Suite displays the xpub, the device shows
-     *   the compressed key — both are correct representations of the same
-     *   underlying secp256k1 point at the requested path.
+     * - Ethereum: byte-identical to the raw compressed public key (`publicKey`,
+     *   33 bytes hex) shown by firmware.
      */
     displayablePublicKey: Type.String(),
 });

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetPublicKey.mdx
@@ -85,16 +85,10 @@ Result with only one public key
         childNum: number,             // BIP32 serialization format
         fingerprint: number,          // BIP32 serialization format
         depth: number,                // BIP32 serialization format
-        displayablePublicKey: string, // canonical user-facing form (= xpub)
+        displayablePublicKey: string, // canonical user-facing form (= publicKey)
     }
 }
 ```
-
-> **`displayablePublicKey` vs. firmware display.** With `showOnTrezor: true` the
-> device shows the raw compressed `publicKey` (33-byte hex). This field is the
-> `xpub` instead, because that's the more useful identifier in host-side UIs
-> (Trezor Suite displays the xpub in its address-confirmation modal). Both are
-> correct representations of the same secp256k1 point at the requested path.
 
 [Read more about BIP32 serialization format](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Serialization_format)
 

--- a/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
@@ -13,7 +13,7 @@ const generatedTests = commonFixtures.tests.flatMap(({ parameters, result }) => 
         chainCode: result.chain_code,
         publicKey: result.public_key,
         xpub: result.xpub,
-        displayablePublicKey: result.xpub,
+        displayablePublicKey: result.public_key,
     },
 }));
 

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -100,7 +100,7 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
                 publicKey: publicKey.node.public_key,
                 fingerprint: publicKey.node.fingerprint,
                 depth: publicKey.node.depth,
-                displayablePublicKey: publicKey.xpub,
+                displayablePublicKey: publicKey.node.public_key,
             };
 
             responses.push(response);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The latest firmware was displaying hex on the device screen for Ethereum exports but Suite was showing the xpub format.  That confuses users because they are being asked to verify two different things, so I switched displayablePublicKey to be the hex value for Ethereum.

<!--- Describe your changes in detail -->
I change `ethereumGetPublicKey.ts` from `publicKey.xpub` to `publicKey.node.public_key` which is the hex representation of the public key.  

## Notes for QA

You can test this by using Connect v10 and exporting an xpub with the Trezor Ethereum code.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31739

## Screenshots:

**Before:** 
<img width="1704" height="919" alt="eth-xpub-export" src="https://github.com/user-attachments/assets/575c576d-9ada-4075-9ac3-3c63738e338a" />

**After**
<img width="4624" height="3472" alt="PXL_20260825_135330940" src="https://github.com/user-attachments/assets/2fdbfa8f-b05c-4f08-91fb-e934e781964f" />
