### PR TITLE
feat (suite): Allow Ethereum depth 1 exports

### DIFF
--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.test.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.test.ts
@@ -1,0 +1,37 @@
+import EthereumGetPublicKey from './ethereumGetPublicKey';
+
+// Minimal MethodMessage that exercises only the constructor's param validation.
+const construct = (path: unknown) =>
+    new EthereumGetPublicKey({ payload: { method: 'ethereumGetPublicKey', path } } as any);
+
+describe('api/ethereum/ethereumGetPublicKey', () => {
+    describe('path validation (validatePath length)', () => {
+        it('accepts a full BIP44 Ethereum path and resolves the network', () => {
+            const method = construct("m/44'/60'/0'");
+
+            expect(method.params).toHaveLength(1);
+            expect(method.params[0].network?.shortcut).toBe('ETH');
+        });
+
+        // The method now validates with length 1 (previously 3), so partial paths that
+        // used to throw "Not a valid path" are accepted.
+        it('accepts a two-element path and still resolves the network from the slip44 part', () => {
+            const method = construct("m/44'/60'");
+
+            expect(method.params).toHaveLength(1);
+            // slip44 lives at path[1], so the network still resolves.
+            expect(method.params[0].network?.shortcut).toBe('ETH');
+        });
+
+        it('accepts a single-element path (network is undefined, no slip44 part)', () => {
+            const method = construct("m/44'");
+
+            expect(method.params).toHaveLength(1);
+            expect(method.params[0].network).toBeUndefined();
+        });
+
+        it('still rejects an empty path (shorter than the required length of 1)', () => {
+            expect(() => construct('m')).toThrow(/Not a valid path/);
+        });
+    });
+});

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -32,7 +32,7 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
         Assert(Bundle(GetPublicKeySchema), payload);
 
         const params = payload.bundle.map(batch => {
-            const path = validatePath(batch.path, 3);
+            const path = validatePath(batch.path, 1);
             const network = getEthereumNetwork(path);
 
             const proto = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change lets Casa use the Ethereum app for m/45' exports, previously Casa was using the Bitcoin app and with Connect v10 messaging it would confuse users 'Why is it saying I am exporting for Bitcoin when I am exporting for Ethereum?'

This also adds unit tests for this.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

I have added unit tests for this, you can see that exporting from root is still blocked.  

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31739

## Screenshots:

These screenshots were taken using the Ethereum Casa export flow.  You can see that there is no longer a reference to "Bitcoin" in the permission block since we are now able to use the Ethereum api.

**Before**
<img width="3456" height="1898" alt="Screenshot 2026-08-19 at 12 18 07 PM" src="https://github.com/user-attachments/assets/b0ba9c45-5a38-405d-a683-e2d603eb8e05" />

**After**
<img width="4624" height="3472" alt="PXL_20260825_135306114" src="https://github.com/user-attachments/assets/3d59a19e-cf3e-4207-959b-0edb5e26f821" />
<img width="4624" height="3472" alt="PXL_20260825_135330940" src="https://github.com/user-attachments/assets/22906711-acff-45d5-b098-fcbcf55aed1d" />
