### PR TITLE
feat (suite): Add optional script type param to Sign Message

### DIFF
--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -640,6 +640,13 @@ export const signMessage = async (api: TrezorConnect) => {
         payload.address.toLowerCase();
         payload.signature.toLowerCase();
     }
+
+    // optional scriptType override
+    api.signMessage({ path: 'm/44', coin: 'btc', message: 'foo', scriptType: 'SPENDTAPROOT' });
+
+    // @ts-expect-error unknown scriptType
+    api.signMessage({ path: 'm/44', coin: 'btc', message: 'foo', scriptType: 'NOT_A_SCRIPT_TYPE' });
+
     const verify = await api.verifyMessage({
         address: 'a',
         signature: 'a',

--- a/packages/connect-common/src/types/api/bitcoin/common.ts
+++ b/packages/connect-common/src/types/api/bitcoin/common.ts
@@ -1,6 +1,6 @@
 import type { AccountAddresses } from '@trezor/blockchain-link';
 import type { BlockbookTransaction } from '@trezor/blockchain-link-types';
-import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
@@ -18,6 +18,7 @@ export const SignMessage = Type.Object({
     message: Type.String(),
     hex: Type.Optional(Type.Boolean()),
     no_script_type: Type.Optional(Type.Boolean()),
+    scriptType: Type.Optional(PROTO.InternalInputScriptType),
 });
 
 // signTransaction

--- a/packages/connect/src/api/signMessage.test.ts
+++ b/packages/connect/src/api/signMessage.test.ts
@@ -1,0 +1,42 @@
+import SignMessage from './signMessage';
+
+// The method constructor is enough to exercise the script_type resolution: it derives
+// proto.script_type from either the caller-supplied scriptType or, failing that, the path
+// (getScriptType). getBitcoinNetwork reads statically-loaded coin data, so no device is needed.
+const buildProto = (params: Record<string, unknown>) =>
+    (new SignMessage({ payload: { method: 'signMessage', ...params } } as any) as any).params.proto;
+
+const base = { coin: 'btc', message: 'This is an example of a signed message.' };
+
+describe('SignMessage script_type resolution', () => {
+    it('derives script_type from the path when no scriptType is given', () => {
+        // m/44' -> legacy, m/84' -> native segwit
+        expect(buildProto({ ...base, path: "m/44'/0'/0'/0/0" }).script_type).toBe('SPENDADDRESS');
+        expect(buildProto({ ...base, path: "m/84'/0'/0'/0/0" }).script_type).toBe('SPENDWITNESS');
+    });
+
+    it('prefers an explicit scriptType over the path-derived one', () => {
+        // legacy path, but the caller overrides to native segwit
+        expect(
+            buildProto({ ...base, path: "m/44'/0'/0'/0/0", scriptType: 'SPENDWITNESS' })
+                .script_type,
+        ).toBe('SPENDWITNESS');
+        expect(
+            buildProto({ ...base, path: "m/44'/0'/0'/0/0", scriptType: 'SPENDTAPROOT' })
+                .script_type,
+        ).toBe('SPENDTAPROOT');
+    });
+
+    it("coerces SPENDMULTISIG to SPENDADDRESS (firmware rejects 'SPENDMULTISIG')", () => {
+        expect(
+            buildProto({ ...base, path: "m/44'/0'/0'/0/0", scriptType: 'SPENDMULTISIG' })
+                .script_type,
+        ).toBe('SPENDADDRESS');
+    });
+
+    it('rejects an unknown scriptType via schema validation', () => {
+        expect(() =>
+            buildProto({ ...base, path: "m/44'/0'/0'/0/0", scriptType: 'NOT_A_SCRIPT_TYPE' }),
+        ).toThrow();
+    });
+});

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -41,7 +41,7 @@ export default class SignMessage extends AbstractMethod<'signMessage', Params> {
 
         const readableMessage = payload.hex ? hexToText(payload.message) : payload.message;
 
-        const scriptType = getScriptType(path);
+        const scriptType = payload.scriptType || getScriptType(path);
         const proto = {
             address_n: path,
             message: messageHex,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently when Signing a message, Trezor Suite chooses what script type should be used based on the derivation path purpose level.  Casa uses 45 (in a custom manner different from bip 45, closer to bip48) and signs healthcheck messages with .  This is failing to be found in pathUtils.ts getScriptType() and falls back to and shows a warning screen as a result.

This commit adds an optional script type param so that callers can specify what script type they want to sign with.


<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31739

## Screenshots:

I no longer see the warning screen when performing the Casa Bitcoin health check:
<img width="4624" height="3472" alt="PXL_20260825_151416671" src="https://github.com/user-attachments/assets/4cc6199f-f71c-4a54-aebf-f7740b8793e4" />
<img width="4624" height="3472" alt="PXL_20260825_151421418" src="https://github.com/user-attachments/assets/7e6c7f8c-1314-4e23-856b-57cb441f027b" />
