### PR TITLE
Unblock Cardano delegation for first-time stakers

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -1,0 +1,93 @@
+import { type AdaPools } from '@suite-common/earn-staking-api';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
+import TrezorConnect, { PROTO } from '@trezor/connect';
+
+import { prepareTxPlan } from './stakeFormCardanoActions';
+
+jest.mock('@trezor/connect', () => {
+    const actual = jest.requireActual('@trezor/connect');
+
+    return {
+        ...actual,
+        __esModule: true,
+        default: {
+            ...actual.default,
+            cardanoComposeTransaction: jest.fn(),
+        },
+    };
+});
+
+const cardanoComposeTransactionMock = TrezorConnect.cardanoComposeTransaction as jest.Mock;
+
+const CHANGE_ADDRESS = {
+    address: 'addr1change',
+    path: "m/1852'/1815'/0'/1/0",
+    transfers: 0,
+    balance: '0',
+    sent: '0',
+    received: '0',
+};
+
+const cardanoPools: AdaPools['pools'] = [];
+
+const mockNeverStakedAccount = (): Account =>
+    mockWalletAccount(
+        {
+            symbol: asNetworkSymbol('ada'),
+            addresses: { change: [CHANGE_ADDRESS], used: [], unused: [] },
+            utxo: [],
+        },
+        {
+            ...networkSpecificDefaultCardano,
+            misc: {
+                staking: { address: '', isActive: false, rewards: '', poolId: null, drep: null },
+            },
+        },
+    );
+
+const mockComposeSuccess = () => {
+    cardanoComposeTransactionMock.mockResolvedValue({
+        success: true,
+        payload: [{ type: 'final', fee: '174301', deposit: '2000000' }],
+    });
+};
+
+describe('prepareTxPlan', () => {
+    beforeEach(() => {
+        cardanoComposeTransactionMock.mockReset();
+    });
+
+    it('composes a delegation for an account that has no staking address and no rewards yet', async () => {
+        mockComposeSuccess();
+
+        const result = await prepareTxPlan({
+            account: mockNeverStakedAccount(),
+            action: 'delegate',
+            cardanoPools,
+        });
+
+        expect(result?.txPlan).toEqual({ type: 'final', fee: '174301', deposit: '2000000' });
+        expect(cardanoComposeTransactionMock).toHaveBeenCalledTimes(1);
+        expect(cardanoComposeTransactionMock.mock.calls[0][0].certificates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: PROTO.CardanoCertificateType.STAKE_REGISTRATION }),
+                expect.objectContaining({ type: PROTO.CardanoCertificateType.STAKE_DELEGATION }),
+            ]),
+        );
+    });
+
+    it('does not compose a withdrawal when there is nothing to withdraw', async () => {
+        mockComposeSuccess();
+
+        const result = await prepareTxPlan({
+            account: mockNeverStakedAccount(),
+            action: 'withdrawal',
+            cardanoPools,
+        });
+
+        expect(result).toBeNull();
+        expect(cardanoComposeTransactionMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -100,12 +100,19 @@ const calculateTransaction = (
     );
 };
 
-export const prepareTxPlan = async (
-    account: Account,
-    action: CardanoAction,
-    cardanoPools: AdaPools['pools'],
-    votingDelegation?: VotingDelegationOption,
-) => {
+type PrepareTxPlanParams = {
+    account: Account;
+    action: CardanoAction;
+    cardanoPools: AdaPools['pools'];
+    votingDelegation?: VotingDelegationOption;
+};
+
+export const prepareTxPlan = async ({
+    account,
+    action,
+    cardanoPools,
+    votingDelegation,
+}: PrepareTxPlanParams) => {
     if (account?.networkType !== 'cardano') return;
 
     const changeAddress = getUnusedChangeAddress(account);
@@ -206,19 +213,19 @@ const getTransactionData = (
     const { account } = selectedAccount;
 
     if (stakeType === 'stake') {
-        return prepareTxPlan(account, 'delegate', cardanoPools, votingDelegation);
+        return prepareTxPlan({ account, action: 'delegate', cardanoPools, votingDelegation });
     }
 
     if (stakeType === 'unstake') {
-        return prepareTxPlan(account, 'deregister', cardanoPools, votingDelegation);
+        return prepareTxPlan({ account, action: 'deregister', cardanoPools, votingDelegation });
     }
 
     if (stakeType === 'claim') {
-        return prepareTxPlan(account, 'withdrawal', cardanoPools, votingDelegation);
+        return prepareTxPlan({ account, action: 'withdrawal', cardanoPools, votingDelegation });
     }
 
     if (stakeType === 'change-delegate') {
-        return prepareTxPlan(account, 'voteDelegate', cardanoPools, votingDelegation);
+        return prepareTxPlan({ account, action: 'voteDelegate', cardanoPools, votingDelegation });
     }
 };
 

--- a/packages/suite/src/hooks/earn/useCardanoStaking.test.tsx
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.test.tsx
@@ -1,0 +1,115 @@
+import { act } from '@testing-library/react';
+
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { stakeInitialState } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
+import TrezorConnect from '@trezor/connect';
+
+import { useCardanoStaking } from './useCardanoStaking';
+
+jest.mock('@trezor/connect', () => {
+    const actual = jest.requireActual('@trezor/connect');
+
+    return {
+        ...actual,
+        __esModule: true,
+        default: {
+            ...actual.default,
+            cardanoComposeTransaction: jest.fn(),
+        },
+    };
+});
+
+const cardanoComposeTransactionMock = TrezorConnect.cardanoComposeTransaction as jest.Mock;
+
+const CHANGE_ADDRESS = {
+    address: 'addr1change',
+    path: "m/1852'/1815'/0'/1/0",
+    transfers: 0,
+    balance: '0',
+    sent: '0',
+    received: '0',
+};
+
+const mockNeverStakedAccount = (): Account =>
+    mockWalletAccount(
+        {
+            symbol: asNetworkSymbol('ada'),
+            availableBalance: '10000000',
+            addresses: { change: [CHANGE_ADDRESS], used: [], unused: [] },
+            utxo: [],
+        },
+        {
+            ...networkSpecificDefaultCardano,
+            misc: {
+                staking: { address: '', isActive: false, rewards: '', poolId: null, drep: null },
+            },
+        },
+    );
+
+const renderCardanoStaking = (account: Account) => {
+    const store = configureMockStore({
+        extra: undefined,
+        preloadedState: {
+            wallet: {
+                selectedAccount: { account },
+                stake: stakeInitialState,
+                transactions: { transactions: {} },
+            },
+        },
+    });
+
+    return renderHookWithStoreProvider(() => useCardanoStaking(), { store });
+};
+
+describe('useCardanoStaking', () => {
+    beforeEach(() => {
+        cardanoComposeTransactionMock.mockReset();
+    });
+
+    it('makes delegation available to an account that has never staked', async () => {
+        cardanoComposeTransactionMock.mockResolvedValue({
+            success: true,
+            payload: [{ type: 'final', fee: '174301', deposit: '2000000' }],
+        });
+
+        const { result } = renderCardanoStaking(mockNeverStakedAccount());
+
+        expect(result.current.delegatingAvailable.status).toBe(false);
+
+        await act(() => result.current.calculateFeeAndDeposit('delegate'));
+
+        expect(result.current.delegatingAvailable.status).toBe(true);
+        expect(result.current.isStakingDisabled).toBe(false);
+        expect(result.current.fee).toBe('174301');
+        expect(result.current.deposit).toBe('2000000');
+    });
+
+    it('keeps staking unavailable when the composed delegation is not final', async () => {
+        cardanoComposeTransactionMock.mockResolvedValue({
+            success: true,
+            payload: [{ type: 'nonfinal', fee: '174301', deposit: '2000000' }],
+        });
+
+        const { result } = renderCardanoStaking(mockNeverStakedAccount());
+
+        await act(() => result.current.calculateFeeAndDeposit('delegate'));
+
+        expect(result.current.delegatingAvailable).toEqual({
+            status: false,
+            reason: 'TX_NOT_FINAL',
+        });
+        expect(result.current.isStakingDisabled).toBe(true);
+    });
+
+    it('does not make withdrawing available when there is nothing to withdraw', async () => {
+        const { result } = renderCardanoStaking(mockNeverStakedAccount());
+
+        await act(() => result.current.calculateFeeAndDeposit('withdrawal'));
+
+        expect(result.current.withdrawingAvailable.status).toBe(false);
+        expect(cardanoComposeTransactionMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -1,22 +1,17 @@
 import { useCallback, useState } from 'react';
 
-import { hasPendingStakeTypeTransaction, selectCardanoPoolsInfo } from '@suite-common/wallet-core';
+import {
+    hasPendingStakeTypeTransaction,
+    selectCardanoPoolsInfo,
+    selectVotingDelegationOption,
+} from '@suite-common/wallet-core';
 import {
     type ActionAvailability,
     type CardanoAction,
     type CardanoStaking,
 } from '@suite-common/wallet-types';
-import {
-    getAddressParameters,
-    getCardanoAccountPoolId,
-    getDelegationCertificates,
-    getStakingPath,
-    getUnusedChangeAddress,
-    isTestnet,
-    selectBestCardanoPool,
-} from '@suite-common/wallet-utils';
-import trezorConnect, { type CardanoCertificate } from '@trezor/connect';
 
+import { prepareTxPlan } from 'src/actions/wallet/stake/stakeFormCardanoActions';
 import { useSelector } from 'src/hooks/suite';
 
 export const useCardanoStaking = (): CardanoStaking => {
@@ -25,6 +20,7 @@ export const useCardanoStaking = (): CardanoStaking => {
     const isCardano = account?.networkType === 'cardano';
 
     const cardanoPools = useSelector(selectCardanoPoolsInfo);
+    const votingDelegation = useSelector(selectVotingDelegationOption);
     const hasPendingTx = useSelector(state =>
         account ? hasPendingStakeTypeTransaction(state, account.key) : false,
     );
@@ -43,88 +39,26 @@ export const useCardanoStaking = (): CardanoStaking => {
         status: false,
     });
 
-    const {
-        rewards: rewardsAmount,
-        address: stakeAddress,
-        isActive: isStakingActive,
-    } = isCardano ? account.misc.staking : {};
+    const { rewards: rewardsAmount, isActive: isStakingActive } = isCardano
+        ? account.misc.staking
+        : {};
 
     const isStakingDisabled =
         (account?.availableBalance === '0' || !delegatingAvailable.status || hasPendingTx) &&
         !loading;
 
-    const prepareTxPlan = useCallback(
+    const calculateFeeAndDeposit = useCallback(
         async (action: CardanoAction) => {
             if (!account) return;
 
-            const changeAddress = getUnusedChangeAddress(account);
-            const stakingPath = getStakingPath(account);
-
-            if (
-                !changeAddress ||
-                !account.utxo ||
-                !account.addresses ||
-                !rewardsAmount ||
-                !stakeAddress
-            )
-                return null;
-
-            const addressParameters = getAddressParameters(account, changeAddress.path);
-
-            const selectedPool = selectBestCardanoPool(
-                cardanoPools,
-                getCardanoAccountPoolId(account),
-            );
-
-            let certificates: CardanoCertificate[] = [];
-
-            if (action === 'delegate') {
-                if (!selectedPool) {
-                    return null;
-                }
-
-                certificates = getDelegationCertificates(
-                    stakingPath,
-                    selectedPool.hex,
-                    !isStakingActive,
-                );
-            }
-
-            const withdrawals =
-                action === 'withdrawal'
-                    ? [
-                          {
-                              amount: rewardsAmount,
-                              path: stakingPath,
-                              stakeAddress,
-                          },
-                      ]
-                    : [];
-
-            const response = await trezorConnect.cardanoComposeTransaction({
-                account: {
-                    descriptor: account.descriptor,
-                    utxo: account.utxo,
-                },
-                certificates,
-                withdrawals,
-                changeAddress,
-                addressParameters,
-                testnet: isTestnet(account.symbol),
-            });
-
-            if (!response.success) throw new Error(response.error.message);
-
-            return { txPlan: response.payload[0], certificates, withdrawals };
-        },
-        [account, isStakingActive, rewardsAmount, stakeAddress, cardanoPools],
-    );
-
-    const calculateFeeAndDeposit = useCallback(
-        async (action: CardanoAction) => {
             setLoading(true);
             try {
-                const composeRes = await prepareTxPlan(action);
+                const composeRes = await prepareTxPlan({
+                    account,
+                    action,
+                    cardanoPools,
+                    votingDelegation,
+                });
                 if (composeRes?.txPlan) {
                     if (composeRes.txPlan.type === 'error') {
                         throw new Error(composeRes.txPlan.error);
@@ -157,7 +91,7 @@ export const useCardanoStaking = (): CardanoStaking => {
 
             setLoading(false);
         },
-        [prepareTxPlan],
+        [account, cardanoPools, votingDelegation],
     );
 
     // TODO: improve this hook for non-cardano accounts


### PR DESCRIPTION
## Description

`useCardanoStaking` composed its own tx plan and bailed out when the account had no staking address or rewards, permanently disabling the Stake button for first-time stakers. It now reuses the shared `prepareTxPlan`, which applies that guard only to withdrawals.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30030

## Screenshots:
<img width="956" height="489" alt="Screenshot 2026-08-26 at 06 47 25" src="https://github.com/user-attachments/assets/137b3152-5ca6-4c08-9e99-7534d20ef8fa" />
