### PR TITLE
test(connect): e2e the WARD offline queue against a firmware branch

### DIFF
--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -15,6 +15,11 @@ on:
         type: "string"
         required: false
         default: "2-latest"
+      testsFirmwareBranch:
+        description: "Build the emulator firmware from this trezor-firmware branch instead of a released version (used by WARD, which ships only in a branch, e.g. petrsusil/ward-draft). Overrides `testsFirmware`."
+        type: "string"
+        required: false
+        default: ""
       testFirmwareModel:
         description: "Firmware model for the tests (example: T3T1)"
         type: "string"
@@ -83,6 +88,8 @@ jobs:
         run: echo "ADDITIONAL_ARGS=-c" >> "$GITHUB_ENV"
       - if: ${{ inputs.testFirmwareModel }}
         run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -m ${{ inputs.testFirmwareModel }}" >> "$GITHUB_ENV"
+      - if: ${{ inputs.testsFirmwareBranch }}
+        run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -b ${{ inputs.testsFirmwareBranch }}" >> "$GITHUB_ENV"
       - if: ${{ inputs.includeFilter }}
         run: echo "ADDITIONAL_ARGS=$ADDITIONAL_ARGS -i ${{ inputs.includeFilter }}" >> "$GITHUB_ENV"
       - if: ${{ inputs.testRandomizedOrder }}

--- a/.github/workflows/test-connect-custom.yml
+++ b/.github/workflows/test-connect-custom.yml
@@ -32,13 +32,17 @@ on:
         description: "Firmware version (e.g. 2-latest, 1-latest, 2-main, 2.11.0...)"
         type: string
         default: "2-latest"
+      deviceBranch:
+        description: "Build the emulator firmware from this trezor-firmware branch (overrides the version). Required to run the `ward` group, since WARD ships only in a branch (use petrsusil/ward-draft). Leave empty for released firmware."
+        type: string
+        default: ""
       groups:
-        description: "Test groups (e.g. api,init,thp)"
+        description: "Test groups (e.g. api,init,thp,ward)"
         type: string
         default: "all"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.testEnv }}-${{ inputs.deviceModel }}-${{ inputs.deviceVersion }}-${{ inputs.transport }}-${{ inputs.groups }}
+  group: ${{ github.workflow }}-${{ inputs.testEnv }}-${{ inputs.deviceModel }}-${{ inputs.deviceVersion }}-${{ inputs.deviceBranch }}-${{ inputs.transport }}-${{ inputs.groups }}
   cancel-in-progress: true
 
 jobs:
@@ -72,6 +76,7 @@ jobs:
       testPattern: ${{ matrix.groups.pattern }}
       includeFilter: ${{ matrix.groups.includeFilter }}
       testsFirmware: ${{ matrix.firmware }}
+      testsFirmwareBranch: ${{ inputs.deviceBranch }}
       testDescription: ${{ matrix.env }}-${{ matrix.groups.pattern }}-${{ matrix.groups.name }}
       disable_cache_tx: ${{ matrix.disable_cache_tx }}
       transport: ${{ matrix.transport }}

--- a/packages/connect/e2e/README.md
+++ b/packages/connect/e2e/README.md
@@ -26,6 +26,39 @@ For local changes to take effect build connect-iframe or connect-web depending w
 TESTS_PATTERN="init" yarn workspace @trezor/connect test:e2e:web
 ```
 
+## WARD (firmware branch)
+
+WARD is not part of any released firmware — it lives in a `trezor-firmware` branch — and its
+multi-session THP parts need the **T3W1** model. So the WARD arc
+([`tests/device/ward.test.ts`](./tests/device/ward.test.ts)) is opt-in: it only runs when the
+emulator is started **from a firmware branch** on T3W1, and skips on every other matrix.
+
+`trezor-user-env` builds the emulator from the branch you name (`-b`, wired through
+`TESTS_FIRMWARE_BRANCH` → `emulator-start-from-branch`). The WARD firmware lives on the
+[`petrsusil/ward-draft`](https://github.com/trezor/trezor-firmware/tree/petrsusil/ward-draft) branch
+of `trezor-firmware`. Run the offline queue arc locally with:
+
+```
+./docker/docker-connect-test.sh node -b petrsusil/ward-draft -m T3W1 -p ward
+```
+
+or directly against a running `trezor-user-env`:
+
+```
+TESTS_FIRMWARE_BRANCH=petrsusil/ward-draft \
+TESTS_FIRMWARE_MODEL=T3W1 \
+TESTS_PATTERN=ward \
+yarn workspace @trezor/connect test:e2e:node
+```
+
+In CI, dispatch the **`[Test] connect custom e2e setup`** workflow with
+`deviceModel=T3W1`, `deviceBranch=petrsusil/ward-draft`, `groups=ward`.
+
+This covers the OFFLINE queue methods (`wardQueueSetEntry` / `wardQueueGetEntry` /
+`wardQueueDeleteEntry` / `wardResetApp`) end to end against real firmware. The ONLINE
+reads/writes/flushes (`wardGetEntry` / `wardSetEntry` / `wardFlushQueue`) need a `wardd` replica and
+are covered by [`packages/connect-cli/e2e/ward-queue.sh`](../../connect-cli/e2e/ward-queue.sh).
+
 ## Transactions cache
 
 Bitcoin-like coins `signTransaction` method require additional data about transactions referenced from used inputs.

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -23,6 +23,13 @@ if (!deviceModel) {
     throw new Error('Device model must be provided');
 }
 
+// Exposed so bespoke tests can gate themselves on the emulator they were handed. WARD, for
+// instance, only exists in a firmware-branch build on T3W1 (see tests/device/ward.test.ts), so
+// its arc must skip every other matrix rather than call methods the firmware does not have. Typed
+// as plain strings so consumers can compare against literals without importing the Model enum.
+export const emulatorModel: string | undefined = deviceModel;
+export const emulatorStartType: string | undefined = emuStartType;
+
 switch (emuStartType) {
     case 'emulator-start':
     case undefined:

--- a/packages/connect/e2e/tests/device/ward.test.ts
+++ b/packages/connect/e2e/tests/device/ward.test.ts
@@ -1,0 +1,118 @@
+import TrezorConnect from '../../../src';
+import {
+    emulatorModel,
+    emulatorStartType,
+    getController,
+    initTrezorConnect,
+    setup,
+} from '../../common.setup';
+
+// WARD is not in any released firmware; it lives in a trezor-firmware branch, and its multi-session
+// THP parts need T3W1 (see packages/connect-cli/e2e/ward-queue.sh, which builds
+// `--model t3w1 --debug-link`). So this arc only makes sense against an emulator started FROM A
+// BRANCH on T3W1 -- every other matrix (released firmware, other models) has no WARD methods to call
+// and skips gracefully. The WARD firmware lives on the trezor-firmware `petrsusil/ward-draft` branch;
+// run it with:
+//
+//   ./docker/docker-connect-test.sh node -b petrsusil/ward-draft -m T3W1 -p ward
+//
+// See packages/connect/e2e/README.md.
+const wardCapable =
+    emulatorModel === 'T3W1' &&
+    (emulatorStartType === 'emulator-start-from-branch' ||
+        emulatorStartType === 'emulator-start-from-url');
+
+// Protobuf `bytes` fields (identifier, value) cross the connect boundary as hex, exactly as the
+// connect-cli does (`toHex` in packages/connect-cli/src/wardRunners.ts). `app_id` is a plain string.
+const toHex = (value: string) => Buffer.from(value, 'utf8').toString('hex');
+
+const controller = getController();
+
+// The WARD store keys entries under the wallet, so the run needs an initialized (seeded) device, and
+// it must start with NO pinned WARD app: the first WARD call pins THIS host, which is what the reset
+// at the end then retires. `setup` wipes and re-seeds the emulator, so both hold.
+(wardCapable ? describe : describe.skip)('TrezorConnect WARD queue', () => {
+    const APP_ID = 'btc_app';
+    // Mixed case on purpose: app_id/identifier are hashed into the entry key and must survive
+    // verbatim -- a lowercased identifier derives a DIFFERENT key, which the case-sensitivity check
+    // below relies on.
+    const IDENTIFIER = toHex('Addr1');
+    const VALUE = toHex('queued_secret');
+
+    beforeAll(async () => {
+        await setup(controller, { mnemonic: 'mnemonic_all' });
+        await initTrezorConnect(controller);
+    });
+
+    afterAll(() => {
+        controller.dispose();
+        TrezorConnect.dispose();
+    });
+
+    // The offline queue arc, the half of WARD that depends on no backend: it reads and writes the
+    // device's OWN store, so it can be exercised against a bare emulator with no service daemon (the
+    // online reads/writes/flushes are covered by packages/connect-cli/e2e/ward-queue.sh, which stands
+    // up a wardd stub).
+    it('queues a change, reads it back, and discards it -- all offline', async () => {
+        // 1. Hold a write on the device. The ack is empty: the value only reaches the tree on flush,
+        //    so there is no leaf, counter or path to return yet.
+        const queued = await TrezorConnect.wardQueueSetEntry({
+            app_id: APP_ID,
+            identifier: IDENTIFIER,
+            value: VALUE,
+        });
+        expect(queued).toMatchObject({ success: true });
+
+        // 2. The device holds it as a PENDING change and hands back the value plus a restore MAC (the
+        //    MAC is what makes the record backupable without letting a host forge one).
+        const got = await TrezorConnect.wardQueueGetEntry({
+            app_id: APP_ID,
+            identifier: IDENTIFIER,
+        });
+        expect(got).toMatchObject({ success: true, payload: { pending: true, value: VALUE } });
+        if (!got.success) throw new Error(got.error.message);
+        expect(got.payload.missing).toBeFalsy();
+        expect(got.payload.mac).toBeTruthy();
+
+        // 3. Case is significant: a lowercased identifier hashes to a different key, so the device
+        //    honestly reports it missing rather than returning the entry above.
+        const wrongCase = await TrezorConnect.wardQueueGetEntry({
+            app_id: APP_ID,
+            identifier: toHex('addr1'),
+        });
+        expect(wrongCase).toMatchObject({ success: true, payload: { missing: true } });
+
+        // 4. Discard the queued change. This touches no trie -- the change was never published -- it
+        //    just drops the pending record.
+        const discarded = await TrezorConnect.wardQueueDeleteEntry({
+            app_id: APP_ID,
+            identifier: IDENTIFIER,
+        });
+        expect(discarded).toMatchObject({ success: true });
+        if (!discarded.success) throw new Error(discarded.error.message);
+        expect(discarded.payload.missing).toBeFalsy();
+
+        // 5. And it is really gone.
+        const gone = await TrezorConnect.wardQueueGetEntry({
+            app_id: APP_ID,
+            identifier: IDENTIFIER,
+        });
+        expect(gone).toMatchObject({ success: true, payload: { missing: true } });
+
+        // 6. Discarding nothing is an answer, not a failure: a host reconciling its own view of the
+        //    queue legitimately asks about a change that has already been published.
+        const discardNothing = await TrezorConnect.wardQueueDeleteEntry({
+            app_id: APP_ID,
+            identifier: IDENTIFIER,
+        });
+        expect(discardNothing).toMatchObject({ success: true, payload: { missing: true } });
+    });
+
+    it('retires the pinned WARD app', async () => {
+        // The queue arc above pinned this host as the WARD app on its first call (the device grants
+        // the role to the first app that asks, on a held confirmation). Retiring it reports that a pin
+        // was actually there to retire -- which success alone does not say.
+        const reset = await TrezorConnect.wardResetApp({});
+        expect(reset).toMatchObject({ success: true, payload: { was_bound: true } });
+    });
+});

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -89,6 +89,15 @@ const groups = {
         pattern: 'methods',
         includeFilter: 'nostrGetPublicKey,nostrSignEvent,ethereumSignAuth7702',
     },
+    // WARD lives in a firmware branch, not a released version, and its bespoke arc runs against an
+    // emulator started FROM THAT BRANCH on T3W1. Like `experimental`, it is opt-in: it never runs as
+    // part of `all` (there is no released firmware to run it against), only via `--groups=ward` with a
+    // firmware branch. See packages/connect/e2e/tests/device/ward.test.ts.
+    ward: {
+        name: 'ward',
+        pattern: 'ward',
+        includeFilter: '',
+    },
 };
 
 const firmwares1 = ['1.9.0', '1-latest', '1-main'];
@@ -114,6 +123,12 @@ const inputs = [
             Object.values(groups).filter(group => {
                 if (group.name === 'thp') {
                     return firmware !== '2.3.0' && model === 'T3W1';
+                }
+
+                // WARD ships only in a firmware branch and needs T3W1 (THP); gate the group the same
+                // way `thp` is gated, and keep it out of `all` (below).
+                if (group.name === 'ward') {
+                    return model === 'T3W1';
                 }
 
                 return true;
@@ -242,8 +257,9 @@ const filterCartesianResultByArgs = () => {
             // CLI args parse into arrays, so `all` arrives as `['all']`
             const filterValues = Array.isArray(filterBy) ? filterBy : [filterBy];
             if (filterValues.includes('all')) {
-                // experimental methods are opt-in; they never run as part of `all`
-                if (key === 'groups' && getValue(m[key]) === 'experimental') {
+                // experimental methods and WARD are opt-in; they never run as part of `all`
+                // (WARD additionally has no released firmware to run against)
+                if (key === 'groups' && ['experimental', 'ward'].includes(getValue(m[key]))) {
                     return false;
                 }
 


### PR DESCRIPTION
Stacked on `petrsusil/ward-draft`. The WARD PR ships **unit** tests for the new connect methods; this adds the **e2e** coverage we usually prefer, wired into the existing connect e2e harness.

## ⚠️ Status — blocked on the firmware branch, not on this PR

The suite-side wiring is complete and the arc executes: a CI dispatch got past matrix generation, the `ward` gate, and `TrezorConnect.init`, and failed **only** at fetching the emulator. The blocker is that trezor-firmware CI cannot currently produce a bootable T3W1 emulator for `petrsusil/ward-draft`:

- **No emulator on `data.trezor.io`.** `emulator-start-from-branch` (`-b`) only ever reads `data.trezor.io/dev/firmware/emu-branches/<branch>/…`. That path is populated by trezor-firmware `core.yml`'s `core_upload_emu_branch` job, whose S3 upload is credential-gated (AWS OIDC role, `continue-on-error`) and does not run for a personal branch → `…/emu-branches/petrsusil/ward-draft/trezor-emu-core-T3W1-universal` is **404** (`main` returns 206, so the URL pattern is correct — the artifact simply isn't there).
- **The firmware build itself is broken in CI.** A `workflow_dispatch` of `core.yml` on `petrsusil/ward-draft` ([run](https://github.com/trezor/trezor-firmware/actions/runs/32952369217)) failed `make -C core test_emu_sanity` for **every** model — the emulator dies at boot:
  ```
  File "apps/base.py", line 571, in boot
  ImportError: no module named 'apps.ward'
  RuntimeError: Emulator process died
  ```
  `apps.ward` is imported at boot but is **not frozen into the build**, so the frozen CI emulator can't start (`test_emu_sanity` fails → the `upload-artifact`/S3 steps are skipped → no emulator is produced at all). It only loads on a local non-frozen `--pyopt false` dev build (the one `packages/connect-cli/e2e/ward-queue.sh` documents), which is why it wasn't caught before.

**Unblock:** the firmware branch needs `apps.ward` in the frozen build set so the emulator boots and CI publishes the artifact. Once that lands, this e2e runs unchanged — via `-b` if the emulator reaches S3, or by pulling the trezor-firmware `core-emu-T3W1-universal-debuglink-noasan` GH artifact (using the existing `trezor-bot` GitHub App token) and pointing trezor-user-env at it with `-u`. No changes to this PR are expected.

## What

A bespoke, stateful arc — `packages/connect/e2e/tests/device/ward.test.ts` — that drives the WARD **offline queue** end to end against a real emulator:

1. `wardQueueSetEntry` — queue a change (empty ack)
2. `wardQueueGetEntry` — read it back: `pending`, the value, and a restore `mac`
3. `wardQueueGetEntry` with a lower-cased identifier — `missing` (app_id/identifier are hashed into the key, case matters)
4. `wardQueueDeleteEntry` — discard it
5. `wardQueueGetEntry` — gone (`missing`)
6. `wardQueueDeleteEntry` again — `missing` is an answer, not a failure
7. `wardResetApp` — retire the app the arc pinned (`was_bound: true`)

It is a hand-written test rather than a `__fixtures__` entry because the queue is a **round trip** (state carried call to call) and the fixture runner wipes the device between methods. It follows the `resetDevice.test.ts` / `thpPairing.test.ts` conventions.

**Scope:** only the OFFLINE queue methods, which depend on no backend and run against a bare emulator (`wardQueueSetEntry` / `wardQueueGetEntry` / `wardQueueDeleteEntry` / `wardResetApp`). The ONLINE reads/writes/flushes (`wardGetEntry` / `wardSetEntry` / `wardFlushQueue`) need a `wardd` replica and stay covered by `packages/connect-cli/e2e/ward-queue.sh`.

## Firmware from a branch (mechanism exists; see Status above for the blocker)

WARD is not in any released firmware and its multi-session THP parts need **T3W1**, so the emulator is built from the firmware branch. The WARD firmware lives on the [`petrsusil/ward-draft`](https://github.com/trezor/trezor-firmware/tree/petrsusil/ward-draft) branch of `trezor-firmware`. That download mechanism is already wired end to end (`TESTS_FIRMWARE_BRANCH` → `emulator-start-from-branch` → `trezor-user-env`; `docker-connect-test.sh -b`); this PR just reuses it and gates the arc so it runs there and skips everywhere else. What is missing today is a published, bootable emulator for the branch (see Status above).

Run it locally:

```
./docker/docker-connect-test.sh node -b petrsusil/ward-draft -m T3W1 -p ward
```

The arc gates itself on a **T3W1 firmware-branch** emulator (new `emulatorModel` / `emulatorStartType` exports from `common.setup.ts`), so a default full run / released firmware / other models skip the whole `describe` instead of calling methods the firmware lacks.

## CI wiring

- `scripts/ci/connect-test-matrix-generator.js`: new **`ward`** group — opt-in, T3W1-only, excluded from `all` (there is no released firmware to run it against). Verified by running the generator.
- `template-connect-test-params.yml` + `test-connect-custom.yml`: a firmware-branch input threaded through to `-b`, so the arc can be dispatched from CI with `deviceModel=T3W1`, `deviceBranch=petrsusil/ward-draft`, `groups=ward`.

## Verification

- Matrix generator behaviour verified by running it (`--groups=ward --model=T3W1` → 1 run; `T2T1` → 0; `all` → ward absent). Workflow YAML validated.
- Type correctness reasoned against the public typed API (`TrezorConnectWard`), the `Result` / `SerializedError` shapes, and the `messages-ward.ts` ack fields; the same methods/params are already called this way in `connect-cli`. Two independent adversarial reviews of the test + wiring came back clean.
- ⚠️ I could **not** run `type-check` or the e2e itself here: this worktree has no `node_modules`, and the e2e needs a bootable ward emulator + a `trezor-user-env` that can build it — both CI/QA-only. The first live run is currently blocked on the firmware branch (see Status above), not on this PR.

One thing worth a look before that run: WARD confirmations are *held* on T3W1, and the e2e auto-confirm presses yes without the `--debuglink-delay` the CLI uses. The existing harness handles held confirms for reset/wipe, so it should be fine, but it is the most likely place for a first-run surprise.
