### PR TITLE
chore(deps): update @tanstack/eslint-plugin-query to 5.101.4

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@tanstack/eslint-plugin-query": "5.101.0",
+        "@tanstack/eslint-plugin-query": "5.101.4",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.16.0",

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.ts
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.ts
@@ -50,7 +50,6 @@ export const useTransactionGraphUpdater = ({
         [allTransactions],
     );
 
-    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- onRequestGraphUpdate is the fetcher itself, not a cache input; what identifies the data is the account and the transactions the graph is synced to
     useQuery({
         queryKey: desktopQueryKeys.accountGraphUpdate(accountKey, newestConfirmedTxids),
         queryFn: async ({ signal }) => {

--- a/packages/suite/src/hooks/suite/useProxyImage.ts
+++ b/packages/suite/src/hooks/suite/useProxyImage.ts
@@ -11,7 +11,6 @@ import { IMAGE_PROXY_API_AUTH_BEARER, IMAGE_PROXY_API_URL } from '@trezor/urls';
  */
 export const useProxyImage = (src?: string) => {
     const abortControllersRef = useRef(new Map<string, AbortController>());
-    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is src; abortControllersRef is a mutable ref used only for abort bookkeeping and must not be part of the key
     const proxyImageQuery = useQuery({
         enabled: Boolean(src),
         queryKey: desktopQueryKeys.proxyImage(src),

--- a/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.ts
+++ b/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.ts
@@ -22,7 +22,6 @@ export const useMissingRateTickersQuery = ({
             ThunkDispatch<UpdateFiatRatesThunkState, Record<never, never>, UnknownAction>
         >();
 
-    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- dispatch from useDispatch() is referentially stable and is not part of the query identity (missingRateTickers + baseCurrencyCode)
     return useQuery({
         queryKey: commonQueryKeys.missingRateTickers(missingRateTickers, baseCurrencyCode),
         queryFn: () =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -16270,9 +16270,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/eslint-plugin-query@npm:5.101.0":
-  version: 5.101.0
-  resolution: "@tanstack/eslint-plugin-query@npm:5.101.0"
+"@tanstack/eslint-plugin-query@npm:5.101.4":
+  version: 5.101.4
+  resolution: "@tanstack/eslint-plugin-query@npm:5.101.4"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.58.1"
   peerDependencies:
@@ -16281,7 +16281,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/f0b4abc774631c5ead7c33b139cb3f28782c2690f273ead4792a02c3733bdf4c4b14556aaf221bf1017116de2310302096ae8b9ff1667edcb2e801ddc86b6e36
+  checksum: 10/93f499c2d9a99187019462891896750103abfffcc1ffe11f675f2d9fa5125ffef643c389d47ee74c9a7fc7bcf288ec96ee5b10eac37f82b31041700080a3c4c0
   languageName: node
   linkType: hard
 
@@ -17011,7 +17011,7 @@ __metadata:
   resolution: "@trezor/eslint@workspace:packages/eslint"
   dependencies:
     "@eslint/js": "npm:^9.39.4"
-    "@tanstack/eslint-plugin-query": "npm:5.101.0"
+    "@tanstack/eslint-plugin-query": "npm:5.101.4"
     eslint: "npm:^9.39.4"
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-jest: "npm:^29.16.0"


### PR DESCRIPTION
## Description

Part of #30670. This patch updates the shared TanStack Query ESLint plugin; 5.101.4 stops requiring function call targets in query keys while retaining nested callback checks, allowing three obsolete suppressions to be removed. Risk is very low and limited to changed lint findings, with no runtime impact; green CI is sufficient because the plugin runs only during linting, and dependency checks plus the full 321-project lint pass exercise its complete integration surface.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-tanstack-eslint-plugin-query/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-tanstack-eslint-plugin-query/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch three broad shared areas—transaction graph updates, image proxying, and missing fiat-rate resolution—plus an eslint dependency bump with no runtime impact. The highest risk is in graph rendering and fiat-denominated displays/conversions, so the targeted tests focus on the transaction graph time-range behavior, fiat currency switching, discreet-mode fiat values, and staking-form crypto/fiat conversion. Medium-priority tests cover the image proxy via guide screenshots and device background changes. The eslint package change has no E2E coverage and can be skipped.

<details><summary><b>Changed files (4)</b></summary>

- `packages/eslint/package.json`
- `packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.ts`
- `packages/suite/src/hooks/suite/useProxyImage.ts`
- `suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Validates fiat-denominated balance placeholders and hover reveals across the dashboard and device switcher; these values depend on fiat rates, so a regression in missing-rate fetching could break the expected '$0.00' reveal behavior.
- `suite/e2e/tests/settings/general.test.ts` — Changes the active fiat currency and asserts the dashboard symbol updates; this directly exercises the fiat-rate fetching path when rates for the newly selected currency are needed.
- `suite/e2e/tests/trading/staking-form.test.ts` — Exercises crypto/fiat input switching in the ETH staking form and asserts conversion values based on the mocked exchange rate; a regression in missing rate resolution would surface here.
- `suite/e2e/tests/wallet/transactions.test.ts` — Cycles the account transaction graph time-range filters and verifies date labels; the changed hook directly drives data updates for the TransactionsGraph component.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — Opens guide articles and enlarges screenshot images; the proxy image hook is likely used when loading guide images, so an image-proxy regression could affect this flow.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Changes the device homescreen background image; the proxy image hook may be used to fetch or preview the selected background, making this a concrete proxy-image code path.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/eslint/package.json`

_Updated: 2026-08-26T10:23:16.519Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-tanstack-eslint-plugin-query&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-tanstack-eslint-plugin-query&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/deps-30670-tanstack-eslint-plugin-query&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-26T10:24:11.579Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-26T10:23:53.374Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->