### PR TITLE
chore(deps): update TanStack React Query packages to 5.101.4

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -140,7 +140,7 @@
         "@suite/tx-simulation": "workspace:^",
         "@suite/ui-animations": "workspace:*",
         "@suite/wallet": "workspace:*",
-        "@tanstack/react-query": "5.101.2",
+        "@tanstack/react-query": "5.101.4",
         "@testing-library/jest-dom": "7.0.1",
         "@trezor/analytics-uploader": "workspace:*",
         "@trezor/asset-utils": "workspace:*",

--- a/suite-common/react-query/package.json
+++ b/suite-common/react-query/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@tanstack/react-query": "5.101.4",
-        "@tanstack/react-query-devtools": "5.101.2",
+        "@tanstack/react-query-devtools": "5.101.4",
         "react": "19.2.3"
     }
 }

--- a/suite-common/react-query/package.json
+++ b/suite-common/react-query/package.json
@@ -11,7 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@tanstack/react-query": "5.101.2",
+        "@tanstack/react-query": "5.101.4",
         "@tanstack/react-query-devtools": "5.101.2",
         "react": "19.2.3"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11177,7 +11177,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/react-query@workspace:suite-common/react-query"
   dependencies:
-    "@tanstack/react-query": "npm:5.101.2"
+    "@tanstack/react-query": "npm:5.101.4"
     "@tanstack/react-query-devtools": "npm:5.101.2"
     react: "npm:19.2.3"
   languageName: unknown
@@ -16478,10 +16478,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:5.101.2":
-  version: 5.101.2
-  resolution: "@tanstack/query-core@npm:5.101.2"
-  checksum: 10/567af5e3c21628745a08c1a5054d838597bc620dcbbeabe20cdd6ccffdcca85a8d38128f6e80829b6e04d10f79ca793a7dd8fddc8a3d6bef10c2d580ae214c7d
+"@tanstack/query-core@npm:5.101.4":
+  version: 5.101.4
+  resolution: "@tanstack/query-core@npm:5.101.4"
+  checksum: 10/df86031035ac9a5cf54efece85718b90e93fca62068a44a176da232b6dd49b27168840f2da18c64a0eb25d171bc3fb1aab417db4643025cd194ff887833bd73f
   languageName: node
   linkType: hard
 
@@ -16504,14 +16504,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:5.101.2":
-  version: 5.101.2
-  resolution: "@tanstack/react-query@npm:5.101.2"
+"@tanstack/react-query@npm:5.101.4":
+  version: 5.101.4
+  resolution: "@tanstack/react-query@npm:5.101.4"
   dependencies:
-    "@tanstack/query-core": "npm:5.101.2"
+    "@tanstack/query-core": "npm:5.101.4"
   peerDependencies:
     react: ^18 || ^19
-  checksum: 10/0837c176b6afb01e3632010bbd8bdfeee7f46c4a25a50ed2ba9ddddce11c34431161d80dd8e53a2f55190c2313bbfb22a84a77308e6ccf29877b4818de68c4b3
+  checksum: 10/926dabad8e2c2cee89c0f10456c8338474abfe75c9baea2fa0619206cfcb7b38f7edcfe9cc8903f8a5c4f018bba44a487fc19687aac8f945c6a20630dbfceb96
   languageName: node
   linkType: hard
 
@@ -18082,7 +18082,7 @@ __metadata:
     "@suite/tx-simulation": "workspace:^"
     "@suite/ui-animations": "workspace:*"
     "@suite/wallet": "workspace:*"
-    "@tanstack/react-query": "npm:5.101.2"
+    "@tanstack/react-query": "npm:5.101.4"
     "@testing-library/jest-dom": "npm:7.0.1"
     "@testing-library/react": "npm:^16.3.2"
     "@testing-library/user-event": "npm:^14.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11178,7 +11178,7 @@ __metadata:
   resolution: "@suite-common/react-query@workspace:suite-common/react-query"
   dependencies:
     "@tanstack/react-query": "npm:5.101.4"
-    "@tanstack/react-query-devtools": "npm:5.101.2"
+    "@tanstack/react-query-devtools": "npm:5.101.4"
     react: "npm:19.2.3"
   languageName: unknown
   linkType: soft
@@ -16485,22 +16485,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-devtools@npm:5.101.2":
-  version: 5.101.2
-  resolution: "@tanstack/query-devtools@npm:5.101.2"
-  checksum: 10/74a7f77648d7f76066bf3edb04b16a678bc1170fc99bfe379c3c459dd7b1de183f0b47e38f13d6e8099246f3146f84e03fe62f5aab1e983fb23ec4d18dedd587
+"@tanstack/query-devtools@npm:5.101.4":
+  version: 5.101.4
+  resolution: "@tanstack/query-devtools@npm:5.101.4"
+  checksum: 10/f733d7382eb395cfed8135bddb4ee448a4c426967f2a66c83337f553a04636a2cf5e9fe79386f0aeabf78c5683beade4e4f45c56d9c26f884497106b905d8976
   languageName: node
   linkType: hard
 
-"@tanstack/react-query-devtools@npm:5.101.2":
-  version: 5.101.2
-  resolution: "@tanstack/react-query-devtools@npm:5.101.2"
+"@tanstack/react-query-devtools@npm:5.101.4":
+  version: 5.101.4
+  resolution: "@tanstack/react-query-devtools@npm:5.101.4"
   dependencies:
-    "@tanstack/query-devtools": "npm:5.101.2"
+    "@tanstack/query-devtools": "npm:5.101.4"
   peerDependencies:
-    "@tanstack/react-query": ^5.101.2
+    "@tanstack/react-query": ^5.101.4
     react: ^18 || ^19
-  checksum: 10/6aa7e72c902f7e64fe91b1d96436f01ff9d5d9959b32d66ec64223a0ab3ff2d0aa02a474b8b14c0e09dd8f4afd88a0f8de5837e9d89d514cb74f01a15f48ece5
+  checksum: 10/b9b3ff3ee5e7b0c98bb59a6f9ff2c50b285da52287a54f26403fdbf4090f35c7e39c4e75156a1dc8b7e9d77fbb67909dd97f8b27289bed255963720b4f3d7769
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update @tanstack/react-query and @tanstack/react-query-devtools from 5.101.2 to 5.101.4 together; part of https://github.com/trezor/trezor-suite/issues/30670. Upstream changes are a partialMatchKey performance improvement plus Devtools dependency synchronization, with no public API changes; risk is low, though cache matching affects all consumers. CI should cover builds and tests; manually verify Devtools during refresh, metadata sync, and live trading quote/status polling.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No static test coverage was found for the changed package.json files, so recommendations are inferred. The most likely impact is a dependency-level change affecting app bootstrap and async data fetching. Run a high-priority onboarding smoke test to catch app-load regressions, plus two medium-priority tests that exercise interval-based metadata refresh and trading quote/status synchronization where react-query behavior matters.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/package.json`
- `suite-common/react-query/package.json`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This is the first user-facing flow after app launch; a dependency or package configuration change in packages/suite/package.json can break rendering, routing, or the analytics consent modal, so a successful onboarding smoke test provides immediate signal.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — The test explicitly verifies periodic refetching/refreshing of cloud metadata labels at FETCH_INTERVAL, which is the kind of caching/refetch behavior that react-query infrastructure governs; a change to suite-common/react-query/package.json could alter refresh timing or query lifecycle.
- `suite/e2e/tests/trading/swap-coins.test.ts` — The swap flow depends on fetching live quotes, polling trade status through multiple phases, and keeping UI state in sync with asynchronous data; this exercises the data-fetching layer that the react-query package likely underpins.

</details>

_Updated: 2026-09-02T14:20:22.540Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-tanstack-react-query/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-tanstack-react-query/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-tanstack-react-query&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-tanstack-react-query&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/deps-30670-tanstack-react-query&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T14:22:59.490Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T14:22:57.805Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->