### PR TITLE
chore(deps): update @tanstack/react-query-devtools to 5.101.4

### DIFF
--- a/suite-common/react-query/package.json
+++ b/suite-common/react-query/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@tanstack/react-query": "5.101.2",
-        "@tanstack/react-query-devtools": "5.101.2",
+        "@tanstack/react-query-devtools": "5.101.4",
         "react": "19.2.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11050,7 +11050,7 @@ __metadata:
   resolution: "@suite-common/react-query@workspace:suite-common/react-query"
   dependencies:
     "@tanstack/react-query": "npm:5.101.2"
-    "@tanstack/react-query-devtools": "npm:5.101.2"
+    "@tanstack/react-query-devtools": "npm:5.101.4"
     react: "npm:19.2.3"
   languageName: unknown
   linkType: soft
@@ -16401,22 +16401,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-devtools@npm:5.101.2":
-  version: 5.101.2
-  resolution: "@tanstack/query-devtools@npm:5.101.2"
-  checksum: 10/74a7f77648d7f76066bf3edb04b16a678bc1170fc99bfe379c3c459dd7b1de183f0b47e38f13d6e8099246f3146f84e03fe62f5aab1e983fb23ec4d18dedd587
+"@tanstack/query-devtools@npm:5.101.4":
+  version: 5.101.4
+  resolution: "@tanstack/query-devtools@npm:5.101.4"
+  checksum: 10/f733d7382eb395cfed8135bddb4ee448a4c426967f2a66c83337f553a04636a2cf5e9fe79386f0aeabf78c5683beade4e4f45c56d9c26f884497106b905d8976
   languageName: node
   linkType: hard
 
-"@tanstack/react-query-devtools@npm:5.101.2":
-  version: 5.101.2
-  resolution: "@tanstack/react-query-devtools@npm:5.101.2"
+"@tanstack/react-query-devtools@npm:5.101.4":
+  version: 5.101.4
+  resolution: "@tanstack/react-query-devtools@npm:5.101.4"
   dependencies:
-    "@tanstack/query-devtools": "npm:5.101.2"
+    "@tanstack/query-devtools": "npm:5.101.4"
   peerDependencies:
-    "@tanstack/react-query": ^5.101.2
+    "@tanstack/react-query": ^5.101.4
     react: ^18 || ^19
-  checksum: 10/6aa7e72c902f7e64fe91b1d96436f01ff9d5d9959b32d66ec64223a0ab3ff2d0aa02a474b8b14c0e09dd8f4afd88a0f8de5837e9d89d514cb74f01a15f48ece5
+  checksum: 10/b9b3ff3ee5e7b0c98bb59a6f9ff2c50b285da52287a54f26403fdbf4090f35c7e39c4e75156a1dc8b7e9d77fbb67909dd97f8b27289bed255963720b4f3d7769
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update @tanstack/react-query-devtools from 5.101.2 to 5.101.4; its changelog contains dependency synchronization only, with no Devtools API or behavior changes. Risk is low and limited to development-only query inspection and dependency resolution. Validate the react-query package tests, Suite Web build/startup, and opening the Query Devtools overlay while a query refreshes; part of https://github.com/trezor/trezor-suite/issues/30670.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is suite-common/react-query/package.json, with no static E2E coverage mapping and no explicit react-query references in the test descriptions. The risk is therefore indirect and most likely concerns shared data-fetching/caching infrastructure. I recommend a small inferred smoke set covering discovery, trading API polling, and metadata sync at medium priority. Most package.json changes would be better validated by build/unit tests, so keep the E2E list short.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/react-query/package.json`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Suite Sync label creation/sync exercises remote server-state fetching and persistence patterns that are likely backed by the shared react-query infrastructure; a dependency or export change in suite-common/react-query could affect how labels are synced to the Evolu relay.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The trading buy flow relies on asynchronous API quote fetching, trade submission, and watch-status polling — all patterns commonly implemented with React Query; this test acts as a smoke test for those data-fetching paths.
- `suite/e2e/tests/wallet/discovery.test.ts` — Account discovery is a core asynchronous data-fetching flow driven by network state and caching; changes to the react-query package configuration could influence discovery behavior or loading states.

</details>

_Updated: 2026-08-27T19:18:08.194Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-tanstack-react-query-devtools/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-tanstack-react-query-devtools/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-tanstack-react-query-devtools&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-tanstack-react-query-devtools&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/deps-30670-tanstack-react-query-devtools&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T19:20:39.610Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T19:20:04.545Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->