### PR TITLE
chore(deps): update @testing-library/user-event to 14.6.4

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,7 +53,7 @@
         "@storybook/react-webpack5": "^10.3.4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
+        "@testing-library/user-event": "^14.6.4",
         "@trezor/eslint": "workspace:*",
         "@types/react": "19.2.14",
         "@types/react-date-range": "^1.4.10",

--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -58,7 +58,7 @@
         "@storybook/react-webpack5": "^10.3.4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
+        "@testing-library/user-event": "^14.6.4",
         "@trezor/eslint": "workspace:*",
         "@types/react": "19.2.14",
         "@types/zxcvbn": "4.4.5",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -202,7 +202,7 @@
     },
     "devDependencies": {
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
+        "@testing-library/user-event": "^14.6.4",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
         "@types/invity-api": "^1.1.19",

--- a/suite/test-utils/package.json
+++ b/suite/test-utils/package.json
@@ -19,7 +19,7 @@
         "@suite/router": "workspace:*",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
+        "@testing-library/user-event": "^14.6.4",
         "@trezor/suite": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "history": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15835,7 +15835,7 @@ __metadata:
     "@suite/router": "workspace:*"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/react": "npm:^16.3.2"
-    "@testing-library/user-event": "npm:^14.6.1"
+    "@testing-library/user-event": "npm:^14.6.4"
     "@trezor/suite": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     history: "npm:^5.3.0"
@@ -16520,12 +16520,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^14.6.1":
-  version: 14.6.1
-  resolution: "@testing-library/user-event@npm:14.6.1"
+"@testing-library/user-event@npm:^14.6.1, @testing-library/user-event@npm:^14.6.4":
+  version: 14.6.4
+  resolution: "@testing-library/user-event@npm:14.6.4"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: 10/34b74fff56a0447731a94b40d4cf246deb8dbc1c1e3aec93acd1c3377a760bb062e979f1572bb34ec164ad28ee2a391744b42d0d6d6cc16c4ce527e5e09610e1
+  checksum: 10/cf0406382327c6751bf282f6acebfc68d08cffc5a01d9cb808f4130a4b713962b32bd5d38c9ff351c3d13495134af72cf2efb330f711e1afa1f6750d3ed2dc68
   languageName: node
   linkType: hard
 
@@ -16726,7 +16726,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.3.2"
-    "@testing-library/user-event": "npm:^14.6.1"
+    "@testing-library/user-event": "npm:^14.6.4"
     "@trezor/env-utils": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@trezor/icons": "workspace:*"
@@ -17353,7 +17353,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/react": "npm:^16.3.2"
-    "@testing-library/user-event": "npm:^14.6.1"
+    "@testing-library/user-event": "npm:^14.6.4"
     "@trezor/asset-utils": "workspace:*"
     "@trezor/components": "workspace:*"
     "@trezor/device-utils": "workspace:*"
@@ -17956,7 +17956,7 @@ __metadata:
     "@tanstack/react-query": "npm:5.101.2"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.3.2"
-    "@testing-library/user-event": "npm:^14.6.1"
+    "@testing-library/user-event": "npm:^14.6.4"
     "@trezor/analytics-uploader": "workspace:*"
     "@trezor/asset-utils": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"


### PR DESCRIPTION
## Description

Update @testing-library/user-event from 14.6.1 to 14.6.4; upstream fixes keyboard repeat metadata, maxlength selection, focus and shadow-root handling, pointer pressure, and operation without window. Risk is low and test-only, but event payload or focus semantics may change assertions. Validate components, product-components, suite, and test-utils unit tests, especially keyboard, pointer, focus, and form interactions; part of https://github.com/trezor/trezor-suite/issues/30670.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-testing-library-user-event/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-testing-library-user-event/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all package.json manifests with no static test coverage, so the exact runtime impact is unknown. The safest strategy is to run a small set of high-value smoke tests that verify the app loads in a browser and that the onboarding and wallet-discovery flows still work, catching dependency or build regressions without broad coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/components/package.json`
- `packages/product-components/package.json`
- `packages/suite/package.json`
- `suite/test-utils/package.json`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — This test verifies the Suite web application loads correctly in Firefox with no unsupported-browser warning. Changes to packages/suite/package.json or packages/components/package.json (dependency versions, build configuration, or peer dependencies) are most likely to manifest first as app-loading or rendering failures, making this a good smoke test.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test exercises the initial onboarding flow from the first route load through analytics consent to the dashboard. It touches core Suite initialization, routing, and UI components that depend on the component libraries and suite package, so it will catch regressions from dependency changes early.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test covers the end-to-end wallet discovery flow after onboarding, including device switching and account loading. It exercises deeper Suite infrastructure that could be affected by changes in the suite package or shared component dependencies, but it is less directly tied to package.json metadata than basic app loading.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/components/package.json`
- `packages/product-components/package.json`
- `packages/suite/package.json`
- `suite/test-utils/package.json`

_Updated: 2026-08-27T19:19:25.395Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-testing-library-user-event&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-testing-library-user-event&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T19:21:39.709Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T19:19:46.965Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->