### PR TITLE
refactor(suite-build): extract shared vite config and browser polyfills

### DIFF
--- a/packages/suite-build/browserPolyfills.ts
+++ b/packages/suite-build/browserPolyfills.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Buffer } from 'buffer';
 
 const base64UrlToBase64 = (input: string) => {

--- a/packages/suite-build/browserPolyfills.ts
+++ b/packages/suite-build/browserPolyfills.ts
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Buffer } from 'buffer';
+
+const base64UrlToBase64 = (input: string) => {
+    const base64 = input.replace(/-/g, '+').replace(/_/g, '/');
+    const pad = base64.length % 4;
+    if (pad === 0) return base64;
+
+    return base64 + '='.repeat(4 - pad);
+};
+
+const base64ToBase64Url = (input: string) =>
+    input.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+
+const patchBase64Url = (BufferCtor: any) => {
+    if (!BufferCtor?.prototype?.toString) return;
+
+    const originalToString = BufferCtor.prototype.toString;
+    if (!BufferCtor.prototype.__trezorPatchedBase64UrlToString) {
+        Object.defineProperty(BufferCtor.prototype, '__trezorPatchedBase64UrlToString', {
+            value: true,
+            enumerable: false,
+        });
+        BufferCtor.prototype.toString = function (this: any, encoding: any, start: any, end: any) {
+            if (encoding === 'base64url') {
+                return base64ToBase64Url(originalToString.call(this, 'base64', start, end));
+            }
+
+            return originalToString.call(this, encoding, start, end);
+        };
+    }
+
+    const originalFrom = BufferCtor.from;
+    if (!BufferCtor.__trezorPatchedBase64UrlFrom) {
+        Object.defineProperty(BufferCtor, '__trezorPatchedBase64UrlFrom', {
+            value: true,
+            enumerable: false,
+        });
+        BufferCtor.from = function (this: any, value: any, encodingOrOffset: any, length: any) {
+            if (encodingOrOffset === 'base64url' && typeof value === 'string') {
+                return originalFrom.call(this, base64UrlToBase64(value), 'base64');
+            }
+
+            return originalFrom.call(this, value, encodingOrOffset, length);
+        };
+    }
+};
+
+// Must stay a function: a bundler may drop a module that only has side effects.
+export const installBrowserPolyfills = () => {
+    // Define Buffer in all possible global scopes
+    if (typeof window !== 'undefined') {
+        (window as any).Buffer = (window as any).Buffer || Buffer;
+    }
+
+    if (typeof global !== 'undefined') {
+        global.Buffer = global.Buffer || Buffer;
+    }
+
+    if (typeof globalThis !== 'undefined') {
+        globalThis.Buffer = globalThis.Buffer || Buffer;
+    }
+
+    patchBase64Url(Buffer);
+    if (typeof window !== 'undefined' && (window as any).Buffer) {
+        patchBase64Url((window as any).Buffer);
+    }
+    if (typeof global !== 'undefined' && global.Buffer) patchBase64Url(global.Buffer);
+    if (typeof globalThis !== 'undefined' && globalThis.Buffer) patchBase64Url(globalThis.Buffer);
+
+    // Make sure global is defined
+    if (typeof window !== 'undefined' && typeof global === 'undefined') {
+        (window as any).global = window;
+    }
+
+    // Make sure globalThis is defined
+    if (typeof window !== 'undefined' && typeof globalThis === 'undefined') {
+        (window as any).globalThis = window;
+    }
+    // Polyfill process.nextTick for jws.createVerify
+    if (
+        typeof window !== 'undefined' &&
+        typeof (window as any).process !== 'undefined' &&
+        typeof (window as any).process.nextTick === 'undefined'
+    ) {
+        (window as any).process.nextTick = (cb: () => void) => Promise.resolve().then(cb);
+    }
+};

--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -2,7 +2,7 @@ import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import babel from '@rolldown/plugin-babel';
 import react from '@vitejs/plugin-react';
 import { execSync } from 'child_process';
-import fs, { readdirSync } from 'fs';
+import fs from 'fs';
 import { createRequire } from 'module';
 import { resolve } from 'path';
 import { Plugin, ViteDevServer, build, defineConfig } from 'vite';
@@ -15,6 +15,7 @@ import {
     project,
     transportBrowserPing,
 } from './utils/env';
+import { sharedAliases as alias, noopCoreJsPlugin } from './viteShared';
 
 const require = createRequire(import.meta.url);
 
@@ -122,62 +123,6 @@ const htmlTemplatePlugin = (): Plugin => ({
         handler: (html: string) => processTemplate(html),
     },
 });
-
-// This helper creates aliases for all workspace packages
-const createWorkspaceAliases = () => {
-    const suiteCommonAliases = readdirSync(resolve(__dirname, '../../suite-common'), {
-        withFileTypes: true,
-    })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => ({
-            find: `@suite-common/${dirent.name}`,
-            replacement: resolve(__dirname, '../../suite-common', dirent.name),
-        }));
-
-    const trezorPackagesAliases = readdirSync(resolve(__dirname, '../'), { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory() && dirent.name !== 'suite-web')
-        .map(dirent => ({
-            find: `@trezor/${dirent.name}`,
-            replacement: resolve(__dirname, '../', dirent.name),
-        }));
-
-    const suiteAliases = readdirSync(resolve(__dirname, '../../suite'), { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => ({
-            find: `@suite/${dirent.name}`,
-            replacement: resolve(__dirname, '../../suite', dirent.name),
-        }));
-
-    return [...suiteCommonAliases, ...trezorPackagesAliases, ...suiteAliases];
-};
-
-const alias = [
-    {
-        find: 'core-js/actual',
-        replacement: 'noop-core-js-actual',
-    },
-    {
-        find: 'src',
-        replacement: resolve(__dirname, '../suite/src'),
-    },
-    {
-        find: 'crypto',
-        replacement: require.resolve('crypto-browserify'),
-    },
-    {
-        find: 'buffer',
-        replacement: require.resolve('buffer'),
-    },
-    {
-        find: 'stream',
-        replacement: require.resolve('stream-browserify'),
-    },
-    {
-        find: 'vm',
-        replacement: require.resolve('vm-browserify'),
-    },
-    ...createWorkspaceAliases(),
-];
 
 // Plugin to serve sessions-background-sharedworker.js as a complete bundle to be used directly as a web worker
 const sessionsSharedWorkerPlugin = () => {
@@ -425,114 +370,14 @@ const resolveWorkerUrlsPlugin = (): Plugin => ({
 
 const commitId = execSync('git rev-parse HEAD').toString().trim();
 
-// Plugin to provide a no-op replacement for core-js/actual as a virtual module
-const noopCoreJsPlugin = (): Plugin => {
-    const virtualModuleId = 'noop-core-js-actual';
-    const resolvedVirtualModuleId = '\0' + virtualModuleId;
-
-    return {
-        name: 'noop-core-js-actual',
-        resolveId(id) {
-            if (id === virtualModuleId) {
-                return resolvedVirtualModuleId;
-            }
-        },
-        load(id) {
-            if (id === resolvedVirtualModuleId) {
-                return '// No-op replacement for core-js/actual\nexport default {};';
-            }
-        },
-    };
-};
-
 // Plugin to provide Buffer polyfill via a virtual module
 const bufferPolyfillPlugin = (): Plugin => {
     const virtualModuleId = 'virtual:buffer-polyfill';
     const resolvedVirtualModuleId = '\0' + virtualModuleId;
 
     const polyfillCode = `
-// Ensure Buffer is available globally
-import { Buffer as ImportedBuffer } from 'buffer';
-
-const base64UrlToBase64 = (input) => {
-    const base64 = input.replace(/-/g, '+').replace(/_/g, '/');
-    const pad = base64.length % 4;
-    if (pad === 0) return base64;
-    return base64 + '='.repeat(4 - pad);
-};
-
-const base64ToBase64Url = (input) => input.replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/g, '');
-
-const patchBase64Url = (BufferCtor) => {
-    if (!BufferCtor?.prototype?.toString) return;
-
-    const originalToString = BufferCtor.prototype.toString;
-    if (!BufferCtor.prototype.__trezorPatchedBase64UrlToString) {
-        Object.defineProperty(BufferCtor.prototype, '__trezorPatchedBase64UrlToString', {
-            value: true,
-            enumerable: false,
-        });
-        BufferCtor.prototype.toString = function (encoding, start, end) {
-            if (encoding === 'base64url') {
-                return base64ToBase64Url(originalToString.call(this, 'base64', start, end));
-            }
-            return originalToString.call(this, encoding, start, end);
-        };
-    }
-
-    const originalFrom = BufferCtor.from;
-    if (!BufferCtor.__trezorPatchedBase64UrlFrom) {
-        Object.defineProperty(BufferCtor, '__trezorPatchedBase64UrlFrom', {
-            value: true,
-            enumerable: false,
-        });
-        BufferCtor.from = function (value, encodingOrOffset, length) {
-            if (encodingOrOffset === 'base64url' && typeof value === 'string') {
-                return originalFrom.call(this, base64UrlToBase64(value), 'base64');
-            }
-            return originalFrom.call(this, value, encodingOrOffset, length);
-        };
-    }
-};
-
-// Define Buffer in all possible global scopes
-if (typeof window !== 'undefined') {
-    window.Buffer = window.Buffer || ImportedBuffer;
-};
-
-if (typeof global !== 'undefined') {
-    global.Buffer = global.Buffer || ImportedBuffer;
-};
-
-if (typeof globalThis !== 'undefined') {
-    globalThis.Buffer = globalThis.Buffer || ImportedBuffer;
-};
-
-patchBase64Url(ImportedBuffer);
-if (typeof window !== 'undefined' && window.Buffer) patchBase64Url(window.Buffer);
-if (typeof global !== 'undefined' && global.Buffer) patchBase64Url(global.Buffer);
-if (typeof globalThis !== 'undefined' && globalThis.Buffer) patchBase64Url(globalThis.Buffer);
-
-// Make sure global is defined
-if (typeof window !== 'undefined' && typeof global === 'undefined') {
-    window.global = window;
-};
-
-// Make sure globalThis is defined
-if (typeof window !== 'undefined' && typeof globalThis === 'undefined') {
-    window.globalThis = window;
-};
-// Polyfill process.nextTick for jws.createVerify
-if (
-    typeof window !== 'undefined' &&
-    typeof window.process !== 'undefined' &&
-    typeof window.process.nextTick === 'undefined'
-) {
-    window.process.nextTick = cb => Promise.resolve().then(cb);
-}
-
-// Export nothing - this module is only for side effects
-export {};
+import { installBrowserPolyfills } from '@trezor/suite-build/browserPolyfills';
+installBrowserPolyfills();
 `;
 
     return {

--- a/packages/suite-build/viteShared.ts
+++ b/packages/suite-build/viteShared.ts
@@ -1,0 +1,91 @@
+import { readdirSync } from 'fs';
+import { createRequire } from 'module';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { type Plugin } from 'vite';
+
+/**
+ * Vite settings shared between the app config in this package and `suite/component-tests`, so the
+ * gallery the component tests render resolves modules the same way the shipped app does.
+ *
+ * `import.meta.url` rather than `__dirname`: depending on the importing config, this file is
+ * either bundled or loaded directly as an ES module, and only the former shims `__dirname`.
+ */
+const require = createRequire(import.meta.url);
+const packageDir = fileURLToPath(new URL('.', import.meta.url));
+
+// This helper creates aliases for all workspace packages
+const createWorkspaceAliases = () => {
+    const suiteCommonAliases = readdirSync(resolve(packageDir, '../../suite-common'), {
+        withFileTypes: true,
+    })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => ({
+            find: `@suite-common/${dirent.name}`,
+            replacement: resolve(packageDir, '../../suite-common', dirent.name),
+        }));
+
+    const trezorPackagesAliases = readdirSync(resolve(packageDir, '../'), { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory() && dirent.name !== 'suite-web')
+        .map(dirent => ({
+            find: `@trezor/${dirent.name}`,
+            replacement: resolve(packageDir, '../', dirent.name),
+        }));
+
+    const suiteAliases = readdirSync(resolve(packageDir, '../../suite'), { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => ({
+            find: `@suite/${dirent.name}`,
+            replacement: resolve(packageDir, '../../suite', dirent.name),
+        }));
+
+    return [...suiteCommonAliases, ...trezorPackagesAliases, ...suiteAliases];
+};
+
+export const sharedAliases = [
+    {
+        find: 'core-js/actual',
+        replacement: 'noop-core-js-actual',
+    },
+    {
+        find: 'src',
+        replacement: resolve(packageDir, '../suite/src'),
+    },
+    {
+        find: 'crypto',
+        replacement: require.resolve('crypto-browserify'),
+    },
+    {
+        find: 'buffer',
+        replacement: require.resolve('buffer'),
+    },
+    {
+        find: 'stream',
+        replacement: require.resolve('stream-browserify'),
+    },
+    {
+        find: 'vm',
+        replacement: require.resolve('vm-browserify'),
+    },
+    ...createWorkspaceAliases(),
+];
+
+// Plugin to provide a no-op replacement for core-js/actual as a virtual module
+export const noopCoreJsPlugin = (): Plugin => {
+    const virtualModuleId = 'noop-core-js-actual';
+    const resolvedVirtualModuleId = '\0' + virtualModuleId;
+
+    return {
+        name: 'noop-core-js-actual',
+        resolveId(id) {
+            if (id === virtualModuleId) {
+                return resolvedVirtualModuleId;
+            }
+        },
+        load(id) {
+            if (id === resolvedVirtualModuleId) {
+                return '// No-op replacement for core-js/actual\nexport default {};';
+            }
+        },
+    };
+};

--- a/suite/test-utils/src/initStoreForTests.ts
+++ b/suite/test-utils/src/initStoreForTests.ts
@@ -9,7 +9,7 @@ import {
     type PlatformEncryption,
 } from '@suite-common/platform-encryption';
 import { type PreloadedState, type SuiteStore, initStore } from '@trezor/suite';
-import { ok } from '@trezor/type-utils';
+import { type DeepPartial, ok } from '@trezor/type-utils';
 
 const testPlatformEncryption: PlatformEncryption = {
     encrypt<T extends EncryptableBranded>({ value }: { value: T }) {
@@ -34,7 +34,9 @@ export type InitStoreForTestsResult = {
  * Test-friendly wrapper for initStore that provides necessary dependencies like history.
  * Returns both the store and history for test assertions.
  */
-export const initStoreForTests = (preloadedState: PreloadedState = {}): InitStoreForTestsResult => {
+export const initStoreForTests = (
+    preloadedState: DeepPartial<PreloadedState> = {},
+): InitStoreForTestsResult => {
     const memoryHistory = createMemoryHistory();
     const suiteRouterHistory = createSuiteRouterHistory({ history: memoryHistory });
 
@@ -46,7 +48,10 @@ export const initStoreForTests = (preloadedState: PreloadedState = {}): InitStor
             getTransportsFactories: () => ({}),
             createGetBinFilesBaseUrl: () => asGetter(() => '/bin'),
         },
-        undefined,
+        // A benign preload action: initStore merges `statePatch` only when a preload action
+        // produced a base state, and an action type unknown to every reducer produces exactly the
+        // initial state — hence the cast to the storage-action union.
+        { type: '@@test/preload' } as unknown as Parameters<typeof initStore>[1],
         { statePatch: preloadedState },
     );
 


### PR DESCRIPTION
## Description

Prerequisites for `@suite/component-tests`; the component tests themselves follow as a stack on top of this branch.

- **`refactor(suite-build)`** — moves the workspace aliases, the `core-js/actual` no-op plugin and the Buffer / `global` / `process.nextTick` polyfills out of `vite.config.mts` into `viteShared.ts` and `browserPolyfills.ts`, so a second Vite config can reuse them. Pure move; the polyfills go from an inlined template string to a real module, logic unchanged.
- **`fix(test-utils)`** — `initStoreForTests(preloadedState)` silently discarded its argument: `initStore` merges `statePatch` only when a preload action produced a base state, and the wrapper passed `undefined`. Now passes a no-op preload action and widens the parameter to `DeepPartial<PreloadedState>`.

## Notes for QA

No user-facing change. Production builds are untouched — `build:web` and `build:desktop` go through webpack; the modified Vite config only serves `yarn dev:web:vite`.

## Related Issue

Resolve

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/component-tests-prerequisites/web/](https://dev.suite.sldev.cz/suite-web/refactor/component-tests-prerequisites/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are build/test infrastructure: browser polyfills, shared Vite config, and a test-store initializer. The highest risk is web-build breakage in browser-specific paths, so run the browser compatibility tests first. initStoreForTests.ts is not exercised by any identifiable E2E test in this set, so it remains uncovered at the E2E level.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite-build/browserPolyfills.ts`
- `packages/suite-build/viteShared.ts`
- `suite/test-utils/src/initStoreForTests.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/browser/ios.test.ts` — This test verifies the iOS unsupported-platform gate and page rendering, which directly depends on browser detection and polyfill behavior in the web build. Changes to browserPolyfills.ts or viteShared.ts could break how this gate loads or is displayed.
- `suite/e2e/tests/browser/safari.test.ts` — This test exercises the unsupported-browser warning and the 'Continue at my own risk' bypass in Safari/WebKit. Browser polyfills and shared Vite configuration directly influence whether this page renders and whether Suite loads after bypass.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — This test confirms Suite loads as a supported browser in Firefox with no compatibility warning. It serves as a smoke test that the shared Vite build still produces a working web bundle for Firefox.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/test-utils/src/initStoreForTests.ts`

_Updated: 2026-08-27T12:21:50.112Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/component-tests-prerequisites&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/component-tests-prerequisites&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T12:24:00.453Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-26T09:46:40.533Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->