### PR TITLE
fix(suite-native): return to earn form after failed transaction

### DIFF
--- a/suite-native/module-earn/src/hooks/useShowPushTransactionFailedDuringReviewAlert.tsx
+++ b/suite-native/module-earn/src/hooks/useShowPushTransactionFailedDuringReviewAlert.tsx
@@ -1,17 +1,9 @@
 import { useCallback } from 'react';
 
-import { useNavigation } from '@react-navigation/native';
+import { StackActions, useNavigation } from '@react-navigation/native';
 
 import { useAlert } from '@suite-native/alerts';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
-import {
-    type AppTabsParamList,
-    AppTabsRoutes,
-    HomeStackRoutes,
-    type RootStackParamList,
-    RootStackRoutes,
-    type StackToStackCompositeNavigationProps,
-} from '@suite-native/navigation';
 
 export type ReviewFormType =
     | 'stake'
@@ -27,16 +19,9 @@ export type ReviewFormType =
 
 export type ReviewAlertKind = 'pushFailed' | 'pendingConflict' | 'signFailed';
 
-type NavigationProps = StackToStackCompositeNavigationProps<
-    AppTabsParamList,
-    AppTabsRoutes.HomeStack,
-    RootStackParamList
->;
-
 type AlertKeys = {
     title: TxKeyPath;
     description: TxKeyPath;
-    primaryButton: TxKeyPath;
 };
 
 type AlertTranslationKeys = {
@@ -51,22 +36,16 @@ const translationKeys = {
             title: 'earn.earnTransactionDataReviewScreen.pushTransactionFailedAlert.title',
             description:
                 'earn.earnTransactionDataReviewScreen.pushTransactionFailedAlert.description',
-            primaryButton:
-                'earn.earnTransactionDataReviewScreen.pushTransactionFailedAlert.primaryButton',
         },
         pendingConflict: {
             title: 'earn.earnTransactionDataReviewScreen.pendingTransactionConflictAlert.title',
             description:
                 'earn.earnTransactionDataReviewScreen.pendingTransactionConflictAlert.description',
-            primaryButton:
-                'earn.earnTransactionDataReviewScreen.pendingTransactionConflictAlert.primaryButton',
         },
         signFailed: {
             title: 'earn.earnTransactionDataReviewScreen.signTransactionFailedAlert.title',
             description:
                 'earn.earnTransactionDataReviewScreen.signTransactionFailedAlert.description',
-            primaryButton:
-                'earn.earnTransactionDataReviewScreen.signTransactionFailedAlert.primaryButton',
         },
     },
     unstake: {
@@ -74,22 +53,16 @@ const translationKeys = {
             title: 'earn.unstakeTransactionDataReviewScreen.pushTransactionFailedAlert.title',
             description:
                 'earn.unstakeTransactionDataReviewScreen.pushTransactionFailedAlert.description',
-            primaryButton:
-                'earn.unstakeTransactionDataReviewScreen.pushTransactionFailedAlert.primaryButton',
         },
         pendingConflict: {
             title: 'earn.unstakeTransactionDataReviewScreen.pendingTransactionConflictAlert.title',
             description:
                 'earn.unstakeTransactionDataReviewScreen.pendingTransactionConflictAlert.description',
-            primaryButton:
-                'earn.unstakeTransactionDataReviewScreen.pendingTransactionConflictAlert.primaryButton',
         },
         signFailed: {
             title: 'earn.unstakeTransactionDataReviewScreen.signTransactionFailedAlert.title',
             description:
                 'earn.unstakeTransactionDataReviewScreen.signTransactionFailedAlert.description',
-            primaryButton:
-                'earn.unstakeTransactionDataReviewScreen.signTransactionFailedAlert.primaryButton',
         },
     },
     claim: {
@@ -97,155 +70,125 @@ const translationKeys = {
             title: 'earn.claimTransactionDataReviewScreen.pushTransactionFailedAlert.title',
             description:
                 'earn.claimTransactionDataReviewScreen.pushTransactionFailedAlert.description',
-            primaryButton:
-                'earn.claimTransactionDataReviewScreen.pushTransactionFailedAlert.primaryButton',
         },
         pendingConflict: {
             title: 'earn.claimTransactionDataReviewScreen.pendingTransactionConflictAlert.title',
             description:
                 'earn.claimTransactionDataReviewScreen.pendingTransactionConflictAlert.description',
-            primaryButton:
-                'earn.claimTransactionDataReviewScreen.pendingTransactionConflictAlert.primaryButton',
         },
         signFailed: {
             title: 'earn.claimTransactionDataReviewScreen.signTransactionFailedAlert.title',
             description:
                 'earn.claimTransactionDataReviewScreen.signTransactionFailedAlert.description',
-            primaryButton:
-                'earn.claimTransactionDataReviewScreen.signTransactionFailedAlert.primaryButton',
         },
     },
     'yield-approval': {
         signFailed: {
             title: 'earn.yieldReview.alerts.approval.signTransactionFailed.title',
             description: 'earn.yieldReview.alerts.approval.signTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pushFailed: {
             title: 'earn.yieldReview.alerts.approval.pushTransactionFailed.title',
             description: 'earn.yieldReview.alerts.approval.pushTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pendingConflict: {
             title: 'earn.yieldReview.alerts.approval.pendingTransactionConflict.title',
             description: 'earn.yieldReview.alerts.approval.pendingTransactionConflict.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
     },
     'yield-deposit': {
         signFailed: {
             title: 'earn.yieldReview.alerts.deposit.signTransactionFailed.title',
             description: 'earn.yieldReview.alerts.deposit.signTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pushFailed: {
             title: 'earn.yieldReview.alerts.deposit.pushTransactionFailed.title',
             description: 'earn.yieldReview.alerts.deposit.pushTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pendingConflict: {
             title: 'earn.yieldReview.alerts.deposit.pendingTransactionConflict.title',
             description: 'earn.yieldReview.alerts.deposit.pendingTransactionConflict.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
     },
     'yield-revoke': {
         signFailed: {
             title: 'earn.yieldReview.alerts.revoke.signTransactionFailed.title',
             description: 'earn.yieldReview.alerts.revoke.signTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pushFailed: {
             title: 'earn.yieldReview.alerts.revoke.pushTransactionFailed.title',
             description: 'earn.yieldReview.alerts.revoke.pushTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pendingConflict: {
             title: 'earn.yieldReview.alerts.revoke.pendingTransactionConflict.title',
             description: 'earn.yieldReview.alerts.revoke.pendingTransactionConflict.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
     },
     'yield-withdraw': {
         signFailed: {
             title: 'earn.yieldReview.alerts.withdraw.signTransactionFailed.title',
             description: 'earn.yieldReview.alerts.withdraw.signTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pushFailed: {
             title: 'earn.yieldReview.alerts.withdraw.pushTransactionFailed.title',
             description: 'earn.yieldReview.alerts.withdraw.pushTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pendingConflict: {
             title: 'earn.yieldReview.alerts.withdraw.pendingTransactionConflict.title',
             description: 'earn.yieldReview.alerts.withdraw.pendingTransactionConflict.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
     },
     'yield-claim': {
         signFailed: {
             title: 'earn.yieldReview.alerts.claim.signTransactionFailed.title',
             description: 'earn.yieldReview.alerts.claim.signTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pushFailed: {
             title: 'earn.yieldReview.alerts.claim.pushTransactionFailed.title',
             description: 'earn.yieldReview.alerts.claim.pushTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pendingConflict: {
             title: 'earn.yieldReview.alerts.claim.pendingTransactionConflict.title',
             description: 'earn.yieldReview.alerts.claim.pendingTransactionConflict.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
     },
     'wrap-native': {
         signFailed: {
             title: 'earn.yieldReview.alerts.wrap.signTransactionFailed.title',
             description: 'earn.yieldReview.alerts.wrap.signTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pushFailed: {
             title: 'earn.yieldReview.alerts.wrap.pushTransactionFailed.title',
             description: 'earn.yieldReview.alerts.wrap.pushTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pendingConflict: {
             title: 'earn.yieldReview.alerts.wrap.pendingTransactionConflict.title',
             description: 'earn.yieldReview.alerts.wrap.pendingTransactionConflict.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
     },
     'unwrap-native': {
         signFailed: {
             title: 'earn.yieldReview.alerts.unwrap.signTransactionFailed.title',
             description: 'earn.yieldReview.alerts.unwrap.signTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pushFailed: {
             title: 'earn.yieldReview.alerts.unwrap.pushTransactionFailed.title',
             description: 'earn.yieldReview.alerts.unwrap.pushTransactionFailed.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
         pendingConflict: {
             title: 'earn.yieldReview.alerts.unwrap.pendingTransactionConflict.title',
             description: 'earn.yieldReview.alerts.unwrap.pendingTransactionConflict.description',
-            primaryButton: 'earn.yieldReview.alerts.primaryButton',
         },
     },
 } as const satisfies Record<ReviewFormType, AlertTranslationKeys>;
 
 export const useShowPushTransactionFailedDuringReviewAlert = (formType: ReviewFormType) => {
     const { showAlert } = useAlert();
-    const navigation = useNavigation<NavigationProps>();
+    const navigation = useNavigation();
     const keys: AlertTranslationKeys = translationKeys[formType];
 
-    const handleGoHome = useCallback(() => {
-        navigation.popTo(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.HomeStack,
-            params: { screen: HomeStackRoutes.Home },
-        });
+    const handleGoBack = useCallback(() => {
+        navigation.dispatch(StackActions.pop());
     }, [navigation]);
 
     const showReviewAlert = useCallback(
@@ -255,12 +198,12 @@ export const useShowPushTransactionFailedDuringReviewAlert = (formType: ReviewFo
             showAlert({
                 title: <Translation id={alertKeys.title} />,
                 description: <Translation id={alertKeys.description} />,
-                primaryButtonTitle: <Translation id={alertKeys.primaryButton} />,
+                primaryButtonTitle: <Translation id="generic.buttons.goBack" />,
                 primaryButtonColorProps: { intent: 'critical', priority: 'primary' },
-                onPressPrimaryButton: handleGoHome,
+                onPressPrimaryButton: handleGoBack,
             });
         },
-        [handleGoHome, keys, showAlert],
+        [handleGoBack, keys, showAlert],
     );
 
     return { showReviewAlert };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Return users to the previous earn form after a failed transaction instead of redirecting them to the Home screen.
- Use the generic “Go back” CTA across staking, yield, wrap, and unwrap transaction alerts.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #31305

## Screenshots:

https://github.com/user-attachments/assets/64c4b00c-2247-4e3c-8aa1-875182b40aa5


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/failed-tx-alert-navigation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->