### PR TITLE
fix(suite): stop the second error when a swap is cancelled on the device

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.cancelledSigning.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.cancelledSigning.test.tsx
@@ -1,0 +1,201 @@
+import type { CryptoId, ExchangeTrade } from 'invity-api';
+
+import { createThunk } from '@suite-common/redux-utils';
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { exchangeInitialState, initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { useTradingExchangeTradeActions } from './useTradingExchangeTradeActions';
+
+const DEVICE_CANCEL_TOAST_ERROR = 'Cancelled';
+
+jest.mock('@suite-common/wallet-core', () => {
+    const actual = jest.requireActual('@suite-common/wallet-core');
+    const actualCompose = actual.composeSendFormTransactionFeeLevelsThunk;
+
+    return {
+        ...actual,
+        composeSendFormTransactionFeeLevelsThunk: Object.assign(jest.fn(), {
+            typePrefix: actualCompose.typePrefix,
+            pending: actualCompose.pending,
+            fulfilled: actualCompose.fulfilled,
+            rejected: actualCompose.rejected,
+        }),
+    };
+});
+
+jest.mock('src/actions/wallet/send/sendFormThunks', () => ({
+    ...jest.requireActual('src/actions/wallet/send/sendFormThunks'),
+    signAndPushSendFormTransactionThunk: jest.fn(() => (dispatch: (action: unknown) => void) => {
+        dispatch(
+            notificationsActions.addToast({
+                type: 'sign-tx-error',
+                error: DEVICE_CANCEL_TOAST_ERROR,
+            }),
+        );
+
+        return { unwrap: () => Promise.resolve(undefined) };
+    }),
+}));
+
+jest.mock('@suite-common/trading', () => ({
+    ...jest.requireActual('@suite-common/trading'),
+    selectTradingIsSlip24Allowed: () => false,
+}));
+
+jest.mock('@suite/device', () => ({
+    ...jest.requireActual('@suite/device'),
+    useDevice: () => ({ device: { connected: true } }),
+}));
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    useTranslation: () => ({ translationString: (id: string) => id }),
+}));
+
+jest.mock('src/hooks/wallet/useBitcoinAmountUnit', () => ({
+    useBitcoinAmountUnit: () => ({ isBtcSatsAmountUnit: false }),
+}));
+
+jest.mock('src/hooks/wallet/trading/form/common/useTradingAssetDecimals', () => ({
+    useTradingAssetDecimals: () => ({ getAssetDecimals: () => 18 }),
+}));
+
+jest.mock('@suite-common/message-system', () => ({
+    ...jest.requireActual('@suite-common/message-system'),
+    selectIsFeatureEnabled: () => false,
+}));
+
+jest.mock('@suite/settings', () => ({
+    ...jest.requireActual('@suite/settings'),
+    selectHasExperimentalFeature: () => () => false,
+}));
+
+jest.mock('src/hooks/wallet/trading/form/common/useTradingExchangeTradeRequest', () => ({
+    useTradingExchangeTradeRequest: () => ({
+        getTradeRequestParams: () =>
+            Promise.resolve({
+                returnUrl: 'https://return.url',
+                triggerAnalyticsTradeConfirmation: jest.fn(),
+                processResponseData: jest.fn(),
+                nextStep: jest.fn(),
+            }),
+    }),
+}));
+
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('eth') });
+
+jest.mock('src/hooks/wallet/trading/form/useTradingFormAccount', () => ({
+    useTradingFormAccount: () => ({
+        tradingAccountKey: ACCOUNT.key,
+        account: ACCOUNT,
+        cryptoId: 'ethereum' as CryptoId,
+    }),
+}));
+
+const SELECTED_QUOTE: ExchangeTrade = {
+    quoteId: 'd369ba9e-7370-4a6e-87dc-aefd3851c735',
+    orderId: 'orderId',
+    exchange: 'changelly',
+    send: 'ethereum' as CryptoId,
+    receive: 'base--usdc' as CryptoId,
+    sendStringAmount: '0.05',
+    receiveStringAmount: '120',
+    sendAddress: 'exchangeDepositAddress',
+    status: 'CONFIRM',
+};
+
+const preloadedState = {
+    wallet: {
+        accounts: [ACCOUNT],
+        fees: {
+            [ACCOUNT.symbol]: {
+                status: 'loaded',
+                data: {
+                    blockHeight: 1,
+                    blockTime: 10,
+                    minFee: 1,
+                    maxFee: 100,
+                    dustLimit: 0,
+                    levels: [{ label: 'normal' as const, feePerUnit: '2', blocks: 2 }],
+                },
+            },
+        },
+        trading: {
+            ...tradingInitialState,
+            composedTransactionInfo: {
+                composed: {
+                    feePerByte: '2',
+                    feeLimit: '21000',
+                    estimatedFeeLimit: '21000',
+                    fee: '42000',
+                    token: undefined,
+                    outputs: [],
+                },
+                selectedFee: 'normal' as const,
+            },
+            exchange: {
+                ...exchangeInitialState,
+                selectedQuote: SELECTED_QUOTE,
+                tradingAccountKey: ACCOUNT.key,
+            },
+        },
+    },
+    device: {
+        devices: [],
+        selectedDevice: {
+            connected: true,
+            unavailableCapabilities: {},
+            features: { major_version: 2, minor_version: 8, patch_version: 11 },
+        },
+    },
+};
+
+describe('cancelling a swap on the device', () => {
+    beforeEach(() => {
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementation(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            totalSpent: '50000000000000000',
+                            fee: '42000',
+                            feePerByte: '2',
+                            feeLimit: '21000',
+                            estimatedFeeLimit: '21000',
+                            bytes: 0,
+                            inputs: [],
+                            outputs: [{ amount: '50000000000000000' }],
+                            outputsPermutation: [0],
+                        },
+                    }),
+            ),
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('reports the cancellation once and nothing else', async () => {
+        const store = configureMockStore({ preloadedState });
+        const { result } = renderHookWithStoreProvider(() => useTradingExchangeTradeActions(), {
+            store,
+        });
+
+        const success = await result.current.sendTransaction();
+
+        const toasts = store
+            .getActions()
+            .filter(action => action.type === notificationsActions.addToast.type);
+
+        expect(success).toBe(false);
+        expect(toasts).toHaveLength(1);
+        expect(toasts[0]?.payload).toMatchObject({ error: DEVICE_CANCEL_TOAST_ERROR });
+    });
+});

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.test.tsx
@@ -1,6 +1,7 @@
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { exchangeInitialState, initialState as tradingInitialState } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
@@ -171,6 +172,41 @@ describe('useTradingExchangeTradeActions', () => {
 
             expect(args.account).toBe(ACCOUNT);
             expect(args.setMaxOutputId).toBeUndefined();
+        });
+
+        const rejectSendWith = (rejection: unknown) => {
+            mockSendTransactionThunk.mockImplementationOnce((args: unknown) =>
+                Object.assign(() => ({ unwrap: () => Promise.reject(rejection) }), { args }),
+            );
+        };
+
+        const toastsOf = (actions: { type: string }[]) =>
+            actions.filter(action => action.type === notificationsActions.addToast.type);
+
+        it('adds no toast of its own when the signing was cancelled', async () => {
+            rejectSendWith({
+                type: 'sign-cancelled',
+                error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+            });
+            const { store, result } = renderActions();
+
+            const success = await result.current.sendTransaction();
+
+            expect(success).toBe(false);
+            expect(toastsOf(store.getActions())).toHaveLength(0);
+        });
+
+        it('reports an error nothing else has reported', async () => {
+            rejectSendWith({
+                type: 'sign-tx-error',
+                error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+            });
+            const { store, result } = renderActions();
+
+            const success = await result.current.sendTransaction();
+
+            expect(success).toBe(false);
+            expect(toastsOf(store.getActions())).toHaveLength(1);
         });
 
         it('returns false without dispatching when the account is missing', async () => {

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.ts
@@ -9,6 +9,7 @@ import {
     type TradingSignAndPushSendFormTransactionProps,
     exchangeThunks,
     isSendRejectedError,
+    isSilentSendRejection,
     selectTradingExchange,
     selectTradingExchangeActiveTrade,
     selectTradingExchangeSelectedQuote,
@@ -148,7 +149,7 @@ export const useTradingExchangeTradeActions = () => {
                 return false;
             }
 
-            if (e.type !== 'sign-transaction-timeout') {
+            if (!isSilentSendRejection(e.type)) {
                 dispatch(
                     notificationsActions.addToast({
                         type: e.type,

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts
@@ -10,6 +10,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type TradingSignAndPushSendFormTransactionProps,
     isSendRejectedError,
+    isSilentSendRejection,
     selectTradingComposedTransactionInfo,
     selectTradingIsSlip24Allowed,
     selectTradingSellActiveTrade,
@@ -148,7 +149,7 @@ export const useTradingSellTradeActions = () => {
                 return false;
             }
 
-            if (e.type !== 'sign-transaction-timeout') {
+            if (!isSilentSendRejection(e.type)) {
                 dispatch(
                     notificationsActions.addToast({
                         type: e.type,

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -576,6 +576,48 @@ describe('recomposeAndSignTxThunk', () => {
         expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(1);
     });
 
+    it('should reject as cancelled when the signing flow returns no result', async () => {
+        const { store, account, tradingFormState } = getMocks();
+
+        const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce(undefined);
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
+                        },
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: 'address',
+                amount: '0.1',
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('rejected');
+        expect(response.payload).toEqual({
+            type: 'sign-cancelled',
+            error: {
+                id: 'TR_TRADING_CANNOT_SEND_TRANSACTION',
+            },
+        });
+        expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(1);
+    });
+
     it('should return successful recomposed and signed transaction using custom fees', async () => {
         const { store, account, tradingFormState } = getMocks({
             composedTransactionInfo: {

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -315,6 +315,13 @@ export const recomposeAndSignTxThunk = createThunk<
             paymentRequests,
         });
 
+        if (!resultOfSignedTransaction) {
+            return rejectWithValue({
+                type: 'sign-cancelled',
+                error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+            });
+        }
+
         return fulfillWithValue(resultOfSignedTransaction);
     },
 );

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.test.ts
@@ -127,6 +127,13 @@ describe('sendDexTransactionThunk', () => {
             ['when payload is undefined', undefined],
             ['when payload contains error', { type: 'error', error: { id: 'TR_ERROR' } }],
             ['when payload is not successful', { success: false }],
+            [
+                'when the signing was cancelled on the device',
+                {
+                    type: 'sign-cancelled',
+                    error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+                },
+            ],
         ])('%s', async (_, recomposeAndSignPayload) => {
             const { store, returnUrl, account } = getMocks();
 

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.test.ts
@@ -245,6 +245,13 @@ describe('sendTransactionThunk', () => {
             ['when payload is undefined', undefined],
             ['when payload contains error', { type: 'error', error: { id: 'TR_ERROR' } }],
             ['when payload is not successful', { success: false }],
+            [
+                'when the signing was cancelled on the device',
+                {
+                    type: 'sign-cancelled',
+                    error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+                },
+            ],
         ])('%s', async (_, recomposeAndSignPayload) => {
             const { store, returnUrl, account, trade } = getMocks();
 

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -271,7 +271,7 @@ export type MinimalExchangeFormProps = {
 export type TradingExchangeStepType = 'RECEIVING_ADDRESS' | 'SEND_TRANSACTION' | 'SIGN_DATA';
 
 export type TradingSendRejectedProps<TranslationKey extends string = string> = {
-    type: 'error' | 'sign-tx-error' | 'sign-transaction-timeout';
+    type: 'error' | 'sign-tx-error' | 'sign-transaction-timeout' | 'sign-cancelled';
     error: {
         id: TranslationKey;
         values?: Record<string, PrimitiveType>;

--- a/suite-common/trading/src/utils/typeGuards.test.ts
+++ b/suite-common/trading/src/utils/typeGuards.test.ts
@@ -1,4 +1,4 @@
-import { isSendRejectedError } from './typeGuards';
+import { isSendRejectedError, isSilentSendRejection } from './typeGuards';
 
 describe('typeGuards', () => {
     describe('isSendRejectedError', () => {
@@ -9,6 +9,17 @@ describe('typeGuards', () => {
                     error: {
                         id: 'TR_GENERIC_ERROR',
                         values: { foo: 'bar' },
+                    },
+                }),
+            ).toBe(true);
+        });
+
+        it('returns true for a cancelled signing', () => {
+            expect(
+                isSendRejectedError({
+                    type: 'sign-cancelled',
+                    error: {
+                        id: 'TR_TRADING_CANNOT_SEND_TRANSACTION',
                     },
                 }),
             ).toBe(true);
@@ -57,6 +68,18 @@ describe('typeGuards', () => {
                     },
                 }),
             ).toBe(false);
+        });
+    });
+
+    describe('isSilentSendRejection', () => {
+        it('is silent for a cancelled signing and for a signing timeout', () => {
+            expect(isSilentSendRejection('sign-cancelled')).toBe(true);
+            expect(isSilentSendRejection('sign-transaction-timeout')).toBe(true);
+        });
+
+        it('is not silent for errors that nothing else reports', () => {
+            expect(isSilentSendRejection('error')).toBe(false);
+            expect(isSilentSendRejection('sign-tx-error')).toBe(false);
         });
     });
 });

--- a/suite-common/trading/src/utils/typeGuards.ts
+++ b/suite-common/trading/src/utils/typeGuards.ts
@@ -2,7 +2,19 @@ import { isArrayMember } from '@trezor/utils';
 
 import { type TradingSendRejectedProps } from '../types';
 
-const TRADING_SEND_REJECTED_TYPES = ['error', 'sign-tx-error', 'sign-transaction-timeout'] as const;
+const TRADING_SEND_REJECTED_TYPES = [
+    'error',
+    'sign-tx-error',
+    'sign-transaction-timeout',
+    'sign-cancelled',
+] as const;
+
+const SILENT_SEND_REJECTED_TYPES = ['sign-transaction-timeout', 'sign-cancelled'] as const;
+
+export const isSilentSendRejection = (
+    type: TradingSendRejectedProps['type'],
+): type is (typeof SILENT_SEND_REJECTED_TYPES)[number] =>
+    isArrayMember(type, SILENT_SEND_REJECTED_TYPES);
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
     typeof value === 'object' && value !== null;


### PR DESCRIPTION
## Description

Cancelling a swap signing on the device produced two toasts: the expected `Cancelled`, plus a misleading `Unable to send transaction, missing data`.

- The signing flow reports the cancellation itself and then returns no result. The trade read that as missing data and raised its own error on top.
- `recomposeAndSignTxThunk` now rejects a signing that ends without a signature as `sign-cancelled`, and the trade hooks stay quiet for rejections something else already reported (cancel, timeout).
- Fixed in the shared thunk, so it covers CEX swaps, DEX swaps and sells.

Tests: an integration test drives the real hook and thunks with only the device faked — it produces the two toasts against the old code and one with the fix — plus unit tests for the new rejection type and the hook's silence.

## Notes for QA

1. Swap BASE ETH → BASE USDC, confirm the address, then cancel on the device when asked to sign.
2. Expect exactly one toast: `Transaction signing error: Cancelled`.
3. Same check for a CEX swap and a sell — they share the signing path.
4. A real signing failure (not a cancel) must still show its error.
5. Cancelling in Suite's own review modal now shows no toast at all, where it previously showed the "missing data" one.

## Related Issue

Resolve #19668

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes focus on core trading transaction hooks and thunks for exchange/swap and sell flows, including transaction recomposition, signing, DEX-specific sending, and type guards. Risk is concentrated in end-to-end swap and sell transaction execution. The recommended strategy runs a small, targeted set of high-priority swap and sell tests covering both DEX and CEX swap paths plus sell flows, with a few medium-priority tests for adjacent paths and different coin types.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.cancelledSigning.test.tsx`
- `packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.test.tsx`
- `packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.ts`
- `packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/sendTransactionThunk.test.ts`
- `suite-common/trading/src/types.ts`
- `suite-common/trading/src/utils/typeGuards.test.ts`
- `suite-common/trading/src/utils/typeGuards.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the full sell flow including confirming a sell offer, initiating the send flow, and verifying the device prompt for the transaction. It directly covers the changed `useTradingSellTradeActions.ts`, `recomposeAndSignTxThunk.ts`, and `sendTransactionThunk.ts` code paths.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test performs a full DEX swap (ETH to USDC via LI.FI), which is the primary end-to-end path for the changed `sendDexTransactionThunk.ts` and `useTradingExchangeTradeActions.ts`. It verifies device review, signing, broadcasting, and status progression.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — This test exercises a regular CEX swap (ETH to SOL) including device confirmation, signing, broadcasting, and swap status flow. It directly covers `useTradingExchangeTradeActions.ts`, `recomposeAndSignTxThunk.ts`, and `sendTransactionThunk.ts` for non-DEX swaps.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test covers an EVM sell flow with custom gas fees, providing additional coverage of `useTradingSellTradeActions.ts` and `recomposeAndSignTxThunk.ts` for Ethereum-specific transaction composition and signing.
- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — This test exercises the token approval step required before DEX swaps, which uses related exchange trade action infrastructure and transaction signing. It helps catch regressions in the DEX approval path adjacent to the changed DEX send thunk.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — This test covers a Solana-to-Bitcoin swap, exercising the swap signing and broadcasting flow for a non-EVM coin pair. It provides broader confidence that the changed `sendTransactionThunk` and `useTradingExchangeTradeActions` work across different blockchain integrations.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.cancelledSigning.test.tsx`
- `packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.test.tsx`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/sendTransactionThunk.test.ts`
- `suite-common/trading/src/types.ts`
- `suite-common/trading/src/utils/typeGuards.test.ts`

_Updated: 2026-08-27T10:15:37.037Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/19668-swap-cancel-double-error/web/](https://dev.suite.sldev.cz/suite-web/19668-swap-cancel-double-error/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=19668-swap-cancel-double-error&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=19668-swap-cancel-double-error&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=19668-swap-cancel-double-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T10:15:02.255Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T10:16:35.478Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
