### PR TITLE
test(component-tests): add csv import test

### DIFF
--- a/suite/component-tests/fixtures/btcTest.csv
+++ b/suite/component-tests/fixtures/btcTest.csv
@@ -1,0 +1,3 @@
+address,amount,currency,label
+bc1qfcjv620stvtzjeelg26ncgww8ks49zy8lracjz,0.31337,BTC,meow
+bc1quqgq44wq0zjh6d920zs42nsy4n4ev5vt8nxke4,0.5,USD, meow2

--- a/suite/component-tests/stories/importCsv.story.tsx
+++ b/suite/component-tests/stories/importCsv.story.tsx
@@ -1,0 +1,34 @@
+import { useMemo, useState } from 'react';
+
+import { ImportTransactionModal } from '@trezor/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal';
+import { createDeferred } from '@trezor/utils';
+
+import { MockStoreStory } from '../gallery/storyProviders';
+
+/**
+ * The modal resolves a deferred with the parsed rows and closes itself, so the story owns the
+ * deferred and records what it received into a hidden input for the test to read.
+ */
+export const CsvImport = () => {
+    const [parsedOutputs, setParsedOutputs] = useState<Record<string, string>[] | null>(null);
+
+    const decision = useMemo(() => {
+        const deferred = createDeferred<Record<string, string>[]>();
+        deferred.promise.then(setParsedOutputs).catch(() => {});
+
+        return deferred;
+    }, []);
+
+    return (
+        <MockStoreStory>
+            <ImportTransactionModal onCancel={() => {}} decision={decision} />
+            <form hidden>
+                <input
+                    data-testid="parsed-outputs"
+                    readOnly
+                    value={parsedOutputs ? JSON.stringify(parsedOutputs) : ''}
+                />
+            </form>
+        </MockStoreStory>
+    );
+};

--- a/suite/component-tests/tests/importCsv.test.ts
+++ b/suite/component-tests/tests/importCsv.test.ts
@@ -1,0 +1,52 @@
+import { test } from '@playwright/test';
+import path from 'path';
+
+import { expect } from '../support/customMatchers';
+
+/**
+ * Importing a CSV into the send form.
+ *
+ * Converted from `suite/e2e/tests/wallet/import-btc-csv.test.ts`, which completed onboarding,
+ * enabled Bitcoin, connected a Dropbox metadata provider and opened the send form before it could
+ * pick a file. The parsing and currency mapping this covers had no test at any level; the e2e
+ * asserted them by reading the populated send-form inputs.
+ *
+ * Still only in the e2e test: that the resolved rows reach the send form's output fields, and the
+ * output labels that go through the metadata provider.
+ */
+const CSV_FIXTURE = path.join(__dirname, '../fixtures/btcTest.csv');
+
+test('parses a CSV and maps display symbols to network symbols', async ({ mount }) => {
+    const component = await mount('importCsv/CsvImport');
+
+    await component.locator('input[type=file]').setInputFiles(CSV_FIXTURE);
+    await component.getByTestId('@import-csv/import-button').click();
+
+    // `BTC` resolves to the `btc` network symbol; `USD` matches no network so it is left alone.
+    await expect(component.getByTestId('parsed-outputs')).toHaveValue(
+        JSON.stringify([
+            {
+                address: 'bc1qfcjv620stvtzjeelg26ncgww8ks49zy8lracjz',
+                amount: '0.31337',
+                currency: 'btc',
+                label: 'meow',
+            },
+            {
+                address: 'bc1quqgq44wq0zjh6d920zs42nsy4n4ev5vt8nxke4',
+                amount: '0.5',
+                currency: 'USD',
+                label: 'meow2',
+            },
+        ]),
+    );
+});
+
+test('the import button stays disabled until a file is chosen', async ({ mount }) => {
+    const component = await mount('importCsv/CsvImport');
+
+    await expect(component.getByTestId('@import-csv/import-button')).toBeDisabled();
+
+    await component.locator('input[type=file]').setInputFiles(CSV_FIXTURE);
+
+    await expect(component.getByTestId('@import-csv/import-button')).toBeEnabled();
+});


### PR DESCRIPTION
## Description

Third layer of the `@suite/component-tests` stack, on top of #31762.

Mounts `ImportTransactionModal` and asserts on the rows it resolves: CSV parsing, the display-symbol → network-symbol mapping (`BTC` → `btc`, `USD` left alone because no network matches it), and the import button staying disabled until a file is chosen.

Converted from `suite/e2e/tests/wallet/import-btc-csv.test.ts`, which completed onboarding, enabled Bitcoin, connected a Dropbox metadata provider and opened the send form before it could pick a file.

That e2e test still uniquely covers the resolved rows reaching the send form's output fields, and the output labels that go through the metadata provider — so it stays, and the fixture is copied rather than moved.

## Notes for QA

Nothing to test — no app code touched.

## Related Issue

Resolve

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in the component-tests gallery/framework and a shared test store initializer. Only two changed component stories/tests have direct E2E equivalents: autodetect and BTC CSV import. Those should be run as high-priority regression checks. The remaining gallery infrastructure and test-utility files have no specific E2E coverage evidence, so no other E2E tests are recommended.

<details><summary><b>Changed files (11)</b></summary>

- `suite/component-tests/gallery/main.tsx`
- `suite/component-tests/gallery/storyProviders.tsx`
- `suite/component-tests/galleryServer.ts`
- `suite/component-tests/package.json`
- `suite/component-tests/stories/autodetect.story.tsx`
- `suite/component-tests/stories/importCsv.story.tsx`
- `suite/component-tests/support/customMatchers.ts`
- `suite/component-tests/tests/autodetect.test.ts`
- `suite/component-tests/tests/importCsv.test.ts`
- `suite/component-tests/tsconfig.json`
- `suite/test-utils/src/initStoreForTests.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — The changed component-test files `stories/autodetect.story.tsx` and `tests/autodetect.test.ts` directly correspond to the browser color-scheme and locale autodetect feature. This E2E test exercises the same autodetect UI path and assertions, so changes to the component test stories or their infrastructure could reflect or mask issues visible here.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — The changed component-test files `stories/importCsv.story.tsx` and `tests/importCsv.test.ts` directly correspond to the BTC CSV import into the send form. This E2E test validates the full CSV import flow, output population, and metadata labels, making it the best regression check for changes affecting that feature.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite/component-tests/gallery/main.tsx`
- `suite/component-tests/gallery/storyProviders.tsx`
- `suite/component-tests/galleryServer.ts`
- `suite/component-tests/package.json`
- `suite/component-tests/support/customMatchers.ts`
- `suite/component-tests/tsconfig.json`
- `suite/test-utils/src/initStoreForTests.ts`

_Updated: 2026-09-01T09:59:01.225Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/component-tests-import-csv&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/component-tests-import-csv&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T10:00:41.676Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T10:01:10.674Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/component-tests-import-csv/web/](https://dev.suite.sldev.cz/suite-web/test/component-tests-import-csv/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->