### PR TITLE
test(component-tests): add eth staking form tests

### DIFF
--- a/suite/component-tests/mocks/mockStakingState.ts
+++ b/suite/component-tests/mocks/mockStakingState.ts
@@ -1,0 +1,77 @@
+import {
+    mockWalletAccount,
+    networkSpecificDefaultEthereum,
+} from '@suite-common/wallet-types/mocks';
+import { getFiatRateKey, networkAmountToSmallestUnit } from '@suite-common/wallet-utils';
+import { type PreloadedState } from '@trezor/suite';
+import { type DeepPartial } from '@trezor/type-utils';
+
+/** Rate the e2e test mocked through blockbook, kept so expected fiat values stay comparable. */
+export const MOCK_ETH_RATE = 0.5;
+
+/**
+ * `formattedBalance` is in ETH; `balance` and `availableBalance` are in wei, as a discovered
+ * account stores them. Amount validation reads `availableBalance`, so passing ETH there silently
+ * turns the balance into 2.5 wei and every amount looks like insufficient funds.
+ */
+export const mockEthereumStakingAccount = (formattedBalance: string) => {
+    const balanceInWei = networkAmountToSmallestUnit(formattedBalance, 'eth');
+
+    return mockWalletAccount(
+        {
+            symbol: 'eth',
+            balance: balanceInWei,
+            availableBalance: balanceInWei,
+            formattedBalance,
+        },
+        networkSpecificDefaultEthereum,
+    );
+};
+
+/**
+ * The slice of wallet state `useStakeForm` reads: the account being staked, the base currency, and
+ * a current fiat rate. Staking limits are constants and `amountLimits` is derived from the balance,
+ * so no composed transaction — and therefore no backend — is involved.
+ */
+export const mockStakingWalletState = (
+    account: ReturnType<typeof mockEthereumStakingAccount>,
+): DeepPartial<PreloadedState> => ({
+    wallet: {
+        accounts: [account],
+        selectedAccount: { status: 'loaded', account },
+        settings: { localCurrency: 'usd', enabledNetworks: ['eth'] },
+        fiat: {
+            current: {
+                [getFiatRateKey('eth', 'usd')]: {
+                    rate: MOCK_ETH_RATE,
+                    lastTickerTimestamp: 0,
+                    isLoading: false,
+                    error: null,
+                },
+            },
+        },
+        // `useFees` reads this; the values match the eth fixture in
+        // packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts. Importing that fixture
+        // instead would pull the app's component tree into the Node test process.
+        fees: {
+            eth: {
+                status: 'loaded',
+                data: {
+                    minPriorityFee: 0,
+                    minFee: 1,
+                    maxFee: 100,
+                    blockHeight: 1,
+                    blockTime: 1,
+                    levels: [
+                        {
+                            label: 'normal',
+                            feePerUnit: '3300000000',
+                            feeLimit: '21000',
+                            blocks: -1,
+                        },
+                    ],
+                },
+            },
+        },
+    },
+});

--- a/suite/component-tests/package.json
+++ b/suite/component-tests/package.json
@@ -18,6 +18,8 @@
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
         "@suite/intl": "workspace:^",
         "@suite/test-utils": "workspace:*",
         "@tanstack/react-query": "5.101.2",

--- a/suite/component-tests/stories/stakeForm.story.tsx
+++ b/suite/component-tests/stories/stakeForm.story.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+
+import { type Account } from '@suite-common/wallet-types';
+import { StakeInputs } from '@trezor/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs';
+import { StakeFormContext, useStakeForm } from '@trezor/suite/src/hooks/earn/useStakeForm';
+
+import { MockStoreStory } from '../gallery/storyProviders';
+import { mockEthereumStakingAccount, mockStakingWalletState } from '../mocks/mockStakingState';
+
+/**
+ * `StakeModal` is the only place that provides `StakeFormContext`, and it also renders a modal,
+ * the info cards and the submit button. This host reproduces just the provider, so the story is
+ * the inputs and nothing else.
+ */
+const StakeInputsHost = ({ account }: { account: Account }) => {
+    const stakeContextValues = useStakeForm({ account });
+
+    if (!stakeContextValues.stakingLimits) {
+        return null;
+    }
+
+    return (
+        <StakeFormContext.Provider value={stakeContextValues}>
+            <StakeInputs />
+        </StakeFormContext.Provider>
+    );
+};
+
+/** Balance is a prop so a test can drive the fraction-button and Max maths from a known number. */
+export const EthereumStakeInputs = ({ balance = '2.5' }: { balance?: string }) => {
+    // Memoized so a re-render (e.g. `component.update()`) keeps the same store instead of silently
+    // resetting all Redux-sourced state mid-test.
+    const { account, preloadedState } = useMemo(() => {
+        const mockedAccount = mockEthereumStakingAccount(balance);
+
+        return { account: mockedAccount, preloadedState: mockStakingWalletState(mockedAccount) };
+    }, [balance]);
+
+    return (
+        <MockStoreStory preloadedState={preloadedState}>
+            <StakeInputsHost account={account} />
+        </MockStoreStory>
+    );
+};

--- a/suite/component-tests/tests/stakeForm.test.ts
+++ b/suite/component-tests/tests/stakeForm.test.ts
@@ -1,0 +1,121 @@
+import { test } from '@playwright/test';
+
+import { localizeNumber } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { MOCK_ETH_RATE } from '../mocks/mockStakingState';
+import { expect } from '../support/customMatchers';
+
+/**
+ * ETH staking form limits, fraction buttons and the fiat/crypto switch.
+ *
+ * Converted from `suite/e2e/tests/staking/staking-form.test.ts`, which completed onboarding,
+ * enabled Ethereum against a mocked blockbook and discovered an account before it could type into
+ * this input. None of that is needed to exercise the form: `amountLimits` derives from the account
+ * balance and staking constants, so a preloaded balance is enough.
+ */
+const BALANCE = '2.5';
+const WITHDRAWAL_BUFFER = '0.005';
+const MIN_AMOUNT_FOR_STAKING = '0.01';
+const ETH_DECIMALS = 18;
+const STORY = 'stakeForm/EthereumStakeInputs';
+
+const cryptoInput = '@staking/form/crypto-input';
+const bottomText = '@staking/form/crypto-input/bottom-text';
+
+test.describe('crypto amount limits', () => {
+    test('rejects an amount below the staking minimum', async ({ mount }) => {
+        const component = await mount(STORY, { balance: BALANCE });
+
+        await component.getByTestId(cryptoInput).fill('0.00000001');
+
+        await expect(component.getByTestId(bottomText)).toHaveTranslation(
+            'TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO',
+            { values: { minimum: `${MIN_AMOUNT_FOR_STAKING} ETH` } },
+        );
+    });
+
+    test('rejects more decimal places than the network supports', async ({ mount }) => {
+        const component = await mount(STORY, { balance: BALANCE });
+
+        await component.getByTestId(cryptoInput).fill('0.0000000000000000001');
+
+        await expect(component.getByTestId(bottomText)).toHaveTranslation(
+            'AMOUNT_IS_NOT_IN_RANGE_DECIMALS',
+            { values: { decimals: ETH_DECIMALS } },
+        );
+    });
+
+    test('rejects an amount above the balance', async ({ mount }) => {
+        const component = await mount(STORY, { balance: BALANCE });
+
+        await component.getByTestId(cryptoInput).fill('4000');
+
+        await expect(component.getByTestId(bottomText)).toHaveTranslation('AMOUNT_IS_NOT_ENOUGH');
+    });
+
+    test('reports an empty amount, then accepts a valid one', async ({ mount }) => {
+        const component = await mount(STORY, { balance: BALANCE });
+        const input = component.getByTestId(cryptoInput);
+
+        await input.fill('0.1');
+        await input.clear();
+        await expect(component.getByTestId(bottomText)).toHaveTranslation('AMOUNT_IS_NOT_SET');
+
+        await input.fill('0.1');
+        await expect(component.getByTestId(bottomText)).toBeHidden();
+    });
+});
+
+test.describe('fraction buttons', () => {
+    [
+        { label: '10%', divisor: 10 },
+        { label: '25%', divisor: 4 },
+        { label: '50%', divisor: 2 },
+    ].forEach(({ label, divisor }) => {
+        test(`${label} fills the matching share of the balance`, async ({ mount }) => {
+            const component = await mount(STORY, { balance: BALANCE });
+
+            await component.getByRole('button', { name: label }).click();
+
+            const expected = new BigNumber(BALANCE).dividedBy(divisor).decimalPlaces(ETH_DECIMALS);
+            await expect(component.getByTestId(cryptoInput)).toHaveValue(
+                localizeNumber(expected.toString()),
+            );
+        });
+    });
+
+    test('Max leaves the withdrawal buffer behind and warns about it', async ({ mount }) => {
+        const component = await mount(STORY, { balance: BALANCE });
+
+        await component.getByRole('button', { name: 'Max' }).click();
+
+        const expectedMax = new BigNumber(BALANCE).minus(WITHDRAWAL_BUFFER);
+        await expect(component.getByTestId(cryptoInput)).toHaveValue(
+            localizeNumber(expectedMax.toString()),
+        );
+        await expect(
+            component.getByTestId('@staking/form/withdrawal-warning'),
+        ).toContainTranslation('TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL', {
+            values: { amount: WITHDRAWAL_BUFFER, networkDisplaySymbol: 'ETH' },
+        });
+    });
+});
+
+test('switching to fiat converts the amount and back again', async ({ mount }) => {
+    const component = await mount(STORY, { balance: BALANCE });
+    const cryptoValue = '500';
+
+    await component.getByTestId(cryptoInput).fill(cryptoValue);
+    await component.getByTestId('@staking/form/switch-inputs').click();
+
+    await expect(component.getByTestId('@staking/form/fiat-input')).toHaveValue(
+        new BigNumber(cryptoValue).times(MOCK_ETH_RATE).toString(),
+    );
+    await expect(component.getByTestId('@staking/form/fiat-input/input-addon')).toHaveText('USD');
+
+    await component.getByTestId('@staking/form/switch-inputs').click();
+
+    await expect(component.getByTestId(cryptoInput)).toHaveValue(cryptoValue);
+    await expect(component.getByTestId('@staking/form/crypto-input/input-addon')).toHaveText('ETH');
+});

--- a/suite/component-tests/tsconfig.json
+++ b/suite/component-tests/tsconfig.json
@@ -12,6 +12,7 @@
     },
     "include": [
         "gallery",
+        "mocks",
         "stories",
         "support",
         "tests",
@@ -27,6 +28,12 @@
         },
         {
             "path": "../../suite-common/test-utils"
+        },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
+            "path": "../../suite-common/wallet-utils"
         },
         { "path": "../intl" },
         { "path": "../test-utils" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15204,6 +15204,8 @@ __metadata:
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
     "@suite/intl": "workspace:^"
     "@suite/test-utils": "workspace:*"
     "@tanstack/react-query": "npm:5.101.2"


### PR DESCRIPTION
## Description

Top layer of the `@suite/component-tests` stack, on top of #31764.

Mounts `StakeInputs` behind a reproduced `StakeFormContext` and covers the ETH staking form: amount limits (below the staking minimum, too many decimals, above the balance, empty), the 10/25/50%/Max fraction buttons including the withdrawal buffer warning, and the fiat/crypto switch.

Converted from `suite/e2e/tests/staking/staking-form.test.ts`, which completed onboarding, enabled Ethereum against a mocked blockbook and discovered an account before it could type into the input. None of that is needed — `amountLimits` derives from the account balance and staking constants, so a preloaded balance is enough; `mocks/mockStakingState.ts` supplies that slice of wallet state.

The e2e test it supersedes stays in place until the component tests run in CI.

## Notes for QA

Nothing to test — no app code touched.

## Related Issue

Resolve

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in component-test stories/tests for autodetect, import CSV, and stake form, plus supporting test infrastructure. The highest-confidence E2E coverage comes from tests that exercise the same end-user flows: settings autodetect, wallet BTC CSV import, and the staking form. ETH and SOL staking flow tests are included at medium priority because they reuse the staking form and state mocks. Gallery/config/test-utility files have no direct E2E coverage and should be validated by their own component/unit test suite.

<details><summary><b>Changed files (14)</b></summary>

- `suite/component-tests/gallery/main.tsx`
- `suite/component-tests/gallery/storyProviders.tsx`
- `suite/component-tests/galleryServer.ts`
- `suite/component-tests/mocks/mockStakingState.ts`
- `suite/component-tests/package.json`
- `suite/component-tests/stories/autodetect.story.tsx`
- `suite/component-tests/stories/importCsv.story.tsx`
- `suite/component-tests/stories/stakeForm.story.tsx`
- `suite/component-tests/support/customMatchers.ts`
- `suite/component-tests/tests/autodetect.test.ts`
- `suite/component-tests/tests/importCsv.test.ts`
- `suite/component-tests/tests/stakeForm.test.ts`
- `suite/component-tests/tsconfig.json`
- `suite/test-utils/src/initStoreForTests.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — The changed component-test files include autodetect.story.tsx and tests/autodetect.test.ts, which directly mirror the settings autodetect behavior (browser color scheme and locale adoption). This E2E test exercises the same user-facing feature end-to-end and is the best regression signal.
- `suite/e2e/tests/staking/staking-form.test.ts` — The changed files include stakeForm.story.tsx, tests/stakeForm.test.ts, and mocks/mockStakingState.ts, all focused on the staking form. This E2E test directly validates staking form input, validation, percentage buttons, crypto/fiat switching, and max amount behavior.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — The changed component-test files include importCsv.story.tsx and tests/importCsv.test.ts. This E2E test exercises the same BTC send-form CSV import flow, validating that imported addresses, amounts, and metadata labels populate correctly.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This flow uses the ETH staking form and staking state that the component-test changes target. A regression in form validation or staking state shape could break the initial stake flow, so it provides meaningful shared-coverage signal.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more flow reuses the same ETH staking form and dashboard state as the changed component tests. It is a good sanity check that the form still works within an existing staked account context.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL initial staking also depends on the staking form and staking-state mocks that were updated. Running this ensures the changes do not inadvertently affect Solana's first-time staking flow.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — SOL stake-more reuses the staking form for an already-staked Solana account, making it a relevant cross-chain check for the shared form and state changes.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite/component-tests/gallery/main.tsx`
- `suite/component-tests/gallery/storyProviders.tsx`
- `suite/component-tests/galleryServer.ts`
- `suite/component-tests/package.json`
- `suite/component-tests/support/customMatchers.ts`
- `suite/component-tests/tsconfig.json`
- `suite/test-utils/src/initStoreForTests.ts`

_Updated: 2026-09-01T09:59:31.996Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/component-tests-stake-form&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/component-tests-stake-form&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/component-tests-stake-form/web/](https://dev.suite.sldev.cz/suite-web/test/component-tests-stake-form/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T10:00:47.647Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T08:23:18.028Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->