### PR TITLE
fix(suite-native): preserve pending yield sheet state

### DIFF
--- a/suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { type YieldPendingTransactionState } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -71,18 +71,11 @@ export const useYieldPendingTransaction = ({
         openPendingBottomSheet();
     }, [closePendingBottomSheet, isFocused, matchingPendingTransaction, openPendingBottomSheet]);
 
-    const reopenPendingBottomSheet = useCallback(() => {
-        if (matchingPendingTransaction !== undefined) {
-            requestAnimationFrame(openPendingBottomSheet);
-        }
-    }, [matchingPendingTransaction, openPendingBottomSheet]);
-
     return {
         displayedPendingTransaction,
         isSheetPresented,
         pendingBottomSheetRef,
         pendingModalProps,
         pendingTransaction: matchingPendingTransaction,
-        reopenPendingBottomSheet,
     };
 };

--- a/suite-native/module-earn/src/hooks/useYieldWrappedNativeStep.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWrappedNativeStep.ts
@@ -80,7 +80,6 @@ export const useYieldWrappedNativeStep = ({
         pendingBottomSheetRef,
         pendingModalProps,
         pendingTransaction,
-        reopenPendingBottomSheet,
     } = useYieldPendingTransaction({
         accountKey: account?.key,
         isFocused,
@@ -178,7 +177,6 @@ export const useYieldWrappedNativeStep = ({
         pendingBottomSheetRef,
         pendingModalProps,
         pendingTransaction,
-        reopenPendingBottomSheet,
         session,
         simulation,
     };

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -71,7 +71,7 @@ export const YieldDepositApprovalScreen = () => {
         bottomSheetRef: infoBottomSheetRef,
         closeModal: closeInfoBottomSheet,
         openModal: openInfoBottomSheet,
-    } = useBottomSheetModal();
+    } = useBottomSheetModal({ isNestedSheet: true });
     const {
         bottomSheetRef: approvalLimitBottomSheetRef,
         closeModal: closeApprovalLimitBottomSheet,
@@ -122,7 +122,6 @@ export const YieldDepositApprovalScreen = () => {
         pendingBottomSheetRef,
         pendingModalProps,
         pendingTransaction: approvalPendingTransaction,
-        reopenPendingBottomSheet,
     } = useYieldPendingTransaction({
         accountKey: account?.key,
         isFocused,
@@ -324,11 +323,6 @@ export const YieldDepositApprovalScreen = () => {
         vault: yieldFlowData.vault,
     });
 
-    const handleCloseInfoBottomSheet = useCallback(() => {
-        closeInfoBottomSheet();
-        reopenPendingBottomSheet();
-    }, [closeInfoBottomSheet, reopenPendingBottomSheet]);
-
     const handleSubmit = form.handleSubmit(async ({ amount }) => {
         if (isSubmitDisabled) {
             return;
@@ -508,7 +502,7 @@ export const YieldDepositApprovalScreen = () => {
                 ref={infoBottomSheetRef}
                 apy={apy}
                 bonusRewardTokenSymbol={bonusRewardTokenSymbol}
-                onClose={handleCloseInfoBottomSheet}
+                onClose={closeInfoBottomSheet}
                 tokenSymbol={tokenSymbol}
                 vaultTokenSymbol={vaultTokenSymbol}
                 account={account}

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -71,7 +71,7 @@ export const YieldDepositScreen = () => {
         bottomSheetRef: infoBottomSheetRef,
         closeModal: closeInfoBottomSheet,
         openModal: openInfoBottomSheet,
-    } = useBottomSheetModal();
+    } = useBottomSheetModal({ isNestedSheet: true });
 
     const {
         bottomSheetRef: simulationBottomSheetRef,
@@ -129,7 +129,6 @@ export const YieldDepositScreen = () => {
         pendingBottomSheetRef,
         pendingModalProps,
         pendingTransaction: actionPendingTransaction,
-        reopenPendingBottomSheet,
     } = useYieldPendingTransaction({
         accountKey: account?.key,
         isFocused,
@@ -370,10 +369,6 @@ export const YieldDepositScreen = () => {
         openInfoBottomSheet();
     }, [account?.symbol, analytics, openInfoBottomSheet, yieldFlowData.vault?.id]);
 
-    const handleCloseInfoBottomSheet = useCallback(() => {
-        closeInfoBottomSheet();
-        reopenPendingBottomSheet();
-    }, [closeInfoBottomSheet, reopenPendingBottomSheet]);
     const handleCloseDeposit = useCallback(() => {
         navigateToInitialScreen();
 
@@ -521,7 +516,7 @@ export const YieldDepositScreen = () => {
                 ref={infoBottomSheetRef}
                 apy={apy}
                 bonusRewardTokenSymbol={bonusRewardTokenSymbol}
-                onClose={handleCloseInfoBottomSheet}
+                onClose={closeInfoBottomSheet}
                 tokenSymbol={tokenSymbol}
                 vaultTokenSymbol={vaultTokenSymbol}
                 account={account}

--- a/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
@@ -55,7 +55,7 @@ export const YieldDepositWrapScreen = () => {
         bottomSheetRef: infoBottomSheetRef,
         closeModal: closeInfoBottomSheet,
         openModal: openInfoBottomSheet,
-    } = useBottomSheetModal();
+    } = useBottomSheetModal({ isNestedSheet: true });
 
     const yieldFlowData = useYieldFlowData(route.params);
 
@@ -167,11 +167,6 @@ export const YieldDepositWrapScreen = () => {
             navigation.replace(YieldStackRoutes.YieldDeposit, route.params);
         }
     }, [isFocused, navigation, route.params, session]);
-
-    const handleCloseInfoBottomSheet = useCallback(() => {
-        closeInfoBottomSheet();
-        step.reopenPendingBottomSheet();
-    }, [closeInfoBottomSheet, step]);
 
     if (resolutionStatus !== 'resolved' || !isWrappedNativeVault) {
         return null;
@@ -339,7 +334,7 @@ export const YieldDepositWrapScreen = () => {
                 ref={infoBottomSheetRef}
                 apy={apy}
                 bonusRewardTokenSymbol={bonusRewardTokenSymbol}
-                onClose={handleCloseInfoBottomSheet}
+                onClose={closeInfoBottomSheet}
                 tokenSymbol={tokenSymbol}
                 vaultTokenSymbol={vaultTokenSymbol}
                 account={account}

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -116,7 +116,7 @@ export const YieldWithdrawScreen = () => {
         bottomSheetRef: infoBottomSheetRef,
         closeModal: closeInfoBottomSheet,
         openModal: openInfoBottomSheet,
-    } = useBottomSheetModal();
+    } = useBottomSheetModal({ isNestedSheet: true });
     const {
         bottomSheetRef: pendingBottomSheetRef,
         closeModal: closePendingBottomSheet,
@@ -435,14 +435,6 @@ export const YieldWithdrawScreen = () => {
         navigation.goBack();
     }, [isWithdrawPending, navigation, openPendingBottomSheet]);
 
-    const handleCloseInfoBottomSheet = useCallback(() => {
-        closeInfoBottomSheet();
-
-        if (isWithdrawPending) {
-            requestAnimationFrame(openPendingBottomSheet);
-        }
-    }, [closeInfoBottomSheet, isWithdrawPending, openPendingBottomSheet]);
-
     const handleInputSwitch = useCallback(
         (activeView: 'primary' | 'secondary') => {
             analytics.report({
@@ -758,7 +750,7 @@ export const YieldWithdrawScreen = () => {
                 ref={infoBottomSheetRef}
                 apy={apy}
                 bonusRewardTokenSymbol={bonusRewardTokenSymbol}
-                onClose={handleCloseInfoBottomSheet}
+                onClose={closeInfoBottomSheet}
                 tokenSymbol={underlyingTokenSymbol}
                 vaultTokenSymbol={resolvedVaultTokenSymbol}
                 account={account}


### PR DESCRIPTION
## Description

Opening `How yield works` during a pending Yield transaction now presents it as a nested bottom sheet. Closing it restores the pending transaction sheet to its previous state instead of reopening it expanded.

The redundant manual pending-sheet reopening logic was removed from the deposit, approval, wrap, and withdraw flows.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #31280

## Screenshots:

https://github.com/user-attachments/assets/a998c0de-1e39-429f-9628-f44c2b2a6193

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/yield-pending-sheet-state&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->