### PR TITLE
refactor(trading): one card for the asset picker groups

### DIFF
--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetGroupsCard.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetGroupsCard.tsx
@@ -1,0 +1,22 @@
+import { type ReactNode } from 'react';
+
+import { Box, Card, Column } from '@trezor/components';
+
+import { ASSET_GROUP_CARD_PADDING } from '../../constants';
+
+export type AssetGroupsCardProps = {
+    height: number;
+    children: ReactNode;
+};
+
+export function AssetGroupsCard({ height, children }: AssetGroupsCardProps) {
+    return (
+        <Box padding={ASSET_GROUP_CARD_PADDING} height={height}>
+            <Card type="flat" paddingType="none">
+                <Column gap={0} hasDivider>
+                    {children}
+                </Column>
+            </Card>
+        </Box>
+    );
+}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowGroup/ExpandableAssetRowGroup.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowGroup/ExpandableAssetRowGroup.tsx
@@ -3,7 +3,7 @@ import { Fragment, type ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { Translation, type TranslationKey } from '@suite/intl';
-import { Box, Card, Collapsible, Row, Text } from '@trezor/components';
+import { Box, Collapsible, Row, Text } from '@trezor/components';
 import { CaretUpDownIcon, CaretUpDownReverseIcon } from '@trezor/icons';
 import { TokenIconSet, type TokenIconSetToken } from '@trezor/product-components';
 
@@ -57,58 +57,56 @@ export function ExpandableAssetRowGroup({
 
     return (
         <Collapsible isOpen={expanded} data-testid={dataTestId}>
-            <Box padding={2} height={getExpandableGroupHeight(expanded, items.length)}>
-                <Card type="contrast" paddingType="none">
-                    <Collapsible.Toggle
-                        onClick={() => {
-                            // The operation will be probably expensive. Ask for fresh frame before switching the state.
-                            requestAnimationFrame(() => {
-                                onExpandToggle(!expanded);
-                            });
+            <Box height={getExpandableGroupHeight(expanded, items.length)}>
+                <Collapsible.Toggle
+                    onClick={() => {
+                        // The operation will be probably expensive. Ask for fresh frame before switching the state.
+                        requestAnimationFrame(() => {
+                            onExpandToggle(!expanded);
+                        });
+                    }}
+                    data-testid={dataTestId ? `${dataTestId}/toggle` : undefined}
+                >
+                    <Row
+                        alignItems="center"
+                        justifyContent="space-between"
+                        gap={12}
+                        padding={{
+                            vertical: 12,
+                            horizontal: 16,
                         }}
-                        data-testid={dataTestId ? `${dataTestId}/toggle` : undefined}
                     >
-                        <Row
-                            alignItems="center"
-                            justifyContent="space-between"
-                            gap={12}
-                            padding={{
-                                vertical: 12,
-                                horizontal: 16,
-                            }}
-                        >
-                            <Text typographyStyle="body-sm">
-                                <Translation id={label} />
-                            </Text>
+                        <Text typographyStyle="body-sm">
+                            <Translation id={label} />
+                        </Text>
 
-                            <Row alignItems="center" gap={12}>
-                                {!expanded && (
-                                    <TokenIconSet
-                                        symbol={account.symbol}
-                                        tokens={items.map(getIconSetToken)}
-                                        size={24}
-                                        gap={20}
-                                        maxVisibleIcons={GROUP_VISIBLE_ICON_COUNT}
-                                        isCentered={false}
-                                        isCountVisible
-                                        isReversed={false}
-                                    />
-                                )}
-
-                                <Collapsible.ToggleIcon
-                                    icon={expanded ? CaretUpDownReverseIcon : CaretUpDownIcon}
+                        <Row alignItems="center" gap={12}>
+                            {!expanded && (
+                                <TokenIconSet
+                                    symbol={account.symbol}
+                                    tokens={items.map(getIconSetToken)}
+                                    size={24}
+                                    gap={20}
+                                    maxVisibleIcons={GROUP_VISIBLE_ICON_COUNT}
+                                    isCentered={false}
+                                    isCountVisible
+                                    isReversed={false}
                                 />
-                            </Row>
-                        </Row>
-                    </Collapsible.Toggle>
+                            )}
 
-                    <CollapsibleContent $contentHeight={contentHeight} $expanded={expanded}>
-                        {expanded &&
-                            items.map(item => (
-                                <Fragment key={getItemKey(item)}>{renderItem(item)}</Fragment>
-                            ))}
-                    </CollapsibleContent>
-                </Card>
+                            <Collapsible.ToggleIcon
+                                icon={expanded ? CaretUpDownReverseIcon : CaretUpDownIcon}
+                            />
+                        </Row>
+                    </Row>
+                </Collapsible.Toggle>
+
+                <CollapsibleContent $contentHeight={contentHeight} $expanded={expanded}>
+                    {expanded &&
+                        items.map(item => (
+                            <Fragment key={getItemKey(item)}>{renderItem(item)}</Fragment>
+                        ))}
+                </CollapsibleContent>
             </Box>
         </Collapsible>
     );

--- a/packages/suite/src/components/suite/asset-picker/components/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/components/index.ts
@@ -3,6 +3,7 @@ export * from './AssetsListEmpty/AssetsListEmpty';
 export * from './AssetsModal/AssetsModal';
 export * from './AssetRow/AssetRowAccount';
 export * from './AssetRow/AssetGroupLabel';
+export * from './AssetRow/AssetGroupsCard';
 export * from './AssetRow/AssetGroupSpace';
 export * from './AssetRow/AssetRowToken/AssetRowToken';
 export * from './AssetRow/AssetRowAsset/AssetRowAsset';

--- a/packages/suite/src/components/suite/asset-picker/constants/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/constants/index.ts
@@ -1,3 +1,5 @@
+import { type SpacingValue } from '@trezor/theme';
+
 import type { AssetGroupSpaceSize } from 'src/components/suite/asset-picker/types';
 
 export const ASSET_ROW_HEIGHT = 68;
@@ -7,4 +9,5 @@ export const ASSET_ROW_HEIGHTS_BY_SIZE = {
     lg: 32,
 } as const satisfies Record<AssetGroupSpaceSize, number>;
 
-export const EXPANDABLE_ASSET_ROW_GROUP_HEADER_HEIGHT = 50;
+export const EXPANDABLE_ASSET_ROW_GROUP_HEADER_HEIGHT = 46;
+export const ASSET_GROUP_CARD_PADDING = 2 satisfies SpacingValue;

--- a/packages/suite/src/components/suite/asset-picker/types/index.ts
+++ b/packages/suite/src/components/suite/asset-picker/types/index.ts
@@ -27,7 +27,6 @@ export type AccountWithTokensOption =
 export type AssetRowOption = Extract<AccountWithTokensOption, { type: 'account' | 'token' }>;
 
 type AssetGroupOptionShape = {
-    account: AccountWithOptionalLabel;
     items: AssetRowOption[];
     expanded: boolean;
 };
@@ -36,7 +35,13 @@ export type AssetGroupOption =
     | ({ type: 'low-balance-group' } & AssetGroupOptionShape)
     | ({ type: 'non-tradable-group' } & AssetGroupOptionShape);
 
-export type AssetPickerOption = AccountWithTokensOption | AssetGroupOption;
+export type AssetGroupsOption = {
+    type: 'asset-groups';
+    account: AccountWithOptionalLabel;
+    groups: AssetGroupOption[];
+};
+
+export type AssetPickerOption = AccountWithTokensOption | AssetGroupsOption;
 
 export type AssetPickerListItem =
     | AssetPickerOption

--- a/packages/suite/src/components/suite/asset-picker/utils/assetPickerItemHeights.test.ts
+++ b/packages/suite/src/components/suite/asset-picker/utils/assetPickerItemHeights.test.ts
@@ -5,6 +5,7 @@ import { BigNumber } from '@trezor/utils';
 import { type TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
 import { getAssetPickerItemHeight } from './assetPickerItemHeights';
+import { type AssetGroupOption, type AssetGroupsOption, type AssetRowOption } from '../types';
 
 import { createAccountOption, createHiddenTokensOption, createTokenOption } from './index';
 
@@ -35,6 +36,17 @@ const createHiddenTokens = (expanded: boolean) =>
         expandedHiddenTokensGroups: expanded ? [account.key] : [],
     });
 
+const groupItems: AssetRowOption[] = [
+    createAccountOption(account),
+    createTokenOption(account, usdt),
+];
+
+const createAssetGroups = (groups: AssetGroupOption[]): AssetGroupsOption => ({
+    type: 'asset-groups',
+    account,
+    groups,
+});
+
 describe('getAssetPickerItemHeight', () => {
     it('gives an account row and a token row the same height', () => {
         expect(getAssetPickerItemHeight(createAccountOption(account))).toBe(68);
@@ -44,25 +56,34 @@ describe('getAssetPickerItemHeight', () => {
     it('measures a collapsed group by its header alone', () => {
         expect(getAssetPickerItemHeight(createHiddenTokens(false))).toBe(50);
         expect(
-            getAssetPickerItemHeight({
-                type: 'low-balance-group',
-                account,
-                items: [createAccountOption(account), createTokenOption(account, usdt)],
-                expanded: false,
-            }),
+            getAssetPickerItemHeight(
+                createAssetGroups([
+                    { type: 'low-balance-group', items: groupItems, expanded: false },
+                ]),
+            ),
         ).toBe(50);
     });
 
     it('grows an expanded group by one row height per item', () => {
         expect(getAssetPickerItemHeight(createHiddenTokens(true))).toBe(50 + 2 * 68);
         expect(
-            getAssetPickerItemHeight({
-                type: 'non-tradable-group',
-                account,
-                items: [createAccountOption(account), createTokenOption(account, usdt)],
-                expanded: true,
-            }),
+            getAssetPickerItemHeight(
+                createAssetGroups([
+                    { type: 'non-tradable-group', items: groupItems, expanded: true },
+                ]),
+            ),
         ).toBe(50 + 2 * 68);
+    });
+
+    it('measures two groups sharing one card by the card padding plus both groups', () => {
+        expect(
+            getAssetPickerItemHeight(
+                createAssetGroups([
+                    { type: 'low-balance-group', items: groupItems, expanded: true },
+                    { type: 'non-tradable-group', items: groupItems, expanded: false },
+                ]),
+            ),
+        ).toBe(4 + (46 + 2 * 68) + 46);
     });
 
     it('measures the account label and the space between accounts', () => {

--- a/packages/suite/src/components/suite/asset-picker/utils/assetPickerItemHeights.ts
+++ b/packages/suite/src/components/suite/asset-picker/utils/assetPickerItemHeights.ts
@@ -1,4 +1,5 @@
 import {
+    ASSET_GROUP_CARD_PADDING,
     ASSET_ROW_GROUP_LABEL_HEIGHT,
     ASSET_ROW_HEIGHT,
     ASSET_ROW_HEIGHTS_BY_SIZE,
@@ -6,11 +7,19 @@ import {
 } from '../constants';
 import { type AssetPickerListItem } from '../types';
 
+type MeasurableAssetGroup = { expanded: boolean; items: readonly unknown[] };
+
 export const getExpandableGroupContentHeight = (rowCount: number) => rowCount * ASSET_ROW_HEIGHT;
 
 export const getExpandableGroupHeight = (expanded: boolean, rowCount: number) =>
     EXPANDABLE_ASSET_ROW_GROUP_HEADER_HEIGHT +
     (expanded ? getExpandableGroupContentHeight(rowCount) : 0);
+
+const getAssetGroupsCardHeight = (groups: readonly MeasurableAssetGroup[]) =>
+    groups.reduce(
+        (height, { expanded, items }) => height + getExpandableGroupHeight(expanded, items.length),
+        2 * ASSET_GROUP_CARD_PADDING,
+    );
 
 export const getAssetPickerItemHeight = (item: AssetPickerListItem): number => {
     switch (item.type) {
@@ -19,11 +28,10 @@ export const getAssetPickerItemHeight = (item: AssetPickerListItem): number => {
             return ASSET_ROW_HEIGHT;
 
         case 'hidden-tokens':
-            return getExpandableGroupHeight(item.expanded, item.tokens.length);
+            return getAssetGroupsCardHeight([{ expanded: item.expanded, items: item.tokens }]);
 
-        case 'low-balance-group':
-        case 'non-tradable-group':
-            return getExpandableGroupHeight(item.expanded, item.items.length);
+        case 'asset-groups':
+            return getAssetGroupsCardHeight(item.groups);
 
         case 'group-label':
             return ASSET_ROW_GROUP_LABEL_HEIGHT;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
@@ -11,6 +11,7 @@ import { setSendFormPrefill } from 'src/actions/suite/suiteActions';
 import {
     AssetGroupLabel,
     AssetGroupSpace,
+    AssetGroupsCard,
     AssetRowAccountWithBalance,
     AssetRowToken,
     AssetsList,
@@ -109,25 +110,29 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
 
                 case 'hidden-tokens':
                     return (
-                        <ExpandableAssetRowGroup
-                            label="TR_HIDDEN_TOKENS"
-                            account={item.account}
-                            items={item.tokens.map(token => createTokenOption(item.account, token))}
-                            renderItem={groupItem =>
-                                groupItem.type === 'token' && (
-                                    <AssetRowToken
-                                        token={groupItem.token}
-                                        account={groupItem.account}
-                                        onClick={handleTokenClick}
-                                        isInsideGroup
-                                    />
-                                )
-                            }
-                            expanded={item.expanded}
-                            onExpandToggle={expanded => {
-                                toggleGroup(item.account.key, expanded);
-                            }}
-                        />
+                        <AssetGroupsCard height={getAssetPickerItemHeight(item)}>
+                            <ExpandableAssetRowGroup
+                                label="TR_HIDDEN_TOKENS"
+                                account={item.account}
+                                items={item.tokens.map(token =>
+                                    createTokenOption(item.account, token),
+                                )}
+                                renderItem={groupItem =>
+                                    groupItem.type === 'token' && (
+                                        <AssetRowToken
+                                            token={groupItem.token}
+                                            account={groupItem.account}
+                                            onClick={handleTokenClick}
+                                            isInsideGroup
+                                        />
+                                    )
+                                }
+                                expanded={item.expanded}
+                                onExpandToggle={expanded => {
+                                    toggleGroup(item.account.key, expanded);
+                                }}
+                            />
+                        </AssetGroupsCard>
                     );
             }
         },

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
@@ -8,6 +8,7 @@ import { Box, Divider } from '@trezor/components';
 import { SearchAsset } from '@trezor/product-components';
 
 import {
+    AssetGroupsCard,
     AssetRowAccountWithBalance,
     AssetRowToken,
     AssetsList,
@@ -170,32 +171,35 @@ export function SelectTokenAssetModal({
 
                 case 'hidden-tokens':
                     return (
-                        <ExpandableAssetRowGroup
-                            label="TR_HIDDEN_TOKENS"
-                            account={item.account}
-                            items={item.tokens.map(token => createTokenOption(item.account, token))}
-                            renderItem={groupItem =>
-                                groupItem.type === 'token' && (
-                                    <AssetRowToken
-                                        token={groupItem.token}
-                                        account={groupItem.account}
-                                        onClick={handleSelectChange}
-                                        isInsideGroup
-                                    />
-                                )
-                            }
-                            expanded={item.expanded}
-                            onExpandToggle={expanded => {
-                                toggleGroup(item.account.key, expanded);
-                            }}
-                            dataTestId={`@asset-picker/send-token/option/hidden-tokens/${item.account.symbol}`}
-                        />
+                        <AssetGroupsCard height={getAssetPickerItemHeight(item)}>
+                            <ExpandableAssetRowGroup
+                                label="TR_HIDDEN_TOKENS"
+                                account={item.account}
+                                items={item.tokens.map(token =>
+                                    createTokenOption(item.account, token),
+                                )}
+                                renderItem={groupItem =>
+                                    groupItem.type === 'token' && (
+                                        <AssetRowToken
+                                            token={groupItem.token}
+                                            account={groupItem.account}
+                                            onClick={handleSelectChange}
+                                            isInsideGroup
+                                        />
+                                    )
+                                }
+                                expanded={item.expanded}
+                                onExpandToggle={expanded => {
+                                    toggleGroup(item.account.key, expanded);
+                                }}
+                                dataTestId={`@asset-picker/send-token/option/hidden-tokens/${item.account.symbol}`}
+                            />
+                        </AssetGroupsCard>
                     );
 
                 case 'group-label':
                 case 'group-space':
-                case 'low-balance-group':
-                case 'non-tradable-group':
+                case 'asset-groups':
                     return null;
             }
         },

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -6,6 +6,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     AssetGroupLabel,
     AssetGroupSpace,
+    AssetGroupsCard,
     AssetRowAccountWithBalance,
     AssetRowToken,
     AssetsModal,
@@ -14,6 +15,7 @@ import {
 import { useExpandableGroups, useSearchFilter } from 'src/components/suite/asset-picker/hooks';
 import {
     type AccountWithOptionalLabel,
+    type AssetGroupOption,
     type AssetPickerListItem,
     type AssetRowOption,
 } from 'src/components/suite/asset-picker/types';
@@ -83,6 +85,39 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
         [handleAccountClick, handleTokenClick],
     );
 
+    const renderAssetGroup = useCallback(
+        (account: AccountWithOptionalLabel, group: AssetGroupOption) => {
+            const isLowBalance = group.type === 'low-balance-group';
+
+            return (
+                <ExpandableAssetRowGroup
+                    key={group.type}
+                    label={
+                        isLowBalance
+                            ? 'TR_ASSET_PICKER_LOW_BALANCE'
+                            : 'TR_ASSET_PICKER_NON_TRADABLE'
+                    }
+                    account={account}
+                    items={group.items}
+                    renderItem={groupItem =>
+                        renderAssetRow(groupItem, {
+                            isInsideGroup: true,
+                            isSelectable: isLowBalance,
+                        })
+                    }
+                    expanded={group.expanded}
+                    onExpandToggle={expanded => {
+                        toggleGroup(getAssetGroupKey(account.key, group.type), expanded);
+                    }}
+                    dataTestId={`${getAccountTestId(account)}/${
+                        isLowBalance ? 'low-balance' : 'non-tradable'
+                    }`}
+                />
+            );
+        },
+        [renderAssetRow, toggleGroup],
+    );
+
     const renderItem = useCallback(
         (item: AssetPickerListItem) => {
             switch (item.type) {
@@ -96,41 +131,15 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                 case 'group-space':
                     return <AssetGroupSpace size={item.size} />;
 
-                case 'low-balance-group':
-                case 'non-tradable-group': {
-                    const isLowBalance = item.type === 'low-balance-group';
-
+                case 'asset-groups':
                     return (
-                        <ExpandableAssetRowGroup
-                            label={
-                                isLowBalance
-                                    ? 'TR_ASSET_PICKER_LOW_BALANCE'
-                                    : 'TR_ASSET_PICKER_NON_TRADABLE'
-                            }
-                            account={item.account}
-                            items={item.items}
-                            renderItem={groupItem =>
-                                renderAssetRow(groupItem, {
-                                    isInsideGroup: true,
-                                    isSelectable: isLowBalance,
-                                })
-                            }
-                            expanded={item.expanded}
-                            onExpandToggle={expanded => {
-                                toggleGroup(
-                                    getAssetGroupKey(item.account.key, item.type),
-                                    expanded,
-                                );
-                            }}
-                            dataTestId={`${getAccountTestId(item.account)}/${
-                                isLowBalance ? 'low-balance' : 'non-tradable'
-                            }`}
-                        />
+                        <AssetGroupsCard height={getAssetPickerItemHeight(item)}>
+                            {item.groups.map(group => renderAssetGroup(item.account, group))}
+                        </AssetGroupsCard>
                     );
-                }
             }
         },
-        [renderAssetRow, toggleGroup],
+        [renderAssetRow, renderAssetGroup],
     );
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/utils/buildGroupedAssetOptions.test.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/utils/buildGroupedAssetOptions.test.ts
@@ -93,10 +93,15 @@ describe('buildGroupedAssetOptions', () => {
         expect(buildOptions({ assetRows: [accountRow, tokenRow] })).toEqual([
             tokenRow,
             {
-                type: 'low-balance-group',
+                type: 'asset-groups',
                 account,
-                items: [accountRow],
-                expanded: false,
+                groups: [
+                    {
+                        type: 'low-balance-group',
+                        items: [accountRow],
+                        expanded: false,
+                    },
+                ],
             },
         ]);
     });
@@ -112,10 +117,15 @@ describe('buildGroupedAssetOptions', () => {
             }),
         ).toEqual([
             {
-                type: 'non-tradable-group',
+                type: 'asset-groups',
                 account,
-                items: [accountRow],
-                expanded: false,
+                groups: [
+                    {
+                        type: 'non-tradable-group',
+                        items: [accountRow],
+                        expanded: false,
+                    },
+                ],
             },
         ]);
     });
@@ -137,7 +147,7 @@ describe('buildGroupedAssetOptions', () => {
         expect(buildOptions({ assetRows: [accountRow], fiatRates: {} })).toEqual([accountRow]);
     });
 
-    it('emits both groups for an account holding only dust and non-sellable assets', () => {
+    it('puts both groups of an account holding only dust and non-sellable assets in one card', () => {
         const account = createEthAccount('dustEthAccount', '0.00000001');
         const accountRow = createAccountOption(account);
         const nonTradableTokenRow = createTokenOption(account, createToken());
@@ -149,16 +159,20 @@ describe('buildGroupedAssetOptions', () => {
             }),
         ).toEqual([
             {
-                type: 'low-balance-group',
+                type: 'asset-groups',
                 account,
-                items: [accountRow],
-                expanded: false,
-            },
-            {
-                type: 'non-tradable-group',
-                account,
-                items: [nonTradableTokenRow],
-                expanded: false,
+                groups: [
+                    {
+                        type: 'low-balance-group',
+                        items: [accountRow],
+                        expanded: false,
+                    },
+                    {
+                        type: 'non-tradable-group',
+                        items: [nonTradableTokenRow],
+                        expanded: false,
+                    },
+                ],
             },
         ]);
     });
@@ -176,12 +190,17 @@ describe('buildGroupedAssetOptions', () => {
 
         expect(options).toEqual([
             expect.objectContaining({
-                type: 'low-balance-group',
-                expanded: true,
-            }),
-            expect.objectContaining({
-                type: 'non-tradable-group',
-                expanded: false,
+                type: 'asset-groups',
+                groups: [
+                    expect.objectContaining({
+                        type: 'low-balance-group',
+                        expanded: true,
+                    }),
+                    expect.objectContaining({
+                        type: 'non-tradable-group',
+                        expanded: false,
+                    }),
+                ],
             }),
         ]);
     });
@@ -194,11 +213,16 @@ describe('buildGroupedAssetOptions', () => {
 
         expect(buildOptions({ assetRows: [firstAccountRow, secondAccountRow] })).toEqual([
             firstAccountRow,
-            expect.objectContaining({
-                type: 'low-balance-group',
+            {
+                type: 'asset-groups',
                 account: secondAccount,
-                items: [secondAccountRow],
-            }),
+                groups: [
+                    expect.objectContaining({
+                        type: 'low-balance-group',
+                        items: [secondAccountRow],
+                    }),
+                ],
+            },
         ]);
     });
 });

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/utils/buildGroupedAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/utils/buildGroupedAssetOptions.ts
@@ -12,6 +12,7 @@ import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import {
     type AccountWithOptionalLabel,
     type AccountWithTokensOption,
+    type AssetGroupOption,
     type AssetPickerOption,
     type AssetRowOption,
 } from 'src/components/suite/asset-picker/types';
@@ -78,6 +79,7 @@ export const buildGroupedAssetOptions = ({
         );
 
     const options: AssetPickerOption[] = [];
+    const expandedGroups = new Set(expandedGroupKeys);
 
     for (const { account, rows } of groupRowsByAccount(assetRows.filter(isAssetRowOption))) {
         const { assets, lowBalanceAssets, nonTradeableAssets } = groupTradeableAssetsByTradability({
@@ -89,26 +91,26 @@ export const buildGroupedAssetOptions = ({
 
         options.push(...assets);
 
+        const groups: AssetGroupOption[] = [];
+
         if (lowBalanceAssets.length > 0) {
-            options.push({
+            groups.push({
                 type: 'low-balance-group',
-                account,
                 items: lowBalanceAssets,
-                expanded: expandedGroupKeys.includes(
-                    getAssetGroupKey(account.key, 'low-balance-group'),
-                ),
+                expanded: expandedGroups.has(getAssetGroupKey(account.key, 'low-balance-group')),
             });
         }
 
         if (nonTradeableAssets.length > 0) {
-            options.push({
+            groups.push({
                 type: 'non-tradable-group',
-                account,
                 items: nonTradeableAssets,
-                expanded: expandedGroupKeys.includes(
-                    getAssetGroupKey(account.key, 'non-tradable-group'),
-                ),
+                expanded: expandedGroups.has(getAssetGroupKey(account.key, 'non-tradable-group')),
             });
+        }
+
+        if (groups.length > 0) {
+            options.push({ type: 'asset-groups', account, groups });
         }
     }
 


### PR DESCRIPTION
## Description

The `Low balance` and `Non-tradable` groups of an account are now segments of one card split by a
border, instead of two stacked cards.

- Both groups collapse into a single virtualized list item, because a wrapper cannot span two of them.
- New `AssetGroupsCard` owns the radius and the divider; groups carry no fill for now, same as native.
- Global send and the send-form token select put their hidden-tokens group in the same card.

## Notes for QA

- Sell and swap "From" are the only pickers with two groups — expand, collapse and scroll them.
- Global send and the send-form token select must look as before, bar the lost grey fill.
- Group testids are unchanged, only their nesting is.

## Related Issue
https://github.com/trezor/trezor-suite/issues/30208

## Screenshots:
<img width="521" height="677" alt="image" src="https://github.com/user-attachments/assets/e4d2b4e7-7f83-4890-9a2d-e33d993c62ab" />


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/30208-asset-group-card/web/](https://dev.suite.sldev.cz/suite-web/refactor/30208-asset-group-card/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/30208-asset-group-card&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/30208-asset-group-card&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T09:01:38.998Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T09:01:48.707Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in asset picker UI components used by the trading sell asset picker, send token selection modal, and global send modal. The highest risk is in asset selection, grouping, and modal rendering flows. A short, targeted set covering swap/sell asset picker inputs and global send/receive provides strong confidence; additional medium-priority trading regression tests guard related selection and navigation paths without broad blanket coverage.

<details><summary><b>Changed files (12)</b></summary>

- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetGroupsCard.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowGroup/ExpandableAssetRowGroup.tsx`
- `packages/suite/src/components/suite/asset-picker/components/index.ts`
- `packages/suite/src/components/suite/asset-picker/constants/index.ts`
- `packages/suite/src/components/suite/asset-picker/types/index.ts`
- `packages/suite/src/components/suite/asset-picker/utils/assetPickerItemHeights.test.ts`
- `packages/suite/src/components/suite/asset-picker/utils/assetPickerItemHeights.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx`
- `packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/utils/buildGroupedAssetOptions.test.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/utils/buildGroupedAssetOptions.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test directly exercises the sell form crypto/fiat inputs, percentage/Max buttons, and asset selection flow that is rendered by the changed TradingFormInputSellAsset AssetPickerModal and buildGroupedAssetOptions utility. A regression here would be immediately visible in the sell trading flow.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test opens the swap form and selects sell/buy assets (including USDC on ETH and cross-network assets), verifies tickers, quotes, fees, and fraction buttons. It is the most direct end-to-end coverage of the changed asset picker grouping and modal components in the swap flow.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test exercises the GlobalSendModal and its asset picker, including network filtering, adding a new account from the picker, and selecting specific receive/send accounts. It directly covers the GlobalSendModal.tsx change and the shared asset picker components.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to buy/sell/swap forms from dashboard, account trade sections, global header, and token pages, verifying correct crypto preselection. It relies on the asset picker and routing infrastructure modified by the changes.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test fills the SOL sell form, reviews the best offer, and confirms the send on device. The sell form asset selection path uses the changed sell asset picker modal and grouped options utility.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test performs an ETH to USDC DEX swap, which requires selecting the buy asset in the swap asset picker and verifying amounts/slippage. It exercises the asset picker selection and grouped options rendering.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test selects a swap asset on a disabled network (XLM) and enables the network from the receive account picker. It directly exercises the asset picker's network grouping and the receive account selection logic built from the changed components.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/components/suite/asset-picker/components/index.ts`
- `packages/suite/src/components/suite/asset-picker/types/index.ts`
- `packages/suite/src/components/suite/asset-picker/utils/assetPickerItemHeights.test.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/utils/buildGroupedAssetOptions.test.ts`

_Updated: 2026-08-27T09:04:05.217Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->