### PR TITLE
chore(e2e): temporary skip failing Import accounts tests

### DIFF
--- a/suite-native/app/e2e/tests/importAltcoinAccount.test.ts
+++ b/suite-native/app/e2e/tests/importAltcoinAccount.test.ts
@@ -7,7 +7,8 @@ import { openApp, preparePreloadedReduxState } from '../support/setup';
 
 const preloadedState = preparePreloadedReduxState(onboardingCompletedState);
 
-describe('Import altcoin accounts. [@noDevice]', () => {
+// Constatntly failing on iOS, TODO issue https://github.com/trezor/trezor-suite/issues/31780
+describe.skip('Import altcoin accounts. [@noDevice]', () => {
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await onTabBar.navigateToMyAssets();


### PR DESCRIPTION
## Description

Temporarily skips the shared native `Import altcoin accounts` E2E suite on Android and iOS while the failures are investigated.

## Notes for QA

No product behavior changes. This is a test-only change and does not require manual QA.

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/31780

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/skip-import-altcoin-accounts-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->