### PR TITLE
fix(blockchain-link): make Solana backend drops survivable and cut sync traffic

### DIFF
--- a/packages/blockchain-link/src/workers/solana/changeDetection.test.ts
+++ b/packages/blockchain-link/src/workers/solana/changeDetection.test.ts
@@ -1,0 +1,149 @@
+import type { AccountInfoParams } from '@trezor/blockchain-link-types';
+import { tokenProgramsInfo } from '@trezor/network-solana/constants';
+import type { SolanaAPI } from '@trezor/network-solana/types';
+
+import { BlockchainLink } from '../../index';
+
+import SolanaWorker from './index';
+
+const descriptor = '2MLmmoKgCrxVEzMeGatnjdABYS5RXsQSNikcWrmnvQna';
+const tokenAccountA = '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R';
+const tokenAccountB = '9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump';
+const mintA = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const mintB = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+
+const splTokenProgram = tokenProgramsInfo['spl-token'].publicKey;
+
+const tokenAccount = (pubkey: string, mint: string) => ({
+    pubkey,
+    account: {
+        data: {
+            program: 'spl-token',
+            parsed: { type: 'account', info: { mint, tokenAmount: { amount: '5', decimals: 6 } } },
+        },
+    },
+});
+
+const createApiMock = () => {
+    // mutable so a test can make one address look changed
+    const lamports: Record<string, number> = {
+        [descriptor]: 1000,
+        [tokenAccountA]: 2000,
+        [tokenAccountB]: 3000,
+    };
+    const signatureCalls: string[] = [];
+    let multipleAccountsCalls = 0;
+
+    const api = {
+        rpc: {
+            getAccountInfo: () => ({
+                send: () => Promise.resolve({ value: { lamports: 1000, data: ['', 'base64'] } }),
+            }),
+            getTokenAccountsByOwner: (_owner: string, filter: { programId: string }) => ({
+                send: () =>
+                    Promise.resolve({
+                        value:
+                            filter.programId === splTokenProgram
+                                ? [
+                                      tokenAccount(tokenAccountA, mintA),
+                                      tokenAccount(tokenAccountB, mintB),
+                                  ]
+                                : [],
+                    }),
+            }),
+            getMultipleAccounts: (addresses: string[]) => ({
+                send: () => {
+                    multipleAccountsCalls += 1;
+
+                    return Promise.resolve({
+                        value: addresses.map(a => ({
+                            lamports: lamports[a] ?? 0,
+                            data: ['', 'base64'],
+                        })),
+                    });
+                },
+            }),
+            getSignaturesForAddress: (address: string) => ({
+                send: () => {
+                    signatureCalls.push(address);
+
+                    return Promise.resolve([{ signature: `sig-${address}`, slot: 1n }]);
+                },
+            }),
+            getEpochInfo: () => ({ send: () => Promise.resolve({ epoch: 7n }) }),
+        },
+    } as unknown as SolanaAPI;
+
+    return {
+        api,
+        signatureCalls,
+        multipleAccountsCalls: () => multipleAccountsCalls,
+        bumpLamports: (address: string) => {
+            lamports[address] = (lamports[address] ?? 0) + 1;
+        },
+    };
+};
+
+describe('solana worker change detection', () => {
+    const originalFetch = global.fetch;
+    let mock: ReturnType<typeof createApiMock>;
+    let blockchain: BlockchainLink;
+
+    beforeAll(() => {
+        // token definitions are fetched over HTTP; only recognised mints reach the fan-out
+        global.fetch = (() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({ [mintA]: { symbol: 'A' }, [mintB]: { symbol: 'B' } }),
+            })) as unknown as typeof global.fetch;
+    });
+
+    afterAll(() => {
+        global.fetch = originalFetch;
+        blockchain.dispose();
+    });
+
+    beforeAll(() => {
+        mock = createApiMock();
+        const worker = SolanaWorker();
+        worker.tryConnect = () => Promise.resolve(mock.api);
+        blockchain = new BlockchainLink({
+            name: 'Solana',
+            worker: () => worker,
+            server: ['dummyUrl'],
+            debug: false,
+        });
+    });
+
+    const sync = () =>
+        blockchain.getAccountInfo({ descriptor, details: 'txids' } as AccountInfoParams);
+
+    it('fans out signature lookups once, then serves unchanged addresses from cache', async () => {
+        const first = await sync();
+
+        expect(mock.multipleAccountsCalls()).toBe(1);
+        expect([...mock.signatureCalls].sort()).toEqual(
+            [descriptor, tokenAccountA, tokenAccountB].sort(),
+        );
+
+        mock.signatureCalls.length = 0;
+        const second = await sync();
+
+        // one getMultipleAccounts told us nothing moved, so no address was refetched
+        expect(mock.multipleAccountsCalls()).toBe(2);
+        expect(mock.signatureCalls).toEqual([]);
+        expect(second.history.txids).toEqual(first.history.txids);
+    });
+
+    it('refetches only the address whose state changed', async () => {
+        mock.signatureCalls.length = 0;
+        mock.bumpLamports(tokenAccountA);
+
+        const result = await sync();
+
+        expect(mock.signatureCalls).toEqual([tokenAccountA]);
+        expect(result.history.txids).toEqual(
+            expect.arrayContaining([`sig-${descriptor}`, `sig-${tokenAccountA}`]),
+        );
+    });
+});

--- a/packages/blockchain-link/src/workers/solana/connectionLoss.test.ts
+++ b/packages/blockchain-link/src/workers/solana/connectionLoss.test.ts
@@ -1,0 +1,172 @@
+import type { SubscriptionAccountInfo } from '@trezor/blockchain-link-types';
+import { tokenProgramsInfo } from '@trezor/network-solana/constants';
+import solanaRuntime from '@trezor/network-solana/runtime';
+import type { SolanaAPI } from '@trezor/network-solana/types';
+
+import { BlockchainLink } from '../../index';
+
+import SolanaWorker from './index';
+
+const descriptor = '2MLmmoKgCrxVEzMeGatnjdABYS5RXsQSNikcWrmnvQna';
+
+const SUBSCRIPTIONS_PER_ACCOUNT = 1 + Object.keys(tokenProgramsInfo).length;
+
+// @solana/kit is not a dependency here, and its isSolanaError only reads the name and the code,
+// so SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED (8190003) is reproduced by hand.
+// subscribeWithClosingChannel asserts the production predicate still recognises it.
+const channelClosedError = Object.assign(new Error('WebSocket connection closed'), {
+    name: 'SolanaError',
+    context: { __code: 8190003 },
+});
+
+const subscribeWithClosingChannel = async () => {
+    const { isConnectionClosedError } = await solanaRuntime();
+    expect(isConnectionClosedError(channelClosedError)).toBe(true);
+
+    const subscriptions: string[] = [];
+    let closing = true;
+    let refusing = false;
+
+    const channel = (label: string) => ({
+        subscribe: () => {
+            subscriptions.push(label);
+            if (refusing) {
+                refusing = false;
+
+                return Promise.reject(new Error('subscribe refused'));
+            }
+
+            return Promise.resolve({
+                async *[Symbol.asyncIterator]() {
+                    if (closing) throw channelClosedError;
+                    // a channel that holds delivers nothing in these tests
+                    yield await new Promise<never>(() => {});
+                },
+            });
+        },
+    });
+
+    const api = {
+        rpcSubscriptions: {
+            accountNotifications: (address: string) => channel(address),
+            programNotifications: (programId: string) => channel(programId),
+        },
+    } as unknown as SolanaAPI;
+
+    const worker = SolanaWorker();
+    let connections = 0;
+    worker.tryConnect = () => {
+        connections += 1;
+
+        return Promise.resolve(api);
+    };
+
+    const blockchain = new BlockchainLink({
+        name: 'Solana',
+        worker: () => worker,
+        server: ['dummyUrl'],
+        debug: false,
+    });
+
+    const disconnected = jest.fn();
+    blockchain.on('disconnected', disconnected);
+
+    const account = { descriptor } as SubscriptionAccountInfo;
+    const subscribed = blockchain.subscribe({ type: 'accounts', accounts: [account] });
+    // the worker handshake is on a 10 ms timer, and the channel closes right after subscribing
+    await jest.advanceTimersByTimeAsync(20);
+    await subscribed;
+
+    return {
+        blockchain,
+        account,
+        disconnected,
+        subscriptions,
+        holdChannel: () => {
+            closing = false;
+        },
+        refuseNextSubscribe: () => {
+            refusing = true;
+        },
+        getConnections: () => connections,
+    };
+};
+
+describe('solana worker connection loss', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    // reproduce-fresh.har: every subscription channel closed within about 1.3 s of subscribing,
+    // and each close was escalated into a full backend teardown — 15 reconnects and 14 rebuilt
+    // workers in 21 s, every rebuild refetching the token definitions and re-syncing all accounts
+    // with an empty cache. The JSON-RPC transport is plain HTTP and stays usable throughout.
+    it('does not report a disconnect when only a subscription channel closes', async () => {
+        const { blockchain, disconnected } = await subscribeWithClosingChannel();
+
+        expect(disconnected).not.toHaveBeenCalled();
+
+        blockchain.dispose();
+    });
+
+    it('keeps the RPC connection when a subscription channel closes', async () => {
+        const { blockchain, account, getConnections } = await subscribeWithClosingChannel();
+
+        const subscribed = blockchain.subscribe({ type: 'accounts', accounts: [account] });
+        await jest.advanceTimersByTimeAsync(0);
+        await subscribed;
+
+        expect(getConnections()).toBe(1);
+
+        blockchain.dispose();
+    });
+
+    it('resubscribes the accounts on the same connection', async () => {
+        const { blockchain, subscriptions, holdChannel, getConnections } =
+            await subscribeWithClosingChannel();
+
+        expect(subscriptions).toHaveLength(SUBSCRIPTIONS_PER_ACCOUNT);
+
+        holdChannel();
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(subscriptions).toHaveLength(2 * SUBSCRIPTIONS_PER_ACCOUNT);
+        expect(getConnections()).toBe(1);
+
+        blockchain.dispose();
+    });
+
+    it('waits longer before each attempt while the channel keeps closing', async () => {
+        const { blockchain, subscriptions } = await subscribeWithClosingChannel();
+
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(subscriptions).toHaveLength(2 * SUBSCRIPTIONS_PER_ACCOUNT);
+
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(subscriptions).toHaveLength(2 * SUBSCRIPTIONS_PER_ACCOUNT);
+
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(subscriptions).toHaveLength(3 * SUBSCRIPTIONS_PER_ACCOUNT);
+
+        blockchain.dispose();
+    });
+
+    it('retries the same accounts after a failed attempt', async () => {
+        const { blockchain, subscriptions, refuseNextSubscribe, holdChannel } =
+            await subscribeWithClosingChannel();
+
+        refuseNextSubscribe();
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(subscriptions).toHaveLength(SUBSCRIPTIONS_PER_ACCOUNT + 1);
+
+        holdChannel();
+        await jest.advanceTimersByTimeAsync(2000);
+        expect(subscriptions.filter(subscription => subscription === descriptor)).toHaveLength(3);
+
+        blockchain.dispose();
+    });
+});

--- a/packages/blockchain-link/src/workers/solana/handlers/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/solana/handlers/getAccountInfo.ts
@@ -267,14 +267,6 @@ export const getAccountInfo = async (request: Request<MessageTypes.GetAccountInf
         misc: { ...misc, owner: accountInfo?.owner },
     };
 
-    // Update token accounts of account stored by the worker since new accounts
-    // might have been created. We otherwise would not get proper updates for new
-    // token accounts.
-    const workerAccount = request.state.getAccount(payload.descriptor);
-    if (workerAccount) {
-        request.state.addAccounts([{ ...workerAccount, tokens }]);
-    }
-
     return {
         type: RESPONSES.GET_ACCOUNT_INFO,
         payload: account,

--- a/packages/blockchain-link/src/workers/solana/handlers/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/solana/handlers/getAccountInfo.ts
@@ -12,7 +12,7 @@ import type { Address, Signature, SolanaTokenAccountInfo } from '@trezor/network
 import { createDeferred, isNotNullOrUndefined } from '@trezor/utils';
 
 import type { Request } from '../types';
-import { fetchTransactionPage, getAllSignatures, isValidTransaction } from '../utils';
+import { fetchTransactionPage, getSignaturesForAddresses, isValidTransaction } from '../utils';
 
 export const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => {
     const { payload } = request;
@@ -66,11 +66,7 @@ export const getAccountInfo = async (request: Request<MessageTypes.GetAccountInf
             details === 'txs' || details === 'txids'
                 ? Array.from(
                       new Set(
-                          (
-                              await Promise.all(
-                                  allAccounts.map(account => getAllSignatures(api, account)),
-                              )
-                          )
+                          (await getSignaturesForAddresses(api, allAccounts, request.state.cache))
                               .flat()
                               .sort((a, b) => Number(b.slot - a.slot))
                               .map(it => it.signature),

--- a/packages/blockchain-link/src/workers/solana/solanaWorker.ts
+++ b/packages/blockchain-link/src/workers/solana/solanaWorker.ts
@@ -5,7 +5,7 @@ import { getSuiteVersion } from '@trezor/env-utils';
 import { SOLANA_MAINNET_GENESIS_HASH } from '@trezor/network-solana/constants';
 import solana from '@trezor/network-solana/runtime';
 import type { SolanaAPI } from '@trezor/network-solana/types';
-import { type IntervalId } from '@trezor/type-utils';
+import { type IntervalId, type TimerId } from '@trezor/type-utils';
 import { createLazy } from '@trezor/utils';
 
 import { BaseWorker } from '../baseWorker';
@@ -15,8 +15,8 @@ import { getInfo } from './handlers/getInfo';
 import { pushTransaction } from './handlers/pushTransaction';
 import { subscribe } from './handlers/subscribe';
 import { unsubscribe } from './handlers/unsubscribe';
-import { abortSubscription } from './subscriptions/accounts';
-import type { Request } from './types';
+import { abortSubscription, subscribeAccounts } from './subscriptions/accounts';
+import type { Context, Request } from './types';
 
 const onRequest = (request: Request<MessageTypes.Message>, isTestnet: boolean) => {
     switch (request.type) {
@@ -37,6 +37,14 @@ const onRequest = (request: Request<MessageTypes.Message>, isTestnet: boolean) =
     }
 };
 
+// A closed subscription channel is re-established on the same connection - the JSON-RPC
+// transport is plain HTTP and keeps working. Delays grow so a backend that keeps closing the
+// channel costs one channel per step instead of a rebuilt worker and a re-sync of every account,
+// and reset once subscriptions have held for STABLE_SUBSCRIPTION_TIME.
+const RESUBSCRIBE_MIN_DELAY = 1000;
+const RESUBSCRIBE_MAX_DELAY = 20000;
+const STABLE_SUBSCRIPTION_TIME = 30000;
+
 export class SolanaWorker extends BaseWorker<SolanaAPI> {
     protected isConnected(api: SolanaAPI | undefined): api is SolanaAPI {
         return !!api;
@@ -44,6 +52,67 @@ export class SolanaWorker extends BaseWorker<SolanaAPI> {
 
     private lazyTokens = createLazy(() => solanaUtils.getTokenMetadata());
     private isTestnet = false;
+    private resubscribeTimeout?: TimerId;
+    private resubscribeAttempt = 0;
+    private resubscribing = false;
+    private channelClosed = false;
+    private lastAttemptAt?: number;
+
+    private get context(): Context {
+        return {
+            connect: () => this.connect(),
+            post: (data: Response) => this.post(data),
+            state: this.state,
+            getTokenMetadata: this.lazyTokens.getOrInit,
+            onSubscriptionsClosed: () => this.resubscribeAccounts(),
+        };
+    }
+
+    private resubscribeAccounts() {
+        if (!this.api) return;
+
+        // Every subscription of every account reports the same closed channel, and one pass
+        // covers them all. Reports arriving while a pass is in flight belong to the subscriptions
+        // that pass is opening, so they schedule the next one instead of aborting this one.
+        if (this.resubscribing) {
+            this.channelClosed = true;
+
+            return;
+        }
+
+        const accounts = [...this.state.getAccounts()];
+        if (!accounts.length) return;
+
+        accounts.forEach(({ subscriptionId }) => {
+            if (subscriptionId != null) abortSubscription(subscriptionId);
+        });
+        this.state.removeAccounts(accounts);
+
+        const idleLongEnough =
+            this.lastAttemptAt === undefined ||
+            Date.now() - this.lastAttemptAt >= STABLE_SUBSCRIPTION_TIME;
+        if (idleLongEnough) this.resubscribeAttempt = 0;
+
+        const delay = Math.min(
+            RESUBSCRIBE_MIN_DELAY * 2 ** this.resubscribeAttempt,
+            RESUBSCRIBE_MAX_DELAY,
+        );
+        this.resubscribeAttempt += 1;
+        this.resubscribing = true;
+
+        this.resubscribeTimeout = setTimeout(async () => {
+            this.resubscribeTimeout = undefined;
+            this.channelClosed = false;
+            this.lastAttemptAt = Date.now();
+            try {
+                await subscribeAccounts(this.context, accounts);
+            } catch {
+                this.channelClosed = true;
+            }
+            this.resubscribing = false;
+            if (this.channelClosed) this.resubscribeAccounts();
+        }, delay);
+    }
 
     async tryConnect(url: string): Promise<SolanaAPI> {
         const { getApi } = await solana();
@@ -61,24 +130,7 @@ export class SolanaWorker extends BaseWorker<SolanaAPI> {
             // skip processed messages
             if (await super.messageHandler(event)) return true;
 
-            const request: Request<MessageTypes.Message> = {
-                ...event.data,
-                connect: () => this.connect(),
-                onNetworkDisconnect: () => {
-                    if (this.api) {
-                        // Broadcast that we are being disconnected
-                        this.post({
-                            id: -1,
-                            type: RESPONSES.DISCONNECTED,
-                            payload: true,
-                        });
-                    }
-                    this.disconnect();
-                },
-                post: (data: Response) => this.post(data),
-                state: this.state,
-                getTokenMetadata: this.lazyTokens.getOrInit,
-            };
+            const request: Request<MessageTypes.Message> = { ...event.data, ...this.context };
 
             const response = await onRequest(request, this.isTestnet);
             this.post({ id: event.data.id, ...response });
@@ -88,6 +140,10 @@ export class SolanaWorker extends BaseWorker<SolanaAPI> {
     }
 
     disconnect(): void {
+        clearTimeout(this.resubscribeTimeout);
+        this.resubscribeTimeout = undefined;
+        this.resubscribing = false;
+
         if (!this.api) {
             return;
         }

--- a/packages/blockchain-link/src/workers/solana/subscriptions.test.ts
+++ b/packages/blockchain-link/src/workers/solana/subscriptions.test.ts
@@ -1,0 +1,107 @@
+import type { SubscriptionAccountInfo } from '@trezor/blockchain-link-types';
+import { tokenProgramsInfo } from '@trezor/network-solana/constants';
+import type { SolanaAPI } from '@trezor/network-solana/types';
+
+import { BlockchainLink } from '../../index';
+
+import SolanaWorker from './index';
+
+const descriptor = '2MLmmoKgCrxVEzMeGatnjdABYS5RXsQSNikcWrmnvQna';
+
+const createApiMock = () => {
+    const accountSubscriptions: string[] = [];
+    const programSubscriptions: { programId: string; filters: unknown }[] = [];
+
+    const noNotifications = {
+        subscribe: () =>
+            Promise.resolve({
+                async *[Symbol.asyncIterator]() {},
+            }),
+    };
+
+    const api = {
+        rpcSubscriptions: {
+            accountNotifications: (address: string) => {
+                accountSubscriptions.push(address);
+
+                return noNotifications;
+            },
+            programNotifications: (programId: string, { filters }: { filters: unknown }) => {
+                programSubscriptions.push({ programId, filters });
+
+                return noNotifications;
+            },
+        },
+    } as unknown as SolanaAPI;
+
+    return { api, accountSubscriptions, programSubscriptions };
+};
+
+const createTokenAccounts = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+        contract: `mint-${i}`,
+        accounts: [{ publicKey: `token-account-${i}`, balance: '1' }],
+    }));
+
+const subscribeAccount = async (account: SubscriptionAccountInfo) => {
+    const mock = createApiMock();
+    const worker = SolanaWorker();
+    worker.tryConnect = () => Promise.resolve(mock.api);
+
+    const blockchain = new BlockchainLink({
+        name: 'Solana',
+        worker: () => worker,
+        server: ['dummyUrl'],
+        debug: false,
+    });
+
+    const result = await blockchain.subscribe({ type: 'accounts', accounts: [account] });
+    blockchain.dispose();
+
+    return { ...mock, result };
+};
+
+describe('solana worker subscriptions', () => {
+    it('subscribes each token program once instead of each token account', async () => {
+        const account = {
+            descriptor,
+            tokens: createTokenAccounts(20),
+        } as unknown as SubscriptionAccountInfo;
+
+        const { result, accountSubscriptions, programSubscriptions } =
+            await subscribeAccount(account);
+
+        expect(result).toEqual({ subscribed: true });
+        expect(accountSubscriptions).toEqual([descriptor]);
+        expect(programSubscriptions.map(({ programId }) => programId)).toEqual(
+            Object.values(tokenProgramsInfo).map(({ publicKey }) => publicKey),
+        );
+    });
+
+    it('keeps the subscription count independent of how many tokens the account holds', async () => {
+        const countSubscriptions = async (tokenCount: number) => {
+            const { accountSubscriptions, programSubscriptions } = await subscribeAccount({
+                descriptor,
+                tokens: createTokenAccounts(tokenCount),
+            } as unknown as SubscriptionAccountInfo);
+
+            return accountSubscriptions.length + programSubscriptions.length;
+        };
+
+        // one account notification plus one program notification per token program
+        const expected = 1 + Object.keys(tokenProgramsInfo).length;
+
+        expect(await countSubscriptions(0)).toBe(expected);
+        expect(await countSubscriptions(68)).toBe(expected);
+    });
+
+    it('filters token notifications by the owner offset of the token account layout', async () => {
+        const { programSubscriptions } = await subscribeAccount({ descriptor });
+
+        programSubscriptions.forEach(({ filters }) => {
+            expect(filters).toEqual([
+                { memcmp: { bytes: descriptor, encoding: 'base58', offset: 32n } },
+            ]);
+        });
+    });
+});

--- a/packages/blockchain-link/src/workers/solana/subscriptions/accounts.ts
+++ b/packages/blockchain-link/src/workers/solana/subscriptions/accounts.ts
@@ -34,7 +34,7 @@ const handleNotifications = async <T>(
     // Address whose history changed, or undefined to ignore the notification.
     getChangedAddress: (notification: T, tokenMetadata: TokenDetailByMint) => string | undefined,
 ) => {
-    const { connect, state, post, getTokenMetadata } = context;
+    const { connect, post, getTokenMetadata } = context;
     const { address, isConnectionClosedError } = await solana();
     try {
         for await (const notification of notifications) {
@@ -80,12 +80,7 @@ const handleNotifications = async <T>(
             });
         }
     } catch (error) {
-        if (isConnectionClosedError(error)) {
-            // The WS was closed, we should unsubscribe
-            if (account.subscriptionId != null) abortSubscription(account.subscriptionId);
-            state.removeAccounts([account]);
-            context.onNetworkDisconnect();
-        }
+        if (isConnectionClosedError(error)) context.onSubscriptionsClosed();
     }
 };
 

--- a/packages/blockchain-link/src/workers/solana/subscriptions/accounts.ts
+++ b/packages/blockchain-link/src/workers/solana/subscriptions/accounts.ts
@@ -1,38 +1,20 @@
 import type { SubscriptionAccountInfo, TokenDetailByMint } from '@trezor/blockchain-link-types';
 import { RESPONSES } from '@trezor/blockchain-link-types';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
+import { tokenProgramsInfo } from '@trezor/network-solana/constants';
 import solana from '@trezor/network-solana/runtime';
-import type { AccountInfoBase, SolanaRpcResponse } from '@trezor/network-solana/types';
+import type { AccountInfoWithJsonData, Base58EncodedBytes } from '@trezor/network-solana/types';
 
 import type { Context } from '../types';
 import { isValidTransaction } from '../utils';
 
-const extractTokenAccounts = (
-    accounts: SubscriptionAccountInfo[],
-    tokenMetadata: TokenDetailByMint,
-): SubscriptionAccountInfo[] =>
-    accounts.flatMap(
-        account =>
-            account.tokens?.flatMap(
-                token =>
-                    token.accounts
-                        ?.filter(
-                            tokenAccount =>
-                                tokenAccount.balance !== '0' && tokenMetadata[token.contract],
-                        )
-                        .map(tokenAccount => ({ descriptor: tokenAccount.publicKey })) || [],
-            ) || [],
-    );
+// Offset of the owner pubkey in the SPL token account layout, shared by Token and Token-2022.
+const TOKEN_ACCOUNT_OWNER_OFFSET = 32n;
 
-const findTokenAccountOwner = (
-    accounts: SubscriptionAccountInfo[],
-    accountDescriptor: string,
-): SubscriptionAccountInfo | undefined =>
-    accounts.find(account =>
-        account.tokens?.find(token =>
-            token.accounts?.find(tokenAccount => tokenAccount.publicKey === accountDescriptor),
-        ),
-    );
+const getTokenAccountMint = (account: AccountInfoWithJsonData) =>
+    'parsed' in account.data
+        ? (account.data.parsed?.info as { mint?: string } | undefined)?.mint
+        : undefined;
 
 let NEXT_ACCOUNT_SUBSCRIPTION_ID = 0;
 // Module-scoped registry of in-flight account subscriptions. Shared between the
@@ -45,24 +27,30 @@ export const abortSubscription = (id: number) => {
     abortController?.abort();
 };
 
-const handleAccountNotification = async (
+const handleNotifications = async <T>(
     context: Context,
-    accountNotifications: AsyncIterable<SolanaRpcResponse<AccountInfoBase>>,
+    notifications: AsyncIterable<T>,
     account: SubscriptionAccountInfo,
+    // Address whose history changed, or undefined to ignore the notification.
+    getChangedAddress: (notification: T, tokenMetadata: TokenDetailByMint) => string | undefined,
 ) => {
     const { connect, state, post, getTokenMetadata } = context;
     const { address, isConnectionClosedError } = await solana();
     try {
-        for await (const _ of accountNotifications) {
+        for await (const notification of notifications) {
+            const tokenMetadata = await getTokenMetadata();
+            const changedAddress = getChangedAddress(notification, tokenMetadata);
+            if (!changedAddress) continue;
+
             const api = await connect();
             // get the last transaction signature for the account, since that what triggered this callback
             const [lastSignatureResponse] = await api.rpc
-                .getSignaturesForAddress(address(account.descriptor), {
+                .getSignaturesForAddress(address(changedAddress), {
                     limit: 1,
                 })
                 .send();
             const lastSignature = lastSignatureResponse?.signature;
-            if (!lastSignature) return;
+            if (!lastSignature) continue;
 
             // get the last transaction
             const lastTx = await api.rpc
@@ -73,23 +61,11 @@ const handleAccountNotification = async (
                 })
                 .send();
 
-            if (!lastTx || !isValidTransaction(lastTx)) {
-                return;
-            }
+            if (!lastTx || !isValidTransaction(lastTx)) continue;
 
-            const tokenMetadata = await getTokenMetadata();
-            const tx = solanaUtils.transformTransaction(
-                lastTx,
-                account.descriptor,
-                [],
-                tokenMetadata,
-            );
-
-            // For token accounts we need to emit an event with the owner account's descriptor
-            // since we don't store token accounts in the user's accounts.
-            const descriptor =
-                findTokenAccountOwner(state.getAccounts(), account.descriptor)?.descriptor ||
-                account.descriptor;
+            // Transformed from the perspective of the address that changed: for a token transfer
+            // that is the token account appearing as the instruction's source or destination.
+            const tx = solanaUtils.transformTransaction(lastTx, changedAddress, [], tokenMetadata);
 
             post({
                 id: -1,
@@ -97,7 +73,7 @@ const handleAccountNotification = async (
                 payload: {
                     type: 'notification',
                     payload: {
-                        descriptor,
+                        descriptor: account.descriptor,
                         tx,
                     },
                 },
@@ -106,7 +82,7 @@ const handleAccountNotification = async (
     } catch (error) {
         if (isConnectionClosedError(error)) {
             // The WS was closed, we should unsubscribe
-            if (account.subscriptionId) abortSubscription(account.subscriptionId);
+            if (account.subscriptionId != null) abortSubscription(account.subscriptionId);
             state.removeAccounts([account]);
             context.onNetworkDisconnect();
         }
@@ -117,10 +93,7 @@ export const subscribeAccounts = async (context: Context, accounts: Subscription
     const { connect, state } = context;
     const api = await connect();
     const subscribedAccounts = state.getAccounts();
-    const tokenMetadata = await context.getTokenMetadata();
-    const tokenAccounts = extractTokenAccounts(accounts, tokenMetadata);
-    // we have to subscribe to both system and token accounts
-    const newAccounts = [...accounts, ...tokenAccounts].filter(
+    const newAccounts = accounts.filter(
         account =>
             !subscribedAccounts.some(
                 subscribedAccount => account.descriptor === subscribedAccount.descriptor,
@@ -131,10 +104,8 @@ export const subscribeAccounts = async (context: Context, accounts: Subscription
 
     await Promise.all(
         newAccounts.map(async a => {
+            // One controller per account, shared by its system and token subscriptions.
             const abortController = new AbortController();
-            const accountNotifications = await api.rpcSubscriptions
-                .accountNotifications(address(a.descriptor), { commitment: 'confirmed' })
-                .subscribe({ abortSignal: abortController.signal });
             const subscriptionId = NEXT_ACCOUNT_SUBSCRIPTION_ID++;
             ACCOUNT_SUBSCRIPTION_ABORT_CONTROLLERS.set(subscriptionId, abortController);
             const account: SubscriptionAccountInfo = {
@@ -142,7 +113,48 @@ export const subscribeAccounts = async (context: Context, accounts: Subscription
                 subscriptionId,
             };
             state.addAccounts([account]);
-            handleAccountNotification(context, accountNotifications, account);
+
+            const accountNotifications = await api.rpcSubscriptions
+                .accountNotifications(address(a.descriptor), { commitment: 'confirmed' })
+                .subscribe({ abortSignal: abortController.signal });
+            handleNotifications(context, accountNotifications, account, () => a.descriptor);
+
+            // One owner-filtered program subscription covers every token account, so the
+            // subscription count scales with accounts rather than with tokens held. It also
+            // catches token accounts created after subscribing, which a per-token-account
+            // subscription cannot — an incoming transfer of a not-yet-held token.
+            await Promise.all(
+                Object.values(tokenProgramsInfo).map(async ({ publicKey }) => {
+                    const tokenNotifications = await api.rpcSubscriptions
+                        .programNotifications(address(publicKey), {
+                            commitment: 'confirmed',
+                            encoding: 'jsonParsed',
+                            filters: [
+                                {
+                                    memcmp: {
+                                        bytes: a.descriptor as Base58EncodedBytes,
+                                        encoding: 'base58',
+                                        offset: TOKEN_ACCOUNT_OWNER_OFFSET,
+                                    },
+                                },
+                            ],
+                        })
+                        .subscribe({ abortSignal: abortController.signal });
+
+                    handleNotifications(
+                        context,
+                        tokenNotifications,
+                        account,
+                        ({ value }, tokenMetadata) => {
+                            const mint = getTokenAccountMint(value.account);
+
+                            // Ignore unrecognised tokens so airdropped spam does not trigger a
+                            // history fetch and an account refresh.
+                            return mint && tokenMetadata[mint] ? value.pubkey : undefined;
+                        },
+                    );
+                }),
+            );
         }),
     );
 
@@ -153,23 +165,12 @@ export const unsubscribeAccounts = (
     { state }: Context,
     accounts: SubscriptionAccountInfo[] | undefined = [],
 ) => {
-    const subscribedAccounts = state.getAccounts();
-
-    accounts.forEach(a => {
-        if (a.subscriptionId != null) {
-            abortSubscription(a.subscriptionId);
-            state.removeAccounts([a]);
+    accounts.forEach(({ descriptor }) => {
+        // The accounts Suite sends back carry no subscriptionId, so take the stored one.
+        const subscribed = state.getAccount(descriptor);
+        if (subscribed?.subscriptionId != null) {
+            abortSubscription(subscribed.subscriptionId);
+            state.removeAccounts([subscribed]);
         }
-
-        // unsubscribe token accounts as well
-        a.tokens?.forEach(t => {
-            t.accounts?.forEach(ta => {
-                const tokenAccount = subscribedAccounts.find(sa => sa.descriptor === ta.publicKey);
-                if (tokenAccount?.subscriptionId != null) {
-                    abortSubscription(tokenAccount.subscriptionId);
-                    state.removeAccounts([tokenAccount]);
-                }
-            });
-        });
     });
 };

--- a/packages/blockchain-link/src/workers/solana/types.ts
+++ b/packages/blockchain-link/src/workers/solana/types.ts
@@ -5,7 +5,7 @@ import type { ContextType } from '../baseWorker';
 
 export type Context = ContextType<SolanaAPI> & {
     getTokenMetadata: () => Promise<TokenDetailByMint>;
-    onNetworkDisconnect: () => void;
+    onSubscriptionsClosed: () => void;
 };
 
 export type Request<T> = T & Context;

--- a/packages/blockchain-link/src/workers/solana/utils.ts
+++ b/packages/blockchain-link/src/workers/solana/utils.ts
@@ -6,7 +6,7 @@ import type {
     SolanaAPI,
     SolanaValidParsedTxWithMeta,
 } from '@trezor/network-solana/types';
-import { isNotNullOrUndefined } from '@trezor/utils';
+import { type Cache, isNotNullOrUndefined } from '@trezor/utils';
 
 import type { SignatureWithSlot } from './types';
 
@@ -39,6 +39,70 @@ export const getAllSignatures = async (
     }
 
     return allSignatures;
+};
+
+// getMultipleAccounts accepts at most 100 addresses per call
+const MULTIPLE_ACCOUNTS_LIMIT = 100;
+// Bounds how long an unchanged address may reuse its cached signatures. A transaction can mention
+// an address without altering its state, and only a refetch discovers those.
+const SIGNATURES_CACHE_TTL = 10 * 60 * 1000;
+// Unfunded addresses do not exist on chain. Cannot collide with a real fingerprint, which always
+// contains a separator.
+const NONEXISTENT_ACCOUNT_FINGERPRINT = 'nonexistent';
+
+type CachedSignatures = { fingerprint: string; signatures: SignatureWithSlot[] };
+
+const getAccountFingerprints = async (api: SolanaAPI, descriptors: string[]) => {
+    const { address } = await solana();
+    const fingerprints = new Map<string, string>();
+
+    for (let i = 0; i < descriptors.length; i += MULTIPLE_ACCOUNTS_LIMIT) {
+        const chunk = descriptors.slice(i, i + MULTIPLE_ACCOUNTS_LIMIT);
+        const { value } = await api.rpc
+            .getMultipleAccounts(chunk.map(address), { encoding: 'base64' })
+            .send();
+
+        chunk.forEach((descriptor, index) => {
+            const account = value[index];
+            fingerprints.set(
+                descriptor,
+                account
+                    ? `${account.lamports}:${account.data[0]}`
+                    : NONEXISTENT_ACCOUNT_FINGERPRINT,
+            );
+        });
+    }
+
+    return fingerprints;
+};
+
+// A single getMultipleAccounts call reveals which addresses moved, so the signature fan-out — by
+// far the most expensive part of a sync — only runs for those.
+export const getSignaturesForAddresses = async (
+    api: SolanaAPI,
+    descriptors: string[],
+    cache: Cache,
+) => {
+    const fingerprints = await getAccountFingerprints(api, descriptors);
+
+    return Promise.all(
+        descriptors.map(async descriptor => {
+            const fingerprint = fingerprints.get(descriptor);
+            const cacheKey = `signatures/${descriptor}`;
+            const cached: CachedSignatures | undefined = cache.get(cacheKey);
+
+            if (fingerprint && cached?.fingerprint === fingerprint) {
+                return cached.signatures;
+            }
+
+            const signatures = await getAllSignatures(api, descriptor);
+            if (fingerprint) {
+                cache.set(cacheKey, { fingerprint, signatures }, SIGNATURES_CACHE_TTL);
+            }
+
+            return signatures;
+        }),
+    );
 };
 
 export const fetchTransactionPage = async (

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -49,6 +49,9 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
             this.params.coinInfo,
             sendCoreMessage,
             this.params.identity,
+            // Suite reconnects a backend through this method (reconnectBlockchainThunk), including
+            // from the reconnect button, so it connects now instead of awaiting the retry delay.
+            { force: true },
         );
 
         return backend.unsubscribeFiatRates();

--- a/packages/connect/src/backend/BackendManager.test.ts
+++ b/packages/connect/src/backend/BackendManager.test.ts
@@ -2,6 +2,7 @@ import { BlockchainLink } from '@trezor/blockchain-link';
 import type { CoinInfo, CoreEventMessage } from '@trezor/connect-common';
 
 import { BackendManager } from './BackendManager';
+import type { Blockchain } from './Blockchain';
 
 const coinInfo = {
     shortcut: 'BTC',
@@ -123,5 +124,75 @@ describe('backend/BackendManager', () => {
         backend.link.emit('disconnected');
 
         expect(delays.at(-1)).toBe(1000);
+    });
+
+    it('does not let a caller preempt a scheduled reconnect', async () => {
+        const backend = await manager.getOrConnect({ coinInfo, postMessage });
+        await backend.subscribeBlocks();
+        expectExactMessages('blockchain-connect');
+
+        backend.link.emit('disconnected');
+        expectExactMessages('blockchain-error', 'blockchain-reconnecting');
+
+        await delay(100);
+        // Suite keeps syncing while the backend is down, and every ACCOUNT.UPDATE goes
+        // ACCOUNT.UPDATE -> subscribeBlockchainThunk -> blockchainSubscribe -> getOrConnect.
+        // The reconnect is scheduled 1000 ms out, so this caller must not open a connection.
+        await manager.getOrConnect({ coinInfo, postMessage }).catch(() => {});
+
+        expectNoMessage();
+    });
+
+    it('lets an explicit reconnect skip the scheduled delay', async () => {
+        const backend = await manager.getOrConnect({ coinInfo, postMessage });
+        await backend.subscribeBlocks();
+        expectExactMessages('blockchain-connect');
+
+        backend.link.emit('disconnected');
+        expectExactMessages('blockchain-error', 'blockchain-reconnecting');
+
+        await delay(100);
+        await manager.getOrConnect({ coinInfo, postMessage }, { force: true });
+
+        expectExactMessages('blockchain-connect');
+    });
+
+    it('keeps the connect rate down when a flapping backend meets a busy caller', async () => {
+        // Timings from reproduce-fresh.har: the subscription channel closed about 1.3 s after
+        // each subscribe, and Suite issued roughly 9 blockchainSubscribe calls per second, each
+        // one reaching getOrConnect. That produced 15 connect attempts in the 21 s window; the
+        // backoff schedule of 1, 2.5, 5, 7.5, 10 s allows 5.
+        const CHANNEL_LIFETIME = 1300;
+        const CALLER_INTERVAL = 110;
+        const WINDOW = 21_000;
+
+        let connects = 0;
+        postMessage = jest.fn((message: CoreEventMessage) => {
+            if (message.type === 'blockchain-connect') connects += 1;
+        });
+
+        let live: Blockchain | undefined;
+        let dropAt = 0;
+
+        for (let now = 0; now <= WINDOW; now += CALLER_INTERVAL) {
+            const backend = await manager
+                .getOrConnect({ coinInfo, postMessage })
+                .catch(() => undefined);
+
+            if (backend && backend !== live) {
+                await backend.subscribeBlocks();
+                live = backend;
+                dropAt = now + CHANNEL_LIFETIME;
+            }
+
+            if (live && now >= dropAt) {
+                live.link.emit('disconnected');
+                live = undefined;
+            }
+
+            await delay(CALLER_INTERVAL);
+        }
+
+        expect(connects).toBeLessThanOrEqual(6);
     });
 });

--- a/packages/connect/src/backend/BackendManager.test.ts
+++ b/packages/connect/src/backend/BackendManager.test.ts
@@ -95,7 +95,33 @@ describe('backend/BackendManager', () => {
         await delay(1000);
         expectExactMessages('blockchain-error', 'blockchain-reconnecting');
 
-        await delay(2000);
+        await delay(2500);
         expectExactMessages('blockchain-error', 'blockchain-reconnecting');
+    });
+
+    it('grows the reconnect delay while a backend keeps dropping, and resets it once one holds', async () => {
+        const delays: number[] = [];
+        postMessage = jest.fn((message: CoreEventMessage) => {
+            if (message.type === 'blockchain-reconnecting') {
+                delays.push(message.payload.time - Date.now());
+            }
+        });
+
+        let backend = await manager.getOrConnect({ coinInfo, postMessage });
+
+        for (const expectedDelay of [1000, 2500, 5000]) {
+            await backend.subscribeBlocks();
+            backend.link.emit('disconnected');
+            expect(delays.at(-1)).toBe(expectedDelay);
+
+            await delay(expectedDelay);
+            backend = await manager.getOrConnect({ coinInfo, postMessage });
+        }
+
+        await backend.subscribeBlocks();
+        await delay(30000);
+        backend.link.emit('disconnected');
+
+        expect(delays.at(-1)).toBe(1000);
     });
 });

--- a/packages/connect/src/backend/BackendManager.ts
+++ b/packages/connect/src/backend/BackendManager.ts
@@ -1,5 +1,6 @@
 import { BLOCKCHAIN, createBlockchainMessage } from '@trezor/connect-common';
 import type { BlockchainLink, CoinInfo, Proxy } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { TimerId } from '@trezor/type-utils';
 import { deepEqual } from '@trezor/utils';
 
@@ -36,8 +37,22 @@ export class BackendManager {
         return this.instances[`${shortcut}/${identity}`] ?? null;
     }
 
-    async getOrConnect({ coinInfo, postMessage, identity }: BackendParams): Promise<Blockchain> {
-        const coinIdentity = `${coinInfo.shortcut}/${identity ?? DEFAULT_IDENTITY}` as const;
+    getOrConnect(params: BackendParams, { force }: { force?: boolean } = {}) {
+        const coinIdentity = this.getCoinIdentity(params);
+
+        // A dropped backend is retried on a growing delay. Connecting on demand instead would
+        // skip that delay entirely, because a coin with accounts is asked for the backend on
+        // every account sync — which is what turned one dropped Solana socket into 15 connect
+        // attempts and 111 requests per second. Only an explicit reconnect may skip the wait.
+        if (!force && this.reconnect[coinIdentity] && !this.instances[coinIdentity]) {
+            return Promise.reject(ERRORS.TypedError('Backend_Disconnected'));
+        }
+
+        return this.connect(params);
+    }
+
+    private async connect({ coinInfo, postMessage, identity }: BackendParams): Promise<Blockchain> {
+        const coinIdentity = this.getCoinIdentity({ coinInfo, identity });
         let backend = this.instances[coinIdentity];
         if (!backend) {
             backend = new Blockchain({
@@ -94,7 +109,7 @@ export class BackendManager {
         backends.forEach(i => i.disconnect());
 
         // initialize again using old backends as params
-        return Promise.all(backends.map(this.getOrConnect, this));
+        return Promise.all(backends.map(backend => this.getOrConnect(backend, { force: true })));
     }
 
     isSupported(coinInfo: CoinInfo) {
@@ -135,7 +150,7 @@ export class BackendManager {
         { coinInfo, postMessage, identity }: BackendParams,
         reconnectAttempt: number | undefined,
     ) {
-        const coinIdentity = `${coinInfo.shortcut}/${identity ?? DEFAULT_IDENTITY}` as const;
+        const coinIdentity = this.getCoinIdentity({ coinInfo, identity });
         this.setInstance(coinIdentity, undefined);
         delete this.connectedAt[coinIdentity];
 
@@ -158,7 +173,7 @@ export class BackendManager {
         );
         const time = Date.now() + timeout;
         const handle = setTimeout(() => {
-            this.getOrConnect({ coinInfo, postMessage, identity }).catch(() => {});
+            this.connect({ coinInfo, postMessage, identity }).catch(() => {});
         }, timeout);
         clearTimeout(this.reconnect[coinIdentity]?.handle);
         this.reconnect[coinIdentity] = { handle };
@@ -166,6 +181,13 @@ export class BackendManager {
         postMessage(
             createBlockchainMessage(BLOCKCHAIN.RECONNECTING, { coin: coinInfo, identity, time }),
         );
+    }
+
+    private getCoinIdentity({
+        coinInfo,
+        identity,
+    }: Pick<BackendParams, 'coinInfo' | 'identity'>): CoinShortcutIdentity {
+        return `${coinInfo.shortcut}/${identity ?? DEFAULT_IDENTITY}`;
     }
 
     private nextAttempt(coinIdentity: CoinShortcutIdentity) {

--- a/packages/connect/src/backend/BackendManager.ts
+++ b/packages/connect/src/backend/BackendManager.ts
@@ -10,16 +10,25 @@ import * as settingsStore from '../data/settingsStore';
 type CoinShortcut = CoinInfo['shortcut'];
 type Identity = string;
 type CoinShortcutIdentity = `${CoinShortcut}/${Identity}`;
-type Reconnect = { attempts: number; handle: TimerId };
+type Reconnect = { handle: TimerId };
 type BackendParams = Pick<BlockchainOptions, 'coinInfo' | 'postMessage' | 'identity'>;
 
 const DEFAULT_IDENTITY = 'default';
+
+const RECONNECT_STEP = 2500;
+const RECONNECT_MIN_TIMEOUT = 1000;
+const RECONNECT_MAX_TIMEOUT = 20000;
+// A backend that drops again sooner than this never really recovered, so the next attempt
+// continues the previous backoff instead of restarting it and hammering the backend.
+const STABLE_CONNECTION_TIME = 30000;
 
 export class BackendManager {
     private proxy?: Proxy;
 
     private readonly instances: { [shortcut: CoinShortcutIdentity]: Blockchain } = {};
     private readonly reconnect: { [shortcut: CoinShortcutIdentity]: Reconnect } = {};
+    private readonly connectedAt: { [shortcut: CoinShortcutIdentity]: number } = {};
+    private readonly attempts: { [shortcut: CoinShortcutIdentity]: number } = {};
     private readonly custom: { [shortcut: CoinShortcut]: BlockchainLink } = {};
     private readonly preferred: { [shortcut: CoinShortcut]: string } = {};
 
@@ -38,7 +47,9 @@ export class BackendManager {
                 proxy: this.proxy,
                 postMessage,
                 onDisconnected: pendingSubscriptions => {
-                    const reconnectAttempts = pendingSubscriptions ? 0 : undefined;
+                    const reconnectAttempts = pendingSubscriptions
+                        ? this.nextAttempt(coinIdentity)
+                        : undefined;
                     this.onDisconnect({ coinInfo, postMessage, identity }, reconnectAttempts);
                 },
             });
@@ -50,10 +61,13 @@ export class BackendManager {
         try {
             const info = await backend.init();
             this.setPreferred(coinInfo.shortcut, info.url);
+            this.connectedAt[coinIdentity] = Date.now();
 
             return backend;
         } catch (error) {
-            this.onDisconnect({ coinInfo, postMessage, identity }, reconnect?.attempts);
+            // only keep retrying if a reconnection was already in flight
+            const attempts = reconnect ? (this.attempts[coinIdentity] ?? 0) : undefined;
+            this.onDisconnect({ coinInfo, postMessage, identity }, attempts);
             throw error;
         }
     }
@@ -62,6 +76,12 @@ export class BackendManager {
         Object.keys(this.reconnect)
             .filter(this.getReconnectFilter())
             .forEach(this.clearReconnect, this);
+        Object.keys(this.attempts).forEach(
+            key => delete this.attempts[key as CoinShortcutIdentity],
+        );
+        Object.keys(this.connectedAt).forEach(
+            key => delete this.connectedAt[key as CoinShortcutIdentity],
+        );
         Object.values(this.instances).forEach(i => i.disconnect());
     }
 
@@ -117,6 +137,7 @@ export class BackendManager {
     ) {
         const coinIdentity = `${coinInfo.shortcut}/${identity ?? DEFAULT_IDENTITY}` as const;
         this.setInstance(coinIdentity, undefined);
+        delete this.connectedAt[coinIdentity];
 
         if (reconnectAttempt === undefined || reconnectAttempt === 4) {
             // Forget preferred backend when no reconnection is wanted
@@ -126,19 +147,33 @@ export class BackendManager {
         }
 
         if (reconnectAttempt === undefined) {
+            delete this.attempts[coinIdentity];
+
             return;
         }
 
-        const timeout = Math.min(2500 * reconnectAttempt, 20000);
+        const timeout = Math.min(
+            Math.max(RECONNECT_STEP * reconnectAttempt, RECONNECT_MIN_TIMEOUT),
+            RECONNECT_MAX_TIMEOUT,
+        );
         const time = Date.now() + timeout;
         const handle = setTimeout(() => {
             this.getOrConnect({ coinInfo, postMessage, identity }).catch(() => {});
         }, timeout);
         clearTimeout(this.reconnect[coinIdentity]?.handle);
-        this.reconnect[coinIdentity] = { attempts: reconnectAttempt + 1, handle };
+        this.reconnect[coinIdentity] = { handle };
+        this.attempts[coinIdentity] = reconnectAttempt + 1;
         postMessage(
             createBlockchainMessage(BLOCKCHAIN.RECONNECTING, { coin: coinInfo, identity, time }),
         );
+    }
+
+    private nextAttempt(coinIdentity: CoinShortcutIdentity) {
+        const connectedAt = this.connectedAt[coinIdentity];
+        const wasStable =
+            connectedAt !== undefined && Date.now() - connectedAt >= STABLE_CONNECTION_TIME;
+
+        return wasStable ? 0 : (this.attempts[coinIdentity] ?? 0);
     }
 
     private clearReconnect(coinIdentity: CoinShortcutIdentity) {

--- a/packages/connect/src/backend/BlockchainLink.ts
+++ b/packages/connect/src/backend/BlockchainLink.ts
@@ -26,7 +26,8 @@ export const initBlockchain = (
     coinInfo: CoinInfo,
     postMessage: Options['postMessage'],
     identity?: string,
-) => backends.getOrConnect({ coinInfo, identity, postMessage });
+    options?: { force?: boolean },
+) => backends.getOrConnect({ coinInfo, identity, postMessage }, options);
 
 export const reconnectAllBackends = (coinInfo?: CoinInfo) => backends.reconnectAll(coinInfo);
 

--- a/packages/e2e-utils/src/mocks/solanaRpcServerMock.ts
+++ b/packages/e2e-utils/src/mocks/solanaRpcServerMock.ts
@@ -55,10 +55,6 @@ export class SolanaRpcServerMock {
         await new Promise<void>(resolve => this.httpServer!.listen(this.port, resolve));
     }
 
-    dropConnections(): void {
-        this.subscriptionServer?.clients.forEach(client => client.terminate());
-    }
-
     async stop(): Promise<void> {
         this.subscriptionServer?.clients.forEach(client => client.terminate());
         this.subscriptionServer?.close();

--- a/suite-common/fiat-services/src/limiter.test.ts
+++ b/suite-common/fiat-services/src/limiter.test.ts
@@ -1,18 +1,28 @@
 import { RateLimiter } from './limiter';
 
 describe('RateLimiter', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
     test('delay is honoured', async () => {
         const delay = 42;
         const limiter = new RateLimiter(delay, 1_000);
-        const task = () => Promise.resolve(performance.now());
+        const task = () => Promise.resolve(Date.now());
 
-        const timestamps = await Promise.all([
+        const results = Promise.all([
             limiter.limit(task),
             limiter.limit(task),
             limiter.limit(task),
         ]);
+        await jest.advanceTimersByTimeAsync(2 * delay);
+        const timestamps = await results;
 
-        expect(timestamps[1] - timestamps[0]).toBeGreaterThanOrEqual(delay);
-        expect(timestamps[2] - timestamps[1]).toBeGreaterThanOrEqual(delay);
+        expect(timestamps[1] - timestamps[0]).toBe(delay);
+        expect(timestamps[2] - timestamps[1]).toBe(delay);
     });
 });

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -147,8 +147,8 @@ const test = suiteBaseTest.extend<Fixtures>({
         await use(blockbookMock);
         blockbookMock.stop();
     },
-    solanaStakingMock: async ({ target }, use) => {
-        const solanaStakingMock = new SolanaStakingMock(target);
+    solanaStakingMock: async ({ page }, use) => {
+        const solanaStakingMock = new SolanaStakingMock(page);
         await solanaStakingMock.start();
         await use(solanaStakingMock);
         await solanaStakingMock.stop();

--- a/suite/e2e/support/mocks/solanaStakingMock.ts
+++ b/suite/e2e/support/mocks/solanaStakingMock.ts
@@ -1,3 +1,5 @@
+import { Page } from '@playwright/test';
+
 import { PASSTHROUGH, SolanaRpcServerMock } from '@trezor/e2e-utils';
 
 import solSimulateStakeTransaction from '../../fixtures/staking/sol-simulate-stake-transaction.json';
@@ -7,12 +9,12 @@ import {
     solStakingAccountDeactivating,
     solStakingAccountFirst,
 } from '../../fixtures/staking/sol-staking-accounts';
-import { isDesktopProject, step } from '../common';
-import { PlaywrightTarget } from '../testExtends/suiteTestOptions';
+import { step } from '../common';
 
 const UPSTREAM_URL = 'https://sol.trezor.io/';
 const ACCOUNT_ADDRESS = '8NapsSamBA2jd8VR8SZw4aXSvSAHiskUZXaiYW1HxTGe';
 const STAKE_PROGRAM_ADDRESS = 'Stake11111111111111111111111111111111111111';
+const SYSTEM_PROGRAM_ADDRESS = '11111111111111111111111111111111';
 const TRANSACTION_SIGNATURE =
     '41ZJr1SqnXVXym6EKrvfELQWh4pPdPeUSrj1GvcPNq9eL7Dh7QyCQXS65yahU6QtoBBNnfEJNGQ7poWRe4Gbk2Zd';
 
@@ -41,12 +43,13 @@ export class SolanaStakingMock {
     private stakeAccounts: SolanaStakingAccount[] = [];
     private simulatedTransaction: unknown = solSimulateStakeTransaction;
     private transactionConfirmed = false;
+    private revision = 0;
 
     readonly stakeFeeFormatted = '0.002298742 SOL';
     readonly unstakeFeeFormatted = '0.000015862 SOL';
     readonly claimFeeFormatted = '0.000008605 SOL';
 
-    constructor(private target: PlaywrightTarget) {}
+    constructor(private readonly page: Page) {}
 
     get url(): string {
         return this.server.url;
@@ -66,29 +69,51 @@ export class SolanaStakingMock {
     @step()
     setBalance(address: string, lamports: number) {
         this.balances.set(address, lamports);
+        this.revision += 1;
     }
 
     @step()
     setStakeAccounts(accounts: SolanaStakingAccount[]) {
         this.stakeAccounts = accounts;
+        this.revision += 1;
     }
 
     @step()
-    setEpoch(epoch: number) {
-        this.applyEpoch(epoch);
+    async setEpoch(epoch: number) {
+        await this.applyEpoch(epoch);
     }
 
     @step()
-    advanceEpoch() {
-        this.applyEpoch(this.epoch + 1);
+    async advanceEpoch() {
+        await this.applyEpoch(this.epoch + 1);
     }
 
-    private applyEpoch(epoch: number) {
+    private async applyEpoch(epoch: number) {
         this.epoch = epoch;
-        // Terminating all connections forces a restart of a worker with clean cache (which includes epoch)
-        if (isDesktopProject(this.target)) {
-            this.server.dropConnections();
-        }
+        this.revision += 1;
+        await this.rebuildBackend();
+    }
+
+    /**
+     * The worker caches the current epoch for an hour, and on desktop it runs in the Electron main
+     * process, out of reach of the test's fake clock. Re-applying the backend setting makes Suite
+     * rebuild the backend, which disposes the worker together with its cache and, on connect,
+     * resyncs the account.
+     */
+    private async rebuildBackend() {
+        await this.page.evaluate(
+            payload => {
+                // Tests set the mocked chain up before the app connects a backend; then there is
+                // nothing to rebuild yet.
+                if (!window.store?.getState().wallet.blockchain.sol?.connected) return;
+
+                window.store.dispatch({
+                    type: '@common/wallet-core/blockchain/setBackend',
+                    payload,
+                });
+            },
+            { symbol: 'sol', type: 'solana', urls: [this.url] },
+        );
     }
 
     // Makes the broadcasted transaction discoverable, simulating its on-chain confirmation. Kept off
@@ -96,6 +121,7 @@ export class SolanaStakingMock {
     @step()
     confirmTransaction() {
         this.transactionConfirmed = true;
+        this.revision += 1;
     }
 
     @step()
@@ -104,15 +130,15 @@ export class SolanaStakingMock {
     }
 
     @step()
-    setupStakedAccount() {
+    async setupStakedAccount() {
         this.setStakeAccounts([solStakingAccountFirst.payload]);
-        this.setEpoch(solStakingAccountFirst.activationEpoch + 1);
+        await this.setEpoch(solStakingAccountFirst.activationEpoch + 1);
     }
 
     @step()
-    setupUnstakingAccount() {
+    async setupUnstakingAccount() {
         this.setStakeAccounts([solStakingAccountDeactivating.payload]);
-        this.setEpoch(solStakingAccountDeactivating.deactivationEpoch);
+        await this.setEpoch(solStakingAccountDeactivating.deactivationEpoch);
     }
 
     private registerHandlers() {
@@ -125,6 +151,25 @@ export class SolanaStakingMock {
         this.server.setHandler('getProgramAccounts', ([programAddress]) =>
             programAddress === STAKE_PROGRAM_ADDRESS ? this.stakeAccounts : PASSTHROUGH,
         );
+        // The worker fingerprints addresses through getMultipleAccounts to decide whose signatures
+        // it may serve from its cache instead of refetching. Only the lamports and the first data
+        // chunk make up that fingerprint, so encoding the revision into the data is what makes every
+        // change to the mocked chain state invalidate the cache.
+        this.server.setHandler('getMultipleAccounts', ([addresses]) => ({
+            context: { slot: 0 },
+            value: (addresses as string[]).map(address => {
+                const data = Buffer.from(`revision:${this.revision}`);
+
+                return {
+                    data: [data.toString('base64'), 'base64'],
+                    executable: false,
+                    lamports: this.balances.get(address) ?? 0,
+                    owner: SYSTEM_PROGRAM_ADDRESS,
+                    rentEpoch: 0,
+                    space: data.byteLength,
+                };
+            }),
+        }));
         this.server.setHandler('simulateTransaction', () => ({ value: this.simulatedTransaction }));
         this.server.setHandler('sendTransaction', () => TRANSACTION_SIGNATURE);
         this.server.setHandler('getSignatureStatuses', () => ({

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -131,7 +131,7 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Wait an epoch and amount moved from pending to staked', async () => {
-                solanaStakingMock.advanceEpoch();
+                await solanaStakingMock.advanceEpoch();
                 await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                 await stakingSection.expectStakingAmounts({
                     expected: {

--- a/suite/e2e/tests/staking/sol/rewards.test.ts
+++ b/suite/e2e/tests/staking/sol/rewards.test.ts
@@ -35,7 +35,7 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
             solStakingAccountSecond.payload,
             solStakingAccountDeactivating.payload,
         ]);
-        solanaStakingMock.setEpoch(solStakingAccountDeactivating.deactivationEpoch);
+        await solanaStakingMock.setEpoch(solStakingAccountDeactivating.deactivationEpoch);
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({
             enableNetworks: [

--- a/suite/e2e/tests/staking/sol/stake-more.test.ts
+++ b/suite/e2e/tests/staking/sol/stake-more.test.ts
@@ -22,8 +22,8 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage, solanaStakingMock }) => {
-        solanaStakingMock.setupStakedAccount();
-        solanaStakingMock.setEpoch(solStakingAccountSecond.activationEpoch);
+        await solanaStakingMock.setupStakedAccount();
+        await solanaStakingMock.setEpoch(solStakingAccountSecond.activationEpoch);
         solanaStakingMock.setSimulatedTransaction(solSimulateStakeMoreTransaction);
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({
@@ -145,7 +145,7 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Wait an epoch and amount moved from pending to staked', async () => {
-                solanaStakingMock.advanceEpoch();
+                await solanaStakingMock.advanceEpoch();
                 await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                 await stakingSection.expectStakingAmounts({
                     expected: {

--- a/suite/e2e/tests/staking/sol/unstake.test.ts
+++ b/suite/e2e/tests/staking/sol/unstake.test.ts
@@ -24,7 +24,7 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
     });
 
     test.beforeEach(async ({ onboardingPage, settingsPage, solanaStakingMock }) => {
-        solanaStakingMock.setupStakedAccount();
+        await solanaStakingMock.setupStakedAccount();
         solanaStakingMock.setSimulatedTransaction(solSimulateUnstakeTransaction);
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({
@@ -119,7 +119,7 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                     account: 'Solana #1',
                     amount: stakedAmountFormatted,
                 });
-                solanaStakingMock.setupUnstakingAccount();
+                await solanaStakingMock.setupUnstakingAccount();
                 await stakingSection.expectStakingAmounts({
                     expected: {
                         pending: 'hidden',
@@ -136,7 +136,7 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
             solanaStakingMock.setSimulatedTransaction(solSimulateClaimTransaction);
 
             await test.step('Wait few epochs for claim to be available', async () => {
-                solanaStakingMock.advanceEpoch();
+                await solanaStakingMock.advanceEpoch();
                 await stakingSection.expectStakingAmounts({
                     expected: {
                         pending: 'hidden',
@@ -210,7 +210,7 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Verify dashboard is back to initial state', async () => {
-                solanaStakingMock.advanceEpoch();
+                await solanaStakingMock.advanceEpoch();
                 await expect(async () => {
                     await page.clock.fastForward(stakingSection.solanaEpochCachePeriod);
                     await expect(stakingSection.stakingEmptyCard).toBeVisible();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A couple of attempts to fix issue with sockets connection recovery on Solana that is happening for large accounts and after some network timeout/device sleep. 

In addition to actual fix also includes optimization for data fetching to reduce amount of queries

## Notes for QA

Needs to be tested under heavy stress on account with many tokens on Solana.

Check out the vids. That's the best I could do. Open 7+ tabs and start refreshing them to produce increased usage in parallel sessions 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31924

## Screenshots:

## Bug fix
### Before: 
https://github.com/user-attachments/assets/51c0f158-8f8d-400d-80e0-80bbb9cd29d0

### After:
https://github.com/user-attachments/assets/b680af5b-9e21-4d44-bf60-05b9201d65ce


## Performance

### Before
https://github.com/user-attachments/assets/ccb77f2f-5089-41cb-9ad6-18a7fbef4451


### After:
https://github.com/user-attachments/assets/c75fc565-6a76-4bb8-946f-2dce35e1e2f0



<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/solana-spam-network/web/](https://dev.suite.sldev.cz/suite-web/feat/solana-spam-network/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The PR changes Solana blockchain-link worker behavior (subscriptions, change detection, connection handling) and Connect backend lifecycle code (BackendManager, BlockchainLink, fiat unsubscribe). The highest regression risk is in Solana network flows and backend configuration/discovery. A targeted set of Solana staking, send, swap, and custom-backend/discovery tests provides strong coverage without running the broad global BackendManager consumer suite.

<details><summary><b>Changed files (8)</b></summary>

- `packages/blockchain-link/src/workers/solana/changeDetection.test.ts`
- `packages/blockchain-link/src/workers/solana/connectionLoss.test.ts`
- `packages/blockchain-link/src/workers/solana/index.ts`
- `packages/blockchain-link/src/workers/solana/subscriptions.test.ts`
- `packages/connect/src/api/blockchainUnsubscribeFiatRates.ts`
- `packages/connect/src/backend/BackendManager.test.ts`
- `packages/connect/src/backend/BackendManager.ts`
- `packages/connect/src/backend/BlockchainLink.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom Blockbook backends, enables networks, and verifies discovery/error behavior, directly exercising the BackendManager and BlockchainLink backend lifecycle code that was changed.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — It runs the full Solana staking flow against the mocked Solana backend, relying on the Solana blockchain-link worker for account state, transaction submission, and epoch transitions that the Solana worker changes affect.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — The test performs a live SOL-to-token swap and verifies Solana send amounts/fees on the device, so it directly depends on the Solana worker for balance, fee, and broadcast behavior.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — A cross-chain SOL-to-BTC swap that exercises Solana account balance, fee calculation, address display, and transaction signing through the changed Solana worker path.
- `suite/e2e/tests/wallet/send-sol.test.ts` — It uses the Send Max feature for SOL and checks balance, fee, reserve, and device confirmation, directly hitting the Solana worker for fee estimation and account state.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — Validates Solana staking reward updates after cache expiration and tab switching, which shares the Solana subscription and account-state infrastructure with the changed worker.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Unstaking and claiming SOL uses the same mocked Solana backend and worker paths as the initial-stake flow, so it is a good secondary check for worker regressions.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Buying a Solana SPL token requires enabling SOL and loading the Solana account/token state, which is handled by the Solana backend worker changed in this PR.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Sells native SOL through the trading flow and depends on Solana balance and fee data from the worker, making it a relevant secondary Solana flow test.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates multiple coins and verifies discovery completes, which exercises BackendManager/BlockchainLink orchestration across networks after backend lifecycle changes.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/blockchain-link/src/workers/solana/changeDetection.test.ts`
- `packages/blockchain-link/src/workers/solana/connectionLoss.test.ts`
- `packages/blockchain-link/src/workers/solana/subscriptions.test.ts`
- `packages/connect/src/backend/BackendManager.test.ts`

_Updated: 2026-08-28T06:58:16.723Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/solana-spam-network&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/solana-spam-network&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/solana-spam-network&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T12:58:51.822Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T12:59:47.677Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->