### PR TITLE
chore(suite-native): fix e2e test by using AnimatedBox

### DIFF
--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import { View } from 'react-native';
-import Animated, { FadeIn } from 'react-native-reanimated';
+import { FadeIn } from 'react-native-reanimated';
 
 import { useFocusEffect } from '@react-navigation/native';
 
@@ -16,7 +16,14 @@ import { getNetworkType } from '@suite-common/wallet-config';
 import { isAddressBasedNetwork } from '@suite-common/wallet-utils';
 import { SelectableNetworkItem } from '@suite-native/accounts';
 import { type Alert, useAlert } from '@suite-native/alerts';
-import { Button, Card, TextDivider, VStack, useBottomSheetModal } from '@suite-native/atoms';
+import {
+    AnimatedBox,
+    Button,
+    Card,
+    TextDivider,
+    VStack,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
 import { isDevelopOrDebugEnv } from '@suite-native/config';
 import { Form, TextInputField, useForm } from '@suite-native/forms';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -202,14 +209,14 @@ export const XpubScanScreen = ({
                             multiline
                         />
                         {isXpubFormFilled && (
-                            <Animated.View entering={FadeIn.duration(FORM_BUTTON_FADE_IN_DURATION)}>
+                            <AnimatedBox entering={FadeIn.duration(FORM_BUTTON_FADE_IN_DURATION)}>
                                 <Button
                                     testID="@accounts-import/sync-coins/xpub-submit"
                                     onPress={onXpubFormSubmit}
                                 >
                                     <Translation id="generic.buttons.confirm" />
                                 </Button>
-                            </Animated.View>
+                            </AnimatedBox>
                         )}
                     </VStack>
                 </Form>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

AnimatedBox component has variant for e2e tests without animation.



On iOS, only Detox synchronization with the main run loop is disabled in. Reanimated FadeIn therefore starts normally, but Detox doesn’t wait for it — and in this case, the wrapper gets stuck at alpha=0.



## Notes for QA

Check Account import in Portfolio tracker on both iOS and Android. 

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Screenshots:

"See" the missing (invisible) confirm button:
<img width="300" alt="testFnFailure" src="https://github.com/user-attachments/assets/45fd9248-6a35-499a-b116-e582f23afff5" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/fix-import-altcoin-account-e2e&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->