### PR TITLE
fix(suite-native): patch Solana RPC abort handling

### DIFF
--- a/.yarn/patches/@solana-rpc-npm-6.9.0-ba7976484d.patch
+++ b/.yarn/patches/@solana-rpc-npm-6.9.0-ba7976484d.patch
@@ -1,0 +1,132 @@
+diff --git a/dist/index.browser.cjs b/dist/index.browser.cjs
+index a996c60f9a3ff4f1bb352ea4d9343e458c127ac5..5e98e9aea5fc4cc38151efc39c97dbc4f8b05672 100644
+--- a/dist/index.browser.cjs
++++ b/dist/index.browser.cjs
+@@ -101,7 +101,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+     if (signal) {
+       const responsePromise = coalescedRequest.responsePromise;
+       return await new Promise((resolve, reject) => {
+-        const handleAbort = (e) => {
++        const handleAbort = () => {
+           signal.removeEventListener("abort", handleAbort);
+           coalescedRequest.numConsumers -= 1;
+           queueMicrotask(() => {
+@@ -110,7 +110,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+               abortController.abort(EXPLICIT_ABORT_TOKEN ||= createExplicitAbortToken());
+             }
+           });
+-          reject(e.target.reason);
++          reject(signal.reason);
+         };
+         signal.addEventListener("abort", handleAbort);
+         responsePromise.then(resolve).catch(reject).finally(() => {
+diff --git a/dist/index.browser.mjs b/dist/index.browser.mjs
+index 30c318ed9ac07f1488d36a264f6f0d60e4b18243..69903ee174a8acabfadaac13350e411ba8595f50 100644
+--- a/dist/index.browser.mjs
++++ b/dist/index.browser.mjs
+@@ -97,7 +97,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+     if (signal) {
+       const responsePromise = coalescedRequest.responsePromise;
+       return await new Promise((resolve, reject) => {
+-        const handleAbort = (e) => {
++        const handleAbort = () => {
+           signal.removeEventListener("abort", handleAbort);
+           coalescedRequest.numConsumers -= 1;
+           queueMicrotask(() => {
+@@ -106,7 +106,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+               abortController.abort(EXPLICIT_ABORT_TOKEN ||= createExplicitAbortToken());
+             }
+           });
+-          reject(e.target.reason);
++          reject(signal.reason);
+         };
+         signal.addEventListener("abort", handleAbort);
+         responsePromise.then(resolve).catch(reject).finally(() => {
+diff --git a/dist/index.native.mjs b/dist/index.native.mjs
+index 69900bba74cc8c2b7c34628fe29e63a9d4a24d60..b887f51283c41901b90f6316c0ac60cf5b0772ce 100644
+--- a/dist/index.native.mjs
++++ b/dist/index.native.mjs
+@@ -97,7 +97,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+     if (signal) {
+       const responsePromise = coalescedRequest.responsePromise;
+       return await new Promise((resolve, reject) => {
+-        const handleAbort = (e) => {
++        const handleAbort = () => {
+           signal.removeEventListener("abort", handleAbort);
+           coalescedRequest.numConsumers -= 1;
+           queueMicrotask(() => {
+@@ -106,7 +106,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+               abortController.abort(EXPLICIT_ABORT_TOKEN ||= createExplicitAbortToken());
+             }
+           });
+-          reject(e.target.reason);
++          reject(signal.reason);
+         };
+         signal.addEventListener("abort", handleAbort);
+         responsePromise.then(resolve).catch(reject).finally(() => {
+diff --git a/dist/index.node.cjs b/dist/index.node.cjs
+index 747e2dfcd3123458b48c16bc7d575e1813a5677c..13d6c2fbd47c29e74da084df8be8a4d55a9bf4bb 100644
+--- a/dist/index.node.cjs
++++ b/dist/index.node.cjs
+@@ -104,7 +104,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+     if (signal) {
+       const responsePromise = coalescedRequest.responsePromise;
+       return await new Promise((resolve, reject) => {
+-        const handleAbort = (e2) => {
++        const handleAbort = () => {
+           signal.removeEventListener("abort", handleAbort);
+           coalescedRequest.numConsumers -= 1;
+           queueMicrotask(() => {
+@@ -113,7 +113,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+               abortController.abort(EXPLICIT_ABORT_TOKEN ||= createExplicitAbortToken());
+             }
+           });
+-          reject(e2.target.reason);
++          reject(signal.reason);
+         };
+         signal.addEventListener("abort", handleAbort);
+         responsePromise.then(resolve).catch(reject).finally(() => {
+diff --git a/dist/index.node.mjs b/dist/index.node.mjs
+index 269c0b64413153ec600f49224491febddfc70411..006c4ef1148974cb19f8829bf1fd71e89954f03a 100644
+--- a/dist/index.node.mjs
++++ b/dist/index.node.mjs
+@@ -100,7 +100,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+     if (signal) {
+       const responsePromise = coalescedRequest.responsePromise;
+       return await new Promise((resolve, reject) => {
+-        const handleAbort = (e2) => {
++        const handleAbort = () => {
+           signal.removeEventListener("abort", handleAbort);
+           coalescedRequest.numConsumers -= 1;
+           queueMicrotask(() => {
+@@ -109,7 +109,7 @@ function getRpcTransportWithRequestCoalescing(transport, getDeduplicationKey) {
+               abortController.abort(EXPLICIT_ABORT_TOKEN ||= createExplicitAbortToken());
+             }
+           });
+-          reject(e2.target.reason);
++          reject(signal.reason);
+         };
+         signal.addEventListener("abort", handleAbort);
+         responsePromise.then(resolve).catch(reject).finally(() => {
+diff --git a/src/rpc-request-coalescer.ts b/src/rpc-request-coalescer.ts
+index 9d83032ea47141be79e3cb3d424cb4657a2904c6..67e7a481ba41534d4782de72b48c69f3bc2a47f0 100644
+--- a/src/rpc-request-coalescer.ts
++++ b/src/rpc-request-coalescer.ts
+@@ -75,7 +75,7 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
+         if (signal) {
+             const responsePromise = coalescedRequest.responsePromise as Promise<RpcResponse<TResponse>>;
+             return await new Promise<RpcResponse<TResponse>>((resolve, reject) => {
+-                const handleAbort = (e: AbortSignalEventMap['abort']) => {
++                const handleAbort = () => {
+                     signal.removeEventListener('abort', handleAbort);
+                     coalescedRequest.numConsumers -= 1;
+                     queueMicrotask(() => {
+@@ -85,7 +85,7 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
+                         }
+                     });
+                     // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+-                    reject((e.target as AbortSignal).reason);
++                    reject(signal.reason);
+                 };
+                 signal.addEventListener('abort', handleAbort);
+                 responsePromise

--- a/.yarn/patches/README.md
+++ b/.yarn/patches/README.md
@@ -18,6 +18,14 @@ Either revert the original patch commit, or simply install a newer version `yarn
 
 ---
 
+## @solana/rpc
+
+Reads the abort reason from the registered signal because `abortcontroller-polyfill` dispatches
+abort events with a null target on React Native. Introduced for
+[#30691](https://github.com/trezor/trezor-suite/issues/30691). Upstream fix:
+[anza-xyz/kit#1994](https://github.com/anza-xyz/kit/pull/1994). Remove after upgrading
+`@solana/rpc` to a release containing the upstream fix.
+
 ## expo-updates
 
 Prevents the Expo dev client from hanging when Detox starts an Android test. Introduced in

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
         "@types/react": "19.2.14",
         "react-dom": "19.2.3",
         "expo-modules-core": "~57.0.6",
-        "test-renderer": "1.2.0"
+        "test-renderer": "1.2.0",
+        "@solana/rpc@npm:6.9.0": "patch:@solana/rpc@npm%3A6.9.0#~/.yarn/patches/@solana-rpc-npm-6.9.0-ba7976484d.patch"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9890,6 +9890,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/rpc@patch:@solana/rpc@npm%3A6.9.0#~/.yarn/patches/@solana-rpc-npm-6.9.0-ba7976484d.patch":
+  version: 6.9.0
+  resolution: "@solana/rpc@patch:@solana/rpc@npm%3A6.9.0#~/.yarn/patches/@solana-rpc-npm-6.9.0-ba7976484d.patch::version=6.9.0&hash=01732c"
+  dependencies:
+    "@solana/errors": "npm:6.9.0"
+    "@solana/fast-stable-stringify": "npm:6.9.0"
+    "@solana/functional": "npm:6.9.0"
+    "@solana/rpc-api": "npm:6.9.0"
+    "@solana/rpc-spec": "npm:6.9.0"
+    "@solana/rpc-spec-types": "npm:6.9.0"
+    "@solana/rpc-transformers": "npm:6.9.0"
+    "@solana/rpc-transport-http": "npm:6.9.0"
+    "@solana/rpc-types": "npm:6.9.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/95643f4f12730e896dbb33543ad2ad47855472458a2bf5bac6e62a8f9b829ad145bf76ddb26615baf4344438f036c510f9e477ba36c55ae4021a63697dbfccfb
+  languageName: node
+  linkType: hard
+
 "@solana/signers@npm:6.9.0":
   version: 6.9.0
   resolution: "@solana/signers@npm:6.9.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the unhandled `Cannot read property 'reason' of null` error after confirming a Solana transaction on mobile.

Patches `@solana/rpc` to read the abort reason directly from the signal. Upstream fix: anza-xyz/kit#1994.

The patch can be removed after Suite upgrades to an `@solana/rpc` release containing that fix.

## Notes for QA

After checking out the branch, run `yarn` from the repository root so the `@solana/rpc` patch is applied.

To reproduce reliably, add this temporary block to `suite-native/app/globalPolyfills.js`, immediately before `installQuickCryptoPolyfills();`:

```js
if (__DEV__) {
      const originalFetch = globalThis.fetch;

      globalThis.fetch = async (input, init) => {
          if (
              typeof init?.body === 'string' &&
              init.body.includes('"method":"getSignatureStatuses"')
          ) {
              await new Promise(resolve => setTimeout(resolve, 20_000));
          }

          return originalFetch(input, init);
      };
}
```

Run the mobile app, send SOL, and wait for confirmation. The send may take about 20 seconds longer, but the transaction should complete without `Cannot read property 'reason' of null` appearing in the console.

Remove the temporary block after testing and verify that a normal SOL transaction still works.

## Related Issue

Resolve #30691

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is package.json, which is a global build manifest. The strongest, concrete link to E2E behavior is the version page's reliance on package.json for the displayed semantic version, so running the version-page test is the minimal and highest-value check. No other tests have specific evidence of impact from this change.

<details><summary><b>Changed files (1)</b></summary>

- `package.json`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/version-page.test.ts` — package.json is explicitly listed as the source for the build-time injected semantic version number that the version page displays, so a change here can break the version page's content or format. This test verifies the displayed version matches the expected pattern and that the commit hash link is rendered correctly.

</details>

_Updated: 2026-08-31T08:05:37.551Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-rpc-abort-handling/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-rpc-abort-handling/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-rpc-abort-handling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-rpc-abort-handling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T08:08:28.469Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T08:08:27.340Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->