### PR TITLE
fix(suite): put the Trezor signature format on the left

### DIFF
--- a/suite/sign-verify/src/SignVerifyForm.tsx
+++ b/suite/sign-verify/src/SignVerifyForm.tsx
@@ -124,11 +124,11 @@ export const SignVerifyForm = ({ account, network, page, onPageChange }: SignVer
                     {isSignPage && signFormatsDiffer && !isCompleted && (
                         <FormatSwitch
                             options={[
+                                { value: false, label: <Translation id="TR_BIP_SIG_FORMAT" /> },
                                 {
                                     value: true,
                                     label: <Translation id="TR_COMPATIBILITY_SIG_FORMAT" />,
                                 },
-                                { value: false, label: <Translation id="TR_BIP_SIG_FORMAT" /> },
                             ]}
                             tooltip={
                                 <Translation


### PR DESCRIPTION
## Description

Follow-up on the merged Sign & verify redesign (#31401). The format switch ended up as **Electrum | Trezor** with Trezor selected; design asked to keep Trezor as the default but return it to the left, where it used to be.

One-line change: the two entries of the `FormatSwitch` options array are swapped, so the order is now **Trezor | Electrum**. `isElectrum` still defaults to `false`, so Trezor stays preselected, and the order now matches the format tooltip, which explains BIP-137 (Trezor) first and Electrum second.

Option testids come from the value (`@sign-verify/format/true` for Electrum), not from the position, so the e2e signing test is unaffected.

## Notes for QA

- Bitcoin account → Sign & verify → Sign: the switch reads **Trezor | Electrum**, with Trezor preselected.
- Signing with each option still produces the format it says (Electrum signatures differ from Trezor/BIP-137 ones); the switch disappears once a signature is generated, as before.
- Cardano's separate public-key format switch is untouched.

## Related Issue

Follow-up on #22459, closed by #31401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)