### PR TITLE
test(suite): fixes dex swap and discovery test

### DIFF
--- a/suite/e2e/support/mocks/trading/tradingMockNew.ts
+++ b/suite/e2e/support/mocks/trading/tradingMockNew.ts
@@ -33,6 +33,7 @@ const TRADE_ENDPOINTS: Record<TradeFlow, TradeEndpoints> = {
 };
 
 const WATCH_POLL_PERIOD = '00:30';
+const TRADE_RESPONSE_TIMEOUT = 90_000;
 const WATCH_POLL_TIMEOUT = 35_000;
 const ADVANCE_ATTEMPTS = 5;
 
@@ -145,7 +146,9 @@ export class TradingMockNew {
     }
 
     async waitForLiveTrade() {
-        const response = await this.page.waitForResponse(this.endpoints.trade);
+        const response = await this.page.waitForResponse(this.endpoints.trade, {
+            timeout: TRADE_RESPONSE_TIMEOUT,
+        });
         const trade = (await response.json()) as ExchangeTrade;
         // A DEX trade sends to the provider's router contract (`dexTx`), so it has no sendAddress.
         const hasDepositAddress = trade.isDex || trade.sendAddress;

--- a/suite/e2e/tests/staking/ada/claim.test.ts
+++ b/suite/e2e/tests/staking/ada/claim.test.ts
@@ -88,9 +88,9 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(stakingAccountItemInLeftSection).toBeVisible();
                 await walletPage.openAccount({ symbol: 'ada', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
-                await expect(walletPage.discoveryWarning).toBeHidden();
                 await expect(stakingSection.claimRewardsButton).toBeEnabled();
                 await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
+                await expect(walletPage.discoveryWarning).toBeHidden();
                 await expect(stakingSection.startStakingButton).toBeHidden();
                 await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
                     startingBalanceFormatted,

--- a/suite/e2e/tests/staking/ada/stake.test.ts
+++ b/suite/e2e/tests/staking/ada/stake.test.ts
@@ -77,13 +77,14 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await page.clock.install();
                 await walletPage.openAccount({ symbol: 'ada', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
+                await expect(stakingSection.startStakingButton).toBeVisible();
+                await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
+                    startingBalanceFormatted,
+                );
                 await expect(walletPage.discoveryWarning).toBeHidden();
                 await expect(stakingSection.claimRewardsButton).toBeHidden();
                 await expect(stakingSection.unstakeToClaimButton).toBeHidden();
                 await expect(stakingAccountItemInLeftSection).toBeHidden();
-                await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
-                    startingBalanceFormatted,
-                );
             });
 
             await test.step('Initiate staking flow', async () => {

--- a/suite/e2e/tests/staking/ada/unstake.test.ts
+++ b/suite/e2e/tests/staking/ada/unstake.test.ts
@@ -84,9 +84,9 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
             await test.step('Verify staked account', async () => {
                 await walletPage.openAccount({ symbol: 'ada', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
-                await expect(walletPage.discoveryWarning).toBeHidden();
                 await expect(stakingSection.claimRewardsButton).toBeDisabled();
                 await expect(stakingSection.unstakeToClaimButton).toBeEnabled();
+                await expect(walletPage.discoveryWarning).toBeHidden();
                 await expect(stakingSection.startStakingButton).toBeHidden();
                 await expect(walletPage.topPanelBalanceWithSymbol).toHaveText(
                     startingBalanceFormatted,

--- a/suite/e2e/tests/staking/eth/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/eth/initial-stake.test.ts
@@ -62,8 +62,8 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await page.clock.install();
                 await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
-                await expect(stakingSection.stakingDashboardCard).toBeHidden();
                 await expect(stakingSection.stakingEmptyCard).toBeVisible();
+                await expect(stakingSection.stakingDashboardCard).toBeHidden();
             });
 
             await test.step('Open and fill staking form', async () => {

--- a/suite/e2e/tests/staking/sol/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/sol/initial-stake.test.ts
@@ -39,6 +39,7 @@ test.describe('sol staking', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await page.clock.install();
                 await walletPage.openAccount({ symbol: 'sol', type: 'normal', atIndex: 0 });
                 await stakingSection.stakingTabButton.click();
+                await expect(stakingSection.startStakingButton).toBeVisible();
                 await expect(stakingSection.stakingDashboardCard).toBeHidden();
                 await expect(stakingSection.stakingEmptyCard).toBeVisible();
                 await expect(stakingSection.stakeMoreButton).toBeHidden();

--- a/suite/e2e/tests/trading/swap-dex-lifi.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi.test.ts
@@ -10,6 +10,7 @@ const sendAmount = '0.03';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
 const accountLabel = 'Ethereum #1';
 const usdcCryptoId = getCryptoId('eth', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+const usdcDecimals = 6;
 const dexProvider = getCompanyNameFromList('lifi', 'swapList');
 
 // A DEX swap broadcasts the swap itself, so there is no CONFIRMING deposit phase.
@@ -97,6 +98,8 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
         let formattedReceiveAmount: string;
         let minimumReceived: BigNumber;
         let formattedMinimumReceived: string;
+        let promptMinimumReceived: string;
+        let displayedMinimumReceived: string;
         let slippagePercent: string;
 
         await test.step('Verify DEX details on the Confirm & send screen', async () => {
@@ -107,6 +110,9 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             const guaranteedShare = new BigNumber(100).minus(swapSlippage!).div(100);
             minimumReceived = new BigNumber(receiveStringAmount).times(guaranteedShare);
             formattedMinimumReceived = `${localizeNumber(minimumReceived.toFixed(4))} USDC`;
+            promptMinimumReceived = `${minimumReceived.toFixed()} USDC`;
+            // The device renders the amount at USDC's own precision, rounded and zero-trimmed.
+            displayedMinimumReceived = `${minimumReceived.decimalPlaces(usdcDecimals).toFixed()} USDC`;
 
             await expect(tradingPage.confirmation.dexExchangeType).toHaveTranslation(
                 'TR_EXCHANGE_DEX',
@@ -175,13 +181,12 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
                 `- ${formattedSendAmount}`,
             );
             await expect(devicePrompt.assetsReceiveCryptoAmount).toHaveText(
-                `+ ${minimumReceived.toFixed()} USDC`,
+                `+ ${promptMinimumReceived}`,
             );
             // The recipient is the user's own receive address, not the LI.FI router (dexTx.to).
             await expect(devicePrompt.assetsReceiveAddress).toHaveText(
                 tradingMockNew.liveTrade.receiveAddress!,
             );
-            const minimumReceivedOnDevice = `${new BigNumber(minimumReceived.toFixed(6)).toFixed()} USDC`;
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: deviceReview.contractTitle },
@@ -189,7 +194,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
                         [deviceReview.sendLabel],
                         device.wrapText(formattedSendAmount, { isAmount: true }),
                         [deviceReview.receiveLabel],
-                        device.wrapText(minimumReceivedOnDevice, { isAmount: true }),
+                        device.wrapText(displayedMinimumReceived, { isAmount: true }),
                     ],
                     actions: { right_button: deviceReview.confirmButton },
                 },
@@ -224,7 +229,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
                 `- ${formattedSendAmount}`,
             );
             await expect(devicePrompt.assetsReceiveCryptoAmount).toHaveText(
-                `+ ${minimumReceived.toFixed()} USDC`,
+                `+ ${promptMinimumReceived}`,
             );
             await expect(devicePrompt.assetsReceiveAddress).toHaveText(
                 tradingMockNew.liveTrade.receiveAddress!,

--- a/suite/e2e/tests/wallet/discovery.test.ts
+++ b/suite/e2e/tests/wallet/discovery.test.ts
@@ -60,6 +60,7 @@ test.describe('Discovery', { tag: ['@T3W1', '@T3T1'] }, () => {
                 timeout: DISCOVERY_LIMIT,
             });
             for (const symbol of coinsToActivate) {
+                await walletPage.balanceOfAccount({ symbol, atIndex: 0 }).scrollIntoViewIfNeeded();
                 await expect
                     .soft(
                         walletPage.balanceOfAccount({ symbol, atIndex: 0 }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes broken tests

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fix-8-27/web/](https://dev.suite.sldev.cz/suite-web/test-fix-8-27/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fix-8-27&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fix-8-27&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T07:33:17.575Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-28T07:32:53.087Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->