### PR TITLE
feat(suite): show a search icon in the trading picker search inputs

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
@@ -10,7 +10,8 @@ import {
     tradingThunks,
     useCountryFilteredData,
 } from '@suite-common/trading';
-import { Column, Flag, Input, Modal, Paragraph, Row } from '@trezor/components';
+import { Column, Flag, Icon, Input, Modal, Paragraph, Row } from '@trezor/components';
+import { MagnifyingGlassIcon } from '@trezor/icons';
 import { CardList } from '@trezor/product-components';
 
 import { useDispatch } from 'src/hooks/suite';
@@ -49,6 +50,14 @@ export const CountrySelectModal = ({ heading, onClose }: CountrySelectModalProps
                 <Input
                     onChange={ev => setFilterValue(ev.target.value)}
                     placeholder={translationString('TR_SEARCH_COUNTRY_PLACEHOLDER')}
+                    leftContent={
+                        <Icon
+                            as={MagnifyingGlassIcon}
+                            intent="neutral"
+                            priority="secondary"
+                            size={16}
+                        />
+                    }
                     onClear={() => setFilterValue('')}
                     showClearButton
                     value={filterValue}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx
@@ -7,7 +7,8 @@ import {
     type TradingCountrySubdivisionOption,
     useCountrySubdivisionFilteredData,
 } from '@suite-common/trading';
-import { CardList, Column, Input, Modal, Paragraph, Text } from '@trezor/components';
+import { CardList, Column, Icon, Input, Modal, Paragraph, Text } from '@trezor/components';
+import { MagnifyingGlassIcon } from '@trezor/icons';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { type TradingTradeBuySellType } from 'src/types/trading/trading';
@@ -47,6 +48,14 @@ export const CountrySubdivisionSelectModal = ({
                     value={filterValue}
                     onChange={event => setFilterValue(event.target.value)}
                     placeholder={translationString('TR_SEARCH_COUNTRY_SUBDIVISION_PLACEHOLDER')}
+                    leftContent={
+                        <Icon
+                            as={MagnifyingGlassIcon}
+                            intent="neutral"
+                            priority="secondary"
+                            size={16}
+                        />
+                    }
                 />
                 {filteredData.length > 0 && (
                     <CardList>

--- a/suite/trading/src/ui/Country/CountrySelectModal.tsx
+++ b/suite/trading/src/ui/Country/CountrySelectModal.tsx
@@ -1,7 +1,8 @@
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { getCountryFlag } from '@suite-common/flags';
 import { type TradingCountryCode, useCountryFilteredData } from '@suite-common/trading';
-import { Column, Flag, Input, Modal, Paragraph, Row } from '@trezor/components';
+import { Column, Flag, Icon, Input, Modal, Paragraph, Row } from '@trezor/components';
+import { MagnifyingGlassIcon } from '@trezor/icons';
 import { CardList } from '@trezor/product-components';
 
 interface CountrySelectModalProps {
@@ -34,6 +35,14 @@ export const CountrySelectModal = ({
                 <Input
                     onChange={ev => setFilterValue(ev.target.value)}
                     placeholder={translationString('TR_SEARCH_COUNTRY_PLACEHOLDER')}
+                    leftContent={
+                        <Icon
+                            as={MagnifyingGlassIcon}
+                            intent="neutral"
+                            priority="secondary"
+                            size={16}
+                        />
+                    }
                     onClear={() => setFilterValue('')}
                     showClearButton
                     value={filterValue}

--- a/suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx
+++ b/suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx
@@ -4,6 +4,7 @@ import {
     CardList,
     Column,
     Flag,
+    Icon,
     IconCircle,
     Input,
     Modal,
@@ -12,7 +13,7 @@ import {
     Row,
     Text,
 } from '@trezor/components';
-import { CoinIcon } from '@trezor/icons';
+import { CoinIcon, MagnifyingGlassIcon } from '@trezor/icons';
 
 import { useFiatCurrencyFilteredData } from './hooks/useFiatCurrencyFilteredData';
 import { type CurrencyPickerOption } from './types/currencyPickerTypes';
@@ -42,6 +43,14 @@ export const CurrencyPickerModal = ({
                 <Input
                     onChange={ev => setFilterValue(ev.target.value)}
                     placeholder={translationString('TR_SEARCH_CURRENCY_PLACEHOLDER')}
+                    leftContent={
+                        <Icon
+                            as={MagnifyingGlassIcon}
+                            intent="neutral"
+                            priority="secondary"
+                            size={16}
+                        />
+                    }
                     onClear={() => setFilterValue('')}
                     showClearButton
                     value={filterValue}


### PR DESCRIPTION
## Description

The currency, country and state pickers opened with a bare search field, while every other search input in the app carries a magnifying glass on the left. Added it with the same markup those use (`NetworkSettingsSearchInput`, `SearchAsset`, `AccountSearchBox`):

```tsx
leftContent={<Icon as={MagnifyingGlassIcon} intent="neutral" priority="secondary" size={16} />}
```

Four files, because country has two modals: the Buy/Sell form has its own, and concierge uses the shared one in `@suite/trading`. Both are covered so the icon does not appear in only one of them.

No new component was introduced — the icon prop is repeated the way the existing search inputs across the app repeat it.

## Notes for QA

Each picker's search field should show the magnifying glass on the left, and typing/clearing must behave exactly as before.

- **Currency** — any account → Buy, Sell **or** Swap → click the currency next to the fiat amount. It is the same picker on the offer/quote step.
- **Country** — Buy or Sell form, second card under the receive address (not in Swap).
- **State** — same card, but it only appears after picking a country that has subdivisions (e.g. United States, Canada).
- **Country in concierge** — the concierge form uses the shared modal, a different file from the Buy/Sell one, so it needs its own look.

Noticed while in there, left alone as out of scope: the state picker's field has no clear (×) button, while currency and country do.

## Related Issue

Resolve #30367

## Screenshots

<img width="520" height="753" alt="Screenshot 2026-08-27 at 2 55 40 PM" src="https://github.com/user-attachments/assets/7cdd2e19-34b7-42b7-9893-7b0259af85aa" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)