### PR TITLE
Fix/solana split instruction tx review modal

### DIFF
--- a/networks/solana/network-solana/src/runtime/staking.ts
+++ b/networks/solana/network-solana/src/runtime/staking.ts
@@ -160,6 +160,7 @@ export const stake = async ({
             feeLamports: feeSummary.feeLamports,
             rentLamports: minimumRent.toString(),
             feeIncludingRentLamports,
+            hasSplitInstruction: false,
         };
 
         return {
@@ -331,6 +332,7 @@ export const unstake = async ({
             feeLamports: feeSummary.feeLamports,
             rentLamports: minimumRent.toString(),
             feeIncludingRentLamports,
+            hasSplitInstruction: accountsToSplit.length > 0,
         };
 
         return { unstakeTx: transactionMessage, unstakeAmount, txMeta };
@@ -395,6 +397,7 @@ export const claim = async ({
             feeLamports: feeSummary.feeLamports,
             rentLamports: '0',
             feeIncludingRentLamports: feeSummary.feeLamports,
+            hasSplitInstruction: false,
         };
 
         return {

--- a/networks/solana/network-solana/src/types/staking.ts
+++ b/networks/solana/network-solana/src/types/staking.ts
@@ -32,6 +32,7 @@ export type SolanaTxMeta = {
     feeLamports: string;
     rentLamports: string;
     feeIncludingRentLamports: string;
+    hasSplitInstruction: boolean;
 };
 
 export type Fee = {

--- a/packages/suite/src/components/suite/DeviceConfirmImage.tsx
+++ b/packages/suite/src/components/suite/DeviceConfirmImage.tsx
@@ -1,4 +1,4 @@
-import { getDeviceInternalModel } from '@suite-common/suite-utils';
+import { getDeviceModelWithFlagshipFallback } from '@suite-common/suite-utils';
 import { type ImageProps } from '@trezor/components';
 import { type Device } from '@trezor/connect';
 import { DeviceWithScene } from '@trezor/product-components';
@@ -16,7 +16,7 @@ export const DeviceConfirmImage = ({
     width,
     ...rest
 }: DeviceConfirmImageProps) => {
-    const deviceModelInternal = getDeviceInternalModel(device);
+    const deviceModelInternal = getDeviceModelWithFlagshipFallback(device);
 
     return (
         <DeviceWithScene

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewFollowDevice.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewFollowDevice.tsx
@@ -1,0 +1,26 @@
+import { Translation } from '@suite/intl';
+import { selectSelectedDevice } from '@suite-common/device';
+import { Column, H2 } from '@trezor/components';
+
+import { DeviceConfirmImage } from 'src/components/suite/DeviceConfirmImage';
+import { useSelector } from 'src/hooks/suite';
+
+interface TransactionReviewFollowDeviceProps {
+    isSigned: boolean;
+}
+
+export const TransactionReviewFollowDevice = ({ isSigned }: TransactionReviewFollowDeviceProps) => {
+    const device = useSelector(selectSelectedDevice);
+
+    return (
+        <Column alignItems="center" gap={16} data-testid="@modal/review/follow-device">
+            <DeviceConfirmImage device={device} />
+
+            {!isSigned && (
+                <H2 align="center" margin={{ left: 16, right: 16, bottom: 16 }}>
+                    <Translation id="TR_CONFIRM_ACTION_ON_YOUR" />
+                </H2>
+            )}
+        </Column>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -24,7 +24,7 @@ import {
     getDecreaseOutputId,
     getStakeType,
     getTxValidityTimeoutInMs,
-    isDeviceReviewOnly,
+    isDeviceReviewOnlyTransaction,
     isEvmApprovalTx,
     isRbfBumpFeeTransaction,
     isRbfCancelTransaction,
@@ -190,7 +190,7 @@ export const TransactionReviewModalBodyInner = ({
         decision?.resolve(false);
     };
 
-    const isDeviceOnlyReview = isDeviceReviewOnly(precomposedTx);
+    const isDeviceOnlyReview = isDeviceReviewOnlyTransaction(precomposedTx);
     const isAwaitingDeviceReview = isDeviceOnlyReview && !serializedTx;
 
     const isCancelRbfAction = isRbfCancelTransaction(precomposedTx);

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -24,6 +24,7 @@ import {
     getDecreaseOutputId,
     getStakeType,
     getTxValidityTimeoutInMs,
+    isDeviceReviewOnly,
     isEvmApprovalTx,
     isRbfBumpFeeTransaction,
     isRbfCancelTransaction,
@@ -189,6 +190,9 @@ export const TransactionReviewModalBodyInner = ({
         decision?.resolve(false);
     };
 
+    const isDeviceOnlyReview = isDeviceReviewOnly(precomposedTx);
+    const isAwaitingDeviceReview = isDeviceOnlyReview && !serializedTx;
+
     const isCancelRbfAction = isRbfCancelTransaction(precomposedTx);
     const isTronStakeFreeze =
         networkType === 'tron' &&
@@ -242,7 +246,9 @@ export const TransactionReviewModalBodyInner = ({
         <ConnectModalBackdrop canSwitchDevice>
             {!isRbfConfirmedError && (
                 <TransactionReviewModalConfirmOnDevice
-                    totalSteps={outputs.length + (showSummary ? 1 : 0)}
+                    totalSteps={
+                        isDeviceOnlyReview ? undefined : outputs.length + (showSummary ? 1 : 0)
+                    }
                     serializedTx={serializedTx}
                     isSending={isSending}
                     reviewStep={reviewStep}
@@ -282,7 +288,7 @@ export const TransactionReviewModalBodyInner = ({
                     )
                 }
                 bottomContent={
-                    areDetailsVisible ? null : (
+                    areDetailsVisible || isAwaitingDeviceReview ? null : (
                         <TransactionReviewModalBottomContent
                             decision={decision}
                             isSending={isSending}
@@ -300,7 +306,7 @@ export const TransactionReviewModalBodyInner = ({
                         />
                     )
                 }
-                width={600}
+                width={isDeviceOnlyReview ? 480 : 600}
             >
                 <TransactionReviewModalContent
                     account={account}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx
@@ -4,9 +4,10 @@ import { Translation } from '@suite/intl';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type SerializedTx } from '@suite-common/wallet-core';
 import { ConfirmOnDevicePill } from '@trezor/product-components';
+import { useMemo } from 'react';
 
 type TransactionReviewModalConfirmOnDeviceProps = {
-    totalSteps: number;
+    totalSteps: number | undefined;
     serializedTx: SerializedTx | undefined;
     isSending: boolean;
     reviewStep: number;
@@ -25,11 +26,17 @@ export const TransactionReviewModalConfirmOnDevice = ({
 
     const offsetReviewStep = reviewStep + 1; // adjust for 0-based index
 
+    const activeStep = useMemo(() => {
+        if (totalSteps === undefined) return undefined;
+
+        return serializedTx ? totalSteps + 1 : Math.min(offsetReviewStep, totalSteps);
+    }, [totalSteps, serializedTx, offsetReviewStep]);
+
     return (
         <ConfirmOnDevicePill
             title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
             steps={totalSteps}
-            activeStep={serializedTx ? totalSteps + 1 : Math.min(offsetReviewStep, totalSteps)}
+            activeStep={activeStep}
             deviceModelInternal={deviceModelInternal}
             deviceUnitColor={device?.features?.unit_color}
             successText={<Translation id="TR_CONFIRMED_TX" />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx
@@ -1,10 +1,10 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Translation } from '@suite/intl';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type SerializedTx } from '@suite-common/wallet-core';
 import { ConfirmOnDevicePill } from '@trezor/product-components';
-import { useMemo } from 'react';
 
 type TransactionReviewModalConfirmOnDeviceProps = {
     totalSteps: number | undefined;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Translation } from '@suite/intl';
@@ -6,13 +5,30 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { type SerializedTx } from '@suite-common/wallet-core';
 import { ConfirmOnDevicePill } from '@trezor/product-components';
 
-type TransactionReviewModalConfirmOnDeviceProps = {
+interface GetActiveStepProps {
+    totalSteps: number | undefined;
+    serializedTx: SerializedTx | undefined;
+    reviewStep: number;
+}
+
+const getActiveStep = ({ totalSteps, serializedTx, reviewStep }: GetActiveStepProps) => {
+    if (totalSteps === undefined) return undefined;
+
+    if (serializedTx) return totalSteps + 1;
+
+    // adjust for 0-based index
+    const offsetReviewStep = reviewStep + 1;
+
+    return Math.min(offsetReviewStep, totalSteps);
+};
+
+interface TransactionReviewModalConfirmOnDeviceProps {
     totalSteps: number | undefined;
     serializedTx: SerializedTx | undefined;
     isSending: boolean;
     reviewStep: number;
     onCancel: () => void;
-};
+}
 
 export const TransactionReviewModalConfirmOnDevice = ({
     totalSteps,
@@ -24,19 +40,11 @@ export const TransactionReviewModalConfirmOnDevice = ({
     const device = useSelector(selectSelectedDevice);
     const deviceModelInternal = device?.features?.internal_model;
 
-    const offsetReviewStep = reviewStep + 1; // adjust for 0-based index
-
-    const activeStep = useMemo(() => {
-        if (totalSteps === undefined) return undefined;
-
-        return serializedTx ? totalSteps + 1 : Math.min(offsetReviewStep, totalSteps);
-    }, [totalSteps, serializedTx, offsetReviewStep]);
-
     return (
         <ConfirmOnDevicePill
             title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
             steps={totalSteps}
-            activeStep={activeStep}
+            activeStep={getActiveStep({ totalSteps, serializedTx, reviewStep })}
             deviceModelInternal={deviceModelInternal}
             deviceUnitColor={device?.features?.unit_color}
             successText={<Translation id="TR_CONFIRMED_TX" />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -17,7 +17,7 @@ import {
     getDecreaseOutputId,
     getStakeType,
     getTxValidityTimeoutInMs,
-    isDeviceReviewOnly,
+    isDeviceReviewOnlyTransaction,
     isRbfBumpFeeTransaction,
     isRbfTransaction,
 } from '@suite-common/wallet-utils';
@@ -108,7 +108,7 @@ export const TransactionReviewModalContent = ({
         return <TransactionReviewDetails tx={precomposedTx} txHash={serializedTx?.tx} />;
     }
 
-    if (isDeviceReviewOnly(precomposedTx)) {
+    if (isDeviceReviewOnlyTransaction(precomposedTx)) {
         return <TransactionReviewFollowDevice isSigned={!!serializedTx} />;
     }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -17,6 +17,7 @@ import {
     getDecreaseOutputId,
     getStakeType,
     getTxValidityTimeoutInMs,
+    isDeviceReviewOnly,
     isRbfBumpFeeTransaction,
     isRbfTransaction,
 } from '@suite-common/wallet-utils';
@@ -27,6 +28,7 @@ import { useSelector } from 'src/hooks/suite';
 import { ReplaceByFeeFailedOriginalTxConfirmed } from '../../UserContextModal/TxDetailModal/ReplaceByFeeFailedOriginalTxConfirmed';
 import { TransactionReviewDetails } from '../TransactionReviewDetails';
 import { TransactionReviewOutputList } from './TransactionReviewOutputList';
+import { TransactionReviewFollowDevice } from '../TransactionReviewFollowDevice';
 
 type TransactionReviewModalContentProps = {
     account: Account;
@@ -104,6 +106,10 @@ export const TransactionReviewModalContent = ({
 
     if (areDetailsVisible) {
         return <TransactionReviewDetails tx={precomposedTx} txHash={serializedTx?.tx} />;
+    }
+
+    if (isDeviceReviewOnly(precomposedTx)) {
+        return <TransactionReviewFollowDevice isSigned={!!serializedTx} />;
     }
 
     if (isRbfConfirmedError && isRbfTransaction(precomposedTx)) {

--- a/suite-common/device/src/deviceSelectors.test.ts
+++ b/suite-common/device/src/deviceSelectors.test.ts
@@ -1,9 +1,13 @@
+import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { portfolioTrackerDevice } from './deviceConstants';
 import { deviceReducerInitialState } from './deviceReducer';
-import { selectIsDeviceAuthenticityCheckSupported } from './deviceSelectors';
+import {
+    selectDeviceModelWithFlagshipFallback,
+    selectIsDeviceAuthenticityCheckSupported,
+} from './deviceSelectors';
 
 describe(selectIsDeviceAuthenticityCheckSupported.name, () => {
     it('returns true for supported Trezor Safe devices', () => {
@@ -37,5 +41,43 @@ describe(selectIsDeviceAuthenticityCheckSupported.name, () => {
         };
 
         expect(selectIsDeviceAuthenticityCheckSupported(state)).toBe(true);
+    });
+});
+
+describe(selectDeviceModelWithFlagshipFallback.name, () => {
+    it('returns the model of the selected device', () => {
+        const state = {
+            device: {
+                ...deviceReducerInitialState,
+                selectedDevice: mockSuiteDevice({}, { internal_model: DeviceModelInternal.T3T1 }),
+            },
+        };
+
+        expect(selectDeviceModelWithFlagshipFallback(state)).toBe(DeviceModelInternal.T3T1);
+    });
+
+    it('returns the flagship model when the model of the selected device cannot be read', () => {
+        const state = {
+            device: {
+                ...deviceReducerInitialState,
+                selectedDevice: mockSuiteDevice(
+                    {},
+                    { internal_model: DeviceModelInternal.UNKNOWN },
+                ),
+            },
+        };
+
+        expect(selectDeviceModelWithFlagshipFallback(state)).toBe(DEFAULT_FLAGSHIP_MODEL);
+    });
+
+    it('returns the flagship model when no device is selected', () => {
+        const state = {
+            device: {
+                ...deviceReducerInitialState,
+                selectedDevice: undefined,
+            },
+        };
+
+        expect(selectDeviceModelWithFlagshipFallback(state)).toBe(DEFAULT_FLAGSHIP_MODEL);
     });
 });

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -13,6 +13,7 @@ import {
     getDeviceInstances,
     getDeviceInstancesGroupedByDeviceId,
     getDeviceInternalModel,
+    getDeviceModelWithFlagshipFallback,
     getFwUpdateVersion,
     getIsDeviceConnectedAndAuthorized,
     getIsDeviceConnectedViaBluetooth,
@@ -416,6 +417,10 @@ export const selectDeviceModelById = createMemoizedSelector(
 export const selectDeviceModel = createMemoizedSelector([selectSelectedDevice], selectedDevice =>
     selectedDevice ? getDeviceInternalModel(selectedDevice) : null,
 );
+
+export const selectDeviceModelWithFlagshipFallback = (
+    state: DeviceRootState,
+): DeviceModelInternal => getDeviceModelWithFlagshipFallback(selectSelectedDevice(state));
 
 export const selectIsDeviceAuthenticityCheckSupported = createMemoizedSelector(
     [selectIsPortfolioTrackerDevice, selectDeviceModel],

--- a/suite-common/staking/src/actions/solanaStakeFormActions.ts
+++ b/suite-common/staking/src/actions/solanaStakeFormActions.ts
@@ -72,34 +72,47 @@ const calculateSolanaStakeTransaction = (
     );
 };
 
+// A split instruction cannot be recreated in Suite, such a transaction is reviewed on the device only.
+const applyDeviceReviewOnly = (
+    composed: PrecomposedLevels,
+    isDeviceReviewOnly: boolean,
+): PrecomposedLevels =>
+    Object.fromEntries(
+        Object.entries(composed).map(([key, tx]) =>
+            tx.type === 'error' ? [key, tx] : [key, { ...tx, isDeviceReviewOnly }],
+        ),
+    );
+
 // Merges solanaTxMeta (rent, fee) into each fee level for device review amounts.
 const applySolanaTxMeta = (
     composed: PrecomposedLevels,
     solanaTxMeta: SolanaTxMeta,
 ): PrecomposedLevels =>
     Object.fromEntries(
-        Object.entries(composed).map(([key, tx]) => {
-            if (tx.type === 'error') return [key, tx];
+        Object.entries(applyDeviceReviewOnly(composed, solanaTxMeta.hasSplitInstruction)).map(
+            ([key, tx]) => {
+                if (tx.type === 'error') return [key, tx];
 
-            const nextTx = { ...tx, solanaTxMeta };
+                const nextTx = { ...tx, solanaTxMeta };
 
-            if (tx.type === 'final') {
-                const totalSpent = new BigNumber(solanaTxMeta.deviceAmountLamports)
-                    .plus(solanaTxMeta.feeIncludingRentLamports)
-                    .toString();
+                if (tx.type === 'final') {
+                    const totalSpent = new BigNumber(solanaTxMeta.deviceAmountLamports)
+                        .plus(solanaTxMeta.feeIncludingRentLamports)
+                        .toString();
 
-                return [
-                    key,
-                    {
-                        ...nextTx,
-                        fee: solanaTxMeta.feeIncludingRentLamports,
-                        totalSpent,
-                    },
-                ];
-            }
+                    return [
+                        key,
+                        {
+                            ...nextTx,
+                            fee: solanaTxMeta.feeIncludingRentLamports,
+                            totalSpent,
+                        },
+                    ];
+                }
 
-            return [key, nextTx];
-        }),
+                return [key, nextTx];
+            },
+        ),
     );
 
 // Turns a prepared staking transaction into a message and asks the backend to estimate its fee.
@@ -244,5 +257,9 @@ export const composeSolanaStakingTransaction = async ({
         }
     }
 
-    return composed;
+    // Fee estimation or the fee-aware preparation failed, keep the review-only flag of the first tx.
+    return applyDeviceReviewOnly(
+        composed,
+        !!txData?.success && txData.solanaTxMeta.hasSplitInstruction,
+    );
 };

--- a/suite-common/suite-utils/package.json
+++ b/suite-common/suite-utils/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@suite-common/suite-config": "workspace:*",
+        "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-common/suite-utils/src/device.test.ts
+++ b/suite-common/suite-utils/src/device.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { type AcquiredDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
@@ -9,6 +10,7 @@ import {
     getCheckBackupUrl,
     getDeviceInstances,
     getDeviceInstancesGroupedByDeviceId,
+    getDeviceModelWithFlagshipFallback,
     getFirmwareDowngradeUrl,
     getFirstDeviceInstance,
     getIsDeviceConnectedViaBluetooth,
@@ -245,5 +247,23 @@ describe(getPhysicalDeviceCount.name, () => {
             mockSuiteDevice(undefined, { device_id: null }),
         ];
         expect(getPhysicalDeviceCount(devices)).toBe(2);
+    });
+});
+
+describe(getDeviceModelWithFlagshipFallback.name, () => {
+    it('returns the model reported by the device', () => {
+        const device = mockSuiteDevice({}, { internal_model: DeviceModelInternal.T3T1 });
+
+        expect(getDeviceModelWithFlagshipFallback(device)).toBe(DeviceModelInternal.T3T1);
+    });
+
+    it('returns the flagship model when the internal_model cannot be read', () => {
+        const device = mockSuiteDevice({}, { internal_model: DeviceModelInternal.UNKNOWN });
+
+        expect(getDeviceModelWithFlagshipFallback(device)).toBe(DEFAULT_FLAGSHIP_MODEL);
+    });
+
+    it('returns the flagship model when there is no device', () => {
+        expect(getDeviceModelWithFlagshipFallback(undefined)).toBe(DEFAULT_FLAGSHIP_MODEL);
     });
 });

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { type AcquiredDevice, type TrezorDevice } from '@suite-common/suite-types';
 import {
     DEVICE,
@@ -508,6 +509,14 @@ export const getDeviceInternalModel = (
     device?.features?.internal_model ??
     (device?.thp?.properties?.internal_model as DeviceModelInternal) ??
     DeviceModelInternal.UNKNOWN;
+
+export const getDeviceModelWithFlagshipFallback = (
+    device?: Pick<Device, 'features' | 'thp'>,
+): DeviceModelInternal => {
+    const deviceModel = getDeviceInternalModel(device);
+
+    return deviceModel === DeviceModelInternal.UNKNOWN ? DEFAULT_FLAGSHIP_MODEL : deviceModel;
+};
 
 export const getIsThpDevice = <T extends Device | TrezorDevice>(
     device: T,

--- a/suite-common/suite-utils/tsconfig.json
+++ b/suite-common/suite-utils/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../suite-config" },
+        { "path": "../suite-constants" },
         { "path": "../suite-types" },
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -145,6 +145,7 @@ export type SolanaTxMeta = {
     feeLamports: string;
     rentLamports: string;
     feeIncludingRentLamports: string;
+    hasSplitInstruction: boolean;
 };
 
 type PrecomposedTransactionNonFinal = PrecomposedTransactionConnectResponseNonFinal & {

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -145,7 +145,6 @@ export type SolanaTxMeta = {
     feeLamports: string;
     rentLamports: string;
     feeIncludingRentLamports: string;
-    hasSplitInstruction: boolean;
 };
 
 type PrecomposedTransactionNonFinal = PrecomposedTransactionConnectResponseNonFinal & {
@@ -157,6 +156,7 @@ type PrecomposedTransactionNonFinal = PrecomposedTransactionConnectResponseNonFi
     accountActivationFee?: string;
     memoFee?: string;
     solanaTxMeta?: SolanaTxMeta;
+    isDeviceReviewOnly?: boolean;
 };
 
 // base of PrecomposedTransactionFinal
@@ -176,6 +176,7 @@ type PrecomposedTransactionBase = PrecomposedTransactionConnectResponseFinal & {
     maxFeePerGas?: string;
     maxPriorityFeePerGas?: string;
     solanaTxMeta?: SolanaTxMeta;
+    isDeviceReviewOnly?: boolean;
 };
 
 // base of PrecomposedTransactionFinal

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -5,6 +5,7 @@ import {
     type Account,
     type FormState,
     type FormStateTrading,
+    type GeneralPrecomposedTransaction,
     type GeneralPrecomposedTransactionFinal,
     type StakeFormState,
 } from '@suite-common/wallet-types';
@@ -16,6 +17,7 @@ import {
     constructTransactionReviewOutputs,
     isClearSignedEvmTradingSwapTransaction,
     isClearSignedWrappedNativeTransaction,
+    isDeviceReviewOnlyTransaction,
 } from './reviewTransactionUtils';
 
 const ethSymbol = asNetworkSymbol('eth');
@@ -544,5 +546,31 @@ describe('constructTransactionReviewOutputs', () => {
                 expect.objectContaining({ type: 'data', value: WETH_DEPOSIT_DATA }),
             ]),
         );
+    });
+});
+
+describe('isDeviceReviewOnlyTransaction', () => {
+    const buildTx = (overrides: Record<string, unknown> = {}): GeneralPrecomposedTransaction =>
+        ({
+            type: 'final',
+            totalSpent: '1000000000',
+            fee: '5000',
+            ...overrides,
+        }) as unknown as GeneralPrecomposedTransaction;
+
+    it('returns false when there is no transaction', () => {
+        expect(isDeviceReviewOnlyTransaction(undefined)).toBe(false);
+    });
+
+    it('returns false for a transaction without the flag', () => {
+        expect(isDeviceReviewOnlyTransaction(buildTx())).toBe(false);
+    });
+
+    it('returns false for a transaction Suite can review step by step', () => {
+        expect(isDeviceReviewOnlyTransaction(buildTx({ isDeviceReviewOnly: false }))).toBe(false);
+    });
+
+    it('returns true for a transaction reviewed on the device only', () => {
+        expect(isDeviceReviewOnlyTransaction(buildTx({ isDeviceReviewOnly: true }))).toBe(true);
     });
 });

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -11,6 +11,7 @@ import { WRAPPED_NATIVE_MIN_FIRMWARE } from '@suite-common/wallet-constants';
 import {
     type Account,
     type FormState,
+    type GeneralPrecomposedTransaction,
     type GeneralPrecomposedTransactionFinal,
     type ReviewOutput,
     type ReviewOutputState,
@@ -40,6 +41,15 @@ import {
 import { getStakeType } from './ethereumStakingUtils';
 import { isExchangeTradingForm } from './sendFormUtils';
 import { isRbfBumpFeeTransaction } from './transactionUtils';
+
+/**
+ * Transactions whose steps cannot be recreated in Suite (e.g. Solana split unstakes) are not broken
+ * down into review outputs, Suite only asks the user to follow the instructions on the device.
+ */
+export const isDeviceReviewOnlyTransaction = (transaction?: GeneralPrecomposedTransaction) =>
+    transaction !== undefined &&
+    'isDeviceReviewOnly' in transaction &&
+    transaction.isDeviceReviewOnly === true;
 
 export const getTransactionReviewOutputState = (
     index: number,

--- a/suite-common/wallet-utils/src/solanaStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.test.ts
@@ -1,8 +1,12 @@
-import { type Account } from '@suite-common/wallet-types';
+import {
+    GeneralPrecomposedTransaction,
+    SolanaTxMeta,
+    type Account,
+} from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import { StakeState } from '@trezor/network-solana/constants';
 
-import { getSolanaUnstakeAmountBounds } from './solanaStakingUtils';
+import { getSolanaUnstakeAmountBounds, isDeviceReviewOnly } from './solanaStakingUtils';
 
 const SOL = 1_000_000_000;
 
@@ -120,5 +124,44 @@ describe('getSolanaUnstakeAmountBounds', () => {
         );
 
         expect(getSolanaUnstakeAmountBounds(account, '1.5')).toBeNull();
+    });
+});
+
+const buildSolanaTxMeta = (overrides: Partial<SolanaTxMeta> = {}): SolanaTxMeta => ({
+    deviceAmountLamports: `${SOL}`,
+    feeLamports: '5000',
+    rentLamports: '0',
+    feeIncludingRentLamports: '5000',
+    hasSplitInstruction: false,
+    ...overrides,
+});
+
+const buildPrecomposedTransaction = (solanaTxMeta?: SolanaTxMeta): GeneralPrecomposedTransaction =>
+    ({
+        type: 'final',
+        totalSpent: `${SOL}`,
+        fee: '5000',
+        solanaTxMeta,
+    }) as unknown as GeneralPrecomposedTransaction;
+
+describe('isDeviceReviewOnly', () => {
+    it('returns false when there is no transaction', () => {
+        expect(isDeviceReviewOnly(undefined)).toBe(false);
+    });
+
+    it('returns false for a transaction of a network without Solana metadata', () => {
+        expect(isDeviceReviewOnly(buildPrecomposedTransaction())).toBe(false);
+    });
+
+    it('returns false for a Solana transaction without a split instruction', () => {
+        expect(isDeviceReviewOnly(buildPrecomposedTransaction(buildSolanaTxMeta()))).toBe(false);
+    });
+
+    it('returns true for a Solana transaction with a split instruction', () => {
+        expect(
+            isDeviceReviewOnly(
+                buildPrecomposedTransaction(buildSolanaTxMeta({ hasSplitInstruction: true })),
+            ),
+        ).toBe(true);
     });
 });

--- a/suite-common/wallet-utils/src/solanaStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.test.ts
@@ -1,7 +1,7 @@
-import {
+import type {
+    Account,
     GeneralPrecomposedTransaction,
     SolanaTxMeta,
-    type Account,
 } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import { StakeState } from '@trezor/network-solana/constants';

--- a/suite-common/wallet-utils/src/solanaStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.test.ts
@@ -1,12 +1,8 @@
-import type {
-    Account,
-    GeneralPrecomposedTransaction,
-    SolanaTxMeta,
-} from '@suite-common/wallet-types';
+import type { Account } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import { StakeState } from '@trezor/network-solana/constants';
 
-import { getSolanaUnstakeAmountBounds, isDeviceReviewOnly } from './solanaStakingUtils';
+import { getSolanaUnstakeAmountBounds } from './solanaStakingUtils';
 
 const SOL = 1_000_000_000;
 
@@ -124,44 +120,5 @@ describe('getSolanaUnstakeAmountBounds', () => {
         );
 
         expect(getSolanaUnstakeAmountBounds(account, '1.5')).toBeNull();
-    });
-});
-
-const buildSolanaTxMeta = (overrides: Partial<SolanaTxMeta> = {}): SolanaTxMeta => ({
-    deviceAmountLamports: `${SOL}`,
-    feeLamports: '5000',
-    rentLamports: '0',
-    feeIncludingRentLamports: '5000',
-    hasSplitInstruction: false,
-    ...overrides,
-});
-
-const buildPrecomposedTransaction = (solanaTxMeta?: SolanaTxMeta): GeneralPrecomposedTransaction =>
-    ({
-        type: 'final',
-        totalSpent: `${SOL}`,
-        fee: '5000',
-        solanaTxMeta,
-    }) as unknown as GeneralPrecomposedTransaction;
-
-describe('isDeviceReviewOnly', () => {
-    it('returns false when there is no transaction', () => {
-        expect(isDeviceReviewOnly(undefined)).toBe(false);
-    });
-
-    it('returns false for a transaction of a network without Solana metadata', () => {
-        expect(isDeviceReviewOnly(buildPrecomposedTransaction())).toBe(false);
-    });
-
-    it('returns false for a Solana transaction without a split instruction', () => {
-        expect(isDeviceReviewOnly(buildPrecomposedTransaction(buildSolanaTxMeta()))).toBe(false);
-    });
-
-    it('returns true for a Solana transaction with a split instruction', () => {
-        expect(
-            isDeviceReviewOnly(
-                buildPrecomposedTransaction(buildSolanaTxMeta({ hasSplitInstruction: true })),
-            ),
-        ).toBe(true);
     });
 });

--- a/suite-common/wallet-utils/src/solanaStakingUtils.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.ts
@@ -1,5 +1,5 @@
 import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
-import type { Account, GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
+import type { Account } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import {
     MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
@@ -111,11 +111,6 @@ export const getSolStakingAccountTotalBalanceByStatus = (account: Account, statu
 
     return formatNetworkAmount(stakingBalance, account.symbol);
 };
-
-export const isDeviceReviewOnly = (transaction?: GeneralPrecomposedTransaction) =>
-    transaction !== undefined &&
-    'solanaTxMeta' in transaction &&
-    transaction.solanaTxMeta?.hasSplitInstruction === true;
 
 export type SolanaUnstakeAmountBounds = {
     closestLower?: string;

--- a/suite-common/wallet-utils/src/solanaStakingUtils.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.ts
@@ -1,5 +1,5 @@
 import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
-import { GeneralPrecomposedTransaction, type Account } from '@suite-common/wallet-types';
+import type { Account, GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import {
     MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,

--- a/suite-common/wallet-utils/src/solanaStakingUtils.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.ts
@@ -1,5 +1,5 @@
 import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
-import { type Account } from '@suite-common/wallet-types';
+import { GeneralPrecomposedTransaction, type Account } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import {
     MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
@@ -111,6 +111,11 @@ export const getSolStakingAccountTotalBalanceByStatus = (account: Account, statu
 
     return formatNetworkAmount(stakingBalance, account.symbol);
 };
+
+export const isDeviceReviewOnly = (transaction?: GeneralPrecomposedTransaction) =>
+    transaction !== undefined &&
+    'solanaTxMeta' in transaction &&
+    transaction.solanaTxMeta?.hasSplitInstruction === true;
 
 export type SolanaUnstakeAmountBounds = {
     closestLower?: string;

--- a/suite-native/device/src/components/ContinueOnTrezorScreenContent.tsx
+++ b/suite-native/device/src/components/ContinueOnTrezorScreenContent.tsx
@@ -2,10 +2,9 @@ import { useSelector } from 'react-redux';
 
 import { type RequireAllOrNone } from 'type-fest';
 
-import { selectDeviceModel } from '@suite-common/device';
+import { selectDeviceModelWithFlagshipFallback } from '@suite-common/device';
 import { Box, Button, Text, VStack } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
-import { DeviceModelInternal } from '@trezor/device-utils';
 import { getScreenHeight } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -40,7 +39,7 @@ export const ContinueOnTrezorScreenContent = ({
 }: ContinueOnTrezorScreenContentProps) => {
     const { applyStyle } = useNativeStyles();
 
-    const deviceModel = useSelector(selectDeviceModel);
+    const deviceModel = useSelector(selectDeviceModelWithFlagshipFallback);
 
     return (
         <VStack testID="@continue-on-trezor" flex={1} spacing="sp24">
@@ -60,7 +59,7 @@ export const ContinueOnTrezorScreenContent = ({
             )}
             <Box flex={1} alignItems="center" justifyContent="flex-end">
                 <DeviceImage
-                    deviceModel={deviceModel || DeviceModelInternal.T3W1}
+                    deviceModel={deviceModel}
                     size="large"
                     maxHeight={0.42 * SCREEN_HEIGHT}
                 />

--- a/suite-native/device/src/components/DeviceImage.tsx
+++ b/suite-native/device/src/components/DeviceImage.tsx
@@ -41,6 +41,7 @@ export const DeviceImage = ({ deviceModel, size = 'normal', maxHeight }: DeviceI
         <Image
             source={deviceImageMap[deviceModel]}
             style={applyStyle(imageStyle, { size, maxHeight })}
+            testID="@device/image"
         />
     );
 };

--- a/suite-native/device/src/components/FollowDeviceScreenContent.tsx
+++ b/suite-native/device/src/components/FollowDeviceScreenContent.tsx
@@ -1,0 +1,40 @@
+import { useSelector } from 'react-redux';
+
+import { selectDeviceModelWithFlagshipFallback } from '@suite-common/device';
+import { Box, Text, VStack } from '@suite-native/atoms';
+import { Translation, type TxKeyPath } from '@suite-native/intl';
+import { getScreenHeight } from '@trezor/env-utils';
+
+import { DeviceImage } from './DeviceImage';
+
+const SCREEN_HEIGHT = getScreenHeight();
+
+type FollowDeviceScreenContentProps = {
+    titleTxKey: TxKeyPath;
+    isTxSigned?: boolean;
+};
+
+export const FollowDeviceScreenContent = ({
+    titleTxKey,
+    isTxSigned = false,
+}: FollowDeviceScreenContentProps) => {
+    const deviceModel = useSelector(selectDeviceModelWithFlagshipFallback);
+
+    return (
+        <VStack flex={1} spacing="sp24" paddingBottom="sp24" testID="@follow-device">
+            <Box flex={1} alignItems="center" justifyContent="center">
+                <DeviceImage
+                    deviceModel={deviceModel}
+                    size="large"
+                    maxHeight={0.42 * SCREEN_HEIGHT}
+                />
+            </Box>
+
+            {!isTxSigned && (
+                <Text variant="headline-md" textAlign="center">
+                    <Translation id={titleTxKey} />
+                </Text>
+            )}
+        </VStack>
+    );
+};

--- a/suite-native/device/src/index.ts
+++ b/suite-native/device/src/index.ts
@@ -11,6 +11,7 @@ export * from './components/ConnectDeviceAnimation';
 export * from './components/ConnectorImage';
 export * from './components/DeviceImage';
 export * from './components/ContinueOnTrezorScreenContent';
+export * from './components/FollowDeviceScreenContent';
 export * from './components/ConnectAndUnlockDeviceScreenContent';
 export * from './components/TurnOnAndUnlockDeviceScreenContent';
 export * from './components/DeviceDangerBanner';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2868,6 +2868,7 @@ export const messages = {
             completeTitle: 'Unstaking complete',
             completeAmountLabel: 'Unstaked',
             viewTransactionButton: 'Unstake now',
+            followDeviceInstructions: "Follow the instructions on your Trezor's screen.",
             pushTransactionFailedAlert: {
                 title: 'Transaction failed',
                 description: 'Failed to complete your unstaking transaction. Try again.',

--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -48,6 +48,7 @@
         "@suite-native/clipboard": "workspace:*",
         "@suite-native/config": "workspace:*",
         "@suite-native/confirm-on-trezor": "workspace:*",
+        "@suite-native/device": "workspace:*",
         "@suite-native/device-manager": "workspace:*",
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/feedback-form": "workspace:*",

--- a/suite-native/module-earn/src/screens/StakingTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/StakingTransactionDataReviewScreen.tsx
@@ -2,17 +2,19 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import { isDeviceReviewOnly, isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Button, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
     useConfirmOnTrezorController,
 } from '@suite-native/confirm-on-trezor';
+import { FollowDeviceScreenContent } from '@suite-native/device';
 import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import {
     type RootStackParamList,
     type RootStackRoutes,
+    Screen,
     ScreenHeader,
     type StackProps,
 } from '@suite-native/navigation';
@@ -189,37 +191,82 @@ export const StakingTransactionDataReviewScreen = ({
         setIsPushing(false);
     }, [stakeType, claimableAmount, handlePush, trackPushedTransaction]);
 
+    const isFollowDeviceReview =
+        stakeType === 'unstake' && isDeviceReviewOnly(precomposedTransaction);
+
+    const timer = showTimer && (
+        <TxValidityTimer
+            secondsLeft={secondsLeft}
+            isPastDeadline={isPastDeadline}
+            isBroadcasting={isBroadcasting}
+            onRetry={onRetry}
+            isRetryDisabled={isRetryDisabled}
+            retryTestID={isFollowDeviceReview ? '@earn/follow-device-retry' : undefined}
+        />
+    );
+
+    const header = (
+        <ScreenHeader
+            customContent={
+                <Text variant="body-md-strong">
+                    <Translation id={screenHeaderTranslationId[stakeType]} />
+                </Text>
+            }
+            closeActionType="close"
+            closeAction={closeReview}
+        />
+    );
+
+    const button = isReadyToContinue && (
+        <ScrollToEndOnMount>
+            <Button
+                isLoading={isPushing}
+                isDisabled={isSolanaAccount && isPastDeadline}
+                onPress={onButtonPress}
+                testID={actionButtonDataTestId[stakeType]}
+            >
+                <Translation id={actionButtonTranslationId[stakeType]} />
+            </Button>
+        </ScrollToEndOnMount>
+    );
+
+    if (isFollowDeviceReview) {
+        return (
+            <Screen
+                isScrollable={false}
+                header={
+                    <ScreenHeader
+                        closeActionType="back"
+                        closeAction={closeReview}
+                        rightIcon={timer}
+                    />
+                }
+            >
+                <VStack flex={1} justifyContent="center" spacing="sp24">
+                    <FollowDeviceScreenContent
+                        titleTxKey="earn.unstakeTransactionDataReviewScreen.followDeviceInstructions"
+                        isTxSigned={isTransactionAlreadySigned}
+                    />
+
+                    {button}
+                </VStack>
+            </Screen>
+        );
+    }
+
     return (
         <ConfirmOnTrezorWrapper
             isManualControlEnabled
             controlRef={confirmOnTrezorRef}
             closeActionType="close"
             closeAction={closeReview}
-            defaultHeader={
-                <ScreenHeader
-                    customContent={
-                        <Text variant="body-md-strong">
-                            <Translation id={screenHeaderTranslationId[stakeType]} />
-                        </Text>
-                    }
-                    closeActionType="close"
-                    closeAction={closeReview}
-                />
-            }
+            defaultHeader={header}
         >
             <VStack flex={1} justifyContent="space-between">
                 <VStack justifyContent="center" spacing="sp24">
-                    {showTimer && (
-                        <TxValidityTimer
-                            secondsLeft={secondsLeft}
-                            isPastDeadline={isPastDeadline}
-                            isBroadcasting={isBroadcasting}
-                            onRetry={onRetry}
-                            isRetryDisabled={isRetryDisabled}
-                        />
-                    )}
+                    {timer}
 
-                    {account && (
+                    {!isFollowDeviceReview && account && (
                         <StakingTransactionDataReviewStepList
                             account={account}
                             stakeType={stakeType}
@@ -228,18 +275,7 @@ export const StakingTransactionDataReviewScreen = ({
                     )}
                 </VStack>
 
-                {isReadyToContinue && (
-                    <ScrollToEndOnMount>
-                        <Button
-                            isLoading={isPushing}
-                            isDisabled={isSolanaAccount && isPastDeadline}
-                            onPress={onButtonPress}
-                            testID={actionButtonDataTestId[stakeType]}
-                        >
-                            <Translation id={actionButtonTranslationId[stakeType]} />
-                        </Button>
-                    </ScrollToEndOnMount>
-                )}
+                {button}
             </VStack>
 
             {isPending && !!pendingTxid && !!submittedAt && !!account && (

--- a/suite-native/module-earn/src/screens/StakingTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/StakingTransactionDataReviewScreen.tsx
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { isDeviceReviewOnly, isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import {
+    isDeviceReviewOnlyTransaction,
+    isSupportedSolStakingNetworkSymbol,
+} from '@suite-common/wallet-utils';
 import { Button, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
@@ -192,7 +195,7 @@ export const StakingTransactionDataReviewScreen = ({
     }, [stakeType, claimableAmount, handlePush, trackPushedTransaction]);
 
     const isFollowDeviceReview =
-        stakeType === 'unstake' && isDeviceReviewOnly(precomposedTransaction);
+        stakeType === 'unstake' && isDeviceReviewOnlyTransaction(precomposedTransaction);
 
     const timer = showTimer && (
         <TxValidityTimer
@@ -230,27 +233,55 @@ export const StakingTransactionDataReviewScreen = ({
         </ScrollToEndOnMount>
     );
 
+    const pendingTxModal = isPending && !!pendingTxid && !!submittedAt && !!account && (
+        <YieldPendingTransactionModal
+            ref={pendingBottomSheetRef}
+            accountLabel={accountLabel}
+            accountSymbol={account.symbol}
+            amount={
+                <CryptoAmountFormatter
+                    value={pendingAmountInBaseUnits}
+                    symbol={account.symbol}
+                    color="contentPrimary"
+                    isBalance={false}
+                    isDiscreetText={false}
+                />
+            }
+            amountLabel={<Translation id={pendingTxModalTitleTranslationId[stakeType]} />}
+            fee={precomposedTransaction?.fee}
+            isExploreDisabled={isExploreDisabled}
+            onExplorePress={openInBlockchain}
+            submittedAt={submittedAt}
+            title={<Translation id={pendingTxModalAmountLabelTranslationId[stakeType]} />}
+            txid={pendingTxid}
+        />
+    );
+
     if (isFollowDeviceReview) {
         return (
-            <Screen
-                isScrollable={false}
-                header={
-                    <ScreenHeader
-                        closeActionType="back"
-                        closeAction={closeReview}
-                        rightIcon={timer}
-                    />
-                }
-            >
-                <VStack flex={1} justifyContent="center" spacing="sp24">
-                    <FollowDeviceScreenContent
-                        titleTxKey="earn.unstakeTransactionDataReviewScreen.followDeviceInstructions"
-                        isTxSigned={isTransactionAlreadySigned}
-                    />
+            <>
+                <Screen
+                    isScrollable={false}
+                    header={
+                        <ScreenHeader
+                            closeActionType="back"
+                            closeAction={closeReview}
+                            rightIcon={timer}
+                        />
+                    }
+                >
+                    <VStack flex={1} justifyContent="center" spacing="sp24">
+                        <FollowDeviceScreenContent
+                            titleTxKey="earn.unstakeTransactionDataReviewScreen.followDeviceInstructions"
+                            isTxSigned={isTransactionAlreadySigned}
+                        />
 
-                    {button}
-                </VStack>
-            </Screen>
+                        {button}
+                    </VStack>
+                </Screen>
+
+                {pendingTxModal}
+            </>
         );
     }
 
@@ -278,29 +309,7 @@ export const StakingTransactionDataReviewScreen = ({
                 {button}
             </VStack>
 
-            {isPending && !!pendingTxid && !!submittedAt && !!account && (
-                <YieldPendingTransactionModal
-                    ref={pendingBottomSheetRef}
-                    accountLabel={accountLabel}
-                    accountSymbol={account.symbol}
-                    amount={
-                        <CryptoAmountFormatter
-                            value={pendingAmountInBaseUnits}
-                            symbol={account.symbol}
-                            color="contentPrimary"
-                            isBalance={false}
-                            isDiscreetText={false}
-                        />
-                    }
-                    amountLabel={<Translation id={pendingTxModalTitleTranslationId[stakeType]} />}
-                    fee={precomposedTransaction?.fee}
-                    isExploreDisabled={isExploreDisabled}
-                    onExplorePress={openInBlockchain}
-                    submittedAt={submittedAt}
-                    title={<Translation id={pendingTxModalAmountLabelTranslationId[stakeType]} />}
-                    txid={pendingTxid}
-                />
-            )}
+            {pendingTxModal}
         </ConfirmOnTrezorWrapper>
     );
 };

--- a/suite-native/module-earn/tsconfig.json
+++ b/suite-native/module-earn/tsconfig.json
@@ -70,6 +70,7 @@
         { "path": "../clipboard" },
         { "path": "../config" },
         { "path": "../confirm-on-trezor" },
+        { "path": "../device" },
         { "path": "../device-manager" },
         { "path": "../device-mutex" },
         { "path": "../feedback-form" },

--- a/suite-native/staking/src/stakeFormSolanaNativeThunks.test.ts
+++ b/suite-native/staking/src/stakeFormSolanaNativeThunks.test.ts
@@ -45,6 +45,7 @@ const solanaTxMetaMock = {
     feeLamports: '5000',
     rentLamports: '2282880',
     feeIncludingRentLamports: '2287880',
+    hasSplitInstruction: false,
 };
 
 const prepareStakeSolTxMock = jest.fn();
@@ -308,6 +309,62 @@ describe('composeSolanaStakingTransactionFeeLevelsNativeThunk', () => {
         expect(blockchainEstimateFeeMock).toHaveBeenCalled();
         const request = blockchainEstimateFeeMock.mock.calls.at(-1)?.[0];
         expect(request.request.specific).not.toHaveProperty('newAccountProgramName');
+    });
+
+    it('marks a transaction with a split instruction as device review only', async () => {
+        // A split instruction cannot be recreated in Suite, the whole review happens on the device.
+        prepareUnstakeSolTxMock.mockResolvedValue({
+            success: true,
+            txShim: solanaTxShim,
+            solanaTxMeta: { ...solanaTxMetaMock, hasSplitInstruction: true },
+        });
+        const store = buildStore();
+
+        const result = await dispatchCompose(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'unstake',
+            amount: '1',
+        });
+
+        expect(result.ok).toBe(true);
+        const levels = (result as { payload: Record<string, any> }).payload;
+        expect(levels.normal.isDeviceReviewOnly).toBe(true);
+    });
+
+    it('keeps the device review only flag when the fee-aware preparation fails', async () => {
+        // The fee-aware rebuild is only a refinement, losing it must not turn a split into a Suite review.
+        prepareUnstakeSolTxMock.mockReset();
+        prepareUnstakeSolTxMock.mockResolvedValueOnce({
+            success: true,
+            txShim: solanaTxShim,
+            solanaTxMeta: { ...solanaTxMetaMock, hasSplitInstruction: true },
+        });
+        prepareUnstakeSolTxMock.mockResolvedValueOnce({ success: false });
+        const store = buildStore();
+
+        const result = await dispatchCompose(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'unstake',
+            amount: '1',
+        });
+
+        expect(result.ok).toBe(true);
+        const levels = (result as { payload: Record<string, any> }).payload;
+        expect(levels.normal.isDeviceReviewOnly).toBe(true);
+    });
+
+    it('leaves a transaction without a split instruction reviewable in Suite', async () => {
+        const store = buildStore();
+
+        const result = await dispatchCompose(store, {
+            accountKey: SOL_ACCOUNT_KEY,
+            stakeType: 'unstake',
+            amount: '1',
+        });
+
+        expect(result.ok).toBe(true);
+        const levels = (result as { payload: Record<string, any> }).payload;
+        expect(levels.normal.isDeviceReviewOnly).toBe(false);
     });
 
     it('passes newAccountProgramName when an unstake splits a stake account (reserves rent)', async () => {

--- a/suite-native/transaction-management/src/components/TxValidityTimer.test.tsx
+++ b/suite-native/transaction-management/src/components/TxValidityTimer.test.tsx
@@ -86,4 +86,17 @@ describe('TxValidityTimer', () => {
             expect(onRetry).not.toHaveBeenCalled();
         });
     });
+
+    describe('compact layout', () => {
+        it('should keep the countdown and a working retry button', () => {
+            const onRetry = jest.fn();
+            const { getByText } = renderTimer({ isCompact: true, onRetry });
+
+            expect(getByText(getCountdownLabel(42))).toBeOnTheScreen();
+
+            fireEvent.press(getByText(tryAgainLabel));
+
+            expect(onRetry).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/suite-native/transaction-management/src/components/TxValidityTimer.test.tsx
+++ b/suite-native/transaction-management/src/components/TxValidityTimer.test.tsx
@@ -88,13 +88,13 @@ describe('TxValidityTimer', () => {
     });
 
     describe('compact layout', () => {
-        it('should keep the countdown and a working retry button', () => {
+        it('should keep the countdown and a working retry button', async () => {
             const onRetry = jest.fn();
-            const { getByText } = renderTimer({ isCompact: true, onRetry });
+            const { getByText } = await renderTimer({ isCompact: true, onRetry });
 
             expect(getByText(getCountdownLabel(42))).toBeOnTheScreen();
 
-            fireEvent.press(getByText(tryAgainLabel));
+            await fireEvent.press(getByText(tryAgainLabel));
 
             expect(onRetry).toHaveBeenCalledTimes(1);
         });

--- a/suite-native/transaction-management/src/components/TxValidityTimer.tsx
+++ b/suite-native/transaction-management/src/components/TxValidityTimer.tsx
@@ -7,6 +7,8 @@ type TxValidityTimerProps = {
     isBroadcasting?: boolean;
     onRetry: () => void;
     isRetryDisabled?: boolean;
+    retryTestID?: string;
+    isCompact?: boolean;
 };
 
 export const TxValidityTimer = ({
@@ -15,6 +17,8 @@ export const TxValidityTimer = ({
     isBroadcasting = false,
     onRetry,
     isRetryDisabled = false,
+    retryTestID,
+    isCompact = false,
 }: TxValidityTimerProps) => {
     const getLabel = () => {
         if (isBroadcasting) {
@@ -33,19 +37,35 @@ export const TxValidityTimer = ({
         );
     };
 
+    const badge = <Badge intent="warning" size="medium" label={getLabel()} />;
+
+    const retryButton = (
+        <Button
+            size="medium"
+            intent="neutral"
+            priority="secondary"
+            iconLeft="arrowsCounterClockwise"
+            isDisabled={isBroadcasting || isRetryDisabled}
+            onPress={onRetry}
+            testID={retryTestID}
+        >
+            <Translation id="generic.buttons.tryAgain" />
+        </Button>
+    );
+
+    if (isCompact) {
+        return (
+            <HStack spacing="sp8" alignItems="center" flexShrink={1}>
+                {retryButton}
+                {badge}
+            </HStack>
+        );
+    }
+
     return (
         <HStack paddingVertical="sp8" justifyContent="space-between" alignItems="center">
-            <Badge intent="warning" size="medium" label={getLabel()} />
-            <Button
-                size="medium"
-                intent="neutral"
-                priority="secondary"
-                iconLeft="arrowsCounterClockwise"
-                isDisabled={isBroadcasting || isRetryDisabled}
-                onPress={onRetry}
-            >
-                <Translation id="generic.buttons.tryAgain" />
-            </Button>
+            {badge}
+            {retryButton}
         </HStack>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11342,6 +11342,7 @@ __metadata:
   resolution: "@suite-common/suite-utils@workspace:suite-common/suite-utils"
   dependencies:
     "@suite-common/suite-config": "workspace:*"
+    "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
@@ -13476,6 +13477,7 @@ __metadata:
     "@suite-native/clipboard": "workspace:*"
     "@suite-native/config": "workspace:*"
     "@suite-native/confirm-on-trezor": "workspace:*"
+    "@suite-native/device": "workspace:*"
     "@suite-native/device-manager": "workspace:*"
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/feedback-form": "workspace:*"


### PR DESCRIPTION
## Description

Show a "follow your Trezor" screen instead of the normal review when a Solana unstake splits across accounts, on desktop and mobile. Also fix the flagship device image not showing when the connected model can't be read yet.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/22438
Resolve #29952
Resolve https://github.com/trezor/trezor-suite/issues/17386

## Screenshots:

https://github.com/user-attachments/assets/54271742-8da8-4414-a997-d9259e7100ee

https://github.com/user-attachments/assets/7c3bb3cf-a4f1-461e-b5d5-fccff6d81d30

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-split-instruction-tx-review-modal/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-split-instruction-tx-review-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily affects Solana staking logic and the desktop transaction review modal. Solana staking e2e tests should be run unconditionally because they directly exercise the changed staking actions and utilities. Several send/swap/trading tests that reach device confirmation screens are also high priority because they verify the exact TransactionReviewModal components and reviewTransactionUtils that were modified. Suite-native files and pure unit-test/config changes have no coverage in the web e2e suite and are listed as uncovered.

<details><summary><b>Changed files (30)</b></summary>

- `networks/solana/network-solana/src/runtime/staking.ts`
- `networks/solana/network-solana/src/types/staking.ts`
- `packages/suite/src/components/suite/DeviceConfirmImage.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewFollowDevice.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx`
- `suite-common/device/src/deviceSelectors.test.ts`
- `suite-common/device/src/deviceSelectors.ts`
- `suite-common/staking/src/actions/solanaStakeFormActions.ts`
- `suite-common/suite-utils/package.json`
- `suite-common/suite-utils/src/device.test.ts`
- `suite-common/suite-utils/src/device.ts`
- `suite-common/suite-utils/tsconfig.json`
- `suite-common/wallet-types/src/transaction.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`
- `suite-common/wallet-utils/src/solanaStakingUtils.test.ts`
- `suite-common/wallet-utils/src/solanaStakingUtils.ts`
- `suite-native/device/src/components/ContinueOnTrezorScreenContent.tsx`
- `suite-native/device/src/components/DeviceImage.tsx`
- `suite-native/device/src/components/FollowDeviceScreenContent.tsx`
- `suite-native/device/src/index.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/package.json`
- `suite-native/module-earn/src/screens/StakingTransactionDataReviewScreen.tsx`
- `suite-native/module-earn/tsconfig.json`
- `suite-native/staking/src/stakeFormSolanaNativeThunks.test.ts`
- `suite-native/transaction-management/src/components/TxValidityTimer.test.tsx`
- `suite-native/transaction-management/src/components/TxValidityTimer.tsx`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Directly exercises the Solana staking flow end-to-end, including stake account creation, device confirmation prompts, and dashboard state updates. Changes to solanaStakeFormActions, solanaStakingUtils, and Solana staking runtime/types are highly likely to affect this test's behavior.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Validates Solana staking dashboard amounts, reward calculations, and epoch cache behavior. Changes to Solana staking utilities and runtime types could break reward aggregation or stake account state rendering.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests adding additional stake to an existing Solana staking account and verifying pending-to-staked transitions. Directly depends on Solana staking form actions and staking utilities changed in this PR.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Covers Solana unstaking and claim flows with device confirmation and dashboard state changes. Changes to Solana staking actions/utils may alter how stake accounts are deactivated or claimed.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Exercises a complex DEX swap confirmation flow with extensive device prompt review screens (amount, fee, contract, slippage). Changes to TransactionReviewModalBodyInner, TransactionReviewModalContent, and reviewTransactionUtils directly impact the screens verified here.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Validates ETH-to-SOL swap device prompts including address, amount, and fee display. The transaction review modal components and review transaction utilities changed here render the confirmation screens this test asserts.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests EVM send on Base with custom fees and verifies the full device prompt review flow including fee info screens. Changes to transaction review modal components and reviewTransactionUtils directly affect these assertions.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Exercises Ethereum send with custom EIP-1559 fees and device confirmation screens. The transaction review modal and review transaction utility changes are directly on the code path this test verifies.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Validates Solana send max calculation, review modal, and device confirmation. Combines Solana-specific logic with the transaction review modal path, both of which are changed in this PR.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking uses the same transaction review and device confirmation infrastructure as the changed modal components. A regression in shared review rendering could affect this flow.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Ethereum staking confirmation flow relies on the transaction review modal and device prompt rendering. Changes to review modal structure or reviewTransactionUtils could alter stake confirmation displays.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Specifically verifies custom Ethereum fee fields (gas limit, max fee per gas, priority fee) in the device prompt and fee info screens. Shares transaction review infrastructure with the changed components.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — SOL-to-BTC swap exercises Solana transaction review prompts and device display. Combines Solana-specific paths with the changed transaction review modal components.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Bitcoin send with locktime and OP_RETURN outputs goes through the transaction review modal and device confirmation. A regression in review output list rendering could break this flow.

</details>

⚠️ **Changes with no test coverage (20)**
- `networks/solana/network-solana/src/runtime/staking.ts`
- `networks/solana/network-solana/src/types/staking.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewFollowDevice.tsx`
- `suite-common/device/src/deviceSelectors.test.ts`
- `suite-common/suite-utils/package.json`
- `suite-common/suite-utils/src/device.test.ts`
- `suite-common/suite-utils/tsconfig.json`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/solanaStakingUtils.test.ts`
- `suite-native/device/src/components/ContinueOnTrezorScreenContent.tsx`
- `suite-native/device/src/components/DeviceImage.tsx`
- `suite-native/device/src/components/FollowDeviceScreenContent.tsx`
- `suite-native/device/src/index.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/package.json`
- `suite-native/module-earn/src/screens/StakingTransactionDataReviewScreen.tsx`
- `suite-native/module-earn/tsconfig.json`
- `suite-native/staking/src/stakeFormSolanaNativeThunks.test.ts`
- `suite-native/transaction-management/src/components/TxValidityTimer.test.tsx`
- `suite-native/transaction-management/src/components/TxValidityTimer.tsx`

_Updated: 2026-08-31T13:57:38.524Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-split-instruction-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-split-instruction-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/solana-split-instruction-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T13:58:56.074Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T13:58:03.404Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->