### PR TITLE
feat(suite-native): redesign yield vault section

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2066,12 +2066,13 @@ export const messages = {
         accountDetail: {
             stablecoinYield: {
                 defiYieldInfoText:
-                    'This token represents your deposit and all rewards in DeFi Yield.',
+                    'This token represents your position in the vault. It grows in value as yield accrues.',
                 vault: 'Vault',
                 deposited: 'Deposited',
                 depositMore: 'Deposit more',
                 deposit: 'Deposit',
                 withdraw: 'Withdraw',
+                managePosition: 'Manage position',
                 firmwareUpdateAlert: {
                     title: 'Firmware update required',
                     description: 'Update firmware on the device {name} to use {featureName}.',
@@ -3603,7 +3604,6 @@ export const messages = {
         potentialRewards: 'Potential yearly rewards',
         potentialRewardsIfYouAdd: 'If you add {amountWithSymbol}',
         tokenBalance: 'Token balance',
-        goToVault: 'Go to vault',
         notAvailableShort: 'N/A',
         yieldRateBadge: {
             apy: '{value}% APY',

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -107,10 +107,6 @@ export const TransactionListHeader = memo(
                         tokenContract={tokenContract}
                     />
 
-                    {tokenContract && (
-                        <YieldVaultBanner accountKey={accountKey} tokenContract={tokenContract} />
-                    )}
-
                     {hasSelectedAssetTransactions && (
                         <Box paddingTop="sp8" paddingHorizontal="sp16">
                             <AccountDetailActionButtons
@@ -121,6 +117,9 @@ export const TransactionListHeader = memo(
                     )}
                     {isPriceCardDisplayed && (
                         <AssetPriceCard accountKey={accountKey} tokenContract={tokenContract} />
+                    )}
+                    {tokenContract && (
+                        <YieldVaultBanner accountKey={accountKey} tokenContract={tokenContract} />
                     )}
                     {isStellarTokenActionsDisplayed && (
                         <StellarTokenActions

--- a/suite-native/module-accounts-management/src/components/YieldVaultBanner.tsx
+++ b/suite-native/module-accounts-management/src/components/YieldVaultBanner.tsx
@@ -2,8 +2,7 @@ import { useCallback } from 'react';
 
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress, toTokenAddress } from '@suite-common/wallet-types';
-import { Box, Button, Card, CardDivider, HStack, Text, VStack } from '@suite-native/atoms';
-import { Icon } from '@suite-native/icons';
+import { Button, Card, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useYieldDetailNavigation, useYieldFlowData } from '@suite-native/module-earn';
 
@@ -23,7 +22,7 @@ export const YieldVaultBanner = ({ accountKey, tokenContract }: YieldVaultBanner
 
     const { navigateToYieldDetail } = useYieldDetailNavigation();
 
-    const onGoToVaultPress = useCallback(() => {
+    const handleManagePositionPress = useCallback(() => {
         if (!account || !vault) {
             return;
         }
@@ -40,42 +39,28 @@ export const YieldVaultBanner = ({ accountKey, tokenContract }: YieldVaultBanner
         });
     }, [account, vault, navigateToYieldDetail]);
 
-    if (resolutionStatus !== 'resolved' || !vault?.outputToken?.name) return null;
+    if (resolutionStatus !== 'resolved') return null;
 
     return (
-        <Box marginHorizontal="sp16">
-            <Card>
-                <VStack spacing="sp16">
-                    <HStack spacing="sp10">
-                        <Icon name="info" size="mediumLarge" />
-                        <Box flex={1}>
-                            <Text variant="body-sm-strong">
-                                <Translation id="moduleAccounts.accountDetail.stablecoinYield.defiYieldInfoText" />
-                            </Text>
-                        </Box>
-                    </HStack>
+        <VStack marginHorizontal="sp16" spacing="sp16">
+            <Text variant="headline-sm">
+                <Translation id="earn.defiYield" />
+            </Text>
 
-                    <CardDivider />
-
-                    <HStack justifyContent="space-between" alignItems="center">
-                        <Text variant="body-sm" color="contentSecondary">
-                            <Translation id="moduleAccounts.accountDetail.stablecoinYield.vault" />
-                        </Text>
-                        <Text variant="body-sm">{vault.outputToken?.name ?? ''}</Text>
-                    </HStack>
-
-                    <CardDivider />
-
-                    <Button
-                        intent="brand"
-                        priority="secondary"
-                        size="medium"
-                        onPress={onGoToVaultPress}
-                    >
-                        <Translation id="earn.goToVault" />
-                    </Button>
-                </VStack>
+            <Card noShadow>
+                <Text variant="body-md">
+                    <Translation id="moduleAccounts.accountDetail.stablecoinYield.defiYieldInfoText" />
+                </Text>
             </Card>
-        </Box>
+
+            <Button
+                intent="brand"
+                priority="secondary"
+                size="medium"
+                onPress={handleManagePositionPress}
+            >
+                <Translation id="moduleAccounts.accountDetail.stablecoinYield.managePosition" />
+            </Button>
+        </VStack>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Redesigns the Morpho yield token section, moves it below Asset price, updates its copy and replaces the “Go to vault” CTA with “Manage position” while preserving navigation to the vault detail.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #31702

## Screenshots:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-27 at 14 08 35" src="https://github.com/user-attachments/assets/cd84d444-ed86-406b-ba31-af3006aef1ac" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/yield-vault-section&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->