### PR TITLE
fix(trading): don't require token approval for non-EVM DEX swaps

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
@@ -9,9 +9,8 @@ import {
     type TradingAssetSellOption,
     type TradingExchangeFormProps,
     type TradingExchangeFormType,
-    cryptoIdToNetwork,
     getDexEstimationData,
-    isSendingEvmNativeToken,
+    requiresErc20Approval,
 } from '@suite-common/trading';
 import { isAccountBasedNetwork } from '@suite-common/wallet-config';
 import { ETHEREUM_ADJUST_GAS_LIMIT, updateFeeInfoThunk } from '@suite-common/wallet-core';
@@ -99,11 +98,7 @@ export const useExchangeDexQuote = ({
             return;
         }
 
-        const sendNetwork = cryptoIdToNetwork(sendCryptoSelect.id);
-        const isEvmNativeToken = isSendingEvmNativeToken(sendCryptoSelect.id);
-        const requiresApproval = sendNetwork?.networkType === 'ethereum' && !isEvmNativeToken;
-
-        const quote = requiresApproval ? selectedQuote : dexQuotes[0];
+        const quote = requiresErc20Approval(sendCryptoSelect.id) ? selectedQuote : dexQuotes[0];
 
         if (!quote?.dexTx) {
             setValue('transactionData', '');

--- a/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.test.ts
@@ -14,6 +14,8 @@ import { exchangeThunks } from './index';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
+const USDT_CRYPTO_ID = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
+
 describe('selectExchangeQuoteThunk', () => {
     afterEach(() => {
         jest.clearAllMocks();
@@ -165,9 +167,14 @@ describe('selectExchangeQuoteThunk', () => {
         expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(dexQuote);
     });
 
-    it('should not save DEX quote with other statuses but still call nextStep', async () => {
+    it('should not save an ERC-20 DEX quote with other statuses but still call nextStep', async () => {
         const { quote, state } = getDataMocks();
-        const dexQuote = { ...quote, isDex: true, status: 'APPROVAL_REQ' as const };
+        const dexQuote = {
+            ...quote,
+            isDex: true,
+            send: USDT_CRYPTO_ID,
+            status: 'APPROVAL_REQ' as const,
+        };
         const { store, mockNextStep } = getMocks(state, { status: 'running' });
 
         await store

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.test.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.test.ts
@@ -9,12 +9,44 @@ import {
     getDisplayComposedLevels,
     getDisplayNetworkFee,
     hasEip712SignDataType,
+    requiresErc20Approval,
     requiresTokenApproval,
     tokenSupportsIncreasingAllowance,
 } from './exchangeUtils';
 
 const USDT_CRYPTO_ID = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
 const DAI_CRYPTO_ID = 'ethereum--0x6b175474e89094c44da98b954eedeac495271d0f' as CryptoId;
+const USDT_SOLANA_CRYPTO_ID = 'solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB' as CryptoId;
+const USDC_BASE_CRYPTO_ID = 'base--0x833589fcd6edb6e08f4c7c32d4f71b54bda02913' as CryptoId;
+
+describe('requiresErc20Approval', () => {
+    it('should return false when no crypto id is provided', () => {
+        expect(requiresErc20Approval(undefined)).toBe(false);
+    });
+
+    it('should return true for an ERC-20 token', () => {
+        expect(requiresErc20Approval(USDT_CRYPTO_ID)).toBe(true);
+    });
+
+    it('should return true for a token on another EVM network', () => {
+        expect(requiresErc20Approval(USDC_BASE_CRYPTO_ID)).toBe(true);
+    });
+
+    it('should return false for a native EVM coin', () => {
+        expect(requiresErc20Approval('ethereum' as CryptoId)).toBe(false);
+    });
+
+    it('should return false for a native EVM coin addressed by the zero contract', () => {
+        expect(
+            requiresErc20Approval('base--0x0000000000000000000000000000000000000000' as CryptoId),
+        ).toBe(false);
+    });
+
+    it('should return false for a non-EVM network, both native and token', () => {
+        expect(requiresErc20Approval('solana' as CryptoId)).toBe(false);
+        expect(requiresErc20Approval(USDT_SOLANA_CRYPTO_ID)).toBe(false);
+    });
+});
 
 describe('requiresTokenApproval', () => {
     it('should return false when no quote is provided', () => {
@@ -46,6 +78,26 @@ describe('requiresTokenApproval', () => {
         const quote = {
             orderId: 'test-order',
             isDex: true,
+        };
+        const result = requiresTokenApproval(quote);
+        expect(result).toBe(false);
+    });
+
+    it('should return false when sending native SOL', () => {
+        const quote = {
+            orderId: 'test-order',
+            isDex: true,
+            send: 'solana' as CryptoId,
+        };
+        const result = requiresTokenApproval(quote);
+        expect(result).toBe(false);
+    });
+
+    it('should return false when sending an SPL token', () => {
+        const quote = {
+            orderId: 'test-order',
+            isDex: true,
+            send: USDT_SOLANA_CRYPTO_ID,
         };
         const result = requiresTokenApproval(quote);
         expect(result).toBe(false);

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -20,18 +20,24 @@ type GetAmountLimitsProps = {
     currency: string;
 };
 
-export const isSendingEvmNativeToken = (cryptoId?: CryptoId) => {
+const isEvmCryptoId = (cryptoId?: CryptoId) =>
+    cryptoIdToNetwork(cryptoId)?.networkType === 'ethereum';
+
+const isNativeCryptoId = (cryptoId?: CryptoId) => {
     if (!cryptoId) {
         return false;
     }
 
-    const isEvmNetwork = cryptoIdToNetwork(cryptoId)?.networkType === 'ethereum';
     const { contractAddress } = parseCryptoId(cryptoId);
 
-    return (
-        isEvmNetwork && (!contractAddress || contractAddress === CONTRACT_ADDRESS_FOR_NATIVE_TOKEN)
-    );
+    return !contractAddress || contractAddress === CONTRACT_ADDRESS_FOR_NATIVE_TOKEN;
 };
+
+export const isSendingEvmNativeToken = (cryptoId?: CryptoId) =>
+    isEvmCryptoId(cryptoId) && isNativeCryptoId(cryptoId);
+
+export const requiresErc20Approval = (cryptoId?: CryptoId) =>
+    isEvmCryptoId(cryptoId) && !isNativeCryptoId(cryptoId);
 
 // loop through quotes and if all quotes are either with error below minimum or over maximum, return error message
 const getAmountLimits = ({
@@ -119,11 +125,7 @@ export const hasEip712SignData = (quote?: ExchangeTrade) =>
     quote?.status === 'SIGN_DATA' && hasEip712SignDataType(quote);
 
 export const requiresTokenApproval = (quote?: ExchangeTrade): boolean =>
-    !!quote &&
-    !!quote.isDex &&
-    !!quote.send &&
-    !isSendingEvmNativeToken(quote.send) &&
-    !hasEip712SignData(quote);
+    !!quote?.isDex && requiresErc20Approval(quote.send) && !hasEip712SignData(quote);
 
 export const getDisplayNetworkFee = (
     quote: ExchangeTrade | undefined,


### PR DESCRIPTION
## Description

- `requiresTokenApproval` returned `true` for every DEX quote whose send asset is not an EVM native coin — including Solana, where allowances don't exist. Solana swaps rendered the approval step with a *Revoke approval* button.
- The predicate now asks *is the send asset an ERC-20 token?* instead of *is it not an EVM native coin?*
- Fixes mobile too — `requiresTokenApproval` is shared with suite-native.

## Notes for QA

Testable on the staging trade api.

- Solana swap DEX: approval step and *Revoke approval* button gone, offer goes straight to preview.
- ERC-20 swap (e.g. USDT on Ethereum): approve / increase / revoke unchanged.
- The `Amount 0 SOL` half of the issue is **not** fixed here — the trade api returns `dexTx.value: "0"` for Solana. Separate ticket.

## Related Issue

Partially resolves #31449

## Screenshots:
<img width="1114" height="845" alt="image" src="https://github.com/user-attachments/assets/3d5ece51-df33-4de4-9ac6-19b2bcda5088" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set centers on DEX quote handling and exchange quote selection utilities. The highest regression risk is in DEX swap flows and swap form quote selection. I recommend running the two LI.FI DEX tests and the swap-inputs test unconditionally, plus a small set of broader swap flow tests for quote-to-confirmation coverage. Live swap tests are omitted because the changes affect shared quote logic rather than live provider integrations.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts`
- `suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.test.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.test.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — This test directly exercises the LI.FI DEX approval flow, including quote selection, approval modal details, and fee handling. Changes to useExchangeDexQuote and exchangeUtils could alter how DEX quotes are computed, selected, or displayed, making this a critical regression check.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This is the core DEX swap end-to-end test covering offer selection, slippage, minimum received amounts, and transaction composition for a LI.FI DEX swap. It directly depends on the DEX quote hook and exchange utility logic being changed.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test validates swap form quote sync, best offer display, provider selection, and fee calculation without requiring a live trade. It is the fastest way to catch regressions in quote selection and provider presentation logic touched by the changed files.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — This test walks through the full swap flow from quote selection to broadcast and status updates. It shares the quote selection and transaction composition path with the DEX code and provides confidence that quote-to-confirmation behavior remains intact.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — The test verifies that selecting the best swap offer composes the transaction correctly with custom Ethereum fees. Changes in exchange quote utilities or quote selection thunks could affect how composedTransactionInfo is populated after selecting an offer.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test covers quote/provider display and the receive account picker in a swap scenario involving a disabled network. It exercises the quote section rendering path that relies on exchange utilities and quote selection state.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.test.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.test.ts`

_Updated: 2026-08-27T12:24:27.178Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31449-solana-dex-approval/web/](https://dev.suite.sldev.cz/suite-web/fix/31449-solana-dex-approval/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31449-solana-dex-approval&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31449-solana-dex-approval&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T12:26:54.659Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T12:26:47.536Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->