### PR TITLE
fix(analytics): report the signature format only where it was chosen

### DIFF
--- a/suite/analytics/src/events/coinSignMessageEvent.ts
+++ b/suite/analytics/src/events/coinSignMessageEvent.ts
@@ -7,7 +7,7 @@ type Attributes = {
     error?: AttributeDef<string>;
     symbol: AttributeDef<string>;
     hex: AttributeDef<boolean>;
-    signatureFormat: AttributeDef<'trezor' | 'electrum'>;
+    signatureFormat?: AttributeDef<'trezor' | 'electrum'>;
 };
 
 export const coinSignMessageEvent: EventDef<Attributes, EventType.CoinSignMessage> = {
@@ -38,7 +38,7 @@ export const coinSignMessageEvent: EventDef<Attributes, EventType.CoinSignMessag
         },
         signatureFormat: {
             description:
-                'The selected signature format: `electrum` when the Electrum-compatible format was chosen, `trezor` otherwise. The choice is offered on Bitcoin-like networks only, so every other `symbol` always reports `trezor` — filter by `symbol` before reading the split',
+                'The selected signature format: `electrum` when the Electrum-compatible format was chosen, `trezor` otherwise. Sent only by accounts that are offered the choice: non-legacy accounts of Bitcoin-like networks that have more than the `normal` account type, such as `btc` and `ltc`. Left out by legacy accounts, by single-account-type coins like `bch`, `doge` and `zec`, and by networks signing in one format such as `eth` and `ada`',
             changelog: [{ version: '26.9.0', notes: 'added' }],
         },
     },

--- a/suite/sign-verify/src/SignVerifyForm.tsx
+++ b/suite/sign-verify/src/SignVerifyForm.tsx
@@ -15,6 +15,7 @@ import { SignVerifyPubKeyField } from './SignVerifyPubKeyField';
 import { SignVerifySignatureField } from './SignVerifySignatureField';
 import { SignVerifyTabs } from './SignVerifyTabs';
 import { isVerifySupported, sign, verify } from './signVerifyActions';
+import { getHasSelectableSignatureFormat } from './signVerifyUtils';
 import { type SignVerifyOutcome, type SignVerifyPage } from './types';
 import { useSignVerifyCopyValue } from './useSignVerifyCopyValue';
 import { type SignVerifyFields, useSignVerifyForm } from './useSignVerifyForm';
@@ -103,11 +104,7 @@ export const SignVerifyForm = ({ account, network, page, onPageChange }: SignVer
         }
     };
 
-    // Empty accountTypes means there is only 'normal' accountType and therefore the signatures are same.
-    const signFormatsDiffer =
-        account.networkType === 'bitcoin' &&
-        account.accountType !== 'legacy' &&
-        Object.keys(network?.accountTypes ?? {}).length >= 1;
+    const signFormatsDiffer = getHasSelectableSignatureFormat(account);
     const canVerify = isVerifySupported(account);
     const isCardano = network?.networkType === 'cardano';
 

--- a/suite/sign-verify/src/signVerifyActions.test.ts
+++ b/suite/sign-verify/src/signVerifyActions.test.ts
@@ -15,6 +15,11 @@ const ADDRESS = 'ADDRESS';
 const MESSAGE = 'MESSAGE';
 const SIGNATURE = 'SIGNATURE';
 const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
+const LEGACY_ACCOUNT = mockWalletAccount({
+    symbol: asNetworkSymbol('btc'),
+    accountType: 'legacy',
+});
+const ETHEREUM_ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('eth') });
 
 const CONNECTED_DEVICE = mockSuiteDevice({ connected: true, available: true });
 
@@ -142,6 +147,23 @@ describe('Sign/Verify actions', () => {
                     hex: true,
                     signatureFormat: 'electrum',
                 },
+            });
+        });
+
+        it.each([
+            ['an account signing in a single format', ETHEREUM_ACCOUNT],
+            ['an account not offered the choice', LEGACY_ACCOUNT],
+        ])('leaves the signature format out for %s', async (_name, account) => {
+            testMocks.setTrezorConnectFixtures({
+                success: true,
+                payload: { address: ADDRESS, signature: SIGNATURE },
+            });
+
+            await sign(account, PATH, MESSAGE)(dispatch, getState, deps);
+
+            expect(deps.services.analytics.report).toHaveBeenCalledWith({
+                type: events.coinSignMessageEvent.name,
+                payload: { status: 'success', symbol: account.symbol, hex: false },
             });
         });
 

--- a/suite/sign-verify/src/signVerifyActions.ts
+++ b/suite/sign-verify/src/signVerifyActions.ts
@@ -20,6 +20,7 @@ import { type ErrorCode, type SerializedError } from '@trezor/connect-common/src
 import { type Result } from '@trezor/type-utils';
 
 import * as SIGN_VERIFY from './signVerifyConstants';
+import { getHasSelectableSignatureFormat } from './signVerifyUtils';
 
 export type SignVerifyRootState = DeviceRootState & WalletSettingsRootState;
 
@@ -235,7 +236,11 @@ export const sign =
     ) =>
     async (dispatch: Dispatch, getState: () => SignThunkState, extra: SignThunkDeps) => {
         const { analytics } = extra.services;
-        const signatureFormat = isElectrum ? 'electrum' : 'trezor';
+        // Networks signing in a single format never offered the choice, so reporting one of its
+        // values would invent an answer the user never gave.
+        const formatAttributes = getHasSelectableSignatureFormat(account)
+            ? { signatureFormat: isElectrum ? ('electrum' as const) : ('trezor' as const) }
+            : {};
 
         try {
             const stateParams = await getStateParams(account, getState);
@@ -254,7 +259,7 @@ export const sign =
                         ...getFailureAttributes(response.error),
                         symbol: account.symbol,
                         hex,
-                        signatureFormat,
+                        ...formatAttributes,
                     },
                 });
 
@@ -263,7 +268,7 @@ export const sign =
 
             analytics.report({
                 type: events.coinSignMessageEvent.name,
-                payload: { status: 'success', symbol: account.symbol, hex, signatureFormat },
+                payload: { status: 'success', symbol: account.symbol, hex, ...formatAttributes },
             });
 
             return onSignSuccess(dispatch)(response.payload);
@@ -275,7 +280,7 @@ export const sign =
                     error: asError(error).message,
                     symbol: account.symbol,
                     hex,
-                    signatureFormat,
+                    ...formatAttributes,
                 },
             });
 

--- a/suite/sign-verify/src/signVerifyUtils.ts
+++ b/suite/sign-verify/src/signVerifyUtils.ts
@@ -1,0 +1,12 @@
+import { getNetwork } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+
+/**
+ * Only Bitcoin-like accounts sign in two formats, so they are the only ones where the user picks
+ * one. Empty accountTypes means the network has the 'normal' account type alone and both formats
+ * produce the same signature.
+ */
+export const getHasSelectableSignatureFormat = (account: Account): boolean =>
+    account.networkType === 'bitcoin' &&
+    account.accountType !== 'legacy' &&
+    Object.keys(getNetwork(account.symbol).accountTypes).length >= 1;


### PR DESCRIPTION
## Description

`coin/sign-message` computed its format as `isElectrum ? 'electrum' : 'trezor'`, so every network that signs in a single format reported `trezor` — making Ethereum and Cardano look like a deliberate choice of the Trezor format, which they never offer. The attribute is now sent only when the account is offered the switch, and omitted otherwise (omitted, not empty: the uploader encodes a present-but-undefined value as an empty string, so the key has to be absent from the payload).

The rule for who is offered the choice lived inline in `SignVerifyForm`. It moves to `getHasSelectableSignatureFormat`, used both by the switch and by the analytics, so the two cannot drift apart. The attribute is optional in the event definition now, and its description names the accounts that send it: non-legacy accounts of Bitcoin-like networks with more than the `normal` account type (`btc`, `ltc`). Left out by legacy accounts, by single-account-type coins (`bch`, `doge`, `zec` — they never show the switch either) and by single-format networks (`eth`, `ada`).

No changelog entry was added: the attribute shipped in 26.9.0, which is still the in-development version (latest release is 26.8.2), so this corrects it before it goes out rather than changing a released contract.

## Notes for QA

Analytics only — no visible change in the app. With analytics enabled and the network tab open on the Sign & verify screen:

- **BTC or LTC, non-legacy** — signing sends `signatureFormat=trezor` or `electrum`, matching the switch.
- **BTC legacy account** — the switch is not shown, so no `signatureFormat` in the request.
- **BCH, DOGE, ZEC** — no switch, so no `signatureFormat`.
- **ETH, ADA** — no `signatureFormat` in the request (previously `trezor`).
- The other attributes (`status`, `error`, `symbol`, `hex`) and `coin/verify-message` are unchanged, and nothing about the message, address or signature is reported.

## Related Issue

Resolve #31805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are tightly scoped to the wallet Sign & Verify feature (form UI, actions, utilities) and a related analytics event. The highest-confidence E2E coverage comes from the Bitcoin and Ethereum Sign & Verify tests, which exercise the full user flow. No other E2E tests directly touch this surface, so a targeted two-test run is sufficient.

<details><summary><b>Changed files (5)</b></summary>

- `suite/analytics/src/events/coinSignMessageEvent.ts`
- `suite/sign-verify/src/SignVerifyForm.tsx`
- `suite/sign-verify/src/signVerifyActions.test.ts`
- `suite/sign-verify/src/signVerifyActions.ts`
- `suite/sign-verify/src/signVerifyUtils.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Directly exercises the Ethereum Sign & Verify feature end-to-end, including the SignVerifyForm UI, signVerifyActions, and signVerifyUtils. A regression in message signing, verification, or form handling would be immediately user-visible here.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Directly exercises the Bitcoin Sign & Verify feature end-to-end, covering standard and Electrum signature formats, the SignVerifyForm, and the underlying actions/utilities. This is the primary regression surface for the changed code.

</details>

_Updated: 2026-08-31T13:47:13.449Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31805-sign-message-analytics-format/web/](https://dev.suite.sldev.cz/suite-web/fix/31805-sign-message-analytics-format/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31805-sign-message-analytics-format&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31805-sign-message-analytics-format&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T13:49:05.955Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T13:47:54.339Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->