### PR TITLE
test(e2e): add tests for new activity tab

### DIFF
--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx
@@ -24,10 +24,15 @@ export const NotificationGroup = ({
 
     if (unseenCount === 0 && seenCount === 0) {
         return (
-            <Column alignItems="center" gap={16} padding={{ vertical: 64 }}>
+            <Column
+                alignItems="center"
+                gap={16}
+                padding={{ vertical: 64 }}
+                data-testid="@activity/empty"
+            >
                 <IconCircle icon={BellZIcon} size={112} intent="info" />
                 <Column alignItems="center" gap={4}>
-                    <H2>
+                    <H2 data-testid="@activity/empty/title">
                         <Translation id={emptyTitle} />
                     </H2>
                     <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
@@ -39,9 +44,9 @@ export const NotificationGroup = ({
     }
 
     return (
-        <Column gap={24}>
+        <Column gap={24} data-testid="@activity/list">
             {unseenCount > 0 && (
-                <Column gap={12}>
+                <Column gap={12} data-testid="@activity/list/unseen">
                     <H4>
                         <Translation
                             id="NOTIFICATIONS_UNSEEN_TITLE"
@@ -53,7 +58,7 @@ export const NotificationGroup = ({
             )}
 
             {seenCount > 0 && (
-                <Column gap={12}>
+                <Column gap={12} data-testid="@activity/list/seen">
                     <H4>
                         <Translation id="NOTIFICATIONS_SEEN_TITLE" />
                     </H4>

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView.tsx
@@ -42,7 +42,7 @@ export const NotificationView = ({
     action: actionProp,
     icon,
     variant,
-    notification: { seen, id },
+    notification: { seen, id, type },
 }: NotificationViewProps) => {
     const { isBelowTablet } = useLayoutSize();
     const defaultIcon = icon ?? getNotificationIcon(variant);
@@ -55,7 +55,7 @@ export const NotificationView = ({
     const action = Array.isArray(actionProp) ? actionProp[0] : actionProp;
 
     return (
-        <Row gap={12}>
+        <Row gap={12} data-testid={`@activity/list/item/${type}`}>
             {defaultIcon &&
                 (typeof defaultIcon === 'function' ? (
                     <Icon size={20} as={defaultIcon} {...colorProps} />

--- a/packages/suite/src/components/suite/notifications/TriggerActivityNotification/TriggerActivityNotification.tsx
+++ b/packages/suite/src/components/suite/notifications/TriggerActivityNotification/TriggerActivityNotification.tsx
@@ -196,15 +196,21 @@ export const TriggerActivityNotification = () => {
                         value={selectedOption}
                         options={options}
                         onChange={(option: { value: string }) => setSelectedValue(option.value)}
+                        data-testid="@activity/debug/preset-select"
                     />
                     <Checkbox
                         isChecked={addAsUnseen}
                         labelAlignment="end"
                         onChange={() => setAddAsUnseen(prev => !prev)}
+                        data-testid="@activity/debug/unseen-checkbox"
                     >
                         <TextColumn description="Add as unseen (new)" />
                     </Checkbox>
-                    <ActionButton intent="brand" onClick={handleAdd}>
+                    <ActionButton
+                        intent="brand"
+                        onClick={handleAdd}
+                        data-testid="@activity/debug/add-button"
+                    >
                         Add activity
                     </ActionButton>
                 </Column>

--- a/packages/suite/src/views/suite/notifications/index.tsx
+++ b/packages/suite/src/views/suite/notifications/index.tsx
@@ -38,20 +38,30 @@ const NotificationsView = () => {
             title: (
                 <Row gap={4} alignItems="center">
                     <Translation id="NOTIFICATIONS_IMPORTANT_TITLE" />
-                    {hasUnseenNotifications && <Dot isAnimated intent="critical" size={8} />}
+                    {hasUnseenNotifications && (
+                        <Dot
+                            isAnimated
+                            intent="critical"
+                            size={8}
+                            data-testid="@notifications/menu/unseen-dot"
+                        />
+                    )}
                 </Row>
             ),
             callback: () => setSelectedTab('transactions'),
+            'data-testid': '@notifications/menu/transactions',
         },
         {
             id: 'all',
             title: <Translation id="NOTIFICATIONS_SYSTEM_TITLE" />,
             callback: () => setSelectedTab('all'),
+            'data-testid': '@notifications/menu/all',
         },
         {
             id: 'release-notes',
             title: <Translation id="TR_RELEASE_NOTES" />,
             callback: () => setSelectedTab('release-notes'),
+            'data-testid': '@notifications/menu/release-notes',
         },
     ];
 
@@ -87,6 +97,7 @@ const NotificationsView = () => {
 
             {isDebugModeActive && (
                 <CollapsibleBox
+                    data-testid="@activity/debug/box"
                     heading={
                         <Row gap={8}>
                             Debug activity

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -12,6 +12,7 @@ import { SolanaStakingMock } from './mocks/solanaStakingMock';
 import { TradingMockNew } from './mocks/trading/tradingMockNew';
 import { TradingMock } from './mocks/tradingMock';
 import { YieldMock } from './mocks/yieldMock';
+import { ActivityPage } from './pageObjects/activityPage';
 import { AnalyticsSection } from './pageObjects/analyticsSection';
 import { AssetsSection } from './pageObjects/assetsSection';
 import { ConnectPermissionsModal } from './pageObjects/connectPermissionsModal';
@@ -39,6 +40,7 @@ import { suiteBaseTest } from './testExtends/suiteBaseFixture';
 import { TradingStoreFixture } from './tradingStore';
 
 type Fixtures = {
+    activityPage: ActivityPage;
     dashboardPage: DashboardPage;
     settingsPage: SettingsPage;
     guidePanel: GuidePanel;
@@ -86,6 +88,9 @@ type Fixtures = {
 };
 
 const test = suiteBaseTest.extend<Fixtures>({
+    activityPage: async ({ page }, use) => {
+        await use(new ActivityPage(page));
+    },
     dashboardPage: async ({ page, device, devicePrompt }, use) => {
         await use(new DashboardPage(page, device, devicePrompt));
     },

--- a/suite/e2e/support/pageObjects/activityPage.ts
+++ b/suite/e2e/support/pageObjects/activityPage.ts
@@ -1,0 +1,90 @@
+import { Locator, Page } from '@playwright/test';
+
+import { step } from '../common';
+import { expect } from '../testExtends/customMatchers';
+
+export type ActivityTab = 'transactions' | 'all' | 'release-notes';
+
+export type ToastActivityPreset =
+    'tx-sent' | 'settings-applied' | 'device-wiped' | 'pin-changed' | 'backup-success';
+
+export type EventActivityPreset = 'tx-received' | 'tx-confirmed';
+
+export type ActivityPreset = ToastActivityPreset | EventActivityPreset;
+
+export class ActivityPage {
+    readonly activityMenuButton: Locator;
+    readonly tabNavigation: Locator;
+    readonly tabItem = (tab: ActivityTab): Locator =>
+        this.page.getByTestId(`@notifications/menu/${tab}`);
+    readonly unseenIndicator: Locator;
+    readonly list: Locator;
+    readonly unseenSection: Locator;
+    readonly seenSection: Locator;
+    readonly listItem = (preset: ActivityPreset): Locator =>
+        this.page.getByTestId(`@activity/list/item/${preset}`);
+    readonly unseenItem = (preset: ActivityPreset): Locator =>
+        this.unseenSection.getByTestId(`@activity/list/item/${preset}`);
+    readonly seenItem = (preset: ActivityPreset): Locator =>
+        this.seenSection.getByTestId(`@activity/list/item/${preset}`);
+    readonly emptyState: Locator;
+    readonly emptyStateTitle: Locator;
+    readonly debugBox: Locator;
+    readonly debugPresetSelect: Locator;
+    readonly debugPresetOption = (preset: ActivityPreset): Locator =>
+        this.page.getByTestId(`@activity/debug/preset-select/option/${preset}`);
+    readonly debugUnseenCheckbox: Locator;
+    readonly debugUnseenCheckboxInput: Locator;
+    readonly debugAddButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.activityMenuButton = this.page.getByTestId('@suite/menu/notifications');
+        this.tabNavigation = this.page.getByTestId('@notifications/menu');
+        this.unseenIndicator = this.page.getByTestId('@notifications/menu/unseen-dot');
+        this.list = this.page.getByTestId('@activity/list');
+        this.unseenSection = this.page.getByTestId('@activity/list/unseen');
+        this.seenSection = this.page.getByTestId('@activity/list/seen');
+        this.emptyState = this.page.getByTestId('@activity/empty');
+        this.emptyStateTitle = this.page.getByTestId('@activity/empty/title');
+        this.debugBox = this.page.getByTestId('@activity/debug/box');
+        this.debugPresetSelect = this.page.getByTestId('@activity/debug/preset-select/input');
+        this.debugUnseenCheckbox = this.page.getByTestId('@activity/debug/unseen-checkbox');
+        this.debugUnseenCheckboxInput = this.debugUnseenCheckbox.locator('input');
+        this.debugAddButton = this.page.getByTestId('@activity/debug/add-button');
+    }
+
+    @step()
+    async navigateTo() {
+        await this.activityMenuButton.click();
+        await expect(this.tabNavigation).toBeVisible();
+    }
+
+    @step()
+    async selectTab(tab: ActivityTab) {
+        await this.tabItem(tab).click();
+    }
+
+    @step()
+    async expandDebugSection() {
+        if (await this.debugAddButton.isVisible()) return;
+
+        await this.debugBox.click();
+        await expect(this.debugAddButton).toBeVisible();
+    }
+
+    @step()
+    async triggerActivity(preset: ActivityPreset, options: { unseen: boolean }) {
+        await this.expandDebugSection();
+        await this.page.selectDropdownOptionWithRetry(
+            this.debugPresetSelect,
+            this.debugPresetOption(preset),
+        );
+
+        if ((await this.debugUnseenCheckboxInput.isChecked()) !== options.unseen) {
+            await this.debugUnseenCheckbox.click();
+        }
+        await expect(this.debugUnseenCheckboxInput).toBeChecked({ checked: options.unseen });
+
+        await this.debugAddButton.click();
+    }
+}

--- a/suite/e2e/support/pageObjects/toastSection.ts
+++ b/suite/e2e/support/pageObjects/toastSection.ts
@@ -1,13 +1,26 @@
 import { type Locator, type Page } from '@playwright/test';
 
+import { type ActivityPreset, type ToastActivityPreset } from './activityPage';
+import { step } from '../common';
+import { expect } from '../testExtends/customMatchers';
+
 export class ToastSection {
     readonly approved: Locator;
     readonly approvedAmount: Locator;
     readonly yieldDeposit: Locator;
+    readonly toast = (preset: ActivityPreset): Locator => this.page.getByTestId(`@toast/${preset}`);
+    readonly toastCloseButton = (preset: ToastActivityPreset): Locator =>
+        this.page.getByTestId(`@toast/${preset}/close`);
 
     constructor(private readonly page: Page) {
         this.approved = this.page.getByTestId('@toast/tx-approved');
         this.approvedAmount = this.page.getByTestId('@toast/tx-approved/amount');
         this.yieldDeposit = this.page.getByTestId('@toast/tx-yield-deposit');
+    }
+
+    @step()
+    async dismiss(preset: ToastActivityPreset) {
+        await this.toastCloseButton(preset).click();
+        await expect(this.toast(preset)).toBeHidden();
     }
 }

--- a/suite/e2e/tests/activity/activity-page.test.ts
+++ b/suite/e2e/tests/activity/activity-page.test.ts
@@ -1,0 +1,122 @@
+import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../support/fixtures';
+
+test.describe('Activity page', { tag: ['@T3W1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, settingsPage, activityPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('application');
+        await settingsPage.toggleDebugModeInSettings();
+        await activityPage.navigateTo();
+    });
+
+    test(
+        'Transaction notifications land in the Notifications tab and mark it unseen',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that an unseen transaction activity is listed in the Notifications tab and that the tab title shows the unseen indicator.',
+                category: TestCategory.Notifications,
+                priority: TestPriority.High,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ activityPage, toastSection }) => {
+            await test.step('Add an unseen received transaction activity', async () => {
+                await activityPage.triggerActivity('tx-received', { unseen: true });
+            });
+
+            await test.step('Transaction is listed as unseen in the Notifications tab', async () => {
+                await activityPage.selectTab('transactions');
+
+                await expect(activityPage.unseenItem('tx-received')).toBeVisible();
+                await expect(activityPage.unseenIndicator).toBeVisible();
+            });
+
+            // The entry above is rendered, so a toast of the same dispatch would be too.
+            await test.step('Received transaction does not pop a toast', async () => {
+                await expect(toastSection.toast('tx-received')).toBeHidden();
+            });
+        },
+    );
+
+    test(
+        'Non-transaction activity lands in the All activity tab',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that non-transaction activity is listed in the All activity tab only and never leaks into the transaction-only Notifications tab.',
+                category: TestCategory.Notifications,
+                priority: TestPriority.High,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ activityPage, toastSection }) => {
+            await test.step('Add a system activity and catch its toast', async () => {
+                await activityPage.triggerActivity('settings-applied', { unseen: true });
+
+                await expect(toastSection.toast('settings-applied')).toBeVisible();
+                // Toasts stack over the injector's Add button, so dismiss before the next click.
+                await toastSection.dismiss('settings-applied');
+            });
+
+            await test.step('Add a second system activity and catch its toast', async () => {
+                await activityPage.triggerActivity('device-wiped', { unseen: true });
+
+                await expect(toastSection.toast('device-wiped')).toBeVisible();
+                await toastSection.dismiss('device-wiped');
+            });
+
+            await test.step('Both activities are listed in the All activity tab', async () => {
+                await activityPage.selectTab('all');
+
+                await expect(activityPage.listItem('settings-applied')).toBeVisible();
+                await expect(activityPage.listItem('device-wiped')).toBeVisible();
+            });
+
+            await test.step('Neither activity leaks into the Notifications tab', async () => {
+                await activityPage.selectTab('transactions');
+
+                await expect(activityPage.listItem('settings-applied')).toBeHidden();
+                await expect(activityPage.listItem('device-wiped')).toBeHidden();
+            });
+        },
+    );
+
+    test(
+        'Unseen indicator clears after leaving the Activity page and stays cleared',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that transaction activity is marked as seen when the user leaves the Activity page, that the unseen indicator disappears and that it does not come back on a repeated visit.',
+                category: TestCategory.Notifications,
+                priority: TestPriority.High,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ activityPage, dashboardPage }) => {
+            await test.step('Add an unseen received transaction activity', async () => {
+                await activityPage.triggerActivity('tx-received', { unseen: true });
+                await activityPage.selectTab('transactions');
+
+                await expect(activityPage.unseenIndicator).toBeVisible();
+            });
+
+            await test.step('Leaving the Activity page marks the transaction as seen', async () => {
+                await dashboardPage.navigateTo();
+                await activityPage.navigateTo();
+
+                await expect(activityPage.unseenIndicator).toBeHidden();
+                await expect(activityPage.seenItem('tx-received')).toBeVisible();
+            });
+
+            await test.step('Indicator stays cleared on a repeated visit', async () => {
+                await dashboardPage.navigateTo();
+                await activityPage.navigateTo();
+
+                await expect(activityPage.unseenIndicator).toBeHidden();
+                await expect(activityPage.seenItem('tx-received')).toBeVisible();
+            });
+        },
+    );
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added tests covering correct funcionality of the Activity tab. 
All scenarios get their activity from the debug-only `TriggerActivityNotification` injector on
the page, so no backend, blockbook mock or discovery is involved.


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/activity-page-e2e/web/](https://dev.suite.sldev.cz/suite-web/test/activity-page-e2e/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/activity-page-e2e&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/activity-page-e2e&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T12:58:02.808Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T12:58:37.931Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->