### PR TITLE
fix(suite-desktop-core): centralize senderFrame.isDestroyed check to fix sentry errors

### DIFF
--- a/packages/ipc-proxy/src/index.ts
+++ b/packages/ipc-proxy/src/index.ts
@@ -2,4 +2,5 @@ export { exposeIpcProxy } from './proxy-generator';
 export { createIpcProxyHandler } from './proxy-handler';
 export { createIpcProxy } from './proxy';
 export { validateIpcMessage } from './validateIpcMessage';
+export { isSenderFrameDestroyed } from './isSenderFrameDestroyed';
 export type { IpcProxyHandlerOptions } from './proxy-handler';

--- a/packages/ipc-proxy/src/isSenderFrameDestroyed.test.ts
+++ b/packages/ipc-proxy/src/isSenderFrameDestroyed.test.ts
@@ -1,0 +1,23 @@
+import { isSenderFrameDestroyed } from './isSenderFrameDestroyed';
+import type { ElectronIpcMainInvokeEvent } from './types';
+
+const createIpcEvent = (destroyed?: boolean): ElectronIpcMainInvokeEvent => ({
+    senderFrame:
+        destroyed === undefined
+            ? null
+            : { url: 'file:///index.html', isDestroyed: () => destroyed },
+});
+
+describe(isSenderFrameDestroyed.name, () => {
+    it('returns true when senderFrame is missing', () => {
+        expect(isSenderFrameDestroyed({ ipcEvent: createIpcEvent() })).toBe(true);
+    });
+
+    it('returns false when senderFrame exists and is not destroyed', () => {
+        expect(isSenderFrameDestroyed({ ipcEvent: createIpcEvent(false) })).toBe(false);
+    });
+
+    it('returns true when senderFrame exists and is destroyed', () => {
+        expect(isSenderFrameDestroyed({ ipcEvent: createIpcEvent(true) })).toBe(true);
+    });
+});

--- a/packages/ipc-proxy/src/isSenderFrameDestroyed.ts
+++ b/packages/ipc-proxy/src/isSenderFrameDestroyed.ts
@@ -1,0 +1,13 @@
+import type { ElectronIpcMainInvokeEvent } from './types';
+
+type IsSenderFrameDestroyed = { ipcEvent: ElectronIpcMainInvokeEvent };
+
+/**
+ * Check whether the sender frame, which this ipcEvent came from, has been destroyed in the meantime.
+ * That can happen as a race condition when renderer process is closed during responding.
+ * It is by itself harmless, but causes a flood of errors.
+ * https://github.com/electron/electron/blob/3536d49/docs/api/structures/ipc-main-event.md
+ * https://github.com/electron/electron/blob/3536d49/docs/breaking-changes.md#behavior-changed-frame-properties-may-retrieve-detached-webframemain-instances-or-none-at-all
+ */
+export const isSenderFrameDestroyed = ({ ipcEvent }: IsSenderFrameDestroyed) =>
+    !ipcEvent?.senderFrame || ipcEvent.senderFrame.isDestroyed();

--- a/packages/ipc-proxy/src/proxy-handler.ts
+++ b/packages/ipc-proxy/src/proxy-handler.ts
@@ -80,7 +80,7 @@ export const createIpcProxyHandler = <Api extends EventEmitterApi>(
 ) => {
     debug?.info(SERVICE_NAME, `Init ipc interface ${channel}`);
     // Handle creation event from proxy-generator and creates actual interface instance
-    ipcMain.handle(`${channel}/create`, async (ipcEvent, [instancePrefix, constructorParams]) => {
+    ipcMain.handle(`${channel}/create`, async (_, [instancePrefix, constructorParams]) => {
         debug?.info(SERVICE_NAME, `Create ipc chanel ${instancePrefix}`);
         const { onRequest, onAddListener, onRemoveListener } = await onCreateInstance(
             ...constructorParams,
@@ -92,13 +92,6 @@ export const createIpcProxyHandler = <Api extends EventEmitterApi>(
                     debug?.info(SERVICE_NAME, `Adding listener ${realEventName}`);
                     onAddListener(realEventName, (...payload: any[]) => {
                         debug?.info(SERVICE_NAME, `Emit ${realEventName} as ${ipcEventName}`);
-
-                        // prevents 'Render frame was disposed before WebFrameMain could be accessed', occurring when renderer process is closed during responding
-                        // https://github.com/electron/electron/blob/3536d49/docs/api/structures/ipc-main-event.md
-                        // https://github.com/electron/electron/blob/3536d49/docs/breaking-changes.md#behavior-changed-frame-properties-may-retrieve-detached-webframemain-instances-or-none-at-all
-                        if (ipcEvent.senderFrame === null || ipcEvent.senderFrame.isDestroyed())
-                            return;
-
                         reply(ipcEventName, payload);
                     });
                 },

--- a/packages/ipc-proxy/src/validateIpcMessage.test.ts
+++ b/packages/ipc-proxy/src/validateIpcMessage.test.ts
@@ -82,25 +82,17 @@ describe(validateIpcMessage.name, () => {
     });
 
     it('errors for invalid senderFrame', () => {
-        const subject = () => {
-            validateIpcMessage({
-                ipcEvent: {} as ElectronIpcMainInvokeEvent,
-                dirnameProvider: appImageDirnameProvider,
-            });
+        const subjectWithEmptyEvent = () => {
+            validateIpcMessage({ ipcEvent: {} as any, dirnameProvider: appImageDirnameProvider });
+        };
+        const subjectWithEmptySenderFrame = () => {
+            const ipcEvent = createSenderFrame('http://localhost:8000/');
+            delete (ipcEvent.senderFrame as any).url;
+            validateIpcMessage({ ipcEvent, dirnameProvider: appImageDirnameProvider });
         };
 
-        expect(subject).toThrow('Invalid ipcEvent: {}');
-    });
-
-    it('errors when senderFrame has been destroyed', () => {
-        const subject = () => {
-            validateIpcMessage({
-                ipcEvent: createSenderFrame('http://localhost:8000/', true),
-                dirnameProvider: appImageDirnameProvider,
-            });
-        };
-
-        expect(subject).toThrow('ipcEvent.senderFrame is destroyed');
+        expect(subjectWithEmptyEvent).toThrow('Invalid ipcEvent: {}');
+        expect(subjectWithEmptySenderFrame).toThrow('Invalid ipcEvent: {"senderFrame":{}}');
     });
 
     it('errors when in production, you get different protocol to file:', () => {

--- a/packages/ipc-proxy/src/validateIpcMessage.ts
+++ b/packages/ipc-proxy/src/validateIpcMessage.ts
@@ -17,10 +17,6 @@ export const validateIpcMessage = ({
     platformProvider = () => process.platform,
     pathProvider = path,
 }: ValidateIpcMessageParams) => {
-    if (ipcEvent?.senderFrame?.isDestroyed()) {
-        throw new Error('ipcEvent.senderFrame is destroyed');
-    }
-
     if (ipcEvent?.senderFrame && 'url' in ipcEvent.senderFrame) {
         // Example of `ipcEvent.senderFrame.url` is:
         //      'file:///tmp/.mount_Trezorztdoqo/resources/app.asar/build/index.html'

--- a/packages/suite-desktop-core/src/ipcMain.test.ts
+++ b/packages/suite-desktop-core/src/ipcMain.test.ts
@@ -2,7 +2,7 @@ import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ipcMain as electronIpcMain } from 'electron';
 
-import { validateIpcMessage } from '@trezor/ipc-proxy';
+import { isSenderFrameDestroyed, validateIpcMessage } from '@trezor/ipc-proxy';
 
 import { ipcMain } from './ipcMain';
 
@@ -20,103 +20,75 @@ jest.mock('electron', () => ({
 
 jest.mock('@trezor/ipc-proxy', () => ({
     validateIpcMessage: jest.fn(),
+    isSenderFrameDestroyed: jest.fn(),
 }));
 
-describe('typed-electron ipcMain validation', () => {
+const createIpcEvent = (): IpcMainEvent =>
+    ({
+        senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
+    }) as unknown as IpcMainEvent;
+
+const createIpcInvokeEvent = (): IpcMainInvokeEvent =>
+    ({
+        senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
+    }) as unknown as IpcMainInvokeEvent;
+
+describe('ipcMain validation wrapper', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.mocked(isSenderFrameDestroyed).mockReturnValue(false);
     });
 
-    it('validates sender before registering on listeners', () => {
-        const originalListener = jest.fn();
-        const ipcEvent = {
-            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
-        } as unknown as IpcMainEvent;
+    it.each([
+        { methodName: 'on', channel: 'theme/change' },
+        { methodName: 'once', channel: 'theme/change' },
+        // Electron defines 'addListener' as an alias for 'on', but Typescript behaves weirdly.
+        { methodName: 'addListener' as 'on', channel: 'theme/change' },
+    ] as const)(
+        'validates sender before registering $methodName listeners',
+        ({ methodName, channel }) => {
+            const originalListener = jest.fn();
+            const ipcEvent = createIpcEvent();
 
-        ipcMain.on('theme/change', originalListener);
+            ipcMain[methodName](channel, originalListener);
 
-        const wrappedListener = jest.mocked(electronIpcMain.on).mock.calls[0]?.[1];
-        expect(wrappedListener).toBeDefined();
-        if (wrappedListener === undefined) {
-            throw new Error('wrappedListener is undefined');
-        }
-        wrappedListener(ipcEvent, 'dark');
+            const wrappedListener = jest.mocked(electronIpcMain[methodName]).mock.calls[0]?.[1];
+            expect(wrappedListener).toBeDefined();
 
-        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
-        expect(originalListener).toHaveBeenCalledWith(ipcEvent, 'dark');
-    });
+            if (wrappedListener === undefined) {
+                throw new Error('wrappedListener is undefined');
+            }
 
-    it('validates sender before registering once listeners', () => {
-        const originalListener = jest.fn();
-        const ipcEvent = {
-            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
-        } as unknown as IpcMainEvent;
+            wrappedListener(ipcEvent, 'dark');
 
-        ipcMain.once('theme/change', originalListener);
+            expect(isSenderFrameDestroyed).toHaveBeenCalledWith({ ipcEvent });
+            expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
+            expect(originalListener).toHaveBeenCalledWith(ipcEvent, 'dark');
+        },
+    );
 
-        const wrappedListener = jest.mocked(electronIpcMain.once).mock.calls[0]?.[1];
-        expect(wrappedListener).toBeDefined();
-        if (wrappedListener === undefined) {
-            throw new Error('wrappedListener is undefined');
-        }
-        wrappedListener(ipcEvent, 'dark');
+    it.each([
+        { methodName: 'handle', channel: 'app/is-visible' },
+        { methodName: 'handleOnce', channel: 'app/is-visible' },
+    ] as const)(
+        'validates sender before registering $methodName listeners and preserves return values',
+        async ({ methodName, channel }) => {
+            const originalListener = jest.fn().mockResolvedValue('result');
+            const ipcEvent = createIpcInvokeEvent();
 
-        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
-        expect(originalListener).toHaveBeenCalledWith(ipcEvent, 'dark');
-    });
+            ipcMain[methodName](channel, originalListener);
 
-    it('validates sender before registering addListener listeners', () => {
-        const originalListener = jest.fn();
-        const ipcEvent = {
-            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
-        } as unknown as IpcMainEvent;
+            const wrappedListener = jest.mocked(electronIpcMain[methodName]).mock.calls[0]?.[1];
+            expect(wrappedListener).toBeDefined();
 
-        ipcMain.addListener('theme/change', originalListener);
+            if (wrappedListener === undefined) {
+                throw new Error('wrappedListener is undefined');
+            }
 
-        const wrappedListener = jest.mocked(electronIpcMain.addListener).mock.calls[0]?.[1];
-        expect(wrappedListener).toBeDefined();
-        if (wrappedListener === undefined) {
-            throw new Error('wrappedListener is undefined');
-        }
-        wrappedListener(ipcEvent, 'dark');
-
-        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
-        expect(originalListener).toHaveBeenCalledWith(ipcEvent, 'dark');
-    });
-
-    it('validates sender before registering handle listeners and preserves return values', async () => {
-        const originalListener = jest.fn().mockResolvedValue('result');
-        const ipcEvent = {
-            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
-        } as unknown as IpcMainInvokeEvent;
-
-        ipcMain.handle('app/is-visible', originalListener);
-
-        const wrappedListener = jest.mocked(electronIpcMain.handle).mock.calls[0]?.[1];
-        expect(wrappedListener).toBeDefined();
-        if (wrappedListener === undefined) {
-            throw new Error('wrappedListener is undefined');
-        }
-        await expect(wrappedListener(ipcEvent)).resolves.toBe('result');
-        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
-        expect(originalListener).toHaveBeenCalledWith(ipcEvent);
-    });
-
-    it('validates sender before registering handleOnce listeners and preserves return values', async () => {
-        const originalListener = jest.fn().mockResolvedValue('result');
-        const ipcEvent = {
-            senderFrame: { url: 'file:///build/index.html', isDestroyed: () => false },
-        } as unknown as IpcMainInvokeEvent;
-
-        ipcMain.handleOnce('app/is-visible', originalListener);
-
-        const wrappedListener = jest.mocked(electronIpcMain.handleOnce).mock.calls[0]?.[1];
-        expect(wrappedListener).toBeDefined();
-        if (wrappedListener === undefined) {
-            throw new Error('wrappedListener is undefined');
-        }
-        await expect(wrappedListener(ipcEvent)).resolves.toBe('result');
-        expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
-        expect(originalListener).toHaveBeenCalledWith(ipcEvent);
-    });
+            await expect(wrappedListener(ipcEvent)).resolves.toBe('result');
+            expect(isSenderFrameDestroyed).toHaveBeenCalledWith({ ipcEvent });
+            expect(validateIpcMessage).toHaveBeenCalledWith({ ipcEvent });
+            expect(originalListener).toHaveBeenCalledWith(ipcEvent);
+        },
+    );
 });

--- a/packages/suite-desktop-core/src/ipcMain.ts
+++ b/packages/suite-desktop-core/src/ipcMain.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ipcMain as baseIpcMain } from 'electron';
 
-import { validateIpcMessage } from '@trezor/ipc-proxy';
+import { isSenderFrameDestroyed, validateIpcMessage } from '@trezor/ipc-proxy';
 import type * as desktopApi from '@trezor/suite-desktop-api';
 
 export type StrictIpcMain = desktopApi.StrictIpcMain<
@@ -12,7 +12,10 @@ export type StrictIpcMain = desktopApi.StrictIpcMain<
 
 const withValidation = <T extends (...args: any[]) => any>(fn: T): T =>
     ((...args: any[]) => {
-        const [ipcEvent] = args;
+        const ipcEvent: Electron.IpcMainEvent = args[0];
+        // If sender frame was closed, it's harmless, so it'll just silently early-return.
+        if (isSenderFrameDestroyed({ ipcEvent })) return;
+        // Failed security validation throws and stops processing.
         validateIpcMessage({ ipcEvent });
 
         return fn(...args);
@@ -24,6 +27,8 @@ const on: Electron.IpcMain['on'] = (channel, listener) =>
 const once: Electron.IpcMain['once'] = (channel, listener) =>
     baseIpcMain.once(channel, withValidation(listener));
 
+// In Electron, 'addListener' is an alias for 'on': https://github.com/electron/electron/blob/fe4cffac230a21114e645834eab06072f4ea2034/docs/api/ipc-main.md?plain=1#L74-L81
+// Currently unused in suite-desktop-core, but in order to cover the interface completely, the same wrapper is applied.
 const addListener: Electron.IpcMain['addListener'] = (channel, listener) =>
     baseIpcMain.addListener(channel, withValidation(listener));
 

--- a/packages/suite-desktop-core/src/modules/safeStorage.test.ts
+++ b/packages/suite-desktop-core/src/modules/safeStorage.test.ts
@@ -25,6 +25,7 @@ jest.mock('electron', () => ({
 
 jest.mock('@trezor/ipc-proxy', () => ({
     validateIpcMessage: jest.fn(),
+    isSenderFrameDestroyed: jest.fn(),
 }));
 
 const delegatedIdentityKey = '0c9d40cd155e7ddb93e7b3c7b2acd8d75e7a3ebd543a3504c8f8164fb692772b';

--- a/suite/sentry/src/ignoreErrors.ts
+++ b/suite/sentry/src/ignoreErrors.ts
@@ -12,9 +12,6 @@ export const ignoreErrors = [
     /.*The database connection is closing.*/,
     /.*Error: InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase'.*/,
 
-    // Common Electron lifecycle errors
-    /.*Frame property was accessed after it navigated or was destroyed.*/, // Renderer process already closed while main is still responding to its IPC
-
     // nodeJS deprecation errors
     /.*DEP0040.*punycode.*/, // used deep within tech stack, not much we can do about it atm
 


### PR DESCRIPTION
## Description

Followup to #31464. This time it's not about security, but annoying Sentry errors.
When I was attempting to solve `Frame property was accessed after it navigated or was destroyed`,
I gave up and added it to inbound & outbound Sentry filters, because I was at my wits end :see_no_evil: 
But now I believe I finally understand:
- [this check is currently only here](https://github.com/trezor/trezor-suite/blob/3241a4e1964a07bfd3ab8789c8aa00be0c9729c1/packages/ipc-proxy/src/proxy-handler.ts#L95-L100), because at the time, I thought that the IpcProxy was _the_ central point for all IPC handlers
- but IpcProxy is only for Connect, bluetooth and CJ!
- while API declared `@trezor/suite-desktop-api` does **not** use the IpcProxy
- so this check would have worked only if I had placed it at **each and every** callback of ipc.on, ipc.handle etc.
  - (just like `validateIpcMessage` was called at every callback before [#31464](https://github.com/trezor/trezor-suite/pull/31464))

:point_right: Therefore:
- Extract `isSenderFrameDestroyed` helper
- Centralize `isSenderFrameDestroyed`, same as was done with `validateIpcMessage`
- Remove the aforementioned outbound Sentry filter
  - I'll set reminder for myself to remove inbound in a few months :calendar:  
- DRY a repetitive unit test

## Notes for QA

Same QA surface as #31464, so it can be tested together to approve both.

I manually tested some most exposed paths (connecting Safe 7 via BT, discover, turn on tor, discover CJ, connecting any device with USB).

## Related Issue

Resolve again https://github.com/trezor/trezor-suite/issues/20569

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set updates Electron IPC infrastructure (ipc-proxy and suite-desktop-core/src/ipcMain.ts) and Sentry error filtering. The highest risk regressions would appear in desktop-mode cross-process communication, especially bridge lifecycle and TrezorConnect core-mode flows. The recommended tests target those paths: bridge spawning for main-process IPC, silentMode for explicit app/focus IPC behavior, and a small set of connect desktop tests as regression detectors. No E2E tests are known to cover the Sentry file or the changed unit-test files.

<details><summary><b>Changed files (10)</b></summary>

- `packages/ipc-proxy/src/index.ts`
- `packages/ipc-proxy/src/isSenderFrameDestroyed.test.ts`
- `packages/ipc-proxy/src/isSenderFrameDestroyed.ts`
- `packages/ipc-proxy/src/proxy-handler.ts`
- `packages/ipc-proxy/src/validateIpcMessage.test.ts`
- `packages/ipc-proxy/src/validateIpcMessage.ts`
- `packages/suite-desktop-core/src/ipcMain.test.ts`
- `packages/suite-desktop-core/src/ipcMain.ts`
- `packages/suite-desktop-core/src/modules/safeStorage.test.ts`
- `suite/sentry/src/ignoreErrors.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test launches the Electron app in bridge-daemon mode and verifies the bundled bridge process is spawned and remains running via main-process lifecycle logic. Changes to ipcMain.ts and the ipc-proxy message handling directly affect how the main process communicates with and manages the bridge daemon.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Validates that the Electron app spawns and stops the bridge process correctly and reconnects after external bridge restarts. This exercises the main-process IPC bridge registration and process management paths touched by ipcMain.ts and the ipc-proxy layer.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Explicitly tests the app/focus IPC event path and connect permissions persistence in suite-desktop core mode. The test verifies that subsequent TrezorConnect calls do or do not bring Suite to the foreground, which is directly mediated by the IPC proxy and main-process IPC handlers.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Runs TrezorConnect in suite-desktop core mode, which routes address-export requests from the renderer through the main process via the IPC proxy. A regression in IPC message validation or proxy handling would likely surface during the permissions/address-confirmation flow.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Covers remembered Connect permissions and the Connect settings tab in the desktop app. Permission grant/revoke state is synchronized across renderer and main process over IPC, so this test exercises the IPC infrastructure that validates and proxies those messages.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Executes a Bitcoin transaction signing flow through TrezorConnect in suite-desktop core mode. The multi-step device prompts and signing requests cross the renderer/main IPC boundary, making this a representative regression detector for the proxy/IPC changes.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Tests TrezorConnect.init with requestedPermissions in suite-desktop core mode. The upfront permission consent modal and subsequent permission-skipping behavior depend on correct IPC message exchange and state persistence between renderer and main process.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/ipc-proxy/src/isSenderFrameDestroyed.test.ts`
- `packages/ipc-proxy/src/validateIpcMessage.test.ts`
- `packages/suite-desktop-core/src/ipcMain.test.ts`
- `packages/suite-desktop-core/src/modules/safeStorage.test.ts`
- `suite/sentry/src/ignoreErrors.ts`

_Updated: 2026-08-28T20:19:14.940Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/destroyed-sender-frame-sentry-errors/web/](https://dev.suite.sldev.cz/suite-web/fix/destroyed-sender-frame-sentry-errors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/destroyed-sender-frame-sentry-errors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/destroyed-sender-frame-sentry-errors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T20:21:29.929Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T20:21:54.848Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->