### PR TITLE
fix(suite): estimate the DEX fee from the selected quote

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx
@@ -56,6 +56,38 @@ const DEX_QUOTE: ExchangeTrade = {
     },
 };
 
+const DEX_QUOTE_WITHOUT_TRANSACTION: ExchangeTrade = {
+    exchange: 'swapkit',
+    send: 'bitcoin' as CryptoId,
+    receive: 'ethereum' as CryptoId,
+    isDex: true,
+};
+
+const SELECTED_DEX_QUOTE: ExchangeTrade = {
+    exchange: 'lifi',
+    send: 'bitcoin' as CryptoId,
+    receive: 'ethereum' as CryptoId,
+    isDex: true,
+    dexTx: {
+        from: '0xUserAddress',
+        to: '0xSelectedDexRouterAddress',
+        data: '0x0987654321fedcba',
+        value: '1000000000000000000',
+    },
+};
+
+const STALE_OUTPUTS: TradingExchangeFormProps['outputs'] = [
+    {
+        type: 'payment',
+        address: '0xstaleAddress',
+        amount: '0.1',
+        fiat: '',
+        currency: { value: 'usd', label: 'USD' },
+        token: null,
+        label: '',
+    },
+];
+
 const buildDefaults = (
     overrides: Partial<TradingExchangeFormProps> = {},
 ): TradingExchangeFormProps => ({
@@ -97,16 +129,21 @@ const mockComposeRequest = jest.fn();
 
 const renderExchangeDexQuote = ({
     defaultValues,
-    dexQuotes = [],
+    quotes = [],
     isFormLoading = false,
     isLoadingQuote = false,
 }: {
     defaultValues: TradingExchangeFormProps;
-    dexQuotes?: ExchangeTrade[];
+    quotes?: ExchangeTrade[];
     isFormLoading?: boolean;
     isLoadingQuote?: boolean;
 }) => {
-    const store = createTestStore({ extra: undefined });
+    const store = createTestStore({
+        extra: undefined,
+        preloadedState: {
+            wallet: { trading: { exchange: { quotes } } },
+        },
+    });
 
     return renderHookWithStoreProvider(
         () => {
@@ -121,8 +158,6 @@ const renderExchangeDexQuote = ({
                 isLoadingQuote,
                 exchangeType: defaultValues.exchangeType,
                 sendCryptoSelect: defaultValues.sendCryptoSelect,
-                selectedQuote: undefined,
-                dexQuotes,
                 composeRequest: mockComposeRequest,
             });
 
@@ -141,7 +176,7 @@ describe('useExchangeDexQuote', () => {
     it('derives transaction data, receive address and gas limit from the active DEX quote', async () => {
         const { result } = renderExchangeDexQuote({
             defaultValues: buildDefaults({ exchangeType: TRADING_EXCHANGE_FORM_DEX }),
-            dexQuotes: [DEX_QUOTE],
+            quotes: [DEX_QUOTE],
         });
 
         await waitFor(() => {
@@ -153,24 +188,51 @@ describe('useExchangeDexQuote', () => {
         });
     });
 
+    it('derives the transaction from the selected quote, not from the best one', async () => {
+        const { result } = renderExchangeDexQuote({
+            defaultValues: buildDefaults({
+                exchangeType: TRADING_EXCHANGE_FORM_DEX,
+                provider: SELECTED_DEX_QUOTE.exchange,
+            }),
+            quotes: [DEX_QUOTE_WITHOUT_TRANSACTION, SELECTED_DEX_QUOTE],
+        });
+
+        await waitFor(() => {
+            expect(result.current.methods.getValues('outputs.0.address')).toBe(
+                '0xSelectedDexRouterAddress',
+            );
+            expect(result.current.methods.getValues('transactionData')).toBe('0x0987654321fedcba');
+            expect(result.current.methods.getValues('ethereumAdjustGasLimit')).toBeDefined();
+        });
+    });
+
+    it('clears transaction data and receive address when the selected quote has no dexTx', async () => {
+        const { result } = renderExchangeDexQuote({
+            defaultValues: buildDefaults({
+                exchangeType: TRADING_EXCHANGE_FORM_DEX,
+                provider: DEX_QUOTE_WITHOUT_TRANSACTION.exchange,
+                transactionData: '0xstale',
+                outputs: STALE_OUTPUTS,
+            }),
+            quotes: [DEX_QUOTE_WITHOUT_TRANSACTION, SELECTED_DEX_QUOTE],
+        });
+
+        await waitFor(() => {
+            expect(result.current.methods.getValues('transactionData')).toBe('');
+            expect(result.current.methods.getValues('outputs.0.address')).toBe('');
+        });
+
+        expect(result.current.methods.getValues('ethereumAdjustGasLimit')).toBeUndefined();
+    });
+
     it('clears transaction data and receive address for a non-DEX exchange type', async () => {
         const { result } = renderExchangeDexQuote({
             defaultValues: buildDefaults({
                 exchangeType: TRADING_EXCHANGE_FORM_CEX,
                 transactionData: '0xstale',
-                outputs: [
-                    {
-                        type: 'payment',
-                        address: '0xstaleAddress',
-                        amount: '0.1',
-                        fiat: '',
-                        currency: { value: 'usd', label: 'USD' },
-                        token: null,
-                        label: '',
-                    },
-                ],
+                outputs: STALE_OUTPUTS,
             }),
-            dexQuotes: [DEX_QUOTE],
+            quotes: [DEX_QUOTE],
         });
 
         await waitFor(() => {
@@ -195,7 +257,7 @@ describe('useExchangeDexQuote', () => {
                     },
                 ],
             }),
-            dexQuotes: [DEX_QUOTE],
+            quotes: [DEX_QUOTE],
             isFormLoading: true,
         });
 

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
@@ -1,17 +1,16 @@
 import { useCallback, useEffect } from 'react';
 import { type UseFormReturn, useWatch } from 'react-hook-form';
 
-import { type ExchangeTrade } from 'invity-api';
-
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     TRADING_EXCHANGE_FORM_DEX,
     TRADING_FORM_OUTPUT_ADDRESS,
+    TRADING_FORM_PROVIDER_SELECT,
     type TradingAssetSellOption,
     type TradingExchangeFormProps,
     type TradingExchangeFormType,
     getDexEstimationData,
-    requiresErc20Approval,
+    selectTradingExchangeQuoteToEstimate,
 } from '@suite-common/trading';
 import { isAccountBasedNetwork } from '@suite-common/wallet-config';
 import { ETHEREUM_ADJUST_GAS_LIMIT, updateFeeInfoThunk } from '@suite-common/wallet-core';
@@ -19,20 +18,19 @@ import { type Account } from '@suite-common/wallet-types';
 import { getEvmTransactionTextSignature } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
 
+import { useSelector } from 'src/hooks/suite';
 import { type TradingSellExchangeFormProps } from 'src/types/trading/tradingForm';
 import { type SendContextValues } from 'src/types/wallet/sendForm';
 
-interface UseExchangeDexQuoteProps {
+type UseExchangeDexQuoteProps = {
     account: Account | undefined;
     methods: UseFormReturn<TradingExchangeFormProps>;
     isFormLoading: boolean;
     isLoadingQuote: boolean;
     exchangeType: TradingExchangeFormType;
     sendCryptoSelect: TradingAssetSellOption | undefined;
-    selectedQuote: ExchangeTrade | undefined;
-    dexQuotes: ExchangeTrade[];
     composeRequest: SendContextValues<TradingSellExchangeFormProps>['composeTransaction'];
-}
+};
 
 /**
  * DEX-quote machinery for the exchange form: syncs the sender address, derives the
@@ -46,8 +44,6 @@ export const useExchangeDexQuote = ({
     isLoadingQuote,
     exchangeType,
     sendCryptoSelect,
-    selectedQuote,
-    dexQuotes,
     composeRequest,
 }: UseExchangeDexQuoteProps) => {
     const dispatch = useDispatch();
@@ -57,6 +53,15 @@ export const useExchangeDexQuote = ({
         control,
         name: ['transactionData', TRADING_FORM_OUTPUT_ADDRESS, 'ethereumAdjustGasLimit'],
     });
+
+    const provider = useWatch({ control, name: TRADING_FORM_PROVIDER_SELECT });
+    const quote = useSelector(reduxState =>
+        selectTradingExchangeQuoteToEstimate(reduxState, {
+            provider,
+            exchangeType,
+            sendCryptoId: sendCryptoSelect?.id,
+        }),
+    );
 
     const accountRef = useCurrentRef(account);
     const composeRequestRef = useCurrentRef(composeRequest);
@@ -98,8 +103,6 @@ export const useExchangeDexQuote = ({
             return;
         }
 
-        const quote = requiresErc20Approval(sendCryptoSelect.id) ? selectedQuote : dexQuotes[0];
-
         if (!quote?.dexTx) {
             setValue('transactionData', '');
             setValue(TRADING_FORM_OUTPUT_ADDRESS, '');
@@ -112,15 +115,7 @@ export const useExchangeDexQuote = ({
         setValue('transactionData', getDexEstimationData(quote) ?? '');
         setValue(TRADING_FORM_OUTPUT_ADDRESS, dexTx.to);
         setValue('ethereumAdjustGasLimit', ETHEREUM_ADJUST_GAS_LIMIT);
-    }, [
-        dexQuotes,
-        selectedQuote,
-        exchangeType,
-        sendCryptoSelect,
-        isFormLoading,
-        isLoadingQuote,
-        setValue,
-    ]);
+    }, [quote, exchangeType, sendCryptoSelect, isFormLoading, isLoadingQuote, setValue]);
 
     const fetchFeesAndComposeRef = useCurrentRef(fetchFeesAndCompose);
     // Fetch fees when the transaction to estimate changes shape.

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts
@@ -153,7 +153,7 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         },
     });
 
-    const { dexQuotes, isScheduledQuotesRefresh, refreshQuotes } = useExchangeQuotes({
+    const { isScheduledQuotesRefresh, refreshQuotes } = useExchangeQuotes({
         methods,
         network,
         shouldSendInSats,
@@ -197,8 +197,6 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         isLoadingQuote,
         exchangeType,
         sendCryptoSelect,
-        selectedQuote,
-        dexQuotes,
         composeRequest,
     });
 

--- a/suite-common/trading/src/selectors/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.test.ts
@@ -65,6 +65,7 @@ import {
     selectTradingExchangeLastErrorMessage,
     selectTradingExchangeLoadingTimestampAndStatus,
     selectTradingExchangeProviders,
+    selectTradingExchangeQuoteToEstimate,
     selectTradingExchangeQuotes,
     selectTradingExchangeQuotesRequest,
     selectTradingExchangeSelectedQuote,
@@ -116,7 +117,7 @@ import coins from '../__fixtures__/coins.json';
 import platforms from '../__fixtures__/platforms.json';
 import { tradeApiFixtures } from '../__fixtures__/tradeApi';
 import { accountBtc, accountEth } from '../__fixtures__/utils';
-import { TRADING_SLIP24_SUPPORTED_NETWORK_TYPES } from '../constants';
+import { TRADING_EXCHANGE_FORM_DEX, TRADING_SLIP24_SUPPORTED_NETWORK_TYPES } from '../constants';
 import { getProviderMetadataFixture } from '../reducers/__fixtures__/providerMetadata';
 import { type BuyInfo, type TradingBuyState } from '../reducers/buyReducer';
 import { type ExchangeInfo, exchangeInitialState } from '../reducers/exchangeReducer';
@@ -1601,6 +1602,49 @@ describe('tradingSelectors', () => {
             data: { primaryType: 'Order' },
         },
     } as unknown as ExchangeTrade;
+
+    describe(selectTradingExchangeQuoteToEstimate.name, () => {
+        const offer: ExchangeTrade = {
+            exchange: 'lifi',
+            isDex: true,
+            dexTx: { from: '0xUser', to: '0xRouter', data: '0xswap', value: '1' },
+        };
+
+        const createdTrade: ExchangeTrade = {
+            exchange: 'lifi',
+            isDex: true,
+            dexTx: { from: '0xUser', to: '0xToken', data: '0xapproval', value: '0' },
+        };
+
+        const stateWithOfferAndTrade = {
+            wallet: {
+                trading: {
+                    exchange: { quotes: [offer], selectedQuote: createdTrade },
+                },
+            },
+        } as TradingRootState;
+
+        const formValues = { provider: 'lifi', exchangeType: TRADING_EXCHANGE_FORM_DEX } as const;
+
+        it('should return the offer selected in the form for a native send', () => {
+            expect(
+                selectTradingExchangeQuoteToEstimate(stateWithOfferAndTrade, {
+                    ...formValues,
+                    sendCryptoId: 'ethereum' as CryptoId,
+                }),
+            ).toBe(offer);
+        });
+
+        it('should return the created trade for a token send, which is where its approval calldata lives', () => {
+            expect(
+                selectTradingExchangeQuoteToEstimate(stateWithOfferAndTrade, {
+                    ...formValues,
+                    sendCryptoId:
+                        'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+                }),
+            ).toBe(createdTrade);
+        });
+    });
 
     describe(selectTradingDisplayComposedFee.name, () => {
         it.each([

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -84,7 +84,7 @@ import {
     isExchangeProvider,
     testnetToProdCryptoId,
 } from '../utils';
-import { getDisplayNetworkFee } from '../utils/exchange/exchangeUtils';
+import { getDisplayNetworkFee, requiresErc20Approval } from '../utils/exchange/exchangeUtils';
 import {
     getTradingCoinInfoByCryptoId,
     getTradingCoinSymbolByCryptoId,
@@ -793,6 +793,25 @@ export const selectTradingSelectedQuoteByFormValues = <T extends TradingType>(
     formValues: TradingSelectedQuoteFormValues,
 ): TradingTradeMapProps[T] | undefined =>
     selectedQuoteByFormValuesResolvers[type](state, formValues);
+
+export const selectTradingExchangeQuoteToEstimate = (
+    state: TradingRootState,
+    {
+        provider,
+        exchangeType,
+        sendCryptoId,
+    }: {
+        provider?: string;
+        exchangeType?: TradingExchangeFormType;
+        sendCryptoId?: CryptoId;
+    },
+): ExchangeTrade | undefined => {
+    if (requiresErc20Approval(sendCryptoId)) {
+        return selectTradingExchangeSelectedQuote(state);
+    }
+
+    return selectTradingSelectedQuoteByFormValues(state, 'exchange', { provider, exchangeType });
+};
 
 export const selectTradingExchangeFormStep = (state: TradingRootState) =>
     state.wallet.trading.exchange.formStep;


### PR DESCRIPTION
## Description

- The gas estimate for a DEX swap was derived from `dexQuotes[0]` — the *best* offer — while the transaction actually signed is built from the `dexTx` of the offer the user selected. Picking any provider other than the first one therefore estimated a different transaction than the one being signed: wrong network fee in the form, wrong Max reserve, and a fee on the device that did not match the offer.
- Which quote the estimate comes from is now a selector, `selectTradingExchangeQuoteToEstimate`:
  - native send → the offer selected in the form (this is the fix),
  - token send → the created trade, because its approval calldata exist nowhere else (unchanged behaviour, only moved).
- `useExchangeDexQuote` no longer takes `selectedQuote` and `dexQuotes` as props; it reads the one quote it needs from redux.

## Notes for QA

Testable on the staging trade api, EVM DEX swaps only.

- Swap ETH → any token, **pick a provider that is not the first offer in the list**. The network fee shown in the form and on the device must belong to that provider's offer. Before this change it belonged to the best offer.
- Max button on an EVM DEX swap: the reserve deducted from the amount now matches the selected offer's transaction.
- ERC-20 swap (e.g. USDT → ETH): approve / increase / revoke flow must be unchanged — the approval fee still comes from the created trade.
- CEX swaps and non-EVM DEX swaps are untouched.

## Related Issue

Resolve #31799

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes concentrate on DEX swap quote computation, the exchange form state hook, and trading selectors. The highest regression risk is in DEX swap flows and core swap form behavior, so prioritize the LI.FI DEX tests and swap-inputs tests. A smaller set of representative cross-chain and fee-related swap tests provides medium-confidence coverage without over-expanding the suite.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts`
- `packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts`
- `suite-common/trading/src/selectors/tradingSelectors.test.ts`
- `suite-common/trading/src/selectors/tradingSelectors.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — This live swap test directly exercises the SOL-to-USDC swap form end-to-end, including quote selection, send confirmation, and transaction detail. Changes to useTradingExchangeForm and useExchangeDexQuote affect the exact quote/compute paths this test hits.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live SPL-token-to-coin swap via CEX exercises the swap form, quote fetching, and confirmation flow. It is a realistic end-to-end check that the form hook and selector-derived state still drive the swap UI correctly.
- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — This test is specifically about DEX token approval flow driven by the LI.FI DEX provider. useExchangeDexQuote.ts is the DEX quote hook, so any change there directly impacts approval quote computation and the approval modal state.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — The core DEX swap test for LI.FI. It validates DEX-specific quote selection, slippage, minimum received, and device confirmation. Changes to the DEX quote hook or exchange form hook would most likely surface here.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Focused on swap form input behavior, validation, fraction buttons, quotes sync, provider selection, and fee display. This is the most direct E2E coverage of useTradingExchangeForm state and validation logic.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — A representative cross-chain mock swap that uses the swap form, best offer selection, and confirmation modal. It shares the same form/quote infrastructure as the changed hooks and can catch regressions in quote-to-confirmation flow.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — ETH-to-SOL swap flow relies on quote computation, receive account selection, and confirmation state managed by the changed form and quote hooks. Good representative of non-DEX swap behavior.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Tests custom fee handling inside the swap flow. Fee computation and composedTransactionInfo are tied to the exchange form hook and trading selectors, so changes there could affect fee display.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee parameters in the swap flow. The composed transaction and fee values depend on the exchange form hook and selectors, making this a relevant sanity check.
- `suite/e2e/tests/trading/swap-history.test.ts` — Validates trading transaction history list and detail rendering. tradingSelectors.ts is broadly mapped to 139 tests, but this one specifically uses trading selectors to render swap history data and is meaningfully affected by selector changes.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests the swap form's receive account picker and dynamic network enabling during quote flow. This exercises form state and selector-derived account/network data touched by the changed files.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx`
- `suite-common/trading/src/selectors/tradingSelectors.test.ts`

_Updated: 2026-09-04T07:20:22.393Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31799-dex-fee-selected-quote/web/](https://dev.suite.sldev.cz/suite-web/fix/31799-dex-fee-selected-quote/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31799-dex-fee-selected-quote&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31799-dex-fee-selected-quote&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31799-dex-fee-selected-quote&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T07:21:26.942Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T07:21:07.425Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->