### PR TITLE
chore(deps): update uint8array-tools to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
         "tsx": "^4.21.0",
         "typescript": "npm:@typescript/typescript6@6.0.2",
         "typescript-eslint": "^8.67.0",
-        "uint8array-tools": "^0.0.8",
+        "uint8array-tools": "^0.0.9",
         "version-bump-prompt": "^6.1.0"
     },
     "dependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -45725,7 +45725,7 @@ __metadata:
     tsx: "npm:^4.21.0"
     typescript: "npm:@typescript/typescript6@6.0.2"
     typescript-eslint: "npm:^8.67.0"
-    uint8array-tools: "npm:^0.0.8"
+    uint8array-tools: "npm:^0.0.9"
     version-bump-prompt: "npm:^6.1.0"
   dependenciesMeta:
     "@anthropic-ai/claude-code":
@@ -46377,6 +46377,13 @@ __metadata:
   version: 0.0.8
   resolution: "uint8array-tools@npm:0.0.8"
   checksum: 10/db3310f197a9a728e45e19149e5b222b633622796e5ef621809d03986f4959b2c895f2347c065eb16c89a07033ee8b9222b9abb607283615bdaeb3297dedbf01
+  languageName: node
+  linkType: hard
+
+"uint8array-tools@npm:^0.0.9":
+  version: 0.0.9
+  resolution: "uint8array-tools@npm:0.0.9"
+  checksum: 10/ea924e6d574f8c24d94400f0635eeffbeb0190fd2e4b781bb8e43b089c799a3d8c11c9b75d7c68524bc7e18f7ffc3d942f122ecf729746ba51612a8463848943
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update uint8array-tools from 0.0.8 to 0.0.9; upstream only adds signed integer read/write helpers and explicit range checks. Risk is low because Suite has no direct calls, though the root Jest mapping can affect Bitcoin code that imports it transitively. Validate the @trezor/utxo-lib unit suite, especially buffer, transaction, address, and BCH coverage (2,287 tests pass locally); part of https://github.com/trezor/trezor-suite/issues/30670.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-uint8array-tools/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-uint8array-tools/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** package.json is a broad, global configuration file, so most E2E tests would be only tangentially affected. The version page test is the only candidate with a concrete, documented dependency on package.json-derived build metadata (version and commit hash), making it the minimal high-value test to run. If the package.json change is unrelated to versioning or build injection, risk is low.

<details><summary><b>Changed files (1)</b></summary>

- `package.json`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/version-page.test.ts` — The version page displays the semantic version and Git commit hash that are typically injected at build time from package.json and git metadata. A change to package.json could alter the version field or build scripts that produce these values, so this test directly validates the user-visible outcome.

</details>

_Updated: 2026-09-02T11:31:00.709Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-uint8array-tools&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-uint8array-tools&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T11:34:09.710Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T11:34:01.621Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->