### PR TITLE
chore(deps): update immer to 11.1.16

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -176,7 +176,7 @@
         "framer-motion": "^12.33.0",
         "history": "^5.3.0",
         "idb": "^8.0.3",
-        "immer": "11.1.8",
+        "immer": "11.1.16",
         "lottie-react": "2.4.1",
         "pako": "^2.1.0",
         "pdfmake": "^0.3.7",

--- a/suite/coinjoin/package.json
+++ b/suite/coinjoin/package.json
@@ -38,7 +38,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^4.1.0",
-        "immer": "11.1.8",
+        "immer": "11.1.16",
         "redux": "^5.0.1"
     },
     "devDependencies": {

--- a/suite/metadata/package.json
+++ b/suite/metadata/package.json
@@ -43,7 +43,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "dropbox": "^10.45.0",
-        "immer": "11.1.8",
+        "immer": "11.1.16",
         "react": "19.2.3",
         "react-redux": "9.3.0",
         "redux": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15266,7 +15266,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^4.1.0"
-    immer: "npm:11.1.8"
+    immer: "npm:11.1.16"
     redux: "npm:^5.0.1"
   languageName: unknown
   linkType: soft
@@ -15642,7 +15642,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     dropbox: "npm:^10.45.0"
-    immer: "npm:11.1.8"
+    immer: "npm:11.1.16"
     react: "npm:19.2.3"
     react-redux: "npm:9.3.0"
     redux: "npm:^5.0.1"
@@ -18129,7 +18129,7 @@ __metadata:
     framer-motion: "npm:^12.33.0"
     history: "npm:^5.3.0"
     idb: "npm:^8.0.3"
-    immer: "npm:11.1.8"
+    immer: "npm:11.1.16"
     jest-canvas-mock: "npm:^2.5.8"
     jest-watch-typeahead: "npm:3.0.1"
     lottie-react: "npm:2.4.1"
@@ -31568,10 +31568,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:11.1.8, immer@npm:^11.0.0":
-  version: 11.1.8
-  resolution: "immer@npm:11.1.8"
-  checksum: 10/59a72aaac68115a8d584cb555a76566fb9c52be4c09055d446e5828c23e08470379b342f615a826cc07715e6a1c88dcdcfd41cc86114c397389cb8a6665768b0
+"immer@npm:11.1.16, immer@npm:^11.0.0":
+  version: 11.1.16
+  resolution: "immer@npm:11.1.16"
+  checksum: 10/ae33169318d1a78099dadc747105709506886387b72bf3468dd81c5c854140719d633da94bbefe4f8167311ad685ea0d069e0dfff5804fe9801777131f515f9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update Immer from 11.1.8 to 11.1.16; upstream fixes inherited-key assignment, DraftMap iteration, array reverse/sort draft references, null patch traversal, and curried types. Risk is medium because produce underpins Suite, metadata, CoinJoin, and Redux Toolkit reducers. Validate reducer immutability, patches, metadata and CoinJoin actions (118 focused tests pass locally), plus wallet state smoke tests; part of https://github.com/trezor/trezor-suite/issues/30670.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-immer/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-immer/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-immer&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-immer&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T13:48:48.997Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T13:49:34.606Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only concrete, inferable impact is from suite/metadata/package.json, which powers all legacy and Suite Sync labeling flows. I recommend running a representative set of metadata tests covering legacy labels, provider handling, Suite Sync, and migration. The other two changed files are package.json files whose dependency deltas are unknown; without static coverage or specific evidence from the LLM analysis, no targeted tests can be confidently selected, so they should be considered uncovered.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/package.json`
- `suite/coinjoin/package.json`
- `suite/metadata/package.json`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test exercises the full legacy metadata/labeling flow (account labels, provider setup with Dropbox, search, add account) that is implemented in or consumed from the suite/metadata package. A dependency change in suite/metadata/package.json could break label persistence, provider integration, or the editing UI.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Covers transaction output labeling and CSV export via the metadata provider stack, which directly depends on the suite/metadata package. Dependency updates there could affect output label CRUD or export formatting.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Tests metadata provider disconnect/reconnect, remembered-device label caching, and provider key handling — all backed by the suite/metadata implementation. A dependency change could break provider state or label restoration.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Validates migration from legacy local labels to Suite Sync, which touches both legacy metadata code and the new sync backend. This is a critical path for users moving between labeling systems and is sensitive to metadata package changes.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Exercises Suite Sync label creation and relay synchronization (account, wallet, address, output). The Evolu/Suite Sync layer is part of the metadata package, so dependency updates could break sync behavior.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Tests downloading labels from the Evolu relay into Suite, including device confirmation for Suite Sync keys. This directly depends on the suite/metadata sync implementation and is a strong regression signal for metadata dependency changes.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/package.json`
- `suite/coinjoin/package.json`

_Updated: 2026-09-02T13:46:47.902Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->