### PR TITLE
chore(deps): update dropbox to 10.45.0

### DIFF
--- a/suite/metadata/package.json
+++ b/suite/metadata/package.json
@@ -42,7 +42,7 @@
         "@trezor/suite-desktop-api": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "dropbox": "^10.38.0",
+        "dropbox": "^10.45.0",
         "immer": "11.1.8",
         "react": "19.2.3",
         "react-redux": "9.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15641,7 +15641,7 @@ __metadata:
     "@trezor/suite-desktop-api": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    dropbox: "npm:^10.38.0"
+    dropbox: "npm:^10.45.0"
     immer: "npm:11.1.8"
     react: "npm:19.2.3"
     react-redux: "npm:9.3.0"
@@ -26162,10 +26162,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dropbox@npm:^10.38.0":
-  version: 10.38.0
-  resolution: "dropbox@npm:10.38.0"
-  checksum: 10/0a97720aec7581d4955bf21f3f54c9f4779985d7b945bdbb3026e9c685657fe03bc8f293d735ad8b116ffaccc4d634ecde2663219c0a6b0e6ce86405c806da8f
+"dropbox@npm:^10.45.0":
+  version: 10.45.0
+  resolution: "dropbox@npm:10.45.0"
+  checksum: 10/a7a72a27c37685be935cf3eb28f4af9f51b7bf827b1bfcc9b2084b0e66c7c07249ff52c77676603b4508addc2a9efab6ed077f93fa4e1bfcf80703c12d4efb32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update Dropbox from 10.38.0 to 10.45.0; upstream adds abort signals, timeouts, custom headers, resumable downloads, and generated API-spec updates. Risk is medium because generated routes, types, and request plumbing back the legacy labeling provider. Validate metadata unit/type checks and the Dropbox labeling E2E flow: authorize, read, write, rename, reload, and disconnect; 35 tests and the 109-task type-check pass locally, part of https://github.com/trezor/trezor-suite/issues/30670.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** suite/metadata/package.json is a package-level configuration file; changes there most commonly involve dependencies or build setup that can affect all metadata/labeling behavior. Rather than running the entire metadata suite, I recommend a representative subset covering legacy labeling, Suite Sync creation, migration, and relay sync. This provides high confidence that the metadata package still functions end-to-end while keeping the run small.

<details><summary><b>Changed files (1)</b></summary>

- `suite/metadata/package.json`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Directly exercises core legacy metadata labeling CRUD (account labels, provider connection, search, new account labeling) which is the primary functionality served by the suite/metadata package. A package.json change affecting dependencies or build configuration would likely surface here.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Covers end-to-end Suite Sync labeling (account, wallet, address, and output labels) and Evolu Relay sync, the main new metadata path. This test is highly sensitive to changes in the metadata package's dependencies and exports.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Exercises the migration path from legacy local/Dropbox labels to Suite Sync, touching both legacy and Suite Sync code paths. Relevant if the package.json change affects shared metadata state or migration logic.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Validates downloading existing labels from the Evolu Relay into Suite, a distinct sync direction from create-new-labels. Useful for catching regressions in metadata package initialization or provider sync dependencies.

</details>

_Updated: 2026-09-02T11:42:04.314Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-dropbox/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-dropbox/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-dropbox&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-dropbox&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T11:44:52.855Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T11:44:57.827Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->