### PR TITLE
chore(deps): update @tanstack/react-virtual to 3.14.9

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,7 +22,7 @@
         "@floating-ui/react": "^0.27.17",
         "@suite-common/flags": "workspace:*",
         "@suite-common/illustrations": "workspace:*",
-        "@tanstack/react-virtual": "^3.13.9",
+        "@tanstack/react-virtual": "^3.14.9",
         "@testing-library/jest-dom": "7.0.1",
         "@trezor/env-utils": "workspace:*",
         "@trezor/icons": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16527,15 +16527,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-virtual@npm:^3.13.9":
-  version: 3.13.9
-  resolution: "@tanstack/react-virtual@npm:3.13.9"
+"@tanstack/react-virtual@npm:^3.13.9, @tanstack/react-virtual@npm:^3.14.9":
+  version: 3.14.10
+  resolution: "@tanstack/react-virtual@npm:3.14.10"
   dependencies:
-    "@tanstack/virtual-core": "npm:3.13.9"
+    "@tanstack/virtual-core": "npm:3.17.8"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/bb7131a3e0b629939f880f1d36b39ed4d1ba4c0fa47877c2edb6f1884a871a661fb4aefab9795ef3bea8dc031b826cad167ab1729fef4bdba976bc0bcb41caa2
+  checksum: 10/2cfb17980499f927c783d0e1dbd2a080433338db358e2cbef5db37fc953207255b88aaa78592081ec9c1c1a6a1e86158e45cb80f3d82700128b8ce292136b534
   languageName: node
   linkType: hard
 
@@ -16546,10 +16546,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/virtual-core@npm:3.13.9":
-  version: 3.13.9
-  resolution: "@tanstack/virtual-core@npm:3.13.9"
-  checksum: 10/32e0d4089361ccaf6d79217c1f5596cee16403afe66913c1f97a7b571069eda8f0b74ab2b62f41705c2975ae5631c8541b02e08423adc41a1e221bc7fed00a3f
+"@tanstack/virtual-core@npm:3.17.8":
+  version: 3.17.8
+  resolution: "@tanstack/virtual-core@npm:3.17.8"
+  checksum: 10/b115caa01ccc748b97b5f1df7ee26e32fe82586da25d900630dc91297d35acaf90709cb5bf7fc0b85a86124aeb640cec7ac1a59ff6de9a6d25b7f53ddfce6a41
   languageName: node
   linkType: hard
 
@@ -16845,7 +16845,7 @@ __metadata:
     "@storybook/react-webpack5": "npm:^10.3.4"
     "@suite-common/flags": "workspace:*"
     "@suite-common/illustrations": "workspace:*"
-    "@tanstack/react-virtual": "npm:^3.13.9"
+    "@tanstack/react-virtual": "npm:^3.14.9"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:7.0.1"
     "@testing-library/react": "npm:^16.3.2"


### PR DESCRIPTION
## Description

Update @tanstack/react-virtual from 3.13.9 to 3.14.9; upstream adds direct DOM updates while virtual-core rewrites measurement storage and fixes paging, resizing, iOS momentum, and scroll compensation. Risk is medium because these internals control Suite VirtualizedList layout and pagination. Validate its nine unit tests plus long-list scrolling, dynamic row resizing, load-more behavior, and iOS scrolling; part of https://github.com/trezor/trezor-suite/issues/30670.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file, `packages/components/package.json`, is a package manifest. There is no static E2E coverage mapping for it, and no LLM-analyzed test describes behavior that would be directly exercised by changes to this file. A package.json edit is most commonly a dependency version, script, or metadata change; unless it alters a runtime dependency that affects component rendering, it carries low regression risk for the Playwright suite. I recommend asking the PR author for the specific diff context, or running a quick manual smoke test, rather than running the full E2E suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/components/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/components/package.json`

_Updated: 2026-09-02T13:51:51.062Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-tanstack-react-virtual/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-tanstack-react-virtual/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-tanstack-react-virtual&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-tanstack-react-virtual&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T13:54:35.921Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T13:54:41.312Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->