### PR TITLE
chore(deps): update @testing-library/jest-dom to 7.0.1

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,7 +23,7 @@
         "@suite-common/flags": "workspace:*",
         "@suite-common/illustrations": "workspace:*",
         "@tanstack/react-virtual": "^3.13.9",
-        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/jest-dom": "7.0.1",
         "@trezor/env-utils": "workspace:*",
         "@trezor/icons": "workspace:*",
         "@trezor/theme": "workspace:*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -141,7 +141,7 @@
         "@suite/ui-animations": "workspace:*",
         "@suite/wallet": "workspace:*",
         "@tanstack/react-query": "5.101.2",
-        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/jest-dom": "7.0.1",
         "@trezor/analytics-uploader": "workspace:*",
         "@trezor/asset-utils": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16466,7 +16466,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:6.9.1, @testing-library/jest-dom@npm:^6.9.1":
+"@testing-library/jest-dom@npm:7.0.1":
+  version: 7.0.1
+  resolution: "@testing-library/jest-dom@npm:7.0.1"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    picocolors: "npm:^1.1.1"
+    redent: "npm:^3.0.0"
+  peerDependencies:
+    "@testing-library/dom": ">=10 <11"
+    vitest: ">= 0.32"
+  peerDependenciesMeta:
+    vitest:
+      optional: true
+  checksum: 10/0770454b47da9370e59cda691f797c0442e53caefcd412c504b33c7a9bee099c8a9e7d1f07f7eae8d380ea52c34a5d70139e875480a57f729588068edc78f57b
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^6.9.1":
   version: 6.9.1
   resolution: "@testing-library/jest-dom@npm:6.9.1"
   dependencies:
@@ -16724,7 +16744,7 @@ __metadata:
     "@suite-common/illustrations": "workspace:*"
     "@tanstack/react-virtual": "npm:^3.13.9"
     "@testing-library/dom": "npm:^10.4.1"
-    "@testing-library/jest-dom": "npm:6.9.1"
+    "@testing-library/jest-dom": "npm:7.0.1"
     "@testing-library/react": "npm:^16.3.2"
     "@testing-library/user-event": "npm:^14.6.1"
     "@trezor/env-utils": "workspace:*"
@@ -17954,7 +17974,7 @@ __metadata:
     "@suite/ui-animations": "workspace:*"
     "@suite/wallet": "workspace:*"
     "@tanstack/react-query": "npm:5.101.2"
-    "@testing-library/jest-dom": "npm:6.9.1"
+    "@testing-library/jest-dom": "npm:7.0.1"
     "@testing-library/react": "npm:^16.3.2"
     "@testing-library/user-event": "npm:^14.6.1"
     "@trezor/analytics-uploader": "workspace:*"


### PR DESCRIPTION
## Description

Update @testing-library/jest-dom from 6.9.1 to 7.0.1; upstream adds query-container matchers, requires Node 22+, and makes @testing-library/dom 10 a peer, all already satisfied by Suite. Risk is low-to-medium and limited to Jest setup, matcher types, and assertion semantics. Validate components and Suite unit tests, especially visibility, accessibility, form-value, and DOM-containment matchers; all 23 components tests pass locally, part of https://github.com/trezor/trezor-suite/issues/30670.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-testing-library-jest-dom/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-testing-library-jest-dom/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed package.json files have broad, global blast radius but no specific runtime code path was changed. Without static coverage mappings, the safest strategy is a small set of smoke tests that exercise app startup, onboarding, component-heavy settings interactions, and build metadata routing. If these pass, deeper feature-specific regressions are unlikely from a package.json change alone.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/package.json`
- `packages/suite/package.json`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — Changes to suite or components package.json can break the dependency tree/build, preventing the app from loading in a browser. This test directly verifies that Suite loads successfully in Firefox with no unsupported-browser warning, making it a fast, high-value smoke test for global build regressions. (Inferred; no static mapping was available.)
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The onboarding flow is the first user-facing path after app load and exercises many shared components and suite package wiring (analytics modal, settings, dashboard layout). A dependency or build change in either package.json is likely to surface here as a startup or rendering failure. (Inferred; no static mapping was available.)

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — Settings general page heavily relies on @trezor/components inputs (selects, toggles) and suite package state. Dependency changes could affect theme, language, fiat, or analytics toggle behavior, so this test provides concrete coverage of interactive UI components. (Inferred; no static mapping was available.)
- `suite/e2e/tests/suite/version-page.test.ts` — This test verifies the hidden /version route and that build metadata (version, commit hash) is correctly injected and rendered. package.json changes can affect build-time metadata and routing, so a quick version-page check catches broad bundling issues. (Inferred; no static mapping was available.)

</details>

_Updated: 2026-08-27T19:32:44.359Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-testing-library-jest-dom&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-testing-library-jest-dom&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T19:34:25.586Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T19:33:50.332Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->