### PR TITLE
chore(deps): update React Hook Form packages

### DIFF
--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -41,7 +41,7 @@
         "framer-motion": "^12.33.0",
         "qrcode.react": "^4.2.0",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-intl": "^8.1.3",
         "react-svg": "16.4.2",
         "styled-components": "^6.3.9",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@floating-ui/react": "^0.27.17",
         "@formatjs/intl": "4.1.2",
-        "@hookform/resolvers": "^5.4.0",
+        "@hookform/resolvers": "^5.7.1",
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.12.0",
         "@sentry/core": "10.69.0",
@@ -186,7 +186,7 @@
         "react-error-boundary": "^6.0.0",
         "react-focus-lock": "^2.13.7",
         "react-helmet-async": "^2.0.5",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-intl": "^8.1.3",
         "react-redux": "9.3.0",
         "react-select": "^5.10.2",

--- a/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
+++ b/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
@@ -34,7 +34,7 @@ const changeDeviceLabelSchema = (t: TranslationFunction) =>
 export const useChangeDeviceLabel = (): {
     form: UseFormReturn<
         {
-            deviceLabel: string | undefined;
+            deviceLabel?: string | undefined;
         },
         unknown,
         {

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -53,6 +53,7 @@ export const useFees = <TFieldValues extends FeesFormValues>({
     const feeLimitRef = useRef<string | undefined>('');
     const maxPriorityFeePerGasRef = useRef<string | undefined>('');
     const maxFeePerGasRef = useRef<string | undefined>('');
+    const composeAfterErrorClearRef = useRef(false);
 
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
     const { clearErrors, getValues, register, setValue, watch } =
@@ -83,6 +84,20 @@ export const useFees = <TFieldValues extends FeesFormValues>({
     const maxPriorityFeePerGas = watch('maxPriorityFeePerGas');
     const maxFeePerGas = watch('maxFeePerGas');
     const estimatedFeeLimit = watch('estimatedFeeLimit');
+
+    useEffect(() => {
+        if (
+            !composeAfterErrorClearRef.current ||
+            errors.feePerUnit ||
+            errors.feeLimit ||
+            !composeRequest
+        ) {
+            return;
+        }
+
+        composeAfterErrorClearRef.current = false;
+        composeRequest();
+    }, [errors.feePerUnit, errors.feeLimit, composeRequest]);
 
     useEffect(() => {
         if (selectedFeeRef.current !== 'custom') return;
@@ -160,8 +175,8 @@ export const useFees = <TFieldValues extends FeesFormValues>({
             // error should be cleared and levels should be precomposed again
             feePerUnit = '';
             feeLimit = '';
+            composeAfterErrorClearRef.current = true;
             clearErrors(['feePerUnit', 'feeLimit', 'maxPriorityFeePerGas', 'maxFeePerGas']);
-            composeRequest?.();
         }
 
         setValue('selectedFee', level);

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -328,9 +328,7 @@ export const useTradingReceiveAddress = ({
     }, [receiveAddress, extraField, receiveAccount, type, dispatch]);
 
     return {
-        form: {
-            ...methods,
-        },
+        form: methods,
         suiteReceiveAccounts,
         selectedAccount: receiveAccount,
         accountAddress,

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -81,6 +81,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
     const [hasAddressChecksummed, setHasAddressChecksummed] = useState<boolean | undefined>();
     const [autocorrectMessage, setAutocorrectMessage] = useState<string | undefined>();
     const autocorrectTimeout = useRef<TimerId>(null);
+    const composeAfterAddressChangeRef = useRef(false);
     const dispatch = useDispatch();
     const { device } = useDevice();
     const {
@@ -157,6 +158,15 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
             trigger(inputName);
         }
     }, [selectedToken, networkType, inputName, trigger, address]);
+
+    useEffect(() => {
+        if (!composeAfterAddressChangeRef.current || addressError) {
+            return;
+        }
+
+        composeAfterAddressChangeRef.current = false;
+        composeTransaction(amountInputName);
+    }, [address, addressError, amountInputName, composeTransaction]);
 
     const handleQrClick = useCallback(async () => {
         const uri = await dispatch(openDeferredModal({ type: 'qr-reader' }));
@@ -370,7 +380,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
 
     const { ref: inputRef, ...inputField } = register(inputName, {
         onChange: () => {
-            composeTransaction(amountInputName);
+            composeAfterAddressChangeRef.current = true;
             setHasAddressChecksummed(false);
             setAutocorrectMessage(undefined);
             setValue(resolvedAddressInputName, undefined);

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -62,7 +62,7 @@
         "@trezor/utils": "workspace:*",
         "lodash": "^4.18.1",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-redux": "9.3.0"
     }
 }

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -40,6 +40,6 @@
         "@trezor/utils": "workspace:*",
         "date-fns": "^4.1.0",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0"
+        "react-hook-form": "^7.85.0"
     }
 }

--- a/suite-native/accounts/package.json
+++ b/suite-native/accounts/package.json
@@ -49,7 +49,7 @@
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:^",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-native": "0.86.0",
         "react-native-reanimated": "4.5.0",
         "react-redux": "9.3.0"

--- a/suite-native/forms/package.json
+++ b/suite-native/forms/package.json
@@ -11,13 +11,13 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@hookform/resolvers": "^5.4.0",
+        "@hookform/resolvers": "^5.7.1",
         "@mobily/ts-belt": "^3.13.1",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/icons": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-native": "0.86.0",
         "react-native-reanimated": "4.5.0"
     }

--- a/suite-native/forms/src/hooks/useForm.ts
+++ b/suite-native/forms/src/hooks/useForm.ts
@@ -26,7 +26,11 @@ export const useForm = <TFieldValues extends FieldValues, TContext extends objec
     // TS7 infers Yup object schemas as transformed optionalized shapes
     // (`MakeKeysOptional<T>`) which does not match the form contract used
     // across suite-native. Keep that mismatch contained in this wrapper.
-    const resolver = yupResolver(validation) as Resolver<TFieldValues, TContext, TFieldValues>;
+    const resolver = yupResolver(validation) as unknown as Resolver<
+        TFieldValues,
+        TContext,
+        TFieldValues
+    >;
 
     const form = hookFormUseForm<TFieldValues, TContext>({
         resolver,

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -49,7 +49,7 @@
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-native": "0.86.0",
         "react-native-reanimated": "4.5.0",
         "react-redux": "9.3.0"

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -69,7 +69,7 @@
         "date-fns": "^4.1.0",
         "jotai": "2.17.1",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-native": "0.86.0",
         "react-native-reanimated": "4.5.0",
         "react-redux": "9.3.0"

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -64,7 +64,7 @@
         "@trezor/utils": "workspace:*",
         "jotai": "2.17.1",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-native": "0.86.0",
         "react-native-reanimated": "4.5.0",
         "react-redux": "9.3.0"

--- a/suite-native/transaction-management/package.json
+++ b/suite-native/transaction-management/package.json
@@ -51,7 +51,7 @@
         "@trezor/utils": "workspace:*",
         "expo-linear-gradient": "~57.0.1",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-native": "0.86.0",
         "react-native-reanimated": "4.5.0",
         "react-redux": "9.3.0"

--- a/suite/sign-verify/package.json
+++ b/suite/sign-verify/package.json
@@ -12,7 +12,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@hookform/resolvers": "^5.4.0",
+        "@hookform/resolvers": "^5.7.1",
         "@suite-common/address": "workspace:*",
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
@@ -36,7 +36,7 @@
         "@trezor/icons": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-redux": "9.3.0",
         "redux": "^5.0.1"
     },

--- a/suite/suite-sync/package.json
+++ b/suite/suite-sync/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@evolu/common": "8.0.0-next.5",
         "@evolu/web": "patch:@evolu/web@npm%3A3.0.0-next.1#~/.yarn/patches/@evolu-web-npm-3.0.0-next.1-9b296ca288.patch",
-        "@hookform/resolvers": "^5.4.0",
+        "@hookform/resolvers": "^5.7.1",
         "@reduxjs/toolkit": "2.12.0",
         "@suite-common/delegated-identity-key-types": "workspace:*",
         "@suite-common/dependency-injection": "workspace:*",
@@ -43,7 +43,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "19.2.3",
-        "react-hook-form": "^7.77.0",
+        "react-hook-form": "^7.85.0",
         "react-redux": "9.3.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4345,14 +4345,87 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hookform/resolvers@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "@hookform/resolvers@npm:5.4.0"
+"@hookform/resolvers@npm:^5.7.1":
+  version: 5.7.1
+  resolution: "@hookform/resolvers@npm:5.7.1"
   dependencies:
     "@standard-schema/utils": "npm:^0.3.0"
   peerDependencies:
+    "@sinclair/typebox": ">=0.25.24"
+    "@standard-schema/spec": ^1.0.0
+    "@typeschema/main": ">=0.13.7"
+    "@vinejs/vine": ^2.0.0 || ^3.0.0 || ^4.0.0
+    ajv: ^8.12.0
+    ajv-errors: ^3.0.0
+    ajv-formats: ^2.1.1
+    arktype: ^2.0.0
+    ata-validator: ^1.2.0
+    class-transformer: ">=0.4.0"
+    class-validator: ">=0.12.0"
+    computed-types: ^1.0.0
+    effect: ^3.10.3
+    fluentvalidation-ts: ^3.0.0
+    fp-ts: ^2.7.0
+    io-ts: ^2.0.0
+    joi: ^17.0.0
+    nope-validator: ">=0.12.0"
     react-hook-form: ^7.55.0
-  checksum: 10/c56e03d3707999bf0bebdcf1a8c5fc1cbbca527425d893e2402ead09e3644681581b8d2ad76eec62f72270534f5dc38159e2d6ee4001a0152363b8eddfedfcab
+    superstruct: ">=0.12.0"
+    typanion: ^3.3.2
+    valibot: ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc"
+    vest: ">=3.0.0"
+    yup: ^1.0.0
+    zod: ^3.25.0 || ^4.0.0
+  peerDependenciesMeta:
+    "@sinclair/typebox":
+      optional: true
+    "@standard-schema/spec":
+      optional: true
+    "@typeschema/main":
+      optional: true
+    "@vinejs/vine":
+      optional: true
+    ajv:
+      optional: true
+    ajv-errors:
+      optional: true
+    ajv-formats:
+      optional: true
+    arktype:
+      optional: true
+    ata-validator:
+      optional: true
+    class-transformer:
+      optional: true
+    class-validator:
+      optional: true
+    computed-types:
+      optional: true
+    effect:
+      optional: true
+    fluentvalidation-ts:
+      optional: true
+    fp-ts:
+      optional: true
+    io-ts:
+      optional: true
+    joi:
+      optional: true
+    nope-validator:
+      optional: true
+    superstruct:
+      optional: true
+    typanion:
+      optional: true
+    valibot:
+      optional: true
+    vest:
+      optional: true
+    yup:
+      optional: true
+    zod:
+      optional: true
+  checksum: 10/27df7989e95373ae133820cc00d0d2e7998fdc444af40179486f92ab000594cbbaab535521fac5f2e3ae127a21e3703926afd1b954e6587a20847db6bea6f3bc
   languageName: node
   linkType: hard
 
@@ -11712,7 +11785,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     lodash: "npm:^4.18.1"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-redux: "npm:9.3.0"
   languageName: unknown
   linkType: soft
@@ -11769,7 +11842,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     date-fns: "npm:^4.1.0"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
   languageName: unknown
   linkType: soft
 
@@ -11849,7 +11922,7 @@ __metadata:
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:^"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-native: "npm:0.86.0"
     react-native-reanimated: "npm:4.5.0"
     react-redux: "npm:9.3.0"
@@ -12822,13 +12895,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/forms@workspace:suite-native/forms"
   dependencies:
-    "@hookform/resolvers": "npm:^5.4.0"
+    "@hookform/resolvers": "npm:^5.7.1"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/icons": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-native: "npm:0.86.0"
     react-native-reanimated: "npm:4.5.0"
   languageName: unknown
@@ -13078,7 +13151,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-native: "npm:0.86.0"
     react-native-reanimated: "npm:4.5.0"
     react-redux: "npm:9.3.0"
@@ -13144,7 +13217,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     jotai: "npm:2.17.1"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-native: "npm:0.86.0"
     react-native-reanimated: "npm:4.5.0"
     react-redux: "npm:9.3.0"
@@ -13839,7 +13912,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     jotai: "npm:2.17.1"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-native: "npm:0.86.0"
     react-native-reanimated: "npm:4.5.0"
     react-redux: "npm:9.3.0"
@@ -15010,7 +15083,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     expo-linear-gradient: "npm:~57.0.1"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-native: "npm:0.86.0"
     react-native-reanimated: "npm:4.5.0"
     react-redux: "npm:9.3.0"
@@ -15824,7 +15897,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite/sign-verify@workspace:suite/sign-verify"
   dependencies:
-    "@hookform/resolvers": "npm:^5.4.0"
+    "@hookform/resolvers": "npm:^5.7.1"
     "@suite-common/address": "workspace:*"
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
@@ -15850,7 +15923,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@types/react": "npm:19.2.14"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-redux: "npm:9.3.0"
     redux: "npm:^5.0.1"
   languageName: unknown
@@ -15870,7 +15943,7 @@ __metadata:
   dependencies:
     "@evolu/common": "npm:8.0.0-next.5"
     "@evolu/web": "patch:@evolu/web@npm%3A3.0.0-next.1#~/.yarn/patches/@evolu-web-npm-3.0.0-next.1-9b296ca288.patch"
-    "@hookform/resolvers": "npm:^5.4.0"
+    "@hookform/resolvers": "npm:^5.7.1"
     "@reduxjs/toolkit": "npm:2.12.0"
     "@suite-common/delegated-identity-key-types": "workspace:*"
     "@suite-common/dependency-injection": "workspace:*"
@@ -15901,7 +15974,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-redux: "npm:9.3.0"
   languageName: unknown
   linkType: soft
@@ -17500,7 +17573,7 @@ __metadata:
     postcss-styled-syntax: "npm:^0.7.1"
     qrcode.react: "npm:^4.2.0"
     react: "npm:19.2.3"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-intl: "npm:^8.1.3"
     react-svg: "npm:16.4.2"
     storybook: "npm:^10.3.4"
@@ -17968,7 +18041,7 @@ __metadata:
   dependencies:
     "@floating-ui/react": "npm:^0.27.17"
     "@formatjs/intl": "npm:4.1.2"
-    "@hookform/resolvers": "npm:^5.4.0"
+    "@hookform/resolvers": "npm:^5.7.1"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.12.0"
     "@sentry/core": "npm:10.69.0"
@@ -18142,7 +18215,7 @@ __metadata:
     react-error-boundary: "npm:^6.0.0"
     react-focus-lock: "npm:^2.13.7"
     react-helmet-async: "npm:^2.0.5"
-    react-hook-form: "npm:^7.77.0"
+    react-hook-form: "npm:^7.85.0"
     react-intl: "npm:^8.1.3"
     react-redux: "npm:9.3.0"
     react-select: "npm:^5.10.2"
@@ -40899,12 +40972,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:^7.77.0":
-  version: 7.77.0
-  resolution: "react-hook-form@npm:7.77.0"
+"react-hook-form@npm:^7.85.0":
+  version: 7.85.0
+  resolution: "react-hook-form@npm:7.85.0"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18 || ^19
-  checksum: 10/0edcc9ebac61991ac300df400917797f67cd41f81cbead16903698ccc04fe5b1eda48960d262c7d3331ae33c6a2517287a10112be6e16c0da73285f09862f4f8
+  checksum: 10/ab3c695866c6f803cb56ac71385a103f12879a72ca353b979b7d159e92cc54de721c988af8ff52ce3bca6181b50bb80e085567aae7819c7a7db1fcb1bfb2565d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Updates react-hook-form 7.77.0→7.85.0 and @hookform/resolvers 5.4.0→5.7.1; upstream fixes dirty/reset and field-array behavior, RN Controller resets, async resolver races, file inputs, plus Yup/Zod/AJV error and default handling. Risk: medium-high because these packages back web and native forms, though both releases remain within their current major versions. Test: sign/verify, Suite Sync, send, account import/settings, validation errors, reset/dirty flows, and field arrays. Part of #30670.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-react-hook-form/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-react-hook-form/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies four web/desktop Suite source files (device label hook, fees hook, trading receive address hook, send address component) alongside several mobile-native and package.json files that have no coverage in the web/desktop E2E suite. The highest-risk regressions are in device renaming, custom fee calculation, trading receive account selection, and send address input. The recommended tests target these specific user flows while avoiding the broad transitive blast radius of the fee and label hooks.

<details><summary><b>Changed files (17)</b></summary>

- `packages/product-components/package.json`
- `packages/suite/package.json`
- `packages/suite/src/hooks/suite/useChangeDeviceLabel.ts`
- `packages/suite/src/hooks/wallet/form/useFees.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts`
- `packages/suite/src/views/wallet/send/Outputs/Address.tsx`
- `suite-common/wallet-core/package.json`
- `suite-common/wallet-utils/package.json`
- `suite-native/accounts/package.json`
- `suite-native/forms/package.json`
- `suite-native/forms/src/hooks/useForm.ts`
- `suite-native/module-accounts-import/package.json`
- `suite-native/module-accounts-management/package.json`
- `suite-native/module-send/package.json`
- `suite-native/transaction-management/package.json`
- `suite/sign-verify/package.json`
- `suite/suite-sync/package.json`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Directly exercises changing the device name/label, which is the exact functionality implemented in useChangeDeviceLabel.ts. A regression here would be immediately user-visible.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Directly exercises changing the device name/label on T3B1, relying on the same useChangeDeviceLabel hook. This is the only other settings test that performs a device label change.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Explicitly tests custom Bitcoin fee configuration during a swap, which directly exercises the useFees hook path for Bitcoin transactions.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Explicitly tests custom Ethereum fee parameters (gas limit, max fee per gas, max priority fee per gas) during a swap, directly covering the useFees hook path for EIP-1559 fees.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests custom Ethereum fees on Base network and recipient address entry, exercising both useFees and the send Outputs/Address component in a single flow.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests custom gas fee parameters and recipient address entry on Ethereum, directly covering both useFees and the Address.tsx send output component.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Explicitly selects a receive address/account during the buy flow, which is the core behavior of useTradingReceiveAddress.ts. Regression would break buy trade initiation.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Directly exercises the receive account picker logic during swap, including enabling a disabled network from the picker. This is a key path for useTradingReceiveAddress.ts.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Involves selecting a receive account (including adding a new Suite account) during a buy flow, sharing the receive address selection infrastructure with useTradingReceiveAddress.ts.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Cross-chain live swap requires selecting a receive address for the destination token, exercising the receive address selection path in trading.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live SPL-token-to-coin swap requires selecting a receive address, sharing receive address selection infrastructure with the changed hook.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests custom fee rate switching for Bitcoin and Solana sell forms, covering the useFees hook in a sell context.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Swap form test that selects a Suite receive account for the destination, exercising receive address selection logic indirectly.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Imports recipient addresses into the send form, which exercises the Address.tsx output address fields and related send form state.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests the Bitcoin send form including recipient address input and multi-output handling, directly covering the Address.tsx component.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests send address entry and fee display on Solana, covering both send address input and fee calculation paths.

</details>

⚠️ **Changes with no test coverage (13)**
- `packages/product-components/package.json`
- `packages/suite/package.json`
- `suite-common/wallet-core/package.json`
- `suite-common/wallet-utils/package.json`
- `suite-native/accounts/package.json`
- `suite-native/forms/package.json`
- `suite-native/forms/src/hooks/useForm.ts`
- `suite-native/module-accounts-import/package.json`
- `suite-native/module-accounts-management/package.json`
- `suite-native/module-send/package.json`
- `suite-native/transaction-management/package.json`
- `suite/sign-verify/package.json`
- `suite/suite-sync/package.json`

_Updated: 2026-09-02T11:44:37.448Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-react-hook-form&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-react-hook-form&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/deps-30670-react-hook-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T11:46:49.379Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T11:46:30.832Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->