### PR TITLE
chore(deps): update @expo/ui to 57.0.10

### DIFF
--- a/suite-native/clipboard/package.json
+++ b/suite-native/clipboard/package.json
@@ -11,7 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@expo/ui": "56.0.24",
+        "@expo/ui": "57.0.10",
         "@suite-native/intl": "workspace:*",
         "@suite-native/toasts": "workspace:*",
         "expo-clipboard": "~57.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3934,9 +3934,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/ui@npm:56.0.24":
-  version: 56.0.24
-  resolution: "@expo/ui@npm:56.0.24"
+"@expo/ui@npm:57.0.10":
+  version: 57.0.10
+  resolution: "@expo/ui@npm:57.0.10"
   dependencies:
     sf-symbols-typescript: "npm:^2.1.0"
     vaul: "npm:^1.1.2"
@@ -3954,7 +3954,7 @@ __metadata:
       optional: true
     react-native-worklets:
       optional: true
-  checksum: 10/ca8cdc4825ab1a905291409794e027908167425bbe75395873bc1dd998387948f870ff2956bc47fed600a9b33089ebc65dcd303005dd7f9c23f07a73e8dab978
+  checksum: 10/d9f3e50ef11db54991e07613eab9a9a4a8a6e7c04bca6203d5d34923480ac0046f8633ddb4553fe9c49df7faf563de393acf9ae28ca9f604244f534ae7c4c709
   languageName: node
   linkType: hard
 
@@ -12279,7 +12279,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/clipboard@workspace:suite-native/clipboard"
   dependencies:
-    "@expo/ui": "npm:56.0.24"
+    "@expo/ui": "npm:57.0.10"
     "@suite-native/intl": "workspace:*"
     "@suite-native/toasts": "workspace:*"
     expo-clipboard: "npm:~57.0.1"


### PR DESCRIPTION
## Description

Updates @expo/ui 56.0.24→57.0.10, aligning it with the existing Expo 57 runtime. Upstream changes include RNHostView touch fixes, ContextMenu presentation/tint fixes, SwiftUI API updates, and removal of the Reanimated worklet dependency; the v57 spacing change does not affect the components used here. Risk: medium, limited to the iOS native clipboard menu. 

## Testing
Test: long-press/copy via the clipboard context menu on iOS, dismissal/touches, light/dark tint, and a native build. Part of #30670.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is suite-native/clipboard/package.json, which belongs to the React Native mobile app clipboard module. None of the available Playwright E2E tests in suite/e2e/tests exercise native mobile clipboard functionality, and the change is not expected to affect the web/desktop Suite flows. Therefore, no additional E2E tests are recommended for this change set.

<details><summary><b>Changed files (1)</b></summary>

- `suite-native/clipboard/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-native/clipboard/package.json`

_Updated: 2026-08-27T19:37:44.830Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-expo-ui/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-expo-ui/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-expo-ui&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-expo-ui&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/deps-30670-expo-ui&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T19:40:56.319Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T19:40:09.070Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->