### PR TITLE
feat(eslint): generalize unused contract member analysis

### DIFF
--- a/eslint-local-rules/no-unused-intersection-members/README.md
+++ b/eslint-local-rules/no-unused-intersection-members/README.md
@@ -95,7 +95,8 @@ the alias is identified as a thunk state contract.
 
 1. At `Program:exit`, collect matching aliases and resolve every root, nested, or service-wrapped
    intersection and object member with the TypeScript type checker.
-2. Mark contracts as opaque when they enter a generic context that the rule cannot safely interpret.
+2. Mark contracts as opaque when they enter a type-level context that the rule cannot safely
+   interpret.
 3. Read `createThunk` configuration and add the state/dependency requirements of dispatched child
    thunks.
 4. Traverse runtime expressions and record property paths, expected argument types, and assignments.
@@ -113,7 +114,8 @@ The complete alias is kept when the implementation contains an ambiguous use, in
 
 - Dynamic access such as `deps[key]`.
 - Passing the whole value to a call whose expected parameter type cannot be resolved.
-- Using the alias as a generic call or type argument outside the supported `createThunk` shape.
+- Deriving another type with `keyof`, indexed access, conditional or mapped types, or a public alias.
+- Using the alias as a generic call or type argument outside supported contract composition.
 - A bare value escaping without a property path or expected type.
 - Recursive, callable, constructable, or indexed structures that cannot be safely composed from
   individual members.

--- a/eslint-local-rules/no-unused-intersection-members/README.md
+++ b/eslint-local-rules/no-unused-intersection-members/README.md
@@ -78,9 +78,9 @@ the alias is identified as a thunk state contract.
    members are checked against usages such as `deps.services.logger` and child-thunk requirements.
 5. **Include transitive thunk requirements.** Dispatching a child thunk implicitly requires the
    child's `state` and `extra` types. Those requirements count even if the parent thunk never calls
-   `getState()` or reads `extra` itself. Thunk factories are recognized from their TypeScript
-   signature, so aliases, namespace properties, named configuration types, extracted callbacks,
-   `api.dispatch(...)`, and dispatch functions passed to typed helpers retain this analysis.
+   `getState()` or reads `extra` itself. Direct `createThunk(...)` calls with inline callbacks are
+   analyzed. Named configuration types, `api.dispatch(...)`, and dispatch functions passed to typed
+   helpers retain this analysis.
 6. **Prefer false negatives over false positives.** When the analysis cannot prove which member is
    needed, it keeps the whole contract. The rule should suggest a removal only when that removal is
    demonstrably safe for every usage visible in the file.

--- a/eslint-local-rules/no-unused-intersection-members/README.md
+++ b/eslint-local-rules/no-unused-intersection-members/README.md
@@ -2,8 +2,8 @@
 
 ## Unused State and Deps intersection members
 
-`no-unused-intersection-members` checks local intersection aliases whose names end in `State` or
-`Deps`:
+`no-unused-intersection-members` checks explicit intersections in local aliases whose names end in
+`State` or `Deps`:
 
 ```ts
 type RunDeps = LoggerDeps & StorageDeps;
@@ -13,6 +13,14 @@ const run = (deps: RunDeps) => deps.logger.log('started');
 
 Here `StorageDeps` is reported because the implementation can satisfy every observed requirement
 without it.
+
+Intersections nested in an object contract are checked as well:
+
+```ts
+type RunDeps = { services: LoggerDeps & StorageDeps };
+
+const run = (deps: RunDeps) => deps.services.logger.log('started');
+```
 
 ### Principles
 
@@ -35,14 +43,14 @@ without it.
    needed, it keeps the whole contract. The rule should suggest a removal only when that removal is
    demonstrably safe for every usage visible in the file.
 7. **Stay local and predictable.** Candidates are type aliases in the current source file, must end
-   in `State` or `Deps`, and must contain either a direct intersection or an intersection inside a
-   transparent `services` container. Usage collection is file-local: a consumer needing an
+   in `State` or `Deps`, and must contain an explicit root or nested intersection, including one
+   inside a transparent `services` container. Usage collection is file-local: a consumer needing an
    additional capability should declare it at the consumer instead of relying on a broader upstream
    alias. This avoids turning lint into an open-ended whole-program dependency analysis.
 
 ### Analysis stages
 
-1. At `Program:exit`, collect matching aliases and resolve every direct or service-wrapped
+1. At `Program:exit`, collect matching aliases and resolve every root, nested, or service-wrapped
    intersection member with the TypeScript type checker.
 2. Mark contracts as opaque when they enter a generic context that the rule cannot safely interpret.
 3. Read `createThunk` configuration and add the state/dependency requirements of dispatched child

--- a/eslint-local-rules/no-unused-intersection-members/README.md
+++ b/eslint-local-rules/no-unused-intersection-members/README.md
@@ -51,7 +51,9 @@ Here the `storage` property is reported.
    members are checked against usages such as `deps.services.logger` and child-thunk requirements.
 5. **Include transitive thunk requirements.** Dispatching a child thunk implicitly requires the
    child's `state` and `extra` types. Those requirements count even if the parent thunk never calls
-   `getState()` or reads `extra` itself.
+   `getState()` or reads `extra` itself. Thunk factories are recognized from their TypeScript
+   signature, so aliases, namespace properties, named configuration types, extracted callbacks,
+   `api.dispatch(...)`, and dispatch functions passed to typed helpers retain this analysis.
 6. **Prefer false negatives over false positives.** When the analysis cannot prove which member is
    needed, it keeps the whole contract. The rule should suggest a removal only when that removal is
    demonstrably safe for every usage visible in the file.

--- a/eslint-local-rules/no-unused-intersection-members/README.md
+++ b/eslint-local-rules/no-unused-intersection-members/README.md
@@ -1,9 +1,9 @@
 # Local ESLint rules
 
-## Unused State and Deps intersection members
+## Unused State and Deps contract members
 
-`no-unused-intersection-members` checks explicit intersections in local aliases whose names end in
-`State` or `Deps`:
+`no-unused-intersection-members` checks explicit intersections and object properties in local aliases
+whose names end in `State` or `Deps`:
 
 ```ts
 type RunDeps = LoggerDeps & StorageDeps;
@@ -22,14 +22,27 @@ type RunDeps = { services: LoggerDeps & StorageDeps };
 const run = (deps: RunDeps) => deps.services.logger.log('started');
 ```
 
+Object properties are reportable contract members too:
+
+```ts
+type RunDeps = {
+    logger: Logger;
+    storage: Storage;
+};
+
+const run = (deps: RunDeps) => deps.logger.log('started');
+```
+
+Here the `storage` property is reported.
+
 ### Principles
 
 1. **Analyze requirements, not textual references.** A member may be needed through
    `deps.logger.log()`, a selector receiving the complete state, or a dispatched child thunk. Looking
    only for the member's type name would miss all of these cases.
-2. **Treat intersection members as capability providers.** Each observed usage becomes a property
-   path such as `logger.log`, optionally paired with the type expected by a function parameter. The
-   rule asks which members can provide that requirement.
+2. **Treat contract members as capability providers.** Each observed usage becomes a property path
+   such as `logger.log`, optionally paired with the type expected by a function parameter. The rule
+   asks which members can provide that requirement.
 3. **Account for structural composition.** A required type can be satisfied by properties spread
    across multiple intersection members. The rule recursively compares their combined properties
    rather than checking each member only in isolation.
@@ -43,15 +56,16 @@ const run = (deps: RunDeps) => deps.services.logger.log('started');
    needed, it keeps the whole contract. The rule should suggest a removal only when that removal is
    demonstrably safe for every usage visible in the file.
 7. **Stay local and predictable.** Candidates are type aliases in the current source file, must end
-   in `State` or `Deps`, and must contain an explicit root or nested intersection, including one
-   inside a transparent `services` container. Usage collection is file-local: a consumer needing an
-   additional capability should declare it at the consumer instead of relying on a broader upstream
-   alias. This avoids turning lint into an open-ended whole-program dependency analysis.
+   in `State` or `Deps`, and must contain an explicit root or nested intersection or object property,
+   including one inside a transparent `services` container. Usage collection is file-local: a
+   consumer needing an additional capability should declare it at the consumer instead of relying
+   on a broader upstream alias. This avoids turning lint into an open-ended whole-program dependency
+   analysis.
 
 ### Analysis stages
 
 1. At `Program:exit`, collect matching aliases and resolve every root, nested, or service-wrapped
-   intersection member with the TypeScript type checker.
+   intersection and object member with the TypeScript type checker.
 2. Mark contracts as opaque when they enter a generic context that the rule cannot safely interpret.
 3. Read `createThunk` configuration and add the state/dependency requirements of dispatched child
    thunks.

--- a/eslint-local-rules/no-unused-intersection-members/README.md
+++ b/eslint-local-rules/no-unused-intersection-members/README.md
@@ -2,8 +2,8 @@
 
 ## Unused State and Deps contract members
 
-`no-unused-intersection-members` checks explicit intersections and object properties in local aliases
-whose names end in `State` or `Deps`:
+`no-unused-intersection-members` checks explicit intersections and object properties in local
+contract aliases. By default, aliases whose names end in `State` or `Deps` are contracts:
 
 ```ts
 type RunDeps = LoggerDeps & StorageDeps;
@@ -35,6 +35,33 @@ const run = (deps: RunDeps) => deps.logger.log('started');
 
 Here the `storage` property is reported.
 
+### Contract discovery
+
+In addition to the default `State` and `Deps` suffixes, a type alias is treated as a contract when it
+is used as:
+
+- The `state` or `extra` type of a thunk factory configuration.
+- The `deps` parameter of a `create*` dependency factory.
+
+Projects can opt additional naming conventions into the analysis:
+
+```js
+{
+    'local-rules/no-unused-intersection-members': [
+        'error',
+        { additionalTypeNameSuffixes: ['Context', 'Services'] },
+    ],
+}
+```
+
+Role-based discovery keeps thunk and DI contracts covered even when their names use another suffix,
+while unrelated data types remain outside the rule by default.
+
+An ordinary `*State` alias may describe persisted reducer data rather than a capability contract. To
+avoid treating fields in that data model as locally removable, suffix-only `*State` aliases retain
+the original root-intersection analysis. Nested intersections and object members are enabled when
+the alias is identified as a thunk state contract.
+
 ### Principles
 
 1. **Analyze requirements, not textual references.** A member may be needed through
@@ -57,11 +84,11 @@ Here the `storage` property is reported.
 6. **Prefer false negatives over false positives.** When the analysis cannot prove which member is
    needed, it keeps the whole contract. The rule should suggest a removal only when that removal is
    demonstrably safe for every usage visible in the file.
-7. **Stay local and predictable.** Candidates are type aliases in the current source file, must end
-   in `State` or `Deps`, and must contain an explicit root or nested intersection or object property,
-   including one inside a transparent `services` container. Usage collection is file-local: a
-   consumer needing an additional capability should declare it at the consumer instead of relying
-   on a broader upstream alias. This avoids turning lint into an open-ended whole-program dependency
+7. **Stay local and predictable.** Candidates are explicit intersections and object properties
+   within recognized contract aliases in the current source file, including intersections inside a
+   transparent `services` container. Usage collection is file-local: a consumer needing an
+   additional capability should declare it at the consumer instead of relying on a broader upstream
+   alias. This avoids turning lint into an open-ended whole-program dependency
    analysis.
 
 ### Analysis stages

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -23,6 +23,7 @@ const typeAwareTestFilename = path.join(__dirname, '../..', 'unused-intersection
 typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMembersRule, {
     valid: [
         {
+            name: 'accepts when every direct intersection member is used',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: (message: string) => void } };
@@ -36,6 +37,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'accepts when every member contributes through a shared services path',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { services: { logger: { log: () => void } } };
@@ -49,6 +51,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'accepts when every WithServices dependency is used',
             filename: typeAwareTestFilename,
             code: `
                     type WithServices<Services extends object> = { services: Services };
@@ -63,6 +66,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'combines state requirements from a selector and direct access',
             filename: typeAwareTestFilename,
             code: `
                     type AccountsRootState = { accounts: { selected: string } };
@@ -78,6 +82,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'combines dependency requirements from a consumer and direct access',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -93,6 +98,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'accepts when every nested intersection member is used',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { logger: { log: () => void } };
@@ -106,6 +112,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'accepts when every object contract member is used',
             filename: typeAwareTestFilename,
             code: `
                     type RunDeps = {
@@ -120,6 +127,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'ignores object-shaped State aliases without state-role usage',
             filename: typeAwareTestFilename,
             code: `
                     type SendState = {
@@ -131,6 +139,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'ignores aliases without a recognized suffix or usage role',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -141,6 +150,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'ignores custom suffixes unless configured or discovered from usage',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { logger: { log: () => void } };
@@ -151,6 +161,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'preserves contracts consumed in type-level positions',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { logger: { log: () => void } };
@@ -167,6 +178,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'preserves contracts accessed through dynamic keys',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -177,6 +189,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'preserves ambiguous members with overlapping properties',
             filename: typeAwareTestFilename,
             code: `
                     type FirstDeps = { logger: { log: () => void } };
@@ -187,6 +200,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'preserves contracts wrapped by an unknown generic',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -200,6 +214,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'preserves state contracts passed as generic arguments',
             filename: typeAwareTestFilename,
             code: `
                     type AccountsRootState = { accounts: { selected: string } };
@@ -214,6 +229,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'combines direct thunk usage with dispatched child requirements',
             filename: typeAwareTestFilename,
             code: `
                     type LocalState = { local: { ready: boolean } };
@@ -252,6 +268,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'accounts for WithServices requirements of dispatched child thunks',
             filename: typeAwareTestFilename,
             code: `
                     type WithServices<Services extends object> = { services: Services };
@@ -286,6 +303,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'accounts for dispatched child requirements in vanilla thunks',
             filename: typeAwareTestFilename,
             code: `
                     type WithServices<Services extends object> = { services: Services };
@@ -312,6 +330,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 `,
         },
         {
+            name: 'preserves members captured by rest destructuring',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -327,6 +346,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
     ],
     invalid: [
         {
+            name: 'reports an unused direct intersection member',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -343,6 +363,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused nested intersection member after destructuring',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { logger: { log: () => void } };
@@ -361,6 +382,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports a state member not required by a narrower selector',
             filename: typeAwareTestFilename,
             code: `
                     type AccountsRootState = { accounts: { selected: string } };
@@ -379,6 +401,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports multiple unused members under a shared services path',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { services: { logger: { log: () => void } } };
@@ -400,6 +423,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused WithServices dependency',
             filename: typeAwareTestFilename,
             code: `
                     type WithServices<Services extends object> = { services: Services };
@@ -417,6 +441,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused WithServices dependency beside root members',
             filename: typeAwareTestFilename,
             code: `
                     type WithServices<Services extends object> = { services: Services };
@@ -439,6 +464,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports parent state unused by both parent and child thunks',
             filename: typeAwareTestFilename,
             code: `
                     type LocalState = { local: { ready: boolean } };
@@ -478,6 +504,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused member with parameter destructuring',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -494,6 +521,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused member with nested parameter destructuring',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { services: { logger: { log: () => void } } };
@@ -512,6 +540,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused nested intersection member after property access',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { logger: { log: () => void } };
@@ -528,6 +557,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports a nested member not required by a narrower consumer',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { logger: { log: () => void } };
@@ -545,6 +575,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused object contract member',
             filename: typeAwareTestFilename,
             code: `
                     type RunDeps = {
@@ -562,6 +593,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused nested object member after destructuring',
             filename: typeAwareTestFilename,
             code: `
                     type RunDeps = {
@@ -581,6 +613,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an object member not required by a narrower consumer',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -600,6 +633,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports an unused inline object intersection member',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDeps = { logger: { log: () => void } };
@@ -612,6 +646,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             errors: [{ messageId: 'unusedIntersectionMember' }],
         },
         {
+            name: 'discovers thunk contracts through aliased factories and callbacks',
             filename: typeAwareTestFilename,
             code: `
                     type ChildState = { child: { ready: boolean } };
@@ -671,6 +706,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'reports only provably unused extras when dispatch escapes',
             filename: typeAwareTestFilename,
             code: `
                     type ServiceDeps = { services: { logger: { log: () => void } } };
@@ -715,6 +751,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'supports configured contract name suffixes',
             filename: typeAwareTestFilename,
             options: [{ additionalTypeNameSuffixes: ['Context'] }],
             code: `
@@ -732,6 +769,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'discovers dependency contracts from service factory parameters',
             filename: typeAwareTestFilename,
             code: `
                     type LoggerDep = { logger: { log: () => void } };
@@ -748,6 +786,7 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             ],
         },
         {
+            name: 'discovers dependency contracts from createThunk extra configuration',
             filename: typeAwareTestFilename,
             code: `
                     type ExtraContext = {

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -153,6 +153,22 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
         {
             filename: typeAwareTestFilename,
             code: `
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunDeps = LoggerDep & StorageDep;
+                    type RunKeys = keyof RunDeps;
+                    type RunStorage = RunDeps['storage'];
+                    type PublicRunContract = RunDeps;
+
+                    const run = (deps: RunDeps) => deps.logger.log();
+                    declare const key: RunKeys;
+                    declare const storage: RunStorage;
+                    declare const publicDeps: PublicRunContract;
+                `,
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
                     type LoggerDeps = { logger: { log: () => void } };
                     type StorageDeps = { storage: { save: () => void } };
                     type RunDeps = LoggerDeps & StorageDeps;

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -122,11 +122,32 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
         {
             filename: typeAwareTestFilename,
             code: `
+                    type SendState = {
+                        drafts: Record<string, unknown>;
+                        serializedTransaction?: string;
+                    };
+
+                    const getDrafts = (state: SendState) => state.drafts;
+                `,
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
                     type LoggerDeps = { logger: { log: () => void } };
                     type StorageDeps = { storage: { save: () => void } };
                     type UnrelatedContract = LoggerDeps & StorageDeps;
 
                     const run = (deps: UnrelatedContract) => deps.logger.log();
+                `,
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunContext = LoggerDep & StorageDep;
+
+                    const run = (context: RunContext) => context.logger.log();
                 `,
         },
         {
@@ -674,6 +695,70 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 {
                     messageId: 'unusedContractMember',
                     data: { memberName: 'storage', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            options: [{ additionalTypeNameSuffixes: ['Context'] }],
+            code: `
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunContext = LoggerDep & StorageDep;
+
+                    const run = (context: RunContext) => context.logger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDep', typeName: 'RunContext' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type ServiceContext = LoggerDep & StorageDep;
+
+                    const createService = (deps: ServiceContext) => () => deps.logger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDep', typeName: 'ServiceContext' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type ExtraContext = {
+                        logger: { log: () => void };
+                        storage: { save: () => void };
+                    };
+
+                    declare const createThunk: <Result, Payload, Config>(
+                        name: string,
+                        callback: (
+                            payload: Payload,
+                            api: {
+                                dispatch: (action: unknown) => unknown;
+                                extra: Config extends { extra: infer Deps } ? Deps : never;
+                            },
+                        ) => Result,
+                    ) => unknown;
+
+                    createThunk<void, void, { extra: ExtraContext }>(
+                        'run',
+                        (_, { extra }) => extra.logger.log(),
+                    );
+                `,
+            errors: [
+                {
+                    messageId: 'unusedContractMember',
+                    data: { memberName: 'storage', typeName: 'ExtraContext' },
                 },
             ],
         },

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -247,6 +247,19 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                         };
                 `,
         },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDeps = { logger: { log: () => void } };
+                    type StorageDeps = { storage: { save: () => void } };
+                    type RunDeps = LoggerDeps & StorageDeps;
+
+                    const run = ({ logger, ...remainingDeps }: RunDeps) => {
+                        logger.log();
+                        return remainingDeps;
+                    };
+                `,
+        },
     ],
     invalid: [
         {
@@ -379,6 +392,40 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                 {
                     messageId: 'unusedIntersectionMember',
                     data: { memberName: 'UnusedState', typeName: 'ParentState' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDeps = { logger: { log: () => void } };
+                    type StorageDeps = { storage: { save: () => void } };
+                    type RunDeps = LoggerDeps & StorageDeps;
+
+                    const run = ({ logger }: RunDeps) => logger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDeps', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDep = { services: { logger: { log: () => void } } };
+                    type StorageDep = { services: { storage: { save: () => void } } };
+                    type RunDeps = LoggerDep & StorageDep;
+
+                    declare const deps: RunDeps;
+                    const { services: { logger: serviceLogger } } = deps;
+                    serviceLogger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDep', typeName: 'RunDeps' },
                 },
             ],
         },

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -95,6 +95,19 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
         {
             filename: typeAwareTestFilename,
             code: `
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunDeps = { services: LoggerDep & StorageDep };
+
+                    const run = (deps: RunDeps) => {
+                        deps.services.logger.log();
+                        deps.services.storage.save();
+                    };
+                `,
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
                     type LoggerDeps = { logger: { log: () => void } };
                     type StorageDeps = { storage: { save: () => void } };
                     type UnrelatedContract = LoggerDeps & StorageDeps;
@@ -421,6 +434,39 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                     declare const deps: RunDeps;
                     const { services: { logger: serviceLogger } } = deps;
                     serviceLogger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDep', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunDeps = { services: LoggerDep & StorageDep };
+
+                    const run = (deps: RunDeps) => deps.services.logger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDep', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunDeps = { services: LoggerDep & StorageDep };
+
+                    declare const useLogger: (deps: { services: LoggerDep }) => void;
+                    const run = (deps: RunDeps) => useLogger(deps);
                 `,
             errors: [
                 {

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -646,66 +646,6 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
             errors: [{ messageId: 'unusedIntersectionMember' }],
         },
         {
-            name: 'discovers thunk contracts through aliased factories and callbacks',
-            filename: typeAwareTestFilename,
-            code: `
-                    type ChildState = { child: { ready: boolean } };
-                    type UnusedState = { unused: { ready: boolean } };
-                    type ChildDeps = { logger: { log: () => void } };
-                    type UnusedDeps = { storage: { save: () => void } };
-                    type ParentState = ChildState & UnusedState;
-                    type ParentDeps = ChildDeps & UnusedDeps;
-                    type ParentConfig = { state: ParentState; extra: ParentDeps };
-                    type ChildAction = (
-                        dispatch: unknown,
-                        getState: () => ChildState,
-                        extra: ChildDeps,
-                    ) => void;
-                    type ParentCallback = (
-                        payload: void,
-                        api: {
-                            dispatch: (action: ChildAction) => unknown;
-                            getState: () => ParentState;
-                            extra: ParentDeps;
-                        },
-                    ) => void;
-
-                    declare const childThunk: () => ChildAction;
-                    declare const createThunk: <Result, Payload, Config>(
-                        name: string,
-                        callback: (
-                            payload: Payload,
-                            api: {
-                                dispatch: (action: ChildAction) => unknown;
-                                getState: () => Config extends { state: infer State } ? State : never;
-                                extra: Config extends { extra: infer Deps } ? Deps : never;
-                            },
-                        ) => Result,
-                    ) => unknown;
-
-                    const parentCallback: ParentCallback = (_, api) => {
-                        api.dispatch(childThunk());
-                    };
-                    const thunkFactories = { createThunk };
-
-                    thunkFactories.createThunk<
-                        void,
-                        void,
-                        ParentConfig
-                    >('parent', parentCallback);
-                `,
-            errors: [
-                {
-                    messageId: 'unusedIntersectionMember',
-                    data: { memberName: 'UnusedState', typeName: 'ParentState' },
-                },
-                {
-                    messageId: 'unusedIntersectionMember',
-                    data: { memberName: 'UnusedDeps', typeName: 'ParentDeps' },
-                },
-            ],
-        },
-        {
             name: 'reports only provably unused extras when dispatch escapes',
             filename: typeAwareTestFilename,
             code: `

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -108,6 +108,20 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
         {
             filename: typeAwareTestFilename,
             code: `
+                    type RunDeps = {
+                        logger: { log: () => void };
+                        storage: { save: () => void };
+                    };
+
+                    const run = (deps: RunDeps) => {
+                        deps.logger.log();
+                        deps.storage.save();
+                    };
+                `,
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
                     type LoggerDeps = { logger: { log: () => void } };
                     type StorageDeps = { storage: { save: () => void } };
                     type UnrelatedContract = LoggerDeps & StorageDeps;
@@ -294,6 +308,24 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
         {
             filename: typeAwareTestFilename,
             code: `
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunDeps = { services: LoggerDep & StorageDep };
+
+                    declare const deps: RunDeps;
+                    const { logger } = deps.services;
+                    logger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDep', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
                     type AccountsRootState = { accounts: { selected: string } };
                     type SettingsRootState = { settings: { enabled: boolean } };
                     type RunState = AccountsRootState & SettingsRootState;
@@ -474,6 +506,73 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                     data: { memberName: 'StorageDep', typeName: 'RunDeps' },
                 },
             ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type RunDeps = {
+                        logger: { log: () => void };
+                        storage: { save: () => void };
+                    };
+
+                    const run = (deps: RunDeps) => deps.logger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedContractMember',
+                    data: { memberName: 'storage', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type RunDeps = {
+                        services: {
+                            logger: { log: () => void };
+                            storage: { save: () => void };
+                        };
+                    };
+
+                    const run = ({ services: { logger } }: RunDeps) => logger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedContractMember',
+                    data: { memberName: 'storage', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDeps = { logger: { log: () => void } };
+                    type RunDeps = {
+                        logger: { log: () => void };
+                        storage: { save: () => void };
+                    };
+
+                    declare const useLogger: (deps: LoggerDeps) => void;
+                    const run = (deps: RunDeps) => useLogger(deps);
+                `,
+            errors: [
+                {
+                    messageId: 'unusedContractMember',
+                    data: { memberName: 'storage', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type LoggerDeps = { logger: { log: () => void } };
+                    type RunDeps = LoggerDeps & {
+                        storage: { save: () => void };
+                    };
+
+                    const run = (deps: RunDeps) => deps.logger.log();
+                `,
+            errors: [{ messageId: 'unusedIntersectionMember' }],
         },
     ],
 } as Parameters<typeof typeAwareRuleTester.run>[2]);

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -571,8 +571,111 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                     };
 
                     const run = (deps: RunDeps) => deps.logger.log();
-                `,
+            `,
             errors: [{ messageId: 'unusedIntersectionMember' }],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type ChildState = { child: { ready: boolean } };
+                    type UnusedState = { unused: { ready: boolean } };
+                    type ChildDeps = { logger: { log: () => void } };
+                    type UnusedDeps = { storage: { save: () => void } };
+                    type ParentState = ChildState & UnusedState;
+                    type ParentDeps = ChildDeps & UnusedDeps;
+                    type ParentConfig = { state: ParentState; extra: ParentDeps };
+                    type ChildAction = (
+                        dispatch: unknown,
+                        getState: () => ChildState,
+                        extra: ChildDeps,
+                    ) => void;
+                    type ParentCallback = (
+                        payload: void,
+                        api: {
+                            dispatch: (action: ChildAction) => unknown;
+                            getState: () => ParentState;
+                            extra: ParentDeps;
+                        },
+                    ) => void;
+
+                    declare const childThunk: () => ChildAction;
+                    declare const createThunk: <Result, Payload, Config>(
+                        name: string,
+                        callback: (
+                            payload: Payload,
+                            api: {
+                                dispatch: (action: ChildAction) => unknown;
+                                getState: () => Config extends { state: infer State } ? State : never;
+                                extra: Config extends { extra: infer Deps } ? Deps : never;
+                            },
+                        ) => Result,
+                    ) => unknown;
+
+                    const parentCallback: ParentCallback = (_, api) => {
+                        api.dispatch(childThunk());
+                    };
+                    const thunkFactories = { createThunk };
+
+                    thunkFactories.createThunk<
+                        void,
+                        void,
+                        ParentConfig
+                    >('parent', parentCallback);
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'UnusedState', typeName: 'ParentState' },
+                },
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'UnusedDeps', typeName: 'ParentDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type ServiceDeps = { services: { logger: { log: () => void } } };
+                    type RunDeps = {
+                        services: { logger: { log: () => void } };
+                        thunks: { run: () => void };
+                        storage: { save: () => void };
+                    };
+                    type ChildAction = (
+                        dispatch: unknown,
+                        getState: () => unknown,
+                        extra: ServiceDeps,
+                    ) => void;
+
+                    declare const complete: (api: {
+                        dispatch: (action: ChildAction) => unknown;
+                    }) => void;
+                    declare const createThunk: <Result, Payload, Config>(
+                        name: string,
+                        callback: (
+                            payload: Payload,
+                            api: {
+                                dispatch: (action: ChildAction) => unknown;
+                                extra: Config extends { extra: infer Deps } ? Deps : never;
+                            },
+                        ) => Result,
+                    ) => unknown;
+
+                    createThunk<void, void, { extra: RunDeps }>(
+                        'run',
+                        (_, { dispatch, extra }) => {
+                            complete({ dispatch });
+                            extra.thunks.run();
+                        },
+                    );
+                `,
+            errors: [
+                {
+                    messageId: 'unusedContractMember',
+                    data: { memberName: 'storage', typeName: 'RunDeps' },
+                },
+            ],
         },
     ],
 } as Parameters<typeof typeAwareRuleTester.run>[2]);

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -547,34 +547,8 @@ const isUsageSatisfied = (
         : areTypesCollectivelyAssignable(typesAtPath, usage.requiredType, checker);
 };
 
-const isCreateThunkCall = (node: ts.CallExpression, checker: ts.TypeChecker) => {
-    if (node.typeArguments?.[2] === undefined) {
-        return false;
-    }
-
-    const signature = checker.getResolvedSignature(node);
-    const callbackParameter = signature?.getParameters()[1];
-
-    if (callbackParameter === undefined) {
-        return false;
-    }
-
-    const callbackType = checker.getTypeOfSymbolAtLocation(callbackParameter, node);
-
-    return checker
-        .getSignaturesOfType(callbackType, ts.SignatureKind.Call)
-        .some(callbackSignature => {
-            const apiParameter = callbackSignature.getParameters()[1];
-
-            if (apiParameter === undefined) {
-                return false;
-            }
-
-            const apiType = checker.getTypeOfSymbolAtLocation(apiParameter, node);
-
-            return checker.getPropertyOfType(apiType, 'dispatch') !== undefined;
-        });
-};
+const isCreateThunkCall = (node: ts.CallExpression) =>
+    ts.isIdentifier(node.expression) && node.expression.text === 'createThunk';
 
 // Type-level consumers may depend on members without producing an observable runtime property path.
 // Supported contract composition and thunk configuration remain transparent; derivation and generic
@@ -585,19 +559,9 @@ const markContractsUsedByOpaqueTypePositions = (
     checker: ts.TypeChecker,
 ) => {
     const supportedThunkConfigProperties = new Set<ts.Declaration>();
-    const supportedThunkCallbackAliases = new Set<ts.Symbol>();
     const collectThunkConfigProperties = (node: ts.Node) => {
-        if (ts.isCallExpression(node) && isCreateThunkCall(node, checker)) {
+        if (ts.isCallExpression(node) && isCreateThunkCall(node)) {
             const configTypeNode = node.typeArguments?.[2];
-            const callback = node.arguments[1];
-
-            if (callback !== undefined) {
-                const callbackType = checker.getTypeAtLocation(callback);
-
-                if (callbackType.aliasSymbol !== undefined) {
-                    supportedThunkCallbackAliases.add(callbackType.aliasSymbol);
-                }
-            }
 
             if (configTypeNode !== undefined) {
                 const configType = checker.getTypeFromTypeNode(configTypeNode);
@@ -661,11 +625,7 @@ const markContractsUsedByOpaqueTypePositions = (
             if (ts.isTypeAliasDeclaration(parent)) {
                 const containingSymbol = checker.getSymbolAtLocation(parent.name);
 
-                return (
-                    containingSymbol === undefined ||
-                    (!contractsBySymbol.has(containingSymbol) &&
-                        !supportedThunkCallbackAliases.has(containingSymbol))
-                );
+                return containingSymbol === undefined || !contractsBySymbol.has(containingSymbol);
             }
 
             if (ts.isParameter(parent) || ts.isVariableDeclaration(parent)) {
@@ -849,7 +809,7 @@ const collectRoleContractSymbols = (sourceFile: ts.SourceFile, checker: ts.TypeC
         }
     };
     const visitNode = (node: ts.Node) => {
-        if (ts.isCallExpression(node) && isCreateThunkCall(node, checker)) {
+        if (ts.isCallExpression(node) && isCreateThunkCall(node)) {
             addTypeAliasSymbol(getConfigPropertyType(node, 'state', checker));
             addTypeAliasSymbol(getConfigPropertyType(node, 'extra', checker));
         }
@@ -887,34 +847,6 @@ const getObjectBindingIdentifier = (parameter: ts.ParameterDeclaration, property
     );
 
     return binding !== undefined && ts.isIdentifier(binding.name) ? binding.name : undefined;
-};
-
-type ThunkCallbackFunction = ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression;
-
-const getThunkCallbackFunction = (
-    expression: ts.Expression,
-    checker: ts.TypeChecker,
-): ThunkCallbackFunction | undefined => {
-    if (ts.isArrowFunction(expression) || ts.isFunctionExpression(expression)) {
-        return expression;
-    }
-
-    const symbol = checker.getSymbolAtLocation(expression);
-    const declaration = symbol?.valueDeclaration;
-
-    if (
-        declaration !== undefined &&
-        ts.isVariableDeclaration(declaration) &&
-        declaration.initializer !== undefined &&
-        (ts.isArrowFunction(declaration.initializer) ||
-            ts.isFunctionExpression(declaration.initializer))
-    ) {
-        return declaration.initializer;
-    }
-
-    return declaration !== undefined && ts.isFunctionDeclaration(declaration)
-        ? declaration
-        : undefined;
 };
 
 const getDispatchSymbol = (parameter: ts.ParameterDeclaration, checker: ts.TypeChecker) => {
@@ -1146,10 +1078,13 @@ const addDispatchedThunkUsages = (
             addVanillaThunkUsages(node, contractsBySymbol, checker);
         }
 
-        if (ts.isCallExpression(node) && isCreateThunkCall(node, checker)) {
+        if (ts.isCallExpression(node) && isCreateThunkCall(node)) {
             const callback = node.arguments[1];
             const callbackFunction =
-                callback === undefined ? undefined : getThunkCallbackFunction(callback, checker);
+                callback !== undefined &&
+                (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))
+                    ? callback
+                    : undefined;
             const apiParameter = callbackFunction?.parameters[1];
             const dispatchSymbol =
                 apiParameter === undefined ? undefined : getDispatchSymbol(apiParameter, checker);

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -576,14 +576,110 @@ const isCreateThunkCall = (node: ts.CallExpression, checker: ts.TypeChecker) => 
         });
 };
 
-// Generic consumers may use a contract through constraints or inference without an observable
-// property path. createThunk is excluded because its state and extra contracts are handled below.
-const markContractsUsedByGenericCallsAsOpaque = (
+// Type-level consumers may depend on members without producing an observable runtime property path.
+// Supported contract composition and thunk configuration remain transparent; derivation and generic
+// contexts keep the source contract intact.
+const markContractsUsedByOpaqueTypePositions = (
     sourceFile: ts.SourceFile,
     contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
     checker: ts.TypeChecker,
 ) => {
-    const visitTypeNode = (node: ts.Node) => {
+    const supportedThunkConfigProperties = new Set<ts.Declaration>();
+    const supportedThunkCallbackAliases = new Set<ts.Symbol>();
+    const collectThunkConfigProperties = (node: ts.Node) => {
+        if (ts.isCallExpression(node) && isCreateThunkCall(node, checker)) {
+            const configTypeNode = node.typeArguments?.[2];
+            const callback = node.arguments[1];
+
+            if (callback !== undefined) {
+                const callbackType = checker.getTypeAtLocation(callback);
+
+                if (callbackType.aliasSymbol !== undefined) {
+                    supportedThunkCallbackAliases.add(callbackType.aliasSymbol);
+                }
+            }
+
+            if (configTypeNode !== undefined) {
+                const configType = checker.getTypeFromTypeNode(configTypeNode);
+
+                for (const propertyName of ['state', 'extra']) {
+                    checker
+                        .getPropertyOfType(configType, propertyName)
+                        ?.declarations?.forEach(declaration =>
+                            supportedThunkConfigProperties.add(declaration),
+                        );
+                }
+            }
+        }
+
+        ts.forEachChild(node, collectThunkConfigProperties);
+    };
+    ts.forEachChild(sourceFile, collectThunkConfigProperties);
+
+    const isInsideSupportedThunkConfig = (node: ts.Node) => {
+        let currentNode: ts.Node | undefined = node.parent;
+
+        while (currentNode !== undefined && !ts.isStatement(currentNode)) {
+            if (
+                ts.isPropertySignature(currentNode) &&
+                supportedThunkConfigProperties.has(currentNode)
+            ) {
+                return true;
+            }
+
+            currentNode = currentNode.parent;
+        }
+
+        return false;
+    };
+
+    const isOpaqueTypePosition = (node: ts.TypeReferenceNode) => {
+        if (isInsideSupportedThunkConfig(node)) {
+            return false;
+        }
+
+        let currentNode: ts.Node = node;
+        let { parent }: { parent: ts.Node | undefined } = node;
+
+        while (parent !== undefined && !ts.isStatement(parent)) {
+            if (
+                ts.isTypeOperatorNode(parent) ||
+                ts.isIndexedAccessTypeNode(parent) ||
+                ts.isConditionalTypeNode(parent) ||
+                ts.isMappedTypeNode(parent)
+            ) {
+                return true;
+            }
+
+            if (
+                (ts.isTypeReferenceNode(parent) || ts.isCallExpression(parent)) &&
+                parent.typeArguments?.includes(currentNode as ts.TypeNode)
+            ) {
+                return true;
+            }
+
+            if (ts.isTypeAliasDeclaration(parent)) {
+                const containingSymbol = checker.getSymbolAtLocation(parent.name);
+
+                return (
+                    containingSymbol === undefined ||
+                    (!contractsBySymbol.has(containingSymbol) &&
+                        !supportedThunkCallbackAliases.has(containingSymbol))
+                );
+            }
+
+            if (ts.isParameter(parent) || ts.isVariableDeclaration(parent)) {
+                return false;
+            }
+
+            currentNode = parent;
+            parent = currentNode.parent;
+        }
+
+        return ts.isInterfaceDeclaration(parent);
+    };
+
+    const visitNode = (node: ts.Node) => {
         if (ts.isTypeReferenceNode(node)) {
             const type = checker.getTypeFromTypeNode(node);
             const contracts =
@@ -591,21 +687,11 @@ const markContractsUsedByGenericCallsAsOpaque = (
                     ? []
                     : (contractsBySymbol.get(type.aliasSymbol) ?? []);
 
-            for (const contract of contracts) {
-                contract.isOpaque = true;
+            if (isOpaqueTypePosition(node)) {
+                for (const contract of contracts) {
+                    contract.isOpaque = true;
+                }
             }
-        }
-
-        ts.forEachChild(node, visitTypeNode);
-    };
-
-    const visitNode = (node: ts.Node) => {
-        if (ts.isCallExpression(node) && !isCreateThunkCall(node, checker)) {
-            node.typeArguments?.forEach(visitTypeNode);
-        }
-
-        if (ts.isTypeReferenceNode(node)) {
-            node.typeArguments?.forEach(visitTypeNode);
         }
 
         ts.forEachChild(node, visitNode);
@@ -622,17 +708,18 @@ const getConfigPropertyType = (
     const configTypeNode = createThunkCall.typeArguments?.[2];
 
     if (configTypeNode === undefined) {
-        return [];
+        return undefined;
     }
 
     const configType = checker.getTypeFromTypeNode(configTypeNode);
     const property = checker.getPropertyOfType(configType, propertyName);
 
     if (property === undefined) {
-        return [];
+        return undefined;
     }
 
     const declaration = property.valueDeclaration ?? property.declarations?.[0] ?? configTypeNode;
+
     return checker.getTypeOfSymbolAtLocation(property, declaration);
 };
 
@@ -943,9 +1030,7 @@ const addRequirementsFromDispatches = (
     depsContracts: readonly IntersectionContract[],
     checker: ts.TypeChecker,
 ) => {
-    const addRequirements = (
-        requirements: ReturnType<typeof getDispatchedThunkRequirements>,
-    ) => {
+    const addRequirements = (requirements: ReturnType<typeof getDispatchedThunkRequirements>) => {
         for (const requirement of requirements) {
             if (requirement.stateType !== undefined) {
                 for (const stateContract of stateContracts) {
@@ -1252,7 +1337,7 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
 
                 // Record ambiguous escapes and hidden child-thunk requirements before evaluating
                 // ordinary expression and property-path usages.
-                markContractsUsedByGenericCallsAsOpaque(sourceFile, contractsBySymbol, checker);
+                markContractsUsedByOpaqueTypePositions(sourceFile, contractsBySymbol, checker);
                 addDispatchedThunkUsages(sourceFile, contractsBySymbol, checker);
 
                 const visitNode = (node: ts.Node) => {

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -18,9 +18,14 @@ type ContractUsage = {
     requiredType?: ts.Type;
 };
 
-type IntersectionContract = {
-    isOpaque: boolean;
+type IntersectionGroup = {
     members: IntersectionMember[];
+    path: string[];
+};
+
+type IntersectionContract = {
+    groups: IntersectionGroup[];
+    isOpaque: boolean;
     name: string;
     rootPath: string[];
     symbol: ts.Symbol;
@@ -362,6 +367,36 @@ const getTypesAtPath = (
     return currentTypes;
 };
 
+const isPathPrefix = (prefix: readonly string[], path: readonly string[]) =>
+    prefix.every((part, index) => path[index] === part);
+
+const getGroupUsages = (
+    contract: IntersectionContract,
+    group: IntersectionGroup,
+    checker: ts.TypeChecker,
+) =>
+    contract.usages.flatMap(usage => {
+        if (isPathPrefix(group.path, usage.path)) {
+            return [{ ...usage, path: usage.path.slice(group.path.length) }];
+        }
+
+        if (!isPathPrefix(usage.path, group.path)) {
+            return [];
+        }
+
+        if (usage.requiredType === undefined) {
+            // Accessing a parent value without a narrower expected type may consume every nested
+            // member.
+            return [{ path: [] }];
+        }
+
+        return getTypesAtPath(
+            [usage.requiredType],
+            group.path.slice(usage.path.length),
+            checker,
+        ).map(requiredType => ({ path: [], requiredType }));
+    });
+
 const isOptionalProperty = (property: ts.Symbol) =>
     (property.flags & ts.SymbolFlags.Optional) !== 0;
 
@@ -538,6 +573,47 @@ const getConfigContracts = (
     return propertyType.aliasSymbol === undefined
         ? []
         : (contractsBySymbol.get(propertyType.aliasSymbol) ?? []);
+};
+
+const collectIntersectionGroups = (
+    node: ts.TypeNode,
+    sourceFile: ts.SourceFile,
+    checker: ts.TypeChecker,
+    path: readonly string[] = [],
+): IntersectionGroup[] => {
+    if (ts.isIntersectionTypeNode(node)) {
+        const group = {
+            members: node.types.map(memberNode => ({
+                name: memberNode.getText(sourceFile),
+                node: memberNode,
+                type: checker.getTypeFromTypeNode(memberNode),
+            })),
+            path: [...path],
+        };
+        const nestedGroups = node.types.flatMap(memberNode =>
+            ts.isTypeLiteralNode(memberNode)
+                ? collectIntersectionGroups(memberNode, sourceFile, checker, path)
+                : [],
+        );
+
+        return [group, ...nestedGroups];
+    }
+
+    if (!ts.isTypeLiteralNode(node)) {
+        return [];
+    }
+
+    return node.members.flatMap(member => {
+        if (!ts.isPropertySignature(member) || member.type === undefined) {
+            return [];
+        }
+
+        const propertyName = getBindingPropertyName(member.name);
+
+        return propertyName === undefined
+            ? []
+            : collectIntersectionGroups(member.type, sourceFile, checker, [...path, propertyName]);
+    });
 };
 
 const getObjectBindingIdentifier = (parameter: ts.ParameterDeclaration, propertyName: string) => {
@@ -804,11 +880,31 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
 
                 const contractsBySymbol = new Map<ts.Symbol, IntersectionContract[]>();
 
+                // Restrict candidates to local aliases with explicit intersections so each proof is
+                // tied to a concrete member list that can be reported and edited reliably.
                 for (const statement of sourceFile.statements) {
                     if (
                         !ts.isTypeAliasDeclaration(statement) ||
                         !contractTypeNamePattern.test(statement.name.text)
                     ) {
+                        continue;
+                    }
+
+                    const groups = [
+                        ...collectIntersectionGroups(statement.type, sourceFile, checker),
+                        ...getWrappedServicesIntersections(statement.type, checker).map(
+                            servicesIntersection => ({
+                                members: servicesIntersection.types.map(memberNode => ({
+                                    name: memberNode.getText(sourceFile),
+                                    node: memberNode,
+                                    type: checker.getTypeFromTypeNode(memberNode),
+                                })),
+                                path: ['services'],
+                            }),
+                        ),
+                    ];
+
+                    if (groups.length === 0) {
                         continue;
                     }
 
@@ -818,53 +914,16 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                         continue;
                     }
 
-                    const contracts: IntersectionContract[] = [];
-
-                    // Direct intersections remain independently editable top-level members.
-                    if (ts.isIntersectionTypeNode(statement.type)) {
-                        contracts.push({
+                    contractsBySymbol.set(symbol, [
+                        {
+                            groups,
                             isOpaque: false,
-                            members: statement.type.types.map(memberNode => ({
-                                name: memberNode.getText(sourceFile),
-                                node: memberNode,
-                                type: checker.getTypeFromTypeNode(memberNode),
-                            })),
                             name: statement.name.text,
                             rootPath: [],
                             symbol,
                             usages: [],
-                        });
-                    }
-
-                    const wrappedServicesIntersections = getWrappedServicesIntersections(
-                        statement.type,
-                        checker,
-                    );
-                    const wrappedServiceMembers = wrappedServicesIntersections.flatMap(
-                        intersection => intersection.types,
-                    );
-
-                    if (wrappedServiceMembers.length > 0) {
-                        // WithServices moves a dependency intersection below the `services` key.
-                        // Analyze those inner members as another local contract while retaining the
-                        // outer contract above for any non-service intersection members.
-                        contracts.push({
-                            isOpaque: false,
-                            members: wrappedServiceMembers.map(memberNode => ({
-                                name: memberNode.getText(sourceFile),
-                                node: memberNode,
-                                type: checker.getTypeFromTypeNode(memberNode),
-                            })),
-                            name: statement.name.text,
-                            rootPath: ['services'],
-                            symbol,
-                            usages: [],
-                        });
-                    }
-
-                    if (contracts.length > 0) {
-                        contractsBySymbol.set(symbol, contracts);
-                    }
+                        },
+                    ]);
                 }
 
                 if (contractsBySymbol.size === 0) {
@@ -911,25 +970,34 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                         continue;
                     }
 
-                    contract.members.forEach((member, memberIndex) => {
-                        const remainingTypes = contract.members
-                            .filter((_, index) => index !== memberIndex)
-                            .map(remainingMember => remainingMember.type);
-                        // Keep overlapping providers instead of choosing one arbitrarily. Otherwise,
-                        // a member is necessary when removing it leaves any usage unsatisfied.
-                        const isMemberUsed = contract.usages.some(
-                            usage =>
-                                isUsageSatisfied(usage, [member.type], checker) ||
-                                !isUsageSatisfied(usage, remainingTypes, checker),
-                        );
+                    for (const group of contract.groups) {
+                        const groupUsages = getGroupUsages(contract, group, checker);
 
-                        if (isMemberUsed) return;
+                        if (groupUsages.length === 0) {
+                            continue;
+                        }
 
-                        report(member.node, 'unusedIntersectionMember', {
-                            memberName: member.name,
-                            typeName: contract.name,
+                        group.members.forEach((member, memberIndex) => {
+                            const remainingTypes = group.members
+                                .filter((_, index) => index !== memberIndex)
+                                .map(remainingMember => remainingMember.type);
+                            // Keep overlapping providers instead of choosing one arbitrarily.
+                            // Otherwise, a member is necessary when removing it leaves any usage
+                            // unsatisfied.
+                            const isMemberUsed = groupUsages.some(
+                                usage =>
+                                    isUsageSatisfied(usage, [member.type], checker) ||
+                                    !isUsageSatisfied(usage, remainingTypes, checker),
+                            );
+
+                            if (isMemberUsed) return;
+
+                            report(member.node, 'unusedIntersectionMember', {
+                                memberName: member.name,
+                                typeName: contract.name,
+                            });
                         });
-                    });
+                    }
                 }
             },
         };

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -23,10 +23,21 @@ type IntersectionGroup = {
     path: string[];
 };
 
+type ContractProperty = {
+    name: string;
+    node: ts.PropertySignature;
+};
+
+type PropertyGroup = {
+    members: ContractProperty[];
+    path: string[];
+};
+
 type IntersectionContract = {
     groups: IntersectionGroup[];
     isOpaque: boolean;
     name: string;
+    propertyGroups: PropertyGroup[];
     rootPath: string[];
     symbol: ts.Symbol;
     usages: ContractUsage[];
@@ -51,6 +62,20 @@ const isInsideTypeNode = (node: ts.Node) => {
 const isNodeDeclarationName = (node: ts.Node) =>
     !ts.isShorthandPropertyAssignment(node.parent) &&
     (node.parent as ts.Node & { name?: ts.Node }).name === node;
+
+const hasAncestorInSet = (node: ts.Node, ancestors: ReadonlySet<ts.Node>) => {
+    let currentNode: ts.Node | undefined = node.parent;
+
+    while (currentNode !== undefined) {
+        if (ancestors.has(currentNode)) {
+            return true;
+        }
+
+        currentNode = currentNode.parent;
+    }
+
+    return false;
+};
 
 const getAliasedContracts = (
     node: ts.Expression,
@@ -297,16 +322,6 @@ const addContractUsage = (
         parent.initializer === terminalExpression &&
         ts.isObjectBindingPattern(parent.name)
     ) {
-        addBindingPatternUsages(parent.name, contract);
-
-        return;
-    }
-
-    if (
-        ts.isVariableDeclaration(parent) &&
-        parent.initializer === terminalExpression &&
-        ts.isObjectBindingPattern(parent.name)
-    ) {
         addBindingPatternUsages(parent.name, contract, checker, path);
 
         return;
@@ -372,7 +387,7 @@ const isPathPrefix = (prefix: readonly string[], path: readonly string[]) =>
 
 const getGroupUsages = (
     contract: IntersectionContract,
-    group: IntersectionGroup,
+    group: { path: readonly string[] },
     checker: ts.TypeChecker,
 ) =>
     contract.usages.flatMap(usage => {
@@ -399,6 +414,34 @@ const getGroupUsages = (
 
 const isOptionalProperty = (property: ts.Symbol) =>
     (property.flags & ts.SymbolFlags.Optional) !== 0;
+
+const isPropertyUsed = (
+    property: ContractProperty,
+    usages: readonly ContractUsage[],
+    checker: ts.TypeChecker,
+) =>
+    usages.some(usage => {
+        const [firstPathPart] = usage.path;
+
+        if (firstPathPart !== undefined) {
+            return firstPathPart === property.name;
+        }
+
+        if (usage.requiredType === undefined) {
+            return true;
+        }
+
+        if (
+            (usage.requiredType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0 ||
+            checker.getIndexInfosOfType(usage.requiredType).length > 0
+        ) {
+            return true;
+        }
+
+        const requiredProperty = checker.getPropertyOfType(usage.requiredType, property.name);
+
+        return requiredProperty !== undefined && !isOptionalProperty(requiredProperty);
+    });
 
 // Different intersection members can collectively satisfy a target even when none is assignable
 // on its own. Compare their properties recursively to account for requirements split across members.
@@ -614,6 +657,49 @@ const collectIntersectionGroups = (
             ? []
             : collectIntersectionGroups(member.type, sourceFile, checker, [...path, propertyName]);
     });
+};
+
+const collectPropertyGroups = (
+    node: ts.TypeNode,
+    path: readonly string[] = [],
+): PropertyGroup[] => {
+    if (ts.isIntersectionTypeNode(node)) {
+        return node.types.flatMap(memberNode => collectPropertyGroups(memberNode, path));
+    }
+
+    if (!ts.isTypeLiteralNode(node)) {
+        return [];
+    }
+
+    const members = node.members.flatMap(member => {
+        if (!ts.isPropertySignature(member) || member.type === undefined) {
+            return [];
+        }
+
+        const propertyName = getBindingPropertyName(member.name);
+
+        return propertyName === undefined
+            ? []
+            : [
+                  {
+                      name: propertyName,
+                      node: member,
+                  },
+              ];
+    });
+    const nestedGroups = node.members.flatMap(member => {
+        if (!ts.isPropertySignature(member) || member.type === undefined) {
+            return [];
+        }
+
+        const propertyName = getBindingPropertyName(member.name);
+
+        return propertyName === undefined
+            ? []
+            : collectPropertyGroups(member.type, [...path, propertyName]);
+    });
+
+    return members.length === 0 ? nestedGroups : [{ members, path: [...path] }, ...nestedGroups];
 };
 
 const getObjectBindingIdentifier = (parameter: ts.ParameterDeclaration, propertyName: string) => {
@@ -842,7 +928,7 @@ const getWrappedServicesIntersections = (node: ts.TypeNode, checker: ts.TypeChec
 };
 
 /**
- * Reports confidently unused members of local State and Deps intersection contracts.
+ * Reports confidently unused members of local State and Deps contracts.
  * See `README.md` for the analysis principles and conservative fallbacks.
  */
 export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
@@ -850,11 +936,13 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
         type: 'suggestion',
         docs: {
             description:
-                'Reports State and Deps intersection members that are not required by their local implementation.',
+                'Reports State and Deps contract members that are not required by their local implementation.',
             category: 'Best Practices',
             recommended: false,
         },
         messages: {
+            unusedContractMember:
+                "'{{memberName}}' is not required by the implementation using '{{typeName}}'. Remove it from the contract.",
             unusedIntersectionMember:
                 "'{{memberName}}' is not required by the implementation using '{{typeName}}'. Remove it from the intersection.",
         },
@@ -903,8 +991,9 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                             }),
                         ),
                     ];
+                    const propertyGroups = collectPropertyGroups(statement.type);
 
-                    if (groups.length === 0) {
+                    if (groups.length === 0 && propertyGroups.length === 0) {
                         continue;
                     }
 
@@ -919,6 +1008,7 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                             groups,
                             isOpaque: false,
                             name: statement.name.text,
+                            propertyGroups,
                             rootPath: [],
                             symbol,
                             usages: [],
@@ -970,6 +1060,8 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                         continue;
                     }
 
+                    const reportedIntersectionMembers = new Set<ts.TypeNode>();
+
                     for (const group of contract.groups) {
                         const groupUsages = getGroupUsages(contract, group, checker);
 
@@ -992,11 +1084,34 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
 
                             if (isMemberUsed) return;
 
+                            reportedIntersectionMembers.add(member.node);
                             report(member.node, 'unusedIntersectionMember', {
                                 memberName: member.name,
                                 typeName: contract.name,
                             });
                         });
+                    }
+
+                    for (const group of contract.propertyGroups) {
+                        const groupUsages = getGroupUsages(contract, group, checker);
+
+                        if (groupUsages.length === 0) {
+                            continue;
+                        }
+
+                        for (const member of group.members) {
+                            if (
+                                hasAncestorInSet(member.node, reportedIntersectionMembers) ||
+                                isPropertyUsed(member, groupUsages, checker)
+                            ) {
+                                continue;
+                            }
+
+                            report(member.node, 'unusedContractMember', {
+                                memberName: member.name,
+                                typeName: contract.name,
+                            });
+                        }
                     }
                 }
             },

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -543,8 +543,34 @@ const isUsageSatisfied = (
         : areTypesCollectivelyAssignable(typesAtPath, usage.requiredType, checker);
 };
 
-const isCreateThunkCall = (node: ts.CallExpression) =>
-    ts.isIdentifier(node.expression) && node.expression.text === 'createThunk';
+const isCreateThunkCall = (node: ts.CallExpression, checker: ts.TypeChecker) => {
+    if (node.typeArguments?.[2] === undefined) {
+        return false;
+    }
+
+    const signature = checker.getResolvedSignature(node);
+    const callbackParameter = signature?.getParameters()[1];
+
+    if (callbackParameter === undefined) {
+        return false;
+    }
+
+    const callbackType = checker.getTypeOfSymbolAtLocation(callbackParameter, node);
+
+    return checker
+        .getSignaturesOfType(callbackType, ts.SignatureKind.Call)
+        .some(callbackSignature => {
+            const apiParameter = callbackSignature.getParameters()[1];
+
+            if (apiParameter === undefined) {
+                return false;
+            }
+
+            const apiType = checker.getTypeOfSymbolAtLocation(apiParameter, node);
+
+            return checker.getPropertyOfType(apiType, 'dispatch') !== undefined;
+        });
+};
 
 // Generic consumers may use a contract through constraints or inference without an observable
 // property path. createThunk is excluded because its state and extra contracts are handled below.
@@ -570,7 +596,7 @@ const markContractsUsedByGenericCallsAsOpaque = (
     };
 
     const visitNode = (node: ts.Node) => {
-        if (ts.isCallExpression(node) && !isCreateThunkCall(node)) {
+        if (ts.isCallExpression(node) && !isCreateThunkCall(node, checker)) {
             node.typeArguments?.forEach(visitTypeNode);
         }
 
@@ -592,26 +618,19 @@ const getConfigContracts = (
 ) => {
     const configTypeNode = createThunkCall.typeArguments?.[2];
 
-    if (configTypeNode === undefined || !ts.isTypeLiteralNode(configTypeNode)) {
+    if (configTypeNode === undefined) {
         return [];
     }
 
-    const property = configTypeNode.members.find(
-        member =>
-            ts.isPropertySignature(member) &&
-            member.type !== undefined &&
-            member.name.getText() === propertyName,
-    );
+    const configType = checker.getTypeFromTypeNode(configTypeNode);
+    const property = checker.getPropertyOfType(configType, propertyName);
 
-    if (
-        property === undefined ||
-        !ts.isPropertySignature(property) ||
-        property.type === undefined
-    ) {
+    if (property === undefined) {
         return [];
     }
 
-    const propertyType = checker.getTypeFromTypeNode(property.type);
+    const declaration = property.valueDeclaration ?? property.declarations?.[0] ?? configTypeNode;
+    const propertyType = checker.getTypeOfSymbolAtLocation(property, declaration);
 
     return propertyType.aliasSymbol === undefined
         ? []
@@ -714,17 +733,73 @@ const getObjectBindingIdentifier = (parameter: ts.ParameterDeclaration, property
     return binding !== undefined && ts.isIdentifier(binding.name) ? binding.name : undefined;
 };
 
-const getDispatchedThunkRequirements = (action: ts.Expression, checker: ts.TypeChecker) => {
-    const actionType = checker.getTypeAtLocation(action);
+type ThunkCallbackFunction = ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression;
 
-    return checker.getSignaturesOfType(actionType, ts.SignatureKind.Call).flatMap(signature => {
+const getThunkCallbackFunction = (
+    expression: ts.Expression,
+    checker: ts.TypeChecker,
+): ThunkCallbackFunction | undefined => {
+    if (ts.isArrowFunction(expression) || ts.isFunctionExpression(expression)) {
+        return expression;
+    }
+
+    const symbol = checker.getSymbolAtLocation(expression);
+    const declaration = symbol?.valueDeclaration;
+
+    if (
+        declaration !== undefined &&
+        ts.isVariableDeclaration(declaration) &&
+        declaration.initializer !== undefined &&
+        (ts.isArrowFunction(declaration.initializer) ||
+            ts.isFunctionExpression(declaration.initializer))
+    ) {
+        return declaration.initializer;
+    }
+
+    return declaration !== undefined && ts.isFunctionDeclaration(declaration)
+        ? declaration
+        : undefined;
+};
+
+const getDispatchSymbol = (parameter: ts.ParameterDeclaration, checker: ts.TypeChecker) => {
+    const bindingIdentifier = getObjectBindingIdentifier(parameter, 'dispatch');
+
+    if (bindingIdentifier !== undefined) {
+        return checker.getSymbolAtLocation(bindingIdentifier);
+    }
+
+    if (!ts.isIdentifier(parameter.name)) {
+        return undefined;
+    }
+
+    return checker.getPropertyOfType(checker.getTypeAtLocation(parameter.name), 'dispatch');
+};
+
+const getCalledSymbol = (expression: ts.LeftHandSideExpression, checker: ts.TypeChecker) => {
+    if (ts.isIdentifier(expression)) {
+        return checker.getSymbolAtLocation(expression);
+    }
+
+    if (ts.isPropertyAccessExpression(expression)) {
+        return checker.getSymbolAtLocation(expression.name);
+    }
+
+    return undefined;
+};
+
+const getThunkActionRequirements = (
+    actionType: ts.Type,
+    location: ts.Node,
+    checker: ts.TypeChecker,
+) =>
+    checker.getSignaturesOfType(actionType, ts.SignatureKind.Call).flatMap(signature => {
         const parameters = signature.getParameters();
         const getStateParameter = parameters[1];
         const extraParameter = parameters[2];
         const getStateType =
             getStateParameter === undefined
                 ? undefined
-                : checker.getTypeOfSymbolAtLocation(getStateParameter, action);
+                : checker.getTypeOfSymbolAtLocation(getStateParameter, location);
         const stateType = getStateType
             ? checker
                   .getSignaturesOfType(getStateType, ts.SignatureKind.Call)
@@ -733,16 +808,64 @@ const getDispatchedThunkRequirements = (action: ts.Expression, checker: ts.TypeC
         const extraType =
             extraParameter === undefined
                 ? undefined
-                : checker.getTypeOfSymbolAtLocation(extraParameter, action);
+                : checker.getTypeOfSymbolAtLocation(extraParameter, location);
 
         return [{ extraType, stateType }];
     });
+
+const getDispatchedThunkRequirements = (action: ts.Expression, checker: ts.TypeChecker) =>
+    getThunkActionRequirements(checker.getTypeAtLocation(action), action, checker);
+
+const getContextualShorthandType = (node: ts.Identifier, checker: ts.TypeChecker) => {
+    const shorthand = node.parent;
+
+    if (!ts.isShorthandPropertyAssignment(shorthand)) {
+        return undefined;
+    }
+
+    const objectLiteral = shorthand.parent;
+
+    if (!ts.isObjectLiteralExpression(objectLiteral)) {
+        return undefined;
+    }
+
+    const contextualType =
+        checker.getContextualType(objectLiteral) ??
+        (ts.isCallExpression(objectLiteral.parent) &&
+        objectLiteral.parent.arguments.includes(objectLiteral)
+            ? getExpectedArgumentType(objectLiteral.parent, objectLiteral, checker)
+            : undefined);
+    const property =
+        contextualType === undefined
+            ? undefined
+            : checker.getPropertyOfType(contextualType, shorthand.name.text);
+
+    return property === undefined
+        ? undefined
+        : checker.getTypeOfSymbolAtLocation(property, shorthand);
 };
 
 const getContractsForType = (
     type: ts.Type | undefined,
     contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
 ) => (type?.aliasSymbol === undefined ? [] : (contractsBySymbol.get(type.aliasSymbol) ?? []));
+
+const getDispatchTypeRequirements = (
+    dispatchType: ts.Type,
+    location: ts.Node,
+    checker: ts.TypeChecker,
+) =>
+    checker.getSignaturesOfType(dispatchType, ts.SignatureKind.Call).flatMap(signature => {
+        const actionParameter = signature.getParameters()[0];
+
+        if (actionParameter === undefined) {
+            return [];
+        }
+
+        const actionType = checker.getTypeOfSymbolAtLocation(actionParameter, location);
+
+        return getThunkActionRequirements(actionType, location, checker);
+    });
 
 const addRequirementsFromDispatches = (
     body: ts.Node,
@@ -751,36 +874,53 @@ const addRequirementsFromDispatches = (
     depsContracts: readonly IntersectionContract[],
     checker: ts.TypeChecker,
 ) => {
+    const addRequirements = (
+        requirements: ReturnType<typeof getDispatchedThunkRequirements>,
+    ) => {
+        for (const requirement of requirements) {
+            if (requirement.stateType !== undefined) {
+                for (const stateContract of stateContracts) {
+                    recordContractUsage(
+                        { path: [], requiredType: requirement.stateType },
+                        stateContract,
+                        checker,
+                    );
+                }
+            }
+
+            if (requirement.extraType !== undefined) {
+                for (const depsContract of depsContracts) {
+                    recordContractUsage(
+                        { path: [], requiredType: requirement.extraType },
+                        depsContract,
+                        checker,
+                    );
+                }
+            }
+        }
+    };
     const visitNode = (node: ts.Node) => {
         if (
             ts.isCallExpression(node) &&
-            ts.isIdentifier(node.expression) &&
-            checker.getSymbolAtLocation(node.expression) === dispatchSymbol
+            getCalledSymbol(node.expression, checker) === dispatchSymbol
         ) {
             const action = node.arguments[0];
 
             if (action !== undefined) {
-                for (const requirement of getDispatchedThunkRequirements(action, checker)) {
-                    if (requirement.stateType !== undefined) {
-                        for (const stateContract of stateContracts) {
-                            recordContractUsage(
-                                { path: [], requiredType: requirement.stateType },
-                                stateContract,
-                                checker,
-                            );
-                        }
-                    }
+                addRequirements(getDispatchedThunkRequirements(action, checker));
+            }
+        }
 
-                    if (requirement.extraType !== undefined) {
-                        for (const depsContract of depsContracts) {
-                            recordContractUsage(
-                                { path: [], requiredType: requirement.extraType },
-                                depsContract,
-                                checker,
-                            );
-                        }
-                    }
-                }
+        if (
+            ts.isIdentifier(node) &&
+            (ts.isShorthandPropertyAssignment(node.parent)
+                ? checker.getShorthandAssignmentValueSymbol(node.parent)
+                : checker.getSymbolAtLocation(node)) === dispatchSymbol
+        ) {
+            const contextualDispatchType = getContextualShorthandType(node, checker);
+
+            if (contextualDispatchType !== undefined) {
+                addRequirements(getDispatchTypeRequirements(contextualDispatchType, node, checker));
             }
         }
 
@@ -852,24 +992,19 @@ const addDispatchedThunkUsages = (
             addVanillaThunkUsages(node, contractsBySymbol, checker);
         }
 
-        if (ts.isCallExpression(node) && isCreateThunkCall(node)) {
+        if (ts.isCallExpression(node) && isCreateThunkCall(node, checker)) {
             const callback = node.arguments[1];
             const callbackFunction =
-                callback !== undefined &&
-                (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))
-                    ? callback
-                    : undefined;
+                callback === undefined ? undefined : getThunkCallbackFunction(callback, checker);
             const apiParameter = callbackFunction?.parameters[1];
-            const dispatchIdentifier =
-                apiParameter === undefined
-                    ? undefined
-                    : getObjectBindingIdentifier(apiParameter, 'dispatch');
             const dispatchSymbol =
-                dispatchIdentifier === undefined
-                    ? undefined
-                    : checker.getSymbolAtLocation(dispatchIdentifier);
+                apiParameter === undefined ? undefined : getDispatchSymbol(apiParameter, checker);
 
-            if (callbackFunction !== undefined && dispatchSymbol !== undefined) {
+            if (
+                callbackFunction?.body !== undefined &&
+                apiParameter !== undefined &&
+                dispatchSymbol !== undefined
+            ) {
                 addRequirementsFromDispatches(
                     callbackFunction.body,
                     dispatchSymbol,

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -43,7 +43,11 @@ type IntersectionContract = {
     usages: ContractUsage[];
 };
 
-const contractTypeNamePattern = /(?:State|Deps)$/;
+type RuleOptions = {
+    additionalTypeNameSuffixes?: string[];
+};
+
+const defaultTypeNameSuffixes = ['State', 'Deps'];
 
 const isInsideTypeNode = (node: ts.Node) => {
     let currentNode: ts.Node | undefined = node.parent;
@@ -610,10 +614,9 @@ const markContractsUsedByGenericCallsAsOpaque = (
     ts.forEachChild(sourceFile, visitNode);
 };
 
-const getConfigContracts = (
+const getConfigPropertyType = (
     createThunkCall: ts.CallExpression,
     propertyName: 'extra' | 'state',
-    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
     checker: ts.TypeChecker,
 ) => {
     const configTypeNode = createThunkCall.typeArguments?.[2];
@@ -630,9 +633,18 @@ const getConfigContracts = (
     }
 
     const declaration = property.valueDeclaration ?? property.declarations?.[0] ?? configTypeNode;
-    const propertyType = checker.getTypeOfSymbolAtLocation(property, declaration);
+    return checker.getTypeOfSymbolAtLocation(property, declaration);
+};
 
-    return propertyType.aliasSymbol === undefined
+const getConfigContracts = (
+    createThunkCall: ts.CallExpression,
+    propertyName: 'extra' | 'state',
+    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
+    checker: ts.TypeChecker,
+) => {
+    const propertyType = getConfigPropertyType(createThunkCall, propertyName, checker);
+
+    return propertyType?.aliasSymbol === undefined
         ? []
         : (contractsBySymbol.get(propertyType.aliasSymbol) ?? []);
 };
@@ -719,6 +731,63 @@ const collectPropertyGroups = (
     });
 
     return members.length === 0 ? nestedGroups : [{ members, path: [...path] }, ...nestedGroups];
+};
+
+const getDependencyFactoryFunction = (node: ts.Node) => {
+    if (
+        ts.isFunctionDeclaration(node) &&
+        node.name !== undefined &&
+        /^create[A-Z]/.test(node.name.text)
+    ) {
+        return node;
+    }
+
+    if (
+        (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+        ts.isVariableDeclaration(node.parent) &&
+        ts.isIdentifier(node.parent.name) &&
+        /^create[A-Z]/.test(node.parent.name.text)
+    ) {
+        return node;
+    }
+
+    return undefined;
+};
+
+const collectRoleContractSymbols = (sourceFile: ts.SourceFile, checker: ts.TypeChecker) => {
+    const symbols = new Set<ts.Symbol>();
+    const addTypeAliasSymbol = (type: ts.Type | undefined) => {
+        if (type?.aliasSymbol !== undefined) {
+            symbols.add(type.aliasSymbol);
+        }
+    };
+    const visitNode = (node: ts.Node) => {
+        if (ts.isCallExpression(node) && isCreateThunkCall(node, checker)) {
+            addTypeAliasSymbol(getConfigPropertyType(node, 'state', checker));
+            addTypeAliasSymbol(getConfigPropertyType(node, 'extra', checker));
+        }
+
+        const dependencyFactory = getDependencyFactoryFunction(node);
+        const depsParameter = dependencyFactory?.parameters[0];
+
+        if (
+            depsParameter !== undefined &&
+            ts.isIdentifier(depsParameter.name) &&
+            depsParameter.name.text === 'deps'
+        ) {
+            addTypeAliasSymbol(
+                depsParameter.type === undefined
+                    ? checker.getTypeAtLocation(depsParameter)
+                    : checker.getTypeFromTypeNode(depsParameter.type),
+            );
+        }
+
+        ts.forEachChild(node, visitNode);
+    };
+
+    ts.forEachChild(sourceFile, visitNode);
+
+    return symbols;
 };
 
 const getObjectBindingIdentifier = (parameter: ts.ParameterDeclaration, propertyName: string) => {
@@ -1063,7 +1132,7 @@ const getWrappedServicesIntersections = (node: ts.TypeNode, checker: ts.TypeChec
 };
 
 /**
- * Reports confidently unused members of local State and Deps contracts.
+ * Reports confidently unused members of recognized local contracts.
  * See `README.md` for the analysis principles and conservative fallbacks.
  */
 export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
@@ -1071,7 +1140,7 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
         type: 'suggestion',
         docs: {
             description:
-                'Reports State and Deps contract members that are not required by their local implementation.',
+                'Reports contract members that are not required by their local implementation.',
             category: 'Best Practices',
             recommended: false,
         },
@@ -1081,7 +1150,19 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
             unusedIntersectionMember:
                 "'{{memberName}}' is not required by the implementation using '{{typeName}}'. Remove it from the intersection.",
         },
-        schema: [],
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    additionalTypeNameSuffixes: {
+                        type: 'array',
+                        items: { type: 'string', minLength: 1 },
+                        uniqueItems: true,
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
     },
     create(context) {
         const parserServices = getTypeScriptParserServices(context);
@@ -1092,6 +1173,11 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
 
         const checker = parserServices.program.getTypeChecker();
         const report = createTypeScriptNodeReporter(context, parserServices);
+        const options = context.options[0] as RuleOptions | undefined;
+        const typeNameSuffixes = [
+            ...defaultTypeNameSuffixes,
+            ...(options?.additionalTypeNameSuffixes ?? []),
+        ];
 
         return {
             'Program:exit': programNode => {
@@ -1102,18 +1188,26 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                 }
 
                 const contractsBySymbol = new Map<ts.Symbol, IntersectionContract[]>();
+                const roleContractSymbols = collectRoleContractSymbols(sourceFile, checker);
 
                 // Restrict candidates to local aliases with explicit intersections so each proof is
                 // tied to a concrete member list that can be reported and edited reliably.
                 for (const statement of sourceFile.statements) {
+                    if (!ts.isTypeAliasDeclaration(statement)) {
+                        continue;
+                    }
+
+                    const symbol = checker.getSymbolAtLocation(statement.name);
+
                     if (
-                        !ts.isTypeAliasDeclaration(statement) ||
-                        !contractTypeNamePattern.test(statement.name.text)
+                        symbol === undefined ||
+                        (!typeNameSuffixes.some(suffix => statement.name.text.endsWith(suffix)) &&
+                            !roleContractSymbols.has(symbol))
                     ) {
                         continue;
                     }
 
-                    const groups = [
+                    const allGroups = [
                         ...collectIntersectionGroups(statement.type, sourceFile, checker),
                         ...getWrappedServicesIntersections(statement.type, checker).map(
                             servicesIntersection => ({
@@ -1126,15 +1220,16 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                             }),
                         ),
                     ];
-                    const propertyGroups = collectPropertyGroups(statement.type);
+                    const isNonRoleStateContract =
+                        statement.name.text.endsWith('State') && !roleContractSymbols.has(symbol);
+                    const groups = isNonRoleStateContract
+                        ? allGroups.filter(group => group.path.length === 0).slice(0, 1)
+                        : allGroups;
+                    const propertyGroups = isNonRoleStateContract
+                        ? []
+                        : collectPropertyGroups(statement.type);
 
                     if (groups.length === 0 && propertyGroups.length === 0) {
-                        continue;
-                    }
-
-                    const symbol = checker.getSymbolAtLocation(statement.name);
-
-                    if (symbol === undefined) {
                         continue;
                     }
 

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -166,6 +166,59 @@ const recordContractUsage = (
     }
 };
 
+const getBindingPropertyName = (name: ts.PropertyName | ts.BindingName) => {
+    if (ts.isIdentifier(name) || ts.isStringLiteralLike(name) || ts.isNumericLiteral(name)) {
+        return name.text;
+    }
+
+    if (
+        ts.isComputedPropertyName(name) &&
+        (ts.isStringLiteralLike(name.expression) || ts.isNumericLiteral(name.expression))
+    ) {
+        return name.expression.text;
+    }
+
+    return undefined;
+};
+
+const addBindingPatternUsages = (
+    pattern: ts.ObjectBindingPattern,
+    contract: IntersectionContract,
+    checker: ts.TypeChecker,
+    parentPath: readonly string[] = [],
+) => {
+    if (pattern.elements.length === 0 && parentPath.length > 0) {
+        recordContractUsage({ path: [...parentPath] }, contract, checker);
+
+        return;
+    }
+
+    for (const element of pattern.elements) {
+        if (element.dotDotDotToken !== undefined) {
+            // A rest binding can read every property not explicitly destructured.
+            contract.isOpaque = true;
+
+            return;
+        }
+
+        const propertyName = getBindingPropertyName(element.propertyName ?? element.name);
+
+        if (propertyName === undefined || ts.isArrayBindingPattern(element.name)) {
+            contract.isOpaque = true;
+
+            return;
+        }
+
+        const path = [...parentPath, propertyName];
+
+        if (ts.isObjectBindingPattern(element.name)) {
+            addBindingPatternUsages(element.name, contract, checker, path);
+        } else {
+            recordContractUsage({ path }, contract, checker);
+        }
+    }
+};
+
 const addContractUsage = (
     rootExpression: ts.Expression,
     contract: IntersectionContract,
@@ -230,6 +283,26 @@ const addContractUsage = (
         }
 
         recordContractUsage({ path, requiredType }, contract, checker);
+
+        return;
+    }
+
+    if (
+        ts.isVariableDeclaration(parent) &&
+        parent.initializer === terminalExpression &&
+        ts.isObjectBindingPattern(parent.name)
+    ) {
+        addBindingPatternUsages(parent.name, contract);
+
+        return;
+    }
+
+    if (
+        ts.isVariableDeclaration(parent) &&
+        parent.initializer === terminalExpression &&
+        ts.isObjectBindingPattern(parent.name)
+    ) {
+        addBindingPatternUsages(parent.name, contract, checker, path);
 
         return;
     }
@@ -804,6 +877,18 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                 addDispatchedThunkUsages(sourceFile, contractsBySymbol, checker);
 
                 const visitNode = (node: ts.Node) => {
+                    if (ts.isParameter(node) && ts.isObjectBindingPattern(node.name)) {
+                        const parameterType =
+                            node.type === undefined
+                                ? checker.getTypeAtLocation(node)
+                                : checker.getTypeFromTypeNode(node.type);
+                        const contracts = getContractsForType(parameterType, contractsBySymbol);
+
+                        for (const contract of contracts) {
+                            addBindingPatternUsages(node.name, contract, checker);
+                        }
+                    }
+
                     if (
                         ts.isExpression(node) &&
                         !isNodeDeclarationName(node) &&


### PR DESCRIPTION
## Description

Extend the rule to cover destructuring, nested and object contracts, thunk state/extra, and DI services, with conservative fallbacks. Benchmark: five alternating warm runs across 322 production TS files (suite-sync + wallet-core) versus develop showed median paired delta +0.468s (+2.3%) and mean +0.515s (+2.5%); PR range 20.737–21.942s, develop 20.039–22.050s. The rule remains gated by ESLINT_RUN_EXPENSIVE_CHECKS=true, so normal lint is unaffected.