### PR TITLE
chore(deps): update @testing-library/react-native to 14.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
         "@types/react": "19.2.14",
         "react-dom": "19.2.3",
         "expo-modules-core": "~57.0.6",
-        "react-test-renderer": "19.2.3"
+        "test-renderer": "1.2.0"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -30,6 +30,7 @@ jest-extended
 jest-junit
 jest-watch-typeahead
 minimist
+test-renderer
 ts-jest
 uri-scheme
 xml2js

--- a/suite-native/accounts/src/components/AccountLabel.test.tsx
+++ b/suite-native/accounts/src/components/AccountLabel.test.tsx
@@ -58,8 +58,8 @@ describe('AccountLabel', () => {
         }),
     } as const;
 
-    const renderAccountLabel = (props: AccountLabelPropsWithAccount) =>
-        renderWithStoreProvider(<AccountLabel {...props} />, {
+    const renderAccountLabel = async (props: AccountLabelPropsWithAccount) =>
+        await renderWithStoreProvider(<AccountLabel {...props} />, {
             store: createLightStore({
                 reducer,
                 preloadedState: {
@@ -71,14 +71,14 @@ describe('AccountLabel', () => {
             }),
         });
 
-    it('should render account label when account is provided', () => {
-        const { getByText } = renderAccountLabel({ account: ethAccount });
+    it('should render account label when account is provided', async () => {
+        const { getByText } = await renderAccountLabel({ account: ethAccount });
 
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
     });
 
-    it('should render account label when descriptors are provided', () => {
-        const { getByText } = renderAccountLabel({
+    it('should render account label when descriptors are provided', async () => {
+        const { getByText } = await renderAccountLabel({
             deviceStaticSessionId: ethAccount.deviceState,
             networkSymbol: ethAccount.symbol,
             accountDescriptor: ethAccount.descriptor,
@@ -87,8 +87,8 @@ describe('AccountLabel', () => {
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
     });
 
-    it('should render nothing when accountLabel is not found', () => {
-        const { toJSON } = renderAccountLabel({
+    it('should render nothing when accountLabel is not found', async () => {
+        const { toJSON } = await renderAccountLabel({
             deviceStaticSessionId: ethAccount.deviceState,
             networkSymbol: btcSymbol,
             accountDescriptor: ethAccount.descriptor,
@@ -97,8 +97,8 @@ describe('AccountLabel', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should propagate text props', () => {
-        const { getByText } = renderAccountLabel({
+    it('should propagate text props', async () => {
+        const { getByText } = await renderAccountLabel({
             account: ethAccount,
             accessibilityLabel: 'ACCESSIBILITY_LABEL',
         });
@@ -106,8 +106,8 @@ describe('AccountLabel', () => {
         expect(getByText('ETH Account #1')).toHaveProp('accessibilityLabel', 'ACCESSIBILITY_LABEL');
     });
 
-    it('should render account type badge when showAccountTypeBadge is set', () => {
-        const { getByText } = renderAccountLabel({
+    it('should render account type badge when showAccountTypeBadge is set', async () => {
+        const { getByText } = await renderAccountLabel({
             account: ethLedgerAccount,
             showAccountTypeBadge: true,
         });
@@ -116,8 +116,8 @@ describe('AccountLabel', () => {
         expect(getByText('Ledger')).toBeOnTheScreen();
     });
 
-    it('should render account type badge for the descriptor variant when showAccountTypeBadge is set', () => {
-        const { getByText } = renderAccountLabel({
+    it('should render account type badge for the descriptor variant when showAccountTypeBadge is set', async () => {
+        const { getByText } = await renderAccountLabel({
             deviceStaticSessionId: ethLedgerAccount.deviceState,
             networkSymbol: ethLedgerAccount.symbol,
             accountDescriptor: ethLedgerAccount.descriptor,
@@ -128,8 +128,8 @@ describe('AccountLabel', () => {
         expect(getByText('Ledger')).toBeOnTheScreen();
     });
 
-    it('should not render account type badge when showAccountTypeBadge is not set', () => {
-        const { getByText, queryByText } = renderAccountLabel({ account: ethLedgerAccount });
+    it('should not render account type badge when showAccountTypeBadge is not set', async () => {
+        const { getByText, queryByText } = await renderAccountLabel({ account: ethLedgerAccount });
 
         expect(getByText('ETH Ledger Account')).toBeOnTheScreen();
         expect(queryByText('Ledger')).not.toBeOnTheScreen();

--- a/suite-native/accounts/src/components/AccountLabelFieldHint.test.tsx
+++ b/suite-native/accounts/src/components/AccountLabelFieldHint.test.tsx
@@ -5,13 +5,13 @@ import { AccountLabelFieldHint, type AccountLabelFieldHintProps } from './Accoun
 import { useAccountLabelForm } from '../hooks/useAccountLabelForm';
 
 describe('AccountLabelFieldHint', () => {
-    const renderComponent = (props: AccountLabelFieldHintProps) =>
-        renderWithBasicProvider(<AccountLabelFieldHint {...props} />);
+    const renderComponent = async (props: AccountLabelFieldHintProps) =>
+        await renderWithBasicProvider(<AccountLabelFieldHint {...props} />);
 
-    it('should render', () => {
-        const { result } = renderHook(() => useAccountLabelForm('Account label'));
+    it('should render', async () => {
+        const { result } = await renderHook(() => useAccountLabelForm('Account label'));
 
-        const { getByText } = renderComponent({ formControl: result.current.control });
+        const { getByText } = await renderComponent({ formControl: result.current.control });
 
         expect(
             getByText(

--- a/suite-native/accounts/src/components/AccountTypeBadge.test.tsx
+++ b/suite-native/accounts/src/components/AccountTypeBadge.test.tsx
@@ -29,25 +29,25 @@ describe('AccountTypeBadge', () => {
 
     const accounts = [ethNormalAccount, ethLedgerAccount];
 
-    const renderAccountTypeBadge = (accountKey: AccountKey) =>
-        renderWithStoreProvider(<AccountTypeBadge accountKey={accountKey} />, {
+    const renderAccountTypeBadge = async (accountKey: AccountKey) =>
+        await renderWithStoreProvider(<AccountTypeBadge accountKey={accountKey} />, {
             preloadedState: { wallet: { accounts } },
         });
 
-    it('should render the formatted account type', () => {
-        const { getByText } = renderAccountTypeBadge(ethLedgerAccount.key);
+    it('should render the formatted account type', async () => {
+        const { getByText } = await renderAccountTypeBadge(ethLedgerAccount.key);
 
         expect(getByText('Ledger')).toBeOnTheScreen();
     });
 
-    it('should render nothing for a normal non-bitcoin account', () => {
-        const { toJSON } = renderAccountTypeBadge(ethNormalAccount.key);
+    it('should render nothing for a normal non-bitcoin account', async () => {
+        const { toJSON } = await renderAccountTypeBadge(ethNormalAccount.key);
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing for an unknown account key', () => {
-        const { toJSON } = renderAccountTypeBadge('unknown-eth-1@2:3' as AccountKey);
+    it('should render nothing for an unknown account key', async () => {
+        const { toJSON } = await renderAccountTypeBadge('unknown-eth-1@2:3' as AccountKey);
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/app/src/navigation/AppTabNavigator.test.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.test.tsx
@@ -35,21 +35,21 @@ const baseState = {
 };
 
 describe('AppTabNavigator', () => {
-    const renderTabs = (overrides: Record<string, unknown> = {}) =>
-        renderWithStoreProvider(<AppTabNavigator />, {
+    const renderTabs = async (overrides: Record<string, unknown> = {}) =>
+        await renderWithStoreProvider(<AppTabNavigator />, {
             preloadedState: mergePreloadedState(baseState, overrides),
         });
 
-    it('should render 3 buttons', () => {
-        const { getByText } = renderTabs();
+    it('should render 3 buttons', async () => {
+        const { getByText } = await renderTabs();
 
         expect(getByText(getTranslation('navigation.tabs.home'))).toBeTruthy();
         expect(getByText(getTranslation('navigation.tabs.accountsList'))).toBeTruthy();
         expect(getByText(getTranslation('navigation.tabs.settings'))).toBeTruthy();
     });
 
-    it('should not render Trade tab when all trading flags are disabled', () => {
-        const { queryByText } = renderTabs({
+    it('should not render Trade tab when all trading flags are disabled', async () => {
+        const { queryByText } = await renderTabs({
             featureFlags: {
                 [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
             },
@@ -64,8 +64,8 @@ describe('AppTabNavigator', () => {
         expect(queryByText(getTranslation('navigation.tabs.trade'))).toBe(null);
     });
 
-    it('should render Trade tab when at least one trading flag is enabled', () => {
-        const { getByText, getByTestId } = renderTabs({
+    it('should render Trade tab when at least one trading flag is enabled', async () => {
+        const { getByText, getByTestId } = await renderTabs({
             featureFlags: {
                 [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
             },
@@ -77,13 +77,13 @@ describe('AppTabNavigator', () => {
             }),
         });
 
-        fireEvent.press(getByText(getTranslation('navigation.tabs.trade')));
+        await fireEvent.press(getByText(getTranslation('navigation.tabs.trade')));
 
         expect(getByTestId('@screen/Trading')).toBeTruthy();
     });
 
-    it('should render Earn tab', () => {
-        const { queryByText } = renderTabs();
+    it('should render Earn tab', async () => {
+        const { queryByText } = await renderTabs();
 
         expect(queryByText(getTranslation('navigation.tabs.earn'))).toBeTruthy();
     });

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.test.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleInput.test.tsx
@@ -4,8 +4,8 @@ import { AnimatedDoubleInput, type AnimatedDoubleInputProps } from './AnimatedDo
 import { Input } from '../Input/Input';
 
 describe('AnimatedDoubleInput', () => {
-    const renderAnimatedDoubleInput = (props: Partial<AnimatedDoubleInputProps>) =>
-        renderWithBasicProvider(
+    const renderAnimatedDoubleInput = async (props: Partial<AnimatedDoubleInputProps>) =>
+        await renderWithBasicProvider(
             <AnimatedDoubleInput
                 renderPrimary={({ onPress, isDisabled, inputRef }) => (
                     <Input
@@ -31,7 +31,7 @@ describe('AnimatedDoubleInput', () => {
 
     it('should call onViewSwitch when Switch button is pressed', async () => {
         const onInputSwitch = jest.fn();
-        const { getByLabelText } = renderAnimatedDoubleInput({ onInputSwitch });
+        const { getByLabelText } = await renderAnimatedDoubleInput({ onInputSwitch });
 
         const switchButton = getByLabelText('Switch');
         await userEvent.press(switchButton);
@@ -42,7 +42,7 @@ describe('AnimatedDoubleInput', () => {
 
     it('should derive the next view from the controlled activeView', async () => {
         const onInputSwitch = jest.fn();
-        const { getByLabelText } = renderAnimatedDoubleInput({
+        const { getByLabelText } = await renderAnimatedDoubleInput({
             onInputSwitch,
             activeView: 'secondary',
         });
@@ -54,9 +54,11 @@ describe('AnimatedDoubleInput', () => {
         expect(onInputSwitch).toHaveBeenCalledWith('primary');
     });
 
-    it('should propagate switch label', () => {
+    it('should propagate switch label', async () => {
         const switchLabel = 'Custom Switch Label';
-        const { getByLabelText, queryByLabelText } = renderAnimatedDoubleInput({ switchLabel });
+        const { getByLabelText, queryByLabelText } = await renderAnimatedDoubleInput({
+            switchLabel,
+        });
 
         expect(queryByLabelText('Switch')).toBeNull();
         expect(getByLabelText(switchLabel)).toBeOnTheScreen();

--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.test.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedDoubleView.test.tsx
@@ -4,8 +4,8 @@ import { Box } from '../Box';
 import { AnimatedDoubleView, type AnimatedDoubleViewProps } from './AnimatedDoubleView';
 
 describe('AnimatedDoubleView', () => {
-    const renderAnimatedDoubleView = (props: Partial<AnimatedDoubleViewProps>) =>
-        renderWithBasicProvider(
+    const renderAnimatedDoubleView = async (props: Partial<AnimatedDoubleViewProps>) =>
+        await renderWithBasicProvider(
             <AnimatedDoubleView
                 renderPrimary={() => <Box accessibilityLabel="PRIMARY_VIEW" />}
                 renderSecondary={() => <Box accessibilityLabel="SECONDARY_VIEW" />}
@@ -13,29 +13,29 @@ describe('AnimatedDoubleView', () => {
             />,
         );
 
-    it('should render primary and secondary component and switcher in between', () => {
-        const { getByLabelText } = renderAnimatedDoubleView({});
+    it('should render primary and secondary component and switcher in between', async () => {
+        const { getByLabelText } = await renderAnimatedDoubleView({});
 
         expect(getByLabelText('PRIMARY_VIEW')).toBeOnTheScreen();
         expect(getByLabelText('SECONDARY_VIEW')).toBeOnTheScreen();
         expect(getByLabelText('Switch')).toBeOnTheScreen();
     });
 
-    it('should call onViewSwitch when Switch button is pressed', () => {
+    it('should call onViewSwitch when Switch button is pressed', async () => {
         const onViewSwitch = jest.fn();
-        const { getByLabelText } = renderAnimatedDoubleView({ onViewSwitch });
+        const { getByLabelText } = await renderAnimatedDoubleView({ onViewSwitch });
 
         const switchButton = getByLabelText('Switch');
-        fireEvent.press(switchButton);
-        fireEvent.press(switchButton);
+        await fireEvent.press(switchButton);
+        await fireEvent.press(switchButton);
 
         expect(onViewSwitch).toHaveBeenCalledTimes(2);
         expect(onViewSwitch).toHaveBeenNthCalledWith(1, 'secondary');
         expect(onViewSwitch).toHaveBeenNthCalledWith(2, 'primary');
     });
 
-    it('should display the controlled active view', () => {
-        const { getByLabelText } = renderWithBasicProvider(
+    it('should display the controlled active view', async () => {
+        const { getByLabelText } = await renderWithBasicProvider(
             <AnimatedDoubleView
                 activeView="secondary"
                 renderPrimary={({ isDisabled }) => (
@@ -53,33 +53,35 @@ describe('AnimatedDoubleView', () => {
         expect(getByLabelText('SECONDARY_ACTIVE')).toBeOnTheScreen();
     });
 
-    it('should propagate switch label', () => {
+    it('should propagate switch label', async () => {
         const switchLabel = 'Custom Switch Label';
-        const { getByLabelText, queryByLabelText } = renderAnimatedDoubleView({ switchLabel });
+        const { getByLabelText, queryByLabelText } = await renderAnimatedDoubleView({
+            switchLabel,
+        });
 
         expect(queryByLabelText('Switch')).toBeNull();
         expect(getByLabelText(switchLabel)).toBeOnTheScreen();
     });
 
-    it('should switch active view on second view press', () => {
+    it('should switch active view on second view press', async () => {
         const onViewSwitch = jest.fn();
-        const { getByLabelText } = renderAnimatedDoubleView({ onViewSwitch });
+        const { getByLabelText } = await renderAnimatedDoubleView({ onViewSwitch });
 
-        fireEvent.press(getByLabelText('SECONDARY_VIEW'));
-        fireEvent.press(getByLabelText('PRIMARY_VIEW'));
+        await fireEvent.press(getByLabelText('SECONDARY_VIEW'));
+        await fireEvent.press(getByLabelText('PRIMARY_VIEW'));
 
         expect(onViewSwitch).toHaveBeenCalledTimes(2);
         expect(onViewSwitch).toHaveBeenNthCalledWith(1, 'secondary');
         expect(onViewSwitch).toHaveBeenNthCalledWith(2, 'primary');
     });
 
-    it('should do nothing when pressing active view', () => {
+    it('should do nothing when pressing active view', async () => {
         const onViewSwitch = jest.fn();
-        const { getByLabelText } = renderAnimatedDoubleView({ onViewSwitch });
+        const { getByLabelText } = await renderAnimatedDoubleView({ onViewSwitch });
 
-        fireEvent.press(getByLabelText('PRIMARY_VIEW'));
-        fireEvent.press(getByLabelText('Switch'));
-        fireEvent.press(getByLabelText('SECONDARY_VIEW'));
+        await fireEvent.press(getByLabelText('PRIMARY_VIEW'));
+        await fireEvent.press(getByLabelText('Switch'));
+        await fireEvent.press(getByLabelText('SECONDARY_VIEW'));
 
         expect(onViewSwitch).toHaveBeenCalledTimes(1);
         expect(onViewSwitch).toHaveBeenNthCalledWith(1, 'secondary');

--- a/suite-native/atoms/src/Button/AsyncButton.test.tsx
+++ b/suite-native/atoms/src/Button/AsyncButton.test.tsx
@@ -1,12 +1,12 @@
 import { Text } from 'react-native';
 
-import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { AsyncButton, type AsyncButtonProps } from './AsyncButton';
 
 describe('AsyncButton', () => {
-    const renderAsyncButton = (props: Partial<AsyncButtonProps>) =>
-        renderWithBasicProvider(
+    const renderAsyncButton = async (props: Partial<AsyncButtonProps>) =>
+        await renderWithBasicProvider(
             <AsyncButton
                 onPress={() => new Promise(resolve => setTimeout(resolve, 1000))}
                 testID="async-button"
@@ -25,59 +25,52 @@ describe('AsyncButton', () => {
     });
 
     it('should display loading indicator after press', async () => {
-        const { getByTestId, getByText } = renderAsyncButton({});
+        const { getByTestId, getByText } = await renderAsyncButton({});
 
-        fireEvent.press(getByText('Press me'));
+        const pressPromise = fireEvent.press(getByText('Press me'));
+        await jest.advanceTimersByTimeAsync(0);
 
         expect(getByTestId('async-button/loading')).toBeOnTheScreen();
 
-        await act(async () => {
-            jest.runAllTimers();
-            await Promise.resolve();
-        });
+        await jest.runAllTimersAsync();
+        await pressPromise;
     });
 
     it('should hide loading indicator after async operation is complete', async () => {
-        const { getByText, queryByTestId } = renderAsyncButton({});
+        const { getByText, queryByTestId } = await renderAsyncButton({});
 
-        fireEvent.press(getByText('Press me'));
-        await act(async () => {
-            jest.runAllTimers();
-            await Promise.resolve();
-        });
+        const pressPromise = fireEvent.press(getByText('Press me'));
+        await jest.runAllTimersAsync();
+        await pressPromise;
 
         expect(queryByTestId('async-button/loading')).toBeNull();
     });
 
     it('should handle onPress rejection gracefully', async () => {
-        const { getByText, queryByTestId } = renderAsyncButton({
+        const { getByText, queryByTestId } = await renderAsyncButton({
             onPress: () =>
                 new Promise((_, reject) => setTimeout(() => reject(new Error('Failed')), 1000)),
         });
 
-        fireEvent.press(getByText('Press me'));
-        await act(async () => {
-            jest.runAllTimers();
-            await Promise.resolve();
-        });
+        const pressPromise = fireEvent.press(getByText('Press me'));
+        await jest.runAllTimersAsync();
+        await pressPromise;
 
         expect(queryByTestId('async-button/loading')).toBeNull();
     });
 
     it('should call onReject on rejection', async () => {
         const mockOnReject = jest.fn();
-        const { getByText } = renderAsyncButton({
+        const { getByText } = await renderAsyncButton({
             onPress: () =>
                 new Promise((_, reject) => setTimeout(() => reject(new Error('Failed')), 1000)),
             onReject: mockOnReject,
         });
 
-        fireEvent.press(getByText('Press me'));
+        const pressPromise = fireEvent.press(getByText('Press me'));
 
-        await act(async () => {
-            jest.runAllTimers();
-            await Promise.resolve();
-        });
+        await jest.runAllTimersAsync();
+        await pressPromise;
 
         expect(mockOnReject).toHaveBeenCalledWith(new Error('Failed'));
     });

--- a/suite-native/atoms/src/Card/Card.test.tsx
+++ b/suite-native/atoms/src/Card/Card.test.tsx
@@ -5,31 +5,31 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { Card, type CardProps } from './Card';
 
 describe('Card', () => {
-    const renderComponent = (props: Omit<CardProps, 'children'>) => {
+    const renderComponent = async (props: Omit<CardProps, 'children'>) => {
         const cardProps = {
             children: <Text>hello</Text>,
             ...props,
         } as CardProps;
 
-        return renderWithBasicProvider(<Card {...cardProps} />);
+        return await renderWithBasicProvider(<Card {...cardProps} />);
     };
 
-    it('should render children prop', () => {
-        const { getByText } = renderComponent({});
+    it('should render children prop', async () => {
+        const { getByText } = await renderComponent({});
 
         expect(getByText('hello')).toBeTruthy();
     });
 
-    it('should render only children if alertProps are not provided, even if alertPosition is set', () => {
-        const { queryByTestId, getByText } = renderComponent({ alertPosition: 'bottom' });
+    it('should render only children if alertProps are not provided, even if alertPosition is set', async () => {
+        const { queryByTestId, getByText } = await renderComponent({ alertPosition: 'bottom' });
 
         expect(getByText('hello')).toBeTruthy();
         expect(queryByTestId('@atom/card/alert/top')).toBeNull();
         expect(queryByTestId('@atom/card/alert/bottom')).toBeNull();
     });
 
-    it('should render alert only on top when alertPosition is not specified', () => {
-        const { getByTestId, getByText, queryByTestId } = renderComponent({
+    it('should render alert only on top when alertPosition is not specified', async () => {
+        const { getByTestId, getByText, queryByTestId } = await renderComponent({
             alertProps: { title: 'alert', intent: 'info' },
         });
 
@@ -40,8 +40,8 @@ describe('Card', () => {
         expect(queryByTestId('@atom/card/alert/bottom')).toBeNull();
     });
 
-    it('should render alert only on top when alertPosition is top', () => {
-        const { getByTestId, getByText, queryByTestId } = renderComponent({
+    it('should render alert only on top when alertPosition is top', async () => {
+        const { getByTestId, getByText, queryByTestId } = await renderComponent({
             alertProps: { title: 'alert', intent: 'info' },
             alertPosition: 'top',
         });
@@ -53,8 +53,8 @@ describe('Card', () => {
         expect(queryByTestId('@atom/card/alert/bottom')).toBeNull();
     });
 
-    it('should render alert only on bottom when alertPosition is bottom', () => {
-        const { getByTestId, getByText, queryByTestId } = renderComponent({
+    it('should render alert only on bottom when alertPosition is bottom', async () => {
+        const { getByTestId, getByText, queryByTestId } = await renderComponent({
             alertProps: { title: 'alert', intent: 'info' },
             alertPosition: 'bottom',
         });
@@ -66,8 +66,8 @@ describe('Card', () => {
         expect(queryByTestId('@atom/card/alert/top')).toBeNull();
     });
 
-    it('should not reset border radiuses if alert is not present', () => {
-        const { queryByTestId } = renderComponent({});
+    it('should not reset border radiuses if alert is not present', async () => {
+        const { queryByTestId } = await renderComponent({});
 
         expect(queryByTestId('@atom/card/alert/top')).toBeNull();
         expect(queryByTestId('@atom/card/alert/bottom')).toBeNull();

--- a/suite-native/atoms/src/DiscreetText/DiscreetCanvas.test.tsx
+++ b/suite-native/atoms/src/DiscreetText/DiscreetCanvas.test.tsx
@@ -17,8 +17,8 @@ jest.mock('./useDiscreetFont', () => ({
 jest.unmock('./DiscreetCanvas');
 
 describe('DiscreetCanvas', () => {
-    it('should fill its parent without defining its own dimensions', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('should fill its parent without defining its own dimensions', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <DiscreetCanvas fontSize={16} lineHeight={24} text="$100" color="contentPrimary" />,
         );
 

--- a/suite-native/atoms/src/DiscreetText/DiscreetText.test.tsx
+++ b/suite-native/atoms/src/DiscreetText/DiscreetText.test.tsx
@@ -1,5 +1,3 @@
-import { View } from 'react-native';
-
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { Box as MockBox } from '../Box';
@@ -17,17 +15,17 @@ jest.mock('./DiscreetCanvas', () => ({
 }));
 
 describe('DiscreetText', () => {
-    it('should render the canvas without reacting to text layout changes', () => {
-        const { getByTestId, UNSAFE_getAllByType } = renderWithBasicProvider(
+    it('should render the canvas without reacting to text layout changes', async () => {
+        const { container, getByTestId } = await renderWithBasicProvider(
             <DiscreetText isForcedDiscreetMode>Hidden amount</DiscreetText>,
         );
 
-        const hasLayoutHandler = UNSAFE_getAllByType(View).some(
+        const hasLayoutHandler = container.queryAll(
             view => typeof view.props.onLayout === 'function',
-        );
+        ).length;
 
         expect(getByTestId('discreet-text')).toBeOnTheScreen();
         expect(getByTestId('discreet-canvas')).toBeOnTheScreen();
-        expect(hasLayoutHandler).toBe(false);
+        expect(hasLayoutHandler).toBe(0);
     });
 });

--- a/suite-native/atoms/src/EdgeFades.test.tsx
+++ b/suite-native/atoms/src/EdgeFades.test.tsx
@@ -3,8 +3,8 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { EdgeFades } from './EdgeFades';
 
 describe('EdgeFades', () => {
-    it('renders horizontal fades at the left and right edges', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('renders horizontal fades at the left and right edges', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <EdgeFades direction="horizontal" startSize={20} endSize={32} testID="edge-fades" />,
         );
 
@@ -27,8 +27,8 @@ describe('EdgeFades', () => {
         });
     });
 
-    it('renders vertical fades at the top and bottom edges', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('renders vertical fades at the top and bottom edges', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <EdgeFades direction="vertical" startSize={24} endSize={40} testID="edge-fades" />,
         );
 

--- a/suite-native/atoms/src/Flag/Flag.test.tsx
+++ b/suite-native/atoms/src/Flag/Flag.test.tsx
@@ -3,8 +3,8 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { Flag } from './Flag';
 
 describe('Flag component', () => {
-    it('should display the correct flag for a valid country code', () => {
-        const { getByLabelText } = renderWithBasicProvider(<Flag country="CZ" />);
+    it('should display the correct flag for a valid country code', async () => {
+        const { getByLabelText } = await renderWithBasicProvider(<Flag country="CZ" />);
 
         expect(getByLabelText('flag-CZ')).toBeTruthy();
     });

--- a/suite-native/atoms/src/PriceChangeBadge.test.tsx
+++ b/suite-native/atoms/src/PriceChangeBadge.test.tsx
@@ -15,45 +15,47 @@ jest.mock('./Skeleton/BoxSkeleton', () => ({
 describe('PriceChangeBadge', () => {
     let colors: NativeStyleUtils['colors'];
 
-    beforeAll(() => {
-        const { result } = renderHook(() => useNativeStyles(), { wrapper: BasicProviderForTests });
+    beforeAll(async () => {
+        const { result } = await renderHook(() => useNativeStyles(), {
+            wrapper: BasicProviderForTests,
+        });
         ({ colors } = result.current.utils);
     });
 
-    it('should render green badge for change > 0', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should render green badge for change > 0', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <PriceChangeBadge valuePercentageChange={0.01} />,
         );
 
         expect(getByText('1.00%')).toHaveStyle({ color: colors.contentBrand });
     });
 
-    it('should render green badge for change = 0', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should render green badge for change = 0', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <PriceChangeBadge valuePercentageChange={0} />,
         );
 
         expect(getByText('0.00%')).toHaveStyle({ color: colors.contentBrand });
     });
 
-    it('should render red badge for change < 0', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should render red badge for change < 0', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <PriceChangeBadge valuePercentageChange={-0.01} />,
         );
 
         expect(getByText('-1.00%')).toHaveStyle({ color: colors.contentCritical });
     });
 
-    it('should render skeleton when value is null', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('should render skeleton when value is null', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <PriceChangeBadge valuePercentageChange={null} />,
         );
 
         expect(getByTestId('skeleton-box')).toBeTruthy();
     });
 
-    it('should render 3 significant digits', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should render 3 significant digits', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <PriceChangeBadge valuePercentageChange={0.1234} />,
         );
 

--- a/suite-native/atoms/src/Sheet/hooks/useBottomSheetControls.test.ts
+++ b/suite-native/atoms/src/Sheet/hooks/useBottomSheetControls.test.ts
@@ -10,17 +10,17 @@ describe('useBottomSheetControls', () => {
     });
 
     describe('isSheetVisible', () => {
-        it('should be false by default', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+        it('should be false by default', async () => {
+            const { result } = await renderHookWithBasicProvider(() => useBottomSheetControls());
 
             expect(result.current.isSheetVisible).toBe(false);
         });
 
-        it('should be true after showSheet call and Keyboard.dismiss should be called one time', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+        it('should be true after showSheet call and Keyboard.dismiss should be called one time', async () => {
+            const { result } = await renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
-            act(() => {
+            await act(() => {
                 result.current.showSheet();
             });
 
@@ -28,11 +28,11 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(true);
         });
 
-        it('should be false after hideSheet call and Keyboard.dismiss should be called two times by default', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+        it('should be false after hideSheet call and Keyboard.dismiss should be called two times by default', async () => {
+            const { result } = await renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
-            act(() => {
+            await act(() => {
                 result.current.showSheet();
                 result.current.hideSheet();
             });
@@ -41,11 +41,11 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(false);
         });
 
-        it('should be false after hideSheet call with shouldHideKeyboard=true and Keyboard.dismiss should be called two times', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+        it('should be false after hideSheet call with shouldHideKeyboard=true and Keyboard.dismiss should be called two times', async () => {
+            const { result } = await renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
-            act(() => {
+            await act(() => {
                 result.current.showSheet();
                 result.current.hideSheet(true);
             });
@@ -54,11 +54,11 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(false);
         });
 
-        it('should be false after hideSheet call with shouldHideKeyboard=false and Keyboard.dismiss should be called only once', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+        it('should be false after hideSheet call with shouldHideKeyboard=false and Keyboard.dismiss should be called only once', async () => {
+            const { result } = await renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
-            act(() => {
+            await act(() => {
                 result.current.showSheet();
                 result.current.hideSheet(false);
             });

--- a/suite-native/atoms/src/SubTabs.test.tsx
+++ b/suite-native/atoms/src/SubTabs.test.tsx
@@ -28,12 +28,14 @@ const items: SubTabItem<string>[] = [
 describe('SubTabs', () => {
     let colors: NativeStyleUtils['colors'];
 
-    beforeAll(() => {
-        const { result } = renderHook(() => useNativeStyles(), { wrapper: BasicProviderForTests });
+    beforeAll(async () => {
+        const { result } = await renderHook(() => useNativeStyles(), {
+            wrapper: BasicProviderForTests,
+        });
         ({ colors } = result.current.utils);
     });
 
-    const renderSubTabs = ({
+    const renderSubTabs = async ({
         onChange = jest.fn(),
         paddingHorizontal,
         size = 'normal',
@@ -44,7 +46,7 @@ describe('SubTabs', () => {
         size?: 'normal' | 'large';
         value?: string;
     } = {}) =>
-        renderWithBasicProvider(
+        await renderWithBasicProvider(
             <SubTabs
                 items={items}
                 onChange={onChange}
@@ -55,8 +57,8 @@ describe('SubTabs', () => {
             />,
         );
 
-    it('renders the active and inactive tabs with accessible selected states', () => {
-        const { getByRole } = renderSubTabs();
+    it('renders the active and inactive tabs with accessible selected states', async () => {
+        const { getByRole } = await renderSubTabs();
 
         const activeTab = getByRole('tab', { selected: true });
         const inactiveTab = getByRole('tab', { selected: false });
@@ -65,25 +67,25 @@ describe('SubTabs', () => {
         expect(within(inactiveTab).getByText('Buy')).toBeOnTheScreen();
     });
 
-    it('calls onChange with the pressed tab value', () => {
+    it('calls onChange with the pressed tab value', async () => {
         const onChange = jest.fn();
-        const { getByText } = renderSubTabs({ onChange });
+        const { getByText } = await renderSubTabs({ onChange });
 
-        fireEvent.press(getByText('Buy'));
+        await fireEvent.press(getByText('Buy'));
 
         expect(onChange).toHaveBeenCalledWith('buy');
     });
 
-    it('applies configurable horizontal padding to the tab list', () => {
-        const { getByTestId } = renderSubTabs({ paddingHorizontal: 'sp4' });
+    it('applies configurable horizontal padding to the tab list', async () => {
+        const { getByTestId } = await renderSubTabs({ paddingHorizontal: 'sp4' });
 
         expect(getByTestId('sub-tabs').props.contentContainerStyle).toEqual(
             expect.objectContaining({ paddingHorizontal: 4 }),
         );
     });
 
-    it('uses normal size dimensions, typography, icon size, and active colors', () => {
-        const { getByTestId } = renderSubTabs();
+    it('uses normal size dimensions, typography, icon size, and active colors', async () => {
+        const { getByTestId } = await renderSubTabs();
 
         expect(getByTestId('exchange-tab')).toHaveStyle({
             height: 36,
@@ -104,8 +106,8 @@ describe('SubTabs', () => {
         expect(getByTestId('buy-tab/text')).toHaveStyle({ color: colors.contentSecondary });
     });
 
-    it('uses large size dimensions, typography, and icon size', () => {
-        const { getByTestId } = renderSubTabs({ size: 'large' });
+    it('uses large size dimensions, typography, and icon size', async () => {
+        const { getByTestId } = await renderSubTabs({ size: 'large' });
 
         expect(getByTestId('exchange-tab')).toHaveStyle({
             height: 40,

--- a/suite-native/device-authorization/src/hooks/useOnThpPairingCanceled.test.ts
+++ b/suite-native/device-authorization/src/hooks/useOnThpPairingCanceled.test.ts
@@ -19,20 +19,20 @@ const mockDeviceThpPairingStatusChange = (status: DeviceThpPairingStatus) => {
 };
 
 describe('useOnThpPairingCanceled', () => {
-    test('callback is triggered', () => {
+    test('callback is triggered', async () => {
         mockDeviceThpPairingStatusChange({ status: 'canceled' });
         const callback = jest.fn();
 
-        renderHookWithBasicProvider(() => useOnThpPairingCanceled(callback));
+        await renderHookWithBasicProvider(() => useOnThpPairingCanceled(callback));
 
         expect(callback).toHaveBeenCalled();
     });
 
-    test('callback is not triggered', () => {
+    test('callback is not triggered', async () => {
         mockDeviceThpPairingStatusChange({ status: 'finished' });
         const callback = jest.fn();
 
-        renderHookWithBasicProvider(() => useOnThpPairingCanceled(callback));
+        await renderHookWithBasicProvider(() => useOnThpPairingCanceled(callback));
 
         expect(callback).not.toHaveBeenCalled();
     });

--- a/suite-native/feedback-form/src/components/FeedbackCard.test.tsx
+++ b/suite-native/feedback-form/src/components/FeedbackCard.test.tsx
@@ -25,8 +25,8 @@ describe('FeedbackCard', () => {
     const presentSpy = jest.spyOn(BottomSheetModal.prototype, 'present');
     const dismissSpy = jest.spyOn(BottomSheetModal.prototype, 'dismiss');
 
-    const renderFeedbackCard = (props?: Partial<Parameters<typeof FeedbackCard>[0]>) =>
-        renderWithBasicProvider(
+    const renderFeedbackCard = async (props?: Partial<Parameters<typeof FeedbackCard>[0]>) =>
+        await renderWithBasicProvider(
             <FeedbackCard
                 heading={HEADING}
                 description={DESCRIPTION}
@@ -39,9 +39,9 @@ describe('FeedbackCard', () => {
             />,
         );
 
-    const dismissSheet = () => {
+    const dismissSheet = async () => {
         const sheetInstance = presentSpy.mock.contexts[0];
-        act(() => {
+        await act(() => {
             sheetInstance.dismiss();
         });
     };
@@ -50,8 +50,8 @@ describe('FeedbackCard', () => {
         jest.clearAllMocks();
     });
 
-    it('shows the heading and the five rating buttons in the card', () => {
-        renderFeedbackCard();
+    it('shows the heading and the five rating buttons in the card', async () => {
+        await renderFeedbackCard();
 
         expect(screen.getByText(HEADING)).toBeOnTheScreen();
         ['1', '2', '3', '4', '5'].forEach(rating => {
@@ -59,21 +59,21 @@ describe('FeedbackCard', () => {
         });
     });
 
-    it('opens the feedback sheet with the pressed rating preselected', () => {
-        renderFeedbackCard();
+    it('opens the feedback sheet with the pressed rating preselected', async () => {
+        await renderFeedbackCard();
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
 
         expect(presentSpy).toHaveBeenCalledTimes(1);
         expectSheetRatingSelection('4', true);
         expectSheetRatingSelection('3', false);
     });
 
-    it('allows changing the rating inside the sheet', () => {
-        renderFeedbackCard();
+    it('allows changing the rating inside the sheet', async () => {
+        await renderFeedbackCard();
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
-        fireEvent.press(screen.getByTestId('@feedback-form/sheet/rating/2'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/sheet/rating/2'));
 
         expectSheetRatingSelection('2', true);
         expectSheetRatingSelection('4', false);
@@ -81,51 +81,51 @@ describe('FeedbackCard', () => {
         expect(presentSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('calls onRatingSelect when a card rating is pressed', () => {
-        renderFeedbackCard({ onRatingSelect });
+    it('calls onRatingSelect when a card rating is pressed', async () => {
+        await renderFeedbackCard({ onRatingSelect });
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
 
         expect(onRatingSelect).toHaveBeenCalledTimes(1);
         expect(onRatingSelect).toHaveBeenCalledWith('4');
     });
 
-    it('calls onRatingSelect again when the rating is changed inside the sheet', () => {
-        renderFeedbackCard({ onRatingSelect });
+    it('calls onRatingSelect again when the rating is changed inside the sheet', async () => {
+        await renderFeedbackCard({ onRatingSelect });
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
-        fireEvent.press(screen.getByTestId('@feedback-form/sheet/rating/2'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/sheet/rating/2'));
 
         expect(onRatingSelect).toHaveBeenCalledTimes(2);
         expect(onRatingSelect).toHaveBeenLastCalledWith('2');
     });
 
-    it('does not render the description row when no description is provided', () => {
-        renderFeedbackCard({ description: undefined });
+    it('does not render the description row when no description is provided', async () => {
+        await renderFeedbackCard({ description: undefined });
 
         expect(screen.queryByText(DESCRIPTION)).not.toBeOnTheScreen();
         expect(screen.getByTestId('@feedback-form/description-input')).toBeOnTheScreen();
     });
 
-    it('does not submit while the feedback text is missing', () => {
-        renderFeedbackCard();
+    it('does not submit while the feedback text is missing', async () => {
+        await renderFeedbackCard();
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
-        fireEvent.changeText(screen.getByTestId('@feedback-form/description-input'), '   ');
-        fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.changeText(screen.getByTestId('@feedback-form/description-input'), '   ');
+        await fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
 
         expect(onSubmit).not.toHaveBeenCalled();
     });
 
-    it('submits the rating and feedback, then shows the success view without closing the sheet', () => {
-        renderFeedbackCard();
+    it('submits the rating and feedback, then shows the success view without closing the sheet', async () => {
+        await renderFeedbackCard();
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/5'));
-        fireEvent.changeText(
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/5'));
+        await fireEvent.changeText(
             screen.getByTestId('@feedback-form/description-input'),
             'Smooth and fast',
         );
-        fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
 
         expect(onSubmit).toHaveBeenCalledWith('5', 'Smooth and fast');
         // Both the sheet and the card behind it switch to the success view.
@@ -138,29 +138,32 @@ describe('FeedbackCard', () => {
         expect(dismissSpy).not.toHaveBeenCalled();
     });
 
-    it('closes the sheet when the close button is pressed after submitting', () => {
-        renderFeedbackCard();
+    it('closes the sheet when the close button is pressed after submitting', async () => {
+        await renderFeedbackCard();
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/5'));
-        fireEvent.changeText(
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/5'));
+        await fireEvent.changeText(
             screen.getByTestId('@feedback-form/description-input'),
             'Smooth and fast',
         );
-        fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
-        fireEvent.press(screen.getByTestId('@feedback-form/close-button'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/close-button'));
 
         expect(dismissSpy).toHaveBeenCalledTimes(1);
         // The card keeps the success view after the sheet is closed.
         expect(screen.getAllByText(SUCCESS_HEADING).length).toBeGreaterThan(0);
     });
 
-    it('resets the form when the sheet is dismissed without submitting', () => {
-        renderFeedbackCard();
+    it('resets the form when the sheet is dismissed without submitting', async () => {
+        await renderFeedbackCard();
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/3'));
-        fireEvent.changeText(screen.getByTestId('@feedback-form/description-input'), 'Draft text');
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/3'));
+        await fireEvent.changeText(
+            screen.getByTestId('@feedback-form/description-input'),
+            'Draft text',
+        );
 
-        dismissSheet();
+        await dismissSheet();
 
         expectSheetRatingSelection('3', false);
         expect(screen.getByTestId('@feedback-form/description-input')).toHaveProp('value', '');
@@ -168,8 +171,8 @@ describe('FeedbackCard', () => {
         expect(screen.getByText(HEADING)).toBeOnTheScreen();
     });
 
-    it('renders the success view directly when defaultView is "success"', () => {
-        renderFeedbackCard({ defaultView: 'success' });
+    it('renders the success view directly when defaultView is "success"', async () => {
+        await renderFeedbackCard({ defaultView: 'success' });
 
         expect(screen.getAllByText(SUCCESS_HEADING).length).toBeGreaterThan(0);
         expect(screen.queryByText(HEADING)).not.toBeOnTheScreen();

--- a/suite-native/formatters/src/components/PercentageDifferenceFormatter.test.tsx
+++ b/suite-native/formatters/src/components/PercentageDifferenceFormatter.test.tsx
@@ -5,32 +5,32 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { PercentageDifferenceFormatter } from './PercentageDifferenceFormatter';
 
 describe('PercentageDifferenceFormatter', () => {
-    it('shows a positive sign and percentage when price increases', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('shows a positive sign and percentage when price increases', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <PercentageDifferenceFormatter oldValue={1} newValue={11} testID="formatter" />,
         );
 
         expect(getByTestId('formatter')).toHaveTextContent('+1,000%');
     });
 
-    it('shows a negative sign and percentage when price decreases', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('shows a negative sign and percentage when price decreases', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <PercentageDifferenceFormatter oldValue={100} newValue={75} testID="formatter" />,
         );
 
         expect(getByTestId('formatter')).toHaveTextContent('-25%');
     });
 
-    it('rounds the percentage to the nearest integer', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('rounds the percentage to the nearest integer', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <PercentageDifferenceFormatter oldValue={300} newValue={301} testID="formatter" />,
         );
 
         expect(getByTestId('formatter')).toHaveTextContent('+0%');
     });
 
-    it('formats percentage using the active intl locale', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('formats percentage using the active intl locale', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <IntlProvider locale="cs">
                 <PercentageDifferenceFormatter oldValue={1} newValue={11} testID="formatter" />
             </IntlProvider>,
@@ -39,8 +39,8 @@ describe('PercentageDifferenceFormatter', () => {
         expect(getByTestId('formatter')).toHaveTextContent('+1 000 %');
     });
 
-    it('shows 0% when oldValue is 0', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('shows 0% when oldValue is 0', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <PercentageDifferenceFormatter oldValue={0} newValue={100} testID="formatter" />,
         );
 

--- a/suite-native/formatters/src/components/TokenAmountFormatter.test.tsx
+++ b/suite-native/formatters/src/components/TokenAmountFormatter.test.tsx
@@ -4,19 +4,19 @@ import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { TokenAmountFormatter, type TokenAmountFormatterProps } from './TokenAmountFormatter';
 
 describe('TokenAmountFormatter', () => {
-    const renderTokenAmountFormatter = (props: Partial<TokenAmountFormatterProps>) =>
-        renderWithStoreProvider(
+    const renderTokenAmountFormatter = async (props: Partial<TokenAmountFormatterProps>) =>
+        await renderWithStoreProvider(
             <TokenAmountFormatter tokenSymbol={'USDC' as TokenSymbol} value="1234.56" {...props} />,
         );
 
-    it('should render formatted value', () => {
-        const { getByTestId } = renderTokenAmountFormatter({});
+    it('should render formatted value', async () => {
+        const { getByTestId } = await renderTokenAmountFormatter({});
 
         expect(getByTestId('plain-text')).toHaveTextContent('1,234.56 USDC');
     });
 
-    it('should render phishing transaction with empty value as discreet text', () => {
-        const { getByTestId } = renderTokenAmountFormatter({
+    it('should render phishing transaction with empty value as discreet text', async () => {
+        const { getByTestId } = await renderTokenAmountFormatter({
             value: '',
             isPhishingTransaction: true,
         });

--- a/suite-native/formatters/src/hooks/useFormattedGraphHeaderValues.test.ts
+++ b/suite-native/formatters/src/hooks/useFormattedGraphHeaderValues.test.ts
@@ -25,8 +25,8 @@ const setNewStoreMockup = (preloadedState: any) => {
 };
 
 describe(useFormattedGraphHeaderValues.name, () => {
-    const renderUseFormattedGraphHeaderValues = (value?: string) =>
-        renderHookWithStoreProvider(() => useFormattedGraphHeaderValues(value), {
+    const renderUseFormattedGraphHeaderValues = async (value?: string) =>
+        await renderHookWithStoreProvider(() => useFormattedGraphHeaderValues(value), {
             store,
         });
 
@@ -34,12 +34,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         jest.clearAllMocks();
     });
 
-    it('should parse balance amount correctly with valid input - english locale + USD', () => {
+    it('should parse balance amount correctly with valid input - english locale + USD', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'usd' } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('1234.56');
+        const { result } = await renderUseFormattedGraphHeaderValues('1234.56');
         expect(result.current).toEqual({
             currencySymbol: '$',
             wholeNumber: '1,234',
@@ -47,12 +47,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses balance amount correctly with valid input - english locale + CZK', () => {
+    it('parses balance amount correctly with valid input - english locale + CZK', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'czk' } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('1234.56');
+        const { result } = await renderUseFormattedGraphHeaderValues('1234.56');
         expect(result.current).toEqual({
             currencySymbol: 'CZK',
             wholeNumber: '1,234',
@@ -60,12 +60,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses balance amount correctly with valid input - czech locale + CZK', () => {
+    it('parses balance amount correctly with valid input - czech locale + CZK', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'cs-CZ' },
             wallet: { settings: { localCurrency: 'czk' } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('1234.56');
+        const { result } = await renderUseFormattedGraphHeaderValues('1234.56');
         expect(result.current).toEqual({
             currencySymbol: 'Kč',
             wholeNumber: '1\u00a0234', // non-breaking space
@@ -73,12 +73,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses balance amount correctly with valid input and no decimal part', () => {
+    it('parses balance amount correctly with valid input and no decimal part', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'eur' } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('2000');
+        const { result } = await renderUseFormattedGraphHeaderValues('2000');
         expect(result.current).toEqual({
             currencySymbol: '€',
             wholeNumber: '2,000',
@@ -86,12 +86,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses balance amount correctly with valid input and only decimal part', () => {
+    it('parses balance amount correctly with valid input and only decimal part', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'czk' } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('0.99');
+        const { result } = await renderUseFormattedGraphHeaderValues('0.99');
         expect(result.current).toEqual({
             currencySymbol: 'CZK',
             wholeNumber: '0',
@@ -99,12 +99,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('handles BTC BaseCurrency correctly', () => {
+    it('handles BTC BaseCurrency correctly', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'btc', bitcoinAmountUnit: AmountUnit.BITCOIN } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('0.01');
+        const { result } = await renderUseFormattedGraphHeaderValues('0.01');
         expect(result.current).toEqual({
             currencySymbol: 'BTC',
             wholeNumber: '0',
@@ -112,12 +112,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('rounds BTC Crypto value correctly', () => {
+    it('rounds BTC Crypto value correctly', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'btc', bitcoinAmountUnit: AmountUnit.BITCOIN } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('0.00124009');
+        const { result } = await renderUseFormattedGraphHeaderValues('0.00124009');
         expect(result.current).toEqual({
             currencySymbol: 'BTC',
             wholeNumber: '0',
@@ -125,12 +125,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses satoshis value correctly - english locale', () => {
+    it('parses satoshis value correctly - english locale', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'btc', bitcoinAmountUnit: AmountUnit.SATOSHI } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('0.01477571');
+        const { result } = await renderUseFormattedGraphHeaderValues('0.01477571');
         expect(result.current).toEqual({
             currencySymbol: 'sat',
             wholeNumber: '1,477,571',
@@ -138,12 +138,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses satoshis value correctly - spanish locale', () => {
+    it('parses satoshis value correctly - spanish locale', async () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'es-ES' as SupportedLocaleCode },
             wallet: { settings: { localCurrency: 'btc', bitcoinAmountUnit: AmountUnit.SATOSHI } },
         });
-        const { result } = renderUseFormattedGraphHeaderValues('0.01477571');
+        const { result } = await renderUseFormattedGraphHeaderValues('0.01477571');
         expect(result.current).toEqual({
             currencySymbol: 'sat',
             wholeNumber: '1.477.571',

--- a/suite-native/helpers/src/hooks/useUpdateEffect.test.ts
+++ b/suite-native/helpers/src/hooks/useUpdateEffect.test.ts
@@ -5,34 +5,34 @@ import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { useUpdateEffect } from './useUpdateEffect';
 
 describe('useUpdateEffect', () => {
-    const renderUseUpdateEffect = (initialEffect: EffectCallback) =>
-        renderHookWithBasicProvider(({ effect }) => useUpdateEffect(effect), {
+    const renderUseUpdateEffect = async (initialEffect: EffectCallback) =>
+        await renderHookWithBasicProvider(({ effect }) => useUpdateEffect(effect), {
             initialProps: { effect: initialEffect },
         });
 
-    it('should do nothing on mount', () => {
+    it('should do nothing on mount', async () => {
         const effect = jest.fn();
-        renderUseUpdateEffect(effect);
+        await renderUseUpdateEffect(effect);
 
         expect(effect).not.toHaveBeenCalled();
     });
 
-    it('should call effect on update', () => {
+    it('should call effect on update', async () => {
         const effect = jest.fn();
-        const { rerender } = renderUseUpdateEffect(jest.fn());
+        const { rerender } = await renderUseUpdateEffect(jest.fn());
 
-        rerender({ effect });
+        await rerender({ effect });
 
         expect(effect).toHaveBeenCalledTimes(1);
     });
 
-    it('should call dispose callback on unmount', () => {
+    it('should call dispose callback on unmount', async () => {
         const dispose = jest.fn();
         const effect = () => dispose;
-        const { rerender, unmount } = renderUseUpdateEffect(jest.fn());
+        const { rerender, unmount } = await renderUseUpdateEffect(jest.fn());
 
-        rerender({ effect });
-        unmount();
+        await rerender({ effect });
+        await unmount();
 
         expect(dispose).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/icons/src/TokenIcon.test.tsx
+++ b/suite-native/icons/src/TokenIcon.test.tsx
@@ -32,31 +32,31 @@ const getTokenIconUrl = (contractAddress: string, size = 32) =>
     });
 
 describe('TokenIcon', () => {
-    const renderTokenIcon = (props: React.ComponentProps<typeof TokenIcon>) =>
-        renderWithBasicProvider(<TokenIcon {...props} />);
+    const renderTokenIcon = async (props: React.ComponentProps<typeof TokenIcon>) =>
+        await renderWithBasicProvider(<TokenIcon {...props} />);
 
-    it('renders the correct icon synchronously when a recycled instance receives new props', () => {
-        const fresh = renderTokenIcon({ symbol: ethSymbol });
+    it('renders the correct icon synchronously when a recycled instance receives new props', async () => {
+        const fresh = await renderTokenIcon({ symbol: ethSymbol });
         const ethSource = fresh.getByHintText(tokenIconHint).props.source;
-        fresh.unmount();
+        await fresh.unmount();
 
-        const { getByHintText, rerender } = renderTokenIcon({
+        const { getByHintText, rerender } = await renderTokenIcon({
             symbol: btcSymbol,
         });
 
         // simulates FlashList cell recycling: same mounted instance, new asset props
-        rerender(<TokenIcon symbol={ethSymbol} />);
+        await rerender(<TokenIcon symbol={ethSymbol} />);
 
         // native network icons resolve synchronously, so there is no placeholder frame
         expect(getByHintText(tokenIconHint).props.source).toEqual(ethSource);
     });
 
-    it('renders a synchronously resolved token icon without a placeholder frame', () => {
+    it('renders a synchronously resolved token icon without a placeholder frame', async () => {
         (getAssetLogoContractAddresses as jest.Mock).mockImplementation(
             (_symbol: string, contract: string) => [contract],
         );
 
-        const { getByHintText } = renderTokenIcon({
+        const { getByHintText } = await renderTokenIcon({
             symbol: ethSymbol,
             contractAddress: contractA,
         });
@@ -73,12 +73,12 @@ describe('TokenIcon', () => {
                 contract === contractA ? deferredA.promise : Promise.resolve([contract]),
         );
 
-        const { getByHintText, rerender } = renderTokenIcon({
+        const { getByHintText, rerender } = await renderTokenIcon({
             symbol: ethSymbol,
             contractAddress: contractA,
         });
 
-        rerender(<TokenIcon symbol={ethSymbol} contractAddress={contractB} />);
+        await rerender(<TokenIcon symbol={ethSymbol} contractAddress={contractB} />);
 
         await waitFor(() => {
             expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
@@ -97,7 +97,7 @@ describe('TokenIcon', () => {
     it('shows a text placeholder when the url resolution rejects', async () => {
         (getAssetLogoContractAddresses as jest.Mock).mockRejectedValue(new Error('failed'));
 
-        const { queryByHintText } = renderTokenIcon({
+        const { queryByHintText } = await renderTokenIcon({
             symbol: ethSymbol,
             contractAddress: contractA,
         });
@@ -112,7 +112,7 @@ describe('TokenIcon', () => {
             (_symbol: string, contract: string) => Promise.resolve([contract]),
         );
 
-        const { getByHintText, queryByHintText, rerender } = renderTokenIcon({
+        const { getByHintText, queryByHintText, rerender } = await renderTokenIcon({
             symbol: ethSymbol,
             contractAddress: contractA,
             size: 32,
@@ -120,10 +120,10 @@ describe('TokenIcon', () => {
         await act(async () => {});
 
         // the only url candidate fails, so the placeholder is shown
-        fireEvent(getByHintText(tokenIconHint), 'error', { nativeEvent: {} });
+        await fireEvent(getByHintText(tokenIconHint), 'error', { nativeEvent: {} });
         expect(queryByHintText(tokenIconHint)).toBeNull();
 
-        rerender(<TokenIcon symbol={ethSymbol} contractAddress={contractA} size={64} />);
+        await rerender(<TokenIcon symbol={ethSymbol} contractAddress={contractA} size={64} />);
         await act(async () => {});
 
         expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
@@ -132,7 +132,7 @@ describe('TokenIcon', () => {
     });
 
     it('should render without network icon for networks that are not l2 networks = op, arb, base', async () => {
-        const { getByHintText, getByLabelText, queryByHintText } = renderTokenIcon({
+        const { getByHintText, getByLabelText, queryByHintText } = await renderTokenIcon({
             symbol: btcSymbol,
             showNetworkIcon: true,
         });
@@ -146,7 +146,7 @@ describe('TokenIcon', () => {
     });
 
     it('should render network with network icon for l2 networks = op, arb, base and ETH as icon', async () => {
-        const { getByHintText, getByLabelText, queryByHintText } = renderTokenIcon({
+        const { getByHintText, getByLabelText, queryByHintText } = await renderTokenIcon({
             symbol: opSymbol,
             showNetworkIcon: true,
         });
@@ -161,7 +161,7 @@ describe('TokenIcon', () => {
 
     it('should render with network icon for contracts', async () => {
         const contract = '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo' as TokenAddress;
-        const { getByHintText, getByLabelText } = renderTokenIcon({
+        const { getByHintText, getByLabelText } = await renderTokenIcon({
             symbol: opSymbol,
             contractAddress: contract,
             showNetworkIcon: true,
@@ -179,7 +179,7 @@ describe('TokenIcon', () => {
         const wethContract = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as TokenAddress;
 
         it('renders the native icon with a network badge for a wrapped-native token when set to network', async () => {
-            const { getByHintText, getByLabelText } = renderTokenIcon({
+            const { getByHintText, getByLabelText } = await renderTokenIcon({
                 symbol: ethSymbol,
                 contractAddress: wethContract,
                 showNetworkIcon: true,
@@ -198,7 +198,7 @@ describe('TokenIcon', () => {
                 (_symbol: string, contract: string) => Promise.resolve([contract]),
             );
 
-            const { getByHintText, getByLabelText } = renderTokenIcon({
+            const { getByHintText, getByLabelText } = await renderTokenIcon({
                 symbol: ethSymbol,
                 contractAddress: wethContract,
                 showNetworkIcon: true,
@@ -217,7 +217,7 @@ describe('TokenIcon', () => {
                 (_symbol: string, contract: string) => Promise.resolve([contract]),
             );
 
-            const { getByLabelText } = renderTokenIcon({
+            const { getByLabelText } = await renderTokenIcon({
                 symbol: ethSymbol,
                 contractAddress: contractA,
                 showNetworkIcon: true,

--- a/suite-native/message-system/src/components/ContextMessage.test.tsx
+++ b/suite-native/message-system/src/components/ContextMessage.test.tsx
@@ -66,37 +66,37 @@ describe('ContextMessage', () => {
         dismissedMessages: [],
     };
 
-    const render = ({
+    const render = async ({
         context,
         preloadedState,
     }: {
         context: ContextDomain;
         preloadedState?: any;
     }) =>
-        renderWithStoreProvider(
+        await renderWithStoreProvider(
             <ContextMessage context={context} accessibilityHint={contextActionId} />,
             {
                 preloadedState: { messageSystem: emptyMessageSystem, ...preloadedState },
             },
         );
 
-    it('should render content when there is message of given context', () => {
-        const { queryByText } = render({
+    it('should render content when there is message of given context', async () => {
+        const { queryByText } = await render({
             context: Context.getTrading('buy'),
             preloadedState: stateWithTradeContextMessage,
         });
         expect(queryByText(contentText)).toBeTruthy();
     });
 
-    it('should return null when there is no message fetched', () => {
-        const { queryByHintText } = render({
+    it('should return null when there is no message fetched', async () => {
+        const { queryByHintText } = await render({
             context: Context.getTrading('buy'),
         });
         expect(queryByHintText(contextActionId)).toBeNull();
     });
 
-    it('should render content in English when locale is en-US', () => {
-        const { queryByText } = render({
+    it('should render content in English when locale is en-US', async () => {
+        const { queryByText } = await render({
             context: Context.getTrading('buy'),
             preloadedState: {
                 ...stateWithTradeContextMessage,
@@ -110,8 +110,8 @@ describe('ContextMessage', () => {
         expect(queryByText(contentTextCs)).toBeNull();
     });
 
-    it('should render content in Czech when locale is cs-CZ - different from en-US', () => {
-        const { queryByText } = render({
+    it('should render content in Czech when locale is cs-CZ - different from en-US', async () => {
+        const { queryByText } = await render({
             context: Context.getTrading('buy'),
             preloadedState: {
                 ...stateWithTradeContextMessage,

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkList.test.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkList.test.tsx
@@ -11,9 +11,9 @@ const getMockPreloadedState = (areTestnetsEnabled: boolean) => ({
 });
 
 describe('SelectableNetworkList', () => {
-    it('should render mainnet and testnet sections when testnets are enabled', () => {
+    it('should render mainnet and testnet sections when testnets are enabled', async () => {
         const onSelectItem = jest.fn();
-        const { getByText } = renderWithStoreProvider(
+        const { getByText } = await renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
             { preloadedState: getMockPreloadedState(true) },
         );
@@ -22,9 +22,9 @@ describe('SelectableNetworkList', () => {
         expect(getByText('Testnet networks (no value–for testing purposes only)')).toBeTruthy();
     });
 
-    it('should split networks into mainnet and testnet sections correctly', () => {
+    it('should split networks into mainnet and testnet sections correctly', async () => {
         const onSelectItem = jest.fn();
-        const { getByText } = renderWithStoreProvider(
+        const { getByText } = await renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
             { preloadedState: getMockPreloadedState(true) },
         );
@@ -35,22 +35,22 @@ describe('SelectableNetworkList', () => {
         expect(getByText('Ethereum Sepolia')).toBeTruthy();
     });
 
-    it('should call onSelectItem with correct network symbol when item is pressed', () => {
+    it('should call onSelectItem with correct network symbol when item is pressed', async () => {
         const onSelectItem = jest.fn();
-        const { getByText } = renderWithStoreProvider(
+        const { getByText } = await renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
             { preloadedState: getMockPreloadedState(true) },
         );
 
-        fireEvent.press(getByText('Bitcoin'));
+        await fireEvent.press(getByText('Bitcoin'));
         expect(onSelectItem).toHaveBeenCalledWith('btc');
-        fireEvent.press(getByText('Bitcoin Testnet'));
+        await fireEvent.press(getByText('Bitcoin Testnet'));
         expect(onSelectItem).toHaveBeenCalledWith('test');
     });
 
-    it('should not render testnet section when testnets are disabled', () => {
+    it('should not render testnet section when testnets are disabled', async () => {
         const onSelectItem = jest.fn();
-        const { getByText, queryByText } = renderWithStoreProvider(
+        const { getByText, queryByText } = await renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
             { preloadedState: getMockPreloadedState(false) },
         );

--- a/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.test.ts
+++ b/suite-native/module-accounts-management/src/hooks/useDayCoinPriceChange.test.ts
@@ -47,7 +47,7 @@ describe('useDayCoinPriceChange', () => {
     it('returns fiat rates of a regular token', async () => {
         mockFetchedRates(100, 110);
 
-        const { result } = renderHookWithStoreProvider(
+        const { result } = await renderHookWithStoreProvider(
             () => useDayCoinPriceChange({ symbol: ethSymbol, tokenContract: underlyingContract }),
             { preloadedState },
         );
@@ -75,7 +75,7 @@ describe('useDayCoinPriceChange', () => {
             exchangeRate: new BigNumber('1.2'),
         });
 
-        const { result } = renderHookWithStoreProvider(
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useDayCoinPriceChange({
                     symbol: ethSymbol,
@@ -108,7 +108,7 @@ describe('useDayCoinPriceChange', () => {
         mockFetchedRates(100, 110);
         fetchErc4626UnderlyingAssetMock.mockRejectedValue(new Error('Fetch failed'));
 
-        const { result } = renderHookWithStoreProvider(
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useDayCoinPriceChange({
                     symbol: ethSymbol,

--- a/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx
@@ -51,8 +51,8 @@ const buildPreloadedState = (account: ReturnType<typeof mockWalletAccount>) => (
 });
 
 describe('AccountSettingsScreen', () => {
-    it('renders Show XPUB button for UTXO account', () => {
-        const { queryAllByText } = renderWithStoreProvider(
+    it('renders Show XPUB button for UTXO account', async () => {
+        const { queryAllByText } = await renderWithStoreProvider(
             <AccountSettingsScreen
                 route={buildRoute(btcAccount.key)}
                 navigation={navigationMock}
@@ -70,8 +70,8 @@ describe('AccountSettingsScreen', () => {
         ).toBeGreaterThan(0);
     });
 
-    it('does not render Show XPUB button for address-based account', () => {
-        const { queryByText } = renderWithStoreProvider(
+    it('does not render Show XPUB button for address-based account', async () => {
+        const { queryByText } = await renderWithStoreProvider(
             <AccountSettingsScreen
                 route={buildRoute(ethAccount.key)}
                 navigation={navigationMock}

--- a/suite-native/module-device-onboarding/src/hooks/useReportOnboardingStepViewedAnalytics.test.tsx
+++ b/suite-native/module-device-onboarding/src/hooks/useReportOnboardingStepViewedAnalytics.test.tsx
@@ -6,12 +6,12 @@ import { act, renderHook } from '@suite-native/test-utils-store';
 
 import { useReportOnboardingStepViewedAnalytics } from './useReportOnboardingStepViewedAnalytics';
 
-const renderUseReportStepViewed = () => {
+const renderUseReportStepViewed = async () => {
     const services: NativeAnalyticsDep = {
         analytics: mockNativeAnalytics(jest.fn()),
     };
 
-    const view = renderHook(() => useReportOnboardingStepViewedAnalytics(), {
+    const view = await renderHook(() => useReportOnboardingStepViewedAnalytics(), {
         wrapper: ({ children }) => (
             <ServicesProvider services={services}>{children}</ServicesProvider>
         ),
@@ -21,10 +21,10 @@ const renderUseReportStepViewed = () => {
 };
 
 describe('useReportOnboardingStepViewedAnalytics', () => {
-    it('reports a step once on entry with mobile platform and per-platform index', () => {
-        const { result, analytics } = renderUseReportStepViewed();
+    it('reports a step once on entry with mobile platform and per-platform index', async () => {
+        const { result, analytics } = await renderUseReportStepViewed();
 
-        act(() => {
+        await act(() => {
             result.current(DeviceOnboardingStackRoutes.FirmwareInfo);
         });
 
@@ -35,10 +35,10 @@ describe('useReportOnboardingStepViewedAnalytics', () => {
         });
     });
 
-    it('does not re-report while moving across screens of the same canonical step', () => {
-        const { result, analytics } = renderUseReportStepViewed();
+    it('does not re-report while moving across screens of the same canonical step', async () => {
+        const { result, analytics } = await renderUseReportStepViewed();
 
-        act(() => {
+        await act(() => {
             result.current(DeviceOnboardingStackRoutes.FirmwareInfo);
             result.current(DeviceOnboardingStackRoutes.ConfirmFirmwareUpdate);
             result.current(DeviceOnboardingStackRoutes.FirmwareInstallation);
@@ -47,10 +47,10 @@ describe('useReportOnboardingStepViewedAnalytics', () => {
         expect(analytics.report).toHaveBeenCalledTimes(1);
     });
 
-    it('reports again when the canonical step changes', () => {
-        const { result, analytics } = renderUseReportStepViewed();
+    it('reports again when the canonical step changes', async () => {
+        const { result, analytics } = await renderUseReportStepViewed();
 
-        act(() => {
+        await act(() => {
             result.current(DeviceOnboardingStackRoutes.FirmwareInfo);
             result.current(DeviceOnboardingStackRoutes.DeviceTutorial);
         });
@@ -63,10 +63,10 @@ describe('useReportOnboardingStepViewedAnalytics', () => {
         );
     });
 
-    it('does not report for non-step (skipped) screens', () => {
-        const { result, analytics } = renderUseReportStepViewed();
+    it('does not report for non-step (skipped) screens', async () => {
+        const { result, analytics } = await renderUseReportStepViewed();
 
-        act(() => {
+        await act(() => {
             result.current(DeviceOnboardingStackRoutes.CreateWalletLoading);
             result.current(DeviceOnboardingStackRoutes.WalletCreatedSuccess);
         });

--- a/suite-native/module-earn/src/components/EarnSummaryOutputItem.test.tsx
+++ b/suite-native/module-earn/src/components/EarnSummaryOutputItem.test.tsx
@@ -27,8 +27,8 @@ jest.mock('@suite-native/transaction-management', () => ({
     },
 }));
 
-const renderItem = (stakeType: EarnFormDraftPrefix) =>
-    renderWithStoreProvider(
+const renderItem = async (stakeType: EarnFormDraftPrefix) =>
+    await renderWithStoreProvider(
         <EarnSummaryOutputItem
             accountKey={accountKey}
             stakeType={stakeType}
@@ -57,10 +57,10 @@ describe('EarnSummaryOutputItem', () => {
     ])(
         // The device omits the amount from the Ethereum claim and the Solana unstake summaries.
         'renders the amount row: $isAmountVisible for $symbol $stakeType',
-        ({ symbol, stakeType, isAmountVisible }) => {
+        async ({ symbol, stakeType, isAmountVisible }) => {
             mockAccountNetworkSymbol = symbol;
 
-            renderItem(stakeType);
+            await renderItem(stakeType);
 
             const renderedKeys = getRenderedTranslationKeys();
             expect(renderedKeys.includes(AMOUNT_TRANSLATION_KEY)).toBe(isAmountVisible);

--- a/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.test.tsx
+++ b/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.test.tsx
@@ -18,7 +18,7 @@ const SOL_WITHDRAWAL_RESERVE = '0.02';
 
 const translate = ((id: string) => id) as EarnFormContext['translate'];
 
-const renderBanner = ({
+const renderBanner = async ({
     balance,
     amount,
     isMaxSelected,
@@ -32,7 +32,7 @@ const renderBanner = ({
         availableBalance: networkAmountToSmallestUnit(balance, 'sol'),
     });
 
-    const { result } = renderHookWithStoreProvider(() =>
+    const { result } = await renderHookWithStoreProvider(() =>
         useForm<EarnFormValues>({
             validation: earnFormValidationSchema,
             mode: 'onTouched',
@@ -42,7 +42,7 @@ const renderBanner = ({
     );
     const form = result.current;
 
-    return renderWithStoreProvider(
+    return await renderWithStoreProvider(
         <EarnWithdrawalFeesBanner
             accountKey={account.key}
             symbol="sol"
@@ -56,14 +56,18 @@ const renderBanner = ({
 };
 
 describe('EarnWithdrawalFeesBanner', () => {
-    it('renders nothing for a manually entered amount that leaves the withdrawal reserve intact', () => {
-        const { toJSON } = renderBanner({ balance: '5', amount: '4', isMaxSelected: false });
+    it('renders nothing for a manually entered amount that leaves the withdrawal reserve intact', async () => {
+        const { toJSON } = await renderBanner({ balance: '5', amount: '4', isMaxSelected: false });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('recommends the reserve for a manually entered amount that eats into it', () => {
-        const { getByText } = renderBanner({ balance: '5', amount: '4.99', isMaxSelected: false });
+    it('recommends the reserve for a manually entered amount that eats into it', async () => {
+        const { getByText } = await renderBanner({
+            balance: '5',
+            amount: '4.99',
+            isMaxSelected: false,
+        });
 
         expect(
             getByText(
@@ -75,9 +79,9 @@ describe('EarnWithdrawalFeesBanner', () => {
         ).toBeTruthy();
     });
 
-    it('confirms the kept reserve for the stake max amount, which leaves exactly the reserve', () => {
+    it('confirms the kept reserve for the stake max amount, which leaves exactly the reserve', async () => {
         const balance = '5';
-        const { getByText } = renderBanner({
+        const { getByText } = await renderBanner({
             balance,
             amount: getMaxStakeAmount({ balance, symbol: 'sol' }),
             isMaxSelected: true,
@@ -93,10 +97,10 @@ describe('EarnWithdrawalFeesBanner', () => {
         ).toBeTruthy();
     });
 
-    it('recommends the reserve when stake max can only leave the smaller fee buffer', () => {
+    it('recommends the reserve when stake max can only leave the smaller fee buffer', async () => {
         // Below MIN_SOL_BALANCE_FOR_STAKING the max amount reserves the 0.005 fee buffer only.
         const balance = '1.01';
-        const { getByText } = renderBanner({
+        const { getByText } = await renderBanner({
             balance,
             amount: getMaxStakeAmount({ balance, symbol: 'sol' }),
             isMaxSelected: true,

--- a/suite-native/module-earn/src/components/SolanaUnstakeAmountBoundsAlert.test.tsx
+++ b/suite-native/module-earn/src/components/SolanaUnstakeAmountBoundsAlert.test.tsx
@@ -41,8 +41,8 @@ const buildEthereumAccount = (): Account =>
 
 const translate = ((id: string) => id) as UnstakeFormContext['translate'];
 
-const renderAlert = (account: Account, amountValue: string) => {
-    const { result } = renderHookWithStoreProvider(() =>
+const renderAlert = async (account: Account, amountValue: string) => {
+    const { result } = await renderHookWithStoreProvider(() =>
         useForm<EarnFormValues>({
             validation: unstakeFormValidationSchema,
             mode: 'onTouched',
@@ -54,49 +54,49 @@ const renderAlert = (account: Account, amountValue: string) => {
 
     return {
         form,
-        ...renderWithStoreProvider(
+        ...(await renderWithStoreProvider(
             <SolanaUnstakeAmountBoundsAlert account={account} amountValue={amountValue} />,
             { wrapper: ({ children }) => <Form form={form}>{children}</Form> },
-        ),
+        )),
     };
 };
 
 describe('SolanaUnstakeAmountBoundsAlert', () => {
-    it('renders nothing for a valid amount', () => {
+    it('renders nothing for a valid amount', async () => {
         const account = buildSolanaAccount([buildStakingAccount({ stake: `${3.12 * SOL}` })]);
-        const { toJSON } = renderAlert(account, '1.5');
+        const { toJSON } = await renderAlert(account, '1.5');
 
         expect(toJSON()).toBeNull();
     });
 
-    it('renders nothing for a non-Solana account', () => {
+    it('renders nothing for a non-Solana account', async () => {
         const account = buildEthereumAccount();
-        const { toJSON } = renderAlert(account, '0.5');
+        const { toJSON } = await renderAlert(account, '0.5');
 
         expect(toJSON()).toBeNull();
     });
 
-    it('renders both suggested amounts when a lower bound exists', () => {
+    it('renders both suggested amounts when a lower bound exists', async () => {
         const account = buildSolanaAccount([
             buildStakingAccount({ stake: `${2 * SOL}` }),
             buildStakingAccount({ stake: `${1.42 * SOL}` }),
         ]);
-        const { getByText } = renderAlert(account, '2');
+        const { getByText } = await renderAlert(account, '2');
 
         expect(getByText('1.42 SOL')).toBeTruthy();
         expect(getByText('2.42 SOL')).toBeTruthy();
     });
 
-    it('renders only the higher suggested amount when there is no valid lower bound', () => {
+    it('renders only the higher suggested amount when there is no valid lower bound', async () => {
         const account = buildSolanaAccount([buildStakingAccount({ stake: `${1.42 * SOL}` })]);
-        const { getByText } = renderAlert(account, '0.5');
+        const { getByText } = await renderAlert(account, '0.5');
 
         expect(getByText('1.42 SOL')).toBeTruthy();
     });
 
     it('fills in the amount when a suggested value is pressed', async () => {
         const account = buildSolanaAccount([buildStakingAccount({ stake: `${1.42 * SOL}` })]);
-        const { getByText, form } = renderAlert(account, '0.5');
+        const { getByText, form } = await renderAlert(account, '0.5');
 
         await userEvent.press(getByText('1.42 SOL'));
 

--- a/suite-native/module-earn/src/hooks/useAutoStartReview.test.tsx
+++ b/suite-native/module-earn/src/hooks/useAutoStartReview.test.tsx
@@ -31,7 +31,7 @@ describe('useAutoStartReview', () => {
     it('starts the review once, arms the device-review reveal and forwards the outcome', async () => {
         const params = buildParams();
 
-        renderHook(() => useAutoStartReview(params));
+        await renderHook(() => useAutoStartReview(params));
 
         await waitFor(() => expect(params.startReview).toHaveBeenCalledTimes(1));
         expect(mockWaitForDeviceReview).toHaveBeenCalledTimes(1);
@@ -40,10 +40,10 @@ describe('useAutoStartReview', () => {
         );
     });
 
-    it('does not start the review while it is not allowed yet', () => {
+    it('does not start the review while it is not allowed yet', async () => {
         const params = buildParams({ shouldAutoStartReview: false });
 
-        renderHook(() => useAutoStartReview(params));
+        await renderHook(() => useAutoStartReview(params));
 
         expect(params.startReview).not.toHaveBeenCalled();
         expect(mockWaitForDeviceReview).not.toHaveBeenCalled();
@@ -63,14 +63,14 @@ describe('useAutoStartReview', () => {
         );
         const params = buildParams({ startReview, onReviewSettled });
 
-        const { rerender } = renderHook((props: Params) => useAutoStartReview(props), {
+        const { rerender } = await renderHook((props: Params) => useAutoStartReview(props), {
             initialProps: params,
         });
 
         await waitFor(() => expect(onReviewSettled).toHaveBeenCalledTimes(1));
 
-        rerender({ ...params, shouldAutoStartReview: false });
-        rerender({ ...params, shouldAutoStartReview: true });
+        await rerender({ ...params, shouldAutoStartReview: false });
+        await rerender({ ...params, shouldAutoStartReview: true });
 
         await waitFor(() => expect(startReview).toHaveBeenCalledTimes(2));
     });
@@ -79,14 +79,14 @@ describe('useAutoStartReview', () => {
         const startReview = jest.fn().mockResolvedValue('failed');
         const params = buildParams({ startReview });
 
-        const { rerender } = renderHook((props: Params) => useAutoStartReview(props), {
+        const { rerender } = await renderHook((props: Params) => useAutoStartReview(props), {
             initialProps: params,
         });
 
         await waitFor(() => expect(startReview).toHaveBeenCalledTimes(1));
 
-        rerender({ ...params, shouldAutoStartReview: false });
-        rerender({ ...params, shouldAutoStartReview: true });
+        await rerender({ ...params, shouldAutoStartReview: false });
+        await rerender({ ...params, shouldAutoStartReview: true });
 
         expect(startReview).toHaveBeenCalledTimes(1);
     });
@@ -98,14 +98,14 @@ describe('useAutoStartReview', () => {
             .mockResolvedValue('signed');
         const params = buildParams({ startReview });
 
-        const { rerender } = renderHook((props: Params) => useAutoStartReview(props), {
+        const { rerender } = await renderHook((props: Params) => useAutoStartReview(props), {
             initialProps: params,
         });
 
         await waitFor(() => expect(startReview).toHaveBeenCalledTimes(1));
 
-        rerender({ ...params, shouldAutoStartReview: false });
-        rerender({ ...params, shouldAutoStartReview: true });
+        await rerender({ ...params, shouldAutoStartReview: false });
+        await rerender({ ...params, shouldAutoStartReview: true });
 
         await waitFor(() => expect(startReview).toHaveBeenCalledTimes(2));
     });
@@ -117,14 +117,14 @@ describe('useAutoStartReview', () => {
             .mockResolvedValue(undefined);
         const params = buildParams({ onReviewSettled });
 
-        const { rerender } = renderHook((props: Params) => useAutoStartReview(props), {
+        const { rerender } = await renderHook((props: Params) => useAutoStartReview(props), {
             initialProps: params,
         });
 
         await waitFor(() => expect(onReviewSettled).toHaveBeenCalledTimes(1));
 
-        rerender({ ...params, shouldAutoStartReview: false });
-        rerender({ ...params, shouldAutoStartReview: true });
+        await rerender({ ...params, shouldAutoStartReview: false });
+        await rerender({ ...params, shouldAutoStartReview: true });
 
         await waitFor(() => expect(onReviewSettled).toHaveBeenCalledTimes(2));
     });
@@ -140,11 +140,11 @@ describe('useAutoStartReview', () => {
         const onReviewSettled = jest.fn();
         const params = buildParams({ startReview, onReviewSettled });
 
-        const { unmount } = renderHook(() => useAutoStartReview(params));
+        const { unmount } = await renderHook(() => useAutoStartReview(params));
 
         await waitFor(() => expect(startReview).toHaveBeenCalledTimes(1));
 
-        unmount();
+        await unmount();
         resolveStart('signed');
         await new Promise<void>(resolve => {
             setTimeout(resolve, 0);

--- a/suite-native/module-earn/src/hooks/useEarnDepositsCardData.test.ts
+++ b/suite-native/module-earn/src/hooks/useEarnDepositsCardData.test.ts
@@ -60,7 +60,7 @@ const createYieldItem = (underlyingContract: TokenAddress): StablecoinYieldEarnI
     apy: 5.3,
 });
 
-const renderDepositsCardData = ({
+const renderDepositsCardData = async ({
     items,
     stakingItems = [],
     currentRates,
@@ -69,7 +69,7 @@ const renderDepositsCardData = ({
     stakingItems?: StakingEarnItem[];
     currentRates: Record<string, { rate: number }>;
 }) =>
-    renderHookWithStoreProvider(
+    await renderHookWithStoreProvider(
         () =>
             useEarnDepositsCardData({
                 stakingActiveItems: stakingItems,
@@ -91,8 +91,8 @@ describe('useEarnDepositsCardData', () => {
         useMissingRateTickersQueryMock.mockReturnValue(createMissingRateTickersQueryResult());
     });
 
-    it('includes the yield position in the total when the token rate is available', () => {
-        const { result } = renderDepositsCardData({
+    it('includes the yield position in the total when the token rate is available', async () => {
+        const { result } = await renderDepositsCardData({
             items: [createYieldItem(USDC_CONTRACT_LOWERCASE)],
             currentRates: {
                 [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: { rate: 1 },
@@ -103,8 +103,8 @@ describe('useEarnDepositsCardData', () => {
         expect(result.current.isFiatRatesLoading).toBe(false);
     });
 
-    it('includes the yield position when the rate is stored under a differently cased contract address', () => {
-        const { result } = renderDepositsCardData({
+    it('includes the yield position when the rate is stored under a differently cased contract address', async () => {
+        const { result } = await renderDepositsCardData({
             items: [createYieldItem(USDC_CONTRACT_LOWERCASE)],
             currentRates: {
                 [getFiatRateKey('eth', 'usd', USDC_CONTRACT_CHECKSUMMED)]: { rate: 1 },
@@ -118,12 +118,12 @@ describe('useEarnDepositsCardData', () => {
         });
     });
 
-    it('requests the missing token rate and reports the fiat loading state', () => {
+    it('requests the missing token rate and reports the fiat loading state', async () => {
         useMissingRateTickersQueryMock.mockReturnValue(
             createMissingRateTickersQueryResult({ isFetching: true }),
         );
 
-        const { result } = renderDepositsCardData({
+        const { result } = await renderDepositsCardData({
             items: [createYieldItem(USDC_CONTRACT_CHECKSUMMED)],
             currentRates: {
                 [getFiatRateKey('eth', 'usd')]: { rate: 3000 },
@@ -141,8 +141,8 @@ describe('useEarnDepositsCardData', () => {
         expect(result.current.totalDepositedFiatAmount.toFixed()).toBe('0');
     });
 
-    it('reports an incomplete total and allows retry when the rate remains missing', () => {
-        const { result } = renderDepositsCardData({
+    it('reports an incomplete total and allows retry when the rate remains missing', async () => {
+        const { result } = await renderDepositsCardData({
             items: [createYieldItem(USDC_CONTRACT_LOWERCASE)],
             currentRates: {},
         });
@@ -156,8 +156,8 @@ describe('useEarnDepositsCardData', () => {
         expect(refetchMissingRateTickersMock).toHaveBeenCalledTimes(1);
     });
 
-    it('reports a lower-bound total when only some yield rates are available', () => {
-        const { result } = renderDepositsCardData({
+    it('reports a lower-bound total when only some yield rates are available', async () => {
+        const { result } = await renderDepositsCardData({
             items: [
                 createYieldItem(USDC_CONTRACT_LOWERCASE),
                 createYieldItem(DAI_CONTRACT_LOWERCASE),
@@ -172,8 +172,8 @@ describe('useEarnDepositsCardData', () => {
         expect(result.current.isFiatTotalUnavailable).toBe(false);
     });
 
-    it('reports an unavailable total and requests a missing staking rate', () => {
-        const { result } = renderDepositsCardData({
+    it('reports an unavailable total and requests a missing staking rate', async () => {
+        const { result } = await renderDepositsCardData({
             items: [],
             stakingItems: [stakingItem],
             currentRates: {},

--- a/suite-native/module-earn/src/hooks/useEarnReviewAutoStart.test.tsx
+++ b/suite-native/module-earn/src/hooks/useEarnReviewAutoStart.test.tsx
@@ -27,17 +27,17 @@ describe('useEarnReviewAutoStart', () => {
     it('auto-starts signing and arms the device-review reveal once the review is ready', async () => {
         const params = buildParams();
 
-        renderHook(() => useEarnReviewAutoStart(params));
+        await renderHook(() => useEarnReviewAutoStart(params));
 
         await waitFor(() => expect(params.handleSign).toHaveBeenCalledTimes(1));
         expect(mockWaitForDeviceReview).toHaveBeenCalledTimes(1);
         expect(params.onSignFailed).not.toHaveBeenCalled();
     });
 
-    it('does not start signing when the transaction is already signed', () => {
+    it('does not start signing when the transaction is already signed', async () => {
         const params = buildParams({ isSigned: true });
 
-        renderHook(() => useEarnReviewAutoStart(params));
+        await renderHook(() => useEarnReviewAutoStart(params));
 
         expect(params.handleSign).not.toHaveBeenCalled();
         expect(mockWaitForDeviceReview).not.toHaveBeenCalled();
@@ -46,13 +46,13 @@ describe('useEarnReviewAutoStart', () => {
     it('waits until the transaction can be signed before starting', async () => {
         const params = buildParams({ canStart: false });
 
-        const { rerender } = renderHook((props: Params) => useEarnReviewAutoStart(props), {
+        const { rerender } = await renderHook((props: Params) => useEarnReviewAutoStart(props), {
             initialProps: params,
         });
 
         expect(params.handleSign).not.toHaveBeenCalled();
 
-        rerender({ ...params, canStart: true });
+        await rerender({ ...params, canStart: true });
 
         await waitFor(() => expect(params.handleSign).toHaveBeenCalledTimes(1));
     });
@@ -60,7 +60,7 @@ describe('useEarnReviewAutoStart', () => {
     it('calls onSignFailed when the signature is declined', async () => {
         const params = buildParams({ handleSign: jest.fn().mockResolvedValue(false) });
 
-        renderHook(() => useEarnReviewAutoStart(params));
+        await renderHook(() => useEarnReviewAutoStart(params));
 
         await waitFor(() => expect(params.onSignFailed).toHaveBeenCalledTimes(1));
     });
@@ -68,14 +68,14 @@ describe('useEarnReviewAutoStart', () => {
     it('signs only once and never re-prompts even if the screen re-renders', async () => {
         const params = buildParams();
 
-        const { rerender } = renderHook((props: Params) => useEarnReviewAutoStart(props), {
+        const { rerender } = await renderHook((props: Params) => useEarnReviewAutoStart(props), {
             initialProps: params,
         });
 
         await waitFor(() => expect(params.handleSign).toHaveBeenCalledTimes(1));
 
-        rerender({ ...params });
-        rerender({ ...params });
+        await rerender({ ...params });
+        await rerender({ ...params });
 
         expect(params.handleSign).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-earn/src/hooks/useEarnTransactionReview.test.ts
+++ b/suite-native/module-earn/src/hooks/useEarnTransactionReview.test.ts
@@ -58,8 +58,8 @@ const createParams = (overrides: Record<string, unknown> = {}) => ({
 
 type HookParams = ReturnType<typeof createParams>;
 
-const renderReview = (params: HookParams, { isDeviceConnected = true } = {}) =>
-    renderHookWithStoreProvider((props: HookParams) => useEarnTransactionReview(props), {
+const renderReview = async (params: HookParams, { isDeviceConnected = true } = {}) =>
+    await renderHookWithStoreProvider((props: HookParams) => useEarnTransactionReview(props), {
         preloadedState: { device: { selectedDevice: { connected: isDeviceConnected } } },
         initialProps: params,
     });
@@ -76,7 +76,7 @@ describe('useEarnTransactionReview', () => {
         it('signs successfully and passes the payload to onSignSuccess', async () => {
             const params = createParams();
             params.signAction.mockResolvedValue(fulfilled(SIGNED_PAYLOAD));
-            const { result } = renderReview(params);
+            const { result } = await renderReview(params);
 
             let signingResult;
             await act(async () => {
@@ -93,7 +93,7 @@ describe('useEarnTransactionReview', () => {
             const errorPayload = { error: 'sign-transaction-failed', message: 'boom' };
             const params = createParams();
             params.signAction.mockResolvedValue(rejected(errorPayload));
-            const { result } = renderReview(params);
+            const { result } = await renderReview(params);
 
             let signingResult;
             await act(async () => {
@@ -111,7 +111,7 @@ describe('useEarnTransactionReview', () => {
             params.signAction.mockResolvedValue(
                 rejected({ error: 'sign-transaction-failed', message: 'tx-cancelled' }),
             );
-            const { result } = renderReview(params);
+            const { result } = await renderReview(params);
 
             let signingResult;
             await act(async () => {
@@ -129,7 +129,7 @@ describe('useEarnTransactionReview', () => {
         it('pushes successfully and marks the navigation success before onPushSuccess', async () => {
             const params = createParams({ isSigned: true });
             params.pushAction.mockResolvedValue(fulfilled(PUSHED_PAYLOAD));
-            const { result } = renderReview(params);
+            const { result } = await renderReview(params);
 
             await act(async () => {
                 await result.current.handleSubmitted();
@@ -151,7 +151,7 @@ describe('useEarnTransactionReview', () => {
             params.pushAction.mockResolvedValue(
                 rejected({ error: 'push-transaction-pending-conflict' }),
             );
-            const { result } = renderReview(params);
+            const { result } = await renderReview(params);
 
             await act(async () => {
                 await result.current.handleSubmitted();
@@ -171,7 +171,7 @@ describe('useEarnTransactionReview', () => {
                     resolvePush = resolve;
                 }),
             );
-            const { result } = renderReview(params);
+            const { result } = await renderReview(params);
 
             await act(async () => {
                 const firstSubmit = result.current.handleSubmitted();
@@ -192,7 +192,7 @@ describe('useEarnTransactionReview', () => {
             params.pushAction
                 .mockResolvedValueOnce(rejected({ error: 'push-transaction-failed' }))
                 .mockResolvedValueOnce(fulfilled(PUSHED_PAYLOAD));
-            const { result } = renderReview(params);
+            const { result } = await renderReview(params);
 
             await act(async () => {
                 await result.current.handleSubmitted();
@@ -212,7 +212,7 @@ describe('useEarnTransactionReview', () => {
         it('does nothing when pushAction returns null and never switches to sending', async () => {
             const params = createParams({ isSigned: true });
             params.pushAction.mockReturnValue(null);
-            const { result } = renderReview(params);
+            const { result } = await renderReview(params);
 
             await act(async () => {
                 await result.current.handleSubmitted();

--- a/suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts
+++ b/suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts
@@ -114,15 +114,15 @@ const createProps = (overrides: Partial<HookProps> = {}): HookProps => ({
     ...overrides,
 });
 
-const renderPreparedTxFees = (initialProps: HookProps) => {
+const renderPreparedTxFees = async (initialProps: HookProps) => {
     const store = createTestStore();
 
     return {
         store,
-        ...renderHookWithStoreProvider((props: HookProps) => usePreparedTxFees(props), {
+        ...(await renderHookWithStoreProvider((props: HookProps) => usePreparedTxFees(props), {
             store,
             initialProps,
-        }),
+        })),
     };
 };
 
@@ -153,7 +153,7 @@ describe('usePreparedTxFees', () => {
 
     it('prepares the transaction and stores fee levels with the form draft', async () => {
         const composeTransaction = jest.fn().mockResolvedValue(composeReady());
-        const { result, store } = renderPreparedTxFees(createProps({ composeTransaction }));
+        const { result, store } = await renderPreparedTxFees(createProps({ composeTransaction }));
 
         expect(result.current.isFeePreparing).toBe(true);
 
@@ -179,10 +179,10 @@ describe('usePreparedTxFees', () => {
             .mockReturnValueOnce(staleCompose.promise)
             .mockReturnValueOnce(freshCompose.promise);
         const props = createProps({ composeTransaction });
-        const { result, rerender } = renderPreparedTxFees(props);
+        const { result, rerender } = await renderPreparedTxFees(props);
 
         await settleDebounce();
-        rerender({ ...props, amount: '2' });
+        await rerender({ ...props, amount: '2' });
         await settleDebounce();
 
         expect(composeTransaction).toHaveBeenNthCalledWith(1, '1');
@@ -201,14 +201,14 @@ describe('usePreparedTxFees', () => {
     it('clears the stored draft and its own fee levels when the context turns invalid', async () => {
         const composeTransaction = jest.fn().mockResolvedValue(composeReady());
         const props = createProps({ composeTransaction });
-        const { rerender, store } = renderPreparedTxFees(props);
+        const { rerender, store } = await renderPreparedTxFees(props);
 
         await settleDebounce();
 
         expect(store.getState().wallet.send.feeLevels).toEqual(FEE_LEVELS);
         expect(store.getState().wallet.formDrafts[FORM_DRAFT_KEY]).toEqual(FORM_DRAFT);
 
-        rerender({ ...props, amount: undefined, hasInvalidContext: true });
+        await rerender({ ...props, amount: undefined, hasInvalidContext: true });
 
         expect(store.getState().wallet.send.feeLevels).toEqual({});
         expect(store.getState().wallet.formDrafts[FORM_DRAFT_KEY]).toBeUndefined();
@@ -217,10 +217,10 @@ describe('usePreparedTxFees', () => {
     it('keeps the fee store intact when only isEnabled turns false', async () => {
         const composeTransaction = jest.fn().mockResolvedValue(composeReady());
         const props = createProps({ composeTransaction });
-        const { rerender, store } = renderPreparedTxFees(props);
+        const { rerender, store } = await renderPreparedTxFees(props);
 
         await settleDebounce();
-        rerender({ ...props, isEnabled: false });
+        await rerender({ ...props, isEnabled: false });
 
         expect(store.getState().wallet.send.feeLevels).toEqual(FEE_LEVELS);
         expect(store.getState().wallet.formDrafts[FORM_DRAFT_KEY]).toEqual(FORM_DRAFT);
@@ -228,7 +228,7 @@ describe('usePreparedTxFees', () => {
 
     it('surfaces an error for every failed compose', async () => {
         const composeTransaction = jest.fn().mockResolvedValue({ type: 'error' });
-        const { result } = renderPreparedTxFees(createProps({ composeTransaction }));
+        const { result } = await renderPreparedTxFees(createProps({ composeTransaction }));
 
         await settleDebounce();
 
@@ -241,7 +241,7 @@ describe('usePreparedTxFees', () => {
     it('surfaces an error when the base fee preview cannot be built', async () => {
         buildFeePreviewMock.mockReturnValue(null);
         const composeTransaction = jest.fn().mockResolvedValue(composeReady());
-        const { result } = renderPreparedTxFees(createProps({ composeTransaction }));
+        const { result } = await renderPreparedTxFees(createProps({ composeTransaction }));
 
         await settleDebounce();
 
@@ -252,7 +252,7 @@ describe('usePreparedTxFees', () => {
 
     it('surfaces an error when the compose function throws', async () => {
         const composeTransaction = jest.fn().mockRejectedValue(new Error('compose exploded'));
-        const { result } = renderPreparedTxFees(createProps({ composeTransaction }));
+        const { result } = await renderPreparedTxFees(createProps({ composeTransaction }));
 
         await settleDebounce();
 
@@ -269,7 +269,7 @@ describe('usePreparedTxFees', () => {
             unsignedTransaction === '0xselected' ? null : BASE_FEE_PREVIEW,
         );
         const composeTransaction = jest.fn().mockResolvedValue(composeReady());
-        const { result } = renderPreparedTxFees(createProps({ composeTransaction }));
+        const { result } = await renderPreparedTxFees(createProps({ composeTransaction }));
 
         await settleDebounce();
 

--- a/suite-native/module-earn/src/hooks/useStakingDetailNavigation.test.tsx
+++ b/suite-native/module-earn/src/hooks/useStakingDetailNavigation.test.tsx
@@ -18,8 +18,8 @@ describe('useStakingDetailNavigation', () => {
         jest.clearAllMocks();
     });
 
-    it('navigates a Solana account to staking management', () => {
-        const { result } = renderHook(() => useStakingDetailNavigation());
+    it('navigates a Solana account to staking management', async () => {
+        const { result } = await renderHook(() => useStakingDetailNavigation());
         result.current.navigateToStakingDetail({ accountKey, symbol: 'sol' });
 
         expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingManagement, {
@@ -27,8 +27,8 @@ describe('useStakingDetailNavigation', () => {
         });
     });
 
-    it('navigates an Ethereum account to staking management', () => {
-        const { result } = renderHook(() => useStakingDetailNavigation());
+    it('navigates an Ethereum account to staking management', async () => {
+        const { result } = await renderHook(() => useStakingDetailNavigation());
         result.current.navigateToStakingDetail({ accountKey, symbol: 'eth' });
 
         expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.StakingManagement, {

--- a/suite-native/module-earn/src/hooks/useStartYieldDepositFlow.test.ts
+++ b/suite-native/module-earn/src/hooks/useStartYieldDepositFlow.test.ts
@@ -145,10 +145,10 @@ const wethHookParams: HookParams = {
     routeParams: wethRouteParams,
 };
 
-const renderUseStartYieldDepositFlow = (
+const renderUseStartYieldDepositFlow = async (
     store: TestStore,
     hookParams: HookParams = defaultHookParams,
-) => renderHookWithStoreProvider(() => useStartYieldDepositFlow(hookParams), { store });
+) => await renderHookWithStoreProvider(() => useStartYieldDepositFlow(hookParams), { store });
 
 describe('useStartYieldDepositFlow', () => {
     beforeEach(() => {
@@ -160,7 +160,7 @@ describe('useStartYieldDepositFlow', () => {
     it('navigates to deposit when allowance initialization skips to action step', async () => {
         const store = buildStore();
         fetchAllowanceMock.mockResolvedValue(allowanceSubunits('1000000'));
-        const { result } = renderUseStartYieldDepositFlow(store);
+        const { result } = await renderUseStartYieldDepositFlow(store);
 
         await act(async () => {
             await result.current.handleStartYieldDepositFlow();
@@ -171,7 +171,7 @@ describe('useStartYieldDepositFlow', () => {
 
     it('navigates to approval when allowance is zero', async () => {
         const store = buildStore();
-        const { result } = renderUseStartYieldDepositFlow(store);
+        const { result } = await renderUseStartYieldDepositFlow(store);
 
         await act(async () => {
             await result.current.handleStartYieldDepositFlow();
@@ -187,7 +187,7 @@ describe('useStartYieldDepositFlow', () => {
         const store = buildStore();
         store.dispatch(stablecoinYieldActions.resetSession(sessionParams));
         store.dispatch(stablecoinYieldActions.skipApprovalStep(sessionParams));
-        const { result } = renderUseStartYieldDepositFlow(store);
+        const { result } = await renderUseStartYieldDepositFlow(store);
 
         await act(async () => {
             await result.current.handleStartYieldDepositFlow();
@@ -209,7 +209,7 @@ describe('useStartYieldDepositFlow', () => {
     it('falls back to approval when allowance initialization fails', async () => {
         const store = buildStore();
         fetchAllowanceMock.mockRejectedValue(new Error('Allowance unavailable.'));
-        const { result } = renderUseStartYieldDepositFlow(store);
+        const { result } = await renderUseStartYieldDepositFlow(store);
 
         await act(async () => {
             await result.current.handleStartYieldDepositFlow();
@@ -231,7 +231,7 @@ describe('useStartYieldDepositFlow', () => {
             decimals: 18,
             balance: '2500000000000000000',
         });
-        const { result } = renderUseStartYieldDepositFlow(store, wethHookParams);
+        const { result } = await renderUseStartYieldDepositFlow(store, wethHookParams);
 
         await act(async () => {
             await result.current.handleStartYieldDepositFlow();
@@ -249,7 +249,7 @@ describe('useStartYieldDepositFlow', () => {
             tokens: [{ contract: wethTokenContract, symbol: 'WETH', decimals: 18, balance: '3' }],
         } as unknown as Account;
         const store = buildStore(trackedAccount);
-        const { result } = renderUseStartYieldDepositFlow(store, wethHookParams);
+        const { result } = await renderUseStartYieldDepositFlow(store, wethHookParams);
 
         await act(async () => {
             await result.current.handleStartYieldDepositFlow();
@@ -264,7 +264,7 @@ describe('useStartYieldDepositFlow', () => {
 
     it('starts on the wrap step when no wrapped-native balance exists', async () => {
         const store = buildStore();
-        const { result } = renderUseStartYieldDepositFlow(store, wethHookParams);
+        const { result } = await renderUseStartYieldDepositFlow(store, wethHookParams);
 
         await act(async () => {
             await result.current.handleStartYieldDepositFlow();
@@ -284,11 +284,11 @@ describe('useStartYieldDepositFlow', () => {
                 resolveAllowance = resolve;
             }),
         );
-        const { result } = renderUseStartYieldDepositFlow(store);
+        const { result } = await renderUseStartYieldDepositFlow(store);
         let startPromise: Promise<boolean> = Promise.resolve(false);
         let duplicateStartPromise: Promise<boolean> = Promise.resolve(false);
 
-        act(() => {
+        await act(() => {
             startPromise = result.current.handleStartYieldDepositFlow();
             duplicateStartPromise = result.current.handleStartYieldDepositFlow();
         });

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.test.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.test.ts
@@ -4,12 +4,12 @@ import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store
 
 import { useWrappedNativeFlowAnalytics } from './useWrappedNativeFlowAnalytics';
 
-const renderFlowAnalytics = (props: Parameters<typeof useWrappedNativeFlowAnalytics>[0]) => {
+const renderFlowAnalytics = async (props: Parameters<typeof useWrappedNativeFlowAnalytics>[0]) => {
     const services: NativeAnalyticsDep = {
         analytics: mockNativeAnalytics(jest.fn()),
     };
 
-    const view = renderHookWithStoreProvider(useWrappedNativeFlowAnalytics, {
+    const view = await renderHookWithStoreProvider(useWrappedNativeFlowAnalytics, {
         initialProps: props,
         services,
     });
@@ -18,13 +18,13 @@ const renderFlowAnalytics = (props: Parameters<typeof useWrappedNativeFlowAnalyt
 };
 
 describe('useWrappedNativeFlowAnalytics', () => {
-    it('reports submit as yield/wrap for the wrap flow', () => {
-        const { result, analytics } = renderFlowAnalytics({
+    it('reports submit as yield/wrap for the wrap flow', async () => {
+        const { result, analytics } = await renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
 
-        act(() => {
+        await act(() => {
             result.current.reportSubmit();
         });
 
@@ -34,13 +34,13 @@ describe('useWrappedNativeFlowAnalytics', () => {
         });
     });
 
-    it('reports a cancelled simulation', () => {
-        const { result, analytics } = renderFlowAnalytics({
+    it('reports a cancelled simulation', async () => {
+        const { result, analytics } = await renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
 
-        act(() => {
+        await act(() => {
             result.current.reportSimulation('cancel');
         });
 
@@ -50,13 +50,13 @@ describe('useWrappedNativeFlowAnalytics', () => {
         });
     });
 
-    it('reports sent', () => {
-        const { result, analytics } = renderFlowAnalytics({
+    it('reports sent', async () => {
+        const { result, analytics } = await renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
 
-        act(() => {
+        await act(() => {
             result.current.reportSent();
         });
 
@@ -66,13 +66,13 @@ describe('useWrappedNativeFlowAnalytics', () => {
         });
     });
 
-    it('reports the given error message', () => {
-        const { result, analytics } = renderFlowAnalytics({
+    it('reports the given error message', async () => {
+        const { result, analytics } = await renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
 
-        act(() => {
+        await act(() => {
             result.current.reportError('push-failed');
         });
 
@@ -87,13 +87,13 @@ describe('useWrappedNativeFlowAnalytics', () => {
         });
     });
 
-    it('reports max selected as yield/interaction with no vaultId', () => {
-        const { result, analytics } = renderFlowAnalytics({
+    it('reports max selected as yield/interaction with no vaultId', async () => {
+        const { result, analytics } = await renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
 
-        act(() => {
+        await act(() => {
             result.current.reportMaxSelected();
         });
 

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowResolutionAnalytics.test.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowResolutionAnalytics.test.ts
@@ -4,14 +4,14 @@ import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store
 
 import { useWrappedNativeFlowResolutionAnalytics } from './useWrappedNativeFlowResolutionAnalytics';
 
-const renderResolutionAnalytics = (
+const renderResolutionAnalytics = async (
     props: Parameters<typeof useWrappedNativeFlowResolutionAnalytics>[0],
 ) => {
     const services: NativeAnalyticsDep = {
         analytics: mockNativeAnalytics(jest.fn()),
     };
 
-    const view = renderHookWithStoreProvider(useWrappedNativeFlowResolutionAnalytics, {
+    const view = await renderHookWithStoreProvider(useWrappedNativeFlowResolutionAnalytics, {
         initialProps: props,
         services,
     });
@@ -27,11 +27,11 @@ const pendingWrap = {
 } as const satisfies Parameters<typeof useWrappedNativeFlowResolutionAnalytics>[0];
 
 describe('useWrappedNativeFlowResolutionAnalytics', () => {
-    it('reports success once when the status moves from pending to confirmed', () => {
-        const { rerender, analytics } = renderResolutionAnalytics(pendingWrap);
+    it('reports success once when the status moves from pending to confirmed', async () => {
+        const { rerender, analytics } = await renderResolutionAnalytics(pendingWrap);
 
-        act(() => {
-            rerender({ ...pendingWrap, status: 'confirmed' });
+        await act(async () => {
+            await rerender({ ...pendingWrap, status: 'confirmed' });
         });
 
         expect(analytics.report).toHaveBeenCalledTimes(1);
@@ -46,12 +46,12 @@ describe('useWrappedNativeFlowResolutionAnalytics', () => {
         });
     });
 
-    it('reports an on-chain-failure error when the status moves to failed', () => {
+    it('reports an on-chain-failure error when the status moves to failed', async () => {
         const pendingUnwrap = { ...pendingWrap, flowType: 'unwrap' } as const;
-        const { rerender, analytics } = renderResolutionAnalytics(pendingUnwrap);
+        const { rerender, analytics } = await renderResolutionAnalytics(pendingUnwrap);
 
-        act(() => {
-            rerender({ ...pendingUnwrap, status: 'failed' });
+        await act(async () => {
+            await rerender({ ...pendingUnwrap, status: 'failed' });
         });
 
         expect(analytics.report).toHaveBeenCalledTimes(1);
@@ -67,25 +67,25 @@ describe('useWrappedNativeFlowResolutionAnalytics', () => {
         });
     });
 
-    it('reports the resolution only once when confirmed twice', () => {
-        const { rerender, analytics } = renderResolutionAnalytics(pendingWrap);
+    it('reports the resolution only once when confirmed twice', async () => {
+        const { rerender, analytics } = await renderResolutionAnalytics(pendingWrap);
 
-        act(() => {
-            rerender({ ...pendingWrap, status: 'confirmed' });
+        await act(async () => {
+            await rerender({ ...pendingWrap, status: 'confirmed' });
         });
 
-        act(() => {
-            rerender({ ...pendingWrap, status: 'confirmed' });
+        await act(async () => {
+            await rerender({ ...pendingWrap, status: 'confirmed' });
         });
 
         expect(analytics.report).toHaveBeenCalledTimes(1);
     });
 
-    it('reports leftPending on unmount while the transaction is still pending', () => {
-        const { unmount, analytics } = renderResolutionAnalytics(pendingWrap);
+    it('reports leftPending on unmount while the transaction is still pending', async () => {
+        const { unmount, analytics } = await renderResolutionAnalytics(pendingWrap);
 
-        act(() => {
-            unmount();
+        await act(async () => {
+            await unmount();
         });
 
         expect(analytics.report).toHaveBeenCalledWith({
@@ -99,37 +99,37 @@ describe('useWrappedNativeFlowResolutionAnalytics', () => {
         });
     });
 
-    it('does not report leftPending on unmount once the transaction already resolved', () => {
-        const { rerender, unmount, analytics } = renderResolutionAnalytics(pendingWrap);
+    it('does not report leftPending on unmount once the transaction already resolved', async () => {
+        const { rerender, unmount, analytics } = await renderResolutionAnalytics(pendingWrap);
 
-        act(() => {
-            rerender({ ...pendingWrap, status: 'confirmed' });
+        await act(async () => {
+            await rerender({ ...pendingWrap, status: 'confirmed' });
         });
 
         expect(analytics.report).toHaveBeenCalledTimes(1);
 
-        act(() => {
-            unmount();
+        await act(async () => {
+            await unmount();
         });
 
         expect(analytics.report).toHaveBeenCalledTimes(1);
     });
 
-    it('resets the resolution guard when the txid changes', () => {
-        const { rerender, analytics } = renderResolutionAnalytics(pendingWrap);
+    it('resets the resolution guard when the txid changes', async () => {
+        const { rerender, analytics } = await renderResolutionAnalytics(pendingWrap);
 
-        act(() => {
-            rerender({ ...pendingWrap, status: 'confirmed' });
+        await act(async () => {
+            await rerender({ ...pendingWrap, status: 'confirmed' });
         });
 
         expect(analytics.report).toHaveBeenCalledTimes(1);
 
-        act(() => {
-            rerender({ ...pendingWrap, status: 'pending', txid: 'tx-2' });
+        await act(async () => {
+            await rerender({ ...pendingWrap, status: 'pending', txid: 'tx-2' });
         });
 
-        act(() => {
-            rerender({ ...pendingWrap, status: 'confirmed', txid: 'tx-2' });
+        await act(async () => {
+            await rerender({ ...pendingWrap, status: 'confirmed', txid: 'tx-2' });
         });
 
         expect(analytics.report).toHaveBeenCalledTimes(2);

--- a/suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.test.ts
+++ b/suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.test.ts
@@ -4,14 +4,14 @@ import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store
 
 import { useYieldCurrencyToggleAnalytics } from './useYieldCurrencyToggleAnalytics';
 
-const renderCurrencyToggleAnalytics = (
+const renderCurrencyToggleAnalytics = async (
     props: Parameters<typeof useYieldCurrencyToggleAnalytics>[0],
 ) => {
     const services: NativeAnalyticsDep = {
         analytics: mockNativeAnalytics(jest.fn()),
     };
 
-    const view = renderHookWithStoreProvider(useYieldCurrencyToggleAnalytics, {
+    const view = await renderHookWithStoreProvider(useYieldCurrencyToggleAnalytics, {
         initialProps: props,
         services,
     });
@@ -20,13 +20,13 @@ const renderCurrencyToggleAnalytics = (
 };
 
 describe('useYieldCurrencyToggleAnalytics', () => {
-    it('reports a switch to the fiat input', () => {
-        const { result, analytics } = renderCurrencyToggleAnalytics({
+    it('reports a switch to the fiat input', async () => {
+        const { result, analytics } = await renderCurrencyToggleAnalytics({
             networkSymbol: 'eth',
             vaultId: 'vault-1',
         });
 
-        act(() => {
+        await act(() => {
             result.current('secondary');
         });
 
@@ -41,13 +41,13 @@ describe('useYieldCurrencyToggleAnalytics', () => {
         });
     });
 
-    it('reports a switch back to the crypto input', () => {
-        const { result, analytics } = renderCurrencyToggleAnalytics({
+    it('reports a switch back to the crypto input', async () => {
+        const { result, analytics } = await renderCurrencyToggleAnalytics({
             networkSymbol: 'eth',
             vaultId: 'vault-1',
         });
 
-        act(() => {
+        await act(() => {
             result.current('primary');
         });
 
@@ -62,10 +62,10 @@ describe('useYieldCurrencyToggleAnalytics', () => {
         });
     });
 
-    it('omits vaultId for the standalone wrap/unwrap forms', () => {
-        const { result, analytics } = renderCurrencyToggleAnalytics({ networkSymbol: 'eth' });
+    it('omits vaultId for the standalone wrap/unwrap forms', async () => {
+        const { result, analytics } = await renderCurrencyToggleAnalytics({ networkSymbol: 'eth' });
 
-        act(() => {
+        await act(() => {
             result.current('secondary');
         });
 
@@ -80,10 +80,10 @@ describe('useYieldCurrencyToggleAnalytics', () => {
         });
     });
 
-    it('reports every switch, so a toggle back and forth is counted twice', () => {
-        const { result, analytics } = renderCurrencyToggleAnalytics({ networkSymbol: 'eth' });
+    it('reports every switch, so a toggle back and forth is counted twice', async () => {
+        const { result, analytics } = await renderCurrencyToggleAnalytics({ networkSymbol: 'eth' });
 
-        act(() => {
+        await act(() => {
             result.current('secondary');
             result.current('primary');
         });

--- a/suite-native/module-earn/src/hooks/useYieldDepositSubmit.test.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositSubmit.test.ts
@@ -33,9 +33,9 @@ describe('useYieldDepositSubmit', () => {
         mockUseShowYieldAlert.mockReturnValue(showYieldAlert);
     });
 
-    it('continues with the current prepared action', () => {
+    it('continues with the current prepared action', async () => {
         const onActionReady = jest.fn();
-        const { result } = renderHookWithBasicProvider(() =>
+        const { result } = await renderHookWithBasicProvider(() =>
             useYieldDepositSubmit({
                 amount: '1',
                 onActionReady,
@@ -43,7 +43,7 @@ describe('useYieldDepositSubmit', () => {
             }),
         );
 
-        act(() => result.current.handleSubmitDeposit());
+        await act(() => result.current.handleSubmitDeposit());
 
         expect(onActionReady).toHaveBeenCalledWith(preparedAction);
         expect(showYieldAlert).not.toHaveBeenCalled();
@@ -54,9 +54,9 @@ describe('useYieldDepositSubmit', () => {
         ['stale', { ...preparedAction, amount: '2' }],
     ] satisfies [string, PreparedYieldDepositAction | null][])(
         'shows an alert when the prepared action is %s',
-        (_caseName, submitPreparedAction) => {
+        async (_caseName, submitPreparedAction) => {
             const onActionReady = jest.fn();
-            const { result } = renderHookWithBasicProvider(() =>
+            const { result } = await renderHookWithBasicProvider(() =>
                 useYieldDepositSubmit({
                     amount: '1',
                     onActionReady,
@@ -64,7 +64,7 @@ describe('useYieldDepositSubmit', () => {
                 }),
             );
 
-            act(() => result.current.handleSubmitDeposit());
+            await act(() => result.current.handleSubmitDeposit());
 
             expect(onActionReady).not.toHaveBeenCalled();
             expect(showYieldAlert).toHaveBeenCalledWith({

--- a/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.test.ts
+++ b/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.test.ts
@@ -29,8 +29,8 @@ jest.mock('@suite-native/app-init', () => ({
 describe('useExitOnboardingFlow', () => {
     let store: TestStore;
 
-    const renderUseExitOnboardingFlow = () =>
-        renderHookWithStoreProvider(() => useExitOnboardingFlow(), { store });
+    const renderUseExitOnboardingFlow = async () =>
+        await renderHookWithStoreProvider(() => useExitOnboardingFlow(), { store });
 
     beforeEach(() => {
         store = createLightStore({
@@ -52,12 +52,12 @@ describe('useExitOnboardingFlow', () => {
         jest.clearAllMocks();
     });
 
-    it('should set onboarding flag and navigate', () => {
+    it('should set onboarding flag and navigate', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExitOnboardingFlow();
+        const { result } = await renderUseExitOnboardingFlow();
 
         // call the returned callback
-        act(() => {
+        await act(() => {
             result.current();
         });
 

--- a/suite-native/module-onboarding/src/screens/BiometricsScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/BiometricsScreen.test.tsx
@@ -42,8 +42,8 @@ jest.mock('@suite-native/app-init', () => ({
 describe('BiometricsScreen', () => {
     let store: TestStore;
 
-    const renderBiometricsScreen = () =>
-        renderWithStoreProvider(
+    const renderBiometricsScreen = async () =>
+        await renderWithStoreProvider(
             <BiometricsScreen
                 navigation={
                     { navigate: mockNavigate } as unknown as BiometricsScreenProps['navigation']
@@ -80,7 +80,7 @@ describe('BiometricsScreen', () => {
                 },
             },
         });
-        const { getByText } = renderBiometricsScreen();
+        const { getByText } = await renderBiometricsScreen();
 
         await userEvent.press(
             getByText(getTranslation('moduleOnboarding.biometricsScreen.button.notNow')),
@@ -112,7 +112,7 @@ describe('BiometricsScreen', () => {
                 },
             },
         });
-        const { getByText } = renderBiometricsScreen();
+        const { getByText } = await renderBiometricsScreen();
 
         await userEvent.press(
             getByText(getTranslation('moduleOnboarding.biometricsScreen.button.notNow')),

--- a/suite-native/module-onboarding/src/screens/TradingLocationScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/TradingLocationScreen.test.tsx
@@ -34,8 +34,8 @@ const defaultMessageSystem = {
 };
 
 describe('TradingLocationOnboardingScreen', () => {
-    const renderTradingLocationScreen = () =>
-        renderWithStoreProvider(<TradingLocationScreen />, {
+    const renderTradingLocationScreen = async () =>
+        await renderWithStoreProvider(<TradingLocationScreen />, {
             preloadedState: {
                 messageSystem: defaultMessageSystem,
                 wallet: {
@@ -51,12 +51,12 @@ describe('TradingLocationOnboardingScreen', () => {
         jest.clearAllMocks();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render all components', () => {
-        const { getByText, getByLabelText } = renderTradingLocationScreen();
+    it('should render all components', async () => {
+        const { getByText, getByLabelText } = await renderTradingLocationScreen();
 
         expect(
             getByText(getTranslation('tradingResidence.locationSettings.title')),
@@ -72,7 +72,7 @@ describe('TradingLocationOnboardingScreen', () => {
     });
 
     it('should log analytics event on country change', async () => {
-        const { getByText } = renderTradingLocationScreen();
+        const { getByText } = await renderTradingLocationScreen();
 
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText('Argentina'));
@@ -88,7 +88,7 @@ describe('TradingLocationOnboardingScreen', () => {
     });
 
     it('should use exitOnboardingFlow on button press', async () => {
-        const { getByText } = renderTradingLocationScreen();
+        const { getByText } = await renderTradingLocationScreen();
         await userEvent.press(getByText('Not now'));
 
         expect(mockExitOnboardingFlow).toHaveBeenCalledTimes(1);

--- a/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
@@ -45,8 +45,8 @@ describe('ReceiveAddressActions', () => {
     const addressPath = "m/84'/0'/0'/0/0";
     const mockUseNavigation = jest.mocked(useNavigation);
 
-    const renderActions = () =>
-        renderWithBasicProvider(
+    const renderActions = async () =>
+        await renderWithBasicProvider(
             <ReceiveAddressInteractionsProvider
                 accountKey={accountKey}
                 address={address}
@@ -76,7 +76,7 @@ describe('ReceiveAddressActions', () => {
     });
 
     it('opens the verification sheet after copying the address', async () => {
-        const { getByText } = renderActions();
+        const { getByText } = await renderActions();
 
         await userEvent.press(getByText(getTranslation('qrCode.copyButton')));
 
@@ -93,7 +93,7 @@ describe('ReceiveAddressActions', () => {
     });
 
     it('closes the sheet and opens address verification', async () => {
-        const { getByTestId } = renderActions();
+        const { getByTestId } = await renderActions();
 
         await userEvent.press(getByTestId('@receive/address-verification/pasted/verify-button'));
 
@@ -109,7 +109,7 @@ describe('ReceiveAddressActions', () => {
     });
 
     it('opens address verification directly', async () => {
-        const { getByText } = renderActions();
+        const { getByText } = await renderActions();
 
         await userEvent.press(getByText(getTranslation('moduleReceive.addressActions.verify')));
 
@@ -126,7 +126,7 @@ describe('ReceiveAddressActions', () => {
     });
 
     it('opens shared address verification after sharing', async () => {
-        const { getByText, getByTestId } = renderActions();
+        const { getByText, getByTestId } = await renderActions();
 
         await userEvent.press(getByText(getTranslation('qrCode.shareButton')));
         await userEvent.press(getByTestId('@receive/address-verification/shared/verify-button'));
@@ -149,7 +149,7 @@ describe('ReceiveAddressActions', () => {
 
     it('does not open shared address verification after cancelling sharing', async () => {
         mockShare.mockResolvedValue({ action: Share.dismissedAction });
-        const { getByText } = renderActions();
+        const { getByText } = await renderActions();
 
         await userEvent.press(getByText(getTranslation('qrCode.shareButton')));
 

--- a/suite-native/module-receive/src/components/ReceiveAddressInfo.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressInfo.test.tsx
@@ -4,8 +4,8 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { ReceiveAddressInfo } from './ReceiveAddressInfo';
 
 describe('ReceiveAddressInfo', () => {
-    it('shows the shared assets and tokens information for an Ethereum account', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('shows the shared assets and tokens information for an Ethereum account', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <ReceiveAddressInfo networkSymbol="eth" isTokenAddress={false} />,
         );
 
@@ -16,8 +16,8 @@ describe('ReceiveAddressInfo', () => {
         ).toBeOnTheScreen();
     });
 
-    it('shows the shared assets and tokens information for an Ethereum token', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('shows the shared assets and tokens information for an Ethereum token', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <ReceiveAddressInfo networkSymbol="eth" isTokenAddress />,
         );
 
@@ -28,8 +28,8 @@ describe('ReceiveAddressInfo', () => {
         ).toBeOnTheScreen();
     });
 
-    it('does not show the shared assets and tokens information for a Bitcoin account', () => {
-        const { queryByText } = renderWithBasicProvider(
+    it('does not show the shared assets and tokens information for a Bitcoin account', async () => {
+        const { queryByText } = await renderWithBasicProvider(
             <ReceiveAddressInfo networkSymbol="btc" isTokenAddress={false} />,
         );
 
@@ -40,8 +40,8 @@ describe('ReceiveAddressInfo', () => {
         ).not.toBeOnTheScreen();
     });
 
-    it('keeps the network-address information for tokens on other networks', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('keeps the network-address information for tokens on other networks', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <ReceiveAddressInfo networkSymbol="sol" isTokenAddress />,
         );
 
@@ -54,8 +54,8 @@ describe('ReceiveAddressInfo', () => {
         ).toBeOnTheScreen();
     });
 
-    it('keeps the long-address information for Cardano', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('keeps the long-address information for Cardano', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <ReceiveAddressInfo networkSymbol="ada" isTokenAddress={false} />,
         );
 

--- a/suite-native/module-receive/src/components/ReceiveAddressVerificationBottomSheet.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressVerificationBottomSheet.test.tsx
@@ -8,10 +8,10 @@ describe('ReceiveAddressVerificationBottomSheet', () => {
     const onVerifyAddress = jest.fn();
     const onSkipVerification = jest.fn();
 
-    const renderBottomSheet = (
+    const renderBottomSheet = async (
         source: ReceiveAddressVerificationSource = ReceiveAddressVerificationSource.Pasted,
     ) =>
-        renderWithBasicProvider(
+        await renderWithBasicProvider(
             <ReceiveAddressVerificationBottomSheet
                 ref={{ current: null }}
                 source={source}
@@ -24,8 +24,8 @@ describe('ReceiveAddressVerificationBottomSheet', () => {
         jest.clearAllMocks();
     });
 
-    it('renders shared address instructions', () => {
-        const { getByText, queryByText } = renderBottomSheet(
+    it('renders shared address instructions', async () => {
+        const { getByText, queryByText } = await renderBottomSheet(
             ReceiveAddressVerificationSource.Shared,
         );
 
@@ -42,8 +42,8 @@ describe('ReceiveAddressVerificationBottomSheet', () => {
         ).not.toBeOnTheScreen();
     });
 
-    it('renders verification instructions', () => {
-        const { getByText } = renderBottomSheet();
+    it('renders verification instructions', async () => {
+        const { getByText } = await renderBottomSheet();
 
         expect(
             getByText(getTranslation('moduleReceive.addressCopiedBottomSheet.title')),
@@ -60,7 +60,7 @@ describe('ReceiveAddressVerificationBottomSheet', () => {
     });
 
     it('calls verification action', async () => {
-        const { getByText } = renderBottomSheet();
+        const { getByText } = await renderBottomSheet();
 
         await userEvent.press(
             getByText(
@@ -72,7 +72,7 @@ describe('ReceiveAddressVerificationBottomSheet', () => {
     });
 
     it('calls skip action', async () => {
-        const { getByText } = renderBottomSheet();
+        const { getByText } = await renderBottomSheet();
 
         await userEvent.press(
             getByText(

--- a/suite-native/module-receive/src/hooks/useReceiveAddressSharing.test.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveAddressSharing.test.ts
@@ -30,8 +30,8 @@ jest.mock('@suite-native/alerts', () => ({
 describe('useReceiveAddressSharing', () => {
     const address = 'bc1qreceiveaddress';
 
-    const renderUseReceiveAddressSharing = () =>
-        renderHookWithBasicProvider(
+    const renderUseReceiveAddressSharing = async () =>
+        await renderHookWithBasicProvider(
             () =>
                 useReceiveAddressSharing({
                     address,
@@ -51,7 +51,7 @@ describe('useReceiveAddressSharing', () => {
     });
 
     it('opens shared address verification after sharing the address', async () => {
-        const { result } = renderUseReceiveAddressSharing();
+        const { result } = await renderUseReceiveAddressSharing();
 
         await act(() => result.current.handleShareAddress());
 
@@ -64,7 +64,7 @@ describe('useReceiveAddressSharing', () => {
 
     it('does not open shared address verification after cancelling sharing', async () => {
         mockShare.mockResolvedValue({ action: Share.dismissedAction });
-        const { result } = renderUseReceiveAddressSharing();
+        const { result } = await renderUseReceiveAddressSharing();
 
         await act(() => result.current.handleShareAddress());
 
@@ -73,10 +73,10 @@ describe('useReceiveAddressSharing', () => {
         expect(mockAnalyticsReport).not.toHaveBeenCalled();
     });
 
-    it('starts shared address verification from the bottom sheet', () => {
-        const { result } = renderUseReceiveAddressSharing();
+    it('starts shared address verification from the bottom sheet', async () => {
+        const { result } = await renderUseReceiveAddressSharing();
 
-        act(() => result.current.handleVerifySharedAddress());
+        await act(() => result.current.handleVerifySharedAddress());
 
         expect(mockCloseSharedAddressBottomSheet).toHaveBeenCalledTimes(1);
         expect(mockVerifyAddress).toHaveBeenCalledWith(ReceiveAddressVerificationSource.Shared);
@@ -84,7 +84,7 @@ describe('useReceiveAddressSharing', () => {
 
     it('shows an error when sharing the address fails', async () => {
         mockShare.mockRejectedValue(new Error('Sharing failed'));
-        const { result } = renderUseReceiveAddressSharing();
+        const { result } = await renderUseReceiveAddressSharing();
 
         await act(() => result.current.handleShareAddress());
 

--- a/suite-native/module-receive/src/hooks/useReceiveQRCodeActions.ios.test.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveQRCodeActions.ios.test.ts
@@ -46,8 +46,8 @@ jest.mock('@suite-native/alerts', () => ({
 describe('useReceiveQRCodeActions', () => {
     const qrCodeView = {} as ViewShotRef;
 
-    const renderUseReceiveQRCodeActions = () =>
-        renderHookWithBasicProvider(() => useReceiveQRCodeActions(), { services });
+    const renderUseReceiveQRCodeActions = async () =>
+        await renderHookWithBasicProvider(() => useReceiveQRCodeActions(), { services });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -60,7 +60,7 @@ describe('useReceiveQRCodeActions', () => {
     });
 
     it('shares the QR code image', async () => {
-        const { result } = renderUseReceiveQRCodeActions();
+        const { result } = await renderUseReceiveQRCodeActions();
         result.current.qrCodeViewRef.current = qrCodeView;
 
         await act(() => result.current.handleShareQRCode());
@@ -82,7 +82,7 @@ describe('useReceiveQRCodeActions', () => {
 
     it('copies the QR code image', async () => {
         mockCaptureRef.mockResolvedValue('base64-image');
-        const { result } = renderUseReceiveQRCodeActions();
+        const { result } = await renderUseReceiveQRCodeActions();
         result.current.qrCodeViewRef.current = qrCodeView;
 
         await act(() => result.current.handleCopyQRCode());
@@ -104,7 +104,7 @@ describe('useReceiveQRCodeActions', () => {
     });
 
     it('saves the QR code image', async () => {
-        const { result } = renderUseReceiveQRCodeActions();
+        const { result } = await renderUseReceiveQRCodeActions();
         result.current.qrCodeViewRef.current = qrCodeView;
 
         await act(() => result.current.handleSaveQRCode());
@@ -131,7 +131,7 @@ describe('useReceiveQRCodeActions', () => {
 
     it('does not save the QR code image when media library permission is denied', async () => {
         mockRequestPermissionsAsync.mockResolvedValue({ granted: false });
-        const { result } = renderUseReceiveQRCodeActions();
+        const { result } = await renderUseReceiveQRCodeActions();
         result.current.qrCodeViewRef.current = qrCodeView;
 
         await act(() => result.current.handleSaveQRCode());
@@ -161,7 +161,7 @@ describe('useReceiveQRCodeActions', () => {
     });
 
     it('shows an error when the QR code is not available', async () => {
-        const { result } = renderUseReceiveQRCodeActions();
+        const { result } = await renderUseReceiveQRCodeActions();
 
         await act(() => result.current.handleShareQRCode());
 

--- a/suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.test.tsx
+++ b/suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.test.tsx
@@ -32,8 +32,8 @@ describe('ReceiveAddressVerificationStackNavigator', () => {
         },
     } as const;
 
-    const renderNavigator = () =>
-        renderWithBasicProvider(
+    const renderNavigator = async () =>
+        await renderWithBasicProvider(
             <ReceiveAddressVerificationStackNavigator navigation={{} as never} route={route} />,
         );
 
@@ -43,19 +43,19 @@ describe('ReceiveAddressVerificationStackNavigator', () => {
     });
 
     it('shows the continuation screen immediately when the device is ready', async () => {
-        const { findByText } = renderNavigator();
+        const { findByText } = await renderNavigator();
 
         expect(await findByText('Continue on Trezor')).toBeTruthy();
     });
 
     it('shows the connection guard until the device is ready', async () => {
         mockIsDeviceConnectionGuardVisible.mockReturnValue(true);
-        const { findByText, rerender } = renderNavigator();
+        const { findByText, rerender } = await renderNavigator();
 
         expect(await findByText('Connect device')).toBeTruthy();
 
         mockIsDeviceConnectionGuardVisible.mockReturnValue(false);
-        rerender(
+        await rerender(
             <ReceiveAddressVerificationStackNavigator navigation={{} as never} route={route} />,
         );
 

--- a/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.test.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.test.tsx
@@ -58,22 +58,22 @@ describe('ReceiveAddressVerificationScreen', () => {
         } as never);
     });
 
-    it('displays pasted address verification instructions', () => {
-        const { getByText } = renderWithBasicProvider(<ReceiveAddressVerificationScreen />);
+    it('displays pasted address verification instructions', async () => {
+        const { getByText } = await renderWithBasicProvider(<ReceiveAddressVerificationScreen />);
 
         expect(getByText('moduleReceive.addressVerificationScreen.pastedTitle')).toBeTruthy();
     });
 
-    it('starts address verification only once when focused repeatedly', () => {
-        renderWithBasicProvider(<ReceiveAddressVerificationScreen />);
+    it('starts address verification only once when focused repeatedly', async () => {
+        await renderWithBasicProvider(<ReceiveAddressVerificationScreen />);
 
-        act(handleScreenFocus);
-        act(handleScreenFocus);
+        await act(handleScreenFocus);
+        await act(handleScreenFocus);
 
         expect(mockVerifyAddressOnDevice).toHaveBeenCalledTimes(1);
     });
 
-    it('displays shared address verification instructions', () => {
+    it('displays shared address verification instructions', async () => {
         mockUseRoute.mockReturnValue({
             params: {
                 accountKey,
@@ -82,7 +82,7 @@ describe('ReceiveAddressVerificationScreen', () => {
             },
         } as never);
 
-        const { getByText } = renderWithBasicProvider(<ReceiveAddressVerificationScreen />);
+        const { getByText } = await renderWithBasicProvider(<ReceiveAddressVerificationScreen />);
 
         expect(getByText('moduleReceive.addressVerificationScreen.sharedTitle')).toBeTruthy();
     });

--- a/suite-native/module-send/src/components/CoinControl/SendUtxoScreenFooter.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxoScreenFooter.test.tsx
@@ -8,8 +8,8 @@ jest.mock('../../hooks/useUtxoSelection', () => ({
 }));
 
 describe('SendUtxosScreenFooter', () => {
-    it('should render footer with selected total and continue button', () => {
-        const { getByText } = renderWithStoreProvider(
+    it('should render footer with selected total and continue button', async () => {
+        const { getByText } = await renderWithStoreProvider(
             <SendUtxoScreenFooter symbol="btc" selectedTotal="800000000" onSubmit={jest.fn()} />,
         );
 
@@ -18,8 +18,8 @@ describe('SendUtxosScreenFooter', () => {
         expect(getByText(getTranslation('generic.buttons.confirm'))).toBeTruthy();
     });
 
-    it('should show remaining amount when amount is provided and selected total is less than amount', () => {
-        const { getByText } = renderWithStoreProvider(
+    it('should show remaining amount when amount is provided and selected total is less than amount', async () => {
+        const { getByText } = await renderWithStoreProvider(
             <SendUtxoScreenFooter
                 symbol="btc"
                 selectedTotal="500000000"
@@ -32,8 +32,8 @@ describe('SendUtxosScreenFooter', () => {
         expect(getByText('3 BTC')).toBeTruthy(); // 800000000 - 500000000 = 300000000 (3 BTC)
     });
 
-    it('should not show remaining amount when selected total is equal to or greater than amount', () => {
-        const { queryByText } = renderWithStoreProvider(
+    it('should not show remaining amount when selected total is equal to or greater than amount', async () => {
+        const { queryByText } = await renderWithStoreProvider(
             <SendUtxoScreenFooter
                 symbol="btc"
                 selectedTotal="800000000"

--- a/suite-native/module-send/src/components/CoinControl/SendUtxosScreenHeader.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxosScreenHeader.test.tsx
@@ -11,7 +11,7 @@ jest.mock('../../hooks/useUtxoSelection', () => ({
 }));
 
 describe('SendUtxosScreenHeader', () => {
-    it('should render delete button when there are selected utxos', () => {
+    it('should render delete button when there are selected utxos', async () => {
         (useUtxoSelection as jest.Mock).mockReturnValue({
             selectedUtxos: [
                 {
@@ -27,20 +27,20 @@ describe('SendUtxosScreenHeader', () => {
             setSelectedUtxos: jest.fn(),
         });
 
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = await renderWithBasicProvider(
             <SendUtxoScreenHeader accountKey={accountKey} />,
         );
 
         expect(getByTestId('coin-control-delete-button')).toBeTruthy();
     });
 
-    it('should not render delete button when there are no selected utxos', () => {
+    it('should not render delete button when there are no selected utxos', async () => {
         (useUtxoSelection as jest.Mock).mockReturnValue({
             selectedUtxos: [],
             setSelectedUtxos: jest.fn(),
         });
 
-        const { queryByTestId } = renderWithBasicProvider(
+        const { queryByTestId } = await renderWithBasicProvider(
             <SendUtxoScreenHeader accountKey={accountKey} />,
         );
 

--- a/suite-native/module-send/src/components/CoinControl/SwitchCoinControlButton.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SwitchCoinControlButton.test.tsx
@@ -19,12 +19,14 @@ const accountKey = mockAccountKey({ descriptor: 'accountKey' });
 describe('renders button with correct color scheme', () => {
     let colors: NativeStyleUtils['colors'];
 
-    beforeAll(() => {
-        const { result } = renderHook(() => useNativeStyles(), { wrapper: BasicProviderForTests });
+    beforeAll(async () => {
+        const { result } = await renderHook(() => useNativeStyles(), {
+            wrapper: BasicProviderForTests,
+        });
         ({ colors } = result.current.utils);
     });
 
-    it('should render warning primary button when selected utxos are not enough', () => {
+    it('should render warning primary button when selected utxos are not enough', async () => {
         (useUtxoSelection as jest.Mock).mockReturnValue({
             isCoinControlEnabled: true,
             selectedUtxos: [
@@ -41,7 +43,7 @@ describe('renders button with correct color scheme', () => {
             totalSelectedAmount: BigNumber(500),
         });
 
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = await renderWithBasicProvider(
             <SwitchCoinControlButton accountKey={accountKey} amount="1000" />,
         );
 
@@ -49,7 +51,7 @@ describe('renders button with correct color scheme', () => {
         expect(button.props.style[1].backgroundColor).toBe(colors.elementFillWarningBold);
     });
 
-    it('should render brand primary button when utxos are selected and amount is sufficient', () => {
+    it('should render brand primary button when utxos are selected and amount is sufficient', async () => {
         (useUtxoSelection as jest.Mock).mockReturnValue({
             isCoinControlEnabled: true,
             selectedUtxos: [
@@ -65,7 +67,7 @@ describe('renders button with correct color scheme', () => {
             ],
             totalSelectedAmount: BigNumber(1000),
         });
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = await renderWithBasicProvider(
             <SwitchCoinControlButton accountKey={accountKey} amount="1000" />,
         );
 
@@ -73,14 +75,14 @@ describe('renders button with correct color scheme', () => {
         expect(button.props.style[1].backgroundColor).toBe(colors.elementFillBrandBold);
     });
 
-    it('should render neutral secondary button when no utxos are selected and no amount is provided', () => {
+    it('should render neutral secondary button when no utxos are selected and no amount is provided', async () => {
         (useUtxoSelection as jest.Mock).mockReturnValue({
             isCoinControlEnabled: false,
             selectedUtxos: [],
             totalSelectedAmount: BigNumber(1000),
         });
 
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = await renderWithBasicProvider(
             <SwitchCoinControlButton accountKey={accountKey} />,
         );
 

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.test.tsx
@@ -92,7 +92,7 @@ describe('useAddressValidationAlerts', () => {
         preloadedState: Record<string, unknown> = defaultPreloadedState,
         { inputIndex = 0 } = {},
     ) => {
-        const result = renderHookWithStoreProvider(
+        const result = await renderHookWithStoreProvider(
             () => useAddressValidationAlerts({ inputIndex }),
             {
                 preloadedState,
@@ -198,7 +198,7 @@ describe('useAddressValidationAlerts', () => {
 
             // Simulate user clicking the primary button
             const alertCall = mockShowAlert.mock.calls[0][0];
-            act(() => {
+            await act(() => {
                 alertCall.onPressPrimaryButton();
             });
 
@@ -296,7 +296,7 @@ describe('useAddressValidationAlerts', () => {
 
             mockShowAlert.mockClear();
 
-            rerender({});
+            await rerender({});
 
             expect(mockShowAlert).not.toHaveBeenCalled();
         });

--- a/suite-native/module-send/src/hooks/useRequestDelayedNavigationToOutputsReview.test.ts
+++ b/suite-native/module-send/src/hooks/useRequestDelayedNavigationToOutputsReview.test.ts
@@ -22,8 +22,8 @@ jest.mock('@react-navigation/native', () => ({
 const accountKey = mockAccountKey({ descriptor: 'accountKey' });
 
 describe('useRequestDelayedNavigationToOutputsReview', () => {
-    const renderUseRequestDelayedNavigationToOutputsReview = () =>
-        renderHookWithStoreProvider(() =>
+    const renderUseRequestDelayedNavigationToOutputsReview = async () =>
+        await renderHookWithStoreProvider(() =>
             useRequestDelayedNavigationToOutputsReview({
                 accountKey,
                 tokenContract: 'tokenContract' as TokenAddress,
@@ -34,17 +34,17 @@ describe('useRequestDelayedNavigationToOutputsReview', () => {
         jest.clearAllMocks();
     });
 
-    it('should call navigate once there are any button requests', () => {
-        const { result, rerender } = renderUseRequestDelayedNavigationToOutputsReview();
+    it('should call navigate once there are any button requests', async () => {
+        const { result, rerender } = await renderUseRequestDelayedNavigationToOutputsReview();
 
-        act(() => {
+        await act(() => {
             result.current();
         });
 
         expect(mockNavigate).not.toHaveBeenCalled();
 
         mockSelectDeviceButtonRequestsCodes.mockReturnValue(['buttonRequestMock1']);
-        rerender({});
+        await rerender({});
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('SendOutputsReview', {

--- a/suite-native/module-send/src/hooks/useUtxoSelection.test.ts
+++ b/suite-native/module-send/src/hooks/useUtxoSelection.test.ts
@@ -28,17 +28,17 @@ describe('useUtxoSelection', () => {
         jest.clearAllMocks();
     });
 
-    it('should return an empty array when no UTXOs are selected', () => {
+    it('should return an empty array when no UTXOs are selected', async () => {
         (useAtom as jest.Mock).mockReturnValue([[], mockSetSelectedUtxos]);
 
-        const { result } = renderHook(() => useUtxoSelection(accountKey));
+        const { result } = await renderHook(() => useUtxoSelection(accountKey));
 
         expect(result.current.selectedUtxos).toEqual([]);
         expect(result.current.totalSelectedAmount.toString()).toEqual('0');
         expect(result.current.isCoinControlEnabled).toBe(false);
     });
 
-    it('should calculate total selected amount correctly', () => {
+    it('should calculate total selected amount correctly', async () => {
         const mockUtxos: SelectedUtxos = {
             [accountKey]: [
                 {
@@ -63,12 +63,12 @@ describe('useUtxoSelection', () => {
         };
         (useAtom as jest.Mock).mockReturnValue([mockUtxos, mockSetSelectedUtxos]);
 
-        const { result } = renderHook(() => useUtxoSelection(accountKey));
+        const { result } = await renderHook(() => useUtxoSelection(accountKey));
 
         expect(result.current.totalSelectedAmount.toString()).toEqual('3000');
     });
 
-    it('should handle correct account key UTXO selection', () => {
+    it('should handle correct account key UTXO selection', async () => {
         (useAtom as jest.Mock).mockReturnValue([
             {
                 ['testAccKey2']: [
@@ -86,7 +86,7 @@ describe('useUtxoSelection', () => {
             mockSetSelectedUtxos,
         ]);
 
-        const { result } = renderHook(() => useUtxoSelection(accountKey));
+        const { result } = await renderHook(() => useUtxoSelection(accountKey));
 
         expect(result.current.selectedUtxos).toEqual([]);
         expect(result.current.totalSelectedAmount.toString()).toEqual('0');

--- a/suite-native/module-settings/src/components/FaqCard.test.tsx
+++ b/suite-native/module-settings/src/components/FaqCard.test.tsx
@@ -21,8 +21,8 @@ const defaultPreloadedState = {
 };
 
 describe('FaqCard', () => {
-    const renderFaqCard = (preloadedState = {}) =>
-        renderWithStoreProvider(<FaqCard />, {
+    const renderFaqCard = async (preloadedState = {}) =>
+        await renderWithStoreProvider(<FaqCard />, {
             preloadedState: { ...defaultPreloadedState, ...preloadedState },
         });
 
@@ -35,8 +35,8 @@ describe('FaqCard', () => {
             mockIsAndroid = true;
         });
 
-        it('should render appropriate sections when BT is enabled', () => {
-            const { getByText } = renderFaqCard();
+        it('should render appropriate sections when BT is enabled', async () => {
+            const { getByText } = await renderFaqCard();
 
             // Android BT-specific info
             expect(
@@ -53,10 +53,10 @@ describe('FaqCard', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should not render trading section when trading is disabled', () => {
+        it('should not render trading section when trading is disabled', async () => {
             mockIsTradingEnabled = false;
 
-            const { queryByText } = renderFaqCard();
+            const { queryByText } = await renderFaqCard();
 
             expect(queryByText(getTranslation('moduleSettings.faq.trading.question'))).toBeNull();
         });
@@ -67,8 +67,8 @@ describe('FaqCard', () => {
             mockIsAndroid = false;
         });
 
-        it('should render appropriate sections when BT is enabled', () => {
-            const { getByText } = renderFaqCard();
+        it('should render appropriate sections when BT is enabled', async () => {
+            const { getByText } = await renderFaqCard();
 
             // iOS BT-specific info
             expect(
@@ -81,10 +81,10 @@ describe('FaqCard', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should not render trading section when trading is disabled', () => {
+        it('should not render trading section when trading is disabled', async () => {
             mockIsTradingEnabled = false;
 
-            const { queryByText } = renderFaqCard();
+            const { queryByText } = await renderFaqCard();
 
             expect(queryByText(getTranslation('moduleSettings.faq.trading.question'))).toBeNull();
         });

--- a/suite-native/module-settings/src/components/GeneralSettings.test.tsx
+++ b/suite-native/module-settings/src/components/GeneralSettings.test.tsx
@@ -9,14 +9,14 @@ jest.mock('@suite-native/trading-state', () => ({
 }));
 
 describe('GeneralSettings', () => {
-    const renderGeneralSettings = () => renderWithStoreProvider(<GeneralSettings />);
+    const renderGeneralSettings = async () => await renderWithStoreProvider(<GeneralSettings />);
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should render trading settings button', () => {
-        const { getByTestId } = renderGeneralSettings();
+    it('should render trading settings button', async () => {
+        const { getByTestId } = await renderGeneralSettings();
 
         expect(getByTestId('@settings/trading')).toBeOnTheScreen();
     });

--- a/suite-native/module-settings/src/components/TradingSettingsCard.test.tsx
+++ b/suite-native/module-settings/src/components/TradingSettingsCard.test.tsx
@@ -13,16 +13,16 @@ jest.mock('@suite-native/trading-state', () => ({
 }));
 
 describe('TradingSettingsCard', () => {
-    const renderTradingSettingsCard = (props: Partial<TradingSettingsCardProps> = {}) =>
-        renderWithStoreProvider(<TradingSettingsCard onPress={jest.fn()} {...props} />);
+    const renderTradingSettingsCard = async (props: Partial<TradingSettingsCardProps> = {}) =>
+        await renderWithStoreProvider(<TradingSettingsCard onPress={jest.fn()} {...props} />);
 
     beforeEach(() => {
         mockIsTradingCountrySet = false;
         mockIsTradingResidenceCheckEnabled = false;
     });
 
-    it('should not render trading settings button when selectIsTradingResidenceCheckEnabled is false', () => {
-        const { toJSON } = renderTradingSettingsCard();
+    it('should not render trading settings button when selectIsTradingResidenceCheckEnabled is false', async () => {
+        const { toJSON } = await renderTradingSettingsCard();
 
         expect(toJSON()).toBeNull();
     });
@@ -32,8 +32,8 @@ describe('TradingSettingsCard', () => {
             mockIsTradingResidenceCheckEnabled = true;
         });
 
-        it('should render "Enable trading" button when selectIsTradingCountrySet is false', () => {
-            const { getByTestId, getByText } = renderTradingSettingsCard({
+        it('should render "Enable trading" button when selectIsTradingCountrySet is false', async () => {
+            const { getByTestId, getByText } = await renderTradingSettingsCard({
                 testID: '@settings/trading',
             });
 
@@ -46,9 +46,9 @@ describe('TradingSettingsCard', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should render "Trading" button when selectIsTradingCountrySet is true', () => {
+        it('should render "Trading" button when selectIsTradingCountrySet is true', async () => {
             mockIsTradingCountrySet = true;
-            const { getByTestId, getByText } = renderTradingSettingsCard({
+            const { getByTestId, getByText } = await renderTradingSettingsCard({
                 testID: '@settings/trading',
             });
 

--- a/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.test.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.test.ts
@@ -197,8 +197,8 @@ describe('useStellarFeeScreen', () => {
         onSuccess: mockOnSuccess,
     };
 
-    const renderUseStellarFeeScreen = (props: UseStellarFeeScreenParams = defaultProps) =>
-        renderHookWithStoreProvider(hookProps => useStellarFeeScreen(hookProps), {
+    const renderUseStellarFeeScreen = async (props: UseStellarFeeScreenParams = defaultProps) =>
+        await renderHookWithStoreProvider(hookProps => useStellarFeeScreen(hookProps), {
             store,
             initialProps: props,
         });
@@ -232,16 +232,16 @@ describe('useStellarFeeScreen', () => {
         mockFetchAndUpdateAccountThunk.mockReturnValue({ type: 'fetch-account' });
     });
 
-    it('returns correct token info for known USDC token', () => {
-        const { result } = renderUseStellarFeeScreen();
+    it('returns correct token info for known USDC token', async () => {
+        const { result } = await renderUseStellarFeeScreen();
 
         expect(result.current.tokenName).toBe('USD Coin');
         expect(result.current.issuerDomain).toBe('centre.io');
         expect(result.current.iconContractAddress).toBe(KNOWN_USDC_CONTRACT);
     });
 
-    it('falls back to unknown issuer for unknown token', () => {
-        const { result } = renderUseStellarFeeScreen({
+    it('falls back to unknown issuer for unknown token', async () => {
+        const { result } = await renderUseStellarFeeScreen({
             ...defaultProps,
             tokenContract: UNKNOWN_TOKEN_CONTRACT,
         });
@@ -251,11 +251,11 @@ describe('useStellarFeeScreen', () => {
         expect(result.current.iconContractAddress).toBeUndefined();
     });
 
-    it('returns insufficientBalanceInfo when balance is insufficient', () => {
+    it('returns insufficientBalanceInfo when balance is insufficient', async () => {
         const lowBalanceAccount = { ...mockAccount, availableBalance: '1' };
         mockSelectAccountByKey.mockReturnValue(lowBalanceAccount);
 
-        const { result } = renderUseStellarFeeScreen();
+        const { result } = await renderUseStellarFeeScreen();
 
         const requiredAmount = BigNumber('100').plus(STELLAR_BASE_RESERVE).toString();
 
@@ -265,11 +265,11 @@ describe('useStellarFeeScreen', () => {
         });
     });
 
-    it('returns null for insufficientBalanceInfo in deactivation mode', () => {
+    it('returns null for insufficientBalanceInfo in deactivation mode', async () => {
         const lowBalanceAccount = { ...mockAccount, availableBalance: '1' };
         mockSelectAccountByKey.mockReturnValue(lowBalanceAccount);
 
-        const { result } = renderUseStellarFeeScreen({
+        const { result } = await renderUseStellarFeeScreen({
             ...defaultProps,
             mode: 'deactivation',
         });
@@ -277,15 +277,15 @@ describe('useStellarFeeScreen', () => {
         expect(result.current.insufficientBalanceInfo).toBeNull();
     });
 
-    it('handleCancel closes sheet, navigates back, and clears submitting state', () => {
-        const { result } = renderUseStellarFeeScreen();
+    it('handleCancel closes sheet, navigates back, and clears submitting state', async () => {
+        const { result } = await renderUseStellarFeeScreen();
 
-        act(() => {
+        await act(() => {
             result.current.handleReviewAndSign();
         });
         expect(result.current.isSubmitting).toBe(true);
 
-        act(() => {
+        await act(() => {
             result.current.handleCancel();
         });
 
@@ -294,10 +294,10 @@ describe('useStellarFeeScreen', () => {
         expect(mockGoBack).toHaveBeenCalledTimes(1);
     });
 
-    it('navigates to device connection guard and sets submitting state', () => {
-        const { result } = renderUseStellarFeeScreen();
+    it('navigates to device connection guard and sets submitting state', async () => {
+        const { result } = await renderUseStellarFeeScreen();
 
-        act(() => {
+        await act(() => {
             result.current.handleReviewAndSign();
         });
 
@@ -313,13 +313,13 @@ describe('useStellarFeeScreen', () => {
     it.each([
         ['activation', StellarManageTokenStackRoutes.ActivationFee],
         ['deactivation', StellarManageTokenStackRoutes.DeactivationFee],
-    ])('uses %s screen as cancel target', (mode, expectedScreen) => {
-        const { result } = renderUseStellarFeeScreen({
+    ])('uses %s screen as cancel target', async (mode, expectedScreen) => {
+        const { result } = await renderUseStellarFeeScreen({
             ...defaultProps,
             mode: mode as 'activation' | 'deactivation',
         });
 
-        act(() => {
+        await act(() => {
             result.current.handleReviewAndSign();
         });
 
@@ -341,9 +341,9 @@ describe('useStellarFeeScreen', () => {
         mockSelectIsDeviceConnectedAndAuthorized.mockReturnValue(true);
         mockThunkAction.mockImplementation(() => () => Promise.resolve(createFulfilledResult()));
 
-        const { result } = renderUseStellarFeeScreen();
+        const { result } = await renderUseStellarFeeScreen();
 
-        act(() => {
+        await act(() => {
             result.current.handleReviewAndSign();
         });
 
@@ -379,9 +379,9 @@ describe('useStellarFeeScreen', () => {
         });
         mockThunkAction.mockImplementation(() => () => Promise.resolve(createFulfilledResult()));
 
-        const { result } = renderUseStellarFeeScreen();
+        const { result } = await renderUseStellarFeeScreen();
 
-        act(() => {
+        await act(() => {
             result.current.handleReviewAndSign();
         });
 
@@ -404,9 +404,9 @@ describe('useStellarFeeScreen', () => {
             () => () => Promise.resolve(createRejectedResult({ message: 'Rejected by device' })),
         );
 
-        const { result } = renderUseStellarFeeScreen();
+        const { result } = await renderUseStellarFeeScreen();
 
-        act(() => {
+        await act(() => {
             result.current.handleReviewAndSign();
         });
 
@@ -429,20 +429,20 @@ describe('useStellarFeeScreen', () => {
         mockSelectDeviceButtonRequestsCodes.mockReturnValue(['button-request']);
         mockThunkAction.mockImplementation(() => () => deferred.promise);
 
-        const { result, rerender } = renderUseStellarFeeScreen();
+        const { result, rerender } = await renderUseStellarFeeScreen();
 
-        act(() => {
+        await act(() => {
             result.current.handleReviewAndSign();
         });
 
-        act(() => {
+        await act(() => {
             triggerFocusEffect();
         });
 
         await waitFor(() => expect(mockRevealConfirmOnTrezorSheet).toHaveBeenCalledTimes(1));
 
         mockSelectDeviceButtonRequestsCodes.mockReturnValue([]);
-        rerender(defaultProps);
+        await rerender(defaultProps);
 
         await waitFor(() => expect(mockCloseSheet).toHaveBeenCalledTimes(1));
 

--- a/suite-native/module-trading/src/components/buy/BuyAlert.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyAlert.test.tsx
@@ -15,38 +15,41 @@ describe('BuyAlert', () => {
         wallet: getWalletState({ tradeType: 'buy' }),
     };
 
-    const renderFormHook = () =>
-        renderHookWithStoreProvider(() => useBuyForm(), {
+    const renderFormHook = async () =>
+        await renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });
 
-    const renderTradingAlert = () =>
-        renderWithBasicProvider(<BuyAlert />, {
+    const renderTradingAlert = async () =>
+        await renderWithBasicProvider(<BuyAlert />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderFormHook();
+    beforeEach(async () => {
+        const { result } = await renderFormHook();
         form = result.current;
     });
 
-    it('should render alert based on form generalAlert value', () => {
-        act(() => {
+    it('should render alert based on form generalAlert value', async () => {
+        await act(() => {
             form.setValue('generalAlert', 'TEST');
         });
 
-        const { getByText } = renderTradingAlert();
+        const { getByText } = await renderTradingAlert();
 
         expect(getByText('TEST')).toBeTruthy();
     });
 
-    it.each([undefined, ''])('should render nothing when generalAlert is %s', generalAlertValue => {
-        act(() => {
-            form.setValue('generalAlert', generalAlertValue);
-        });
+    it.each([undefined, ''])(
+        'should render nothing when generalAlert is %s',
+        async generalAlertValue => {
+            await act(() => {
+                form.setValue('generalAlert', generalAlertValue);
+            });
 
-        const { toJSON } = renderTradingAlert();
+            const { toJSON } = await renderTradingAlert();
 
-        expect(toJSON()).toBeNull();
-    });
+            expect(toJSON()).toBeNull();
+        },
+    );
 });

--- a/suite-native/module-trading/src/components/buy/BuyCard.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.test.tsx
@@ -29,21 +29,24 @@ describe('BuyCard', () => {
         featureFlags: createTradingFeatureFlags(),
     };
 
-    const renderForm = () => renderHookWithTradingProvider(() => useBuyForm(), { overrides });
+    const renderForm = async () =>
+        await renderHookWithTradingProvider(() => useBuyForm(), { overrides });
 
-    const renderBuyCard = (extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
-        renderWithTradingProvider(<BuyCard isAmountInputActive={false} />, {
+    const renderBuyCard = async (
+        extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+    ) =>
+        await renderWithTradingProvider(<BuyCard isAmountInputActive={false} />, {
             overrides: { ...overrides, ...extraOverrides },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderForm();
+    beforeEach(async () => {
+        const { result } = await renderForm();
         form = result.current;
     });
 
-    it('should render default BuyCard', () => {
-        const { getByLabelText, getByTestId, getByText } = renderBuyCard();
+    it('should render default BuyCard', async () => {
+        const { getByLabelText, getByTestId, getByText } = await renderBuyCard();
 
         expect(getByText(getTranslation('moduleTrading.selectFiat.buy.title'))).toBeOnTheScreen();
         expect(getByText(getTranslation('moduleTrading.selectCoin.title'))).toBeOnTheScreen();
@@ -58,18 +61,18 @@ describe('BuyCard', () => {
         });
     });
 
-    it('should convert cryptoValue to the base unit before passing it to CryptoToFiatValueBadge when bitcoin amount unit is sats', () => {
-        act(() => {
+    it('should convert cryptoValue to the base unit before passing it to CryptoToFiatValueBadge when bitcoin amount unit is sats', async () => {
+        await act(() => {
             form.setValue('asset', btcAsset);
         });
-        act(() => {
+        await act(() => {
             form.setValue('amountInCrypto', true);
         });
-        act(() => {
+        await act(() => {
             form.setValue('cryptoValue', '1234567123456');
         });
 
-        const { getByText, queryByText } = renderBuyCard({
+        const { getByText, queryByText } = await renderBuyCard({
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         });
 

--- a/suite-native/module-trading/src/components/buy/BuyConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyConfirmation.test.tsx
@@ -31,8 +31,8 @@ describe('BuyConfirmation', () => {
     const mockUseTradingStellarActivateToken =
         require('../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
 
-    const renderConfirmation = () =>
-        renderWithStoreProvider(<BuyConfirmation />, {
+    const renderConfirmation = async () =>
+        await renderWithStoreProvider(<BuyConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
@@ -43,7 +43,7 @@ describe('BuyConfirmation', () => {
         });
     });
 
-    it('should render buy button when canProceed is true', () => {
+    it('should render buy button when canProceed is true', async () => {
         mockUseBuyFlow.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
@@ -52,11 +52,11 @@ describe('BuyConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { getByText } = renderConfirmation();
+        const { getByText } = await renderConfirmation();
         expect(getByText(CTA_TEXT)).toBeTruthy();
     });
 
-    it('should not render buy button when canProceed is false', () => {
+    it('should not render buy button when canProceed is false', async () => {
         mockUseBuyFlow.mockReturnValue({
             canProceed: false,
             selectQuote: jest.fn(),
@@ -65,12 +65,12 @@ describe('BuyConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { queryByText } = renderConfirmation();
+        const { queryByText } = await renderConfirmation();
 
         expect(queryByText(CTA_TEXT)).toBeNull();
     });
 
-    it('should render activate button when trading inactive Stellar token', () => {
+    it('should render activate button when trading inactive Stellar token', async () => {
         mockUseBuyFlow.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
@@ -84,12 +84,12 @@ describe('BuyConfirmation', () => {
             activateButtonElement: <Button>Activate</Button>,
         });
 
-        const { queryByText } = renderConfirmation();
+        const { queryByText } = await renderConfirmation();
         expect(queryByText('Activate')).toBeTruthy();
         expect(queryByText(CTA_TEXT)).toBeNull();
     });
 
-    it('should not render activate button when not trading inactive Stellar token', () => {
+    it('should not render activate button when not trading inactive Stellar token', async () => {
         mockUseBuyFlow.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
@@ -103,7 +103,7 @@ describe('BuyConfirmation', () => {
             activateButtonElement: <Button>Activate</Button>,
         });
 
-        const { queryByText } = renderConfirmation();
+        const { queryByText } = await renderConfirmation();
         expect(queryByText('Activate')).toBeNull();
         expect(queryByText(CTA_TEXT)).toBeTruthy();
     });

--- a/suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.test.tsx
@@ -15,22 +15,22 @@ import {
 } from '../../test-utils/tradingTestUtils';
 
 describe('BuyCryptoAmountInput', () => {
-    const renderCryptoAmountInput = (
+    const renderCryptoAmountInput = async (
         props: Partial<CryptoAmountInputProps>,
         form: BuyFormType,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <Form form={form}>
                 <BuyCryptoAmountInput showAssetsSheet={jest.fn()} {...props} />
             </Form>,
             { overrides },
         );
 
-    const renderUseTradingBuyForm = (
+    const renderUseTradingBuyForm = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) => {
-        const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
+        const { result } = await renderHookWithTradingProvider(() => useBuyForm(), {
             overrides,
         });
 
@@ -38,11 +38,11 @@ describe('BuyCryptoAmountInput', () => {
     };
 
     it('should set fiat value in form', async () => {
-        const form = renderUseTradingBuyForm();
-        act(() => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
@@ -52,9 +52,9 @@ describe('BuyCryptoAmountInput', () => {
         expect(form.getValues('cryptoValue')).toEqual('100');
     });
 
-    it('should be disabled when asset is not selected', () => {
-        const form = renderUseTradingBuyForm();
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+    it('should be disabled when asset is not selected', async () => {
+        const form = await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
@@ -63,8 +63,8 @@ describe('BuyCryptoAmountInput', () => {
 
     it('should call showAssetsSheet when disabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = renderUseTradingBuyForm();
-        const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
+        const form = await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
@@ -75,11 +75,11 @@ describe('BuyCryptoAmountInput', () => {
 
     it('should not call showAssetsSheet when enabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = renderUseTradingBuyForm();
-        act(() => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
+        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
@@ -89,11 +89,11 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should format input value to be decimal by default', async () => {
-        const form = renderUseTradingBuyForm();
-        act(() => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
@@ -107,11 +107,11 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should preserve a leading-zero decimal while typing', async () => {
-        const form = renderUseTradingBuyForm();
-        act(() => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
         const input = getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel'));
 
         await userEvent.type(input, '0.0001');
@@ -124,11 +124,11 @@ describe('BuyCryptoAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = renderUseTradingBuyForm();
-        act(() => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
@@ -145,11 +145,11 @@ describe('BuyCryptoAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = renderUseTradingBuyForm();
-        act(() => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
@@ -162,10 +162,10 @@ describe('BuyCryptoAmountInput', () => {
         ).toHaveDisplayValue('');
     });
 
-    it('should display loading skeleton while amountInCrypto is false and buyInfo is loading', () => {
-        const form = renderUseTradingBuyForm();
+    it('should display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {
+        const form = await renderUseTradingBuyForm();
 
-        const { getByLabelText } = renderCryptoAmountInput({}, form, {
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, {
             wallet: { trading: { buy: { isLoading: true } } },
         });
 
@@ -174,13 +174,13 @@ describe('BuyCryptoAmountInput', () => {
         ).toBeTruthy();
     });
 
-    it('should not display loading skeleton while amountInCrypto is true and buyInfo is loading', () => {
-        const form = renderUseTradingBuyForm();
-        act(() => {
+    it('should not display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('amountInCrypto', true);
         });
 
-        const { queryByLabelText } = renderCryptoAmountInput({}, form, {
+        const { queryByLabelText } = await renderCryptoAmountInput({}, form, {
             wallet: { trading: { buy: { isLoading: true } } },
         });
 
@@ -190,11 +190,11 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should limit value to 9 decimals', async () => {
-        const form = renderUseTradingBuyForm();
-        act(() => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),

--- a/suite-native/module-trading/src/components/buy/BuyFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatAmountInput.test.tsx
@@ -13,21 +13,21 @@ import {
 } from '../../test-utils/tradingTestUtils';
 
 describe('BuyFiatAmountInput', () => {
-    const renderFiatAmountInput = (
+    const renderFiatAmountInput = async (
         form: BuyFormType,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <Form form={form}>
                 <BuyFiatAmountInput />
             </Form>,
             { tradeType: 'buy', overrides },
         );
 
-    const renderUseTradingBuyForm = (
+    const renderUseTradingBuyForm = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) => {
-        const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
+        const { result } = await renderHookWithTradingProvider(() => useBuyForm(), {
             tradeType: 'buy',
             overrides,
         });
@@ -40,8 +40,8 @@ describe('BuyFiatAmountInput', () => {
     };
 
     it('should set fiat value in form', async () => {
-        const form = renderUseTradingBuyForm();
-        const { getByLabelText } = renderFiatAmountInput(form);
+        const form = await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
@@ -52,8 +52,8 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should format input value to be decimal', async () => {
-        const form = renderUseTradingBuyForm();
-        const { getByLabelText } = renderFiatAmountInput(form);
+        const form = await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
@@ -67,8 +67,8 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should always escape non-numeric characters', async () => {
-        const form = renderUseTradingBuyForm();
-        const { getByLabelText } = renderFiatAmountInput(form);
+        const form = await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
@@ -81,23 +81,23 @@ describe('BuyFiatAmountInput', () => {
         ).toHaveDisplayValue('');
     });
 
-    it('should display loading skeleton while amountInCrypto is true and buyInfo is loading', () => {
-        const form = renderUseTradingBuyForm();
-        act(() => {
+    it('should display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {
+        const form = await renderUseTradingBuyForm();
+        await act(() => {
             form.setValue('amountInCrypto', true);
         });
 
-        const { getByLabelText } = renderFiatAmountInput(form, withBuyLoading);
+        const { getByLabelText } = await renderFiatAmountInput(form, withBuyLoading);
 
         expect(
             getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
         ).toBeTruthy();
     });
 
-    it('should not display loading skeleton while amountInCrypto is false and buyInfo is loading', () => {
-        const form = renderUseTradingBuyForm();
+    it('should not display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {
+        const form = await renderUseTradingBuyForm();
 
-        const { queryByLabelText } = renderFiatAmountInput(form, withBuyLoading);
+        const { queryByLabelText } = await renderFiatAmountInput(form, withBuyLoading);
 
         expect(
             queryByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
@@ -105,8 +105,8 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should limit value to 3 decimals', async () => {
-        const form = renderUseTradingBuyForm();
-        const { getByLabelText } = renderFiatAmountInput(form);
+        const form = await renderUseTradingBuyForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),

--- a/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.test.tsx
@@ -34,19 +34,19 @@ describe('BuyFiatCurrencyPicker', () => {
     let form: BuyFormType;
     let store: TestStore;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         mockUseListDataFilter = jest.requireActual('@suite-common/trading').useListDataFilter;
         reportMock.mockClear();
         store = createTradingLightStore({ tradeType: 'buy' });
-        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
+        const { result } = await renderHookWithStoreProvider(() => useBuyForm(), {
             services,
             store,
         });
         form = result.current;
     });
 
-    const renderFiatCurrencyPicker = () =>
-        renderWithStoreProvider(
+    const renderFiatCurrencyPicker = async () =>
+        await renderWithStoreProvider(
             <Form form={form}>
                 <BuyFiatCurrencyPicker />
             </Form>,
@@ -56,12 +56,12 @@ describe('BuyFiatCurrencyPicker', () => {
             },
         );
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should display selected currency', () => {
-        const { getByLabelText } = renderFiatCurrencyPicker();
+    it('should display selected currency', async () => {
+        const { getByLabelText } = await renderFiatCurrencyPicker();
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
@@ -69,10 +69,12 @@ describe('BuyFiatCurrencyPicker', () => {
     });
 
     it('should allow to select currency', async () => {
-        const { getByText, getByLabelText } = renderFiatCurrencyPicker();
+        const { getByText, getByLabelText } = await renderFiatCurrencyPicker();
 
-        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
-        fireEvent.press(getByText('USD'));
+        await fireEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        );
+        await fireEvent.press(getByText('USD'));
 
         // wait for validators to run
         await act(() => Promise.resolve());
@@ -86,10 +88,12 @@ describe('BuyFiatCurrencyPicker', () => {
         form.setValue('fiatValue', '100');
         form.setValue('cryptoValue', '0.1');
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { getByText, getByLabelText } = renderFiatCurrencyPicker();
+        const { getByText, getByLabelText } = await renderFiatCurrencyPicker();
 
-        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
-        fireEvent.press(getByText('USD'));
+        await fireEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        );
+        await fireEvent.press(getByText('USD'));
         await act(() => Promise.resolve());
 
         expect(form.getValues('fiatValue')).toBeUndefined();
@@ -104,14 +108,14 @@ describe('BuyFiatCurrencyPicker', () => {
         });
     });
 
-    it('should display empty component when filtered data is empty', () => {
+    it('should display empty component when filtered data is empty', async () => {
         mockUseListDataFilter = () => ({
             filteredData: [],
             setFilterValue: jest.fn(),
             filterValue: 'test-key',
         });
 
-        const { getByText } = renderFiatCurrencyPicker();
+        const { getByText } = await renderFiatCurrencyPicker();
 
         expect(
             getByText(getTranslation('moduleTrading.fiatCurrencySheet.emptyTitle')),

--- a/suite-native/module-trading/src/components/buy/BuyFiatCurrencySheet.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatCurrencySheet.test.tsx
@@ -4,18 +4,18 @@ import { getWalletState } from '@suite-native/trading-fixtures';
 import { BuyFiatCurrencySheet } from './BuyFiatCurrencySheet';
 
 describe('BuyFiatCurrencySheet', () => {
-    const renderBuyFiatCurrencySheet = () =>
-        renderWithStoreProvider(
+    const renderBuyFiatCurrencySheet = async () =>
+        await renderWithStoreProvider(
             <BuyFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
             { preloadedState: { wallet: getWalletState({ tradeType: 'buy' }) } },
         );
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render items based on buy state', () => {
-        const { getByText } = renderBuyFiatCurrencySheet();
+    it('should render items based on buy state', async () => {
+        const { getByText } = await renderBuyFiatCurrencySheet();
 
         expect(getByText('USD')).toBeOnTheScreen();
         expect(getByText('EUR')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/buy/BuyForm.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyForm.test.tsx
@@ -43,25 +43,26 @@ describe('BuyForm', () => {
         },
     };
 
-    const renderFormHook = (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
-        renderHookWithTradingProvider(() => useBuyForm(), { overrides });
+    const renderFormHook = async (
+        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+    ) => await renderHookWithTradingProvider(() => useBuyForm(), { overrides });
 
-    const renderBuyForm = (
+    const renderBuyForm = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState>,
         form: BuyFormType,
     ) =>
-        renderWithTradingProvider(<BuyForm />, {
+        await renderWithTradingProvider(<BuyForm />, {
             overrides,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render when buy data are not preloaded', () => {
-        const { result } = renderFormHook(residenceCheckDisabledOverrides);
-        const { queryByText, getByText, getByLabelText } = renderBuyForm(
+    it('should render when buy data are not preloaded', async () => {
+        const { result } = await renderFormHook(residenceCheckDisabledOverrides);
+        const { queryByText, getByText, getByLabelText } = await renderBuyForm(
             residenceCheckDisabledOverrides,
             result.current,
         );
@@ -94,13 +95,13 @@ describe('BuyForm', () => {
             featureFlags: createTradingFeatureFlags(),
         };
 
-        beforeEach(() => {
-            const { result } = renderFormHook(overrides);
+        beforeEach(async () => {
+            const { result } = await renderFormHook(overrides);
             form = result.current;
         });
 
-        it('should render with default values', () => {
-            const { queryByText, getByLabelText, getByText } = renderBuyForm(overrides, form);
+        it('should render with default values', async () => {
+            const { queryByText, getByLabelText, getByText } = await renderBuyForm(overrides, form);
 
             expect(
                 getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
@@ -130,11 +131,11 @@ describe('BuyForm', () => {
             ).toBeNull();
         });
 
-        it('should render only BuyCard and Done when amount input is active', () => {
-            act(() => {
+        it('should render only BuyCard and Done when amount input is active', async () => {
+            await act(() => {
                 form.setValue('focusedValue', 'fiatValue');
             });
-            const { queryByText, getByText } = renderBuyForm(overrides, form);
+            const { queryByText, getByText } = await renderBuyForm(overrides, form);
 
             expect(
                 getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.test.tsx
@@ -20,38 +20,41 @@ import {
 describe('BuyFormFieldErrorBadge', () => {
     let tradingForm: BuyFormType;
 
-    const renderUseTradingBuyForm = (
+    const renderUseTradingBuyForm = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) => {
-        const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
+        const { result } = await renderHookWithTradingProvider(() => useBuyForm(), {
             overrides,
         });
 
         return result.current;
     };
 
-    const renderBuyFormFieldErrorBadge = (
+    const renderBuyFormFieldErrorBadge = async (
         props: BuyFormFieldErrorBadgeProps,
         form: BuyFormType,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(<BuyFormFieldErrorBadge {...props} />, {
+        await renderWithTradingProvider(<BuyFormFieldErrorBadge {...props} />, {
             overrides,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        tradingForm = renderUseTradingBuyForm();
+    beforeEach(async () => {
+        tradingForm = await renderUseTradingBuyForm();
     });
 
-    it('should render nothing when there is no error in form', () => {
-        const { toJSON } = renderBuyFormFieldErrorBadge({ fieldName: 'fiatValue' }, tradingForm);
+    it('should render nothing when there is no error in form', async () => {
+        const { toJSON } = await renderBuyFormFieldErrorBadge(
+            { fieldName: 'fiatValue' },
+            tradingForm,
+        );
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render children when there is no error in form', () => {
-        const { getByText } = renderBuyFormFieldErrorBadge(
+    it('should render children when there is no error in form', async () => {
+        const { getByText } = await renderBuyFormFieldErrorBadge(
             { fieldName: 'fiatValue', children: <Text>CHILDREN</Text> },
             tradingForm,
         );
@@ -59,24 +62,27 @@ describe('BuyFormFieldErrorBadge', () => {
         expect(getByText('CHILDREN')).toBeOnTheScreen();
     });
 
-    it('should render error when field has error', () => {
-        act(() => {
+    it('should render error when field has error', async () => {
+        await act(() => {
             tradingForm.setError('fiatValue', {
                 type: 'manual',
                 message: 'Error message',
             });
         });
-        const { getByText } = renderBuyFormFieldErrorBadge({ fieldName: 'fiatValue' }, tradingForm);
+        const { getByText } = await renderBuyFormFieldErrorBadge(
+            { fieldName: 'fiatValue' },
+            tradingForm,
+        );
 
         expect(getByText('Error message')).toBeTruthy();
     });
 
     describe('with selected quote', () => {
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 tradingForm.setValue('asset', btcAsset);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('quote', {
                     fiatStringAmount: '10',
                     fiatCurrency: 'USD',
@@ -93,15 +99,15 @@ describe('BuyFormFieldErrorBadge', () => {
             });
         });
 
-        it('should render badge when quote has different crypto value than requested', () => {
-            act(() => {
+        it('should render badge when quote has different crypto value than requested', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '0.0006');
             });
 
-            const { getByText } = renderBuyFormFieldErrorBadge(
+            const { getByText } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -115,15 +121,15 @@ describe('BuyFormFieldErrorBadge', () => {
             ).toBeTruthy();
         });
 
-        it('should not render badge when crypto amount does not differ', () => {
-            act(() => {
+        it('should not render badge when crypto amount does not differ', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '0.0005');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -131,15 +137,15 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when crypto amount does not differ but contains trailing zeros', () => {
-            act(() => {
+        it('should not render badge when crypto amount does not differ but contains trailing zeros', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '0.0005000');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -147,11 +153,11 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge while quotes are loading', () => {
-            act(() => {
+        it('should not render badge while quotes are loading', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '0.0006');
             });
             const preloadedState = {
@@ -159,7 +165,7 @@ describe('BuyFormFieldErrorBadge', () => {
             };
             preloadedState!.wallet!.trading!.buy!.isLoading = true;
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
                 preloadedState,
@@ -168,12 +174,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should render badge when quote has different fiat value than requested', () => {
-            act(() => {
+        it('should render badge when quote has different fiat value than requested', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatValue', '11.0');
             });
 
-            const { getByText } = renderBuyFormFieldErrorBadge(
+            const { getByText } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -187,12 +193,12 @@ describe('BuyFormFieldErrorBadge', () => {
             ).toBeTruthy();
         });
 
-        it('should not render badge when fiat amount does not differ', () => {
-            act(() => {
+        it('should not render badge when fiat amount does not differ', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatValue', '10.0');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -200,15 +206,15 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge for cryptoValue when rendering different form field badge', () => {
-            act(() => {
+        it('should not render badge for cryptoValue when rendering different form field badge', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '0.0006');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -216,12 +222,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge for fiatValue when rendering different form field badge', () => {
-            act(() => {
+        it('should not render badge for fiatValue when rendering different form field badge', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatValue', '11.0');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -229,12 +235,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when fiat amount does not differ but contains trailing zeros', () => {
-            act(() => {
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatValue', '10.000');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -242,15 +248,15 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should correctly compare with amount in sats', () => {
-            act(() => {
+        it('should correctly compare with amount in sats', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '50000');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
                 {
@@ -265,15 +271,15 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should correctly display amount in sats', () => {
-            act(() => {
+        it('should correctly display amount in sats', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '51000');
             });
 
-            const { getByText } = renderBuyFormFieldErrorBadge(
+            const { getByText } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
                 {
@@ -296,11 +302,11 @@ describe('BuyFormFieldErrorBadge', () => {
     });
 
     describe('with quote with trailing zeros', () => {
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 tradingForm.setValue('asset', btcAsset);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('quote', {
                     fiatStringAmount: '10.0000',
                     fiatCurrency: 'USD',
@@ -317,15 +323,15 @@ describe('BuyFormFieldErrorBadge', () => {
             });
         });
 
-        it('should not render badge when crypto amount does not differ', () => {
-            act(() => {
+        it('should not render badge when crypto amount does not differ', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '0.0005');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -333,15 +339,15 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when crypto amount does not differ but contains trailing zeros', () => {
-            act(() => {
+        it('should not render badge when crypto amount does not differ but contains trailing zeros', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoValue', '0.0005000');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -349,12 +355,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when fiat amount does not differ', () => {
-            act(() => {
+        it('should not render badge when fiat amount does not differ', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatValue', '10.0');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -362,12 +368,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when fiat amount does not differ but contains trailing zeros', () => {
-            act(() => {
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatValue', '10.000');
             });
 
-            const { toJSON } = renderBuyFormFieldErrorBadge(
+            const { toJSON } = await renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );

--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.test.tsx
@@ -58,7 +58,7 @@ describe('BuyPaymentMethodPicker', () => {
         }),
     } as const;
 
-    const renderPaymentMethodPicker = (
+    const renderPaymentMethodPicker = async (
         componentPreloadedState: PreloadedStatePartial<typeof defaultPreloadedState> = {},
         store?: EnhancedStore,
         formPreloadedState: PreloadedStatePartial<
@@ -71,14 +71,14 @@ describe('BuyPaymentMethodPicker', () => {
             componentPreloadedState,
         );
 
-        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
+        const { result } = await renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState: mergedFormPreloadedState,
             services,
             store,
         });
         form = result.current;
 
-        return renderWithStoreProvider(
+        return await renderWithStoreProvider(
             <Form form={form}>
                 <BuyPaymentMethodPicker />
             </Form>,
@@ -90,22 +90,22 @@ describe('BuyPaymentMethodPicker', () => {
         jest.clearAllMocks();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should not render when there are no payment methods', () => {
-        const { toJSON } = renderPaymentMethodPicker();
+    it('should not render when there are no payment methods', async () => {
+        const { toJSON } = await renderPaymentMethodPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display loader when loading initial quotes', () => {
+    it('should display loader when loading initial quotes', async () => {
         const preloadedState = {
             wallet: { trading: { buy: { isLoading: true, quotes: [] } } },
         } satisfies PreloadedStatePartial<typeof defaultPreloadedState>;
 
-        const { getByLabelText } = renderPaymentMethodPicker(preloadedState);
+        const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
 
         expect(
             getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
@@ -117,19 +117,21 @@ describe('BuyPaymentMethodPicker', () => {
             wallet: { trading: getInitializedTradingStateWithQuotes() },
         };
 
-        it('should display "Not selected" when no method is selected in form', () => {
-            const { getByLabelText } = renderPaymentMethodPicker(withQuotes);
+        it('should display "Not selected" when no method is selected in form', async () => {
+            const { getByLabelText } = await renderPaymentMethodPicker(withQuotes);
             expect(
                 getByLabelText(getTranslation('moduleTrading.tradingScreen.noPaymentMethod')),
             ).toHaveTextContent(getTranslation('moduleTrading.notSelected'));
         });
 
-        it('should allow to select payment method', () => {
+        it('should allow to select payment method', async () => {
             const { getByText, getByLabelText, getByTestId } =
-                renderPaymentMethodPicker(withQuotes);
+                await renderPaymentMethodPicker(withQuotes);
 
-            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')));
-            fireEvent.press(getByText(creditCardPaymentMethodTranslation));
+            await fireEvent.press(
+                getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
+            );
+            await fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
             expect(
                 getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedPaymentMethod')),
@@ -142,8 +144,8 @@ describe('BuyPaymentMethodPicker', () => {
             ).toBeTruthy();
         });
 
-        it('should display loader while quotes are fetched', () => {
-            const { getByLabelText } = renderPaymentMethodPicker(
+        it('should display loader while quotes are fetched', async () => {
+            const { getByLabelText } = await renderPaymentMethodPicker(
                 mergeDeepObject(withQuotes, {
                     wallet: { trading: { buy: { isLoading: true } } },
                 }),
@@ -154,7 +156,7 @@ describe('BuyPaymentMethodPicker', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should display sheet even while quotes are fetched', () => {
+        it('should display sheet even while quotes are fetched', async () => {
             const store = createLightStore({
                 reducer,
                 preloadedState: {
@@ -165,10 +167,12 @@ describe('BuyPaymentMethodPicker', () => {
                 },
             });
             store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
-            const { getByText } = renderPaymentMethodPicker(undefined, store);
+            const { getByText } = await renderPaymentMethodPicker(undefined, store);
 
-            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')));
-            act(() => {
+            await fireEvent.press(
+                getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
+            );
+            await act(() => {
                 store.dispatch(tradingBuyActions.setIsLoading(true));
             });
 
@@ -180,13 +184,13 @@ describe('BuyPaymentMethodPicker', () => {
                 reportMock.mockClear();
             });
 
-            it('should fire analytics event on payment method select', () => {
-                const { getByText } = renderPaymentMethodPicker(withQuotes);
+            it('should fire analytics event on payment method select', async () => {
+                const { getByText } = await renderPaymentMethodPicker(withQuotes);
 
-                fireEvent.press(
+                await fireEvent.press(
                     getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
                 );
-                fireEvent.press(getByText(creditCardPaymentMethodTranslation));
+                await fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
                 expect(reportMock).toHaveBeenCalledWith({
                     type: events.tradingParameterChangedEvent.name,
@@ -197,34 +201,34 @@ describe('BuyPaymentMethodPicker', () => {
                 });
             });
 
-            it('should fire analytics event on payment method change', () => {
-                const { getByText } = renderPaymentMethodPicker(withQuotes);
+            it('should fire analytics event on payment method change', async () => {
+                const { getByText } = await renderPaymentMethodPicker(withQuotes);
 
-                act(() => {
+                await act(() => {
                     form.setValue('quote', cexdirectCreditCardBuyQuote);
                 });
 
-                fireEvent.press(
+                await fireEvent.press(
                     getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
                 );
-                fireEvent.press(getByText('Apple Pay'));
+                await fireEvent.press(getByText('Apple Pay'));
 
                 expect(reportMock).toHaveBeenCalledTimes(1);
             });
 
-            it('should not fire analytics event when same payment method is selected', () => {
-                const { getByText, getAllByText } = renderPaymentMethodPicker(withQuotes);
+            it('should not fire analytics event when same payment method is selected', async () => {
+                const { getByText, getAllByText } = await renderPaymentMethodPicker(withQuotes);
 
-                act(() => {
+                await act(() => {
                     form.setValue('quote', cexdirectCreditCardBuyQuote);
                 });
 
-                fireEvent.press(
+                await fireEvent.press(
                     getByText(getTranslation('moduleTrading.tradingScreen.paymentMethod')),
                 );
                 const creditCardOption = getAllByText(creditCardPaymentMethodTranslation)[1];
                 if (!creditCardOption) throw new Error('Credit Card option [1] not found');
-                fireEvent.press(creditCardOption);
+                await fireEvent.press(creditCardOption);
 
                 expect(reportMock).toHaveBeenCalledTimes(0);
             });

--- a/suite-native/module-trading/src/components/buy/BuyPreview/BuyGeneralErrorScreen.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPreview/BuyGeneralErrorScreen.test.tsx
@@ -16,14 +16,14 @@ describe('BuyGeneralErrorScreen', () => {
         jest.clearAllMocks();
     });
 
-    it('renders unknown error text', () => {
-        const { getByText } = renderWithTradingProvider(<BuyGeneralErrorScreen />);
+    it('renders unknown error text', async () => {
+        const { getByText } = await renderWithTradingProvider(<BuyGeneralErrorScreen />);
 
         expect(getByText(getTranslation('generic.unknownError'))).toBeOnTheScreen();
     });
 
-    it('logs console.error on mount', () => {
-        renderWithTradingProvider(<BuyGeneralErrorScreen />);
+    it('logs console.error on mount', async () => {
+        await renderWithTradingProvider(<BuyGeneralErrorScreen />);
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
             'TradingBuyPreviewScreen: No quote or providerMetadata specified',

--- a/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewContinueButton.test.tsx
@@ -12,8 +12,8 @@ jest.mock('../../../hooks/buy/useBuyPreviewFlow', () => ({
 describe('BuyPreviewContinueButton', () => {
     const mockUseBuyPreviewFlow = jest.mocked(useBuyPreviewFlow);
 
-    const renderBuyPreviewContinueButton = (companyName = 'MoonPay') =>
-        renderWithTradingProvider(<BuyPreviewContinueButton companyName={companyName} />, {
+    const renderBuyPreviewContinueButton = async (companyName = 'MoonPay') =>
+        await renderWithTradingProvider(<BuyPreviewContinueButton companyName={companyName} />, {
             tradeType: 'buy',
         });
 
@@ -29,13 +29,13 @@ describe('BuyPreviewContinueButton', () => {
         });
     });
 
-    it('renders button with company name', () => {
-        const { getByText } = renderBuyPreviewContinueButton();
+    it('renders button with company name', async () => {
+        const { getByText } = await renderBuyPreviewContinueButton();
 
         expect(getByText(buttonText)).toBeOnTheScreen();
     });
 
-    it('calls confirmTrade when button is pressed and canProceed is true', () => {
+    it('calls confirmTrade when button is pressed and canProceed is true', async () => {
         const confirmTradeMock = jest.fn();
         mockUseBuyPreviewFlow.mockReturnValue({
             confirmTrade: confirmTradeMock,
@@ -43,14 +43,14 @@ describe('BuyPreviewContinueButton', () => {
             isLoading: false,
         });
 
-        const { getByText } = renderBuyPreviewContinueButton();
+        const { getByText } = await renderBuyPreviewContinueButton();
 
-        fireEvent.press(getByText(buttonText));
+        await fireEvent.press(getByText(buttonText));
 
         expect(confirmTradeMock).toHaveBeenCalledTimes(1);
     });
 
-    it('does not call confirmTrade when button canProceed is false', () => {
+    it('does not call confirmTrade when button canProceed is false', async () => {
         const confirmTradeMock = jest.fn();
         mockUseBuyPreviewFlow.mockReturnValue({
             confirmTrade: confirmTradeMock,
@@ -58,14 +58,14 @@ describe('BuyPreviewContinueButton', () => {
             isLoading: false,
         });
 
-        const { getByText } = renderBuyPreviewContinueButton();
+        const { getByText } = await renderBuyPreviewContinueButton();
 
-        fireEvent.press(getByText(buttonText));
+        await fireEvent.press(getByText(buttonText));
 
         expect(confirmTradeMock).not.toHaveBeenCalled();
     });
 
-    it('does not call confirmTrade while loading', () => {
+    it('does not call confirmTrade while loading', async () => {
         const confirmTradeMock = jest.fn();
         mockUseBuyPreviewFlow.mockReturnValue({
             confirmTrade: confirmTradeMock,
@@ -73,9 +73,9 @@ describe('BuyPreviewContinueButton', () => {
             isLoading: true,
         });
 
-        const { getByText } = renderBuyPreviewContinueButton();
+        const { getByText } = await renderBuyPreviewContinueButton();
 
-        fireEvent.press(getByText(buttonText));
+        await fireEvent.press(getByText(buttonText));
 
         expect(confirmTradeMock).not.toHaveBeenCalled();
     });

--- a/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewInfoCard.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewInfoCard.test.tsx
@@ -5,11 +5,11 @@ import { BuyPreviewInfoCard } from './BuyPreviewInfoCard';
 import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
 
 describe('BuyPreviewInfoCard', () => {
-    const renderCard = (quote = mercuryoApplePayBuyQuote) =>
-        renderWithTradingProvider(<BuyPreviewInfoCard quote={quote} />, { tradeType: 'buy' });
+    const renderCard = async (quote = mercuryoApplePayBuyQuote) =>
+        await renderWithTradingProvider(<BuyPreviewInfoCard quote={quote} />, { tradeType: 'buy' });
 
-    it('displays "you pay" label with formatted fiat amount', () => {
-        const { getByText } = renderCard();
+    it('displays "you pay" label with formatted fiat amount', async () => {
+        const { getByText } = await renderCard();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingBuyPreviewScreen.youPay')),
@@ -17,16 +17,16 @@ describe('BuyPreviewInfoCard', () => {
         expect(getByText('€10.00')).toBeOnTheScreen();
     });
 
-    it('displays payment method name', () => {
-        const { getByLabelText } = renderCard();
+    it('displays payment method name', async () => {
+        const { getByLabelText } = await renderCard();
 
         expect(
             getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedPaymentMethod')),
         ).toHaveTextContent('Apple Pay');
     });
 
-    it('displays provider name', () => {
-        const { getByText } = renderCard();
+    it('displays provider name', async () => {
+        const { getByText } = await renderCard();
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewReceiveCard.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewReceiveCard.test.tsx
@@ -18,7 +18,7 @@ describe('BuyPreviewReceiveCard', () => {
     };
 
     const renderBuyPreviewReceiveCard = async (overrides?: typeof withReceiveAccount) => {
-        const result = renderWithTradingProvider(
+        const result = await renderWithTradingProvider(
             <BuyPreviewReceiveCard quote={mercuryoApplePayBuyQuote} />,
             { tradeType: 'buy', overrides },
         );

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.test.tsx
@@ -30,35 +30,35 @@ const services: NativeAnalyticsDep = {
 describe('BuyProviderPicker', () => {
     let form: BuyFormType;
 
-    const renderTradingProviderPicker = (
+    const renderTradingProviderPicker = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <Form form={form}>
                 <BuyProviderPicker />
             </Form>,
             { overrides, services },
         );
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
 
-        const { result } = renderHookWithTradingProvider(() => useBuyForm(), { services });
+        const { result } = await renderHookWithTradingProvider(() => useBuyForm(), { services });
         form = result.current;
     });
 
-    it('should display nothing when in default state', () => {
-        const { toJSON } = renderTradingProviderPicker();
+    it('should display nothing when in default state', async () => {
+        const { toJSON } = await renderTradingProviderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display loader while quotes are fetched', () => {
-        const { getByLabelText } = renderTradingProviderPicker({
+    it('should display loader while quotes are fetched', async () => {
+        const { getByLabelText } = await renderTradingProviderPicker({
             wallet: { trading: { buy: { isLoading: true, quotes: [] } } },
         });
 
@@ -88,25 +88,27 @@ describe('BuyProviderPicker', () => {
             },
         };
 
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 form.setValue('quote', cexdirectCreditCardBuyQuote);
             });
         });
 
-        it('should allow to select provider', () => {
-            const { getByText, getByLabelText } = renderTradingProviderPicker(withQuotes);
+        it('should allow to select provider', async () => {
+            const { getByText, getByLabelText } = await renderTradingProviderPicker(withQuotes);
 
-            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
-            fireEvent.press(getByText('Mercuryo'));
+            await fireEvent.press(
+                getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+            );
+            await fireEvent.press(getByText('Mercuryo'));
 
             expect(
                 getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedProvider')),
             ).toHaveTextContent('Mercuryo');
         });
 
-        it('should display loader while quotes are re-fetched', () => {
-            const { getByLabelText } = renderTradingProviderPicker(
+        it('should display loader while quotes are re-fetched', async () => {
+            const { getByLabelText } = await renderTradingProviderPicker(
                 mergeDeepObject(withQuotes, {
                     wallet: { trading: { buy: { isLoading: true } } },
                 }),
@@ -117,14 +119,16 @@ describe('BuyProviderPicker', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should display sheet even while quotes are fetched', () => {
-            const { getByText } = renderTradingProviderPicker(
+        it('should display sheet even while quotes are fetched', async () => {
+            const { getByText } = await renderTradingProviderPicker(
                 mergeDeepObject(withQuotes, {
                     wallet: { trading: { buy: { isLoading: true } } },
                 }),
             );
 
-            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
+            await fireEvent.press(
+                getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+            );
 
             expect(getByText('Mercuryo')).toBeOnTheScreen();
         });
@@ -134,11 +138,13 @@ describe('BuyProviderPicker', () => {
                 reportMock.mockClear();
             });
 
-            it('should fire analytics event on provider select', () => {
-                const { getByText } = renderTradingProviderPicker(withQuotes);
+            it('should fire analytics event on provider select', async () => {
+                const { getByText } = await renderTradingProviderPicker(withQuotes);
 
-                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
-                fireEvent.press(getByText('Mercuryo'));
+                await fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+                );
+                await fireEvent.press(getByText('Mercuryo'));
 
                 expect(reportMock).toHaveBeenCalledTimes(2);
                 expect(reportMock).toHaveBeenCalledWith({
@@ -156,20 +162,24 @@ describe('BuyProviderPicker', () => {
                 });
             });
 
-            it('should fire analytics event on provider change', () => {
-                const { getByText } = renderTradingProviderPicker(withQuotes);
+            it('should fire analytics event on provider change', async () => {
+                const { getByText } = await renderTradingProviderPicker(withQuotes);
 
-                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
-                fireEvent.press(getByText('Mercuryo'));
+                await fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+                );
+                await fireEvent.press(getByText('Mercuryo'));
 
                 expect(reportMock).toHaveBeenCalledTimes(2);
             });
 
-            it('should not fire analytics event when same provider is selected', () => {
-                const { getByText, getAllByText } = renderTradingProviderPicker(withQuotes);
+            it('should not fire analytics event when same provider is selected', async () => {
+                const { getByText, getAllByText } = await renderTradingProviderPicker(withQuotes);
 
-                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
-                fireEvent.press(getIndexOrThrow(getAllByText('Cexdirect'), 1));
+                await fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+                );
+                await fireEvent.press(getIndexOrThrow(getAllByText('Cexdirect'), 1));
 
                 expect(reportMock).toHaveBeenCalledTimes(1);
                 expect(reportMock).toHaveBeenCalledWith({
@@ -180,14 +190,16 @@ describe('BuyProviderPicker', () => {
                 });
             });
 
-            it('should not call analytics when user tries to open sheet while quotes are loading', () => {
-                const { getByText } = renderTradingProviderPicker(
+            it('should not call analytics when user tries to open sheet while quotes are loading', async () => {
+                const { getByText } = await renderTradingProviderPicker(
                     mergeDeepObject(withQuotes, {
                         wallet: { trading: { buy: { isLoading: true } } },
                     }),
                 );
 
-                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
+                await fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+                );
 
                 expect(reportMock).not.toHaveBeenCalled();
             });

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.test.tsx
@@ -21,43 +21,43 @@ describe('BuyReceiveAccountCryptoBalance', () => {
         wallet: getWalletState({ tradeType: 'buy' }),
     };
 
-    const renderBuyForm = () => {
-        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
+    const renderBuyForm = async () => {
+        const { result } = await renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });
 
         return result.current;
     };
 
-    const renderComponent = () =>
-        renderWithStoreProvider(<BuyReceiveAccountCryptoBalance />, {
+    const renderComponent = async () =>
+        await renderWithStoreProvider(<BuyReceiveAccountCryptoBalance />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={buyForm}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        buyForm = renderBuyForm();
+    beforeEach(async () => {
+        buyForm = await renderBuyForm();
     });
 
-    it('should use asset form field as default symbol', () => {
-        act(() => {
+    it('should use asset form field as default symbol', async () => {
+        await act(() => {
             buyForm.setValue('asset', btcAsset);
         });
-        const { getByTestId } = renderComponent();
+        const { getByTestId } = await renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should use receiveAccount form field to obtain account', () => {
-        act(() => {
+    it('should use receiveAccount form field to obtain account', async () => {
+        await act(() => {
             buyForm.setValue('asset', btcAsset);
         });
-        act(() => {
+        await act(() => {
             buyForm.setValue('receiveAccount', {
                 account: getBtcAccount(),
             });
         });
-        const { getByTestId } = renderComponent();
+        const { getByTestId } = await renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
     });

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.test.tsx
@@ -44,48 +44,48 @@ const tradingStateWithReceiveAccount = (
 describe('BuyReceiveAccountPicker', () => {
     let buyForm: BuyFormType;
 
-    const renderBuyForm = () => {
-        const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
+    const renderBuyForm = async () => {
+        const { result } = await renderHookWithTradingProvider(() => useBuyForm(), {
             tradeType: 'buy',
         });
 
         return result.current;
     };
 
-    const renderPicker = (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
-        renderWithTradingProvider(<BuyReceiveAccountPicker />, {
+    const renderPicker = async (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
+        await renderWithTradingProvider(<BuyReceiveAccountPicker />, {
             tradeType: 'buy',
             overrides,
             wrapper: ({ children }) => <Form form={buyForm}>{children}</Form>,
         });
 
-    const setSelectedAsset = (asset: TradeableAsset) => {
-        act(() => {
+    const setSelectedAsset = async (asset: TradeableAsset) => {
+        await act(() => {
             buyForm.setValue('asset', asset);
         });
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
-        buyForm = renderBuyForm();
+        buyForm = await renderBuyForm();
     });
 
-    it('should display nothing when selectedSymbol is not specified', () => {
-        const { toJSON } = renderPicker();
+    it('should display nothing when selectedSymbol is not specified', async () => {
+        const { toJSON } = await renderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display "Not selected" when asset is not specified', () => {
-        setSelectedAsset(btcAsset);
-        const { getByText } = renderPicker();
+    it('should display "Not selected" when asset is not specified', async () => {
+        await setSelectedAsset(btcAsset);
+        const { getByText } = await renderPicker();
 
         expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
-    it('should display selected account name', () => {
-        setSelectedAsset(btcAsset);
-        const { getByText } = renderPicker(
+    it('should display selected account name', async () => {
+        await setSelectedAsset(btcAsset);
+        const { getByText } = await renderPicker(
             tradingStateWithReceiveAccount({
                 account: btc1NormalAccount,
                 address: btc1NormalAccount.addresses?.used[0],
@@ -95,16 +95,18 @@ describe('BuyReceiveAccountPicker', () => {
         expect(getByText(btcAccountName1)).toBeTruthy();
     });
 
-    it('should call navigate with correct params on press', () => {
-        setSelectedAsset(btcAsset);
-        const { getByText } = renderPicker(
+    it('should call navigate with correct params on press', async () => {
+        await setSelectedAsset(btcAsset);
+        const { getByText } = await renderPicker(
             tradingStateWithReceiveAccount({
                 account: btc1NormalAccount,
                 address: btc1NormalAccount.addresses?.used[0],
             }),
         );
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')));
+        await fireEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+        );
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', {

--- a/suite-native/module-trading/src/components/buy/BuyTab.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTab.test.tsx
@@ -40,8 +40,8 @@ describe('BuyTab', () => {
         (selectIsTradingBuyEnabled as jest.Mock).mockReturnValue(true);
     });
 
-    const renderBuyTab = (overrides?: PreloadedStatePartial<TradingTestPreloadedState>) =>
-        renderWithTradingProvider(<BuyTab />, { overrides });
+    const renderBuyTab = async (overrides?: PreloadedStatePartial<TradingTestPreloadedState>) =>
+        await renderWithTradingProvider(<BuyTab />, { overrides });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);
@@ -57,50 +57,50 @@ describe('BuyTab', () => {
         expect(screen.getByText("It's not you, it's us.")).toBeTruthy();
     };
 
-    it('should render Buy skeleton when isLoading is true', () => {
+    it('should render Buy skeleton when isLoading is true', async () => {
         mockUseTradingBuyData.mockReturnValue({
             isLoading: true,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        renderBuyTab();
+        await renderBuyTab();
 
         expectSkeleton();
     });
 
-    it('should render Buy skeleton when lastLoadedTimestamp is 0', () => {
+    it('should render Buy skeleton when lastLoadedTimestamp is 0', async () => {
         mockUseTradingBuyData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 0,
             isFullyLoaded: false,
         });
 
-        renderBuyTab();
+        await renderBuyTab();
 
         expectSkeleton();
     });
 
-    it('should render Buy form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', () => {
+    it('should render Buy form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', async () => {
         mockUseTradingBuyData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: true,
         });
 
-        renderBuyTab();
+        await renderBuyTab();
 
         expectBuyForm();
     });
 
-    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', () => {
+    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', async () => {
         mockUseTradingBuyData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        renderBuyTab();
+        await renderBuyTab();
 
         expectServerOffline();
     });
@@ -118,7 +118,7 @@ describe('BuyTab', () => {
                 isFullyLoaded: true,
             });
 
-        const { getByText } = renderBuyTab();
+        const { getByText } = await renderBuyTab();
 
         const reloadButton = getByText(getTranslation('tradingAtoms.error.serverOfflineRetry'));
 
@@ -132,9 +132,9 @@ describe('BuyTab', () => {
         expect(mockUseTradingBuyData).toHaveBeenCalledWith(1);
     });
 
-    it('should render disabled info when buy is disabled by FFs', () => {
+    it('should render disabled info when buy is disabled by FFs', async () => {
         (selectIsTradingBuyEnabled as jest.Mock).mockReturnValue(false);
-        const { getByText } = renderBuyTab();
+        const { getByText } = await renderBuyTab();
 
         expect(
             getByText(

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.test.tsx
@@ -81,8 +81,8 @@ describe('BuyTradeableAssetPicker', () => {
             },
         });
 
-    const renderFormHook = () => {
-        const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
+    const renderFormHook = async () => {
+        const { result } = await renderHookWithTradingProvider(() => useBuyForm(), {
             services,
             store,
         });
@@ -91,7 +91,7 @@ describe('BuyTradeableAssetPicker', () => {
     };
 
     const renderTradeableAssetPicker = async () => {
-        const res = renderWithTradingProvider(
+        const res = await renderWithTradingProvider(
             <Form form={form}>
                 <BuyTradeableAssetPicker />
             </Form>,
@@ -104,17 +104,17 @@ describe('BuyTradeableAssetPicker', () => {
         return res;
     };
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
     describe('with regular firmware', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             jest.clearAllMocks();
             mockTradingType = 'buy';
             mockSelectedTradeableAssetCryptoId = undefined;
             store = initPreloadedStore(FirmwareType.Universal);
-            form = renderFormHook();
+            form = await renderFormHook();
         });
 
         it('should render "Select asset" button with caret', async () => {
@@ -130,7 +130,9 @@ describe('BuyTradeableAssetPicker', () => {
         it('should navigate to the buy asset screen', async () => {
             const { getByLabelText } = await renderTradeableAssetPicker();
 
-            fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')));
+            await fireEvent.press(
+                getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+            );
 
             expect(mockNavigate).toHaveBeenCalledWith('TradingTradeableAsset', {
                 tradingType: 'buy',
@@ -187,12 +189,12 @@ describe('BuyTradeableAssetPicker', () => {
     });
 
     describe('receiveAccount preselection', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             jest.clearAllMocks();
             mockTradingType = 'buy';
             mockSelectedTradeableAssetCryptoId = undefined;
             store = initPreloadedStoreWithAccounts();
-            form = renderFormHook();
+            form = await renderFormHook();
         });
 
         it('should keep the selected receiveAccount when switching to another asset on the same network', async () => {
@@ -205,7 +207,7 @@ describe('BuyTradeableAssetPicker', () => {
                 });
             });
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingBuyActions.setTradingAccountKey(eth2AccountKey));
                 store.dispatch(tradingBuyActions.setReceiveAccountKey(eth2AccountKey));
             });
@@ -217,7 +219,7 @@ describe('BuyTradeableAssetPicker', () => {
             });
 
             mockSelectedTradeableAssetCryptoId = usdcAsset.cryptoId;
-            result.rerender(
+            await result.rerender(
                 <Form form={form}>
                     <BuyTradeableAssetPicker />
                 </Form>,
@@ -232,12 +234,12 @@ describe('BuyTradeableAssetPicker', () => {
     });
 
     describe('with BTC-only firmware', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             jest.clearAllMocks();
             mockTradingType = 'buy';
             mockSelectedTradeableAssetCryptoId = undefined;
             store = initPreloadedStore(FirmwareType.BitcoinOnly);
-            form = renderFormHook();
+            form = await renderFormHook();
         });
 
         it('should preselect BTC and do not render caret', async () => {
@@ -252,8 +254,12 @@ describe('BuyTradeableAssetPicker', () => {
             const { getByLabelText } = await renderTradeableAssetPicker();
 
             // no need to act as there should be no action
-            fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')));
-            fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')));
+            await fireEvent.press(
+                getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+            );
+            await fireEvent.press(
+                getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+            );
 
             expect(
                 getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),

--- a/suite-native/module-trading/src/components/concierge/ConciergeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeAlert.test.tsx
@@ -74,7 +74,7 @@ const mockConciergeForm = ({
     } as unknown as ReturnType<typeof useFormContext<ConciergeAlertFormValues>>);
 };
 
-const renderConciergeAlert = ({
+const renderConciergeAlert = async ({
     tradingType = 'buy',
     values,
     errors,
@@ -85,7 +85,7 @@ const renderConciergeAlert = ({
 } = {}) => {
     mockConciergeForm({ errors, values });
 
-    return renderWithTradingProvider(<ConciergeAlert tradingType={tradingType} />, {
+    return await renderWithTradingProvider(<ConciergeAlert tradingType={tradingType} />, {
         tradeType: tradingType,
     });
 };
@@ -100,8 +100,8 @@ describe('ConciergeAlert', () => {
         } as unknown as ReturnType<typeof useFetchOtc>);
     });
 
-    it('should show alert when fiat amount is equal or over the limit', () => {
-        const { getByText } = renderConciergeAlert({
+    it('should show alert when fiat amount is equal or over the limit', async () => {
+        const { getByText } = await renderConciergeAlert({
             values: {
                 fiatValue: '1000',
             },
@@ -115,8 +115,8 @@ describe('ConciergeAlert', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should show sell alert when fiat string amount is equal or over the limit', () => {
-        const { getByText } = renderConciergeAlert({
+    it('should show sell alert when fiat string amount is equal or over the limit', async () => {
+        const { getByText } = await renderConciergeAlert({
             tradingType: 'sell',
             values: {
                 fiatStringAmount: '1000',
@@ -131,8 +131,8 @@ describe('ConciergeAlert', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should show alert when CRYPTO_MAX_FORM_TYPE is present in form', () => {
-        const { getByText } = renderConciergeAlert({
+    it('should show alert when CRYPTO_MAX_FORM_TYPE is present in form', async () => {
+        const { getByText } = await renderConciergeAlert({
             errors: {
                 cryptoValue: {
                     type: CRYPTO_MAX_FORM_TYPE,
@@ -148,8 +148,8 @@ describe('ConciergeAlert', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should not show alert when CRYPTO_MIN_FORM_TYPE is present in form', () => {
-        const { queryByText } = renderConciergeAlert({
+    it('should not show alert when CRYPTO_MIN_FORM_TYPE is present in form', async () => {
+        const { queryByText } = await renderConciergeAlert({
             errors: {
                 cryptoValue: {
                     type: CRYPTO_MIN_FORM_TYPE,
@@ -165,8 +165,8 @@ describe('ConciergeAlert', () => {
         ).not.toBeOnTheScreen();
     });
 
-    it('should not show alert when fiat amount is under the limit', () => {
-        const { queryByText } = renderConciergeAlert({
+    it('should not show alert when fiat amount is under the limit', async () => {
+        const { queryByText } = await renderConciergeAlert({
             values: {
                 fiatValue: '999',
             },

--- a/suite-native/module-trading/src/components/concierge/ConciergeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeConfirmation.test.tsx
@@ -26,17 +26,17 @@ describe('ConciergeConfirmation', () => {
         mockUseOpenLink.mockReturnValue(mockOpenLink);
     });
 
-    it('should not render when no provider is selected', () => {
+    it('should not render when no provider is selected', async () => {
         mockUseConciergeProviders.mockReturnValue({
             selectedProvider: undefined,
         } as unknown as ReturnType<typeof useConciergeProviders>);
 
-        const { queryByText } = renderWithBasicProvider(<ConciergeConfirmation />);
+        const { queryByText } = await renderWithBasicProvider(<ConciergeConfirmation />);
 
         expect(queryByText(getTranslation('generic.buttons.continue'))).toBeNull();
     });
 
-    it('should render and open provider link on press when provider is selected', () => {
+    it('should render and open provider link on press when provider is selected', async () => {
         mockUseConciergeProviders.mockReturnValue({
             selectedProvider: {
                 name: 'Trezor OTC',
@@ -45,13 +45,13 @@ describe('ConciergeConfirmation', () => {
             },
         } as unknown as ReturnType<typeof useConciergeProviders>);
 
-        const { getByText } = renderWithBasicProvider(<ConciergeConfirmation />);
+        const { getByText } = await renderWithBasicProvider(<ConciergeConfirmation />);
 
         const continueButton = getByText(getTranslation('generic.buttons.continue'));
 
         expect(continueButton).toBeOnTheScreen();
 
-        fireEvent.press(continueButton);
+        await fireEvent.press(continueButton);
 
         expect(mockOpenLink).toHaveBeenCalledWith(TREZOR_URL);
     });

--- a/suite-native/module-trading/src/components/concierge/ConciergeProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeProviderPicker.test.tsx
@@ -54,13 +54,15 @@ const ConciergeProviderPickerWrapper = ({ country = 'CZ' }: { country?: TradingC
     );
 };
 
-const renderConciergeProviderPicker = (props?: { country?: TradingCountryCode }) => {
+const renderConciergeProviderPicker = async (props?: { country?: TradingCountryCode }) => {
     mockUseFetchOtc.mockReturnValue({
         data: otcData,
         isLoading: false,
     } as unknown as ReturnType<typeof useFetchOtc>);
 
-    return renderWithBasicProvider(<ConciergeProviderPickerWrapper country={props?.country} />);
+    return await renderWithBasicProvider(
+        <ConciergeProviderPickerWrapper country={props?.country} />,
+    );
 };
 
 describe('ConciergeProviderPicker', () => {
@@ -68,27 +70,27 @@ describe('ConciergeProviderPicker', () => {
         jest.clearAllMocks();
     });
 
-    it('should select first provider by default', () => {
-        const { getByTestId } = renderConciergeProviderPicker();
+    it('should select first provider by default', async () => {
+        const { getByTestId } = await renderConciergeProviderPicker();
 
         expect(getByTestId('@trading/concierge/provider-picker/value')).toHaveTextContent(
             'Trezor OTC',
         );
     });
 
-    it('should open sheet and select Invity OTC', () => {
-        const { getByTestId, getByText } = renderConciergeProviderPicker();
+    it('should open sheet and select Invity OTC', async () => {
+        const { getByTestId, getByText } = await renderConciergeProviderPicker();
 
-        fireEvent.press(getByTestId('@trading/concierge/provider-picker'));
-        fireEvent.press(getByText('Invity OTC'));
+        await fireEvent.press(getByTestId('@trading/concierge/provider-picker'));
+        await fireEvent.press(getByText('Invity OTC'));
 
         expect(getByTestId('@trading/concierge/provider-picker/value')).toHaveTextContent(
             'Invity OTC',
         );
     });
 
-    it('should show warning when no providers are available', () => {
-        const { getByText } = renderConciergeProviderPicker({ country: 'US' });
+    it('should show warning when no providers are available', async () => {
+        const { getByText } = await renderConciergeProviderPicker({ country: 'US' });
 
         expect(
             getByText(getTranslation('moduleTrading.tradingScreen.concierge.noProvidersAvailable')),

--- a/suite-native/module-trading/src/components/concierge/ConciergeTab.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeTab.test.tsx
@@ -14,10 +14,10 @@ jest.mock('./ConciergeTabContent', () => ({
 }));
 
 describe('ConciergeTab', () => {
-    it('should render disabled info when concierge is disabled by FFs', () => {
+    it('should render disabled info when concierge is disabled by FFs', async () => {
         (selectIsTradingConciergeEnabled as jest.Mock).mockReturnValue(false);
 
-        const { getByText } = renderWithTradingProvider(<ConciergeTab />);
+        const { getByText } = await renderWithTradingProvider(<ConciergeTab />);
 
         expect(
             getByText(
@@ -28,10 +28,10 @@ describe('ConciergeTab', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should not render disabled message when concierge is enabled', () => {
+    it('should not render disabled message when concierge is enabled', async () => {
         (selectIsTradingConciergeEnabled as jest.Mock).mockReturnValue(true);
 
-        const { queryByText } = renderWithTradingProvider(<ConciergeTab />);
+        const { queryByText } = await renderWithTradingProvider(<ConciergeTab />);
 
         expect(
             queryByText(

--- a/suite-native/module-trading/src/components/concierge/ConciergeTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeTabContent.test.tsx
@@ -37,10 +37,10 @@ const otcData = {
     ],
 } as TradingOTC;
 
-const renderConciergeTabContent = (
+const renderConciergeTabContent = async (
     overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
 ) =>
-    renderWithTradingProvider(<ConciergeTabContent />, {
+    await renderWithTradingProvider(<ConciergeTabContent />, {
         overrides: {
             ...residenceCheckDisabledState,
             ...overrides,
@@ -55,8 +55,8 @@ describe('ConciergeTabContent', () => {
         } as unknown as ReturnType<typeof useFetchOtc>);
     });
 
-    it('should use OTC country as form default when saved residence country is not set', () => {
-        renderConciergeTabContent();
+    it('should use OTC country as form default when saved residence country is not set', async () => {
+        await renderConciergeTabContent();
 
         expect(
             screen.getByText(
@@ -66,8 +66,8 @@ describe('ConciergeTabContent', () => {
         expect(screen.getByTestId('@trading/concierge/country/value')).toHaveTextContent('CZE');
     });
 
-    it('should prefer saved residence country over OTC country', () => {
-        renderConciergeTabContent({
+    it('should prefer saved residence country over OTC country', async () => {
+        await renderConciergeTabContent({
             wallet: {
                 trading: {
                     residence: {
@@ -80,8 +80,8 @@ describe('ConciergeTabContent', () => {
         expect(screen.getByTestId('@trading/concierge/country/value')).toHaveTextContent('USA');
     });
 
-    it('should filter providers by form country', () => {
-        const { getAllByText, getByText, queryByText } = renderConciergeTabContent({
+    it('should filter providers by form country', async () => {
+        const { getAllByText, getByText, queryByText } = await renderConciergeTabContent({
             wallet: {
                 trading: {
                     residence: {
@@ -91,14 +91,14 @@ describe('ConciergeTabContent', () => {
             },
         });
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
+        await fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
 
         expect(getAllByText('US OTC').length).toBeGreaterThan(0);
         expect(queryByText('Alpha OTC')).toBeNull();
     });
 
     it('should clear selected provider when country changes', async () => {
-        const { getByText, queryByText } = renderConciergeTabContent({
+        const { getByText, queryByText } = await renderConciergeTabContent({
             wallet: {
                 trading: {
                     residence: {

--- a/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.test.tsx
@@ -30,8 +30,8 @@ const ethAccountKey = mockAccountKey({ symbol: 'eth', descriptor: 'eth1normal' }
 describe('ApprovalButton', () => {
     let store: TestStore;
 
-    const renderApprovalButton = (props: Partial<ApprovalButtonProps>) =>
-        renderWithStoreProvider(<ApprovalButton flowType="approve" isReady {...props} />, {
+    const renderApprovalButton = async (props: Partial<ApprovalButtonProps>) =>
+        await renderWithStoreProvider(<ApprovalButton flowType="approve" isReady {...props} />, {
             store,
         });
 
@@ -53,16 +53,16 @@ describe('ApprovalButton', () => {
         });
     });
 
-    it('should render continue button when isReady is true', () => {
-        const { getByText } = renderApprovalButton({ isReady: true });
+    it('should render continue button when isReady is true', async () => {
+        const { getByText } = await renderApprovalButton({ isReady: true });
 
         const button = getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue'));
         expect(button).toBeOnTheScreen();
         expect(button).toBeEnabled();
     });
 
-    it('should render disabled button when isReady is false', () => {
-        const { getByText } = renderApprovalButton({ isReady: false });
+    it('should render disabled button when isReady is false', async () => {
+        const { getByText } = await renderApprovalButton({ isReady: false });
 
         const button = getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue'));
         expect(button).toBeOnTheScreen();
@@ -70,7 +70,7 @@ describe('ApprovalButton', () => {
     });
 
     it('should navigate to TradingExchangeOutputsReview on press', async () => {
-        const { getByText } = renderApprovalButton({ isReady: true });
+        const { getByText } = await renderApprovalButton({ isReady: true });
 
         await userEvent.press(
             getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
@@ -85,7 +85,7 @@ describe('ApprovalButton', () => {
     });
 
     it('should report to analytics on press', async () => {
-        const { getByText } = renderApprovalButton({ isReady: true });
+        const { getByText } = await renderApprovalButton({ isReady: true });
 
         await userEvent.press(
             getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
@@ -95,7 +95,7 @@ describe('ApprovalButton', () => {
     });
 
     it('should navigate to TradingExchangeOutputsReview on press for flowType revoke', async () => {
-        const { getByText } = renderApprovalButton({ isReady: true, flowType: 'revoke' });
+        const { getByText } = await renderApprovalButton({ isReady: true, flowType: 'revoke' });
 
         await userEvent.press(
             getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
@@ -110,7 +110,7 @@ describe('ApprovalButton', () => {
     });
 
     it('should report to analytics on press for flowType revoke', async () => {
-        const { getByText } = renderApprovalButton({ isReady: true, flowType: 'revoke' });
+        const { getByText } = await renderApprovalButton({ isReady: true, flowType: 'revoke' });
 
         await userEvent.press(
             getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
@@ -119,10 +119,10 @@ describe('ApprovalButton', () => {
         expect(mockAnalyticsReport).toHaveBeenCalledWith('revoke-preview', 'continue');
     });
 
-    it('should render nothing when no selected quote is provided', () => {
+    it('should render nothing when no selected quote is provided', async () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { toJSON } = renderApprovalButton({ isReady: true });
+        const { toJSON } = await renderApprovalButton({ isReady: true });
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.test.tsx
@@ -30,10 +30,10 @@ describe('ExchangeApprovalDetails', () => {
         },
     };
 
-    const renderExchangeApprovalDetails = (
+    const renderExchangeApprovalDetails = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = defaultOverrides,
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ExchangeApprovalDetails
                 exchange="mercuryo"
                 onApprovalTypeChange={mockOnApprovalTypeChange}
@@ -48,8 +48,8 @@ describe('ExchangeApprovalDetails', () => {
         errorSpy.mockClear();
     });
 
-    it('should render approval details', () => {
-        const { getByText } = renderExchangeApprovalDetails();
+    it('should render approval details', async () => {
+        const { getByText } = await renderExchangeApprovalDetails();
 
         expect(
             getByText(getTranslation('moduleTrading.exchangeTradePreviewCard.account')),
@@ -61,8 +61,8 @@ describe('ExchangeApprovalDetails', () => {
         expect(errorSpy).not.toHaveBeenCalled();
     });
 
-    it('should render error when account is not found', () => {
-        const { getByText, queryByText } = renderExchangeApprovalDetails({
+    it('should render error when account is not found', async () => {
+        const { getByText, queryByText } = await renderExchangeApprovalDetails({
             wallet: {
                 trading: {
                     exchange: {

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitCard.test.tsx
@@ -12,7 +12,7 @@ describe('ExchangeApprovalLimitCard', () => {
     const renderExchangeApprovalLimitCard = async (
         props: Partial<ExchangeApprovalLimitCardProps>,
     ) => {
-        const res = renderWithBasicProvider(
+        const res = await renderWithBasicProvider(
             <ExchangeApprovalLimitCard
                 title={<Text>Test limit</Text>}
                 description="Test description"
@@ -56,14 +56,14 @@ describe('ExchangeApprovalLimitCard', () => {
     it('should call onChange when card is pressed', async () => {
         const { getByText } = await renderExchangeApprovalLimitCard({});
 
-        fireEvent.press(getByText('Test limit'));
+        await fireEvent.press(getByText('Test limit'));
         expect(mockOnChange).toHaveBeenCalledTimes(1);
     });
 
     it('should call onChange when description is pressed', async () => {
         const { getByText } = await renderExchangeApprovalLimitCard({});
 
-        fireEvent.press(getByText('Test description'));
+        await fireEvent.press(getByText('Test description'));
         expect(mockOnChange).toHaveBeenCalledTimes(1);
     });
 

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitSheet.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitSheet.test.tsx
@@ -15,7 +15,7 @@ const renderSheet = async (
     quote = testQuote,
     selectedApprovalType: 'INFINITE' | 'MINIMAL' = 'INFINITE',
 ) => {
-    const res = renderWithTradingProvider(
+    const res = await renderWithTradingProvider(
         <ExchangeApprovalLimitSheet
             isVisible={isVisible}
             onDismiss={mockOnDismiss}

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeRevokeDetails.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeRevokeDetails.test.tsx
@@ -23,10 +23,10 @@ describe('ExchangeRevokeDetails', () => {
         },
     };
 
-    const renderExchangeRevokeDetails = (
+    const renderExchangeRevokeDetails = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = defaultOverrides,
     ) =>
-        renderWithTradingProvider(<ExchangeRevokeDetails exchange="mercuryo" />, {
+        await renderWithTradingProvider(<ExchangeRevokeDetails exchange="mercuryo" />, {
             tradeType: 'exchange',
             overrides,
         });
@@ -35,8 +35,8 @@ describe('ExchangeRevokeDetails', () => {
         errorSpy.mockClear();
     });
 
-    it('should render revoke details', () => {
-        const { getByText } = renderExchangeRevokeDetails();
+    it('should render revoke details', async () => {
+        const { getByText } = await renderExchangeRevokeDetails();
 
         expect(
             getByText(getTranslation('moduleTrading.exchangeTradePreviewCard.account')),
@@ -51,8 +51,8 @@ describe('ExchangeRevokeDetails', () => {
         expect(errorSpy).not.toHaveBeenCalled();
     });
 
-    it('should render error when account is not found', () => {
-        const { getByText, queryByText } = renderExchangeRevokeDetails({
+    it('should render error when account is not found', async () => {
+        const { getByText, queryByText } = await renderExchangeRevokeDetails({
             wallet: {
                 trading: {
                     exchange: {

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitInfoRow.test.tsx
@@ -16,7 +16,10 @@ describe('LimitInfoRow', () => {
         onPress: jest.fn(),
     };
 
-    const renderLimitInfoRow = (props: Partial<LimitInfoRowProps> = {}, quoteOverrides = {}) => {
+    const renderLimitInfoRow = async (
+        props: Partial<LimitInfoRowProps> = {},
+        quoteOverrides = {},
+    ) => {
         const walletState = getWalletState({ tradeType: 'exchange' });
         const preloadedState = {
             wallet: {
@@ -34,13 +37,13 @@ describe('LimitInfoRow', () => {
             },
         };
 
-        return renderWithStoreProvider(<LimitInfoRow {...defaultProps} {...props} />, {
+        return await renderWithStoreProvider(<LimitInfoRow {...defaultProps} {...props} />, {
             preloadedState,
         });
     };
 
-    it('should render formatted amount when approval type is MINIMAL', () => {
-        const { getByText } = renderLimitInfoRow(
+    it('should render formatted amount when approval type is MINIMAL', async () => {
+        const { getByText } = await renderLimitInfoRow(
             {},
             { approvalType: 'MINIMAL', sendStringAmount: '100' },
         );
@@ -48,22 +51,22 @@ describe('LimitInfoRow', () => {
         expect(getByText('100 USDC')).toBeOnTheScreen();
     });
 
-    it('should render unlimited label when approval type is INFINITE', () => {
+    it('should render unlimited label when approval type is INFINITE', async () => {
         const unlimitedText = getTranslation(
             'moduleTrading.tradingExchangeApprovalScreen.unlimitedLabel',
         );
 
-        const { getByText } = renderLimitInfoRow({}, { approvalType: 'INFINITE' });
+        const { getByText } = await renderLimitInfoRow({}, { approvalType: 'INFINITE' });
 
         expect(getByText(unlimitedText)).toBeOnTheScreen();
     });
 
-    it('should render unlimited label without coin symbol when approval type is INFINITE and coin is missing in trading info', () => {
+    it('should render unlimited label without coin symbol when approval type is INFINITE and coin is missing in trading info', async () => {
         const unlimitedText = getTranslation(
             'moduleTrading.tradingExchangeApprovalScreen.unlimitedLabel',
         );
 
-        const { getByText, queryByText } = renderLimitInfoRow(
+        const { getByText, queryByText } = await renderLimitInfoRow(
             {},
             { approvalType: 'INFINITE', send: cryptoIdWithoutCoinInfo },
         );
@@ -72,8 +75,8 @@ describe('LimitInfoRow', () => {
         expect(getByText(new RegExp(`^${unlimitedText}\\s*$`))).toBeOnTheScreen();
     });
 
-    it('should render children', () => {
-        const { getByText } = renderLimitInfoRow({
+    it('should render children', async () => {
+        const { getByText } = await renderLimitInfoRow({
             children: <Text>Child content</Text>,
         });
 
@@ -82,7 +85,7 @@ describe('LimitInfoRow', () => {
 
     it('should call onPress when pressed', async () => {
         const onPress = jest.fn();
-        const { getByTestId } = renderLimitInfoRow({
+        const { getByTestId } = await renderLimitInfoRow({
             onPress,
             testID: 'test-limit-info-row',
         });
@@ -92,16 +95,16 @@ describe('LimitInfoRow', () => {
         expect(onPress).toHaveBeenCalledTimes(1);
     });
 
-    it('should render "Limit" label when quote has not preapproved limit', () => {
-        const { getByText } = renderLimitInfoRow();
+    it('should render "Limit" label when quote has not preapproved limit', async () => {
+        const { getByText } = await renderLimitInfoRow();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingExchangeApprovalScreen.limitLabel')),
         ).toBeOnTheScreen();
     });
 
-    it('should render "New limit" label when quote has preapproved limit', () => {
-        const { getByText } = renderLimitInfoRow({}, { preapprovedStringAmount: '25' });
+    it('should render "New limit" label when quote has preapproved limit', async () => {
+        const { getByText } = await renderLimitInfoRow({}, { preapprovedStringAmount: '25' });
 
         expect(
             getByText(getTranslation('moduleTrading.tradingExchangeApprovalScreen.newLimitLabel')),

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.test.tsx
@@ -15,8 +15,8 @@ describe('LimitPicker', () => {
     let store: TestStore;
     const mockOnApprovalTypeChange = jest.fn();
 
-    const renderLimitPicker = () =>
-        renderWithStoreProvider(
+    const renderLimitPicker = async () =>
+        await renderWithStoreProvider(
             <LimitPicker
                 onApprovalTypeChange={approvalType => {
                     mockOnApprovalTypeChange(approvalType);
@@ -52,8 +52,8 @@ describe('LimitPicker', () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(quote));
     });
 
-    it('should render limit by default', () => {
-        const { getByTestId } = renderLimitPicker();
+    it('should render limit by default', async () => {
+        const { getByTestId } = await renderLimitPicker();
 
         const picker = getByTestId('ExchangeApproval/LimitPicker');
 
@@ -66,7 +66,7 @@ describe('LimitPicker', () => {
     });
 
     it('should render Unlimited when selected by user', async () => {
-        const { getByTestId } = renderLimitPicker();
+        const { getByTestId } = await renderLimitPicker();
 
         const picker = getByTestId('ExchangeApproval/LimitPicker');
         const sheet = getByTestId('ExchangeApproval/LimitSheet');
@@ -102,7 +102,7 @@ describe('LimitPicker', () => {
     });
 
     it('should update limit when users selects new value', async () => {
-        const { getByTestId } = renderLimitPicker();
+        const { getByTestId } = await renderLimitPicker();
 
         const picker = getByTestId('ExchangeApproval/LimitPicker');
         const sheet = getByTestId('ExchangeApproval/LimitSheet');
@@ -122,10 +122,10 @@ describe('LimitPicker', () => {
         );
     });
 
-    it('should render nothing without quote', () => {
+    it('should render nothing without quote', async () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { toJSON } = renderLimitPicker();
+        const { toJSON } = await renderLimitPicker();
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/OriginalLimit.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/OriginalLimit.test.tsx
@@ -15,8 +15,8 @@ jest.mock('@suite-common/trading', () => ({
 }));
 
 describe('OriginalLimit', () => {
-    const renderOriginalLimit = () =>
-        renderWithStoreProvider(<OriginalLimit />, {
+    const renderOriginalLimit = async () =>
+        await renderWithStoreProvider(<OriginalLimit />, {
             preloadedState: {
                 wallet: getWalletState({
                     tradeType: 'exchange',
@@ -37,21 +37,21 @@ describe('OriginalLimit', () => {
             { send: 'bitcoin', preapprovedStringAmount: '' },
         ],
         ['quote.preapprovedStringAmount is "0"', { send: 'bitcoin', preapprovedStringAmount: '0' }],
-    ] as const)('should render nothing when %s', (_description, quote) => {
+    ] as const)('should render nothing when %s', async (_description, quote) => {
         mockSelectTradingExchangeSelectedQuote.mockReturnValue(quote);
 
-        const { toJSON } = renderOriginalLimit();
+        const { toJSON } = await renderOriginalLimit();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render limit label and amount when quote has valid data', () => {
+    it('should render limit label and amount when quote has valid data', async () => {
         mockSelectTradingExchangeSelectedQuote.mockReturnValue({
             send: 'bitcoin',
             preapprovedStringAmount: '100',
         } as Partial<ExchangeTrade>);
 
-        const { getByText } = renderOriginalLimit();
+        const { getByText } = await renderOriginalLimit();
 
         expect(
             getByText(

--- a/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.test.tsx
@@ -10,10 +10,10 @@ import {
 } from '../../../test-utils/tradingTestUtils';
 
 describe('RevokeLimitInfoRow', () => {
-    const renderRevokeLimitInfoRow = (
+    const renderRevokeLimitInfoRow = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(<RevokeLimitInfoRow />, {
+        await renderWithTradingProvider(<RevokeLimitInfoRow />, {
             tradeType: 'exchange',
             overrides,
         });
@@ -32,26 +32,26 @@ describe('RevokeLimitInfoRow', () => {
         },
     };
 
-    it('should render that new limit is 0', () => {
-        const { getByText } = renderRevokeLimitInfoRow(withPreselectedQuote);
+    it('should render that new limit is 0', async () => {
+        const { getByText } = await renderRevokeLimitInfoRow(withPreselectedQuote);
 
         expect(getByText('0 USDC')).toBeOnTheScreen();
     });
 
-    it('should display preapprovedStringAmount', () => {
-        const { getByText } = renderRevokeLimitInfoRow(withPreselectedQuote);
+    it('should display preapprovedStringAmount', async () => {
+        const { getByText } = await renderRevokeLimitInfoRow(withPreselectedQuote);
 
         expect(getByText('100 USDC')).toBeOnTheScreen();
     });
 
-    it('should use token decimals to detect unlimited allowance', () => {
+    it('should use token decimals to detect unlimited allowance', async () => {
         const amountUnlimitedOnlyWithEthDecimals = new BigNumber(UINT256_MAX)
             .dividedBy(2)
             .shiftedBy(-18)
             .integerValue(BigNumber.ROUND_CEIL)
             .toFixed();
 
-        const { queryByText } = renderRevokeLimitInfoRow({
+        const { queryByText } = await renderRevokeLimitInfoRow({
             wallet: {
                 trading: {
                     exchange: {
@@ -68,8 +68,8 @@ describe('RevokeLimitInfoRow', () => {
         expect(queryByText('Unlimited USDC')).toBeNull();
     });
 
-    it('should render nothing when no quote is set', () => {
-        const { toJSON } = renderRevokeLimitInfoRow();
+    it('should render nothing when no quote is set', async () => {
+        const { toJSON } = await renderRevokeLimitInfoRow();
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationHeader.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationHeader.test.tsx
@@ -16,16 +16,16 @@ const testQuote = exchangeQuotes[0];
 describe('ExchangeConfirmationHeader', () => {
     let store: TestStore;
 
-    const renderHeader = (props: ExchangeConfirmationHeaderProps) =>
-        renderWithStoreProvider(<ExchangeConfirmationHeader {...props} />, { store });
+    const renderHeader = async (props: ExchangeConfirmationHeaderProps) =>
+        await renderWithStoreProvider(<ExchangeConfirmationHeader {...props} />, { store });
 
     beforeEach(() => {
         store = createTradingLightStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
     });
 
-    it('should render approve title with coin symbol when flowType is approve', () => {
-        const { getByTestId } = renderHeader({ flowType: 'approve' });
+    it('should render approve title with coin symbol when flowType is approve', async () => {
+        const { getByTestId } = await renderHeader({ flowType: 'approve' });
 
         expect(getByTestId('@screen/sub-header/title')).toHaveTextContent(
             getTranslation('moduleTrading.tradingConfirmationScreen.approveHeaderTitle', {
@@ -34,8 +34,8 @@ describe('ExchangeConfirmationHeader', () => {
         );
     });
 
-    it('should render revoke title with coin symbol when flowType is revoke', () => {
-        const { getByTestId } = renderHeader({ flowType: 'revoke' });
+    it('should render revoke title with coin symbol when flowType is revoke', async () => {
+        const { getByTestId } = await renderHeader({ flowType: 'revoke' });
 
         expect(getByTestId('@screen/sub-header/title')).toHaveTextContent(
             getTranslation('moduleTrading.tradingConfirmationScreen.revokeHeaderTitle', {
@@ -44,22 +44,22 @@ describe('ExchangeConfirmationHeader', () => {
         );
     });
 
-    it('should render empty label when quote is not available', () => {
+    it('should render empty label when quote is not available', async () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { getByTestId } = renderHeader({ flowType: 'approve' });
+        const { getByTestId } = await renderHeader({ flowType: 'approve' });
 
         expect(getByTestId('@screen/sub-header/title')).toHaveTextContent('');
     });
 
-    it('should render empty label when symbol was not found', () => {
+    it('should render empty label when symbol was not found', async () => {
         const quoteWithUnknownSend = {
             ...testQuote,
             send: 'unknown-crypto-id',
         } as ExchangeTrade;
         store.dispatch(tradingExchangeActions.saveSelectedQuote(quoteWithUnknownSend));
 
-        const { getByTestId } = renderHeader({ flowType: 'revoke' });
+        const { getByTestId } = await renderHeader({ flowType: 'revoke' });
 
         expect(getByTestId('@screen/sub-header/title')).toHaveTextContent('');
     });

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationInfo.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationInfo.test.tsx
@@ -17,61 +17,61 @@ const testQuote = exchangeQuotes[0];
 describe('ExchangeConfirmationInfo', () => {
     let store: TestStore;
 
-    const renderInfo = (props: ExchangeConfirmationInfoCardProps) =>
-        renderWithStoreProvider(<ExchangeConfirmationInfo {...props} />, { store });
+    const renderInfo = async (props: ExchangeConfirmationInfoCardProps) =>
+        await renderWithStoreProvider(<ExchangeConfirmationInfo {...props} />, { store });
 
     beforeEach(() => {
         store = createTradingLightStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
     });
 
-    it('should render nothing when quote is not available', () => {
+    it('should render nothing when quote is not available', async () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { toJSON } = renderInfo({ flowType: 'approve', transaction: null });
+        const { toJSON } = await renderInfo({ flowType: 'approve', transaction: null });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when quote has no send field', () => {
+    it('should render nothing when quote has no send field', async () => {
         const quoteWithoutSend = { ...testQuote, send: undefined } as ExchangeTrade;
         store.dispatch(tradingExchangeActions.saveSelectedQuote(quoteWithoutSend));
 
-        const { toJSON } = renderInfo({ flowType: 'approve', transaction: null });
+        const { toJSON } = await renderInfo({ flowType: 'approve', transaction: null });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when send crypto id has unknown network', () => {
+    it('should render nothing when send crypto id has unknown network', async () => {
         const quoteWithUnknownSend = {
             ...testQuote,
             send: 'unknown-crypto-id' as CryptoId,
         } as ExchangeTrade;
         store.dispatch(tradingExchangeActions.saveSelectedQuote(quoteWithUnknownSend));
 
-        const { toJSON } = renderInfo({ flowType: 'approve', transaction: null });
+        const { toJSON } = await renderInfo({ flowType: 'approve', transaction: null });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should not render date row when transaction is not available', () => {
-        renderInfo({ flowType: 'approve', transaction: null });
+    it('should not render date row when transaction is not available', async () => {
+        await renderInfo({ flowType: 'approve', transaction: null });
 
         expect(
             screen.queryByText(getTranslation('moduleTrading.tradingConfirmationScreen.date')),
         ).toBeNull();
     });
 
-    it('should render date row when transaction has blockTime', () => {
-        renderInfo({ flowType: 'approve', transaction: mockTransaction });
+    it('should render date row when transaction has blockTime', async () => {
+        await renderInfo({ flowType: 'approve', transaction: mockTransaction });
 
         expect(
             screen.getByText(getTranslation('moduleTrading.tradingConfirmationScreen.date')),
         ).toBeOnTheScreen();
     });
 
-    it('should render provider, limit and fee rows', () => {
-        renderInfo({ flowType: 'approve', transaction: null });
+    it('should render provider, limit and fee rows', async () => {
+        await renderInfo({ flowType: 'approve', transaction: null });
 
         expect(screen.getByText('Mercuryo')).toBeOnTheScreen();
         expect(
@@ -82,25 +82,25 @@ describe('ExchangeConfirmationInfo', () => {
         expect(screen.getByText(getTranslation('transactions.detail.feeLabel'))).toBeOnTheScreen();
     });
 
-    it('should render fee as "0" when transaction is not available and quote has no numeric fee', () => {
-        renderInfo({ flowType: 'approve', transaction: null });
+    it('should render fee as "0" when transaction is not available and quote has no numeric fee', async () => {
+        await renderInfo({ flowType: 'approve', transaction: null });
 
         expect(screen.getByText('0 ETH')).toBeOnTheScreen();
     });
 
-    it('should render fee from quote when transaction is not available and quote has numeric fee', () => {
+    it('should render fee from quote when transaction is not available and quote has numeric fee', async () => {
         const quoteWithNumericFee = { ...testQuote, fee: 42000000000000000 } as ExchangeTrade;
         store.dispatch(tradingExchangeActions.saveSelectedQuote(quoteWithNumericFee));
 
-        renderInfo({ flowType: 'approve', transaction: null });
+        await renderInfo({ flowType: 'approve', transaction: null });
 
         expect(screen.getByText('0.042 ETH')).toBeOnTheScreen();
     });
 
-    it('should render fee from transaction', () => {
+    it('should render fee from transaction', async () => {
         const transactionWithFee = { ...mockTransaction, fee: '42000000000000000' };
 
-        renderInfo({ flowType: 'approve', transaction: transactionWithFee });
+        await renderInfo({ flowType: 'approve', transaction: transactionWithFee });
 
         expect(screen.getByText('0.042 ETH')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationTitle.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationTitle.test.tsx
@@ -7,11 +7,11 @@ import {
 } from './ExchangeConfirmationTitle';
 
 describe('ExchangeConfirmationTitle', () => {
-    const renderTitle = (props: ExchangeConfirmationTitleProps) =>
-        renderWithBasicProvider(<ExchangeConfirmationTitle {...props} />);
+    const renderTitle = async (props: ExchangeConfirmationTitleProps) =>
+        await renderWithBasicProvider(<ExchangeConfirmationTitle {...props} />);
 
-    it('should display approve title when flowType is approve', () => {
-        const { getByText } = renderTitle({
+    it('should display approve title when flowType is approve', async () => {
+        const { getByText } = await renderTitle({
             flowType: 'approve',
             isFailed: false,
             isPending: true,
@@ -22,16 +22,20 @@ describe('ExchangeConfirmationTitle', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should display revoke title when flowType is revoke', () => {
-        const { getByText } = renderTitle({ flowType: 'revoke', isFailed: false, isPending: true });
+    it('should display revoke title when flowType is revoke', async () => {
+        const { getByText } = await renderTitle({
+            flowType: 'revoke',
+            isFailed: false,
+            isPending: true,
+        });
 
         expect(
             getByText(getTranslation('moduleTrading.tradingConfirmationScreen.revokeTitle')),
         ).toBeOnTheScreen();
     });
 
-    it('should display revoke title when flowType is revoke-and-approve', () => {
-        const { getByText } = renderTitle({
+    it('should display revoke title when flowType is revoke-and-approve', async () => {
+        const { getByText } = await renderTitle({
             flowType: 'revoke-and-approve',
             isFailed: false,
             isPending: true,
@@ -42,8 +46,8 @@ describe('ExchangeConfirmationTitle', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should display subtitle', () => {
-        const { getByText } = renderTitle({
+    it('should display subtitle', async () => {
+        const { getByText } = await renderTitle({
             flowType: 'approve',
             isFailed: false,
             isPending: true,
@@ -54,8 +58,8 @@ describe('ExchangeConfirmationTitle', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should display pending badge when isPending', () => {
-        const { getByText } = renderTitle({
+    it('should display pending badge when isPending', async () => {
+        const { getByText } = await renderTitle({
             flowType: 'approve',
             isFailed: false,
             isPending: true,
@@ -66,8 +70,8 @@ describe('ExchangeConfirmationTitle', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should not display pending badge when isPending is false', () => {
-        const { queryByText } = renderTitle({
+    it('should not display pending badge when isPending is false', async () => {
+        const { queryByText } = await renderTitle({
             flowType: 'approve',
             isFailed: false,
             isPending: false,
@@ -78,8 +82,8 @@ describe('ExchangeConfirmationTitle', () => {
         ).not.toBeOnTheScreen();
     });
 
-    it('should display error alert when isFailed', () => {
-        const { getByText } = renderTitle({
+    it('should display error alert when isFailed', async () => {
+        const { getByText } = await renderTitle({
             flowType: 'approve',
             isFailed: true,
             isPending: false,
@@ -90,8 +94,8 @@ describe('ExchangeConfirmationTitle', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should not display pending alert when isFailed is false', () => {
-        const { queryByText } = renderTitle({
+    it('should not display pending alert when isFailed is false', async () => {
+        const { queryByText } = await renderTitle({
             flowType: 'approve',
             isFailed: false,
             isPending: false,

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExploreInBlockchainButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExploreInBlockchainButton.test.tsx
@@ -9,15 +9,15 @@ describe('ExploreInBlockchainButton', () => {
             getTranslation('moduleTrading.tradingConfirmationScreen.exploreInBlockchain'),
         );
 
-    it('renders the button with correct label', () => {
-        renderWithBasicProvider(<ExploreInBlockchainButton onPress={jest.fn()} />);
+    it('renders the button with correct label', async () => {
+        await renderWithBasicProvider(<ExploreInBlockchainButton onPress={jest.fn()} />);
 
         expect(getButtonByText()).toBeOnTheScreen();
     });
 
     it('calls onPress when pressed', async () => {
         const onPress = jest.fn();
-        renderWithBasicProvider(<ExploreInBlockchainButton onPress={onPress} />);
+        await renderWithBasicProvider(<ExploreInBlockchainButton onPress={onPress} />);
 
         await userEvent.press(getButtonByText());
 

--- a/suite-native/module-trading/src/components/exchange/ExchangeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeAlert.test.tsx
@@ -20,38 +20,41 @@ describe('ExchangeAlert', () => {
         wallet: getWalletState({ tradeType: 'exchange' }),
     };
 
-    const renderFormHook = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), {
+    const renderFormHook = async () =>
+        await renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
         });
 
-    const renderTradingAlert = () =>
-        renderWithBasicProvider(<ExchangeAlert />, {
+    const renderTradingAlert = async () =>
+        await renderWithBasicProvider(<ExchangeAlert />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderFormHook();
+    beforeEach(async () => {
+        const { result } = await renderFormHook();
         form = result.current;
     });
 
-    it('should render alert based on form generalAlert value', () => {
-        act(() => {
+    it('should render alert based on form generalAlert value', async () => {
+        await act(() => {
             form.setValue('generalAlert', 'TEST');
         });
 
-        const { getByText } = renderTradingAlert();
+        const { getByText } = await renderTradingAlert();
 
         expect(getByText('TEST')).toBeTruthy();
     });
 
-    it.each([undefined, ''])('should render nothing when generalAlert is %s', generalAlertValue => {
-        act(() => {
-            form.setValue('generalAlert', generalAlertValue);
-        });
+    it.each([undefined, ''])(
+        'should render nothing when generalAlert is %s',
+        async generalAlertValue => {
+            await act(() => {
+                form.setValue('generalAlert', generalAlertValue);
+            });
 
-        const { toJSON } = renderTradingAlert();
+            const { toJSON } = await renderTradingAlert();
 
-        expect(toJSON()).toBeNull();
-    });
+            expect(toJSON()).toBeNull();
+        },
+    );
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangeCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeCard.test.tsx
@@ -38,30 +38,30 @@ describe('ExchangeCard', () => {
         },
     });
 
-    const renderForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), {
+    const renderForm = async () =>
+        await renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
         });
 
-    const renderExchangeCard = () =>
-        renderWithStoreProvider(<ExchangeCard isAmountInputActive={false} />, {
+    const renderExchangeCard = async () =>
+        await renderWithStoreProvider(<ExchangeCard isAmountInputActive={false} />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderForm();
+    beforeEach(async () => {
+        const { result } = await renderForm();
         form = result.current;
     });
 
-    it('should render send and receive sections with selected assets', () => {
-        act(() => {
+    it('should render send and receive sections with selected assets', async () => {
+        await act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendCryptoAmount', '100');
             form.setValue('receiveAsset', ethOnBaseAsset);
         });
 
-        const { getByTestId } = renderExchangeCard();
+        const { getByTestId } = await renderExchangeCard();
         const sendSection = getByTestId('@trading/exchangeCard/sendSection');
         const receiveSection = getByTestId('@trading/exchangeCard/receiveSection');
 
@@ -103,7 +103,7 @@ describe('ExchangeCard', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should convert receiveCryptoAmount to the base unit before passing it to CryptoToFiatValueBadge when bitcoin amount unit is sats', () => {
+    it('should convert receiveCryptoAmount to the base unit before passing it to CryptoToFiatValueBadge when bitcoin amount unit is sats', async () => {
         const satsPreloadedState = createTradingPreloadedState({
             tradeType: 'exchange',
             overrides: {
@@ -120,14 +120,14 @@ describe('ExchangeCard', () => {
             },
         });
 
-        act(() => {
+        await act(() => {
             form.setValue('receiveAsset', btcAsset);
         });
-        act(() => {
+        await act(() => {
             form.setValue('receiveCryptoAmount', '1234567123456');
         });
 
-        const { getByText, queryByText } = renderWithStoreProvider(
+        const { getByText, queryByText } = await renderWithStoreProvider(
             <ExchangeCard isAmountInputActive={false} />,
             {
                 preloadedState: satsPreloadedState,

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.test.tsx
@@ -43,8 +43,8 @@ describe('ExchangeConfirmation', () => {
         isDex: false,
     };
 
-    const setQuote = (quote: ExchangeTrade | undefined) => {
-        act(() => {
+    const setQuote = async (quote: ExchangeTrade | undefined) => {
+        await act(() => {
             exchangeForm.setValue('quote', quote);
         });
     };
@@ -65,8 +65,8 @@ describe('ExchangeConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-    const renderConfirmation = () =>
-        renderWithTradingProvider(<ExchangeConfirmation />, {
+    const renderConfirmation = async () =>
+        await renderWithTradingProvider(<ExchangeConfirmation />, {
             tradeType: 'exchange',
             overrides: baseOverrides,
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
@@ -77,15 +77,15 @@ describe('ExchangeConfirmation', () => {
     const queryRevokeButton = () =>
         screen.queryByText(getTranslation('moduleTrading.tradingScreen.buttons.revoke'));
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
 
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: baseOverrides,
         });
         exchangeForm = result.current;
-        setQuote(defaultQuote);
+        await setQuote(defaultQuote);
 
         mockUseTradingStellarActivateToken.mockReturnValue({
             isReceivingInactiveStellarToken: false,
@@ -93,78 +93,78 @@ describe('ExchangeConfirmation', () => {
         });
     });
 
-    it('should render "Continue" button when canProceed is true', () => {
+    it('should render "Continue" button when canProceed is true', async () => {
         mockSelectQuote({});
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryContinueButton()).toBeOnTheScreen();
     });
 
-    it('should not render "Continue" button when canProceed is false', () => {
+    it('should not render "Continue" button when canProceed is false', async () => {
         mockSelectQuote({ canProceed: false });
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryContinueButton()).not.toBeOnTheScreen();
     });
 
-    it('should render "Continue" button when canProceed is false but is isLoading', () => {
+    it('should render "Continue" button when canProceed is false but is isLoading', async () => {
         mockSelectQuote({ canProceed: false, isLoading: true });
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryContinueButton()).toBeOnTheScreen();
         expect(queryContinueButton()).toBeDisabled();
     });
 
-    it('should render "Continue" button when canProceed is false but is isDexQuoteApprovalPrefetchLoadingForCandidateQuote', () => {
+    it('should render "Continue" button when canProceed is false but is isDexQuoteApprovalPrefetchLoadingForCandidateQuote', async () => {
         mockSelectQuote({
             canProceed: false,
             isDexQuoteApprovalPrefetchLoadingForCandidateQuote: true,
         });
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryContinueButton()).toBeOnTheScreen();
         expect(queryContinueButton()).toBeDisabled();
     });
 
-    it('should not render "Revoke" button when approval is not needed', () => {
+    it('should not render "Revoke" button when approval is not needed', async () => {
         mockSelectQuote({});
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryRevokeButton()).not.toBeOnTheScreen();
     });
 
-    it('should not render "Revoke" button when approval is needed', () => {
-        setQuote({
+    it('should not render "Revoke" button when approval is needed', async () => {
+        await setQuote({
             ...defaultQuote,
             isDex: true,
         });
         mockSelectQuote({});
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryRevokeButton()).not.toBeOnTheScreen();
     });
 
-    it('should render "Revoke" button when approval status is approved', () => {
-        setQuote({
+    it('should render "Revoke" button when approval status is approved', async () => {
+        await setQuote({
             ...defaultQuote,
             isDex: true,
             preapprovedStringAmount: '100',
         });
         mockSelectQuote({});
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryRevokeButton()).toBeOnTheScreen();
     });
 
-    it('should render "Revoke" button when approval status is needs_increase', () => {
-        setQuote({
+    it('should render "Revoke" button when approval status is needs_increase', async () => {
+        await setQuote({
             ...defaultQuote,
             isDex: true,
             preapprovedStringAmount: '100',
@@ -173,22 +173,22 @@ describe('ExchangeConfirmation', () => {
 
         mockSelectQuote({});
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryRevokeButton()).toBeOnTheScreen();
     });
 
-    it('should not render "Revoke" button when approval status is null', () => {
-        setQuote(undefined);
+    it('should not render "Revoke" button when approval status is null', async () => {
+        await setQuote(undefined);
         mockSelectQuote({});
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryRevokeButton()).not.toBeOnTheScreen();
     });
 
-    it('should render "Revoke" button when approval status is needs_revoke', () => {
-        setQuote({
+    it('should render "Revoke" button when approval status is needs_revoke', async () => {
+        await setQuote({
             ...defaultQuote,
             isDex: true,
             preapprovedStringAmount: '100',
@@ -198,12 +198,12 @@ describe('ExchangeConfirmation', () => {
 
         mockSelectQuote({});
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryRevokeButton()).toBeOnTheScreen();
     });
 
-    it('should render activate button when trading inactive Stellar token', () => {
+    it('should render activate button when trading inactive Stellar token', async () => {
         mockSelectQuote({});
 
         mockUseTradingStellarActivateToken.mockReturnValue({
@@ -211,14 +211,14 @@ describe('ExchangeConfirmation', () => {
             activateButtonElement: <Button>Activate</Button>,
         });
 
-        const { queryByText } = renderConfirmation();
+        const { queryByText } = await renderConfirmation();
         expect(queryByText('Activate')).toBeTruthy();
         expect(
             queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
         ).toBeNull();
     });
 
-    it('should not render activate button when not trading inactive Stellar token', () => {
+    it('should not render activate button when not trading inactive Stellar token', async () => {
         mockSelectQuote({});
 
         mockUseTradingStellarActivateToken.mockReturnValue({
@@ -226,15 +226,15 @@ describe('ExchangeConfirmation', () => {
             activateButtonElement: <Button>Activate</Button>,
         });
 
-        const { queryByText } = renderConfirmation();
+        const { queryByText } = await renderConfirmation();
         expect(queryByText('Activate')).toBeNull();
         expect(
             queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
         ).toBeTruthy();
     });
 
-    it('should not render Revoke button, when canProceed is false', () => {
-        setQuote({
+    it('should not render Revoke button, when canProceed is false', async () => {
+        await setQuote({
             ...defaultQuote,
             isDex: true,
             preapprovedStringAmount: '100',
@@ -244,7 +244,7 @@ describe('ExchangeConfirmation', () => {
 
         mockSelectQuote({ canProceed: false });
 
-        renderConfirmation();
+        await renderConfirmation();
 
         expect(queryRevokeButton()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/ExchangeForm.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeForm.test.tsx
@@ -39,13 +39,13 @@ describe('ExchangeForm', () => {
         },
     });
 
-    const renderForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), {
+    const renderForm = async () =>
+        await renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState: defaultPreloadedState,
         });
 
-    const renderExchangeForm = () =>
-        renderWithStoreProvider(<ExchangeForm />, {
+    const renderExchangeForm = async () =>
+        await renderWithStoreProvider(<ExchangeForm />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
             preloadedState: {
                 ...defaultPreloadedState,
@@ -56,17 +56,17 @@ describe('ExchangeForm', () => {
             },
         });
 
-    beforeEach(() => {
-        const { result } = renderForm();
+    beforeEach(async () => {
+        const { result } = await renderForm();
         form = result.current;
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render form', () => {
-        const { getByText, queryByText } = renderExchangeForm();
+    it('should render form', async () => {
+        const { getByText, queryByText } = await renderExchangeForm();
 
         expect(
             getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
@@ -78,14 +78,14 @@ describe('ExchangeForm', () => {
     });
 
     describe('with receive asset selected', () => {
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 form.setValue('receiveAsset', btcAsset);
             });
         });
 
-        it('should display Receive account picker', () => {
-            const { getByText, queryByText } = renderExchangeForm();
+        it('should display Receive account picker', async () => {
+            const { getByText, queryByText } = await renderExchangeForm();
 
             expect(
                 getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
@@ -96,11 +96,11 @@ describe('ExchangeForm', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should display Done button when any input is active', () => {
-            act(() => {
+        it('should display Done button when any input is active', async () => {
+            await act(() => {
                 form.setValue('focusedValue', 'sendCryptoAmount');
             });
-            const { getByText, queryByText } = renderExchangeForm();
+            const { getByText, queryByText } = await renderExchangeForm();
 
             expect(
                 getByText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
@@ -112,14 +112,14 @@ describe('ExchangeForm', () => {
         });
 
         describe('with quote selected', () => {
-            beforeEach(() => {
-                act(() => {
+            beforeEach(async () => {
+                await act(() => {
                     form.setValue('quote', mercuryoFixedWorstQuote);
                 });
             });
 
-            it('should display provider', () => {
-                const { getByText } = renderExchangeForm();
+            it('should display provider', async () => {
+                const { getByText } = await renderExchangeForm();
 
                 expect(
                     getByText(getTranslation('moduleTrading.tradingScreen.provider')),

--- a/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.test.tsx
@@ -47,7 +47,8 @@ jest.mock('./ExchangeUsdcPresetButton', () => ({
 }));
 
 describe('ExchangeFormQuoteDebugView', () => {
-    const renderDebugView = () => renderWithBasicProvider(<ExchangeFormQuoteDebugView />);
+    const renderDebugView = async () =>
+        await renderWithBasicProvider(<ExchangeFormQuoteDebugView />);
 
     beforeEach(() => {
         mockQuote = undefined;
@@ -55,7 +56,7 @@ describe('ExchangeFormQuoteDebugView', () => {
         mockDebugMode = false;
     });
 
-    it('should render nothing when debug mode is disabled', () => {
+    it('should render nothing when debug mode is disabled', async () => {
         mockDebugMode = false;
         mockQuote = {
             send: 'ethereum' as CryptoId,
@@ -64,32 +65,32 @@ describe('ExchangeFormQuoteDebugView', () => {
             isDex: false,
         };
 
-        const { toJSON } = renderDebugView();
+        const { toJSON } = await renderDebugView();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render approval status "none" when no quote is selected', () => {
+    it('should render approval status "none" when no quote is selected', async () => {
         mockDebugMode = true;
         mockQuote = undefined;
 
-        renderDebugView();
+        await renderDebugView();
 
         expect(screen.getByText('Approval status')).toBeOnTheScreen();
         expect(screen.getByText('none')).toBeOnTheScreen();
     });
 
-    it('should render "not defined" for pre-approved amount when no quote is selected', () => {
+    it('should render "not defined" for pre-approved amount when no quote is selected', async () => {
         mockDebugMode = true;
         mockQuote = undefined;
 
-        renderDebugView();
+        await renderDebugView();
 
         expect(screen.getByText('Pre-approved')).toBeOnTheScreen();
         expect(screen.getByText('not defined')).toBeOnTheScreen();
     });
 
-    it('should render approval status "not_needed" for a non-DEX quote', () => {
+    it('should render approval status "not_needed" for a non-DEX quote', async () => {
         mockDebugMode = true;
         mockQuote = {
             send: USDC_CRYPTO_ID,
@@ -98,12 +99,12 @@ describe('ExchangeFormQuoteDebugView', () => {
             isDex: false,
         };
 
-        renderDebugView();
+        await renderDebugView();
 
         expect(screen.getByText('not_needed')).toBeOnTheScreen();
     });
 
-    it('should render approval status "needs_approval" for a DEX quote without pre-approval', () => {
+    it('should render approval status "needs_approval" for a DEX quote without pre-approval', async () => {
         mockDebugMode = true;
         mockQuote = {
             send: USDC_CRYPTO_ID,
@@ -112,12 +113,12 @@ describe('ExchangeFormQuoteDebugView', () => {
             isDex: true,
         };
 
-        renderDebugView();
+        await renderDebugView();
 
         expect(screen.getByText('needs_approval')).toBeOnTheScreen();
     });
 
-    it('should display "unlimited" for pre-approved amount when preapprovedStringAmount is max uint256', () => {
+    it('should display "unlimited" for pre-approved amount when preapprovedStringAmount is max uint256', async () => {
         mockDebugMode = true;
         mockSendAccount = {
             tokens: [
@@ -135,13 +136,13 @@ describe('ExchangeFormQuoteDebugView', () => {
             preapprovedStringAmount: UINT256_MAX,
         };
 
-        renderDebugView();
+        await renderDebugView();
 
         expect(screen.getByText('Pre-approved')).toBeOnTheScreen();
         expect(screen.getByText('unlimited')).toBeOnTheScreen();
     });
 
-    it('should display the specific amount for pre-approved amount when preapprovedStringAmount is not max uint256', () => {
+    it('should display the specific amount for pre-approved amount when preapprovedStringAmount is not max uint256', async () => {
         mockDebugMode = true;
         const specificAmount = '1000000000000000000';
         mockQuote = {
@@ -152,7 +153,7 @@ describe('ExchangeFormQuoteDebugView', () => {
             preapprovedStringAmount: specificAmount,
         };
 
-        renderDebugView();
+        await renderDebugView();
 
         expect(screen.getByText('Pre-approved')).toBeOnTheScreen();
         expect(screen.getByText(specificAmount)).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/exchange/ExchangePickersCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePickersCard.test.tsx
@@ -37,10 +37,10 @@ describe('ExchangePickersCard', () => {
         featureFlags: createTradingFeatureFlags(),
     };
 
-    const renderExchangePickersCard = (
+    const renderExchangePickersCard = async (
         extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) => {
-        const result = renderWithTradingProvider(<ExchangePickersCard />, {
+        const result = await renderWithTradingProvider(<ExchangePickersCard />, {
             services,
             tradeType: 'exchange',
             overrides: { ...baseOverrides, ...extraOverrides },
@@ -52,10 +52,10 @@ describe('ExchangePickersCard', () => {
         return result;
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
 
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             services,
             tradeType: 'exchange',
             overrides: baseOverrides,
@@ -63,42 +63,42 @@ describe('ExchangePickersCard', () => {
         exchangeForm = result.current;
     });
 
-    afterEach(() => {
-        unmount?.();
+    afterEach(async () => {
+        await unmount?.();
     });
 
-    it('should render nothing when no picker can be displayed', () => {
-        const { toJSON } = renderExchangePickersCard();
+    it('should render nothing when no picker can be displayed', async () => {
+        const { toJSON } = await renderExchangePickersCard();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render receive account picker when receive asset is selected', () => {
-        act(() => {
+    it('should render receive account picker when receive asset is selected', async () => {
+        await act(() => {
             exchangeForm.setValue('receiveAsset', btcAsset);
         });
 
-        const { getByText } = renderExchangePickersCard();
+        const { getByText } = await renderExchangePickersCard();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
         ).toBeOnTheScreen();
     });
 
-    it('should render provider picker when quotes are loading', () => {
-        const { getByText } = renderExchangePickersCard({
+    it('should render provider picker when quotes are loading', async () => {
+        const { getByText } = await renderExchangePickersCard({
             wallet: { trading: { exchange: { isLoading: true } } },
         });
 
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
     });
 
-    it('should render provider picker when quote is selected', () => {
-        act(() => {
+    it('should render provider picker when quote is selected', async () => {
+        await act(() => {
             exchangeForm.setValue('quote', mercuryoFixedWorstQuote);
         });
 
-        const { getByText } = renderExchangePickersCard();
+        const { getByText } = await renderExchangePickersCard();
 
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeEIP712Info.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeEIP712Info.test.tsx
@@ -7,33 +7,33 @@ import { ExchangeEIP712Info, type ExchangeEIP712InfoProps } from './ExchangeEIP7
 import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
 
 describe('ExchangeEIP712Info', () => {
-    const renderExchangeEIP712Info = (
+    const renderExchangeEIP712Info = async (
         exchange: string,
         children?: ExchangeEIP712InfoProps['children'],
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ExchangeEIP712Info exchange={exchange}>{children}</ExchangeEIP712Info>,
             {
                 tradeType: 'exchange',
             },
         );
 
-    it('should render the provider name for Fusion+', () => {
-        const { getByText } = renderExchangeEIP712Info('1inchfusionplus');
+    it('should render the provider name for Fusion+', async () => {
+        const { getByText } = await renderExchangeEIP712Info('1inchfusionplus');
 
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
         expect(getByText(exchangeOneInchFusionPlus.companyName)).toBeOnTheScreen();
     });
 
-    it('should render the provider name for Fusion', () => {
-        const { getByText } = renderExchangeEIP712Info('1inchfusion');
+    it('should render the provider name for Fusion', async () => {
+        const { getByText } = await renderExchangeEIP712Info('1inchfusion');
 
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
         expect(getByText(exchangeOneInchFusion.companyName)).toBeOnTheScreen();
     });
 
-    it('should render all three bullet points', () => {
-        const { getByText } = renderExchangeEIP712Info('1inchfusionplus');
+    it('should render all three bullet points', async () => {
+        const { getByText } = await renderExchangeEIP712Info('1inchfusionplus');
 
         expect(
             getByText(
@@ -52,8 +52,8 @@ describe('ExchangeEIP712Info', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render children', () => {
-        const { getByText } = renderExchangeEIP712Info(
+    it('should render children', async () => {
+        const { getByText } = await renderExchangeEIP712Info(
             '1inchfusionplus',
             <Text>child content</Text>,
         );

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.test.tsx
@@ -9,11 +9,11 @@ import {
 import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
 
 describe('ExchangeFromAccountTradePreviewCard', () => {
-    const renderExchangeFromAccountTradePreviewCard = (
+    const renderExchangeFromAccountTradePreviewCard = async (
         props: Partial<ExchangeFromAccountTradePreviewCardProps> = {},
         tradingAccountKey = eth1NormalAccount.key,
     ) =>
-        renderWithTradingProvider(<ExchangeFromAccountTradePreviewCard {...props} />, {
+        await renderWithTradingProvider(<ExchangeFromAccountTradePreviewCard {...props} />, {
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -32,14 +32,14 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
             },
         });
 
-    it('should render nothing when there is no quote', () => {
-        const { toJSON } = renderExchangeFromAccountTradePreviewCard({});
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderExchangeFromAccountTradePreviewCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', () => {
-        const { toJSON } = renderExchangeFromAccountTradePreviewCard(
+    it('should render nothing when account is not found', async () => {
+        const { toJSON } = await renderExchangeFromAccountTradePreviewCard(
             { quote: mercuryoFixedWorstQuote },
             mockAccountKey({ descriptor: 'unknownAccountKey' }),
         );
@@ -47,8 +47,8 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render TradeSideCard otherwise', () => {
-        const { getByText } = renderExchangeFromAccountTradePreviewCard({
+    it('should render TradeSideCard otherwise', async () => {
+        const { getByText } = await renderExchangeFromAccountTradePreviewCard({
             quote: mercuryoFixedWorstQuote,
         });
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeInfo.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeInfo.test.tsx
@@ -15,19 +15,19 @@ jest.mock('@suite-native/transaction-management', () => ({
 }));
 
 describe('ExchangeInfo', () => {
-    const renderExchangeInfo = (
+    const renderExchangeInfo = async (
         props: Partial<ExchangeInfoProps> = {},
         tradingAccountKey: AccountKey = btc1NormalAccount.key,
     ) =>
-        renderWithTradingProvider(<ExchangeInfo isTxnError={false} {...props} />, {
+        await renderWithTradingProvider(<ExchangeInfo isTxnError={false} {...props} />, {
             tradeType: 'exchange',
             overrides: {
                 wallet: { trading: { exchange: { tradingAccountKey } } },
             },
         });
 
-    it('should render nothing when isTxnError', () => {
-        const { toJSON } = renderExchangeInfo({
+    it('should render nothing when isTxnError', async () => {
+        const { toJSON } = await renderExchangeInfo({
             quote: mercuryoFixedWorstQuote,
             isTxnError: true,
         });
@@ -35,14 +35,14 @@ describe('ExchangeInfo', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when there is no quote', () => {
-        const { toJSON } = renderExchangeInfo({});
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderExchangeInfo({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', () => {
-        const { toJSON } = renderExchangeInfo(
+    it('should render nothing when account is not found', async () => {
+        const { toJSON } = await renderExchangeInfo(
             { quote: mercuryoFixedWorstQuote },
             mockAccountKey({ descriptor: 'unknownAccountKey' }),
         );
@@ -50,15 +50,15 @@ describe('ExchangeInfo', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render TradeInfo otherwise', () => {
-        const { getByText } = renderExchangeInfo({ quote: mercuryoFixedWorstQuote });
+    it('should render TradeInfo otherwise', async () => {
+        const { getByText } = await renderExchangeInfo({ quote: mercuryoFixedWorstQuote });
 
         // 1st line of trade info is provider
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
     });
 
-    it('should render children inside TradeInfo', () => {
-        const { getByText } = renderExchangeInfo({
+    it('should render children inside TradeInfo', async () => {
+        const { getByText } = await renderExchangeInfo({
             quote: mercuryoFixedWorstQuote,
             children: <Text>child content</Text>,
         });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.test.tsx
@@ -47,11 +47,11 @@ describe('ExchangePreviewContinueButton', () => {
         },
     };
 
-    const renderExchangePreviewContinueButton = (
+    const renderExchangePreviewContinueButton = async (
         props: Partial<ExchangePreviewContinueButtonProps> = {},
         extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ExchangePreviewContinueButton
                 isDisabled={false}
                 onSignTransactionNavigation={jest.fn()}
@@ -67,8 +67,8 @@ describe('ExchangePreviewContinueButton', () => {
         jest.restoreAllMocks();
     });
 
-    it('should render disabled button when precomposed transaction is not in final state', () => {
-        const { getByText } = renderExchangePreviewContinueButton(
+    it('should render disabled button when precomposed transaction is not in final state', async () => {
+        const { getByText } = await renderExchangePreviewContinueButton(
             {},
             { wallet: { send: { precomposedTx: { type: 'composing' } as any } } },
         );
@@ -76,20 +76,20 @@ describe('ExchangePreviewContinueButton', () => {
         expect(getByText(getTranslation('generic.buttons.continue'))).toBeDisabled();
     });
 
-    it('should render continue button', () => {
-        const { getByText } = renderExchangePreviewContinueButton();
+    it('should render continue button', async () => {
+        const { getByText } = await renderExchangePreviewContinueButton();
 
         expect(getByText(getTranslation('generic.buttons.continue'))).toBeOnTheScreen();
     });
 
-    it('should render disabled button when isDisabled prop is specified', () => {
-        const { getByText } = renderExchangePreviewContinueButton({ isDisabled: true });
+    it('should render disabled button when isDisabled prop is specified', async () => {
+        const { getByText } = await renderExchangePreviewContinueButton({ isDisabled: true });
 
         expect(getByText(getTranslation('generic.buttons.continue'))).toBeDisabled();
     });
 
-    it('should keep continue button enabled when dex quote approval prefetch is loading', () => {
-        const { getByTestId, queryByTestId } = renderExchangePreviewContinueButton(
+    it('should keep continue button enabled when dex quote approval prefetch is loading', async () => {
+        const { getByTestId, queryByTestId } = await renderExchangePreviewContinueButton(
             {},
             {
                 wallet: {
@@ -106,8 +106,8 @@ describe('ExchangePreviewContinueButton', () => {
         expect(queryByTestId('@trading/exchange-preview/continue-button/loading')).toBeNull();
     });
 
-    it('should render nothing when quote is finalized', () => {
-        const { toJSON } = renderExchangePreviewContinueButton(
+    it('should render nothing when quote is finalized', async () => {
+        const { toJSON } = await renderExchangePreviewContinueButton(
             {},
             {
                 wallet: {
@@ -126,7 +126,7 @@ describe('ExchangePreviewContinueButton', () => {
     it('should fire console.warn and do not navigate when quote is not specified', async () => {
         const mockOnSignTransactionNavigation = jest.fn();
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const { getByText } = renderExchangePreviewContinueButton(
+        const { getByText } = await renderExchangePreviewContinueButton(
             { onSignTransactionNavigation: mockOnSignTransactionNavigation },
             {
                 wallet: {
@@ -150,7 +150,7 @@ describe('ExchangePreviewContinueButton', () => {
     it('should fire console.warn and do not navigate when fromAccount is not found', async () => {
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const mockOnSignTransactionNavigation = jest.fn();
-        const { getByText } = renderExchangePreviewContinueButton(
+        const { getByText } = await renderExchangePreviewContinueButton(
             { onSignTransactionNavigation: mockOnSignTransactionNavigation },
             {
                 wallet: {
@@ -176,7 +176,7 @@ describe('ExchangePreviewContinueButton', () => {
     it('should navigate to TradingExchangeOutputsReview on continue press', async () => {
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const mockOnSignTransactionNavigation = jest.fn();
-        const { getByText } = renderExchangePreviewContinueButton({
+        const { getByText } = await renderExchangePreviewContinueButton({
             onSignTransactionNavigation: mockOnSignTransactionNavigation,
         });
 
@@ -194,7 +194,7 @@ describe('ExchangePreviewContinueButton', () => {
 
     it('should navigate with flowType sign-data when formStep is SIGN_DATA', async () => {
         const mockOnSignTransactionNavigation = jest.fn();
-        const { getByText } = renderExchangePreviewContinueButton(
+        const { getByText } = await renderExchangePreviewContinueButton(
             { onSignTransactionNavigation: mockOnSignTransactionNavigation },
             {
                 wallet: {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewFooter.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewFooter.test.tsx
@@ -69,10 +69,10 @@ describe('ExchangePreviewFooter', () => {
         },
     };
 
-    const renderExchangePreviewFooter = (
+    const renderExchangePreviewFooter = async (
         extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ExchangePreviewFooter
                 isContinueDisabled={false}
                 onSignTransactionNavigation={jest.fn()}
@@ -88,17 +88,17 @@ describe('ExchangePreviewFooter', () => {
         setIssue(null);
     });
 
-    it('renders the continue button without an issue', () => {
-        const { getByTestId, queryByTestId } = renderExchangePreviewFooter();
+    it('renders the continue button without an issue', async () => {
+        const { getByTestId, queryByTestId } = await renderExchangePreviewFooter();
 
         expect(getByTestId('@trading/exchange-preview/continue-button')).toBeOnTheScreen();
         expect(queryByTestId('@trading/exchange-preview/back-to-form-button')).toBeNull();
     });
 
-    it('replaces the continue button with back to trade form on an issue', () => {
+    it('replaces the continue button with back to trade form on an issue', async () => {
         setIssue(priceImpactIssue);
 
-        const { getByTestId, queryByTestId } = renderExchangePreviewFooter();
+        const { getByTestId, queryByTestId } = await renderExchangePreviewFooter();
 
         expect(getByTestId('@trading/exchange-preview/back-to-form-button')).toBeOnTheScreen();
         expect(queryByTestId('@trading/exchange-preview/continue-button')).toBeNull();
@@ -107,7 +107,7 @@ describe('ExchangePreviewFooter', () => {
     it('pops back to the trade form on back press', async () => {
         setIssue(priceImpactIssue);
 
-        const { getByText } = renderExchangePreviewFooter();
+        const { getByText } = await renderExchangePreviewFooter();
 
         await userEvent.press(
             getByText(getTranslation('moduleTrading.transactionSimulation.backToTradeForm')),
@@ -117,10 +117,10 @@ describe('ExchangePreviewFooter', () => {
         expect(mockNavigate).not.toHaveBeenCalled();
     });
 
-    it('renders nothing when the trade is finalized despite an issue', () => {
+    it('renders nothing when the trade is finalized despite an issue', async () => {
         setIssue(priceImpactIssue);
 
-        const { toJSON } = renderExchangePreviewFooter({
+        const { toJSON } = await renderExchangePreviewFooter({
             wallet: {
                 trading: {
                     exchange: {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewIssueBanner.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewIssueBanner.test.tsx
@@ -75,8 +75,10 @@ describe('ExchangePreviewIssueBanner', () => {
         },
     };
 
-    const renderExchangePreviewIssueBanner = ({ onSignTransactionNavigation = jest.fn() } = {}) =>
-        renderWithTradingProvider(
+    const renderExchangePreviewIssueBanner = async ({
+        onSignTransactionNavigation = jest.fn(),
+    } = {}) =>
+        await renderWithTradingProvider(
             <ExchangePreviewIssueBanner
                 onSignTransactionNavigation={onSignTransactionNavigation}
             />,
@@ -88,16 +90,16 @@ describe('ExchangePreviewIssueBanner', () => {
         setIssue(null);
     });
 
-    it('renders nothing without an issue', () => {
-        const { toJSON } = renderExchangePreviewIssueBanner();
+    it('renders nothing without an issue', async () => {
+        const { toJSON } = await renderExchangePreviewIssueBanner();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('renders the price impact issue with a formatted percent', () => {
+    it('renders the price impact issue with a formatted percent', async () => {
         setIssue(priceImpactIssue);
 
-        const { getByText } = renderExchangePreviewIssueBanner();
+        const { getByText } = await renderExchangePreviewIssueBanner();
 
         expect(
             getByText(
@@ -115,10 +117,10 @@ describe('ExchangePreviewIssueBanner', () => {
         ).toBeOnTheScreen();
     });
 
-    it('renders the high-risk issue with its title and description', () => {
+    it('renders the high-risk issue with its title and description', async () => {
         setIssue(highRiskIssue);
 
-        const { getByText } = renderExchangePreviewIssueBanner();
+        const { getByText } = await renderExchangePreviewIssueBanner();
 
         expect(
             getByText(getTranslation('moduleTrading.transactionSimulation.issues.highRisk.title')),
@@ -130,7 +132,7 @@ describe('ExchangePreviewIssueBanner', () => {
         ).toBeOnTheScreen();
     });
 
-    it('renders the combined issue as bullets under the high-risk title', () => {
+    it('renders the combined issue as bullets under the high-risk title', async () => {
         setIssue({
             type: 'high-risk-with-price-impact',
             severity: 'critical',
@@ -138,7 +140,7 @@ describe('ExchangePreviewIssueBanner', () => {
             deviation: 0.99,
         });
 
-        const { getByText } = renderExchangePreviewIssueBanner();
+        const { getByText } = await renderExchangePreviewIssueBanner();
 
         expect(
             getByText(getTranslation('moduleTrading.transactionSimulation.issues.highRisk.title')),
@@ -157,10 +159,10 @@ describe('ExchangePreviewIssueBanner', () => {
         ).toBeOnTheScreen();
     });
 
-    it('renders the issue without continue anyway when the simulation is disabled', () => {
+    it('renders the issue without continue anyway when the simulation is disabled', async () => {
         setIssue(priceImpactIssue, { isSimulationEnabled: false });
 
-        const { getByText, queryByText } = renderExchangePreviewIssueBanner();
+        const { getByText, queryByText } = await renderExchangePreviewIssueBanner();
 
         expect(
             getByText(
@@ -178,7 +180,7 @@ describe('ExchangePreviewIssueBanner', () => {
         const mockOnSignTransactionNavigation = jest.fn();
         setIssue(priceImpactIssue);
 
-        const { getByText } = renderExchangePreviewIssueBanner({
+        const { getByText } = await renderExchangePreviewIssueBanner({
             onSignTransactionNavigation: mockOnSignTransactionNavigation,
         });
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx
@@ -11,8 +11,8 @@ jest.mock('../../../hooks/exchange/useDexExchangeTxSimulation', () => ({
 
 const mockUseDexExchangeTxSimulation = jest.mocked(useDexExchangeTxSimulation);
 
-const renderExchangePreviewScreenHeader = () =>
-    renderWithTradingProvider(<ExchangePreviewScreenHeader />, { tradeType: 'exchange' });
+const renderExchangePreviewScreenHeader = async () =>
+    await renderWithTradingProvider(<ExchangePreviewScreenHeader />, { tradeType: 'exchange' });
 
 describe('ExchangePreviewScreenHeader', () => {
     beforeEach(() => {
@@ -25,8 +25,8 @@ describe('ExchangePreviewScreenHeader', () => {
         });
     });
 
-    it('renders only the exchange preview title when simulation is disabled', () => {
-        const { getByText, queryByText } = renderExchangePreviewScreenHeader();
+    it('renders only the exchange preview title when simulation is disabled', async () => {
+        const { getByText, queryByText } = await renderExchangePreviewScreenHeader();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.title')),
@@ -34,7 +34,7 @@ describe('ExchangePreviewScreenHeader', () => {
         expect(queryByText(getTranslation('moduleTrading.transactionSimulation.title'))).toBeNull();
     });
 
-    it('renders the loading status while the simulation is loading', () => {
+    it('renders the loading status while the simulation is loading', async () => {
         mockUseDexExchangeTxSimulation.mockReturnValue({
             isEnabled: true,
             isLoading: true,
@@ -42,14 +42,14 @@ describe('ExchangePreviewScreenHeader', () => {
             data: undefined,
         });
 
-        const { getByText } = renderExchangePreviewScreenHeader();
+        const { getByText } = await renderExchangePreviewScreenHeader();
 
         expect(
             getByText(getTranslation('moduleTrading.transactionSimulation.simulating')),
         ).toBeOnTheScreen();
     });
 
-    it('renders the simulation title after a successful simulation', () => {
+    it('renders the simulation title after a successful simulation', async () => {
         mockUseDexExchangeTxSimulation.mockReturnValue({
             isEnabled: true,
             isLoading: false,
@@ -57,14 +57,14 @@ describe('ExchangePreviewScreenHeader', () => {
             data: undefined,
         });
 
-        const { getByText } = renderExchangePreviewScreenHeader();
+        const { getByText } = await renderExchangePreviewScreenHeader();
 
         expect(
             getByText(getTranslation('moduleTrading.transactionSimulation.title')),
         ).toBeOnTheScreen();
     });
 
-    it('renders only the exchange preview title when simulation fails', () => {
+    it('renders only the exchange preview title when simulation fails', async () => {
         mockUseDexExchangeTxSimulation.mockReturnValue({
             isEnabled: true,
             isLoading: false,
@@ -72,7 +72,7 @@ describe('ExchangePreviewScreenHeader', () => {
             data: undefined,
         });
 
-        const { getByText, queryByText } = renderExchangePreviewScreenHeader();
+        const { getByText, queryByText } = await renderExchangePreviewScreenHeader();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.title')),
@@ -83,7 +83,7 @@ describe('ExchangePreviewScreenHeader', () => {
         ).toBeNull();
     });
 
-    it('renders only the exchange preview title for a cross-chain trade', () => {
+    it('renders only the exchange preview title for a cross-chain trade', async () => {
         mockUseDexExchangeTxSimulation.mockReturnValue({
             isEnabled: true,
             isLoading: false,
@@ -91,7 +91,7 @@ describe('ExchangePreviewScreenHeader', () => {
             data: undefined,
         });
 
-        const { getByText, queryByText } = renderWithTradingProvider(
+        const { getByText, queryByText } = await renderWithTradingProvider(
             <ExchangePreviewScreenHeader />,
             {
                 tradeType: 'exchange',

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.test.tsx
@@ -43,8 +43,8 @@ describe('ExchangePreviewView', () => {
         });
     });
 
-    const renderExchangePreviewView = (props: Partial<ExchangePreviewViewProps> = {}) =>
-        renderWithTradingProvider(
+    const renderExchangePreviewView = async (props: Partial<ExchangePreviewViewProps> = {}) =>
+        await renderWithTradingProvider(
             <ExchangePreviewView
                 quote={mercuryoFixedWorstQuote}
                 txnErrorString={null}
@@ -76,8 +76,8 @@ describe('ExchangePreviewView', () => {
             },
         );
 
-    it('should render all sections except alert', () => {
-        const { getByText } = renderExchangePreviewView({});
+    it('should render all sections except alert', async () => {
+        const { getByText } = await renderExchangePreviewView({});
 
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
@@ -87,8 +87,8 @@ describe('ExchangePreviewView', () => {
         expect(getByText('ERROR_MESSAGE')).toBeOnTheScreen();
     });
 
-    it('should render txnErrorString but no fee picker when isTxnError is true', () => {
-        const { getByText, queryByText } = renderExchangePreviewView({
+    it('should render txnErrorString but no fee picker when isTxnError is true', async () => {
+        const { getByText, queryByText } = await renderExchangePreviewView({
             txnErrorString: 'txnErrorString',
         });
 
@@ -100,8 +100,8 @@ describe('ExchangePreviewView', () => {
         ).toBeNull();
     });
 
-    it('should render EIP-712 info with provider name when quote has EIP-712 sign data', () => {
-        const { getByTestId } = renderExchangePreviewView({
+    it('should render EIP-712 info with provider name when quote has EIP-712 sign data', async () => {
+        const { getByTestId } = await renderExchangePreviewView({
             quote: oneInchFusionPlusWithEip712SignDataQuote,
         });
 
@@ -110,8 +110,8 @@ describe('ExchangePreviewView', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should not render transaction fee for quotes with EIP-712 sign data', () => {
-        const { queryByText } = renderExchangePreviewView({
+    it('should not render transaction fee for quotes with EIP-712 sign data', async () => {
+        const { queryByText } = await renderExchangePreviewView({
             quote: oneInchFusionPlusWithEip712SignDataQuote,
         });
 
@@ -120,24 +120,24 @@ describe('ExchangePreviewView', () => {
         ).toBeNull();
     });
 
-    it('should not render EIP-712 info when quote has no EIP-712 sign data', () => {
-        const { queryByTestId } = renderExchangePreviewView({
+    it('should not render EIP-712 info when quote has no EIP-712 sign data', async () => {
+        const { queryByTestId } = await renderExchangePreviewView({
             quote: oneInchFusionPlusWithoutEip712SignDataQuote,
         });
 
         expect(queryByTestId('@trading/exchange-preview/eip712-info')).toBeNull();
     });
 
-    it('should render KYC warning for provider with "KYC-required"', () => {
-        const { getByText } = renderExchangePreviewView({
+    it('should render KYC warning for provider with "KYC-required"', async () => {
+        const { getByText } = await renderExchangePreviewView({
             quote: cexdirectFloatingQuote,
         });
 
         expect(getByText(getTranslation('moduleTrading.kyc.kycRequired'))).toBeOnTheScreen();
     });
 
-    it('should not render KYC provider warning for providers with "noKYC"', () => {
-        const { queryByText } = renderExchangePreviewView({
+    it('should not render KYC provider warning for providers with "noKYC"', async () => {
+        const { queryByText } = await renderExchangePreviewView({
             quote: mercuryoFixedWorstQuote,
         });
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.test.tsx
@@ -9,11 +9,11 @@ import {
 import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
 
 describe('ExchangeToAccountTradePreviewCard', () => {
-    const renderExchangeToAccountTradePreviewCard = (
+    const renderExchangeToAccountTradePreviewCard = async (
         props: Partial<ExchangeToAccountTradePreviewCardProps> = {},
         receiveAccountKey = btc1NormalAccount.key,
     ) =>
-        renderWithTradingProvider(<ExchangeToAccountTradePreviewCard {...props} />, {
+        await renderWithTradingProvider(<ExchangeToAccountTradePreviewCard {...props} />, {
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -32,14 +32,14 @@ describe('ExchangeToAccountTradePreviewCard', () => {
             },
         });
 
-    it('should render nothing when there is no quote', () => {
-        const { toJSON } = renderExchangeToAccountTradePreviewCard({});
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderExchangeToAccountTradePreviewCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', () => {
-        const { toJSON } = renderExchangeToAccountTradePreviewCard(
+    it('should render nothing when account is not found', async () => {
+        const { toJSON } = await renderExchangeToAccountTradePreviewCard(
             { quote: mercuryoFixedWorstQuote },
             mockAccountKey({ descriptor: 'unknownAccountKey' }),
         );
@@ -47,8 +47,8 @@ describe('ExchangeToAccountTradePreviewCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render TradeSideCard otherwise', () => {
-        const { getByText } = renderExchangeToAccountTradePreviewCard({
+    it('should render TradeSideCard otherwise', async () => {
+        const { getByText } = await renderExchangeToAccountTradePreviewCard({
             quote: mercuryoFixedWorstQuote,
         });
 

--- a/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.test.tsx
@@ -9,8 +9,8 @@ import { type TradingTestPreloadedState } from '../../test-utils/tradingTestUtil
 describe('ExchangeProviderPicker', () => {
     let preloadedState: PreloadedStatePartial<TradingTestPreloadedState>;
 
-    const renderExchangeProviderPicker = (props: Partial<ExchangeProviderPickerProps>) =>
-        renderWithStoreProvider(
+    const renderExchangeProviderPicker = async (props: Partial<ExchangeProviderPickerProps>) =>
+        await renderWithStoreProvider(
             <ExchangeProviderPicker
                 isLoading={false}
                 selectedValue={undefined}
@@ -26,14 +26,14 @@ describe('ExchangeProviderPicker', () => {
         preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
     });
 
-    it('should render nothing when no quote is selected and isLoading is false', () => {
-        const { toJSON } = renderExchangeProviderPicker({});
+    it('should render nothing when no quote is selected and isLoading is false', async () => {
+        const { toJSON } = await renderExchangeProviderPicker({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render skeleton when quotes are being fetched', () => {
-        const { getByText, getByLabelText } = renderExchangeProviderPicker({
+    it('should render skeleton when quotes are being fetched', async () => {
+        const { getByText, getByLabelText } = await renderExchangeProviderPicker({
             isLoading: true,
         });
 
@@ -43,8 +43,8 @@ describe('ExchangeProviderPicker', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render provider when quote is selected', () => {
-        const { getByText } = renderExchangeProviderPicker({
+    it('should render provider when quote is selected', async () => {
+        const { getByText } = await renderExchangeProviderPicker({
             selectedValue: mercuryoFixedWorstQuote,
         });
 

--- a/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.test.tsx
@@ -33,10 +33,10 @@ describe('ExchangeRateAndProviderPicker', () => {
         },
     };
 
-    const renderExchangeRateAndProviderPicker = (
+    const renderExchangeRateAndProviderPicker = async (
         extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) => {
-        const result = renderWithTradingProvider(<ExchangeRateAndProviderPicker />, {
+        const result = await renderWithTradingProvider(<ExchangeRateAndProviderPicker />, {
             services,
             tradeType: 'exchange',
             overrides: { ...baseOverrides, ...extraOverrides },
@@ -48,10 +48,10 @@ describe('ExchangeRateAndProviderPicker', () => {
         return result;
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
 
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             services,
             tradeType: 'exchange',
             overrides: baseOverrides,
@@ -59,33 +59,33 @@ describe('ExchangeRateAndProviderPicker', () => {
         exchangeForm = result.current;
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         if (unmount) {
-            unmount();
+            await unmount();
             unmount = undefined;
         }
     });
 
-    it('should render nothing when no quote is selected and quotes are not loading', () => {
-        const { toJSON } = renderExchangeRateAndProviderPicker();
+    it('should render nothing when no quote is selected and quotes are not loading', async () => {
+        const { toJSON } = await renderExchangeRateAndProviderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render provider picker when no quote is selected and quotes are loading', () => {
-        const { getByText } = renderExchangeRateAndProviderPicker({
+    it('should render provider picker when no quote is selected and quotes are loading', async () => {
+        const { getByText } = await renderExchangeRateAndProviderPicker({
             wallet: { trading: { exchange: { isLoading: true } } },
         });
 
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
     });
 
-    it('should render provider when quote is selected', () => {
-        act(() => {
+    it('should render provider when quote is selected', async () => {
+        await act(() => {
             exchangeForm.setValue('quote', mercuryoFixedWorstQuote);
         });
 
-        const { getByText } = renderExchangeRateAndProviderPicker();
+        const { getByText } = await renderExchangeRateAndProviderPicker();
 
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
@@ -96,15 +96,15 @@ describe('ExchangeRateAndProviderPicker', () => {
             wallet: { trading: { exchange: { quotes: exchangeQuotes } } },
         };
 
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 exchangeForm.setValue('quote', mercuryoFixedWorstQuote);
             });
             reportMock.mockClear();
         });
 
         it('should fire analytics event on provider select', async () => {
-            const { getByText } = renderExchangeRateAndProviderPicker(withQuotes);
+            const { getByText } = await renderExchangeRateAndProviderPicker(withQuotes);
 
             await userEvent.press(
                 getByText(getTranslation('moduleTrading.tradingScreen.provider')),
@@ -128,7 +128,8 @@ describe('ExchangeRateAndProviderPicker', () => {
         });
 
         it('should not fire analytics event when same provider is selected', async () => {
-            const { getByText, getAllByText } = renderExchangeRateAndProviderPicker(withQuotes);
+            const { getByText, getAllByText } =
+                await renderExchangeRateAndProviderPicker(withQuotes);
 
             await userEvent.press(
                 getByText(getTranslation('moduleTrading.tradingScreen.provider')),

--- a/suite-native/module-trading/src/components/exchange/ExchangeTab.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeTab.test.tsx
@@ -35,8 +35,8 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('ExchangeTab', () => {
-    const renderExchangeTab = () =>
-        renderWithTradingProvider(<ExchangeTab />, { tradeType: 'exchange' });
+    const renderExchangeTab = async () =>
+        await renderWithTradingProvider(<ExchangeTab />, { tradeType: 'exchange' });
 
     beforeEach(() => {
         mockIsDeviceInViewOnlyMode = false;
@@ -45,8 +45,8 @@ describe('ExchangeTab', () => {
         mockIsTradingExchangeEnabled = true;
     });
 
-    it('should render exchange form', () => {
-        const { getByText } = renderExchangeTab();
+    it('should render exchange form', async () => {
+        const { getByText } = await renderExchangeTab();
 
         expect(
             getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
@@ -56,9 +56,9 @@ describe('ExchangeTab', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render disabled info when exchange FF is not enabled', () => {
+    it('should render disabled info when exchange FF is not enabled', async () => {
         mockIsTradingExchangeEnabled = false;
-        const { getByText, queryByText } = renderExchangeTab();
+        const { getByText, queryByText } = await renderExchangeTab();
 
         expect(
             getByText(
@@ -70,20 +70,20 @@ describe('ExchangeTab', () => {
         expect(queryByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel'))).toBeNull();
     });
 
-    it('should display BTC only firmware info with BTC only wallet connected', () => {
+    it('should display BTC only firmware info with BTC only wallet connected', async () => {
         mockHasBitcoinOnlyFirmware = true;
-        const { getByText } = renderExchangeTab();
+        const { getByText } = await renderExchangeTab();
 
         expect(
             getByText(getTranslation('tradingAtoms.error.btcOnlyFirmwareTitle')),
         ).toBeOnTheScreen();
     });
 
-    it('should display Portfolio Tracker info with Portfolio Tracker "wallet" selected', () => {
+    it('should display Portfolio Tracker info with Portfolio Tracker "wallet" selected', async () => {
         // Portfolio Tracker sets both selectors to true
         mockIsPortfolioTrackerDevice = true;
         mockIsDeviceInViewOnlyMode = true;
-        const { getByText, queryByText } = renderExchangeTab();
+        const { getByText, queryByText } = await renderExchangeTab();
 
         expect(
             getByText(getTranslation('tradingAtoms.error.portfolioTrackerTitle')),
@@ -91,9 +91,9 @@ describe('ExchangeTab', () => {
         expect(queryByText('View-only wallet')).toBeNull();
     });
 
-    it('should display exchange form for view-only wallet', () => {
+    it('should display exchange form for view-only wallet', async () => {
         mockIsDeviceInViewOnlyMode = true;
-        const { getByText } = renderExchangeTab();
+        const { getByText } = await renderExchangeTab();
 
         expect(
             getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),

--- a/suite-native/module-trading/src/components/exchange/ExchangeTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeTabContent.test.tsx
@@ -30,8 +30,8 @@ describe('ExchangeTab', () => {
         }));
     });
 
-    const renderExchangeTab = () =>
-        renderWithTradingProvider(<ExchangeTabContent />, { tradeType: 'exchange' });
+    const renderExchangeTab = async () =>
+        await renderWithTradingProvider(<ExchangeTabContent />, { tradeType: 'exchange' });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);
@@ -50,50 +50,50 @@ describe('ExchangeTab', () => {
         expect(screen.getByText("It's not you, it's us.")).toBeOnTheScreen();
     };
 
-    it('should render Exchange skeleton when isLoading is true', () => {
+    it('should render Exchange skeleton when isLoading is true', async () => {
         mockUseTradingExchangeData.mockReturnValue({
             isLoading: true,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        renderExchangeTab();
+        await renderExchangeTab();
 
         expectSkeleton();
     });
 
-    it('should render Exchange skeleton when lastLoadedTimestamp is 0', () => {
+    it('should render Exchange skeleton when lastLoadedTimestamp is 0', async () => {
         mockUseTradingExchangeData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 0,
             isFullyLoaded: false,
         });
 
-        renderExchangeTab();
+        await renderExchangeTab();
 
         expectSkeleton();
     });
 
-    it('should render Exchange form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', () => {
+    it('should render Exchange form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', async () => {
         mockUseTradingExchangeData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: true,
         });
 
-        renderExchangeTab();
+        await renderExchangeTab();
 
         expectExchangeForm();
     });
 
-    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', () => {
+    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', async () => {
         mockUseTradingExchangeData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        renderExchangeTab();
+        await renderExchangeTab();
 
         expectServerOffline();
     });
@@ -111,7 +111,7 @@ describe('ExchangeTab', () => {
                 isFullyLoaded: true,
             });
 
-        const { getByText } = renderExchangeTab();
+        const { getByText } = await renderExchangeTab();
 
         const reloadButton = getByText(getTranslation('tradingAtoms.error.serverOfflineRetry'));
 

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
@@ -40,13 +40,13 @@ describe('ExchangeUsdcPresetButton', () => {
         mockSetValue.mockClear();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('without a matching account shows an error message', () => {
+    it('without a matching account shows an error message', async () => {
         const store = createTradingLightStore({ tradeType: 'exchange' });
-        renderWithTradingProvider(<ExchangeUsdcPresetButton />, { store });
+        await renderWithTradingProvider(<ExchangeUsdcPresetButton />, { store });
 
         expect(screen.getByText('No account with USDC found.')).toBeOnTheScreen();
     });
@@ -54,21 +54,21 @@ describe('ExchangeUsdcPresetButton', () => {
     describe('with a matching ETH account that has a USDC token', () => {
         let store: TestStore;
 
-        beforeEach(() => {
+        beforeEach(async () => {
             const preloadedState = createTradingPreloadedState({
                 tradeType: 'exchange',
                 overrides: { wallet: { accounts: [ethAccountWithUsdc] } },
             });
             store = createTradingLightStore({ tradeType: 'exchange', overrides: preloadedState });
-            renderWithTradingProvider(<ExchangeUsdcPresetButton />, { store });
+            await renderWithTradingProvider(<ExchangeUsdcPresetButton />, { store });
         });
 
         it('renders the preset button', () => {
             expect(screen.getByText('Prefill 1 USDC→USDT')).toBeOnTheScreen();
         });
 
-        it('fills form for 1 USDC -> USDT trade', () => {
-            fireEvent.press(screen.getByText(/1 USDC.*USDT/));
+        it('fills form for 1 USDC -> USDT trade', async () => {
+            await fireEvent.press(screen.getByText(/1 USDC.*USDT/));
 
             expect(mockSetValue).toHaveBeenCalledWith(
                 'sendAsset',

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountCryptoBalance.test.tsx
@@ -26,41 +26,41 @@ describe('ExchangeReceiveAccountCryptoBalance', () => {
         wallet: getWalletState({ tradeType: 'exchange' }),
     };
 
-    const renderExchangeForm = () => {
-        const { result } = renderHookWithStoreProvider(() => useExchangeForm(), {
+    const renderExchangeForm = async () => {
+        const { result } = await renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
         });
 
         return result.current;
     };
 
-    const renderComponent = () =>
-        renderWithStoreProvider(<ExchangeReceiveAccountCryptoBalance />, {
+    const renderComponent = async () =>
+        await renderWithStoreProvider(<ExchangeReceiveAccountCryptoBalance />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        exchangeForm = renderExchangeForm();
+    beforeEach(async () => {
+        exchangeForm = await renderExchangeForm();
     });
 
-    it('should use asset form field as default symbol', () => {
-        act(() => {
+    it('should use asset form field as default symbol', async () => {
+        await act(() => {
             exchangeForm.setValue('receiveAsset', btcAsset);
         });
-        const { getByTestId } = renderComponent();
+        const { getByTestId } = await renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should use receiveAccount form field to obtain account', () => {
-        act(() => {
+    it('should use receiveAccount form field to obtain account', async () => {
+        await act(() => {
             exchangeForm.setValue('receiveAsset', btcAsset);
         });
-        act(() => {
+        await act(() => {
             exchangeForm.setValue('receiveAccount', { account: getBtcAccount() });
         });
-        const { getByTestId } = renderComponent();
+        const { getByTestId } = await renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
     });

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountPicker.test.tsx
@@ -50,8 +50,8 @@ describe('ExchangeReceiveAccountPicker', () => {
         featureFlags: createTradingFeatureFlags(),
     };
 
-    const renderExchangeForm = () => {
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+    const renderExchangeForm = async () => {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: baseOverrides,
         });
@@ -59,40 +59,40 @@ describe('ExchangeReceiveAccountPicker', () => {
         return result.current;
     };
 
-    const renderPicker = (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
-        renderWithTradingProvider(<ExchangeReceiveAccountPicker />, {
+    const renderPicker = async (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
+        await renderWithTradingProvider(<ExchangeReceiveAccountPicker />, {
             tradeType: 'exchange',
             overrides: mergeDeepObject(baseOverrides, overrides),
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
 
-    const setSelectedAsset = (asset: TradeableAsset) => {
-        act(() => {
+    const setSelectedAsset = async (asset: TradeableAsset) => {
+        await act(() => {
             exchangeForm.setValue('receiveAsset', asset);
         });
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
-        exchangeForm = renderExchangeForm();
+        exchangeForm = await renderExchangeForm();
     });
 
-    it('should display nothing when selectedSymbol is not specified', () => {
-        const { toJSON } = renderPicker();
+    it('should display nothing when selectedSymbol is not specified', async () => {
+        const { toJSON } = await renderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display "Not selected" when asset is not specified', () => {
-        setSelectedAsset(btcAsset);
-        const { getByText } = renderPicker();
+    it('should display "Not selected" when asset is not specified', async () => {
+        await setSelectedAsset(btcAsset);
+        const { getByText } = await renderPicker();
 
         expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
-    it('should display selected account name', () => {
-        setSelectedAsset(btcAsset);
-        const { getByText } = renderPicker(
+    it('should display selected account name', async () => {
+        await setSelectedAsset(btcAsset);
+        const { getByText } = await renderPicker(
             exchangeStateWithReceiveAccount({
                 account: btc1NormalAccount,
                 address: btc1NormalAccount.addresses?.used[0],
@@ -102,16 +102,18 @@ describe('ExchangeReceiveAccountPicker', () => {
         expect(getByText(btcAccountName1)).toBeTruthy();
     });
 
-    it('should call navigate with correct params on press', () => {
-        setSelectedAsset(btcAsset);
-        const { getByText } = renderPicker(
+    it('should call navigate with correct params on press', async () => {
+        await setSelectedAsset(btcAsset);
+        const { getByText } = await renderPicker(
             exchangeStateWithReceiveAccount({
                 account: btc1NormalAccount,
                 address: btc1NormalAccount.addresses?.used[0],
             }),
         );
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')));
+        await fireEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+        );
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', {

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.test.tsx
@@ -27,11 +27,11 @@ describe('ExchangeReceiveAmountInput', () => {
         },
     };
 
-    const renderExchangeReceiveAmountInput = (
+    const renderExchangeReceiveAmountInput = async (
         props: Partial<ExchangeReceiveAmountInputProps> = {},
         extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ExchangeReceiveAmountInput showAssetsSheet={jest.fn()} {...props} />,
             {
                 tradeType: 'exchange',
@@ -40,16 +40,16 @@ describe('ExchangeReceiveAmountInput', () => {
             },
         );
 
-    beforeEach(() => {
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+    beforeEach(async () => {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: baseOverrides,
         });
         form = result.current;
     });
 
-    it('should render receiveCryptoAmount form value', () => {
-        act(() => {
+    it('should render receiveCryptoAmount form value', async () => {
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
             form.setValue('receiveAsset', usdcAsset);
             form.setValue('quote', {
@@ -59,26 +59,28 @@ describe('ExchangeReceiveAmountInput', () => {
             });
         });
 
-        const { getByLabelText } = renderExchangeReceiveAmountInput();
+        const { getByLabelText } = await renderExchangeReceiveAmountInput();
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
         ).toHaveDisplayValue('0.00083554');
     });
 
-    it('should call showAssetsSheet callback on press', () => {
+    it('should call showAssetsSheet callback on press', async () => {
         const showAssetsSheetMock = jest.fn();
-        const { getByLabelText } = renderExchangeReceiveAmountInput({
+        const { getByLabelText } = await renderExchangeReceiveAmountInput({
             showAssetsSheet: showAssetsSheetMock,
         });
 
-        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')));
+        await fireEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.amountLabel')),
+        );
 
         expect(showAssetsSheetMock).toHaveBeenCalled();
     });
 
-    it('should display loading skeleton when quotes are being fetched', () => {
-        const { getByLabelText } = renderExchangeReceiveAmountInput(
+    it('should display loading skeleton when quotes are being fetched', async () => {
+        const { getByLabelText } = await renderExchangeReceiveAmountInput(
             {},
             { wallet: { trading: { exchange: { isLoading: true } } } },
         );

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveContent.test.tsx
@@ -39,24 +39,24 @@ describe('ExchangeReceiveContent', () => {
         },
     });
 
-    const renderForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), {
+    const renderForm = async () =>
+        await renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
         });
 
-    const renderExchangeReceiveContent = () =>
-        renderWithStoreProvider(<ExchangeReceiveContent />, {
+    const renderExchangeReceiveContent = async () =>
+        await renderWithStoreProvider(<ExchangeReceiveContent />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderForm();
+    beforeEach(async () => {
+        const { result } = await renderForm();
         form = result.current;
     });
 
-    it('should render all components', () => {
-        act(() => {
+    it('should render all components', async () => {
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
             form.setValue('receiveAsset', usdcAsset);
             form.setValue('quote', {
@@ -65,7 +65,7 @@ describe('ExchangeReceiveContent', () => {
                 receive: usdcAsset.cryptoId,
             });
         });
-        const { getByText, getByLabelText } = renderExchangeReceiveContent();
+        const { getByText, getByLabelText } = await renderExchangeReceiveContent();
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.test.tsx
@@ -91,8 +91,8 @@ describe('ExchangeTradeableAssetPicker', () => {
             },
         });
 
-    const renderFormHook = () => {
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+    const renderFormHook = async () => {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             services,
             store,
         });
@@ -100,27 +100,27 @@ describe('ExchangeTradeableAssetPicker', () => {
         return result.current;
     };
 
-    const renderTradeableAssetPicker = () =>
-        renderWithTradingProvider(<ExchangeTradeableAssetPicker />, {
+    const renderTradeableAssetPicker = async () =>
+        await renderWithTradingProvider(<ExchangeTradeableAssetPicker />, {
             services,
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
         mockTradingType = 'exchange';
         mockSelectedTradeableAssetCryptoId = undefined;
         store = initPreloadedStore(FirmwareType.Universal);
-        form = renderFormHook();
+        form = await renderFormHook();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render "Select asset" button with caret', () => {
-        const { getByLabelText } = renderTradeableAssetPicker();
+    it('should render "Select asset" button with caret', async () => {
+        const { getByLabelText } = await renderTradeableAssetPicker();
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
@@ -129,20 +129,22 @@ describe('ExchangeTradeableAssetPicker', () => {
         );
     });
 
-    it('should navigate to the exchange asset screen', () => {
-        const { getByLabelText } = renderTradeableAssetPicker();
+    it('should navigate to the exchange asset screen', async () => {
+        const { getByLabelText } = await renderTradeableAssetPicker();
 
-        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')));
+        await fireEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),
+        );
 
         expect(mockNavigate).toHaveBeenCalledWith('TradingTradeableAsset', {
             tradingType: 'exchange',
         });
     });
 
-    it('should apply receive asset change effects for an asset selected on the screen', () => {
+    it('should apply receive asset change effects for an asset selected on the screen', async () => {
         mockSelectedTradeableAssetCryptoId = btcAsset.cryptoId;
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        renderTradeableAssetPicker();
+        await renderTradeableAssetPicker();
 
         expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
         expect(mockSetParams).toHaveBeenCalledWith({
@@ -157,11 +159,11 @@ describe('ExchangeTradeableAssetPicker', () => {
         });
     });
 
-    it('should clear the send asset and its typed amount when it collides with the newly selected receive asset', () => {
+    it('should clear the send asset and its typed amount when it collides with the newly selected receive asset', async () => {
         form.setValue('sendAsset', btcAsset);
         form.setValue('sendCryptoAmount', '1');
         mockSelectedTradeableAssetCryptoId = btcAsset.cryptoId;
-        renderTradeableAssetPicker();
+        await renderTradeableAssetPicker();
 
         expect(form.getValues('sendAsset')).toBeUndefined();
         expect(form.getValues('sendCryptoAmount')).toBeUndefined();
@@ -175,16 +177,16 @@ describe('ExchangeTradeableAssetPicker', () => {
     });
 
     describe('receiveAccount preselection', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             jest.clearAllMocks();
             mockSelectedTradeableAssetCryptoId = undefined;
             store = initPreloadedStoreWithAccounts();
-            form = renderFormHook();
+            form = await renderFormHook();
         });
 
         it('should preselect a new receiveAccount for the new asset network after a cross-network change', async () => {
             mockSelectedTradeableAssetCryptoId = btcAsset.cryptoId;
-            const result = renderTradeableAssetPicker();
+            const result = await renderTradeableAssetPicker();
 
             await waitFor(() => {
                 expect(form.getValues('receiveAccount')).toEqual(
@@ -195,7 +197,7 @@ describe('ExchangeTradeableAssetPicker', () => {
             });
 
             mockSelectedTradeableAssetCryptoId = usdcAsset.cryptoId;
-            result.rerender(<ExchangeTradeableAssetPicker />);
+            await result.rerender(<ExchangeTradeableAssetPicker />);
 
             await waitFor(() => {
                 expect(form.getValues('receiveAccount')).toEqual(
@@ -208,7 +210,7 @@ describe('ExchangeTradeableAssetPicker', () => {
 
         it('should keep the selected receiveAccount when switching to another asset on the same network', async () => {
             mockSelectedTradeableAssetCryptoId = ethAsset.cryptoId;
-            const result = renderTradeableAssetPicker();
+            const result = await renderTradeableAssetPicker();
 
             await waitFor(() => {
                 expect(form.getValues('receiveAccount')).toEqual(
@@ -218,7 +220,7 @@ describe('ExchangeTradeableAssetPicker', () => {
                 );
             });
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setReceiveAccountKey(eth2AccountKey));
             });
 
@@ -231,7 +233,7 @@ describe('ExchangeTradeableAssetPicker', () => {
             });
 
             mockSelectedTradeableAssetCryptoId = usdcAsset.cryptoId;
-            result.rerender(<ExchangeTradeableAssetPicker />);
+            await result.rerender(<ExchangeTradeableAssetPicker />);
 
             await waitFor(() => {
                 expect(form.getValues('receiveAccount')).toEqual(

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAccountCryptoBalance.test.tsx
@@ -16,41 +16,41 @@ import {
 describe('ExchangeSendAccountCryptoBalance', () => {
     let exchangeForm: ExchangeFormType;
 
-    const renderExchangeForm = () => {
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+    const renderExchangeForm = async () => {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
         });
 
         return result.current;
     };
 
-    const renderComponent = () =>
-        renderWithTradingProvider(<ExchangeSendAccountCryptoBalance />, {
+    const renderComponent = async () =>
+        await renderWithTradingProvider(<ExchangeSendAccountCryptoBalance />, {
             tradeType: 'exchange',
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        exchangeForm = renderExchangeForm();
+    beforeEach(async () => {
+        exchangeForm = await renderExchangeForm();
     });
 
-    it('should use asset form field as default symbol', () => {
-        act(() => {
+    it('should use asset form field as default symbol', async () => {
+        await act(() => {
             exchangeForm.setValue('sendAsset', btcAsset);
         });
-        const { getByTestId } = renderComponent();
+        const { getByTestId } = await renderComponent();
 
         expect(getByTestId(SEND_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should use sendAccount form field to obtain account', () => {
-        act(() => {
+    it('should use sendAccount form field to obtain account', async () => {
+        await act(() => {
             exchangeForm.setValue('sendAsset', btcAsset);
         });
-        act(() => {
+        await act(() => {
             exchangeForm.setValue('sendAccount', getBtcAccount());
         });
-        const { getByTestId } = renderComponent();
+        const { getByTestId } = await renderComponent();
 
         expect(getByTestId(SEND_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
     });

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.test.tsx
@@ -23,64 +23,64 @@ describe('ExchangeSendAmountBadge', () => {
         },
     };
 
-    const renderExchangeSendAmountBadge = (
+    const renderExchangeSendAmountBadge = async (
         extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(<ExchangeSendAmountBadge />, {
+        await renderWithTradingProvider(<ExchangeSendAmountBadge />, {
             tradeType: 'exchange',
             overrides: { ...baseOverrides, ...extraOverrides },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+    beforeEach(async () => {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: baseOverrides,
         });
         form = result.current;
     });
 
-    it('should display nothing when asset is not selected', () => {
-        const { toJSON } = renderExchangeSendAmountBadge();
+    it('should display nothing when asset is not selected', async () => {
+        const { toJSON } = await renderExchangeSendAmountBadge();
 
         expect(toJSON()).toBeNull();
     });
 
     describe('with asset', () => {
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
             });
         });
 
-        it('should display nothing when amount is not set', () => {
-            const { toJSON } = renderExchangeSendAmountBadge();
+        it('should display nothing when amount is not set', async () => {
+            const { toJSON } = await renderExchangeSendAmountBadge();
 
             expect(toJSON()).toBeNull();
         });
 
-        it('should display formatted value when amount is 0', () => {
-            act(() => {
+        it('should display formatted value when amount is 0', async () => {
+            await act(() => {
                 form.setValue('sendCryptoAmount', '0');
             });
 
-            const { getByText } = renderExchangeSendAmountBadge();
+            const { getByText } = await renderExchangeSendAmountBadge();
 
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should display formatted value when amount is set', () => {
-            act(() => {
+        it('should display formatted value when amount is set', async () => {
+            await act(() => {
                 form.setValue('sendCryptoAmount', '1234567');
             });
 
-            const { getByText } = renderExchangeSendAmountBadge();
+            const { getByText } = await renderExchangeSendAmountBadge();
 
             expect(getByText('$1,234.57')).toBeOnTheScreen();
         });
 
-        it('should display error message when field has error', () => {
-            act(() => {
+        it('should display error message when field has error', async () => {
+            await act(() => {
                 form.setError('sendCryptoAmount', {
                     type: 'manual',
                     message: 'VALIDATION_ERROR',
@@ -88,14 +88,14 @@ describe('ExchangeSendAmountBadge', () => {
                 form.setValue('sendCryptoAmount', '1000');
             });
 
-            const { getByText, queryByText } = renderExchangeSendAmountBadge();
+            const { getByText, queryByText } = await renderExchangeSendAmountBadge();
 
             expect(queryByText('$1.00')).toBeNull();
             expect(getByText('VALIDATION_ERROR')).toBeOnTheScreen();
         });
 
-        it('should display formatted fiat value when field has error, but quotes are loading', () => {
-            act(() => {
+        it('should display formatted fiat value when field has error, but quotes are loading', async () => {
+            await act(() => {
                 form.setError('sendCryptoAmount', {
                     type: 'manual',
                     message: 'VALIDATION_ERROR',
@@ -103,7 +103,7 @@ describe('ExchangeSendAmountBadge', () => {
                 form.setValue('sendCryptoAmount', '1000');
             });
 
-            const { getByText, queryByText } = renderExchangeSendAmountBadge({
+            const { getByText, queryByText } = await renderExchangeSendAmountBadge({
                 wallet: { trading: { exchange: { isLoading: true } } },
             });
 
@@ -111,12 +111,12 @@ describe('ExchangeSendAmountBadge', () => {
             expect(getByText('$1.00')).toBeOnTheScreen();
         });
 
-        it('should display correct value when using sats', () => {
-            act(() => {
+        it('should display correct value when using sats', async () => {
+            await act(() => {
                 form.setValue('sendCryptoAmount', '1234567123456');
             });
 
-            const { getByText } = renderExchangeSendAmountBadge({
+            const { getByText } = await renderExchangeSendAmountBadge({
                 wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
             });
 

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountInput.test.tsx
@@ -38,12 +38,12 @@ describe('ExchangeSendAmountInput', () => {
         },
     };
 
-    const renderCryptoAmountInput = (
+    const renderCryptoAmountInput = async (
         props: Partial<ExchangeSendAmountInputProps>,
         form: ExchangeFormType,
         extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <Form form={form}>
                 <ExchangeSendAmountInput onSelectAsset={jest.fn()} {...props} />
             </Form>,
@@ -53,10 +53,10 @@ describe('ExchangeSendAmountInput', () => {
             },
         );
 
-    const renderUseTradingExchangeForm = (
+    const renderUseTradingExchangeForm = async (
         extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) => {
-        const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
+        const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: mergeDeepObject(baseOverrides, extraOverrides),
         });
@@ -69,11 +69,11 @@ describe('ExchangeSendAmountInput', () => {
     });
 
     it('should set send value in form', async () => {
-        const form = renderUseTradingExchangeForm();
-        act(() => {
+        const form = await renderUseTradingExchangeForm();
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -83,9 +83,9 @@ describe('ExchangeSendAmountInput', () => {
         expect(form.getValues('sendCryptoAmount')).toEqual('100');
     });
 
-    it('should be disabled when asset is not selected', () => {
-        const form = renderUseTradingExchangeForm();
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+    it('should be disabled when asset is not selected', async () => {
+        const form = await renderUseTradingExchangeForm();
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -94,8 +94,8 @@ describe('ExchangeSendAmountInput', () => {
 
     it('should call showAssetsScreen when disabled and pressed', async () => {
         const showAssetsScreen = jest.fn();
-        const form = renderUseTradingExchangeForm();
-        const { getByLabelText } = renderCryptoAmountInput(
+        const form = await renderUseTradingExchangeForm();
+        const { getByLabelText } = await renderCryptoAmountInput(
             { onSelectAsset: showAssetsScreen },
             form,
         );
@@ -109,11 +109,11 @@ describe('ExchangeSendAmountInput', () => {
 
     it('should not call showAssetsScreen when enabled and pressed', async () => {
         const showAssetsScreen = jest.fn();
-        const form = renderUseTradingExchangeForm();
-        act(() => {
+        const form = await renderUseTradingExchangeForm();
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput(
+        const { getByLabelText } = await renderCryptoAmountInput(
             { onSelectAsset: showAssetsScreen },
             form,
         );
@@ -126,11 +126,11 @@ describe('ExchangeSendAmountInput', () => {
     });
 
     it('should format input value to be decimal by default', async () => {
-        const form = renderUseTradingExchangeForm();
-        act(() => {
+        const form = await renderUseTradingExchangeForm();
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -147,11 +147,11 @@ describe('ExchangeSendAmountInput', () => {
         const satoshiOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = renderUseTradingExchangeForm(satoshiOverrides);
-        act(() => {
+        const form = await renderUseTradingExchangeForm(satoshiOverrides);
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form, satoshiOverrides);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, satoshiOverrides);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -168,11 +168,11 @@ describe('ExchangeSendAmountInput', () => {
         const satoshiOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = renderUseTradingExchangeForm(satoshiOverrides);
-        act(() => {
+        const form = await renderUseTradingExchangeForm(satoshiOverrides);
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form, satoshiOverrides);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, satoshiOverrides);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -187,15 +187,15 @@ describe('ExchangeSendAmountInput', () => {
 
     it('should limit value to decimals based on useAmountInputDecimals return value', async () => {
         const accountKey = mockAccountKey({ symbol: 'eth', descriptor: 'accountKey' });
-        const form = renderUseTradingExchangeForm();
-        act(() => {
+        const form = await renderUseTradingExchangeForm();
+        await act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendAccount', {
                 key: accountKey,
                 symbol: 'eth',
             } as Account);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.test.tsx
@@ -112,17 +112,17 @@ describe('ExchangeSendAssetPicker', () => {
         },
     });
 
-    const renderExchangeForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), { services, store });
+    const renderExchangeForm = async () =>
+        await renderHookWithStoreProvider(() => useExchangeForm(), { services, store });
 
-    const renderExchangeSendAssetPicker = () =>
-        renderWithStoreProvider(<ExchangeSendAssetPicker />, {
+    const renderExchangeSendAssetPicker = async () =>
+        await renderWithStoreProvider(<ExchangeSendAssetPicker />, {
             services,
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
         mockSelectedMyAssetAccountKey = undefined;
         mockSelectedMyAssetCryptoId = undefined;
@@ -146,7 +146,7 @@ describe('ExchangeSendAssetPicker', () => {
             },
             preloadedState: getPreloadedState(),
         });
-        const { result } = renderExchangeForm();
+        const { result } = await renderExchangeForm();
         form = result.current;
 
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue(
@@ -154,20 +154,20 @@ describe('ExchangeSendAssetPicker', () => {
         );
     });
 
-    it('should navigate to the my asset screen', () => {
-        const { getByLabelText } = renderExchangeSendAssetPicker();
+    it('should navigate to the my asset screen', async () => {
+        const { getByLabelText } = await renderExchangeSendAssetPicker();
 
-        fireEvent.press(getByLabelText('Select asset'));
+        await fireEvent.press(getByLabelText('Select asset'));
 
         expect(mockNavigate).toHaveBeenCalledWith('TradingMyAsset', {
             tradingType: 'exchange',
         });
     });
 
-    it('should select asset returned from the screen', () => {
+    it('should select asset returned from the screen', async () => {
         mockSelectedMyAssetAccountKey = btcAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
-        renderExchangeSendAssetPicker();
+        await renderExchangeSendAssetPicker();
 
         const asset = form.getValues('sendAsset');
 
@@ -178,10 +178,10 @@ describe('ExchangeSendAssetPicker', () => {
         );
     });
 
-    it('should select account returned from the screen', () => {
+    it('should select account returned from the screen', async () => {
         mockSelectedMyAssetAccountKey = btcAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
-        renderExchangeSendAssetPicker();
+        await renderExchangeSendAssetPicker();
 
         const accountForm = form.getValues('sendAccount');
         const accountKeyStore = store.getState().wallet.trading.exchange.tradingAccountKey;
@@ -190,12 +190,12 @@ describe('ExchangeSendAssetPicker', () => {
         expect(accountKeyStore).toBe(btcAccount.key);
     });
 
-    it('should apply exchange send asset change effects for an asset returned from the screen', () => {
+    it('should apply exchange send asset change effects for an asset returned from the screen', async () => {
         form.setValue('sendCryptoAmount', '1');
         mockSelectedMyAssetAccountKey = btcAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        renderExchangeSendAssetPicker();
+        await renderExchangeSendAssetPicker();
 
         expect(form.getValues('sendCryptoAmount')).toBeUndefined();
         expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.sendAssetChanged());
@@ -212,13 +212,13 @@ describe('ExchangeSendAssetPicker', () => {
         });
     });
 
-    it('should clear the receive asset and apply its change effects on collision', () => {
+    it('should clear the receive asset and apply its change effects on collision', async () => {
         form.setValue('sendCryptoAmount', '1');
         form.setValue('receiveAsset', btcAsset);
         mockSelectedMyAssetAccountKey = btcAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        renderExchangeSendAssetPicker();
+        await renderExchangeSendAssetPicker();
 
         expect(form.getValues('receiveAsset')).toBeUndefined();
         expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());
@@ -231,12 +231,12 @@ describe('ExchangeSendAssetPicker', () => {
         });
     });
 
-    it('should not apply receive asset change effects when there is no collision', () => {
+    it('should not apply receive asset change effects when there is no collision', async () => {
         form.setValue('sendCryptoAmount', '1');
         mockSelectedMyAssetAccountKey = btcAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        renderExchangeSendAssetPicker();
+        await renderExchangeSendAssetPicker();
 
         expect(form.getValues('receiveAsset')).toBeUndefined();
         expect(dispatchSpy).not.toHaveBeenCalledWith(exchangeActions.receiveAssetChanged());

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.test.tsx
@@ -29,28 +29,28 @@ describe('ExchangeSendContent', () => {
         },
     });
 
-    const renderForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), {
+    const renderForm = async () =>
+        await renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
         });
 
-    const renderExchangeSendContent = () =>
-        renderWithStoreProvider(<ExchangeSendContent />, {
+    const renderExchangeSendContent = async () =>
+        await renderWithStoreProvider(<ExchangeSendContent />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
             preloadedState,
         });
 
-    beforeEach(() => {
-        const { result } = renderForm();
+    beforeEach(async () => {
+        const { result } = await renderForm();
         form = result.current;
     });
 
-    it('should render all components', () => {
-        act(() => {
+    it('should render all components', async () => {
+        await act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendCryptoAmount', '100');
         });
-        const { getByText, getByLabelText } = renderExchangeSendContent();
+        const { getByText, getByLabelText } = await renderExchangeSendContent();
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectCoin.buttonTitle')),

--- a/suite-native/module-trading/src/components/general/AccountList/AccountList.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountList.test.tsx
@@ -43,7 +43,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe(AccountList.name, () => {
-    const renderAccountList = (
+    const renderAccountList = async (
         props: Partial<AccountsListProps> = {},
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = defaultOverrides,
     ) => {
@@ -57,7 +57,7 @@ describe(AccountList.name, () => {
             receiveAccounts.length === 0
                 ? []
                 : [{ key: '', label: '', data: receiveAccounts, sectionData: undefined }];
-        const result = renderWithStoreProvider(
+        const result = await renderWithStoreProvider(
             <AccountList
                 symbol={symbol}
                 tradingType="buy"
@@ -79,17 +79,17 @@ describe(AccountList.name, () => {
         });
     });
 
-    it('displays all accounts for the selected network', () => {
-        const { getByText } = renderAccountList();
+    it('displays all accounts for the selected network', async () => {
+        const { getByText } = await renderAccountList();
 
         expect(getByText('BTC Account #1')).toBeTruthy();
         expect(getByText('BTC Account #2')).toBeTruthy();
     });
 
-    it('opens the address picker without changing trading state for an address-based account', () => {
-        const { getByText, store } = renderAccountList();
+    it('opens the address picker without changing trading state for an address-based account', async () => {
+        const { getByText, store } = await renderAccountList();
 
-        fireEvent.press(getByText('BTC Account #1'));
+        await fireEvent.press(getByText('BTC Account #1'));
 
         expect(navigationNavigate).toHaveBeenCalledWith(RootStackRoutes.TradingReceiveAddress, {
             accountKey: btc1NormalAccount.key,
@@ -99,10 +99,10 @@ describe(AccountList.name, () => {
         expect(navigationPopToTop).not.toHaveBeenCalled();
     });
 
-    it('selects an account-based buy account and closes the picker', () => {
-        const { getByText, store } = renderAccountList({ symbol: 'eth' });
+    it('selects an account-based buy account and closes the picker', async () => {
+        const { getByText, store } = await renderAccountList({ symbol: 'eth' });
 
-        fireEvent.press(getByText('ETH Account #1'));
+        await fireEvent.press(getByText('ETH Account #1'));
 
         expect(selectBuySelectedReceiveAccount(store.getState())).toEqual({
             account: eth1NormalAccount,
@@ -110,10 +110,13 @@ describe(AccountList.name, () => {
         expect(navigationPopToTop).toHaveBeenCalledTimes(1);
     });
 
-    it('selects an account-based exchange account and closes the picker', () => {
-        const { getByText, store } = renderAccountList({ symbol: 'eth', tradingType: 'exchange' });
+    it('selects an account-based exchange account and closes the picker', async () => {
+        const { getByText, store } = await renderAccountList({
+            symbol: 'eth',
+            tradingType: 'exchange',
+        });
 
-        fireEvent.press(getByText('ETH Account #1'));
+        await fireEvent.press(getByText('ETH Account #1'));
 
         expect(selectExchangeSelectedReceiveAccount(store.getState())).toEqual({
             account: eth1NormalAccount,
@@ -121,19 +124,19 @@ describe(AccountList.name, () => {
         expect(navigationPopToTop).toHaveBeenCalledTimes(1);
     });
 
-    it('renders the separate add account button for a populated list', () => {
+    it('renders the separate add account button for a populated list', async () => {
         const onAddAccountTap = jest.fn();
-        const { getByText } = renderAccountList({ onAddAccountTap });
+        const { getByText } = await renderAccountList({ onAddAccountTap });
 
-        fireEvent.press(
+        await fireEvent.press(
             getByText(getTranslation('moduleAddAccounts.coinDiscoveryFinishedScreen.addButton')),
         );
 
         expect(onAddAccountTap).toHaveBeenCalledTimes(1);
     });
 
-    it('renders the redesigned empty state when no account exists', () => {
-        const { getByText } = renderAccountList(
+    it('renders the redesigned empty state when no account exists', async () => {
+        const { getByText } = await renderAccountList(
             {},
             {
                 ...defaultOverrides,

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.test.tsx
@@ -51,8 +51,11 @@ const createAccount = (
 describe(AccountListAddressItem.name, () => {
     const onPressMock = jest.fn();
 
-    const renderAccountListAddressItem = (receiveAccount: ReceiveAccount, isFreshAddress = false) =>
-        renderWithTradingProvider(
+    const renderAccountListAddressItem = async (
+        receiveAccount: ReceiveAccount,
+        isFreshAddress = false,
+    ) =>
+        await renderWithTradingProvider(
             <AccountListAddressItem
                 receiveAccount={receiveAccount}
                 isFreshAddress={isFreshAddress}
@@ -64,7 +67,7 @@ describe(AccountListAddressItem.name, () => {
         jest.clearAllMocks();
     });
 
-    it('should call onPress callback when pressed', () => {
+    it('should call onPress callback when pressed', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: mockAccountKey({ symbol: 'btc', descriptor: 'btc1' }),
@@ -81,14 +84,14 @@ describe(AccountListAddressItem.name, () => {
                 received: '',
             },
         };
-        const { getByText } = renderAccountListAddressItem(receiveAccount);
+        const { getByText } = await renderAccountListAddressItem(receiveAccount);
 
-        fireEvent.press(getByText('BTC_address'));
+        await fireEvent.press(getByText('BTC_address'));
 
         expect(onPressMock).toHaveBeenCalled();
     });
 
-    it('should not display caret for address addresses', () => {
+    it('should not display caret for address addresses', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: mockAccountKey({ symbol: 'btc', descriptor: 'btc1' }),
@@ -106,7 +109,7 @@ describe(AccountListAddressItem.name, () => {
             },
         };
         const { getByText, queryByAccessibilityHint } =
-            renderAccountListAddressItem(receiveAccount);
+            await renderAccountListAddressItem(receiveAccount);
 
         expect(getByText('BTC_address')).toBeTruthy();
         expect(
@@ -114,7 +117,7 @@ describe(AccountListAddressItem.name, () => {
         ).toBeNull();
     });
 
-    it('should display address', () => {
+    it('should display address', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: mockAccountKey({ symbol: 'btc', descriptor: 'btc1' }),
@@ -132,7 +135,7 @@ describe(AccountListAddressItem.name, () => {
             },
         };
         const { getByText, queryByText, queryByAccessibilityHint, getByLabelText } =
-            renderAccountListAddressItem(receiveAccount);
+            await renderAccountListAddressItem(receiveAccount);
 
         expect(getByText('BTC_address')).toBeTruthy();
         expect(queryByText('My BTC account')).toBeNull();
@@ -151,7 +154,7 @@ describe(AccountListAddressItem.name, () => {
         ).toHaveTextContent('0.05 BTC');
     });
 
-    it('should display zero balance', () => {
+    it('should display zero balance', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: mockAccountKey({ symbol: 'btc', descriptor: 'btc1' }),
@@ -168,7 +171,7 @@ describe(AccountListAddressItem.name, () => {
                 received: '',
             },
         };
-        const { getByLabelText } = renderAccountListAddressItem(receiveAccount);
+        const { getByLabelText } = await renderAccountListAddressItem(receiveAccount);
 
         expect(
             getByLabelText(getTranslation('moduleTrading.accountScreen.balanceFiat')),
@@ -182,7 +185,7 @@ describe(AccountListAddressItem.name, () => {
         ).toHaveTextContent('0 BTC');
     });
 
-    it('should hide balance for a fresh address', () => {
+    it('should hide balance for a fresh address', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: mockAccountKey({ symbol: 'btc', descriptor: 'btc1' }),
@@ -199,7 +202,7 @@ describe(AccountListAddressItem.name, () => {
                 received: '',
             },
         };
-        const { queryByLabelText } = renderAccountListAddressItem(receiveAccount, true);
+        const { queryByLabelText } = await renderAccountListAddressItem(receiveAccount, true);
 
         expect(
             queryByLabelText(
@@ -213,7 +216,7 @@ describe(AccountListAddressItem.name, () => {
         ).toBeNull();
     });
 
-    it('should render nothing when no address is specified', () => {
+    it('should render nothing when no address is specified', async () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: mockAccountKey({ symbol: 'btc', descriptor: 'btc1' }),
@@ -223,7 +226,7 @@ describe(AccountListAddressItem.name, () => {
             }),
             address: undefined,
         };
-        const { toJSON } = renderAccountListAddressItem(receiveAccount);
+        const { toJSON } = await renderAccountListAddressItem(receiveAccount);
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListFooter.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListFooter.test.tsx
@@ -4,13 +4,13 @@ import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 import { AccountListFooter } from './AccountListFooter';
 
 describe('AccountListFooter', () => {
-    it('renders a standalone add account action', () => {
+    it('renders a standalone add account action', async () => {
         const onAddAccountTap = jest.fn();
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = await renderWithBasicProvider(
             <AccountListFooter onAddAccountTap={onAddAccountTap} />,
         );
 
-        fireEvent.press(
+        await fireEvent.press(
             getByText(getTranslation('moduleAddAccounts.coinDiscoveryFinishedScreen.addButton')),
         );
 

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
@@ -60,13 +60,13 @@ describe('AccountListItem', () => {
 
     let store: TestStore;
 
-    const renderAccountListItem = (
+    const renderAccountListItem = async (
         receiveAccount: ReceiveAccount,
         overrides: Record<string, unknown> = defaultOverrides,
     ) => {
         store = createTradingTestStore({ overrides });
 
-        return renderWithStoreProvider(
+        return await renderWithStoreProvider(
             <AccountListItem onPress={onPressMock} receiveAccount={receiveAccount} />,
             { store },
         );
@@ -76,23 +76,23 @@ describe('AccountListItem', () => {
         jest.clearAllMocks();
     });
 
-    it('should call onPress callback when pressed', () => {
+    it('should call onPress callback when pressed', async () => {
         const receiveAccount: ReceiveAccount = {
             account: btc10000000Account,
         };
-        const { getByText } = renderAccountListItem(receiveAccount);
+        const { getByText } = await renderAccountListItem(receiveAccount);
 
-        fireEvent.press(getByText('My BTC account'));
+        await fireEvent.press(getByText('My BTC account'));
 
         expect(onPressMock).toHaveBeenCalled();
     });
 
-    it('should render account name', () => {
+    it('should render account name', async () => {
         const receiveAccount: ReceiveAccount = {
             account: btc10000000Account,
         };
         const { getByText, queryByAccessibilityHint, getByLabelText } =
-            renderAccountListItem(receiveAccount);
+            await renderAccountListItem(receiveAccount);
 
         expect(getByText('My BTC account')).toBeTruthy();
         expect(
@@ -110,7 +110,7 @@ describe('AccountListItem', () => {
         ).toHaveTextContent('0.1 BTC');
     });
 
-    it('should display caret when account defines addresses', () => {
+    it('should display caret when account defines addresses', async () => {
         const receiveAccount: ReceiveAccount = {
             account: {
                 ...btc10000000Account,
@@ -121,7 +121,7 @@ describe('AccountListItem', () => {
                 },
             },
         };
-        const { getByText, getByAccessibilityHint } = renderAccountListItem(receiveAccount);
+        const { getByText, getByAccessibilityHint } = await renderAccountListItem(receiveAccount);
 
         expect(getByText('My BTC account')).toBeTruthy();
         expect(
@@ -129,7 +129,7 @@ describe('AccountListItem', () => {
         ).toBeTruthy();
     });
 
-    it('should display the descriptor for an account-based network', () => {
+    it('should display the descriptor for an account-based network', async () => {
         const account = mockWalletAccount({
             descriptor: asAccountDescriptor('0x1234567890abcdef'),
             symbol: asNetworkSymbol('eth'),
@@ -137,7 +137,7 @@ describe('AccountListItem', () => {
             accountLabel: 'My ETH account',
             availableBalance: '1000000000000000000',
         });
-        const { getByText } = renderAccountListItem(
+        const { getByText } = await renderAccountListItem(
             { account },
             {
                 ...defaultOverrides,

--- a/suite-native/module-trading/src/components/general/AccountList/NoAccountsComponent.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/NoAccountsComponent.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-sto
 import { NoAccountsComponent } from './NoAccountsComponent';
 
 describe('NoAccountsComponent', () => {
-    const renderNoAccountsComponent = ({
+    const renderNoAccountsComponent = async ({
         isConnected,
         id,
         onActivateAccount = jest.fn(),
@@ -13,7 +13,7 @@ describe('NoAccountsComponent', () => {
         id?: string;
         onActivateAccount?: () => void;
     }) =>
-        renderWithStoreProvider(
+        await renderWithStoreProvider(
             <NoAccountsComponent symbol="btc" onActivateAccount={onActivateAccount} />,
             {
                 preloadedState: {
@@ -28,9 +28,9 @@ describe('NoAccountsComponent', () => {
             },
         );
 
-    it('renders the connected-device state and activates the configured network', () => {
+    it('renders the connected-device state and activates the configured network', async () => {
         const onActivateAccount = jest.fn();
-        const { getByText } = renderNoAccountsComponent({
+        const { getByText } = await renderNoAccountsComponent({
             isConnected: true,
             onActivateAccount,
         });
@@ -46,7 +46,7 @@ describe('NoAccountsComponent', () => {
             ),
         ).toBeTruthy();
 
-        fireEvent.press(
+        await fireEvent.press(
             getByText(
                 getTranslation('moduleTrading.accountScreen.accountEmpty.activate', {
                     network: 'Bitcoin',
@@ -57,8 +57,8 @@ describe('NoAccountsComponent', () => {
         expect(onActivateAccount).toHaveBeenCalledTimes(1);
     });
 
-    it('renders the view-only explanation without activation', () => {
-        const { getByText, queryByText } = renderNoAccountsComponent({ isConnected: false });
+    it('renders the view-only explanation without activation', async () => {
+        const { getByText, queryByText } = await renderNoAccountsComponent({ isConnected: false });
 
         expect(
             getByText(
@@ -74,8 +74,8 @@ describe('NoAccountsComponent', () => {
         ).toBeNull();
     });
 
-    it('renders the Portfolio Tracker explanation without activation', () => {
-        const { getByText, queryByText } = renderNoAccountsComponent({
+    it('renders the Portfolio Tracker explanation without activation', async () => {
+        const { getByText, queryByText } = await renderNoAccountsComponent({
             isConnected: false,
             id: 'hiddenDeviceWithImportedAccounts',
         });

--- a/suite-native/module-trading/src/components/general/ActiveTab.test.tsx
+++ b/suite-native/module-trading/src/components/general/ActiveTab.test.tsx
@@ -17,24 +17,24 @@ jest.mock('@suite-native/trading-state', () => ({
 }));
 
 describe('ActiveTab', () => {
-    const renderActiveTab = (overrides: PreloadedStatePartial<TradingTestPreloadedState>) =>
-        renderWithTradingProvider(<ActiveTab />, { overrides });
+    const renderActiveTab = async (overrides: PreloadedStatePartial<TradingTestPreloadedState>) =>
+        await renderWithTradingProvider(<ActiveTab />, { overrides });
 
     it.each<[TradingTypeWithConcierge, string]>([
         ['buy', 'Buy disabled'],
         ['exchange', 'Swap disabled'],
         ['sell', 'Sell disabled'],
         ['concierge', 'Concierge disabled'],
-    ])('should display correct trading type tab for %s', (tradingType, expectedTitle) => {
-        const { getByText } = renderActiveTab({
+    ])('should display correct trading type tab for %s', async (tradingType, expectedTitle) => {
+        const { getByText } = await renderActiveTab({
             wallet: { trading: { activeTradingType: tradingType } },
         });
 
         expect(getByText(expectedTitle)).toBeOnTheScreen();
     });
 
-    it('should render nothing when no active tab is specified', () => {
-        const { toJSON } = renderActiveTab({
+    it('should render nothing when no active tab is specified', async () => {
+        const { toJSON } = await renderActiveTab({
             wallet: { trading: { activeTradingType: undefined } },
         });
 

--- a/suite-native/module-trading/src/components/general/CryptoAmountRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/CryptoAmountRow.test.tsx
@@ -4,43 +4,43 @@ import { CryptoAmountRow, type CryptoAmountRowProps } from './CryptoAmountRow';
 import { renderWithTradingProvider } from '../../test-utils/tradingTestUtils';
 
 describe('CryptoAmountRow', () => {
-    const renderCryptoAmountRow = (overriders: Partial<CryptoAmountRowProps>) =>
-        renderWithTradingProvider(
+    const renderCryptoAmountRow = async (overriders: Partial<CryptoAmountRowProps>) =>
+        await renderWithTradingProvider(
             <CryptoAmountRow cryptoId={'bitcoin' as CryptoId} direction="from" {...overriders} />,
         );
 
-    it('should render nothing for unknown cryptoId', () => {
-        const { toJSON } = renderCryptoAmountRow({ cryptoId: 'unknown' as CryptoId });
+    it('should render nothing for unknown cryptoId', async () => {
+        const { toJSON } = await renderCryptoAmountRow({ cryptoId: 'unknown' as CryptoId });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('renders amount with minus prefix for "from" direction', () => {
-        const { getByText } = renderCryptoAmountRow({ amount: '0.001' });
+    it('renders amount with minus prefix for "from" direction', async () => {
+        const { getByText } = await renderCryptoAmountRow({ amount: '0.001' });
 
         expect(getByText('-0.001 BTC')).toBeOnTheScreen();
     });
 
-    it('renders amount with plus prefix for "to" direction', () => {
-        const { getByText } = renderCryptoAmountRow({ amount: '0.001', direction: 'to' });
+    it('renders amount with plus prefix for "to" direction', async () => {
+        const { getByText } = await renderCryptoAmountRow({ amount: '0.001', direction: 'to' });
 
         expect(getByText('+0.001 BTC')).toBeOnTheScreen();
     });
 
-    it('does not render amount text when amount is undefined', () => {
-        const { queryByText } = renderCryptoAmountRow({});
+    it('does not render amount text when amount is undefined', async () => {
+        const { queryByText } = await renderCryptoAmountRow({});
 
         expect(queryByText(/^[-+]/)).toBeNull();
     });
 
-    it('does not render amount text when amount is empty string', () => {
-        const { queryByText } = renderCryptoAmountRow({ amount: '' });
+    it('does not render amount text when amount is empty string', async () => {
+        const { queryByText } = await renderCryptoAmountRow({ amount: '' });
 
         expect(queryByText(/^[-+]/)).toBeNull();
     });
 
-    it('renders amount text when amount is 0', () => {
-        const { queryByText } = renderCryptoAmountRow({ amount: '0' });
+    it('renders amount text when amount is 0', async () => {
+        const { queryByText } = await renderCryptoAmountRow({ amount: '0' });
 
         expect(queryByText('-0 BTC')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/general/Error/LastErrorMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/Error/LastErrorMessage.test.tsx
@@ -25,24 +25,24 @@ describe('LastErrorMessage', () => {
         }),
     } as const;
 
-    const renderLastErrorMessage = (props: LastErrorMessageProps) =>
-        renderWithStoreProvider(<LastErrorMessage {...props} />, { store });
+    const renderLastErrorMessage = async (props: LastErrorMessageProps) =>
+        await renderWithStoreProvider(<LastErrorMessage {...props} />, { store });
 
     beforeEach(() => {
         store = createLightStore({ reducer });
     });
 
-    it('should render nothing when no error is specified', () => {
-        const { toJSON } = renderLastErrorMessage({ tradingType: 'buy' });
+    it('should render nothing when no error is specified', async () => {
+        const { toJSON } = await renderLastErrorMessage({ tradingType: 'buy' });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render the last error message for the specified trading type', () => {
+    it('should render the last error message for the specified trading type', async () => {
         const errorMessage = 'An error occurred during the buy process';
         store.dispatch(tradingBuyActions.setLastErrorMessage(errorMessage));
 
-        const { getByText } = renderLastErrorMessage({ tradingType: 'buy' });
+        const { getByText } = await renderLastErrorMessage({ tradingType: 'buy' });
 
         expect(getByText(errorMessage)).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/general/Error/TradingTypeDisabled.test.tsx
+++ b/suite-native/module-trading/src/components/general/Error/TradingTypeDisabled.test.tsx
@@ -4,15 +4,15 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { TradingTypeDisabled, type TradingTypeDisabledProps } from './TradingTypeDisabled';
 
 describe('TradingTypeDisabled', () => {
-    const renderTradingTypeDisabled = (props: TradingTypeDisabledProps) =>
-        renderWithBasicProvider(<TradingTypeDisabled {...props} />);
+    const renderTradingTypeDisabled = async (props: TradingTypeDisabledProps) =>
+        await renderWithBasicProvider(<TradingTypeDisabled {...props} />);
 
     it.each<[TradingType, string]>([
         ['buy', 'Buy disabled'],
         ['exchange', 'Swap disabled'],
         ['sell', 'Sell disabled'],
-    ])('should render correct title for %s', (tradingType, expectedTitle) => {
-        const { getByText } = renderTradingTypeDisabled({ tradingType });
+    ])('should render correct title for %s', async (tradingType, expectedTitle) => {
+        const { getByText } = await renderTradingTypeDisabled({ tradingType });
 
         expect(getByText(expectedTitle)).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/general/FiatAmountBadge.test.tsx
+++ b/suite-native/module-trading/src/components/general/FiatAmountBadge.test.tsx
@@ -5,33 +5,33 @@ import { BigNumber } from '@trezor/utils';
 import { FiatAmountBadge, type FiatAmountBadgeProps } from './FiatAmountBadge';
 
 describe('FiatAmountBadge', () => {
-    const renderFiatAmountBadge = (props: FiatAmountBadgeProps) =>
-        renderWithBasicProvider(<FiatAmountBadge {...props} />);
+    const renderFiatAmountBadge = async (props: FiatAmountBadgeProps) =>
+        await renderWithBasicProvider(<FiatAmountBadge {...props} />);
 
-    it('should display nothing when amount is not provided', () => {
-        const { toJSON } = renderFiatAmountBadge({ amount: undefined });
+    it('should display nothing when amount is not provided', async () => {
+        const { toJSON } = await renderFiatAmountBadge({ amount: undefined });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display formatted value in app currency', () => {
-        const { getByText } = renderFiatAmountBadge({
+    it('should display formatted value in app currency', async () => {
+        const { getByText } = await renderFiatAmountBadge({
             amount: asBaseCurrencyAmount(new BigNumber('1234.56')),
         });
 
         expect(getByText('$1,234.56')).toBeDefined();
     });
 
-    it('should display 0 value', () => {
-        const { getByText } = renderFiatAmountBadge({
+    it('should display 0 value', async () => {
+        const { getByText } = await renderFiatAmountBadge({
             amount: asBaseCurrencyAmount(new BigNumber('0')),
         });
 
         expect(getByText('$0.00')).toBeDefined();
     });
 
-    it('should display nothing for empty string value', () => {
-        const { toJSON } = renderFiatAmountBadge({
+    it('should display nothing for empty string value', async () => {
+        const { toJSON } = await renderFiatAmountBadge({
             amount: asBaseCurrencyAmount(new BigNumber('')),
         });
 

--- a/suite-native/module-trading/src/components/general/FiatCurrencyButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyButton.test.tsx
@@ -4,24 +4,26 @@ import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 import { FiatCurrencyButton, type FiatCurrencyButtonProps } from './FiatCurrencyButton';
 
 describe('FiatCurrencyButton', () => {
-    const renderFiatCurrencyButton = (props: Partial<FiatCurrencyButtonProps>) =>
-        renderWithBasicProvider(
+    const renderFiatCurrencyButton = async (props: Partial<FiatCurrencyButtonProps>) =>
+        await renderWithBasicProvider(
             <FiatCurrencyButton currency="czk" onPress={jest.fn()} {...props} />,
         );
 
-    it('should render fiat currency uppercase', () => {
-        const { getByLabelText } = renderFiatCurrencyButton({});
+    it('should render fiat currency uppercase', async () => {
+        const { getByLabelText } = await renderFiatCurrencyButton({});
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
         ).toHaveTextContent(/CZK/);
     });
 
-    it('should call onPress callback when pressed', () => {
+    it('should call onPress callback when pressed', async () => {
         const onPress = jest.fn();
-        const { getByLabelText } = renderFiatCurrencyButton({ onPress });
+        const { getByLabelText } = await renderFiatCurrencyButton({ onPress });
 
-        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
+        await fireEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        );
 
         expect(onPress).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencyListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencyListItem.test.tsx
@@ -3,8 +3,8 @@ import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 import { FiatCurrencyListItem, type FiatCurrencyListItemProps } from './FiatCurrencyListItem';
 
 describe('FiatCurrencyListItem', () => {
-    const renderFiatCurrencyListItem = (props: Partial<FiatCurrencyListItemProps>) =>
-        renderWithBasicProvider(
+    const renderFiatCurrencyListItem = async (props: Partial<FiatCurrencyListItemProps>) =>
+        await renderWithBasicProvider(
             <FiatCurrencyListItem
                 label="LABEL"
                 displayValue="DISPLAY_VALUE"
@@ -14,18 +14,18 @@ describe('FiatCurrencyListItem', () => {
             />,
         );
 
-    it('should render label and display value', () => {
-        const { getByText } = renderFiatCurrencyListItem({});
+    it('should render label and display value', async () => {
+        const { getByText } = await renderFiatCurrencyListItem({});
 
         expect(getByText('LABEL')).toBeTruthy();
         expect(getByText('DISPLAY_VALUE')).toBeTruthy();
     });
 
-    it('should call onPress callback when pressed', () => {
+    it('should call onPress callback when pressed', async () => {
         const onPress = jest.fn();
-        const { getByText } = renderFiatCurrencyListItem({ onPress });
+        const { getByText } = await renderFiatCurrencyListItem({ onPress });
 
-        fireEvent.press(getByText('LABEL'));
+        await fireEvent.press(getByText('LABEL'));
 
         expect(onPress).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-trading/src/components/general/FilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/FilterTabs.test.tsx
@@ -12,12 +12,12 @@ describe('FilterTabs', () => {
         { label: 'Ethereum', value: 'eth' },
     ];
 
-    const renderComponent = (
+    const renderComponent = async (
         onChange = jest.fn(),
         value = 'all',
         keyExtractor?: (item: FilterItem<string>) => string,
     ) =>
-        renderWithStoreProvider(
+        await renderWithStoreProvider(
             <FilterTabs
                 items={items}
                 onChange={onChange}
@@ -26,8 +26,8 @@ describe('FilterTabs', () => {
             />,
         );
 
-    it('should render all filter tabs', () => {
-        const { getByText } = renderComponent();
+    it('should render all filter tabs', async () => {
+        const { getByText } = await renderComponent();
 
         expect(
             getByText(getTranslation('moduleTrading.tradeableAssetsSheet.allFilterTabTitle')),
@@ -36,19 +36,19 @@ describe('FilterTabs', () => {
         expect(getByText('Ethereum')).toBeTruthy();
     });
 
-    it('should call onChange with the correct value when a tab is pressed', () => {
+    it('should call onChange with the correct value when a tab is pressed', async () => {
         const onChange = jest.fn();
-        const { getByText } = renderComponent(onChange);
+        const { getByText } = await renderComponent(onChange);
 
         const bitcoinTab = getByText('Bitcoin');
         expect(bitcoinTab).toBeTruthy();
-        fireEvent.press(bitcoinTab!);
+        await fireEvent.press(bitcoinTab!);
 
         expect(onChange).toHaveBeenCalledWith('btc');
     });
 
-    it('should have the correct tab active based on the value prop', () => {
-        const { getByRole } = renderComponent(jest.fn(), 'btc');
+    it('should have the correct tab active based on the value prop', async () => {
+        const { getByRole } = await renderComponent(jest.fn(), 'btc');
 
         const activeTab = getByRole('tab', { selected: true });
         expect(within(activeTab).getByText('Bitcoin')).toBeTruthy();
@@ -64,9 +64,9 @@ describe('FilterTabs', () => {
         ).toBeTruthy();
     });
 
-    it('should use custom keyExtractor if provided', () => {
+    it('should use custom keyExtractor if provided', async () => {
         const keyExtractor = jest.fn(item => item.label);
-        renderComponent(jest.fn(), 'all', keyExtractor);
+        await renderComponent(jest.fn(), 'all', keyExtractor);
         expect(keyExtractor).toHaveBeenCalledWith(items[0]);
         expect(keyExtractor).toHaveBeenCalledWith(items[1]);
         expect(keyExtractor).toHaveBeenCalledWith(items[2]);

--- a/suite-native/module-trading/src/components/general/GeneralAlert.test.tsx
+++ b/suite-native/module-trading/src/components/general/GeneralAlert.test.tsx
@@ -3,23 +3,23 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { GeneralAlert, type GeneralAlertProps } from './GeneralAlert';
 
 describe('GeneralAlert', () => {
-    const renderGeneralAlert = (props: GeneralAlertProps) =>
-        renderWithBasicProvider(<GeneralAlert {...props} />);
+    const renderGeneralAlert = async (props: GeneralAlertProps) =>
+        await renderWithBasicProvider(<GeneralAlert {...props} />);
 
-    it('should render nothing when no text is provided', () => {
-        const { toJSON } = renderGeneralAlert({});
-
-        expect(toJSON()).toBeNull();
-    });
-
-    it('should render nothing for empty text', () => {
-        const { toJSON } = renderGeneralAlert({ text: '' });
+    it('should render nothing when no text is provided', async () => {
+        const { toJSON } = await renderGeneralAlert({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render alert with provided text', () => {
-        const { getByText } = renderGeneralAlert({ text: 'Test Alert' });
+    it('should render nothing for empty text', async () => {
+        const { toJSON } = await renderGeneralAlert({ text: '' });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render alert with provided text', async () => {
+        const { getByText } = await renderGeneralAlert({ text: 'Test Alert' });
 
         expect(getByText('Test Alert')).toBeTruthy();
     });

--- a/suite-native/module-trading/src/components/general/Header/Header.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/Header.test.tsx
@@ -30,24 +30,24 @@ describe('Header', () => {
         return { reportMock, services };
     };
 
-    const renderHeader = (
+    const renderHeader = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = getFFOverrides(),
     ) => {
         const { reportMock, services } = setupReportMock();
 
         return {
-            renderer: renderWithTradingProvider(<Header />, { overrides, services }),
+            renderer: await renderWithTradingProvider(<Header />, { overrides, services }),
             reportMock,
         };
     };
 
     const createTestStore = () => createTradingLightStore({ overrides: getFFOverrides() });
 
-    const renderHeaderWithStore = (store: TestStore) => {
+    const renderHeaderWithStore = async (store: TestStore) => {
         const { reportMock, services } = setupReportMock();
 
         return {
-            renderer: renderWithTradingProvider(<Header />, { services, store }),
+            renderer: await renderWithTradingProvider(<Header />, { services, store }),
             reportMock,
         };
     };
@@ -58,8 +58,8 @@ describe('Header', () => {
         { buy: false, exchange: true, sell: false },
         { buy: false, exchange: false, sell: true },
         { buy: false, exchange: false, sell: false },
-    ])('should display Buy, Swap and Sell tabs regardless of enabled flags (%o)', config => {
-        const { renderer } = renderHeader({
+    ])('should display Buy, Swap and Sell tabs regardless of enabled flags (%o)', async config => {
+        const { renderer } = await renderHeader({
             ...getFFOverrides(),
             messageSystem: mockMessageSystemStateWithFeatureFlags({
                 'trading.buy': config.buy,
@@ -79,8 +79,8 @@ describe('Header', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should display nothing when isAmountInputActive is true', () => {
-        const { renderer } = renderHeader({
+    it('should display nothing when isAmountInputActive is true', async () => {
+        const { renderer } = await renderHeader({
             ...getFFOverrides(),
             wallet: { trading: { isAmountInputActive: true } },
         });
@@ -88,11 +88,11 @@ describe('Header', () => {
         expect(renderer.toJSON()).toBeNull();
     });
 
-    it('should set state on tab button press', () => {
+    it('should set state on tab button press', async () => {
         const store = createTestStore();
-        const { renderer } = renderHeaderWithStore(store);
+        const { renderer } = await renderHeaderWithStore(store);
 
-        fireEvent.press(
+        await fireEvent.press(
             renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
         );
 
@@ -106,10 +106,10 @@ describe('Header', () => {
             store = createTestStore();
         });
 
-        it('should report TradingNavigate event on tab change', () => {
-            const { renderer, reportMock } = renderHeaderWithStore(store);
+        it('should report TradingNavigate event on tab change', async () => {
+            const { renderer, reportMock } = await renderHeaderWithStore(store);
 
-            fireEvent.press(
+            await fireEvent.press(
                 renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
             );
 
@@ -123,30 +123,30 @@ describe('Header', () => {
             });
         });
 
-        it('should not report TradingNavigate event when tab was not changed', () => {
-            const { renderer, reportMock } = renderHeaderWithStore(store);
+        it('should not report TradingNavigate event when tab was not changed', async () => {
+            const { renderer, reportMock } = await renderHeaderWithStore(store);
 
-            fireEvent.press(
+            await fireEvent.press(
                 renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
             );
             reportMock.mockClear();
 
-            fireEvent.press(
+            await fireEvent.press(
                 renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
             );
 
             expect(reportMock).not.toHaveBeenCalled();
         });
 
-        it('should report TradingNavigate event when tab was changed to buy', () => {
-            const { renderer, reportMock } = renderHeaderWithStore(store);
+        it('should report TradingNavigate event when tab was changed to buy', async () => {
+            const { renderer, reportMock } = await renderHeaderWithStore(store);
 
-            fireEvent.press(
+            await fireEvent.press(
                 renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.exchange')),
             );
             reportMock.mockClear();
 
-            fireEvent.press(
+            await fireEvent.press(
                 renderer.getByText(getTranslation('moduleTrading.tradingScreen.tabs.buy')),
             );
 

--- a/suite-native/module-trading/src/components/general/HistoryButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/HistoryButton.test.tsx
@@ -26,16 +26,16 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('HistoryButton', () => {
-    const renderHistoryButton = (
+    const renderHistoryButton = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(<HistoryButton />, {
+        await renderWithTradingProvider(<HistoryButton />, {
             overrides,
         });
 
-    it('should render nothing where no trades are available', () => {
+    it('should render nothing where no trades are available', async () => {
         mockSelectDeviceTradingTrades = [];
-        const { toJSON } = renderHistoryButton({});
+        const { toJSON } = await renderHistoryButton({});
 
         expect(toJSON()).toBeNull();
     });
@@ -46,16 +46,16 @@ describe('HistoryButton', () => {
             mockNavigate = jest.fn();
         });
 
-        it('should render button when at least one trade is specified', () => {
-            const { getByText } = renderHistoryButton({});
+        it('should render button when at least one trade is specified', async () => {
+            const { getByText } = await renderHistoryButton({});
 
             expect(
                 getByText(getTranslation('moduleTrading.tradeHistory.list.title')),
             ).toBeOnTheScreen();
         });
 
-        it('should render nothing when isAmountInputActive is true', () => {
-            const { toJSON } = renderHistoryButton({
+        it('should render nothing when isAmountInputActive is true', async () => {
+            const { toJSON } = await renderHistoryButton({
                 wallet: {
                     trading: {
                         isAmountInputActive: true,
@@ -66,10 +66,12 @@ describe('HistoryButton', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should navigate on press', () => {
-            const { getByText } = renderHistoryButton({});
+        it('should navigate on press', async () => {
+            const { getByText } = await renderHistoryButton({});
 
-            fireEvent.press(getByText(getTranslation('moduleTrading.tradeHistory.list.title')));
+            await fireEvent.press(
+                getByText(getTranslation('moduleTrading.tradeHistory.list.title')),
+            );
 
             expect(mockNavigate).toHaveBeenCalledWith('TradingHistory');
         });

--- a/suite-native/module-trading/src/components/general/Input/AmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/general/Input/AmountInput.test.tsx
@@ -4,8 +4,8 @@ import { palette } from '@trezor/theme';
 import { AMOUNT_INPUT_TEST_ID, AmountInput, type AmountInputProps } from './AmountInput';
 
 describe('AmountInput', () => {
-    const renderAmountInput = (props: Partial<AmountInputProps>) =>
-        renderWithBasicProvider(
+    const renderAmountInput = async (props: Partial<AmountInputProps>) =>
+        await renderWithBasicProvider(
             <AmountInput
                 inputTransformer={v => v}
                 onChangeText={jest.fn()}
@@ -16,7 +16,7 @@ describe('AmountInput', () => {
 
     it('should respect maxLength property', async () => {
         const changeTextMock = jest.fn();
-        const { getByLabelText } = renderAmountInput({
+        const { getByLabelText } = await renderAmountInput({
             maxLength: 5,
             onChangeText: changeTextMock,
         });
@@ -28,7 +28,7 @@ describe('AmountInput', () => {
     });
 
     it('should have no limit by default', async () => {
-        const { getByLabelText } = renderAmountInput({});
+        const { getByLabelText } = await renderAmountInput({});
 
         await userEvent.type(
             getByLabelText('INPUT'),
@@ -42,7 +42,7 @@ describe('AmountInput', () => {
 
     it('should call onChangeText with undefined instead of empty text', async () => {
         const changeTextMock = jest.fn();
-        const { getByLabelText } = renderAmountInput({ onChangeText: changeTextMock });
+        const { getByLabelText } = await renderAmountInput({ onChangeText: changeTextMock });
         const input = getByLabelText('INPUT');
         await userEvent.type(input, '1234567890');
 
@@ -52,35 +52,37 @@ describe('AmountInput', () => {
         expect(changeTextMock).toHaveBeenLastCalledWith(undefined);
     });
 
-    it('should have default color for valid input value', () => {
-        const { getByLabelText } = renderAmountInput({ value: '1' });
+    it('should have default color for valid input value', async () => {
+        const { getByLabelText } = await renderAmountInput({ value: '1' });
 
         expect(getByLabelText('INPUT')).toHaveStyle({ color: palette.lightCoolGreyAlpha900 });
     });
 
-    it('should have alert color for invalid input value', () => {
-        const { getByLabelText } = renderAmountInput({ value: '1', hasError: true });
+    it('should have alert color for invalid input value', async () => {
+        const { getByLabelText } = await renderAmountInput({ value: '1', hasError: true });
 
         expect(getByLabelText('INPUT')).toHaveStyle({ color: palette.lightRed700 });
     });
 
-    it('should have font size of 34 before layout events', () => {
-        const { getByLabelText } = renderAmountInput({});
+    it('should have font size of 34 before layout events', async () => {
+        const { getByLabelText } = await renderAmountInput({});
 
         expect(getByLabelText('INPUT')).toHaveStyle({ fontSize: 34, lineHeight: 41 });
     });
 
     describe('font size scaling on content change', () => {
-        let input: ReturnType<ReturnType<typeof renderAmountInput>['getByLabelText']>;
-        let box: ReturnType<ReturnType<typeof renderAmountInput>['getByTestId']>;
+        let input: ReturnType<Awaited<ReturnType<typeof renderAmountInput>>['getByLabelText']>;
+        let box: ReturnType<Awaited<ReturnType<typeof renderAmountInput>>['getByTestId']>;
 
-        beforeEach(() => {
-            const { getByLabelText, getByTestId } = renderAmountInput({ value: '1234567890' });
+        beforeEach(async () => {
+            const { getByLabelText, getByTestId } = await renderAmountInput({
+                value: '1234567890',
+            });
             input = getByLabelText('INPUT');
             box = getByTestId(AMOUNT_INPUT_TEST_ID);
 
             // Simulate initial layout event
-            fireEvent(box, 'layout', {
+            await fireEvent(box, 'layout', {
                 nativeEvent: {
                     layout: {
                         width: 120,
@@ -100,8 +102,8 @@ describe('AmountInput', () => {
             [250, 17, 20],
         ])(
             'should downscale font when not enough space is available for content with width %i',
-            (contentWidth, expectedFontSize, expectedLineHeight) => {
-                fireEvent(input, 'layout', {
+            async (contentWidth, expectedFontSize, expectedLineHeight) => {
+                await fireEvent(input, 'layout', {
                     nativeEvent: {
                         layout: {
                             width: contentWidth,
@@ -122,15 +124,15 @@ describe('AmountInput', () => {
             [10, 34, 41],
         ])(
             'should upscale font when enough space is available for content with width %i',
-            (contentWidth, expectedFontSize, expectedLineHeight) => {
-                fireEvent(input, 'layout', {
+            async (contentWidth, expectedFontSize, expectedLineHeight) => {
+                await fireEvent(input, 'layout', {
                     nativeEvent: {
                         layout: {
                             width: 200,
                         },
                     },
                 });
-                fireEvent(input, 'layout', {
+                await fireEvent(input, 'layout', {
                     nativeEvent: {
                         layout: {
                             width: contentWidth,
@@ -147,15 +149,15 @@ describe('AmountInput', () => {
 
         it.each([100, 80])(
             'should not upscale until hysteresis is reached for content with width %i',
-            contentWidth => {
-                fireEvent(input, 'layout', {
+            async contentWidth => {
+                await fireEvent(input, 'layout', {
                     nativeEvent: {
                         layout: {
                             width: 200,
                         },
                     },
                 });
-                fireEvent(input, 'layout', {
+                await fireEvent(input, 'layout', {
                     nativeEvent: {
                         layout: {
                             width: contentWidth,
@@ -170,8 +172,8 @@ describe('AmountInput', () => {
             },
         );
 
-        it('should not divide by zero', () => {
-            fireEvent(input, 'layout', {
+        it('should not divide by zero', async () => {
+            await fireEvent(input, 'layout', {
                 nativeEvent: {
                     layout: {
                         width: 0,
@@ -185,8 +187,8 @@ describe('AmountInput', () => {
             });
         });
 
-        it('should use full sized font when available space is equal zero', () => {
-            fireEvent(box, 'layout', {
+        it('should use full sized font when available space is equal zero', async () => {
+            await fireEvent(box, 'layout', {
                 nativeEvent: {
                     layout: {
                         width: 0,
@@ -209,7 +211,7 @@ describe('AmountInput', () => {
         });
 
         it('should not limit input value when property is not set', async () => {
-            const { getByLabelText } = renderAmountInput({ onChangeText });
+            const { getByLabelText } = await renderAmountInput({ onChangeText });
 
             await userEvent.type(getByLabelText('INPUT'), '1234567890.123456789');
 
@@ -217,7 +219,7 @@ describe('AmountInput', () => {
         });
 
         it('should truncate decimals exceeding specified limit', async () => {
-            const { getByLabelText } = renderAmountInput({ onChangeText, maxDecimals: 3 });
+            const { getByLabelText } = await renderAmountInput({ onChangeText, maxDecimals: 3 });
 
             await userEvent.type(getByLabelText('INPUT'), '1234567890.123456789');
 
@@ -225,7 +227,7 @@ describe('AmountInput', () => {
         });
 
         it('should truncate zero decimals exceeding specified limit', async () => {
-            const { getByLabelText } = renderAmountInput({ onChangeText, maxDecimals: 3 });
+            const { getByLabelText } = await renderAmountInput({ onChangeText, maxDecimals: 3 });
 
             await userEvent.type(getByLabelText('INPUT'), '1234567890.100000000');
 
@@ -235,7 +237,7 @@ describe('AmountInput', () => {
         it.each(['0', '123456', '0.1', '12345.789'])(
             'should do nothing when number of decimals is not exceeding limit, case [%s]',
             async typedValue => {
-                const { getByLabelText } = renderAmountInput({
+                const { getByLabelText } = await renderAmountInput({
                     onChangeText,
                     maxDecimals: 3,
                 });
@@ -248,8 +250,8 @@ describe('AmountInput', () => {
     });
 
     describe('isLoading property', () => {
-        it('should not display input and should display skeleton instead', () => {
-            const { getByTestId, queryByLabelText } = renderAmountInput({
+        it('should not display input and should display skeleton instead', async () => {
+            const { getByTestId, queryByLabelText } = await renderAmountInput({
                 isLoading: true,
                 loadingAccessibilityLabel: 'LOADING',
             });

--- a/suite-native/module-trading/src/components/general/LegalGatewayContextMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/LegalGatewayContextMessage.test.tsx
@@ -14,11 +14,11 @@ jest.mock('@suite-common/message-system', () => {
 });
 
 describe('LegalGatewayContextMessage', () => {
-    const renderLegalGatewayContextMessage = () =>
-        renderWithStoreProvider(<LegalGatewayContextMessage />);
+    const renderLegalGatewayContextMessage = async () =>
+        await renderWithStoreProvider(<LegalGatewayContextMessage />);
 
-    it('should render legal.gateway context message', () => {
-        const { getByText } = renderLegalGatewayContextMessage();
+    it('should render legal.gateway context message', async () => {
+        const { getByText } = await renderLegalGatewayContextMessage();
 
         expect(getByText('Legal gateway message')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/general/MyAssetList/MyAssetGroup.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetList/MyAssetGroup.test.tsx
@@ -19,9 +19,9 @@ const createAsset = (index: number, isEnabled = true): MyAsset => ({
 describe('MyAssetGroup', () => {
     const assets = [createAsset(1), createAsset(2), createAsset(3)];
 
-    it('shows two preview icons and an overflow count while collapsed', () => {
+    it('shows two preview icons and an overflow count while collapsed', async () => {
         const testID = '@trading/my-asset-group';
-        const { getByTestId, getByText } = renderWithStoreProvider(
+        const { getByTestId, getByText } = await renderWithStoreProvider(
             <MyAssetGroup
                 assets={assets}
                 onAssetSelect={jest.fn()}
@@ -39,9 +39,9 @@ describe('MyAssetGroup', () => {
         });
     });
 
-    it('renders all assets when expanded', () => {
+    it('renders all assets when expanded', async () => {
         const testID = '@trading/my-asset-group';
-        const { getByTestId, getByText } = renderWithStoreProvider(
+        const { getByTestId, getByText } = await renderWithStoreProvider(
             <MyAssetGroup
                 assets={assets}
                 onAssetSelect={jest.fn()}
@@ -50,7 +50,7 @@ describe('MyAssetGroup', () => {
             />,
         );
 
-        fireEvent.press(getByTestId(`${testID}/toggle`));
+        await fireEvent.press(getByTestId(`${testID}/toggle`));
 
         expect(getByTestId(`${testID}/toggle`).props.accessibilityState).toEqual({
             expanded: true,
@@ -60,9 +60,9 @@ describe('MyAssetGroup', () => {
         expect(getByText('Token 3')).toBeOnTheScreen();
     });
 
-    it('does not select a non-tradeable asset', () => {
+    it('does not select a non-tradeable asset', async () => {
         const onAssetSelect = jest.fn();
-        const { getByText } = renderWithStoreProvider(
+        const { getByText } = await renderWithStoreProvider(
             <MyAssetGroup
                 assets={[createAsset(1, false)]}
                 onAssetSelect={onAssetSelect}
@@ -71,8 +71,8 @@ describe('MyAssetGroup', () => {
             />,
         );
 
-        fireEvent.press(getByText('Non-tradeable'));
-        fireEvent.press(getByText('Token 1'));
+        await fireEvent.press(getByText('Non-tradeable'));
+        await fireEvent.press(getByText('Token 1'));
 
         expect(onAssetSelect).not.toHaveBeenCalled();
     });

--- a/suite-native/module-trading/src/components/general/MyAssetList/MyAssetList.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetList/MyAssetList.test.tsx
@@ -36,8 +36,8 @@ const section: MyAssetsSection = {
 describe('MyAssetList', () => {
     const testID = '@trading/sell/send-asset-screen';
 
-    const renderList = (assets: MyAssetsSection[] = [section]) =>
-        renderWithTradingProvider(
+    const renderList = async (assets: MyAssetsSection[] = [section]) =>
+        await renderWithTradingProvider(
             <MyAssetList
                 assets={assets}
                 onAssetSelect={jest.fn()}
@@ -49,8 +49,8 @@ describe('MyAssetList', () => {
             />,
         );
 
-    it('expands low-balance and non-tradeable groups independently', () => {
-        const { getByTestId, getByText } = renderList();
+    it('expands low-balance and non-tradeable groups independently', async () => {
+        const { getByTestId, getByText } = await renderList();
         const lowBalanceTestID = `${testID}/${eth1NormalAccount.key}/low-balance`;
         const nonTradeableTestID = `${testID}/${eth1NormalAccount.key}/non-tradeable`;
 
@@ -62,7 +62,7 @@ describe('MyAssetList', () => {
             expanded: false,
         });
 
-        fireEvent.press(getByTestId(`${lowBalanceTestID}/toggle`));
+        await fireEvent.press(getByTestId(`${lowBalanceTestID}/toggle`));
 
         expect(getByTestId(`${lowBalanceTestID}/toggle`).props.accessibilityState).toEqual({
             expanded: true,
@@ -71,7 +71,7 @@ describe('MyAssetList', () => {
             expanded: false,
         });
 
-        fireEvent.press(getByTestId(`${nonTradeableTestID}/toggle`));
+        await fireEvent.press(getByTestId(`${nonTradeableTestID}/toggle`));
 
         expect(getByTestId(`${lowBalanceTestID}/toggle`).props.accessibilityState).toEqual({
             expanded: true,
@@ -82,8 +82,8 @@ describe('MyAssetList', () => {
         expect(getByText('Disabled')).toBeDisabled();
     });
 
-    it('renders the existing empty-state copy', () => {
-        const { getByText } = renderList([]);
+    it('renders the existing empty-state copy', async () => {
+        const { getByText } = await renderList([]);
 
         expect(
             getByText(getTranslation('moduleTrading.myAssetScreen.emptyTitle')),

--- a/suite-native/module-trading/src/components/general/MyAssetList/TokenIconGroup.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetList/TokenIconGroup.test.tsx
@@ -17,9 +17,9 @@ const createAsset = (index: number): MyAsset => ({
 });
 
 describe('TokenIconGroup', () => {
-    it('overlaps preview icons and the overflow badge', () => {
+    it('overlaps preview icons and the overflow badge', async () => {
         const testID = '@trading/token-icon-group';
-        const { getByTestId, getByText } = renderWithStoreProvider(
+        const { getByTestId, getByText } = await renderWithStoreProvider(
             <TokenIconGroup
                 assets={[createAsset(1), createAsset(2), createAsset(3), createAsset(4)]}
                 testID={testID}

--- a/suite-native/module-trading/src/components/general/NetworkPicker/NetworkPicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/NetworkPicker/NetworkPicker.test.tsx
@@ -24,7 +24,7 @@ jest.mock('@suite-native/discovery', () => ({
 describe('NetworkPicker', () => {
     const testID = '@trading/test/network-picker';
 
-    const renderNetworkPicker = ({
+    const renderNetworkPicker = async ({
         networkFilterMode,
         selectedNetwork,
         onSelectNetwork = jest.fn(),
@@ -33,7 +33,7 @@ describe('NetworkPicker', () => {
         selectedNetwork?: Network['symbol'];
         onSelectNetwork?: jest.Mock;
     } = {}) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <NetworkPicker
                 networkFilterMode={networkFilterMode}
                 selectedNetwork={selectedNetwork}
@@ -42,49 +42,49 @@ describe('NetworkPicker', () => {
             />,
         );
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('renders the available networks in the sheet', () => {
-        const { getByTestId, getByText } = renderNetworkPicker();
+    it('renders the available networks in the sheet', async () => {
+        const { getByTestId, getByText } = await renderNetworkPicker();
 
-        fireEvent.press(getByTestId(testID));
+        await fireEvent.press(getByTestId(testID));
 
         expect(getByText('Bitcoin')).toBeOnTheScreen();
         expect(getByText('Ethereum')).toBeOnTheScreen();
     });
 
-    it('applies a selected network', () => {
+    it('applies a selected network', async () => {
         const onSelectNetwork = jest.fn();
-        const { getByTestId } = renderNetworkPicker({ onSelectNetwork });
-        fireEvent.press(getByTestId(testID));
+        const { getByTestId } = await renderNetworkPicker({ onSelectNetwork });
+        await fireEvent.press(getByTestId(testID));
 
-        fireEvent.press(getByTestId(`${testID}/networks-sheet/eth`));
+        await fireEvent.press(getByTestId(`${testID}/networks-sheet/eth`));
 
         expect(onSelectNetwork).toHaveBeenCalledWith('eth');
     });
 
-    it('renders only discovered networks in discovered mode', () => {
-        const { getByTestId, getByText, queryByText } = renderNetworkPicker({
+    it('renders only discovered networks in discovered mode', async () => {
+        const { getByTestId, getByText, queryByText } = await renderNetworkPicker({
             networkFilterMode: 'discovered',
         });
 
-        fireEvent.press(getByTestId(testID));
+        await fireEvent.press(getByTestId(testID));
 
         expect(getByText('Ethereum')).toBeOnTheScreen();
         expect(queryByText('Bitcoin')).not.toBeOnTheScreen();
     });
 
-    it('selects all networks', () => {
+    it('selects all networks', async () => {
         const onSelectNetwork = jest.fn();
-        const { getByTestId } = renderNetworkPicker({
+        const { getByTestId } = await renderNetworkPicker({
             selectedNetwork: 'eth',
             onSelectNetwork,
         });
-        fireEvent.press(getByTestId(testID));
+        await fireEvent.press(getByTestId(testID));
 
-        fireEvent.press(getByTestId(`${testID}/networks-sheet/all`));
+        await fireEvent.press(getByTestId(`${testID}/networks-sheet/all`));
 
         expect(onSelectNetwork).toHaveBeenCalledWith(undefined);
     });

--- a/suite-native/module-trading/src/components/general/NetworkSymbolExtendedFormatter.test.tsx
+++ b/suite-native/module-trading/src/components/general/NetworkSymbolExtendedFormatter.test.tsx
@@ -3,8 +3,8 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { NetworkSymbolExtendedFormatter } from './NetworkSymbolExtendedFormatter';
 
 describe('NetworkSymbolExtendedFormatter', () => {
-    it('should render symbol uppercase', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should render symbol uppercase', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <NetworkSymbolExtendedFormatter symbol="btc" />,
         );
 

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.test.tsx
@@ -78,11 +78,11 @@ describe('PaymentMethodListItem', () => {
         },
     };
 
-    const renderPaymentMethodListItem = (
+    const renderPaymentMethodListItem = async (
         props: Partial<PaymentMethodListItemProps<any>>,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = defaultOverrides,
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <PaymentMethodListItem
                 quote={mercuryoApplePayBuyQuote}
                 onPress={jest.fn()}
@@ -91,29 +91,32 @@ describe('PaymentMethodListItem', () => {
             { overrides },
         );
 
-    it('should render given name and receive amount', () => {
-        const { getByText, queryByText } = renderPaymentMethodListItem({});
+    it('should render given name and receive amount', async () => {
+        const { getByText, queryByText } = await renderPaymentMethodListItem({});
 
         expect(getByText('Apple Pay')).toBeOnTheScreen();
         expect(getByText('0.00100017 BTC')).toBeOnTheScreen();
         expect(queryByText(getTranslation('moduleTrading.providerListItem.rate'))).toBeNull();
     });
 
-    it('should display fiat amount instead of receive amount when user requested a crypto amount', () => {
-        const { getByText, queryByText } = renderPaymentMethodListItem({}, wantCryptoOverrides);
+    it('should display fiat amount instead of receive amount when user requested a crypto amount', async () => {
+        const { getByText, queryByText } = await renderPaymentMethodListItem(
+            {},
+            wantCryptoOverrides,
+        );
 
         expect(getByText('€10.00')).toBeOnTheScreen();
         expect(queryByText('0.00100017 BTC')).toBeNull();
     });
 
-    it('should display crypto amount difference in shortfall note when user requested a crypto amount', () => {
+    it('should display crypto amount difference in shortfall note when user requested a crypto amount', async () => {
         const cryptoShortfallQuote = {
             ...mercuryoApplePayBuyQuote,
             receiveStringAmount: '0.001',
             orderId: 'order-id-crypto-shortfall',
         };
 
-        const { getByText } = renderPaymentMethodListItem(
+        const { getByText } = await renderPaymentMethodListItem(
             { quote: cryptoShortfallQuote },
             cryptoShortfallOverrides,
         );
@@ -121,8 +124,8 @@ describe('PaymentMethodListItem', () => {
         expect(getByText('50% less to receive than requested (0.001 BTC)')).toBeOnTheScreen();
     });
 
-    it('should render shortfall note for a shortfall quote', () => {
-        const { getByText } = renderPaymentMethodListItem(
+    it('should render shortfall note for a shortfall quote', async () => {
+        const { getByText } = await renderPaymentMethodListItem(
             { quote: shortfallQuote },
             shortfallOverrides,
         );
@@ -130,20 +133,20 @@ describe('PaymentMethodListItem', () => {
         expect(getByText('20% less to receive than requested (€2.00)')).toBeOnTheScreen();
     });
 
-    it('should not render shortfall note when shortfall is not present', () => {
-        const { queryByText } = renderPaymentMethodListItem({});
+    it('should not render shortfall note when shortfall is not present', async () => {
+        const { queryByText } = await renderPaymentMethodListItem({});
 
         expect(queryByText(/less to receive/)).toBeNull();
     });
 
-    it('should render payment method logo for branded payment methods', () => {
-        const { getByTestId } = renderPaymentMethodListItem({});
+    it('should render payment method logo for branded payment methods', async () => {
+        const { getByTestId } = await renderPaymentMethodListItem({});
 
         expect(getByTestId('@icons/payment-method-logo/applePay')).toBeOnTheScreen();
     });
 
-    it('should render fallback icon for non-branded payment methods', () => {
-        const { getByTestId } = renderPaymentMethodListItem({
+    it('should render fallback icon for non-branded payment methods', async () => {
+        const { getByTestId } = await renderPaymentMethodListItem({
             quote: cexdirectCreditCardBuyQuote,
         });
 
@@ -152,7 +155,7 @@ describe('PaymentMethodListItem', () => {
 
     it('should call onPress callback on item press', async () => {
         const onPress = jest.fn();
-        const { getByText } = renderPaymentMethodListItem({ onPress });
+        const { getByText } = await renderPaymentMethodListItem({ onPress });
 
         await act(async () => {
             await userEvent.press(getByText('Apple Pay'));
@@ -161,8 +164,8 @@ describe('PaymentMethodListItem', () => {
         expect(onPress).toHaveBeenCalledTimes(1);
     });
 
-    it('should not render receive amount row when receive amount is unknown', () => {
-        const { getByText, queryByText } = renderPaymentMethodListItem({
+    it('should not render receive amount row when receive amount is unknown', async () => {
+        const { getByText, queryByText } = await renderPaymentMethodListItem({
             quote: { ...mercuryoApplePayBuyQuote, receiveStringAmount: undefined },
         });
 
@@ -215,8 +218,8 @@ describe('PaymentMethodListItem', () => {
             },
         };
 
-        it('should display crypto amount to sell when user requested a fixed fiat amount', () => {
-            const { getByText, queryByText } = renderPaymentMethodListItem(
+        it('should display crypto amount to sell when user requested a fixed fiat amount', async () => {
+            const { getByText, queryByText } = await renderPaymentMethodListItem(
                 { quote: sellQuote },
                 sellFiatRequestOverrides,
             );
@@ -225,8 +228,8 @@ describe('PaymentMethodListItem', () => {
             expect(queryByText('$100.00')).toBeNull();
         });
 
-        it('should display fiat amount to receive when user requested a fixed crypto amount', () => {
-            const { getByText, queryByText } = renderPaymentMethodListItem(
+        it('should display fiat amount to receive when user requested a fixed crypto amount', async () => {
+            const { getByText, queryByText } = await renderPaymentMethodListItem(
                 { quote: sellQuote },
                 sellCryptoRequestOverrides,
             );
@@ -235,14 +238,14 @@ describe('PaymentMethodListItem', () => {
             expect(queryByText('1 ETH')).toBeNull();
         });
 
-        it('should render shortfall note when sell quote receives less fiat than requested', () => {
+        it('should render shortfall note when sell quote receives less fiat than requested', async () => {
             const shortfallSellQuote = {
                 ...sellQuote,
                 fiatStringAmount: '70',
                 orderId: 'order-id-sell-shortfall',
             };
 
-            const { getByText } = renderPaymentMethodListItem(
+            const { getByText } = await renderPaymentMethodListItem(
                 { quote: shortfallSellQuote },
                 sellFiatRequestOverrides,
             );
@@ -250,8 +253,8 @@ describe('PaymentMethodListItem', () => {
             expect(getByText('30% less to receive than requested ($30.00)')).toBeOnTheScreen();
         });
 
-        it('should not render shortfall note for a sell quote when there is no shortfall', () => {
-            const { queryByText } = renderPaymentMethodListItem({ quote: sellQuote });
+        it('should not render shortfall note for a sell quote when there is no shortfall', async () => {
+            const { queryByText } = await renderPaymentMethodListItem({ quote: sellQuote });
 
             expect(queryByText(/less to receive/)).toBeNull();
         });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/NoProvidersPlaceholder.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/NoProvidersPlaceholder.test.tsx
@@ -4,10 +4,11 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { NoProvidersPlaceholder } from './NoProvidersPlaceholder';
 
 describe('NoProvidersPlaceholder', () => {
-    const renderNoProvidersPlaceholder = () => renderWithBasicProvider(<NoProvidersPlaceholder />);
+    const renderNoProvidersPlaceholder = async () =>
+        await renderWithBasicProvider(<NoProvidersPlaceholder />);
 
-    it('should render text and icon with label', () => {
-        const { getByLabelText, getByText } = renderNoProvidersPlaceholder();
+    it('should render text and icon with label', async () => {
+        const { getByLabelText, getByText } = await renderNoProvidersPlaceholder();
 
         expect(
             getByText(getTranslation('moduleTrading.providerSheet.noProviders')),

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.test.tsx
@@ -24,12 +24,12 @@ const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
 };
 
 describe('ProviderListItem', () => {
-    const renderProviderListItem = (
+    const renderProviderListItem = async (
         quote: TradingTradeType,
         props?: Partial<ProviderListItemProps<TradingTradeType>>,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = baseOverrides,
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ProviderListItem
                 isSelected={false}
                 onPress={jest.fn()}
@@ -41,14 +41,14 @@ describe('ProviderListItem', () => {
             { overrides },
         );
 
-    it('should render provider information correctly', () => {
-        const { getByText } = renderProviderListItem(mercuryoApplePayBuyQuote);
+    it('should render provider information correctly', async () => {
+        const { getByText } = await renderProviderListItem(mercuryoApplePayBuyQuote);
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should render the amount in the header and not the rate row for a buy quote', () => {
-        const { getByText, queryByText } = renderProviderListItem(mercuryoApplePayBuyQuote);
+    it('should render the amount in the header and not the rate row for a buy quote', async () => {
+        const { getByText, queryByText } = await renderProviderListItem(mercuryoApplePayBuyQuote);
 
         expect(
             queryByText(getTranslation('moduleTrading.providerListItem.centralizedExchange')),
@@ -57,16 +57,16 @@ describe('ProviderListItem', () => {
         expect(queryByText('€9,998.32 / 1 BTC')).toBeNull();
     });
 
-    it('should render the received amount in the header for an exchange quote', () => {
-        const { getByText } = renderProviderListItem(cexdirectFloatingQuote, {
+    it('should render the received amount in the header for an exchange quote', async () => {
+        const { getByText } = await renderProviderListItem(cexdirectFloatingQuote, {
             tradingType: 'exchange',
         });
 
         expect(getByText('0.00089118 BTC')).toBeOnTheScreen();
     });
 
-    it('should render centralized exchange information for CEX providers when enabled', () => {
-        const { getByText } = renderProviderListItem(cexdirectFloatingQuote, {
+    it('should render centralized exchange information for CEX providers when enabled', async () => {
+        const { getByText } = await renderProviderListItem(cexdirectFloatingQuote, {
             shouldShowExchangeType: true,
             tradingType: 'exchange',
         });
@@ -76,16 +76,16 @@ describe('ProviderListItem', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render KYC information when provider has KYC policy', () => {
-        const { getByText } = renderProviderListItem(cexdirectFloatingQuote, {
+    it('should render KYC information when provider has KYC policy', async () => {
+        const { getByText } = await renderProviderListItem(cexdirectFloatingQuote, {
             tradingType: 'exchange',
         });
 
         expect(getByText(getTranslation('moduleTrading.kyc.kycRequired'))).toBeOnTheScreen();
     });
 
-    it('should render anonymous information for DEX providers', () => {
-        const { getByText } = renderProviderListItem(invityDexQuote, {
+    it('should render anonymous information for DEX providers', async () => {
+        const { getByText } = await renderProviderListItem(invityDexQuote, {
             shouldShowExchangeType: true,
             tradingType: 'exchange',
         });
@@ -98,25 +98,25 @@ describe('ProviderListItem', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should not render when quote has no orderId', () => {
+    it('should not render when quote has no orderId', async () => {
         const { orderId, ...quoteWithoutOrderId } = mercuryoApplePayBuyQuote;
         const quote = quoteWithoutOrderId as TradingTradeType;
 
-        const { queryByText } = renderProviderListItem(quote);
+        const { queryByText } = await renderProviderListItem(quote);
 
         expect(queryByText('TestProvider')).toBeNull();
     });
 
-    it('should render KYC warning for buy quote', () => {
-        const { getByText } = renderProviderListItem(mercuryoApplePayBuyQuote);
+    it('should render KYC warning for buy quote', async () => {
+        const { getByText } = await renderProviderListItem(mercuryoApplePayBuyQuote);
 
         expect(
             getByText(getTranslation('moduleTrading.providerListItem.kycRequired')),
         ).toBeOnTheScreen();
     });
 
-    it('should render KYC warning for sell quote', () => {
-        const { getByText } = renderProviderListItem(banxaCreditCardSellQuote, {
+    it('should render KYC warning for sell quote', async () => {
+        const { getByText } = await renderProviderListItem(banxaCreditCardSellQuote, {
             tradingType: 'sell',
         });
 

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemAmount.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemAmount.test.tsx
@@ -52,19 +52,19 @@ const sellAmountInCryptoOverrides: PreloadedStatePartial<TradingTestPreloadedSta
 };
 
 describe('ProviderListItemAmount', () => {
-    const renderProviderListItemAmount = (
+    const renderProviderListItemAmount = async (
         quote: TradingTradeType,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = overridesWithQuotes,
-    ) => renderWithTradingProvider(<ProviderListItemAmount quote={quote} />, { overrides });
+    ) => await renderWithTradingProvider(<ProviderListItemAmount quote={quote} />, { overrides });
 
-    it('should render the received amount when the user entered the "from" amount', () => {
-        const { getByText } = renderProviderListItemAmount(mercuryoApplePayBuyQuote);
+    it('should render the received amount when the user entered the "from" amount', async () => {
+        const { getByText } = await renderProviderListItemAmount(mercuryoApplePayBuyQuote);
 
         expect(getByText('0.00100017 BTC')).toBeOnTheScreen();
     });
 
-    it('should render the fiat amount when the user requested a crypto ("to") amount for buy', () => {
-        const { getByText } = renderProviderListItemAmount(
+    it('should render the fiat amount when the user requested a crypto ("to") amount for buy', async () => {
+        const { getByText } = await renderProviderListItemAmount(
             mercuryoApplePayBuyQuote,
             buyWantCryptoOverrides,
         );
@@ -72,8 +72,8 @@ describe('ProviderListItemAmount', () => {
         expect(getByText('€10.00')).toBeOnTheScreen();
     });
 
-    it('should render the received fiat amount when the user entered a crypto amount for sell', () => {
-        const { getByText } = renderProviderListItemAmount(
+    it('should render the received fiat amount when the user entered a crypto amount for sell', async () => {
+        const { getByText } = await renderProviderListItemAmount(
             banxaCreditCardSellQuote,
             sellAmountInCryptoOverrides,
         );
@@ -81,13 +81,13 @@ describe('ProviderListItemAmount', () => {
         expect(getByText('$90.17')).toBeOnTheScreen();
     });
 
-    it('should render nothing when the amount is missing', () => {
+    it('should render nothing when the amount is missing', async () => {
         const quoteWithoutReceiveAmount = {
             ...mercuryoApplePayBuyQuote,
             receiveStringAmount: undefined,
         } as TradingTradeType;
 
-        const { toJSON } = renderProviderListItemAmount(quoteWithoutReceiveAmount);
+        const { toJSON } = await renderProviderListItemAmount(quoteWithoutReceiveAmount);
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.test.tsx
@@ -18,11 +18,11 @@ const overridesWithQuotes: PreloadedStatePartial<TradingTestPreloadedState> = {
 };
 
 describe('ProviderListItemInfo', () => {
-    const renderProviderListItemInfo = (
+    const renderProviderListItemInfo = async (
         quote: TradingTradeType,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = overridesWithQuotes,
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ProviderListItemInfo
                 quote={quote}
                 provider={provider}
@@ -31,7 +31,7 @@ describe('ProviderListItemInfo', () => {
             { overrides },
         );
 
-    it('should render shortfall note for a shortfall quote', () => {
+    it('should render shortfall note for a shortfall quote', async () => {
         const shortfallQuote = {
             ...mercuryoApplePayBuyQuote,
             fiatStringAmount: '8',
@@ -55,14 +55,14 @@ describe('ProviderListItemInfo', () => {
             },
         };
 
-        const { getByText } = renderProviderListItemInfo(shortfallQuote, shortfallOverrides);
+        const { getByText } = await renderProviderListItemInfo(shortfallQuote, shortfallOverrides);
 
         // The note is shown in the fiat currency the user is trading in (EUR from the quote).
         expect(getByText('20% less to receive than requested (€2.00)')).toBeOnTheScreen();
     });
 
-    it('should not render shortfall note when quote does not have shortfall', () => {
-        const { queryByText } = renderProviderListItemInfo(mercuryoApplePayBuyQuote);
+    it('should not render shortfall note when quote does not have shortfall', async () => {
+        const { queryByText } = await renderProviderListItemInfo(mercuryoApplePayBuyQuote);
 
         expect(queryByText(/less to receive/)).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.test.tsx
@@ -15,11 +15,11 @@ import {
 } from '../../../test-utils/tradingTestUtils';
 
 describe('ProviderSheet', () => {
-    const renderProviderSheet = (
+    const renderProviderSheet = async (
         props: Partial<ProviderSheetProps<TradingType, TradingTradeType>> = {},
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ProviderSheet
                 onClose={jest.fn()}
                 isVisible={true}
@@ -31,12 +31,12 @@ describe('ProviderSheet', () => {
             { overrides },
         );
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render empty providers placeholder and no section header and for buy', () => {
-        const { queryByText, getByText } = renderProviderSheet({}, {});
+    it('should render empty providers placeholder and no section header and for buy', async () => {
+        const { queryByText, getByText } = await renderProviderSheet({}, {});
 
         expect(
             getByText(getTranslation('moduleTrading.providerSheet.noProviders')),
@@ -44,8 +44,8 @@ describe('ProviderSheet', () => {
         expect(queryByText(getTranslation('moduleTrading.providerSheet.fixed.title'))).toBeNull();
     });
 
-    it('should render section header and empty placeholder for exchange', () => {
-        const { getByText } = renderProviderSheet({ tradingType: 'exchange' }, {});
+    it('should render section header and empty placeholder for exchange', async () => {
+        const { getByText } = await renderProviderSheet({ tradingType: 'exchange' }, {});
 
         expect(
             getByText(getTranslation('moduleTrading.providerSheet.noProviders')),
@@ -55,8 +55,8 @@ describe('ProviderSheet', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render all section headers for exchange', () => {
-        const { getByText } = renderProviderSheet({
+    it('should render all section headers for exchange', async () => {
+        const { getByText } = await renderProviderSheet({
             tradingType: 'exchange',
             quotes: EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES,
         });
@@ -72,8 +72,8 @@ describe('ProviderSheet', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render provided quotes', () => {
-        const { queryByText, getByText } = renderProviderSheet({
+    it('should render provided quotes', async () => {
+        const { queryByText, getByText } = await renderProviderSheet({
             quotes: { fixed: [mercuryoApplePayBuyQuote] },
         });
 
@@ -84,8 +84,8 @@ describe('ProviderSheet', () => {
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should render exchange type information for exchange quotes', () => {
-        const { getByText } = renderProviderSheet({
+    it('should render exchange type information for exchange quotes', async () => {
+        const { getByText } = await renderProviderSheet({
             quotes: { fixed: [cexdirectFloatingQuote] },
             tradingType: 'exchange',
         });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetHandle.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetHandle.test.tsx
@@ -22,11 +22,11 @@ jest.mock('@suite-common/message-system', () => {
 });
 
 describe('ProviderSheetHandle', () => {
-    const renderProviderSheetHandle = (
+    const renderProviderSheetHandle = async (
         props: Partial<ProviderSheetHandleProps> = {},
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ProviderSheetHandle
                 onClose={jest.fn()}
                 shouldShowFilters={true}
@@ -51,8 +51,8 @@ describe('ProviderSheetHandle', () => {
             { overrides },
         );
 
-    it('should render component with title and filter', () => {
-        const { getByText } = renderProviderSheetHandle({}, {});
+    it('should render component with title and filter', async () => {
+        const { getByText } = await renderProviderSheetHandle({}, {});
 
         expect(getByText(getTranslation('moduleTrading.providerSheet.title'))).toBeOnTheScreen();
         expect(
@@ -66,8 +66,8 @@ describe('ProviderSheetHandle', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should not render filters when shouldShowFilters is false', () => {
-        const { getByText, queryByText } = renderProviderSheetHandle(
+    it('should not render filters when shouldShowFilters is false', async () => {
+        const { getByText, queryByText } = await renderProviderSheetHandle(
             { shouldShowFilters: false },
             {},
         );
@@ -78,26 +78,26 @@ describe('ProviderSheetHandle', () => {
         expect(queryByText(getTranslation('moduleTrading.providerSheet.filters.dex'))).toBeNull();
     });
 
-    it('should call onClose when close button is pressed', () => {
+    it('should call onClose when close button is pressed', async () => {
         const onClose = jest.fn();
-        const { getByLabelText } = renderProviderSheetHandle({ onClose }, {});
+        const { getByLabelText } = await renderProviderSheetHandle({ onClose }, {});
 
-        fireEvent.press(getByLabelText(getTranslation('generic.buttons.close')));
+        await fireEvent.press(getByLabelText(getTranslation('generic.buttons.close')));
 
         expect(onClose).toHaveBeenCalled();
     });
 
-    it('should setSelectedFilter when filter item is pressed', () => {
+    it('should setSelectedFilter when filter item is pressed', async () => {
         const setSelectedFilter = jest.fn();
-        const { getByText } = renderProviderSheetHandle({ setSelectedFilter }, {});
+        const { getByText } = await renderProviderSheetHandle({ setSelectedFilter }, {});
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.providerSheet.filters.cex')));
+        await fireEvent.press(getByText(getTranslation('moduleTrading.providerSheet.filters.cex')));
 
         expect(setSelectedFilter).toHaveBeenCalledWith('cex');
     });
 
-    it('should display context message', () => {
-        const { getByText } = renderProviderSheetHandle(
+    it('should display context message', async () => {
+        const { getByText } = await renderProviderSheetHandle(
             {},
             {
                 wallet: {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetSectionHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetSectionHeader.test.tsx
@@ -7,15 +7,15 @@ import {
 import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
 
 describe('ProviderSheetSectionHeader', () => {
-    const renderProviderSheetSectionHeader = (props: ProviderSheetSectionHeaderProps) =>
-        renderWithTradingProvider(<ProviderSheetSectionHeader {...props} />);
+    const renderProviderSheetSectionHeader = async (props: ProviderSheetSectionHeaderProps) =>
+        await renderWithTradingProvider(<ProviderSheetSectionHeader {...props} />);
 
     it.each<[QuotesCategory, string]>([
         ['fixed', 'Fixed-rate CEX'],
         ['float', 'Floating-rate CEX'],
         ['dex', 'DEX'],
-    ])('should render correct section based on category [%s]', (category, expectedTitle) => {
-        const { getByText } = renderProviderSheetSectionHeader({ category });
+    ])('should render correct section based on category [%s]', async (category, expectedTitle) => {
+        const { getByText } = await renderProviderSheetSectionHeader({ category });
 
         expect(getByText(expectedTitle)).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.test.tsx
@@ -30,13 +30,13 @@ jest.mock('@react-navigation/native', () => ({
 describe('ReceiveAccountPicker', () => {
     let store: TestStore;
 
-    const renderReceiveAccountPicker = (
+    const renderReceiveAccountPicker = async (
         props: Partial<ReceiveAccountPickerProps>,
         overrides: Record<string, unknown> = defaultOverrides,
     ) => {
         store = createTradingTestStore({ overrides });
 
-        return renderWithStoreProvider(
+        return await renderWithStoreProvider(
             <ReceiveAccountPicker
                 symbol="btc"
                 tradingType="buy"
@@ -54,27 +54,29 @@ describe('ReceiveAccountPicker', () => {
         jest.clearAllMocks();
     });
 
-    it('should display nothing when selectedSymbol is not specified', () => {
-        const { toJSON } = renderReceiveAccountPicker({ symbol: undefined });
+    it('should display nothing when selectedSymbol is not specified', async () => {
+        const { toJSON } = await renderReceiveAccountPicker({ symbol: undefined });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display "Not selected" when receiveAccount is not specified', () => {
-        const { getByText } = renderReceiveAccountPicker({
+    it('should display "Not selected" when receiveAccount is not specified', async () => {
+        const { getByText } = await renderReceiveAccountPicker({
             receiveAccount: undefined,
         });
 
         expect(getByText(getTranslation('moduleTrading.notSelected'))).toBeTruthy();
     });
 
-    it('should call navigate to account picker when symbol is specified and picker pressed', () => {
-        const { getByText } = renderReceiveAccountPicker({
+    it('should call navigate to account picker when symbol is specified and picker pressed', async () => {
+        const { getByText } = await renderReceiveAccountPicker({
             symbol: 'btc',
             receiveAccount: undefined,
         });
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')));
+        await fireEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+        );
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', {
@@ -83,14 +85,16 @@ describe('ReceiveAccountPicker', () => {
         });
     });
 
-    it('should call navigate to account picker when tradingType is exchange, symbol is specified and picker pressed', () => {
-        const { getByText } = renderReceiveAccountPicker({
+    it('should call navigate to account picker when tradingType is exchange, symbol is specified and picker pressed', async () => {
+        const { getByText } = await renderReceiveAccountPicker({
             symbol: 'btc',
             receiveAccount: undefined,
             tradingType: 'exchange',
         });
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')));
+        await fireEvent.press(
+            getByText(getTranslation('moduleTrading.tradingScreen.receiveAccount')),
+        );
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('ReceiveAccounts', {
@@ -99,8 +103,8 @@ describe('ReceiveAccountPicker', () => {
         });
     });
 
-    it('should display account name', () => {
-        const { getByText } = renderReceiveAccountPicker({
+    it('should display account name', async () => {
+        const { getByText } = await renderReceiveAccountPicker({
             receiveAccount: {
                 account: btc1NormalAccount,
                 address: undefined,
@@ -110,8 +114,8 @@ describe('ReceiveAccountPicker', () => {
         expect(getByText('BTC Account #1')).toBeTruthy();
     });
 
-    it('should display account name when address is selected', () => {
-        const { getByText } = renderReceiveAccountPicker({
+    it('should display account name when address is selected', async () => {
+        const { getByText } = await renderReceiveAccountPicker({
             receiveAccount: {
                 account: btc1NormalAccount,
                 address: btc1NormalAccount.addresses!.used[0],
@@ -122,8 +126,8 @@ describe('ReceiveAccountPicker', () => {
     });
 
     describe('with testID specified', () => {
-        it('should render correctly with no receiveAccount', () => {
-            const { getByTestId } = renderReceiveAccountPicker({
+        it('should render correctly with no receiveAccount', async () => {
+            const { getByTestId } = await renderReceiveAccountPicker({
                 receiveAccount: undefined,
                 testID: 'TEST_ID',
             });
@@ -133,8 +137,8 @@ describe('ReceiveAccountPicker', () => {
             );
         });
 
-        it('should render correctly with receiveAccount but no address', () => {
-            const { getByTestId } = renderReceiveAccountPicker({
+        it('should render correctly with receiveAccount but no address', async () => {
+            const { getByTestId } = await renderReceiveAccountPicker({
                 receiveAccount: {
                     account: btc1NormalAccount,
                     address: undefined,
@@ -145,8 +149,8 @@ describe('ReceiveAccountPicker', () => {
             expect(getByTestId('TEST_ID/selected-account')).toHaveTextContent('BTC Account #1');
         });
 
-        it('should render correctly with receiveAccount and address', () => {
-            const { getByTestId } = renderReceiveAccountPicker({
+        it('should render correctly with receiveAccount and address', async () => {
+            const { getByTestId } = await renderReceiveAccountPicker({
                 receiveAccount: {
                     account: btc1NormalAccount,
                     address: btc1NormalAccount.addresses!.used[0],

--- a/suite-native/module-trading/src/components/general/RequestedAmountShortfallNote.test.tsx
+++ b/suite-native/module-trading/src/components/general/RequestedAmountShortfallNote.test.tsx
@@ -8,15 +8,18 @@ import {
 } from '../../test-utils/tradingTestUtils';
 
 describe('RequestedAmountShortfallNote', () => {
-    const renderNote = (
+    const renderNote = async (
         quote: typeof mercuryoApplePayBuyQuote,
         overrides: PreloadedStatePartial<TradingTestPreloadedState>,
-    ) => renderWithTradingProvider(<RequestedAmountShortfallNote quote={quote} />, { overrides });
+    ) =>
+        await renderWithTradingProvider(<RequestedAmountShortfallNote quote={quote} />, {
+            overrides,
+        });
 
-    it('renders a fiat shortfall formatted in the quote fiat currency', () => {
+    it('renders a fiat shortfall formatted in the quote fiat currency', async () => {
         const quote = { ...mercuryoApplePayBuyQuote, fiatStringAmount: '8' };
 
-        const { getByText } = renderNote(quote, {
+        const { getByText } = await renderNote(quote, {
             wallet: {
                 trading: {
                     buy: {
@@ -34,14 +37,14 @@ describe('RequestedAmountShortfallNote', () => {
         expect(getByText('20% less to receive than requested (€2.00)')).toBeOnTheScreen();
     });
 
-    it('renders nothing when there is a fiat shortfall but the quote has no fiat currency', () => {
+    it('renders nothing when there is a fiat shortfall but the quote has no fiat currency', async () => {
         const quote = {
             ...mercuryoApplePayBuyQuote,
             fiatCurrency: undefined,
             fiatStringAmount: '8',
         };
 
-        const { toJSON } = renderNote(quote, {
+        const { toJSON } = await renderNote(quote, {
             wallet: {
                 trading: {
                     buy: {
@@ -59,10 +62,10 @@ describe('RequestedAmountShortfallNote', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('renders a crypto shortfall amount when the user requested a fixed crypto amount', () => {
+    it('renders a crypto shortfall amount when the user requested a fixed crypto amount', async () => {
         const quote = { ...mercuryoApplePayBuyQuote, receiveStringAmount: '0.001' };
 
-        const { getByText } = renderNote(quote, {
+        const { getByText } = await renderNote(quote, {
             wallet: {
                 trading: {
                     buy: {
@@ -80,8 +83,8 @@ describe('RequestedAmountShortfallNote', () => {
         expect(getByText('50% less to receive than requested (0.001 BTC)')).toBeOnTheScreen();
     });
 
-    it('renders nothing when there is no requested amount shortfall', () => {
-        const { toJSON } = renderNote(mercuryoApplePayBuyQuote, {});
+    it('renders nothing when there is no requested amount shortfall', async () => {
+        const { toJSON } = await renderNote(mercuryoApplePayBuyQuote, {});
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/SelectTradeableAssetButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/SelectTradeableAssetButton.test.tsx
@@ -9,7 +9,7 @@ import {
 
 describe('SelectTradeableAssetButton', () => {
     const renderButton = async (initialProps: Partial<SelectTradeableAssetButtonProps>) => {
-        const res = renderWithBasicProvider(
+        const res = await renderWithBasicProvider(
             <SelectTradeableAssetButton
                 onPress={jest.fn()}
                 selectedAsset={undefined}

--- a/suite-native/module-trading/src/components/general/SimpleSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/SimpleSheetHeader.test.tsx
@@ -4,26 +4,26 @@ import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 import { SimpleSheetHeader, type SimpleSheetHeaderProps } from './SimpleSheetHeader';
 
 describe('SimpleSheetHeader', () => {
-    const renderSimpleSheetHeader = (props: SimpleSheetHeaderProps) =>
-        renderWithBasicProvider(<SimpleSheetHeader {...props} />);
+    const renderSimpleSheetHeader = async (props: SimpleSheetHeaderProps) =>
+        await renderWithBasicProvider(<SimpleSheetHeader {...props} />);
 
-    it('should render title', () => {
-        const { getByText } = renderSimpleSheetHeader({
+    it('should render title', async () => {
+        const { getByText } = await renderSimpleSheetHeader({
             title: 'Test title',
             onClose: jest.fn(),
         });
 
         expect(getByText('Test title')).toBeTruthy();
     });
-    it('should call onClose when X button is pressed', () => {
+    it('should call onClose when X button is pressed', async () => {
         const onCloseMock = jest.fn();
-        const { getByLabelText } = renderSimpleSheetHeader({
+        const { getByLabelText } = await renderSimpleSheetHeader({
             title: 'Test title',
             onClose: onCloseMock,
         });
 
         const closeButton = getByLabelText(getTranslation('generic.buttons.close'));
-        fireEvent.press(closeButton);
+        await fireEvent.press(closeButton);
 
         expect(onCloseMock).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-trading/src/components/general/TradeInfo/ProviderInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/ProviderInfoRow.test.tsx
@@ -5,14 +5,14 @@ import { getWalletState } from '@suite-native/trading-fixtures';
 import { ProviderInfoRow, type ProviderInfoRowProps } from './ProviderInfoRow';
 
 describe('ProviderInfoRow', () => {
-    const renderProviderInfoRow = (props: Partial<ProviderInfoRowProps> = {}) => {
+    const renderProviderInfoRow = async (props: Partial<ProviderInfoRowProps> = {}) => {
         const preloadedState = {
             wallet: getWalletState({
                 tradeType: 'exchange',
             }),
         };
 
-        return renderWithStoreProvider(
+        return await renderWithStoreProvider(
             <ProviderInfoRow exchange="mercuryo" tradingType="exchange" {...props} />,
             {
                 preloadedState,
@@ -20,15 +20,15 @@ describe('ProviderInfoRow', () => {
         );
     };
 
-    it('should render provider', () => {
-        const { getByText } = renderProviderInfoRow({});
+    it('should render provider', async () => {
+        const { getByText } = await renderProviderInfoRow({});
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
     });
 
-    it('should render nothing when no provider is found', () => {
-        const { toJSON } = renderProviderInfoRow({ exchange: 'non-existing-provider' });
+    it('should render nothing when no provider is found', async () => {
+        const { toJSON } = await renderProviderInfoRow({ exchange: 'non-existing-provider' });
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.test.tsx
@@ -1,3 +1,4 @@
+import { Text } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-types';
@@ -5,13 +6,13 @@ import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-type
 import { TradeFiatSideCard, type TradeFiatSideCardProps } from './TradeFiatSideCard';
 
 describe('TradeFiatSideCard', () => {
-    const renderTradeFiatSideCard = (props: TradeFiatSideCardProps) =>
-        renderWithBasicProvider(<TradeFiatSideCard {...props} />);
+    const renderTradeFiatSideCard = async (props: TradeFiatSideCardProps) =>
+        await renderWithBasicProvider(<TradeFiatSideCard {...props} />);
 
-    it('should render credit card payment method', () => {
-        const { getByText } = renderTradeFiatSideCard({
+    it('should render credit card payment method', async () => {
+        const { getByText } = await renderTradeFiatSideCard({
             paymentMethod: 'creditCard',
-            amount: '+90.17',
+            amount: <Text>+90.17</Text>,
             title: 'To',
             fiatCurrency: 'usd',
         });
@@ -24,10 +25,10 @@ describe('TradeFiatSideCard', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render bank transfer payment method', () => {
-        const { getByText } = renderTradeFiatSideCard({
+    it('should render bank transfer payment method', async () => {
+        const { getByText } = await renderTradeFiatSideCard({
             paymentMethod: 'bankTransfer',
-            amount: '+100.00',
+            amount: <Text>+100.00</Text>,
             title: 'To',
             fiatCurrency: 'usd',
         });
@@ -40,10 +41,10 @@ describe('TradeFiatSideCard', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render unknown payment method', () => {
-        const { getByText } = renderTradeFiatSideCard({
+    it('should render unknown payment method', async () => {
+        const { getByText } = await renderTradeFiatSideCard({
             paymentMethod: 'customMethod' as ExtendedSellCryptoPaymentMethod,
-            amount: '+100.00',
+            amount: <Text>+100.00</Text>,
             title: 'To',
             fiatCurrency: 'usd',
         });

--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeInfo.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeInfo.test.tsx
@@ -29,25 +29,25 @@ describe('TradeInfo', () => {
         tradingType: 'exchange' as TradingExchangeType | TradingSellType,
     };
 
-    const renderTradeInfo = (props = {}) => {
+    const renderTradeInfo = async (props = {}) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return renderWithTradingProvider(<TradeInfo {...finalProps} />);
+        return await renderWithTradingProvider(<TradeInfo {...finalProps} />);
     };
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should render provider', () => {
-        const { getByText } = renderTradeInfo();
+    it('should render provider', async () => {
+        const { getByText } = await renderTradeInfo();
 
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should pass correct props to FeeSelector', () => {
-        renderTradeInfo();
+    it('should pass correct props to FeeSelector', async () => {
+        await renderTradeInfo();
 
         expect(mockFeeSelectorProps).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -58,8 +58,8 @@ describe('TradeInfo', () => {
         );
     });
 
-    it('should render children', () => {
-        const { getByText } = renderTradeInfo({
+    it('should render children', async () => {
+        const { getByText } = await renderTradeInfo({
             children: <Text>child content</Text>,
         });
 

--- a/suite-native/module-trading/src/components/general/TradeableAssetAccountBalance.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetAccountBalance.test.tsx
@@ -16,11 +16,11 @@ import {
 } from './TradeableAssetAccountBalance';
 
 describe('TradeableAssetAccountBalance', () => {
-    const renderTradeableAssetAccountBalance = (
+    const renderTradeableAssetAccountBalance = async (
         props: Partial<TradeableAssetAccountBalanceProps> = {},
         preloadedState = {},
     ) =>
-        renderWithStoreProvider(
+        await renderWithStoreProvider(
             <TradeableAssetAccountBalance
                 asset={undefined}
                 account={undefined}
@@ -30,8 +30,8 @@ describe('TradeableAssetAccountBalance', () => {
             { preloadedState },
         );
 
-    it('should render nothing without asset selected', () => {
-        const { toJSON } = renderTradeableAssetAccountBalance({});
+    it('should render nothing without asset selected', async () => {
+        const { toJSON } = await renderTradeableAssetAccountBalance({});
 
         expect(toJSON()).toBeNull();
     });
@@ -43,23 +43,23 @@ describe('TradeableAssetAccountBalance', () => {
         [usdcAsset, 'USDC'],
     ])(
         'should render empty balance when account is not selected, case %#',
-        (asset, expectedSymbol) => {
-            const { getByText } = renderTradeableAssetAccountBalance({ asset });
+        async (asset, expectedSymbol) => {
+            const { getByText } = await renderTradeableAssetAccountBalance({ asset });
 
             expect(getByText(getTranslation('moduleTrading.tradingScreen.balance'))).toBeDefined();
             expect(getByText(`- ${expectedSymbol}`)).toBeDefined();
         },
     );
 
-    it('should use correct TestIDs when no balance is displayed', () => {
-        const { getByTestId } = renderTradeableAssetAccountBalance({ asset: btcAsset });
+    it('should use correct TestIDs when no balance is displayed', async () => {
+        const { getByTestId } = await renderTradeableAssetAccountBalance({ asset: btcAsset });
 
         expect(getByTestId('TEST_ID')).toHaveTextContent('Balance:- BTC');
         expect(getByTestId('TEST_ID/no-value')).toHaveTextContent('- BTC');
     });
 
-    it('should render without TestID', () => {
-        const { getByText } = renderTradeableAssetAccountBalance({
+    it('should render without TestID', async () => {
+        const { getByText } = await renderTradeableAssetAccountBalance({
             asset: btcAsset,
             testID: undefined,
         });
@@ -79,8 +79,8 @@ describe('TradeableAssetAccountBalance', () => {
             [ethAsset, '0.00000081 ETH'],
             [usdcAsset, '1 USDC'],
             [usdtAsset, '0 USDT'],
-        ])('should display correct balance for asset, case %s', (asset, expectedBalance) => {
-            const { getByText, getByTestId } = renderTradeableAssetAccountBalance(
+        ])('should display correct balance for asset, case %s', async (asset, expectedBalance) => {
+            const { getByText, getByTestId } = await renderTradeableAssetAccountBalance(
                 {
                     asset,
                     account: getEthAccount(),

--- a/suite-native/module-trading/src/components/general/TradeableAssetButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetButton.test.tsx
@@ -5,7 +5,7 @@ import { TradeableAssetButton, type TradeableAssetButtonProps } from './Tradeabl
 
 describe('TradeableAssetButton', () => {
     const renderButton = async (initialProps: Partial<TradeableAssetButtonProps>) => {
-        const ret = renderWithBasicProvider(
+        const ret = await renderWithBasicProvider(
             <TradeableAssetButton
                 asset={btcAsset}
                 onPress={jest.fn()}
@@ -42,9 +42,9 @@ describe('TradeableAssetButton', () => {
         const { getByText } = await renderButton({ asset: btcAsset, onPress: pressSpy });
 
         const button = getByText('BTC');
-        fireEvent.press(button);
+        await fireEvent.press(button);
 
-        expect(pressSpy).toHaveBeenCalledWith();
+        expect(pressSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should render ETH icon for ETH on BASE asset', async () => {

--- a/suite-native/module-trading/src/components/general/TradeableAssetList/TradeableAssetList.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetList/TradeableAssetList.test.tsx
@@ -9,8 +9,8 @@ import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils'
 describe('TradeableAssetList', () => {
     const defaultAssets: TradeableAsset[] = [btcAsset, usdcAsset, adaAsset];
 
-    const renderTradeableAssetList = (props: Partial<TradeableAssetListProps>) =>
-        renderWithTradingProvider(
+    const renderTradeableAssetList = async (props: Partial<TradeableAssetListProps>) =>
+        await renderWithTradingProvider(
             <TradeableAssetList
                 assets={defaultAssets}
                 onAssetSelect={jest.fn()}
@@ -23,21 +23,21 @@ describe('TradeableAssetList', () => {
             />,
         );
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('selects a pressed asset', () => {
+    it('selects a pressed asset', async () => {
         const onAssetSelect = jest.fn();
-        const { getByText } = renderTradeableAssetList({ onAssetSelect });
+        const { getByText } = await renderTradeableAssetList({ onAssetSelect });
 
-        fireEvent.press(getByText('BTC'));
+        await fireEvent.press(getByText('BTC'));
 
         expect(onAssetSelect).toHaveBeenCalledWith(btcAsset);
     });
 
-    it('renders the empty state', () => {
-        const { getByText } = renderTradeableAssetList({ assets: [] });
+    it('renders the empty state', async () => {
+        const { getByText } = await renderTradeableAssetList({ assets: [] });
 
         expect(
             getByText(getTranslation('moduleTrading.tradeableAssetsSheet.emptyTitleText')),

--- a/suite-native/module-trading/src/components/general/TradeableAssetList/TradeableAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetList/TradeableAssetListItem.test.tsx
@@ -7,33 +7,33 @@ import { TradeableAssetListItem, type TradeableAssetListItemProps } from './Trad
 import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
 
 describe('TradeableAssetListItem', () => {
-    const renderComponent = ({
+    const renderComponent = async ({
         onPress = jest.fn(),
         asset = btcAsset,
         balance,
     }: Partial<TradeableAssetListItemProps>) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <TradeableAssetListItem asset={asset} balance={balance} onPress={onPress} />,
         );
 
-    it('should render with correct labels', () => {
-        const { getAllByText } = renderComponent({ asset: usdcAsset });
+    it('should render with correct labels', async () => {
+        const { getAllByText } = await renderComponent({ asset: usdcAsset });
 
         expect(getAllByText('USDC').length).toBeGreaterThan(0);
         expect(getAllByText('Ethereum').length).toBeGreaterThan(0);
     });
 
-    it('should call onPress callback when clicked', () => {
+    it('should call onPress callback when clicked', async () => {
         const onPress = jest.fn();
-        const { getByText } = renderComponent({ asset: btcAsset, onPress });
+        const { getByText } = await renderComponent({ asset: btcAsset, onPress });
 
-        fireEvent.press(getByText('BTC'));
+        await fireEvent.press(getByText('BTC'));
 
-        expect(onPress).toHaveBeenCalledWith();
+        expect(onPress).toHaveBeenCalledTimes(1);
     });
 
-    it('displays the total fiat and crypto balances', () => {
-        const { getByText } = renderComponent({
+    it('displays the total fiat and crypto balances', async () => {
+        const { getByText } = await renderComponent({
             asset: btcAsset,
             balance: {
                 cryptoAmount: '0.5',

--- a/suite-native/module-trading/src/components/general/TradeableAssetNetworkInfo.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetNetworkInfo.test.tsx
@@ -8,24 +8,27 @@ import {
 } from './TradeableAssetNetworkInfo';
 
 describe('TradeableAssetNetworkInfo', () => {
-    const renderTradeableAssetNetworkInfo = (asset: TradeableAssetNetworkInfoProps['asset']) =>
-        renderWithBasicProvider(<TradeableAssetNetworkInfo asset={asset} />);
+    const renderTradeableAssetNetworkInfo = async (
+        asset: TradeableAssetNetworkInfoProps['asset'],
+    ) => await renderWithBasicProvider(<TradeableAssetNetworkInfo asset={asset} />);
 
-    it('should render nothing when asset is not set', () => {
-        const { toJSON } = renderTradeableAssetNetworkInfo(undefined);
+    it('should render nothing when asset is not set', async () => {
+        const { toJSON } = await renderTradeableAssetNetworkInfo(undefined);
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render empty box for networks that are not l2 networks = op, arb, base', () => {
-        const { queryByHintText, queryByLabelText } = renderTradeableAssetNetworkInfo(btcAsset);
+    it('should render empty box for networks that are not l2 networks = op, arb, base', async () => {
+        const { queryByHintText, queryByLabelText } =
+            await renderTradeableAssetNetworkInfo(btcAsset);
 
         expect(queryByHintText('Network Icon')).toBeNull();
         expect(queryByLabelText(getTranslation('moduleTrading.networkName'))).toBeNull();
     });
 
-    it('should render network icon and name for l2 networks = op, arb, base and ETH as icon', () => {
-        const { getByHintText, getByLabelText } = renderTradeableAssetNetworkInfo(ethOnBaseAsset);
+    it('should render network icon and name for l2 networks = op, arb, base and ETH as icon', async () => {
+        const { getByHintText, getByLabelText } =
+            await renderTradeableAssetNetworkInfo(ethOnBaseAsset);
 
         expect(getByHintText('Network Icon')).toBeTruthy();
         expect(getByLabelText(getTranslation('moduleTrading.networkName'))).toHaveTextContent(
@@ -33,8 +36,8 @@ describe('TradeableAssetNetworkInfo', () => {
         );
     });
 
-    it('should render network icon and name for contracts', () => {
-        const { getByHintText, getByLabelText } = renderTradeableAssetNetworkInfo(usdcAsset);
+    it('should render network icon and name for contracts', async () => {
+        const { getByHintText, getByLabelText } = await renderTradeableAssetNetworkInfo(usdcAsset);
 
         expect(getByHintText('Network Icon')).toBeTruthy();
         expect(getByLabelText(getTranslation('moduleTrading.networkName'))).toHaveTextContent(

--- a/suite-native/module-trading/src/components/general/TradingAccountCard.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradingAccountCard.test.tsx
@@ -8,8 +8,10 @@ import { TradingAccountCard } from './TradingAccountCard';
 import { renderWithTradingProvider } from '../../test-utils/tradingTestUtils';
 
 describe('TradingAccountCard', () => {
-    const renderCard = (overrides: Partial<React.ComponentProps<typeof TradingAccountCard>> = {}) =>
-        renderWithTradingProvider(
+    const renderCard = async (
+        overrides: Partial<React.ComponentProps<typeof TradingAccountCard>> = {},
+    ) =>
+        await renderWithTradingProvider(
             <TradingAccountCard
                 title="From"
                 account={eth1NormalAccount}
@@ -21,26 +23,26 @@ describe('TradingAccountCard', () => {
             { tradeType: 'exchange' },
         );
 
-    it('renders title', () => {
-        const { getByText } = renderCard({ title: 'From Account' });
+    it('renders title', async () => {
+        const { getByText } = await renderCard({ title: 'From Account' });
 
         expect(getByText('From Account')).toBeOnTheScreen();
     });
 
-    it('renders account label', () => {
-        const { getByText } = renderCard();
+    it('renders account label', async () => {
+        const { getByText } = await renderCard();
 
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
     });
 
-    it('renders amount with minus prefix for "from" direction', () => {
-        const { getByText } = renderCard({ amount: '100' });
+    it('renders amount with minus prefix for "from" direction', async () => {
+        const { getByText } = await renderCard({ amount: '100' });
 
         expect(getByText('-100 USDC')).toBeOnTheScreen();
     });
 
-    it('renders amount with plus prefix for "to" direction', () => {
-        const { getByText } = renderCard({
+    it('renders amount with plus prefix for "to" direction', async () => {
+        const { getByText } = await renderCard({
             account: btc1NormalAccount,
             cryptoId: mercuryoFixedWorstQuote.receive,
             amount: '0.00083554',
@@ -50,26 +52,26 @@ describe('TradingAccountCard', () => {
         expect(getByText('+0.00083554 BTC')).toBeOnTheScreen();
     });
 
-    it('does not render amount text when amount is undefined', () => {
-        const { queryByText } = renderCard();
+    it('does not render amount text when amount is undefined', async () => {
+        const { queryByText } = await renderCard();
 
         expect(queryByText(/^[-+]/)).toBeNull();
     });
 
-    it('renders fiat badge when amount is provided', () => {
-        const { getByText } = renderCard({ amount: '100' });
+    it('renders fiat badge when amount is provided', async () => {
+        const { getByText } = await renderCard({ amount: '100' });
 
         expect(getByText(`100-${mercuryoFixedWorstQuote.send}`)).toBeOnTheScreen();
     });
 
-    it('does not render fiat badge when amount is undefined', () => {
-        const { queryByText } = renderCard();
+    it('does not render fiat badge when amount is undefined', async () => {
+        const { queryByText } = await renderCard();
 
         expect(queryByText(new RegExp(`-${mercuryoFixedWorstQuote.send}`))).toBeNull();
     });
 
-    it('returns null when cryptoId is not specified', () => {
-        const { toJSON } = renderCard({ cryptoId: undefined });
+    it('returns null when cryptoId is not specified', async () => {
+        const { toJSON } = await renderCard({ cryptoId: undefined });
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/TradingAssetListHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradingAssetListHeader.test.tsx
@@ -11,10 +11,10 @@ jest.mock('@suite-native/discovery', () => ({
 describe('TradingAssetListHeader', () => {
     const testID = '@trading/test/asset-list';
 
-    it('forwards search and network changes', () => {
+    it('forwards search and network changes', async () => {
         const onFilterChange = jest.fn();
         const onSelectedNetworkFilter = jest.fn();
-        const { getByTestId } = renderWithTradingProvider(
+        const { getByTestId } = await renderWithTradingProvider(
             <TradingAssetListHeader
                 networkFilterMode="discovered"
                 onFilterChange={onFilterChange}
@@ -25,9 +25,9 @@ describe('TradingAssetListHeader', () => {
             />,
         );
 
-        fireEvent.changeText(getByTestId(`${testID}/search-input`), 'ether');
-        fireEvent.press(getByTestId(`${testID}/network-picker`));
-        fireEvent.press(getByTestId(`${testID}/network-picker/networks-sheet/eth`));
+        await fireEvent.changeText(getByTestId(`${testID}/search-input`), 'ether');
+        await fireEvent.press(getByTestId(`${testID}/network-picker`));
+        await fireEvent.press(getByTestId(`${testID}/network-picker/networks-sheet/eth`));
 
         expect(onFilterChange).toHaveBeenCalledWith('ether');
         expect(onSelectedNetworkFilter).toHaveBeenCalledWith('eth');

--- a/suite-native/module-trading/src/components/general/TradingCoinAmountFormatter.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradingCoinAmountFormatter.test.tsx
@@ -9,15 +9,15 @@ import {
 } from './TradingCoinAmountFormatter';
 
 describe('TradingCoinAmountFormatter', () => {
-    const renderTradingCoinAmountFormatter = (
+    const renderTradingCoinAmountFormatter = async (
         props: Partial<TradingCoinAmountFormatterProps> = {},
     ) =>
-        renderWithStoreProvider(<TradingCoinAmountFormatter {...props} />, {
+        await renderWithStoreProvider(<TradingCoinAmountFormatter {...props} />, {
             preloadedState: { wallet: getWalletState() },
         });
 
-    it('should render formatted value for network', () => {
-        const { getByText } = renderTradingCoinAmountFormatter({
+    it('should render formatted value for network', async () => {
+        const { getByText } = await renderTradingCoinAmountFormatter({
             amount: '123456',
             cryptoId: btcAsset.cryptoId,
         });
@@ -25,8 +25,8 @@ describe('TradingCoinAmountFormatter', () => {
         expect(getByText('123,456 BTC')).toBeOnTheScreen();
     });
 
-    it('should render formatted value for token', () => {
-        const { getByText } = renderTradingCoinAmountFormatter({
+    it('should render formatted value for token', async () => {
+        const { getByText } = await renderTradingCoinAmountFormatter({
             amount: '123456',
             cryptoId: usdcAsset.cryptoId,
         });
@@ -34,22 +34,22 @@ describe('TradingCoinAmountFormatter', () => {
         expect(getByText('123,456 USDC')).toBeOnTheScreen();
     });
 
-    it('should render null when cryptoId is undefined', () => {
-        const { toJSON } = renderTradingCoinAmountFormatter();
+    it('should render null when cryptoId is undefined', async () => {
+        const { toJSON } = await renderTradingCoinAmountFormatter();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render null when cryptoId is unknown', () => {
-        const { toJSON } = renderTradingCoinAmountFormatter({
+    it('should render null when cryptoId is unknown', async () => {
+        const { toJSON } = await renderTradingCoinAmountFormatter({
             cryptoId: 'unknown-crypto-id' as CryptoId,
         });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render 0 value when amount is undefined', () => {
-        const { getByText } = renderTradingCoinAmountFormatter({
+    it('should render 0 value when amount is undefined', async () => {
+        const { getByText } = await renderTradingCoinAmountFormatter({
             cryptoId: btcAsset.cryptoId,
         });
 

--- a/suite-native/module-trading/src/components/general/TradingDeviceConnectionGuard.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradingDeviceConnectionGuard.test.tsx
@@ -27,8 +27,8 @@ jest.mock('@suite-common/device', () => ({
 describe('TradingDeviceConnectionGuard', () => {
     let store: TestStore;
 
-    const renderTradingDeviceConnectionGuard = () =>
-        renderWithStoreProvider(
+    const renderTradingDeviceConnectionGuard = async () =>
+        await renderWithStoreProvider(
             <TradingDeviceConnectionGuard>
                 <Text>CHILDREN</Text>
             </TradingDeviceConnectionGuard>,
@@ -41,9 +41,9 @@ describe('TradingDeviceConnectionGuard', () => {
         store = createTradingTestStore();
     });
 
-    it('should display connect trezor info when no device is connected', () => {
+    it('should display connect trezor info when no device is connected', async () => {
         mockSelectIsDeviceConnected = false;
-        const { getByText, queryByText } = renderTradingDeviceConnectionGuard();
+        const { getByText, queryByText } = await renderTradingDeviceConnectionGuard();
 
         expect(
             getByText(getTranslation('moduleConnectDevice.connectAndUnlockScreen.title')),
@@ -51,9 +51,9 @@ describe('TradingDeviceConnectionGuard', () => {
         expect(queryByText('CHILDREN')).not.toBeOnTheScreen();
     });
 
-    it('should display children when device is connected', () => {
+    it('should display children when device is connected', async () => {
         mockSelectIsDeviceConnected = true;
-        const { getByText, queryByText } = renderTradingDeviceConnectionGuard();
+        const { getByText, queryByText } = await renderTradingDeviceConnectionGuard();
 
         expect(
             queryByText(getTranslation('moduleConnectDevice.connectAndUnlockScreen.title')),

--- a/suite-native/module-trading/src/components/general/TradingTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradingTabContent.test.tsx
@@ -33,8 +33,8 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('TradingTabContent', () => {
-    const renderTradingTabContent = (isBlacklisted: boolean = false) =>
-        renderWithTradingProvider(<TradingTabContent />, {
+    const renderTradingTabContent = async (isBlacklisted: boolean = false) =>
+        await renderWithTradingProvider(<TradingTabContent />, {
             overrides: {
                 wallet: {
                     trading: {
@@ -70,32 +70,32 @@ describe('TradingTabContent', () => {
         mockIsInternetReachable = true;
     });
 
-    it('should render error screen when isInternetReachable is false', () => {
+    it('should render error screen when isInternetReachable is false', async () => {
         mockIsInternetReachable = false;
 
-        renderTradingTabContent();
+        await renderTradingTabContent();
 
         expectDeviceOffline();
     });
 
-    it('should render trading not allowed in your country warning when ff is set up', () => {
-        renderTradingTabContent(true);
+    it('should render trading not allowed in your country warning when ff is set up', async () => {
+        await renderTradingTabContent(true);
 
         expectTradingNotAllowedInCountry();
     });
 
-    it('trading not allowed should have priority over offline notice', () => {
+    it('trading not allowed should have priority over offline notice', async () => {
         mockIsInternetReachable = false;
 
-        renderTradingTabContent(true);
+        await renderTradingTabContent(true);
 
         expectTradingNotAllowedInCountry();
     });
 
-    it('should render form even when isInternetReachable is null', () => {
+    it('should render form even when isInternetReachable is null', async () => {
         mockIsInternetReachable = null;
 
-        renderTradingTabContent();
+        await renderTradingTabContent();
 
         expectBuyForm();
     });

--- a/suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradingTypeAwareContextMessage.test.tsx
@@ -37,9 +37,9 @@ describe('TradingTypeAwareContextMessage', () => {
         },
     });
 
-    const renderTradingTypeAwareContextMessage = (
+    const renderTradingTypeAwareContextMessage = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState>,
-    ) => renderWithTradingProvider(<TradingTypeAwareContextMessage />, { overrides });
+    ) => await renderWithTradingProvider(<TradingTypeAwareContextMessage />, { overrides });
 
     it.each<[TradingType, string]>([
         ['buy', 'Trading buy message'],
@@ -47,8 +47,8 @@ describe('TradingTypeAwareContextMessage', () => {
         ['sell', 'Trading sell message'],
     ])(
         'should render correct context message for trading type %s',
-        (tradingType, expectedMessage) => {
-            const { getByText } = renderTradingTypeAwareContextMessage(
+        async (tradingType, expectedMessage) => {
+            const { getByText } = await renderTradingTypeAwareContextMessage(
                 overridesForTradingType(tradingType),
             );
 
@@ -56,8 +56,10 @@ describe('TradingTypeAwareContextMessage', () => {
         },
     );
 
-    it('should render nothing when trading type is not specified', () => {
-        const { toJSON } = renderTradingTypeAwareContextMessage(overridesForTradingType(undefined));
+    it('should render nothing when trading type is not specified', async () => {
+        const { toJSON } = await renderTradingTypeAwareContextMessage(
+            overridesForTradingType(undefined),
+        );
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsBody.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsBody.test.tsx
@@ -14,19 +14,19 @@ const defaultProps: ReviewOutputsBodyProps = {
 };
 
 describe('ReviewOutputsBody', () => {
-    const renderReviewOutputsBody = (props: Partial<ReviewOutputsBodyProps> = {}) =>
-        renderWithTradingProvider(<ReviewOutputsBody {...defaultProps} {...props} />, {
+    const renderReviewOutputsBody = async (props: Partial<ReviewOutputsBodyProps> = {}) =>
+        await renderWithTradingProvider(<ReviewOutputsBody {...defaultProps} {...props} />, {
             tradeType: 'exchange',
         });
 
-    it('renders loading skeleton when shouldDisplayReviewList is false', () => {
-        const { getByTestId } = renderReviewOutputsBody({ shouldDisplayReviewList: false });
+    it('renders loading skeleton when shouldDisplayReviewList is false', async () => {
+        const { getByTestId } = await renderReviewOutputsBody({ shouldDisplayReviewList: false });
 
         expect(getByTestId('@trading/outputs-review/skeleton')).toBeOnTheScreen();
     });
 
-    it('renders output item list when shouldDisplayReviewList is true', () => {
-        const { getByText, queryByTestId } = renderReviewOutputsBody({});
+    it('renders output item list when shouldDisplayReviewList is true', async () => {
+        const { getByText, queryByTestId } = await renderReviewOutputsBody({});
 
         // invalid account id is provided, expect error
         expect(
@@ -35,8 +35,8 @@ describe('ReviewOutputsBody', () => {
         expect(queryByTestId('@trading/outputs-review/skeleton')).not.toBeOnTheScreen();
     });
 
-    it('renders SignDataMessageReview when exchangeFlowType is sign-data', () => {
-        const { getByText, queryByText } = renderWithTradingProvider(
+    it('renders SignDataMessageReview when exchangeFlowType is sign-data', async () => {
+        const { getByText, queryByText } = await renderWithTradingProvider(
             <ReviewOutputsBody {...defaultProps} exchangeFlowType="sign-data" />,
             {
                 tradeType: 'exchange',

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.test.tsx
@@ -29,10 +29,10 @@ jest.mock('./ReviewOutputsBody', () => ({
 }));
 
 describe('ReviewOutputsContent', () => {
-    const renderReviewOutputsContent = (
+    const renderReviewOutputsContent = async (
         props: Partial<Omit<ReviewOutputsContentProps, 'exchangeFlowType' | 'tradingType'>>,
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ReviewOutputsContent
                 orderId="ORDER_ID"
                 accountKey={mockAccountKey({ descriptor: 'accountKey' })}
@@ -55,18 +55,18 @@ describe('ReviewOutputsContent', () => {
         });
     });
 
-    it('should not display footer if transaction is not signed yet', () => {
-        const { queryByTestId } = renderReviewOutputsContent({});
+    it('should not display footer if transaction is not signed yet', async () => {
+        const { queryByTestId } = await renderReviewOutputsContent({});
 
         expect(queryByTestId('@trading/outputs-review/footer')).not.toBeOnTheScreen();
     });
 
-    it('should display footer if transaction is signed', () => {
+    it('should display footer if transaction is signed', async () => {
         mockUseTradingOutputsReviewScreenControls.mockReturnValue({
             isTransactionAlreadySigned: true,
             confirmOnTrezorRef: { current: null },
         });
-        const { getByTestId } = renderReviewOutputsContent({});
+        const { getByTestId } = await renderReviewOutputsContent({});
 
         expect(getByTestId('@trading/outputs-review/footer')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.test.tsx
@@ -9,11 +9,11 @@ import {
 } from '../../test-utils/tradingTestUtils';
 
 describe('ReviewOutputsFooter', () => {
-    const renderReviewOutputsFooter = (
+    const renderReviewOutputsFooter = async (
         props: Partial<ReviewOutputsFooterProps>,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <ReviewOutputsFooter
                 resolveConsent={jest.fn()}
                 isConsentRequested={true}
@@ -23,8 +23,8 @@ describe('ReviewOutputsFooter', () => {
             { overrides },
         );
 
-    it('should display "Send transaction" button', () => {
-        const { getByTestId } = renderReviewOutputsFooter({});
+    it('should display "Send transaction" button', async () => {
+        const { getByTestId } = await renderReviewOutputsFooter({});
 
         expect(getByTestId('TEST_ID/submit-button')).toHaveTextContent(
             getTranslation('moduleTrading.tradingReviewOutputs.submitButton'),
@@ -32,8 +32,8 @@ describe('ReviewOutputsFooter', () => {
         expect(getByTestId('TEST_ID/submit-button')).toBeEnabled();
     });
 
-    it('should be disabled when isConsentRequested is false', () => {
-        const { getByText } = renderReviewOutputsFooter({ isConsentRequested: false });
+    it('should be disabled when isConsentRequested is false', async () => {
+        const { getByText } = await renderReviewOutputsFooter({ isConsentRequested: false });
 
         expect(
             getByText(getTranslation('moduleTrading.tradingReviewOutputs.submitButton')),
@@ -42,7 +42,7 @@ describe('ReviewOutputsFooter', () => {
 
     it('should resolveConsent on press', async () => {
         const resolveConsent = jest.fn();
-        const { getByTestId } = renderReviewOutputsFooter({ resolveConsent });
+        const { getByTestId } = await renderReviewOutputsFooter({ resolveConsent });
 
         await userEvent.press(getByTestId('TEST_ID/submit-button'));
 
@@ -52,7 +52,7 @@ describe('ReviewOutputsFooter', () => {
 
     it('should resolveConsent only once', async () => {
         const resolveConsent = jest.fn();
-        const { getByTestId } = renderReviewOutputsFooter({ resolveConsent });
+        const { getByTestId } = await renderReviewOutputsFooter({ resolveConsent });
 
         await userEvent.press(getByTestId('TEST_ID/submit-button'));
         await userEvent.press(getByTestId('TEST_ID/submit-button'));

--- a/suite-native/module-trading/src/components/reviewOutputs/SignDataMessageReview.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/SignDataMessageReview.test.tsx
@@ -56,17 +56,17 @@ const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
     },
 };
 
-const renderSignDataMessageReview = (
+const renderSignDataMessageReview = async (
     overrides: PreloadedStatePartial<TradingTestPreloadedState> = baseOverrides,
 ) =>
-    renderWithTradingProvider(<SignDataMessageReview />, {
+    await renderWithTradingProvider(<SignDataMessageReview />, {
         tradeType: 'exchange',
         overrides,
     });
 
 describe('SignDataMessageReview', () => {
-    it('should render nothing when quote has no signData', () => {
-        const { toJSON } = renderSignDataMessageReview({
+    it('should render nothing when quote has no signData', async () => {
+        const { toJSON } = await renderSignDataMessageReview({
             wallet: {
                 trading: {
                     exchange: {
@@ -79,8 +79,8 @@ describe('SignDataMessageReview', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when signData type is not eip712-typed-data', () => {
-        const { toJSON } = renderSignDataMessageReview({
+    it('should render nothing when signData type is not eip712-typed-data', async () => {
+        const { toJSON } = await renderSignDataMessageReview({
             wallet: {
                 trading: {
                     exchange: {
@@ -96,16 +96,16 @@ describe('SignDataMessageReview', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render heading', () => {
-        const { getByText } = renderSignDataMessageReview();
+    it('should render heading', async () => {
+        const { getByText } = await renderSignDataMessageReview();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.heading')),
         ).toBeOnTheScreen();
     });
 
-    it('should render domain card with simplified JSON', () => {
-        const { getByText } = renderSignDataMessageReview();
+    it('should render domain card with simplified JSON', async () => {
+        const { getByText } = await renderSignDataMessageReview();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.domain')),
@@ -113,8 +113,8 @@ describe('SignDataMessageReview', () => {
         expect(getByText(/1inch Aggregation Router/)).toBeOnTheScreen();
     });
 
-    it('should render message card with labeled field rows', () => {
-        const { getByText } = renderSignDataMessageReview();
+    it('should render message card with labeled field rows', async () => {
+        const { getByText } = await renderSignDataMessageReview();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.message')),
@@ -128,16 +128,16 @@ describe('SignDataMessageReview', () => {
         expect(getByText(/amount: 42/)).toBeOnTheScreen();
     });
 
-    it('should render address card when send account is available', () => {
-        const { getByText } = renderSignDataMessageReview();
+    it('should render address card when send account is available', async () => {
+        const { getByText } = await renderSignDataMessageReview();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingReviewOutputs.signData.address')),
         ).toBeOnTheScreen();
     });
 
-    it('should not render address card when send account is not found', () => {
-        const { queryByText } = renderSignDataMessageReview({
+    it('should not render address card when send account is not found', async () => {
+        const { queryByText } = await renderSignDataMessageReview({
             wallet: {
                 trading: {
                     exchange: {

--- a/suite-native/module-trading/src/components/sell/SellAlert.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellAlert.test.tsx
@@ -11,38 +11,41 @@ describe('SellAlert', () => {
     let form: SellFormType;
     const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
 
-    const renderFormHook = () =>
-        renderHookWithStoreProvider(() => useSellForm(), {
+    const renderFormHook = async () =>
+        await renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
         });
 
-    const renderTradingAlert = () =>
-        renderWithBasicProvider(<SellAlert />, {
+    const renderTradingAlert = async () =>
+        await renderWithBasicProvider(<SellAlert />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderFormHook();
+    beforeEach(async () => {
+        const { result } = await renderFormHook();
         form = result.current;
     });
 
-    it('should render alert based on form generalAlert value', () => {
-        act(() => {
+    it('should render alert based on form generalAlert value', async () => {
+        await act(() => {
             form.setValue('generalAlert', 'TEST');
         });
 
-        const { getByText } = renderTradingAlert();
+        const { getByText } = await renderTradingAlert();
 
         expect(getByText('TEST')).toBeTruthy();
     });
 
-    it.each([undefined, ''])('should render nothing when generalAlert is %s', generalAlertValue => {
-        act(() => {
-            form.setValue('generalAlert', generalAlertValue);
-        });
+    it.each([undefined, ''])(
+        'should render nothing when generalAlert is %s',
+        async generalAlertValue => {
+            await act(() => {
+                form.setValue('generalAlert', generalAlertValue);
+            });
 
-        const { toJSON } = renderTradingAlert();
+            const { toJSON } = await renderTradingAlert();
 
-        expect(toJSON()).toBeNull();
-    });
+            expect(toJSON()).toBeNull();
+        },
+    );
 });

--- a/suite-native/module-trading/src/components/sell/SellCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCard.test.tsx
@@ -22,12 +22,12 @@ describe('SellCard', () => {
     let form: SellFormType;
     const preloadedState = createTradingPreloadedState({ tradeType: 'sell' });
 
-    const renderForm = () =>
-        renderHookWithStoreProvider(() => useSellForm(), {
+    const renderForm = async () =>
+        await renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
         });
 
-    const renderSellCard = (isAmountInputActive: boolean) => {
+    const renderSellCard = async (isAmountInputActive: boolean) => {
         const cardPreloadedState = createTradingPreloadedState({
             tradeType: 'sell',
             overrides: {
@@ -35,28 +35,31 @@ describe('SellCard', () => {
             },
         });
 
-        return renderWithStoreProvider(<SellCard isAmountInputActive={isAmountInputActive} />, {
-            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
-            preloadedState: cardPreloadedState,
-        });
+        return await renderWithStoreProvider(
+            <SellCard isAmountInputActive={isAmountInputActive} />,
+            {
+                wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+                preloadedState: cardPreloadedState,
+            },
+        );
     };
 
-    beforeEach(() => {
-        const { result } = renderForm();
+    beforeEach(async () => {
+        const { result } = await renderForm();
         form = result.current;
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render all components for "you pay" part', () => {
-        act(() => {
+    it('should render all components for "you pay" part', async () => {
+        await act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('amountInCrypto', true);
             form.setValue('cryptoStringAmount', '100');
         });
-        const { getByText, getByLabelText } = renderSellCard(false);
+        const { getByText, getByLabelText } = await renderSellCard(false);
 
         expect(
             getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),

--- a/suite-native/module-trading/src/components/sell/SellCompletion/BankAccount/SellBankAccountItem.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCompletion/BankAccount/SellBankAccountItem.test.tsx
@@ -5,8 +5,8 @@ import { unverifiedBankAccount, verifiedBankAccount } from '@suite-native/tradin
 import { BANK_ACCOUNT_ITEM_TEST_ID, SellBankAccountItem } from './SellBankAccountItem';
 
 describe('SellBankAccountItem', () => {
-    const renderBankAccountItem = (props = {}) =>
-        renderWithBasicProvider(
+    const renderBankAccountItem = async (props = {}) =>
+        await renderWithBasicProvider(
             <SellBankAccountItem
                 bankAccount={verifiedBankAccount}
                 accessoryType="none"
@@ -15,20 +15,20 @@ describe('SellBankAccountItem', () => {
         );
 
     describe('Rendering', () => {
-        it('should render bank account holder name', () => {
-            const { getByText } = renderBankAccountItem();
+        it('should render bank account holder name', async () => {
+            const { getByText } = await renderBankAccountItem();
 
             expect(getByText('John Doe')).toBeOnTheScreen();
         });
 
-        it('should render formatted IBAN', () => {
-            const { getByText } = renderBankAccountItem();
+        it('should render formatted IBAN', async () => {
+            const { getByText } = await renderBankAccountItem();
 
             expect(getByText('CZ65 0800 0000 1920 0014 5399')).toBeOnTheScreen();
         });
 
-        it('should render verified status for verified bank account', () => {
-            const { getByText, getByTestId } = renderBankAccountItem({
+        it('should render verified status for verified bank account', async () => {
+            const { getByText, getByTestId } = await renderBankAccountItem({
                 bankAccount: verifiedBankAccount,
             });
 
@@ -38,8 +38,8 @@ describe('SellBankAccountItem', () => {
             expect(getByTestId('check-icon')).toBeOnTheScreen();
         });
 
-        it('should render not verified status for unverified bank account', () => {
-            const { getByText, queryByTestId } = renderBankAccountItem({
+        it('should render not verified status for unverified bank account', async () => {
+            const { getByText, queryByTestId } = await renderBankAccountItem({
                 bankAccount: unverifiedBankAccount,
             });
 
@@ -51,16 +51,16 @@ describe('SellBankAccountItem', () => {
     });
 
     describe('Accessory Types', () => {
-        it('should render caret accessory', () => {
-            const { getByTestId } = renderBankAccountItem({
+        it('should render caret accessory', async () => {
+            const { getByTestId } = await renderBankAccountItem({
                 accessoryType: 'caret',
             });
 
             expect(getByTestId('caret-right-icon')).toBeOnTheScreen();
         });
 
-        it('should render select accessory (radio button)', () => {
-            const { getByTestId } = renderBankAccountItem({
+        it('should render select accessory (radio button)', async () => {
+            const { getByTestId } = await renderBankAccountItem({
                 accessoryType: 'select',
                 isSelected: false,
             });
@@ -68,8 +68,8 @@ describe('SellBankAccountItem', () => {
             expect(getByTestId('radio-button-select')).toBeOnTheScreen();
         });
 
-        it('should render no accessory', () => {
-            const { queryByTestId } = renderBankAccountItem({
+        it('should render no accessory', async () => {
+            const { queryByTestId } = await renderBankAccountItem({
                 accessoryType: 'none',
             });
 
@@ -81,7 +81,7 @@ describe('SellBankAccountItem', () => {
     describe('User Interactions', () => {
         it('should call onPress when pressed', async () => {
             const mockOnPress = jest.fn();
-            const { getByTestId } = renderBankAccountItem({
+            const { getByTestId } = await renderBankAccountItem({
                 onPress: mockOnPress,
             });
 
@@ -92,7 +92,7 @@ describe('SellBankAccountItem', () => {
 
         it('should call onPress when radio button is pressed', async () => {
             const mockOnPress = jest.fn();
-            const { getByTestId } = renderBankAccountItem({
+            const { getByTestId } = await renderBankAccountItem({
                 accessoryType: 'select',
                 onPress: mockOnPress,
             });

--- a/suite-native/module-trading/src/components/sell/SellCompletion/BankAccount/SellBankAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCompletion/BankAccount/SellBankAccountPicker.test.tsx
@@ -35,11 +35,11 @@ describe('SellBankAccountPicker', () => {
         },
     });
 
-    const renderPicker = (
+    const renderPicker = async (
         props: ComponentProps<typeof SellBankAccountPicker>,
         overrides: PreloadedStatePartial<TradingTestPreloadedState>,
     ) =>
-        renderWithTradingProvider(<SellBankAccountPicker {...props} />, {
+        await renderWithTradingProvider(<SellBankAccountPicker {...props} />, {
             tradeType: 'sell',
             overrides,
         });
@@ -49,8 +49,8 @@ describe('SellBankAccountPicker', () => {
     });
 
     describe('Conditional Rendering', () => {
-        it('should not render when no bank accounts are available', () => {
-            const { queryByTestId } = renderPicker(
+        it('should not render when no bank accounts are available', async () => {
+            const { queryByTestId } = await renderPicker(
                 {
                     orderId: 'order_id_1',
                     selectedBankAccountIban: '',
@@ -69,8 +69,8 @@ describe('SellBankAccountPicker', () => {
             expect(queryByTestId('@trading/sell/bank-account-item')).not.toBeOnTheScreen();
         });
 
-        it('should not render when bankAccounts is undefined', () => {
-            const { queryByTestId } = renderPicker(
+        it('should not render when bankAccounts is undefined', async () => {
+            const { queryByTestId } = await renderPicker(
                 {
                     orderId: 'order_id_1',
                     selectedBankAccountIban: '',
@@ -89,8 +89,8 @@ describe('SellBankAccountPicker', () => {
             expect(queryByTestId('@trading/sell/bank-account-item')).not.toBeOnTheScreen();
         });
 
-        it('should not render when orderId is undefined', () => {
-            const { queryByTestId } = renderPicker(
+        it('should not render when orderId is undefined', async () => {
+            const { queryByTestId } = await renderPicker(
                 {
                     orderId: undefined,
                     selectedBankAccountIban: verifiedBankAccount.bankAccount,

--- a/suite-native/module-trading/src/components/sell/SellCompletion/BankAccount/SellBankAccountSheet.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCompletion/BankAccount/SellBankAccountSheet.test.tsx
@@ -8,8 +8,8 @@ describe('SellBankAccountSheet', () => {
     const mockCloseModal = jest.fn();
     const mockRef = { current: null };
 
-    const renderBankAccountSheet = (props = {}) =>
-        renderWithBasicProvider(
+    const renderBankAccountSheet = async (props = {}) =>
+        await renderWithBasicProvider(
             <SellBankAccountSheet
                 ref={mockRef}
                 bankAccounts={bankAccounts}
@@ -25,8 +25,8 @@ describe('SellBankAccountSheet', () => {
     });
 
     describe('User Experience', () => {
-        it('should display all bank accounts', () => {
-            const { getByText } = renderBankAccountSheet();
+        it('should display all bank accounts', async () => {
+            const { getByText } = await renderBankAccountSheet();
 
             // User should see bank account holder names
             expect(getByText('John Doe')).toBeOnTheScreen();
@@ -35,7 +35,7 @@ describe('SellBankAccountSheet', () => {
         });
 
         it('should allow user to select a bank account', async () => {
-            const { getByText } = renderBankAccountSheet();
+            const { getByText } = await renderBankAccountSheet();
 
             // User should be able to tap on a bank account to select it
             await userEvent.press(getByText('John Doe'));
@@ -44,7 +44,7 @@ describe('SellBankAccountSheet', () => {
         });
 
         it('should close the modal after user selects a bank account', async () => {
-            const { getByText } = renderBankAccountSheet();
+            const { getByText } = await renderBankAccountSheet();
 
             // When user selects any bank account, modal should close
             await userEvent.press(getByText('Jane Smith'));

--- a/suite-native/module-trading/src/components/sell/SellCompletion/SellCompletionConfirmButton.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCompletion/SellCompletionConfirmButton.test.tsx
@@ -16,8 +16,8 @@ jest.mock('@react-navigation/native', () => ({
 const ethAccountKey = mockAccountKey({ symbol: 'eth', descriptor: 'eth1normal' });
 
 describe('SellCompletionConfirmButton', () => {
-    const renderSellCompletionButton = (precomposedTx: Record<string, unknown> | undefined) =>
-        renderWithTradingProvider(
+    const renderSellCompletionButton = async (precomposedTx: Record<string, unknown> | undefined) =>
+        await renderWithTradingProvider(
             <SellCompletionConfirmButton quote={banxaCreditCardSellQuote} />,
             {
                 tradeType: 'sell',
@@ -34,10 +34,10 @@ describe('SellCompletionConfirmButton', () => {
         jest.clearAllMocks();
     });
 
-    it('renders only when the transaction is final', () => {
-        expect(renderSellCompletionButton({ type: 'composing' }).toJSON()).toBeNull();
+    it('renders only when the transaction is final', async () => {
+        expect((await renderSellCompletionButton({ type: 'composing' })).toJSON()).toBeNull();
 
-        const { getByText } = renderSellCompletionButton(
+        const { getByText } = await renderSellCompletionButton(
             createPrecomposedTxFinal({ totalSpent: '1100', fee: '1000' }),
         );
 
@@ -48,8 +48,8 @@ describe('SellCompletionConfirmButton', () => {
         ).toBeOnTheScreen();
     });
 
-    it('does not render when there is not final type', () => {
-        const { toJSON } = renderWithTradingProvider(
+    it('does not render when there is not final type', async () => {
+        const { toJSON } = await renderWithTradingProvider(
             <SellCompletionConfirmButton quote={banxaCreditCardSellQuote} />,
             {
                 tradeType: 'sell',
@@ -66,7 +66,7 @@ describe('SellCompletionConfirmButton', () => {
     });
 
     it('navigates to outputs review', async () => {
-        const { getByText } = renderSellCompletionButton(
+        const { getByText } = await renderSellCompletionButton(
             createPrecomposedTxFinal({ totalSpent: '1100', fee: '1000' }),
         );
 

--- a/suite-native/module-trading/src/components/sell/SellCompletion/SellCompletionFeeInfo.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCompletion/SellCompletionFeeInfo.test.tsx
@@ -13,12 +13,12 @@ jest.mock('../../general/TradeInfo/TradeFeeInfoRow', () => {
 });
 
 describe('SellCompletionFeeInfo', () => {
-    const renderSellCompletionFeeInfo = (
+    const renderSellCompletionFeeInfo = async (
         props: Partial<SellCompletionFeeInfoProps> = {},
         tradingAccountKey: AccountKey = eth1NormalAccount.key,
         providerConfirmationStatus: ProviderConfirmationStatus = 'confirmation_success',
     ) =>
-        renderWithTradingProvider(<SellCompletionFeeInfo isTxnError={false} {...props} />, {
+        await renderWithTradingProvider(<SellCompletionFeeInfo isTxnError={false} {...props} />, {
             tradeType: 'sell',
             overrides: {
                 wallet: {
@@ -30,8 +30,8 @@ describe('SellCompletionFeeInfo', () => {
             },
         });
 
-    it('should render nothing when isTxnError', () => {
-        const { toJSON } = renderSellCompletionFeeInfo({
+    it('should render nothing when isTxnError', async () => {
+        const { toJSON } = await renderSellCompletionFeeInfo({
             quote: banxaCreditCardSellQuote,
             isTxnError: true,
         });
@@ -39,24 +39,24 @@ describe('SellCompletionFeeInfo', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when there is no quote', () => {
-        const { toJSON } = renderSellCompletionFeeInfo({});
+    it('should render nothing when there is no quote', async () => {
+        const { toJSON } = await renderSellCompletionFeeInfo({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when quote has no cryptoCurrency', () => {
+    it('should render nothing when quote has no cryptoCurrency', async () => {
         const quoteWithoutCrypto = {
             ...banxaCreditCardSellQuote,
             cryptoCurrency: undefined,
         };
-        const { toJSON } = renderSellCompletionFeeInfo({ quote: quoteWithoutCrypto });
+        const { toJSON } = await renderSellCompletionFeeInfo({ quote: quoteWithoutCrypto });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', () => {
-        const { toJSON } = renderSellCompletionFeeInfo(
+    it('should render nothing when account is not found', async () => {
+        const { toJSON } = await renderSellCompletionFeeInfo(
             { quote: banxaCreditCardSellQuote },
             mockAccountKey({ descriptor: 'unknownAccountKey' }),
         );
@@ -64,8 +64,8 @@ describe('SellCompletionFeeInfo', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when providerConfirmationStatus is not in "confirmation_success" state', () => {
-        const { toJSON } = renderSellCompletionFeeInfo(
+    it('should render nothing when providerConfirmationStatus is not in "confirmation_success" state', async () => {
+        const { toJSON } = await renderSellCompletionFeeInfo(
             { quote: banxaCreditCardSellQuote },
             eth1NormalAccount.key,
             'window_closed_with_success',
@@ -74,8 +74,8 @@ describe('SellCompletionFeeInfo', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render fee info otherwise', () => {
-        const { getByTestId } = renderSellCompletionFeeInfo({
+    it('should render fee info otherwise', async () => {
+        const { getByTestId } = await renderSellCompletionFeeInfo({
             quote: banxaCreditCardSellQuote,
         });
 

--- a/suite-native/module-trading/src/components/sell/SellCompletion/SellCompletionView.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCompletion/SellCompletionView.test.tsx
@@ -49,11 +49,11 @@ describe('SellCompletionView', () => {
         },
     });
 
-    const renderSellCompletionView = (
+    const renderSellCompletionView = async (
         props: Partial<SellCompletionViewProps> = {},
         formStep?: TradingSellStepType,
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <SellCompletionView
                 quote={banxaBankTransferSellQuote}
                 txnErrorString={null}
@@ -66,8 +66,8 @@ describe('SellCompletionView', () => {
             },
         );
 
-    it('renders the sell summary', () => {
-        const { getByText } = renderSellCompletionView();
+    it('renders the sell summary', async () => {
+        const { getByText } = await renderSellCompletionView();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingSellPreviewScreen.youPay')),
@@ -81,22 +81,22 @@ describe('SellCompletionView', () => {
         ).toBeOnTheScreen();
     });
 
-    it('renders the transaction error', () => {
-        const { getByText } = renderSellCompletionView({
+    it('renders the transaction error', async () => {
+        const { getByText } = await renderSellCompletionView({
             txnErrorString: 'Transaction error occurred',
         });
 
         expect(getByText('Transaction error occurred')).toBeOnTheScreen();
     });
 
-    it('renders bank accounts during the bank account step', () => {
-        const { getAllByTestId } = renderSellCompletionView({}, 'BANK_ACCOUNT');
+    it('renders bank accounts during the bank account step', async () => {
+        const { getAllByTestId } = await renderSellCompletionView({}, 'BANK_ACCOUNT');
 
         expect(getAllByTestId(BANK_ACCOUNT_ITEM_TEST_ID).length).toBeGreaterThan(0);
     });
 
-    it('renders the quote passed to the view', () => {
-        const { getByText } = renderSellCompletionView({
+    it('renders the quote passed to the view', async () => {
+        const { getByText } = await renderSellCompletionView({
             quote: banxaCreditCardSellQuote,
         });
 

--- a/suite-native/module-trading/src/components/sell/SellConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellConfirmation.test.tsx
@@ -20,12 +20,12 @@ describe('SellConfirmation', () => {
     const mockUseSellSelectQuote =
         require('../../hooks/sell/useSellSelectQuote').useSellSelectQuote;
 
-    const renderConfirmation = () =>
-        renderWithStoreProvider(<SellConfirmation />, {
+    const renderConfirmation = async () =>
+        await renderWithStoreProvider(<SellConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
-    it('should render continue button when canProceed is true', () => {
+    it('should render continue button when canProceed is true', async () => {
         mockUseSellSelectQuote.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
@@ -34,12 +34,12 @@ describe('SellConfirmation', () => {
             cancelLegalTermsConsent: jest.fn(),
         });
 
-        const { getByText } = renderConfirmation();
+        const { getByText } = await renderConfirmation();
 
         expect(getByText(CTA_TEXT)).toBeTruthy();
     });
 
-    it('should not render sell button when canProceed is false', () => {
+    it('should not render sell button when canProceed is false', async () => {
         mockUseSellSelectQuote.mockReturnValue({
             canProceed: false,
             selectQuote: jest.fn(),
@@ -48,7 +48,7 @@ describe('SellConfirmation', () => {
             cancelLegalTermsConsent: jest.fn(),
         });
 
-        const { queryByText } = renderConfirmation();
+        const { queryByText } = await renderConfirmation();
 
         expect(queryByText(CTA_TEXT)).toBeNull();
     });

--- a/suite-native/module-trading/src/components/sell/SellForm.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellForm.test.tsx
@@ -40,18 +40,20 @@ const services: NativeAnalyticsDep = {
 };
 
 describe('SellForm', () => {
-    const renderFormHook = (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
-        renderHookWithTradingProvider(() => useSellForm(), {
+    const renderFormHook = async (
+        overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
+    ) =>
+        await renderHookWithTradingProvider(() => useSellForm(), {
             services,
             tradeType: 'sell',
             overrides,
         });
 
-    const renderSellForm = (
+    const renderSellForm = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
         form: SellFormType,
     ) =>
-        renderWithTradingProvider(<SellForm />, {
+        await renderWithTradingProvider(<SellForm />, {
             services,
             tradeType: 'sell',
             overrides,
@@ -62,13 +64,13 @@ describe('SellForm', () => {
         jest.clearAllMocks();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render when sell data are not preloaded', () => {
-        const { result } = renderFormHook();
-        const { getByText, getByLabelText } = renderSellForm({}, result.current);
+    it('should render when sell data are not preloaded', async () => {
+        const { result } = await renderFormHook();
+        const { getByText, getByLabelText } = await renderSellForm({}, result.current);
 
         expect(
             getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
@@ -87,15 +89,15 @@ describe('SellForm', () => {
         let form: SellFormType;
         let overrides: PreloadedStatePartial<TradingTestPreloadedState>;
 
-        beforeEach(() => {
+        beforeEach(async () => {
             overrides = {
                 wallet: { trading: { sell: { quotes: sellQuotes } } },
                 ...residenceCheckDisabledState,
             };
 
-            const { result } = renderFormHook(overrides);
+            const { result } = await renderFormHook(overrides);
             form = result.current;
-            act(() => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('sendAccount', getBtcAccount());
                 form.setValue('amountInCrypto', true);
@@ -104,8 +106,8 @@ describe('SellForm', () => {
             });
         });
 
-        it('should render with default values', () => {
-            const { getByLabelText, getByText } = renderSellForm(overrides, form);
+        it('should render with default values', async () => {
+            const { getByLabelText, getByText } = await renderSellForm(overrides, form);
 
             expect(
                 getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
@@ -124,11 +126,11 @@ describe('SellForm', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should render only SellCard and Done when amount input is active', () => {
-            act(() => {
+        it('should render only SellCard and Done when amount input is active', async () => {
+            await act(() => {
                 form.setValue('focusedValue', 'fiatStringAmount');
             });
-            const { queryByText, getByText } = renderSellForm(overrides, form);
+            const { queryByText, getByText } = await renderSellForm(overrides, form);
 
             expect(
                 getByText(getTranslation('moduleTrading.selectFiat.buy.amountLabel')),
@@ -147,9 +149,9 @@ describe('SellForm', () => {
         });
     });
 
-    it('should report to analytics on mount', () => {
-        const { result } = renderFormHook();
-        renderSellForm({}, result.current);
+    it('should report to analytics on mount', async () => {
+        const { result } = await renderFormHook();
+        await renderSellForm({}, result.current);
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingSellEvent.name,

--- a/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.test.tsx
@@ -20,8 +20,8 @@ import {
 describe('SellFormFieldErrorBadge', () => {
     let tradingForm: SellFormType;
 
-    const renderUseTradingSellForm = () => {
-        const { result } = renderHookWithTradingProvider(() => useSellForm(), {
+    const renderUseTradingSellForm = async () => {
+        const { result } = await renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
         });
 
@@ -34,25 +34,25 @@ describe('SellFormFieldErrorBadge', () => {
         wallet: { settings: { bitcoinAmountUnit } },
     });
 
-    const renderSellFormFieldErrorBadge = (
+    const renderSellFormFieldErrorBadge = async (
         props: SellFormFieldErrorBadgeProps,
         form: SellFormType,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = getOverrides(),
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <Form form={form}>
                 <SellFormFieldErrorBadge {...props} />
             </Form>,
             { tradeType: 'sell', overrides },
         );
 
-    beforeEach(() => {
-        tradingForm = renderUseTradingSellForm();
+    beforeEach(async () => {
+        tradingForm = await renderUseTradingSellForm();
     });
 
     describe('for fiatStringAmount', () => {
-        it('should render nothing where there is no error in form', () => {
-            const { toJSON } = renderSellFormFieldErrorBadge(
+        it('should render nothing where there is no error in form', async () => {
+            const { toJSON } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -60,14 +60,14 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should render error when field has error', () => {
-            act(() => {
+        it('should render error when field has error', async () => {
+            await act(() => {
                 tradingForm.setError('fiatStringAmount', {
                     type: 'manual',
                     message: 'Error message',
                 });
             });
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -77,8 +77,8 @@ describe('SellFormFieldErrorBadge', () => {
     });
 
     describe('for cryptoStringAmount', () => {
-        it('should display nothing when asset is not selected', () => {
-            const { toJSON } = renderSellFormFieldErrorBadge(
+        it('should display nothing when asset is not selected', async () => {
+            const { toJSON } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -87,14 +87,14 @@ describe('SellFormFieldErrorBadge', () => {
         });
 
         describe('with asset', () => {
-            beforeEach(() => {
-                act(() => {
+            beforeEach(async () => {
+                await act(() => {
                     tradingForm.setValue('sendAsset', btcAsset);
                 });
             });
 
-            it('should display nothing when amount is not set', () => {
-                const { toJSON } = renderSellFormFieldErrorBadge(
+            it('should display nothing when amount is not set', async () => {
+                const { toJSON } = await renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                 );
@@ -102,12 +102,12 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(toJSON()).toBeNull();
             });
 
-            it('should display formatted value when amount is 0', () => {
-                act(() => {
+            it('should display formatted value when amount is 0', async () => {
+                await act(() => {
                     tradingForm.setValue('cryptoStringAmount', '0');
                 });
 
-                const { getByText } = renderSellFormFieldErrorBadge(
+                const { getByText } = await renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                 );
@@ -115,12 +115,12 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(getByText('$0.00')).toBeOnTheScreen();
             });
 
-            it('should display formatted value when amount is set', () => {
-                act(() => {
+            it('should display formatted value when amount is set', async () => {
+                await act(() => {
                     tradingForm.setValue('cryptoStringAmount', '1234567');
                 });
 
-                const { getByText } = renderSellFormFieldErrorBadge(
+                const { getByText } = await renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                 );
@@ -128,8 +128,8 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(getByText('$1,234.57')).toBeOnTheScreen();
             });
 
-            it('should display error message when field has error', () => {
-                act(() => {
+            it('should display error message when field has error', async () => {
+                await act(() => {
                     tradingForm.setError('cryptoStringAmount', {
                         type: 'manual',
                         message: 'VALIDATION_ERROR',
@@ -137,7 +137,7 @@ describe('SellFormFieldErrorBadge', () => {
                     tradingForm.setValue('cryptoStringAmount', '1000');
                 });
 
-                const { getByText, queryByText } = renderSellFormFieldErrorBadge(
+                const { getByText, queryByText } = await renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                 );
@@ -146,8 +146,8 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(getByText('VALIDATION_ERROR')).toBeOnTheScreen();
             });
 
-            it('should display formatted fiat value when field has error, but quotes are loading', () => {
-                act(() => {
+            it('should display formatted fiat value when field has error, but quotes are loading', async () => {
+                await act(() => {
                     tradingForm.setError('cryptoStringAmount', {
                         type: 'manual',
                         message: 'VALIDATION_ERROR',
@@ -158,7 +158,7 @@ describe('SellFormFieldErrorBadge', () => {
                     wallet: { trading: { sell: { isLoading: true } } },
                 };
 
-                const { getByText, queryByText } = renderSellFormFieldErrorBadge(
+                const { getByText, queryByText } = await renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                     overrides,
@@ -168,12 +168,12 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(getByText('$1.00')).toBeOnTheScreen();
             });
 
-            it('should display correct value when using sats', () => {
-                act(() => {
+            it('should display correct value when using sats', async () => {
+                await act(() => {
                     tradingForm.setValue('cryptoStringAmount', '1234567123456');
                 });
 
-                const { getByText } = renderSellFormFieldErrorBadge(
+                const { getByText } = await renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                     getOverrides(PROTO.AmountUnit.SATOSHI),
@@ -185,22 +185,22 @@ describe('SellFormFieldErrorBadge', () => {
     });
 
     describe('with selected quote', () => {
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 tradingForm.setValue('sendAsset', btcAsset);
                 tradingForm.setValue('quote', banxaCreditCardSellQuote);
             });
         });
 
-        it('should render badge when quote has different crypto value than requested', () => {
-            act(() => {
+        it('should render badge when quote has different crypto value than requested', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '0.0235');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -214,15 +214,15 @@ describe('SellFormFieldErrorBadge', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should render $ value badge when crypto amount does not differ', () => {
-            act(() => {
+        it('should render $ value badge when crypto amount does not differ', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '0.0233');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -230,15 +230,15 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should render $ value badge when crypto amount does not differ but contains trailing zeros', () => {
-            act(() => {
+        it('should render $ value badge when crypto amount does not differ but contains trailing zeros', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '0.023300');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -246,18 +246,18 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should render $ value badge while quotes are loading', () => {
-            act(() => {
+        it('should render $ value badge while quotes are loading', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '0.0006');
             });
             const overrides = {
                 wallet: { trading: { sell: { isLoading: true } } },
             };
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
                 overrides,
@@ -266,12 +266,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should render badge when quote has different fiat value than requested', () => {
-            act(() => {
+        it('should render badge when quote has different fiat value than requested', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatStringAmount', '91');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -285,12 +285,12 @@ describe('SellFormFieldErrorBadge', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should not render badge when fiat amount does not differ', () => {
-            act(() => {
+        it('should not render badge when fiat amount does not differ', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatStringAmount', '90.17');
             });
 
-            const { toJSON } = renderSellFormFieldErrorBadge(
+            const { toJSON } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -298,15 +298,15 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge for cryptoStringAmount when rendering different form field badge', () => {
-            act(() => {
+        it('should not render badge for cryptoStringAmount when rendering different form field badge', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '0.0006');
             });
 
-            const { toJSON } = renderSellFormFieldErrorBadge(
+            const { toJSON } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -314,12 +314,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge for fiatStringAmount when rendering different form field badge', () => {
-            act(() => {
+        it('should not render badge for fiatStringAmount when rendering different form field badge', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatStringAmount', '11.0');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -327,12 +327,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should not render badge when fiat amount does not differ but contains trailing zeros', () => {
-            act(() => {
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatStringAmount', '90.170');
             });
 
-            const { toJSON } = renderSellFormFieldErrorBadge(
+            const { toJSON } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -340,15 +340,15 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should correctly compare with amount in sats', () => {
-            act(() => {
+        it('should correctly compare with amount in sats', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '2330000');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
                 getOverrides(PROTO.AmountUnit.SATOSHI),
@@ -357,15 +357,15 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should correctly display amount in sats', () => {
-            act(() => {
+        it('should correctly display amount in sats', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '2330001');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
                 getOverrides(PROTO.AmountUnit.SATOSHI),
@@ -382,8 +382,8 @@ describe('SellFormFieldErrorBadge', () => {
     });
 
     describe('with quote with trailing zeros', () => {
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 tradingForm.setValue('sendAsset', btcAsset);
                 tradingForm.setValue('quote', {
                     ...banxaCreditCardSellQuote,
@@ -393,15 +393,15 @@ describe('SellFormFieldErrorBadge', () => {
             });
         });
 
-        it('should not render badge when crypto amount does not differ', () => {
-            act(() => {
+        it('should not render badge when crypto amount does not differ', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '0.0005');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -409,15 +409,15 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should not render badge when crypto amount does not differ but contains trailing zeros', () => {
-            act(() => {
+        it('should not render badge when crypto amount does not differ but contains trailing zeros', async () => {
+            await act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
-            act(() => {
+            await act(() => {
                 tradingForm.setValue('cryptoStringAmount', '0.0005000');
             });
 
-            const { getByText } = renderSellFormFieldErrorBadge(
+            const { getByText } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -425,12 +425,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should not render badge when fiat amount does not differ', () => {
-            act(() => {
+        it('should not render badge when fiat amount does not differ', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatStringAmount', '10.0');
             });
 
-            const { toJSON } = renderSellFormFieldErrorBadge(
+            const { toJSON } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -438,12 +438,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when fiat amount does not differ but contains trailing zeros', () => {
-            act(() => {
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+            await act(() => {
                 tradingForm.setValue('fiatStringAmount', '10.000');
             });
 
-            const { toJSON } = renderSellFormFieldErrorBadge(
+            const { toJSON } = await renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );

--- a/suite-native/module-trading/src/components/sell/SellFromAccountCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellFromAccountCard.test.tsx
@@ -5,11 +5,11 @@ import { SellFromAccountCard, type SellFromAccountCardProps } from './SellFromAc
 import { renderWithTradingProvider } from '../../test-utils/tradingTestUtils';
 
 describe('SellFromAccountCard', () => {
-    const renderSellFromAccountCard = (
+    const renderSellFromAccountCard = async (
         props: Partial<SellFromAccountCardProps> = {},
         tradingAccountKey = eth1NormalAccount.key,
     ) =>
-        renderWithTradingProvider(<SellFromAccountCard {...props} />, {
+        await renderWithTradingProvider(<SellFromAccountCard {...props} />, {
             tradeType: 'sell',
             overrides: {
                 wallet: {
@@ -18,8 +18,8 @@ describe('SellFromAccountCard', () => {
             },
         });
 
-    it('should render TradeSideCard', () => {
-        const { getByText } = renderSellFromAccountCard({
+    it('should render TradeSideCard', async () => {
+        const { getByText } = await renderSellFromAccountCard({
             quote: banxaCreditCardSellQuote,
         });
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewContinueButton.test.tsx
@@ -17,8 +17,8 @@ describe('SellPreviewContinueButton', () => {
         jest.clearAllMocks();
     });
 
-    const renderButton = (withRequiredState = true) =>
-        renderWithTradingProvider(<SellPreviewContinueButton companyName="Banxa" />, {
+    const renderButton = async (withRequiredState = true) =>
+        await renderWithTradingProvider(<SellPreviewContinueButton companyName="Banxa" />, {
             tradeType: 'sell',
             overrides: withRequiredState
                 ? {
@@ -34,8 +34,8 @@ describe('SellPreviewContinueButton', () => {
                 : undefined,
         });
 
-    it('renders provider CTA', () => {
-        const { getByText } = renderButton();
+    it('renders provider CTA', async () => {
+        const { getByText } = await renderButton();
 
         expect(
             getByText(
@@ -47,7 +47,7 @@ describe('SellPreviewContinueButton', () => {
     });
 
     it('replaces preview with completion screen', async () => {
-        const { getByText } = renderButton();
+        const { getByText } = await renderButton();
 
         await userEvent.press(
             getByText(
@@ -60,8 +60,8 @@ describe('SellPreviewContinueButton', () => {
         expect(mockReplace).toHaveBeenCalledWith('TradingSellCompletion');
     });
 
-    it('is disabled without a quote and account', () => {
-        const { getByText } = renderButton(false);
+    it('is disabled without a quote and account', async () => {
+        const { getByText } = await renderButton(false);
 
         expect(
             getByText(

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.test.tsx
@@ -12,8 +12,8 @@ import { SellPreviewView } from './SellPreviewView';
 import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
 
 describe('SellPreviewView', () => {
-    const renderSellPreviewView = (quote: SellFiatTrade = banxaBankTransferSellQuote) =>
-        renderWithTradingProvider(<SellPreviewView quote={quote} />, {
+    const renderSellPreviewView = async (quote: SellFiatTrade = banxaBankTransferSellQuote) =>
+        await renderWithTradingProvider(<SellPreviewView quote={quote} />, {
             tradeType: 'sell',
             overrides: {
                 wallet: {
@@ -47,8 +47,8 @@ describe('SellPreviewView', () => {
             },
         });
 
-    it('renders the sell summary', () => {
-        const { getByText } = renderSellPreviewView();
+    it('renders the sell summary', async () => {
+        const { getByText } = await renderSellPreviewView();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingSellPreviewScreen.youPay')),
@@ -62,16 +62,16 @@ describe('SellPreviewView', () => {
         ).toBeOnTheScreen();
     });
 
-    it('renders the quote passed to the view', () => {
-        const { getByText } = renderSellPreviewView(banxaCreditCardSellQuote);
+    it('renders the quote passed to the view', async () => {
+        const { getByText } = await renderSellPreviewView(banxaCreditCardSellQuote);
 
         expect(
             getByText(getTranslation('moduleTrading.paymentMethods.creditCard')),
         ).toBeOnTheScreen();
     });
 
-    it('does not render completion-only bank account or fee controls', () => {
-        const { queryByTestId } = renderSellPreviewView();
+    it('does not render completion-only bank account or fee controls', async () => {
+        const { queryByTestId } = await renderSellPreviewView();
 
         expect(queryByTestId('@trading/sell/bank-account-item')).not.toBeOnTheScreen();
         expect(queryByTestId('@transactionManagement/fee-selector-row')).not.toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/sell/SellTab.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellTab.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../concierge/ConciergeAlert', () => ({
 
 describe('SellTab', () => {
     const renderSellTab = async (overrides: Record<string, unknown> = {}) => {
-        const result = renderWithTradingProvider(<SellTab />, {
+        const result = await renderWithTradingProvider(<SellTab />, {
             tradeType: 'sell',
             overrides,
         });

--- a/suite-native/module-trading/src/components/sell/SellTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellTabContent.test.tsx
@@ -32,8 +32,8 @@ describe('SellTabContent', () => {
         }));
     });
 
-    const renderSellTabContent = () =>
-        renderWithTradingProvider(<SellTabContent />, { tradeType: 'sell' });
+    const renderSellTabContent = async () =>
+        await renderWithTradingProvider(<SellTabContent />, { tradeType: 'sell' });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);
@@ -51,50 +51,50 @@ describe('SellTabContent', () => {
         ).toBeOnTheScreen();
     };
 
-    it('should render Sell skeleton when isLoading is true', () => {
+    it('should render Sell skeleton when isLoading is true', async () => {
         mockUseSellData.mockReturnValue({
             isLoading: true,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        renderSellTabContent();
+        await renderSellTabContent();
 
         expectSkeleton();
     });
 
-    it('should render Sell skeleton when lastLoadedTimestamp is 0', () => {
+    it('should render Sell skeleton when lastLoadedTimestamp is 0', async () => {
         mockUseSellData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 0,
             isFullyLoaded: false,
         });
 
-        renderSellTabContent();
+        await renderSellTabContent();
 
         expectSkeleton();
     });
 
-    it('should render Sell form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', () => {
+    it('should render Sell form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', async () => {
         mockUseSellData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: true,
         });
 
-        renderSellTabContent();
+        await renderSellTabContent();
 
         expectSellForm();
     });
 
-    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', () => {
+    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', async () => {
         mockUseSellData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        renderSellTabContent();
+        await renderSellTabContent();
 
         expectServerOffline();
     });
@@ -112,7 +112,7 @@ describe('SellTabContent', () => {
                 isFullyLoaded: true,
             });
 
-        const { getByText } = renderSellTabContent();
+        const { getByText } = await renderSellTabContent();
 
         const reloadButton = getByText(getTranslation('tradingAtoms.error.serverOfflineRetry'));
 

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatAmountInput.test.tsx
@@ -11,16 +11,16 @@ import {
 } from '../../../test-utils/tradingTestUtils';
 
 describe('SellFiatAmountInput', () => {
-    const renderFiatAmountInput = (form: SellFormType) =>
-        renderWithTradingProvider(
+    const renderFiatAmountInput = async (form: SellFormType) =>
+        await renderWithTradingProvider(
             <Form form={form}>
                 <SellFiatAmountInput />
             </Form>,
             { tradeType: 'sell' },
         );
 
-    const renderUseTradingSellForm = () => {
-        const { result } = renderHookWithTradingProvider(() => useSellForm(), {
+    const renderUseTradingSellForm = async () => {
+        const { result } = await renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
         });
 
@@ -28,8 +28,8 @@ describe('SellFiatAmountInput', () => {
     };
 
     it('should set fiat value in form', async () => {
-        const form = renderUseTradingSellForm();
-        const { getByLabelText } = renderFiatAmountInput(form);
+        const form = await renderUseTradingSellForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
@@ -40,8 +40,8 @@ describe('SellFiatAmountInput', () => {
     });
 
     it('should format input value to be decimal', async () => {
-        const form = renderUseTradingSellForm();
-        const { getByLabelText } = renderFiatAmountInput(form);
+        const form = await renderUseTradingSellForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
@@ -55,8 +55,8 @@ describe('SellFiatAmountInput', () => {
     });
 
     it('should always escape non-numeric characters', async () => {
-        const form = renderUseTradingSellForm();
-        const { getByLabelText } = renderFiatAmountInput(form);
+        const form = await renderUseTradingSellForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),
@@ -70,8 +70,8 @@ describe('SellFiatAmountInput', () => {
     });
 
     it('should limit value to 3 decimals', async () => {
-        const form = renderUseTradingSellForm();
-        const { getByLabelText } = renderFiatAmountInput(form);
+        const form = await renderUseTradingSellForm();
+        const { getByLabelText } = await renderFiatAmountInput(form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectFiat.sell.amountLabel')),

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.test.tsx
@@ -34,23 +34,23 @@ describe('SellFiatCurrencyPicker', () => {
     let form: SellFormType;
     let store: TestStore;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         mockUseListDataFilter = jest.requireActual('@suite-common/trading').useListDataFilter;
         reportMock.mockClear();
         store = createTradingLightStore({ tradeType: 'sell' });
-        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
+        const { result } = await renderHookWithStoreProvider(() => useSellForm(), {
             services,
             store,
         });
         form = result.current;
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    const renderFiatCurrencyPicker = () =>
-        renderWithStoreProvider(
+    const renderFiatCurrencyPicker = async () =>
+        await renderWithStoreProvider(
             <Form form={form}>
                 <SellFiatCurrencyPicker />
             </Form>,
@@ -60,8 +60,8 @@ describe('SellFiatCurrencyPicker', () => {
             },
         );
 
-    it('should display selected currency', () => {
-        const { getByLabelText } = renderFiatCurrencyPicker();
+    it('should display selected currency', async () => {
+        const { getByLabelText } = await renderFiatCurrencyPicker();
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
@@ -69,10 +69,12 @@ describe('SellFiatCurrencyPicker', () => {
     });
 
     it('should allow to select currency', async () => {
-        const { getByText, getByLabelText } = renderFiatCurrencyPicker();
+        const { getByText, getByLabelText } = await renderFiatCurrencyPicker();
 
-        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
-        fireEvent.press(getByText('PLN'));
+        await fireEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        );
+        await fireEvent.press(getByText('PLN'));
 
         // wait for validators to run
         await act(() => Promise.resolve());
@@ -85,10 +87,12 @@ describe('SellFiatCurrencyPicker', () => {
     it('should apply sell fiat currency change effects on selection', async () => {
         form.setValue('fiatStringAmount', '100');
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { getByText, getByLabelText } = renderFiatCurrencyPicker();
+        const { getByText, getByLabelText } = await renderFiatCurrencyPicker();
 
-        fireEvent.press(getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')));
-        fireEvent.press(getByText('PLN'));
+        await fireEvent.press(
+            getByLabelText(getTranslation('moduleTrading.selectFiat.buttonTitle')),
+        );
+        await fireEvent.press(getByText('PLN'));
         await act(() => Promise.resolve());
 
         expect(form.getValues('fiatStringAmount')).toBeUndefined();
@@ -102,14 +106,14 @@ describe('SellFiatCurrencyPicker', () => {
         });
     });
 
-    it('should display empty component when filtered data is empty', () => {
+    it('should display empty component when filtered data is empty', async () => {
         mockUseListDataFilter = () => ({
             filteredData: [],
             setFilterValue: jest.fn(),
             filterValue: 'test-key',
         });
 
-        const { getByText } = renderFiatCurrencyPicker();
+        const { getByText } = await renderFiatCurrencyPicker();
 
         expect(
             getByText(getTranslation('moduleTrading.fiatCurrencySheet.emptyTitle')),

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencySheet.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencySheet.test.tsx
@@ -4,18 +4,18 @@ import { getWalletState } from '@suite-native/trading-fixtures';
 import { SellFiatCurrencySheet } from './SellFiatCurrencySheet';
 
 describe('SellFiatCurrencySheet', () => {
-    const renderSellFiatCurrencySheet = () =>
-        renderWithStoreProvider(
+    const renderSellFiatCurrencySheet = async () =>
+        await renderWithStoreProvider(
             <SellFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
             { preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) } },
         );
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render items based on Sell state', () => {
-        const { getByText } = renderSellFiatCurrencySheet();
+    it('should render items based on Sell state', async () => {
+        const { getByText } = await renderSellFiatCurrencySheet();
 
         expect(getByText('USD')).toBeOnTheScreen();
         expect(getByText('EUR')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.test.tsx
@@ -33,37 +33,37 @@ const services: NativeAnalyticsDep = {
 describe('SellReceiveMethodPicker', () => {
     let form: SellFormType;
 
-    const renderSellReceiveMethodPicker = (
+    const renderSellReceiveMethodPicker = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithStoreProvider(<SellReceiveMethodPicker />, {
+        await renderWithStoreProvider(<SellReceiveMethodPicker />, {
             preloadedState: createTradingPreloadedState({ tradeType: 'sell', overrides }),
             services,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
 
-        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
+        const { result } = await renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState: createTradingPreloadedState({ tradeType: 'sell' }),
             services,
         });
         form = result.current;
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render nothing when no quotes are loaded', () => {
-        const { toJSON } = renderSellReceiveMethodPicker();
+    it('should render nothing when no quotes are loaded', async () => {
+        const { toJSON } = await renderSellReceiveMethodPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render loading skeleton when no quotes are loaded and new quotes are loading', () => {
-        const { getByLabelText } = renderSellReceiveMethodPicker({
+    it('should render loading skeleton when no quotes are loaded and new quotes are loading', async () => {
+        const { getByLabelText } = await renderSellReceiveMethodPicker({
             wallet: { trading: { sell: { isLoading: true } } },
         });
 
@@ -72,8 +72,8 @@ describe('SellReceiveMethodPicker', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render "Not selected" when no quote is selected', () => {
-        const { getByLabelText } = renderSellReceiveMethodPicker({
+    it('should render "Not selected" when no quote is selected', async () => {
+        const { getByLabelText } = await renderSellReceiveMethodPicker({
             wallet: { trading: { sell: { quotes: sellQuotes } } },
         });
 
@@ -87,14 +87,14 @@ describe('SellReceiveMethodPicker', () => {
             wallet: { trading: { sell: { quotes: sellQuotes } } },
         };
 
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 form.setValue('quote', banxaBankTransferSellQuote);
             });
         });
 
-        it('should render selected receive method', () => {
-            const { getByLabelText, getByTestId } = renderSellReceiveMethodPicker(withQuotes);
+        it('should render selected receive method', async () => {
+            const { getByLabelText, getByTestId } = await renderSellReceiveMethodPicker(withQuotes);
 
             expect(
                 getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedReceiveMethod')),
@@ -104,8 +104,8 @@ describe('SellReceiveMethodPicker', () => {
             expect(within(picker).getByTestId('@icons/payment-method-icon/bank')).toBeTruthy();
         });
 
-        it('should render loading skeleton when quotes are loaded and new quotes are loading', () => {
-            const { getByLabelText } = renderSellReceiveMethodPicker({
+        it('should render loading skeleton when quotes are loaded and new quotes are loading', async () => {
+            const { getByLabelText } = await renderSellReceiveMethodPicker({
                 wallet: { trading: { sell: { quotes: sellQuotes, isLoading: true } } },
             });
 
@@ -114,11 +114,13 @@ describe('SellReceiveMethodPicker', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should allow to select receive method', () => {
-            const { getByText, getByLabelText } = renderSellReceiveMethodPicker(withQuotes);
+        it('should allow to select receive method', async () => {
+            const { getByText, getByLabelText } = await renderSellReceiveMethodPicker(withQuotes);
 
-            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.receiveMethod')));
-            fireEvent.press(getByText(creditCardPaymentMethodTranslation));
+            await fireEvent.press(
+                getByText(getTranslation('moduleTrading.tradingScreen.receiveMethod')),
+            );
+            await fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
             expect(
                 getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedReceiveMethod')),
@@ -130,13 +132,13 @@ describe('SellReceiveMethodPicker', () => {
                 reportMock.mockClear();
             });
 
-            it('should fire analytics event on receive method select', () => {
-                const { getByText } = renderSellReceiveMethodPicker(withQuotes);
+            it('should fire analytics event on receive method select', async () => {
+                const { getByText } = await renderSellReceiveMethodPicker(withQuotes);
 
-                fireEvent.press(
+                await fireEvent.press(
                     getByText(getTranslation('moduleTrading.tradingScreen.receiveMethod')),
                 );
-                fireEvent.press(getByText(creditCardPaymentMethodTranslation));
+                await fireEvent.press(getByText(creditCardPaymentMethodTranslation));
 
                 expect(reportMock).toHaveBeenCalledWith({
                     type: events.tradingParameterChangedEvent.name,
@@ -147,16 +149,16 @@ describe('SellReceiveMethodPicker', () => {
                 });
             });
 
-            it('should not fire analytics event when same receive method is selected', () => {
-                const { getAllByText } = renderSellReceiveMethodPicker(withQuotes);
+            it('should not fire analytics event when same receive method is selected', async () => {
+                const { getAllByText } = await renderSellReceiveMethodPicker(withQuotes);
 
-                fireEvent.press(
+                await fireEvent.press(
                     getIndexOrThrow(
                         getAllByText(getTranslation('moduleTrading.paymentMethods.bankTransfer')),
                         0,
                     ),
                 );
-                fireEvent.press(
+                await fireEvent.press(
                     getIndexOrThrow(
                         getAllByText(getTranslation('moduleTrading.paymentMethods.bankTransfer')),
                         1,

--- a/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.test.tsx
@@ -29,37 +29,37 @@ const services: NativeAnalyticsDep = {
 describe('SellProviderPicker', () => {
     let form: SellFormType;
 
-    const renderSellProviderPicker = (
+    const renderSellProviderPicker = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithStoreProvider(<SellProviderPicker />, {
+        await renderWithStoreProvider(<SellProviderPicker />, {
             preloadedState: createTradingPreloadedState({ tradeType: 'sell', overrides }),
             services,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
 
-        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
+        const { result } = await renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState: createTradingPreloadedState({ tradeType: 'sell' }),
             services,
         });
         form = result.current;
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render nothing when no quotes are loaded', () => {
-        const { toJSON } = renderSellProviderPicker();
+    it('should render nothing when no quotes are loaded', async () => {
+        const { toJSON } = await renderSellProviderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render loading skeleton when no quotes are loaded and new quotes are loading', () => {
-        const { getByLabelText } = renderSellProviderPicker({
+    it('should render loading skeleton when no quotes are loaded and new quotes are loading', async () => {
+        const { getByLabelText } = await renderSellProviderPicker({
             wallet: { trading: { sell: { isLoading: true } } },
         });
 
@@ -73,14 +73,14 @@ describe('SellProviderPicker', () => {
             wallet: { trading: { sell: { quotes: sellQuotes } } },
         };
 
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 form.setValue('quote', banxaCreditCardSellQuote);
             });
         });
 
-        it('should render loading skeleton when quotes are loaded and new quotes are loading', () => {
-            const { getByLabelText } = renderSellProviderPicker({
+        it('should render loading skeleton when quotes are loaded and new quotes are loading', async () => {
+            const { getByLabelText } = await renderSellProviderPicker({
                 wallet: { trading: { sell: { quotes: sellQuotes, isLoading: true } } },
             });
 
@@ -89,19 +89,21 @@ describe('SellProviderPicker', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should render selected payment provider', () => {
-            const { getByLabelText } = renderSellProviderPicker(withQuotes);
+        it('should render selected payment provider', async () => {
+            const { getByLabelText } = await renderSellProviderPicker(withQuotes);
 
             expect(
                 getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedProvider')),
             ).toHaveTextContent('Banxa');
         });
 
-        it('should allow to select provider', () => {
-            const { getByText, getByLabelText } = renderSellProviderPicker(withQuotes);
+        it('should allow to select provider', async () => {
+            const { getByText, getByLabelText } = await renderSellProviderPicker(withQuotes);
 
-            fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
-            fireEvent.press(getByText('MoonPay'));
+            await fireEvent.press(
+                getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+            );
+            await fireEvent.press(getByText('MoonPay'));
 
             expect(
                 getByLabelText(getTranslation('moduleTrading.tradingScreen.selectedProvider')),
@@ -113,11 +115,13 @@ describe('SellProviderPicker', () => {
                 reportMock.mockClear();
             });
 
-            it('should fire analytics event on provider select', () => {
-                const { getByText } = renderSellProviderPicker(withQuotes);
+            it('should fire analytics event on provider select', async () => {
+                const { getByText } = await renderSellProviderPicker(withQuotes);
 
-                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
-                fireEvent.press(getByText('MoonPay'));
+                await fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+                );
+                await fireEvent.press(getByText('MoonPay'));
 
                 expect(reportMock).toHaveBeenCalledTimes(2);
                 expect(reportMock).toHaveBeenCalledWith({
@@ -135,11 +139,11 @@ describe('SellProviderPicker', () => {
                 });
             });
 
-            it('should not fire analytics event when same provider is selected', () => {
-                const { getAllByText } = renderSellProviderPicker(withQuotes);
+            it('should not fire analytics event when same provider is selected', async () => {
+                const { getAllByText } = await renderSellProviderPicker(withQuotes);
 
-                fireEvent.press(getIndexOrThrow(getAllByText('Banxa'), 0));
-                fireEvent.press(getIndexOrThrow(getAllByText('Banxa'), 1));
+                await fireEvent.press(getIndexOrThrow(getAllByText('Banxa'), 0));
+                await fireEvent.press(getIndexOrThrow(getAllByText('Banxa'), 1));
 
                 expect(reportMock).toHaveBeenCalledTimes(1);
                 expect(reportMock).toHaveBeenCalledWith({
@@ -150,12 +154,14 @@ describe('SellProviderPicker', () => {
                 });
             });
 
-            it('should not call analytics when user tries to open sheet while quotes are loading', () => {
-                const { getByText } = renderSellProviderPicker({
+            it('should not call analytics when user tries to open sheet while quotes are loading', async () => {
+                const { getByText } = await renderSellProviderPicker({
                     wallet: { trading: { sell: { quotes: sellQuotes, isLoading: true } } },
                 });
 
-                fireEvent.press(getByText(getTranslation('moduleTrading.tradingScreen.provider')));
+                await fireEvent.press(
+                    getByText(getTranslation('moduleTrading.tradingScreen.provider')),
+                );
 
                 expect(reportMock).not.toHaveBeenCalled();
             });

--- a/suite-native/module-trading/src/components/sell/send/SellSendAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAccountCryptoBalance.test.tsx
@@ -16,41 +16,41 @@ import {
 describe('SellSendAccountCryptoBalance', () => {
     let sellForm: SellFormType;
 
-    const renderSellForm = () => {
-        const { result } = renderHookWithTradingProvider(() => useSellForm(), {
+    const renderSellForm = async () => {
+        const { result } = await renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
         });
 
         return result.current;
     };
 
-    const renderComponent = () =>
-        renderWithTradingProvider(<SellSendAccountCryptoBalance />, {
+    const renderComponent = async () =>
+        await renderWithTradingProvider(<SellSendAccountCryptoBalance />, {
             tradeType: 'sell',
             wrapper: ({ children }) => <Form form={sellForm}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        sellForm = renderSellForm();
+    beforeEach(async () => {
+        sellForm = await renderSellForm();
     });
 
-    it('should use asset form field as default symbol', () => {
-        act(() => {
+    it('should use asset form field as default symbol', async () => {
+        await act(() => {
             sellForm.setValue('sendAsset', btcAsset);
         });
-        const { getByTestId } = renderComponent();
+        const { getByTestId } = await renderComponent();
 
         expect(getByTestId(SEND_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should use sendAccount form field to obtain account', () => {
-        act(() => {
+    it('should use sendAccount form field to obtain account', async () => {
+        await act(() => {
             sellForm.setValue('sendAsset', btcAsset);
         });
-        act(() => {
+        await act(() => {
             sellForm.setValue('sendAccount', getBtcAccount());
         });
-        const { getByTestId } = renderComponent();
+        const { getByTestId } = await renderComponent();
 
         expect(getByTestId(SEND_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
     });

--- a/suite-native/module-trading/src/components/sell/send/SellSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAmountInput.test.tsx
@@ -27,22 +27,22 @@ jest.mock('../../../hooks/general/useAmountInputDecimals', () => ({
 }));
 
 describe('SellSendAmountInput', () => {
-    const renderCryptoAmountInput = (
+    const renderCryptoAmountInput = async (
         props: Partial<SellSendAmountInputProps>,
         form: SellFormType,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderWithTradingProvider(
+        await renderWithTradingProvider(
             <Form form={form}>
                 <SellSendAmountInput showAssetsScreen={jest.fn()} {...props} />
             </Form>,
             { tradeType: 'sell', overrides },
         );
 
-    const renderUseTradingSellForm = (
+    const renderUseTradingSellForm = async (
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) => {
-        const { result } = renderHookWithTradingProvider(() => useSellForm(), {
+        const { result } = await renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
             overrides,
         });
@@ -55,11 +55,11 @@ describe('SellSendAmountInput', () => {
     });
 
     it('should set send value in form', async () => {
-        const form = renderUseTradingSellForm();
-        act(() => {
+        const form = await renderUseTradingSellForm();
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -69,9 +69,9 @@ describe('SellSendAmountInput', () => {
         expect(form.getValues('cryptoStringAmount')).toEqual('100');
     });
 
-    it('should be disabled when asset is not selected', () => {
-        const form = renderUseTradingSellForm();
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+    it('should be disabled when asset is not selected', async () => {
+        const form = await renderUseTradingSellForm();
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         expect(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -80,8 +80,8 @@ describe('SellSendAmountInput', () => {
 
     it('should call showAssetsScreen when disabled and pressed', async () => {
         const showAssetsScreen = jest.fn();
-        const form = renderUseTradingSellForm();
-        const { getByLabelText } = renderCryptoAmountInput({ showAssetsScreen }, form);
+        const form = await renderUseTradingSellForm();
+        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsScreen }, form);
 
         await userEvent.press(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -92,11 +92,11 @@ describe('SellSendAmountInput', () => {
 
     it('should not call showAssetsScreen when enabled and pressed', async () => {
         const showAssetsScreen = jest.fn();
-        const form = renderUseTradingSellForm();
-        act(() => {
+        const form = await renderUseTradingSellForm();
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({ showAssetsScreen }, form);
+        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsScreen }, form);
 
         await userEvent.press(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -106,11 +106,11 @@ describe('SellSendAmountInput', () => {
     });
 
     it('should format input value to be decimal by default', async () => {
-        const form = renderUseTradingSellForm();
-        act(() => {
+        const form = await renderUseTradingSellForm();
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -124,11 +124,11 @@ describe('SellSendAmountInput', () => {
     });
 
     it('should preserve a leading-zero decimal while typing', async () => {
-        const form = renderUseTradingSellForm();
-        act(() => {
+        const form = await renderUseTradingSellForm();
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
         const input = getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel'));
 
         await userEvent.type(input, '0.0001');
@@ -141,11 +141,11 @@ describe('SellSendAmountInput', () => {
         const overrides = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = renderUseTradingSellForm(overrides);
-        act(() => {
+        const form = await renderUseTradingSellForm(overrides);
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form, overrides);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, overrides);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -162,11 +162,11 @@ describe('SellSendAmountInput', () => {
         const overrides = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = renderUseTradingSellForm(overrides);
-        act(() => {
+        const form = await renderUseTradingSellForm(overrides);
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form, overrides);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, overrides);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -181,15 +181,15 @@ describe('SellSendAmountInput', () => {
 
     it('should limit value to decimals based on useAmountInputDecimals return value', async () => {
         const accountKey = mockAccountKey({ symbol: 'eth', descriptor: 'accountKey' });
-        const form = renderUseTradingSellForm();
-        act(() => {
+        const form = await renderUseTradingSellForm();
+        await act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendAccount', {
                 key: accountKey,
                 symbol: 'eth',
             } as Account);
         });
-        const { getByLabelText } = renderCryptoAmountInput({}, form);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form);
 
         await userEvent.type(
             getByLabelText(getTranslation('moduleTrading.selectCoinToSell.amountLabel')),
@@ -203,30 +203,30 @@ describe('SellSendAmountInput', () => {
         );
     });
 
-    it('should display loading skeleton while amountInCrypto is false and quotes are loading', () => {
+    it('should display loading skeleton while amountInCrypto is false and quotes are loading', async () => {
         const overrides = { wallet: { trading: { sell: { isLoading: true } } } };
-        const form = renderUseTradingSellForm(overrides);
+        const form = await renderUseTradingSellForm(overrides);
 
-        act(() => {
+        await act(() => {
             form.setValue('amountInCrypto', false);
         });
 
-        const { getByLabelText } = renderCryptoAmountInput({}, form, overrides);
+        const { getByLabelText } = await renderCryptoAmountInput({}, form, overrides);
 
         expect(
             getByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),
         ).toBeTruthy();
     });
 
-    it('should not display loading skeleton when amountInCrypto is true', () => {
+    it('should not display loading skeleton when amountInCrypto is true', async () => {
         const overrides = { wallet: { trading: { sell: { isLoading: true } } } };
-        const form = renderUseTradingSellForm(overrides);
+        const form = await renderUseTradingSellForm(overrides);
 
-        act(() => {
+        await act(() => {
             form.setValue('amountInCrypto', true);
         });
 
-        const { queryByLabelText } = renderCryptoAmountInput({}, form, overrides);
+        const { queryByLabelText } = await renderCryptoAmountInput({}, form, overrides);
 
         expect(
             queryByLabelText(getTranslation('moduleTrading.tradingScreen.quotesLoadingLabel')),

--- a/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.test.tsx
@@ -85,17 +85,17 @@ describe('SellSendAssetPicker', () => {
         },
     ];
 
-    const renderSellForm = () =>
-        renderHookWithStoreProvider(() => useSellForm(), { services, store });
+    const renderSellForm = async () =>
+        await renderHookWithStoreProvider(() => useSellForm(), { services, store });
 
-    const renderSellSendAssetPicker = () =>
-        renderWithStoreProvider(<SellSendAssetPicker />, {
+    const renderSellSendAssetPicker = async () =>
+        await renderWithStoreProvider(<SellSendAssetPicker />, {
             services,
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         reportMock.mockClear();
         jest.clearAllMocks();
         mockSelectedMyAssetAccountKey = undefined;
@@ -109,7 +109,7 @@ describe('SellSendAssetPicker', () => {
                 },
             },
         });
-        const { result } = renderSellForm();
+        const { result } = await renderSellForm();
         form = result.current;
 
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue(
@@ -118,17 +118,17 @@ describe('SellSendAssetPicker', () => {
     });
 
     it('should navigate to the my asset screen', async () => {
-        const { getByLabelText } = renderSellSendAssetPicker();
+        const { getByLabelText } = await renderSellSendAssetPicker();
 
         await userEvent.press(getByLabelText('Select asset'));
 
         expect(mockNavigate).toHaveBeenCalledWith('TradingMyAsset', { tradingType: 'sell' });
     });
 
-    it('should select asset returned from the screen', () => {
+    it('should select asset returned from the screen', async () => {
         mockSelectedMyAssetAccountKey = btcAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
-        renderSellSendAssetPicker();
+        await renderSellSendAssetPicker();
 
         const asset = form.getValues('sendAsset');
 
@@ -139,16 +139,16 @@ describe('SellSendAssetPicker', () => {
         );
     });
 
-    it('should select account returned from the screen', () => {
+    it('should select account returned from the screen', async () => {
         mockSelectedMyAssetAccountKey = btcAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
-        renderSellSendAssetPicker();
+        await renderSellSendAssetPicker();
 
         const accountKeyStore = store.getState().wallet.trading.sell.tradingAccountKey;
         expect(accountKeyStore).toBe(btcAccount.key);
     });
 
-    it('should select the exact account when the same asset is present in multiple accounts', () => {
+    it('should select the exact account when the same asset is present in multiple accounts', async () => {
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue([
             defaultAccounts[0],
             {
@@ -160,24 +160,24 @@ describe('SellSendAssetPicker', () => {
         mockSelectedMyAssetAccountKey = ethAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
 
-        renderSellSendAssetPicker();
+        await renderSellSendAssetPicker();
 
         expect(store.getState().wallet.trading.sell.tradingAccountKey).toBe(ethAccount.key);
     });
 
-    it('should leave the form unchanged when the screen is closed without a selection', () => {
-        renderSellSendAssetPicker();
+    it('should leave the form unchanged when the screen is closed without a selection', async () => {
+        await renderSellSendAssetPicker();
 
         expect(form.getValues('sendAsset')).toBeUndefined();
         expect(mockSetParams).not.toHaveBeenCalled();
     });
 
-    it('should apply sell asset change effects for an asset returned from the screen', () => {
+    it('should apply sell asset change effects for an asset returned from the screen', async () => {
         form.setValue('cryptoStringAmount', '1');
         mockSelectedMyAssetAccountKey = btcAccount.key;
         mockSelectedMyAssetCryptoId = 'bitcoin';
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        renderSellSendAssetPicker();
+        await renderSellSendAssetPicker();
 
         expect(form.getValues('cryptoStringAmount')).toBeUndefined();
         expect(dispatchSpy).toHaveBeenCalledWith(sellActions.sendAssetChanged());

--- a/suite-native/module-trading/src/hooks/buy/useBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/useBuyData.test.tsx
@@ -53,7 +53,7 @@ describe('useBuyData', () => {
     };
 
     const renderUseBuyData = async (reloadRequestOrdinalInitialValue: number, store: TestStore) => {
-        const ret = renderHookWithStoreProvider(
+        const ret = await renderHookWithStoreProvider(
             ({ reloadRequestOrdinal }) => useBuyData(reloadRequestOrdinal),
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
@@ -110,7 +110,7 @@ describe('useBuyData', () => {
 
         const store = configureMockStore({ reducer });
         const { rerender } = await renderUseBuyData(0, store);
-        rerender({ reloadRequestOrdinal: 0 });
+        await rerender({ reloadRequestOrdinal: 0 });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
     });
@@ -122,7 +122,7 @@ describe('useBuyData', () => {
 
         const store = configureMockStore({ reducer });
         const { rerender } = await renderUseBuyData(0, store);
-        rerender({ reloadRequestOrdinal: 1 });
+        await rerender({ reloadRequestOrdinal: 1 });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(2);
     });
@@ -143,7 +143,7 @@ describe('useBuyData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingBuyActions.setTradingAccountKey(btc2Account.key));
             });
 
@@ -165,7 +165,7 @@ describe('useBuyData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingBuyActions.setTradingAccountKey(btc2Account.key));
             });
 
@@ -184,7 +184,7 @@ describe('useBuyData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingBuyActions.setTradingAccountKey(btc3Account.key));
             });
 
@@ -207,7 +207,7 @@ describe('useBuyData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingBuyActions.setTradingAccountKey(undefined));
             });
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.test.ts
@@ -45,47 +45,48 @@ describe('useBuyFlow', () => {
             },
         });
 
-    const renderBuyForm = () => renderHookWithStoreProvider(() => useBuyForm(), { store });
+    const renderBuyForm = async () =>
+        await renderHookWithStoreProvider(() => useBuyForm(), { store });
 
-    const renderUseTradingBuyFlow = () =>
-        renderHookWithStoreProvider(() => useBuyFlow(buyForm), { store });
+    const renderUseTradingBuyFlow = async () =>
+        await renderHookWithStoreProvider(() => useBuyFlow(buyForm), { store });
 
     describe('while loading quotes', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             store = getInitializedStore({ isLoading: true });
 
-            const { result } = renderBuyForm();
+            const { result } = await renderBuyForm();
             buyForm = result.current;
         });
 
-        it('should canProceed be false when loading', () => {
-            const { result } = renderUseTradingBuyFlow();
+        it('should canProceed be false when loading', async () => {
+            const { result } = await renderUseTradingBuyFlow();
             expect(result.current.canProceed).toBe(false);
         });
     });
 
     describe('with quote loaded and selected', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             store = getInitializedStore({ isLoading: false });
 
-            const { result } = renderBuyForm();
+            const { result } = await renderBuyForm();
             buyForm = result.current;
 
-            act(() => {
+            await act(() => {
                 buyForm.setValue('quote', invityErrorBuyQuote);
             });
         });
 
-        it('should canProceed be true when not loading and orderId filters one in quotes', () => {
-            const { result } = renderUseTradingBuyFlow();
+        it('should canProceed be true when not loading and orderId filters one in quotes', async () => {
+            const { result } = await renderUseTradingBuyFlow();
 
             expect(result.current.canProceed).toBe(true);
         });
 
         describe('and receive account selected', () => {
-            beforeEach(() => {
+            beforeEach(async () => {
                 const btcAccount = getBtcAccount();
-                act(() => {
+                await act(() => {
                     buyForm.setValue('receiveAccount', {
                         account: btcAccount,
                         address: btcAccount.addresses?.used?.[0],
@@ -93,14 +94,14 @@ describe('useBuyFlow', () => {
                 });
             });
 
-            it('should store receive address and account key in Redux before navigating to preview', () => {
+            it('should store receive address and account key in Redux before navigating to preview', async () => {
                 const btcAccount = getBtcAccount();
                 const expectedAddress =
                     btcAccount.addresses?.used?.[0]?.address ?? btcAccount.descriptor;
 
-                const { result } = renderUseTradingBuyFlow();
+                const { result } = await renderUseTradingBuyFlow();
 
-                act(() => {
+                await act(() => {
                     result.current.selectQuote();
                 });
 
@@ -109,17 +110,17 @@ describe('useBuyFlow', () => {
                 expect(state.wallet.trading.buy.receiveAccountKey).toBe(btcAccount.key);
             });
 
-            it('should reset form when navigating to preview', () => {
-                const { result } = renderUseTradingBuyFlow();
+            it('should reset form when navigating to preview', async () => {
+                const { result } = await renderUseTradingBuyFlow();
                 const resetSpy = jest.spyOn(buyForm, 'reset');
 
-                act(() => {
+                await act(() => {
                     result.current.selectQuote();
                 });
 
                 const [payload] = mockSelectQuoteThunk.mock.calls[0] as [any];
 
-                act(() => {
+                await act(() => {
                     payload.nextStep();
                 });
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.test.tsx
@@ -46,8 +46,8 @@ const btc2AccountKey = btc2legacyAccount.key;
 const accountDeviceState = btc1NormalAccount.deviceState;
 
 describe('useBuyForm', () => {
-    const renderUseTradingBuyForm = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useBuyForm(), { store });
+    const renderUseTradingBuyForm = async (store: TestStore) =>
+        await renderHookWithStoreProvider(() => useBuyForm(), { store });
 
     const getInitializedStore = (amountInSats = false) => {
         const tradingState = getInitializedTradingState();
@@ -80,13 +80,13 @@ describe('useBuyForm', () => {
         });
     };
 
-    const initFormAndQuotes = (form: BuyFormType, store: EnhancedStore) => {
-        act(() => {
+    const initFormAndQuotes = async (form: BuyFormType, store: EnhancedStore) => {
+        await act(() => {
             form.setValue('fiatValue', '10');
             form.setValue('asset', btcAsset);
         });
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
         });
     };
@@ -101,11 +101,11 @@ describe('useBuyForm', () => {
         );
     });
 
-    it('should update form value when account in redux store is changed', () => {
+    it('should update form value when account in redux store is changed', async () => {
         const store = getInitializedStore();
-        const { result } = renderUseTradingBuyForm(store);
+        const { result } = await renderUseTradingBuyForm(store);
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingBuyActions.setTradingAccountKey(btc2AccountKey));
         });
 
@@ -116,9 +116,9 @@ describe('useBuyForm', () => {
 
     it('should preselect receiveAccount when asset is selected', async () => {
         const store = getInitializedStore();
-        const { result } = renderUseTradingBuyForm(store);
+        const { result } = await renderUseTradingBuyForm(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('asset', btcAsset);
         });
 
@@ -131,11 +131,11 @@ describe('useBuyForm', () => {
         });
     });
 
-    it('should not clear selected account when asset is set to undefined', () => {
+    it('should not clear selected account when asset is set to undefined', async () => {
         const store = getInitializedStore();
-        const { result } = renderUseTradingBuyForm(store);
+        const { result } = await renderUseTradingBuyForm(store);
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingBuyActions.setTradingAccountKey(btc1AccountKey));
             result.current.setValue('asset', undefined as unknown as TradeableAsset);
         });
@@ -152,15 +152,15 @@ describe('useBuyForm', () => {
             ['web', 'creditCard'],
         ])(
             'if no quote is selected should select 1st quote with %s payment method based on %s',
-            (platform, method) => {
+            async (platform, method) => {
                 jest.spyOn(Platform, 'select').mockImplementation(
                     (option: any) => option[platform],
                 );
 
                 const store = getInitializedStore();
-                const { result } = renderUseTradingBuyForm(store);
+                const { result } = await renderUseTradingBuyForm(store);
 
-                initFormAndQuotes(result.current, store);
+                await initFormAndQuotes(result.current, store);
 
                 expect(result.current.getValues('quote')).toEqual(
                     expect.objectContaining({
@@ -172,12 +172,12 @@ describe('useBuyForm', () => {
             },
         );
 
-        it('if no quote is selected and preferred method is not available should select 1st quote with credit card', () => {
+        it('if no quote is selected and preferred method is not available should select 1st quote with credit card', async () => {
             jest.spyOn(Platform, 'select').mockImplementation((option: any) => option['ios']);
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('fiatValue', '10');
                 result.current.setValue('asset', btcAsset);
                 // Only provide credit card quote
@@ -193,28 +193,28 @@ describe('useBuyForm', () => {
             jest.restoreAllMocks();
         });
 
-        it('should set quote to undefined when no quotes are available', () => {
+        it('should set quote to undefined when no quotes are available', async () => {
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
             // this will load quotes and selects one
-            initFormAndQuotes(result.current, store);
+            await initFormAndQuotes(result.current, store);
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingBuyActions.saveQuotes([]));
             });
 
             expect(result.current.getValues('quote')).toBeUndefined();
         });
 
-        it('should clear cryptoValue when no quotes are available', () => {
+        it('should clear cryptoValue when no quotes are available', async () => {
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
             // this will load quotes and selects one
-            initFormAndQuotes(result.current, store);
+            await initFormAndQuotes(result.current, store);
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingBuyActions.saveQuotes([]));
             });
 
@@ -222,19 +222,19 @@ describe('useBuyForm', () => {
             expect(result.current.getValues('fiatValue')).toBe('10');
         });
 
-        it('should clear fiatValue when no quotes are available and user inserted cryptoValue', () => {
+        it('should clear fiatValue when no quotes are available and user inserted cryptoValue', async () => {
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
             // this will load quotes and selects one
-            act(() => {
+            await act(() => {
                 result.current.setValue('amountInCrypto', true);
                 result.current.setValue('asset', btcAsset);
                 result.current.setValue('cryptoValue', '1');
                 store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
             });
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingBuyActions.saveQuotes([]));
             });
 
@@ -242,13 +242,13 @@ describe('useBuyForm', () => {
             expect(result.current.getValues('cryptoValue')).toBe('1');
         });
 
-        it('should update cryptoValue when selected quote is changed and truncate it to 9 decimals', () => {
+        it('should update cryptoValue when selected quote is changed and truncate it to 9 decimals', async () => {
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            initFormAndQuotes(result.current, store);
+            await initFormAndQuotes(result.current, store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('quote', mercuryoApplePayBuyQuote);
             });
 
@@ -256,13 +256,13 @@ describe('useBuyForm', () => {
             expect(result.current.getValues('fiatValue')).toEqual('10');
         });
 
-        it('should not update cryptoValue from a quote for a different asset', () => {
+        it('should not update cryptoValue from a quote for a different asset', async () => {
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            initFormAndQuotes(result.current, store);
+            await initFormAndQuotes(result.current, store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('asset', ethAsset);
                 result.current.setValue('cryptoValue', undefined);
             });
@@ -270,18 +270,18 @@ describe('useBuyForm', () => {
             expect(result.current.getValues('cryptoValue')).toBeUndefined();
         });
 
-        it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount and truncate it to 3 decimals', () => {
+        it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount and truncate it to 3 decimals', async () => {
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('asset', btcAsset);
                 result.current.setValue('amountInCrypto', true);
                 result.current.setValue('cryptoValue', '100');
                 store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
             });
 
-            act(() => {
+            await act(() => {
                 const newQuote = {
                     ...mercuryoApplePayBuyQuote,
                     fiatStringAmount: '10.123456789',
@@ -293,13 +293,13 @@ describe('useBuyForm', () => {
             expect(result.current.getValues('fiatValue')).toEqual('10.123');
         });
 
-        it('should persist provider metadata to redux', () => {
+        it('should persist provider metadata to redux', async () => {
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            initFormAndQuotes(result.current, store);
+            await initFormAndQuotes(result.current, store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('quote', mercuryoApplePayBuyQuote);
             });
 
@@ -310,35 +310,35 @@ describe('useBuyForm', () => {
             let store: EnhancedStore;
             let form: BuyFormType;
 
-            beforeEach(() => {
+            beforeEach(async () => {
                 store = getInitializedStore();
-                const { result } = renderUseTradingBuyForm(store);
+                const { result } = await renderUseTradingBuyForm(store);
                 form = result.current;
 
-                act(() => {
+                await act(() => {
                     result.current.setValue('asset', btcAsset);
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('cryptoValue', '100');
                 });
             });
 
-            it('should select quote with same payment method and provider', () => {
-                act(() => {
+            it('should select quote with same payment method and provider', async () => {
+                await act(() => {
                     form.setValue('quote', {
                         ...mercuryoCreditCardBuyQuote,
                         orderId: 'test1',
                     } as BuyTrade);
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
                 });
 
                 expect(form.getValues('quote')).toEqual(mercuryoCreditCardBuyQuote);
             });
 
-            it('should select 1st quote with same payment method if same provider is not available', () => {
-                act(() => {
+            it('should select 1st quote with same payment method if same provider is not available', async () => {
+                await act(() => {
                     form.setValue('quote', {
                         ...mercuryoCreditCardBuyQuote,
                         orderId: 'test1',
@@ -346,19 +346,19 @@ describe('useBuyForm', () => {
                     } as BuyTrade);
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
                 });
 
                 expect(form.getValues('quote')).toEqual(cexdirectCreditCardBuyQuote);
             });
 
-            it('should select 1st quote on new quotes when payment method is not available even with different provider', () => {
-                act(() => {
+            it('should select 1st quote on new quotes when payment method is not available even with different provider', async () => {
+                await act(() => {
                     store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingBuyActions.saveQuotes([mercuryoApplePayBuyQuote]));
                 });
 
@@ -371,11 +371,11 @@ describe('useBuyForm', () => {
         });
     });
 
-    it('should set correct cryptoValue when using BTC and amount in sats', () => {
+    it('should set correct cryptoValue when using BTC and amount in sats', async () => {
         const store = getInitializedStore(true);
-        const { result } = renderUseTradingBuyForm(store);
+        const { result } = await renderUseTradingBuyForm(store);
 
-        initFormAndQuotes(result.current, store);
+        await initFormAndQuotes(result.current, store);
 
         expect(result.current.getValues('cryptoValue')).toEqual('100016.8');
     });
@@ -387,14 +387,14 @@ describe('useBuyForm', () => {
         ])('should display fiat error for amount %s', async (amount, expectedValue) => {
             const store = getInitializedStore(true);
 
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('fiatValue', amount);
                 result.current.setValue('asset', btcAsset);
             });
 
-            act(() => {
+            await act(() => {
                 store.dispatch(
                     tradingBuyActions.setAmountLimits({
                         minFiat: '1000',
@@ -421,13 +421,13 @@ describe('useBuyForm', () => {
             'should display crypto error for amount %s',
             async (amount, amountInSats, expectedValue) => {
                 const store = getInitializedStore(amountInSats);
-                const { result } = renderUseTradingBuyForm(store);
+                const { result } = await renderUseTradingBuyForm(store);
 
-                act(() => {
+                await act(() => {
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('asset', btcAsset);
                 });
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingBuyActions.setAmountLimits({
                             minCrypto: '0.1',
@@ -436,7 +436,7 @@ describe('useBuyForm', () => {
                         }),
                     );
                 });
-                act(() => {
+                await act(() => {
                     result.current.setValue('cryptoValue', amount);
                 });
 
@@ -451,13 +451,13 @@ describe('useBuyForm', () => {
 
         it('should correctly compute limits with SATS', async () => {
             const store = getInitializedStore(true);
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('amountInCrypto', true);
                 result.current.setValue('asset', btcAsset);
             });
-            act(() => {
+            await act(() => {
                 store.dispatch(
                     tradingBuyActions.setAmountLimits({
                         minCrypto: '0.1',
@@ -466,7 +466,7 @@ describe('useBuyForm', () => {
                     }),
                 );
             });
-            act(() => {
+            await act(() => {
                 result.current.setValue('cryptoValue', '20000000');
             });
 
@@ -479,7 +479,7 @@ describe('useBuyForm', () => {
 
         it('should format a token named BTC as a token', async () => {
             const store = getInitializedStore(true);
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
             const btcTokenAsset: TradeableAsset = {
                 ...btcAsset,
                 cryptoId: 'ethereum--0x123' as CryptoId,
@@ -487,11 +487,11 @@ describe('useBuyForm', () => {
                 contractAddress: '0x123' as TokenAddress,
             };
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('amountInCrypto', true);
                 result.current.setValue('asset', btcTokenAsset);
             });
-            act(() => {
+            await act(() => {
                 store.dispatch(
                     tradingBuyActions.setAmountLimits({
                         minCrypto: '0.1',
@@ -499,7 +499,7 @@ describe('useBuyForm', () => {
                     }),
                 );
             });
-            act(() => {
+            await act(() => {
                 result.current.setValue('cryptoValue', '0.01');
             });
 
@@ -513,7 +513,7 @@ describe('useBuyForm', () => {
 
         it('should validate a token named BTC in base units when SATS are enabled', async () => {
             const store = getInitializedStore(true);
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
             const btcTokenAsset: TradeableAsset = {
                 ...btcAsset,
                 cryptoId: 'ethereum--0x123' as CryptoId,
@@ -521,11 +521,11 @@ describe('useBuyForm', () => {
                 contractAddress: '0x123' as TokenAddress,
             };
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('amountInCrypto', true);
                 result.current.setValue('asset', btcTokenAsset);
             });
-            act(() => {
+            await act(() => {
                 store.dispatch(
                     tradingBuyActions.setAmountLimits({
                         minCrypto: '0.1',
@@ -534,7 +534,7 @@ describe('useBuyForm', () => {
                     }),
                 );
             });
-            act(() => {
+            await act(() => {
                 result.current.setValue('cryptoValue', '0.2');
             });
 
@@ -542,7 +542,7 @@ describe('useBuyForm', () => {
 
             expect(result.current.getFieldState('cryptoValue').invalid).toBe(false);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('cryptoValue', '3');
             });
 
@@ -556,9 +556,9 @@ describe('useBuyForm', () => {
 
         it('should trigger validation once limits are loaded', async () => {
             const store = getInitializedStore(true);
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('fiatValue', '1');
                 result.current.setValue('asset', btcAsset);
             });
@@ -580,11 +580,11 @@ describe('useBuyForm', () => {
         });
 
         describe('generalAlert', () => {
-            it('should be undefined by default', () => {
+            it('should be undefined by default', async () => {
                 const store = getInitializedStore(true);
-                const { result } = renderUseTradingBuyForm(store);
+                const { result } = await renderUseTradingBuyForm(store);
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingBuyActions.saveQuotes([] as BuyTrade[]));
                     store.dispatch(tradingBuyActions.setAmountLimits(undefined));
                 });
@@ -592,11 +592,11 @@ describe('useBuyForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be set when empty quotes are fetched and no limits are set', () => {
+            it('should be set when empty quotes are fetched and no limits are set', async () => {
                 const store = getInitializedStore(true);
-                const { result } = renderUseTradingBuyForm(store);
+                const { result } = await renderUseTradingBuyForm(store);
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingBuyActions.saveQuoteRequest({
                             receiveCurrency: 'BTC' as CryptoId,
@@ -614,11 +614,11 @@ describe('useBuyForm', () => {
                 );
             });
 
-            it('should be undefined when empty quotes are fetched and limits are set', () => {
+            it('should be undefined when empty quotes are fetched and limits are set', async () => {
                 const store = getInitializedStore(true);
-                const { result } = renderUseTradingBuyForm(store);
+                const { result } = await renderUseTradingBuyForm(store);
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingBuyActions.saveQuoteRequest({
                             receiveCurrency: 'BTC' as CryptoId,
@@ -639,11 +639,11 @@ describe('useBuyForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be undefined when quotes are being fetched ', () => {
+            it('should be undefined when quotes are being fetched ', async () => {
                 const store = getInitializedStore(true);
-                const { result } = renderUseTradingBuyForm(store);
+                const { result } = await renderUseTradingBuyForm(store);
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingBuyActions.saveQuoteRequest({
                             receiveCurrency: 'BTC' as CryptoId,
@@ -659,11 +659,11 @@ describe('useBuyForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be cleared once quotes are fetched', () => {
+            it('should be cleared once quotes are fetched', async () => {
                 const store = getInitializedStore(true);
-                const { result } = renderUseTradingBuyForm(store);
+                const { result } = await renderUseTradingBuyForm(store);
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingBuyActions.saveQuoteRequest({
                             receiveCurrency: 'BTC' as CryptoId,
@@ -676,7 +676,7 @@ describe('useBuyForm', () => {
                     store.dispatch(tradingBuyActions.setAmountLimits(undefined));
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
                 });
 
@@ -686,11 +686,11 @@ describe('useBuyForm', () => {
     });
 
     describe('on country change', () => {
-        it('should set country to redux on change', () => {
+        it('should set country to redux on change', async () => {
             const store = getInitializedStore(true);
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('country', {
                     value: 'CA',
                     label: '🇨🇦 Canada',
@@ -706,17 +706,17 @@ describe('useBuyForm', () => {
     });
 
     describe('clearBuyFormQuoteData', () => {
-        it('should clear quote, fiatValue, cryptoValue and generalAlert data', () => {
+        it('should clear quote, fiatValue, cryptoValue and generalAlert data', async () => {
             const store = getInitializedStore();
-            const { result } = renderUseTradingBuyForm(store);
+            const { result } = await renderUseTradingBuyForm(store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('fiatValue', '10');
                 result.current.setValue('cryptoValue', '10');
                 result.current.setValue('quote', mercuryoApplePayBuyQuote);
             });
 
-            act(() => {
+            await act(() => {
                 clearBuyFormQuoteData(result.current);
             });
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyInputFormControls.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/useBuyInputFormControls.test.tsx
@@ -9,28 +9,28 @@ import { renderHookWithTradingProvider } from '../../test-utils/tradingTestUtils
 describe('useBuyInputFormControls', () => {
     let form: BuyFormType;
 
-    const renderBuyFormHook = () => renderHookWithTradingProvider(() => useBuyForm());
+    const renderBuyFormHook = async () => await renderHookWithTradingProvider(() => useBuyForm());
 
-    const renderUseBuyInputFormControls = (name: 'fiatValue' | 'cryptoValue' = 'fiatValue') =>
-        renderHookWithBasicProvider(() => useBuyInputFormControls(name), {
+    const renderUseBuyInputFormControls = async (name: 'fiatValue' | 'cryptoValue' = 'fiatValue') =>
+        await renderHookWithBasicProvider(() => useBuyInputFormControls(name), {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderBuyFormHook();
+    beforeEach(async () => {
+        const { result } = await renderBuyFormHook();
         form = result.current;
     });
 
-    it('should use value from given form field', () => {
+    it('should use value from given form field', async () => {
         form.setValue('fiatValue', '123');
 
-        const { result } = renderUseBuyInputFormControls();
+        const { result } = await renderUseBuyInputFormControls();
 
         expect(result.current.value).toEqual('123');
     });
 
-    it('should return correct structure', () => {
-        const { result } = renderUseBuyInputFormControls();
+    it('should return correct structure', async () => {
+        const { result } = await renderUseBuyInputFormControls();
 
         expect(result.current).toEqual(
             expect.objectContaining({
@@ -42,33 +42,33 @@ describe('useBuyInputFormControls', () => {
         );
     });
 
-    it('should keep onChangeText stable when the value changes', () => {
-        const { result } = renderUseBuyInputFormControls();
+    it('should keep onChangeText stable when the value changes', async () => {
+        const { result } = await renderUseBuyInputFormControls();
         const initialOnChangeText = result.current.onChangeText;
 
-        act(() => form.setValue('fiatValue', '123'));
+        await act(() => form.setValue('fiatValue', '123'));
 
         expect(result.current.onChangeText).toBe(initialOnChangeText);
     });
 
-    it('should switch to fiat amount and clear crypto amount on fiat input change', () => {
+    it('should switch to fiat amount and clear crypto amount on fiat input change', async () => {
         form.setValue('amountInCrypto', true);
         form.setValue('cryptoValue', '0.1');
-        const { result } = renderUseBuyInputFormControls('fiatValue');
+        const { result } = await renderUseBuyInputFormControls('fiatValue');
 
-        act(() => result.current.onChangeText('100'));
+        await act(() => result.current.onChangeText('100'));
 
         expect(form.getValues('fiatValue')).toBe('100');
         expect(form.getValues('cryptoValue')).toBeUndefined();
         expect(form.getValues('amountInCrypto')).toBe(false);
     });
 
-    it('should switch to crypto amount and clear fiat amount on crypto input change', () => {
+    it('should switch to crypto amount and clear fiat amount on crypto input change', async () => {
         form.setValue('amountInCrypto', false);
         form.setValue('fiatValue', '100');
-        const { result } = renderUseBuyInputFormControls('cryptoValue');
+        const { result } = await renderUseBuyInputFormControls('cryptoValue');
 
-        act(() => result.current.onChangeText('0.1'));
+        await act(() => result.current.onChangeText('0.1'));
 
         expect(form.getValues('cryptoValue')).toBe('0.1');
         expect(form.getValues('fiatValue')).toBeUndefined();

--- a/suite-native/module-trading/src/hooks/buy/useBuyPreviewFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyPreviewFlow.test.ts
@@ -82,8 +82,8 @@ describe('useBuyPreviewFlow', () => {
         });
     };
 
-    const renderHook = (store: ReturnType<typeof getInitializedStore>) =>
-        renderHookWithStoreProvider(() => useBuyPreviewFlow(), { store, services });
+    const renderHook = async (store: ReturnType<typeof getInitializedStore>) =>
+        await renderHookWithStoreProvider(() => useBuyPreviewFlow(), { store, services });
 
     const getProcessResponseData = () => {
         const [payload] = mockConfirmTradeThunk.mock.calls[0] as [any];
@@ -92,34 +92,34 @@ describe('useBuyPreviewFlow', () => {
     };
 
     describe('canProceed', () => {
-        it('is false when isLoading is true', () => {
+        it('is false when isLoading is true', async () => {
             const store = getInitializedStore({ isLoading: true, withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
             expect(result.current.canProceed).toBe(false);
         });
 
-        it('is false when receive address or account key is missing', () => {
+        it('is false when receive address or account key is missing', async () => {
             const store = getInitializedStore({ withFullState: false });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
             expect(result.current.canProceed).toBe(false);
         });
 
-        it('is true when not loading and all required state is set', () => {
+        it('is true when not loading and all required state is set', async () => {
             const store = getInitializedStore({ withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
             expect(result.current.canProceed).toBe(true);
         });
     });
 
     describe('confirmTrade', () => {
-        it('dispatches confirmTradeThunk with correct address and account when canProceed is true', () => {
+        it('dispatches confirmTradeThunk with correct address and account when canProceed is true', async () => {
             const store = getInitializedStore({ withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
-            act(() => {
+            await act(() => {
                 result.current.confirmTrade();
             });
 
@@ -131,11 +131,11 @@ describe('useBuyPreviewFlow', () => {
             );
         });
 
-        it('does not dispatch confirmTradeThunk when canProceed is false', () => {
+        it('does not dispatch confirmTradeThunk when canProceed is false', async () => {
             const store = getInitializedStore({ isLoading: true, withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
-            act(() => {
+            await act(() => {
                 result.current.confirmTrade();
             });
 
@@ -146,9 +146,9 @@ describe('useBuyPreviewFlow', () => {
     describe('handleTradeResponse', () => {
         it('opens browser, pops to top, and clears Redux state when tradeForm is present', async () => {
             const store = getInitializedStore({ withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
-            act(() => {
+            await act(() => {
                 result.current.confirmTrade();
             });
 
@@ -168,9 +168,9 @@ describe('useBuyPreviewFlow', () => {
 
         it('navigates to trading screen before clearing Redux state', async () => {
             const store = getInitializedStore({ withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
-            act(() => {
+            await act(() => {
                 result.current.confirmTrade();
             });
 
@@ -192,9 +192,9 @@ describe('useBuyPreviewFlow', () => {
 
         it('does not open browser or navigate when tradeForm is absent', async () => {
             const store = getInitializedStore({ withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
-            act(() => {
+            await act(() => {
                 result.current.confirmTrade();
             });
 
@@ -213,11 +213,11 @@ describe('useBuyPreviewFlow', () => {
     });
 
     describe('analytics', () => {
-        it('reports buy-preview continue when confirmTrade is called and canProceed is true', () => {
+        it('reports buy-preview continue when confirmTrade is called and canProceed is true', async () => {
             const store = getInitializedStore({ withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
-            act(() => {
+            await act(() => {
                 result.current.confirmTrade();
             });
 
@@ -233,22 +233,22 @@ describe('useBuyPreviewFlow', () => {
             );
         });
 
-        it('does not report analytics when canProceed is false', () => {
+        it('does not report analytics when canProceed is false', async () => {
             const store = getInitializedStore({ isLoading: true, withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
-            act(() => {
+            await act(() => {
                 result.current.confirmTrade();
             });
 
             expect(mockReport).not.toHaveBeenCalled();
         });
 
-        it('triggerAnalyticsTradeConfirmation reports tradingConfirmTradeEvent', () => {
+        it('triggerAnalyticsTradeConfirmation reports tradingConfirmTradeEvent', async () => {
             const store = getInitializedStore({ withFullState: true });
-            const { result } = renderHook(store);
+            const { result } = await renderHook(store);
 
-            act(() => {
+            await act(() => {
                 result.current.confirmTrade();
             });
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.test.ts
@@ -49,8 +49,8 @@ describe('useBuyQuotes', () => {
         });
     };
 
-    const renderUseBuyQuotes = (store: TestStore) =>
-        renderHookWithStoreProvider(
+    const renderUseBuyQuotes = async (store: TestStore) =>
+        await renderHookWithStoreProvider(
             () => {
                 const form = useBuyForm();
                 useBuyQuotes(form);
@@ -64,16 +64,16 @@ describe('useBuyQuotes', () => {
         jest.useRealTimers();
     });
 
-    it('should query quotes once all required data is selected', () => {
+    it('should query quotes once all required data is selected', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseBuyQuotes(store);
+        const { result } = await renderUseBuyQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('asset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
         });
-        act(() => {
+        await act(() => {
             result.current.setValue('fiatValue', '100');
         });
 
@@ -84,16 +84,16 @@ describe('useBuyQuotes', () => {
         );
     });
 
-    it('should query quotes once all required data is selected for BNB', () => {
+    it('should query quotes once all required data is selected for BNB', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseBuyQuotes(store);
+        const { result } = await renderUseBuyQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('asset', bnbAsset);
             result.current.setValue('fiatCurrency', 'usd');
         });
-        act(() => {
+        await act(() => {
             result.current.setValue('fiatValue', '100');
         });
 
@@ -104,37 +104,40 @@ describe('useBuyQuotes', () => {
         );
     });
 
-    it.each<string>(['0', '-1'])('should not query quotes when amount is zero or less', amount => {
+    it.each<string>(['0', '-1'])(
+        'should not query quotes when amount is zero or less',
+        async amount => {
+            const store = getInitializedStore();
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = await renderUseBuyQuotes(store);
+
+            await act(() => {
+                result.current.setValue('asset', bnbAsset);
+                result.current.setValue('fiatCurrency', 'usd');
+            });
+            await act(() => {
+                result.current.setValue('fiatValue', amount);
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'handleRequestThunkMock',
+                }),
+            );
+        },
+    );
+
+    it('should accept amount in crypto when requested', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseBuyQuotes(store);
+        const { result } = await renderUseBuyQuotes(store);
 
-        act(() => {
-            result.current.setValue('asset', bnbAsset);
-            result.current.setValue('fiatCurrency', 'usd');
-        });
-        act(() => {
-            result.current.setValue('fiatValue', amount);
-        });
-
-        expect(dispatchSpy).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: 'handleRequestThunkMock',
-            }),
-        );
-    });
-
-    it('should accept amount in crypto when requested', () => {
-        const store = getInitializedStore();
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseBuyQuotes(store);
-
-        act(() => {
+        await act(() => {
             result.current.setValue('asset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('amountInCrypto', true);
         });
-        act(() => {
+        await act(() => {
             result.current.setValue('cryptoValue', '0.1');
         });
 
@@ -145,13 +148,13 @@ describe('useBuyQuotes', () => {
         );
     });
 
-    it('should clear buy state on unmount', () => {
+    it('should clear buy state on unmount', async () => {
         const store = getInitializedStore();
         store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { unmount } = renderUseBuyQuotes(store);
+        const { unmount } = await renderUseBuyQuotes(store);
 
-        unmount();
+        await unmount();
 
         expect(dispatchSpy).toHaveBeenCalledWith({
             payload: undefined,
@@ -171,20 +174,20 @@ describe('useBuyQuotes', () => {
         ],
     ] as [keyof BuyFormValues, BuyFormValues[keyof BuyFormValues]][])(
         'should re-fetch quotes on %s value change',
-        (field, value) => {
+        async (field, value) => {
             const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseBuyQuotes(store);
-            act(() => {
+            const { result } = await renderUseBuyQuotes(store);
+            await act(() => {
                 result.current.setValue('asset', usdcAsset);
                 result.current.setValue('fiatCurrency', 'usd');
             });
-            act(() => {
+            await act(() => {
                 result.current.setValue('fiatValue', '100');
             });
 
             dispatchSpy.mockClear();
-            act(() => {
+            await act(() => {
                 result.current.setValue(field, value);
             });
 
@@ -196,23 +199,23 @@ describe('useBuyQuotes', () => {
         },
     );
 
-    it('should not re-fetch quotes when no address is selected on btc account', () => {
+    it('should not re-fetch quotes when no address is selected on btc account', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseBuyQuotes(store);
-        act(() => {
+        const { result } = await renderUseBuyQuotes(store);
+        await act(() => {
             result.current.setValue('asset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
         });
-        act(() => {
+        await act(() => {
             result.current.setValue('fiatValue', '100');
         });
 
-        act(() => {
+        await act(() => {
             result.current.setValue('receiveAccount', undefined);
         });
         dispatchSpy.mockClear();
-        act(() => {
+        await act(() => {
             result.current.setValue('receiveAccount', {
                 account: btc1NormalAccount,
             });
@@ -225,19 +228,19 @@ describe('useBuyQuotes', () => {
         );
     });
 
-    it('should re-fetch quotes when re-fetch time elapsed', () => {
+    it('should re-fetch quotes when re-fetch time elapsed', async () => {
         jest.useFakeTimers();
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseBuyQuotes(store);
+        const { result } = await renderUseBuyQuotes(store);
         dispatchSpy.mockClear();
 
-        act(() => {
+        await act(() => {
             result.current.setValue('asset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
         });
 
-        act(() => {
+        await act(() => {
             result.current.setValue('fiatValue', '100');
         });
 
@@ -247,12 +250,12 @@ describe('useBuyQuotes', () => {
             }),
         );
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
         });
         dispatchSpy.mockClear();
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(TRADE_API_RELOAD_QUOTES_AFTER_SECONDS * 1000);
         });
 
@@ -264,22 +267,22 @@ describe('useBuyQuotes', () => {
         );
     });
 
-    it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', () => {
+    it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', async () => {
         jest.useFakeTimers();
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseBuyQuotes(store);
+        const { result } = await renderUseBuyQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('fiatCurrency', 'usd');
         });
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
         });
         dispatchSpy.mockClear();
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(TRADE_API_RELOAD_QUOTES_AFTER_SECONDS * 1000);
         });
 
@@ -288,24 +291,24 @@ describe('useBuyQuotes', () => {
         );
     });
 
-    it('should clear quotes when data in form becomes invalid', () => {
+    it('should clear quotes when data in form becomes invalid', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseBuyQuotes(store);
+        const { result } = await renderUseBuyQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('asset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('fiatValue', '100');
         });
         // handleRequestThunk is mocked, add quotes manually
-        act(() => {
+        await act(() => {
             store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
         });
 
         dispatchSpy.mockClear();
         // clear some value to make form invalid
-        act(() => {
+        await act(() => {
             result.current.setValue('fiatValue', undefined);
         });
 

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.test.ts
@@ -11,7 +11,7 @@ const mockConfirmApprovalThunk: any = () => () => ({
 jest.spyOn(exchangeThunks, 'confirmApprovalThunk').mockImplementation(mockConfirmApprovalThunk);
 
 describe('useApprovalFlow', () => {
-    it('should return selected quote from exchange state', () => {
+    it('should return selected quote from exchange state', async () => {
         const store = createTradingLightStore({
             tradeType: 'exchange',
             overrides: {
@@ -25,7 +25,7 @@ describe('useApprovalFlow', () => {
             },
         });
 
-        const { result } = renderHookWithStoreProvider(() => useApprovalFlow(), { store });
+        const { result } = await renderHookWithStoreProvider(() => useApprovalFlow(), { store });
 
         expect(result.current.quote).toEqual(invityDexQuote);
     });
@@ -44,7 +44,7 @@ describe('useApprovalFlow', () => {
                 },
             },
         });
-        const { result } = renderHookWithStoreProvider(() => useApprovalFlow(), { store });
+        const { result } = await renderHookWithStoreProvider(() => useApprovalFlow(), { store });
 
         await act(async () => {
             await result.current.onApprovalTypeChange('INFINITE');

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.test.ts
@@ -70,10 +70,10 @@ describe('useEvmApprovalFees', () => {
             overrides: mergeDeepObject(baseOverrides, extraOverrides),
         });
 
-    const renderUseEvmApprovalFees = (
+    const renderUseEvmApprovalFees = async (
         store: TestStore,
         params?: Parameters<typeof useEvmApprovalFees>[0],
-    ) => renderHookWithStoreProvider(() => useEvmApprovalFees(params), { store });
+    ) => await renderHookWithStoreProvider(() => useEvmApprovalFees(params), { store });
 
     beforeEach(() => {
         mockComposeEvmApprovalFeeLevelsThunk.mockReset().mockImplementation(() => ({
@@ -82,8 +82,8 @@ describe('useEvmApprovalFees', () => {
         }));
     });
 
-    it('should return isLoading true when fee is undefined', () => {
-        const { result } = renderUseEvmApprovalFees(createStore());
+    it('should return isLoading true when fee is undefined', async () => {
+        const { result } = await renderUseEvmApprovalFees(createStore());
 
         expect(result.current).toEqual(
             expect.objectContaining({
@@ -95,7 +95,7 @@ describe('useEvmApprovalFees', () => {
         );
     });
 
-    it('should return fee and isLoading false when composed transaction info is available', () => {
+    it('should return fee and isLoading false when composed transaction info is available', async () => {
         const store = createStore({
             wallet: { trading: { exchange: { selectedQuote: undefined } } },
         });
@@ -107,7 +107,7 @@ describe('useEvmApprovalFees', () => {
             }),
         );
 
-        const { result } = renderUseEvmApprovalFees(store);
+        const { result } = await renderUseEvmApprovalFees(store);
 
         expect(result.current.fee).toBe('50000');
         expect(result.current.error).toBeNull();
@@ -137,7 +137,7 @@ describe('useEvmApprovalFees', () => {
             },
         });
 
-        const { result } = renderUseEvmApprovalFees(store);
+        const { result } = await renderUseEvmApprovalFees(store);
 
         await waitFor(() => {
             expect(result.current.error).toBe(
@@ -148,8 +148,8 @@ describe('useEvmApprovalFees', () => {
         expect(result.current.isLoading).toBe(false);
     });
 
-    it('should accept approvalTypeOverride parameter', () => {
-        const { result } = renderUseEvmApprovalFees(createStore(), {
+    it('should accept approvalTypeOverride parameter', async () => {
+        const { result } = await renderUseEvmApprovalFees(createStore(), {
             approvalTypeOverride: 'ZERO',
         });
 
@@ -170,7 +170,7 @@ describe('useEvmApprovalFees', () => {
             },
         });
 
-        renderUseEvmApprovalFees(store);
+        await renderUseEvmApprovalFees(store);
 
         await waitFor(() => {
             expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalled();
@@ -199,7 +199,7 @@ describe('useEvmApprovalFees', () => {
             },
         });
 
-        renderUseEvmApprovalFees(store);
+        await renderUseEvmApprovalFees(store);
 
         await waitFor(() => {
             expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalled();
@@ -240,7 +240,7 @@ describe('useEvmApprovalFees', () => {
             },
         });
 
-        renderUseEvmApprovalFees(store);
+        await renderUseEvmApprovalFees(store);
 
         await waitFor(() => {
             expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalled();

--- a/suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.test.ts
@@ -26,8 +26,8 @@ describe('useDexExchangeTxSimulation', () => {
         mockUseCommonDexExchangeTxSimulation.mockReturnValue(simulation);
     });
 
-    const renderUseDexExchangeTxSimulation = (isRemoteFeatureEnabled?: boolean) =>
-        renderHookWithTradingProvider(() => useDexExchangeTxSimulation(), {
+    const renderUseDexExchangeTxSimulation = async (isRemoteFeatureEnabled?: boolean) =>
+        await renderHookWithTradingProvider(() => useDexExchangeTxSimulation(), {
             tradeType: 'exchange',
             overrides: {
                 ...(isRemoteFeatureEnabled === undefined
@@ -48,8 +48,8 @@ describe('useDexExchangeTxSimulation', () => {
             },
         });
 
-    it('passes the enabled native exchange context to the common hook', () => {
-        const { result } = renderUseDexExchangeTxSimulation();
+    it('passes the enabled native exchange context to the common hook', async () => {
+        const { result } = await renderUseDexExchangeTxSimulation();
 
         expect(mockUseCommonDexExchangeTxSimulation).toHaveBeenCalledWith({
             account: btc1NormalAccount,
@@ -59,8 +59,8 @@ describe('useDexExchangeTxSimulation', () => {
         expect(result.current).toBe(simulation);
     });
 
-    it('passes a disabled state when the message-system feature is disabled', () => {
-        renderUseDexExchangeTxSimulation(false);
+    it('passes a disabled state when the message-system feature is disabled', async () => {
+        await renderUseDexExchangeTxSimulation(false);
 
         expect(mockUseCommonDexExchangeTxSimulation).toHaveBeenCalledWith({
             account: btc1NormalAccount,

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeData.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeData.test.ts
@@ -41,7 +41,7 @@ describe('useExchangeData', () => {
     ) => {
         const effectiveStore = store ?? createTradingLightStore({ tradeType: 'exchange' });
 
-        const ret = renderHookWithStoreProvider(
+        const ret = await renderHookWithStoreProvider(
             ({ reloadRequestOrdinal }) => useExchangeData(reloadRequestOrdinal),
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
@@ -95,7 +95,7 @@ describe('useExchangeData', () => {
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
         const { rerender } = await renderUseExchangeData();
-        rerender({ reloadRequestOrdinal: 0 });
+        await rerender({ reloadRequestOrdinal: 0 });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
     });
@@ -106,7 +106,7 @@ describe('useExchangeData', () => {
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
         const { rerender } = await renderUseExchangeData();
-        rerender({ reloadRequestOrdinal: 1 });
+        await rerender({ reloadRequestOrdinal: 1 });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(2);
     });
@@ -127,7 +127,7 @@ describe('useExchangeData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc2Account.key));
             });
 
@@ -149,7 +149,7 @@ describe('useExchangeData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc2Account.key));
             });
 
@@ -168,7 +168,7 @@ describe('useExchangeData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc3Account.key));
             });
 
@@ -191,7 +191,7 @@ describe('useExchangeData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(undefined));
             });
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.test.ts
@@ -74,7 +74,7 @@ describe('useExchangeFlow', () => {
         });
     };
 
-    const renderUseExchangeFlow = ({
+    const renderUseExchangeFlow = async ({
         store,
         flowType,
     }: {
@@ -88,10 +88,12 @@ describe('useExchangeFlow', () => {
 
         return {
             reportMock,
-            result: renderHookWithStoreProvider(() => useExchangeFlow({ flowType }), {
-                services,
-                store,
-            }).result,
+            result: (
+                await renderHookWithStoreProvider(() => useExchangeFlow({ flowType }), {
+                    services,
+                    store,
+                })
+            ).result,
         };
     };
 
@@ -118,7 +120,7 @@ describe('useExchangeFlow', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const mockNextStep = jest.fn();
 
-            const { result } = renderUseExchangeFlow({ store });
+            const { result } = await renderUseExchangeFlow({ store });
 
             const mockTrade = {
                 exchange: 'test-exchange',
@@ -163,7 +165,7 @@ describe('useExchangeFlow', () => {
                 unwrap: () => Promise.resolve(false),
             }));
 
-            const { result } = renderUseExchangeFlow({ store });
+            const { result } = await renderUseExchangeFlow({ store });
 
             const confirmResult = await act(() =>
                 result.current.confirmTrade({
@@ -184,7 +186,7 @@ describe('useExchangeFlow', () => {
             const store = getInitializedStore();
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
 
-            const { result } = renderUseExchangeFlow({ store });
+            const { result } = await renderUseExchangeFlow({ store });
 
             const confirmResult = await act(() =>
                 result.current.confirmTrade({
@@ -221,7 +223,7 @@ describe('useExchangeFlow', () => {
                     },
                 },
             });
-            const { result } = renderUseExchangeFlow({ store });
+            const { result } = await renderUseExchangeFlow({ store });
 
             const confirmResult = await act(() =>
                 result.current.confirmTrade({
@@ -249,7 +251,7 @@ describe('useExchangeFlow', () => {
             const mockNextStep = jest.fn();
             const mockOnError = jest.fn();
 
-            const { result } = renderUseExchangeFlow({ store });
+            const { result } = await renderUseExchangeFlow({ store });
 
             const signResult = await act(() =>
                 result.current.signDataAndConfirm({
@@ -284,7 +286,7 @@ describe('useExchangeFlow', () => {
             const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
             const store = getInitializedStore();
 
-            const { result } = renderUseExchangeFlow({ store });
+            const { result } = await renderUseExchangeFlow({ store });
 
             const signResult = await act(() =>
                 result.current.signDataAndConfirm({
@@ -315,7 +317,7 @@ describe('useExchangeFlow', () => {
                 unwrap: () => Promise.reject(error),
             }));
 
-            const { result } = renderUseExchangeFlow({ store });
+            const { result } = await renderUseExchangeFlow({ store });
 
             const signResult = await act(() =>
                 result.current.signDataAndConfirm({
@@ -336,7 +338,7 @@ describe('useExchangeFlow', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const mockNextStep = jest.fn();
 
-            const { result, reportMock } = renderUseExchangeFlow({ store });
+            const { result, reportMock } = await renderUseExchangeFlow({ store });
 
             const mockTrade = {
                 exchange: 'test-exchange',
@@ -367,7 +369,7 @@ describe('useExchangeFlow', () => {
     });
 
     describe('navigation', () => {
-        it('should navigate to TradingConfirming with flowType approve when quoteStatus is APPROVAL_PENDING', () => {
+        it('should navigate to TradingConfirming with flowType approve when quoteStatus is APPROVAL_PENDING', async () => {
             const tradingState = getInitializedTradingStateWithQuotes();
             tradingState.exchange.tradingAccountKey = btc1Account.key;
             tradingState.exchange.receiveAccountKey = btc2Account.key;
@@ -386,14 +388,14 @@ describe('useExchangeFlow', () => {
                 },
             });
 
-            renderUseExchangeFlow({ store });
+            await renderUseExchangeFlow({ store });
 
             expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.TradingConfirming, {
                 flowType: 'approve',
             });
         });
 
-        it('should navigate with flowType revoke when quoteStatus is APPROVAL_PENDING and flowType is revoke', () => {
+        it('should navigate with flowType revoke when quoteStatus is APPROVAL_PENDING and flowType is revoke', async () => {
             const tradingState = getInitializedTradingStateWithQuotes();
             tradingState.exchange.tradingAccountKey = btc1Account.key;
             tradingState.exchange.receiveAccountKey = btc2Account.key;
@@ -412,14 +414,14 @@ describe('useExchangeFlow', () => {
                 },
             });
 
-            renderUseExchangeFlow({ store, flowType: 'revoke' });
+            await renderUseExchangeFlow({ store, flowType: 'revoke' });
 
             expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.TradingConfirming, {
                 flowType: 'revoke',
             });
         });
 
-        it('should navigate with flowType revoke-and-approve when quoteStatus is APPROVAL_PENDING and flowType is revoke-and-approve', () => {
+        it('should navigate with flowType revoke-and-approve when quoteStatus is APPROVAL_PENDING and flowType is revoke-and-approve', async () => {
             const tradingState = getInitializedTradingStateWithQuotes();
             tradingState.exchange.tradingAccountKey = btc1Account.key;
             tradingState.exchange.receiveAccountKey = btc2Account.key;
@@ -438,17 +440,17 @@ describe('useExchangeFlow', () => {
                 },
             });
 
-            renderUseExchangeFlow({ store, flowType: 'revoke-and-approve' });
+            await renderUseExchangeFlow({ store, flowType: 'revoke-and-approve' });
 
             expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.TradingConfirming, {
                 flowType: 'revoke-and-approve',
             });
         });
 
-        it('should not navigate to TradingConfirming when quoteStatus is not APPROVAL_PENDING', () => {
+        it('should not navigate to TradingConfirming when quoteStatus is not APPROVAL_PENDING', async () => {
             const store = getInitializedStore();
 
-            renderUseExchangeFlow({ store });
+            await renderUseExchangeFlow({ store });
 
             expect(mockNavigate).not.toHaveBeenCalledWith(
                 RootStackRoutes.TradingConfirming,

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.test.ts
@@ -78,8 +78,8 @@ const accountDeviceState = btc1NormalAccount.deviceState;
 describe('useExchangeForm', () => {
     let store: TestStore;
 
-    const renderUseExchangeForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), { store });
+    const renderUseExchangeForm = async () =>
+        await renderHookWithStoreProvider(() => useExchangeForm(), { store });
 
     const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
         createTradingLightStore({
@@ -112,9 +112,9 @@ describe('useExchangeForm', () => {
     });
 
     describe('on quotes change', () => {
-        it('should select first fixed quote if rate is better than first floating quote', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
+        it('should select first fixed quote if rate is better than first floating quote', async () => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 store.dispatch(
                     tradingExchangeActions.saveQuotes([
                         mercuryoFixedWorstQuote,
@@ -131,9 +131,9 @@ describe('useExchangeForm', () => {
             );
         });
 
-        it('should select first floating quote if rate is better than first fixed quote', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
+        it('should select first floating quote if rate is better than first fixed quote', async () => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
 
@@ -144,9 +144,9 @@ describe('useExchangeForm', () => {
             );
         });
 
-        it('should select first fixed quote if no floating quote is available', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
+        it('should select first fixed quote if no floating quote is available', async () => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 store.dispatch(
                     tradingExchangeActions.saveQuotes([
                         mercuryoFixedWorstQuote,
@@ -162,9 +162,9 @@ describe('useExchangeForm', () => {
             );
         });
 
-        it('should select floating quote when fixed is not available', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
+        it('should select floating quote when fixed is not available', async () => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 store.dispatch(
                     tradingExchangeActions.saveQuotes([cexdirectFloatingQuote, invityDexQuote]),
                 );
@@ -177,9 +177,9 @@ describe('useExchangeForm', () => {
             );
         });
 
-        it('should select dex quote when no other quotes are available', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
+        it('should select dex quote when no other quotes are available', async () => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes([invityDexQuote]));
             });
 
@@ -190,21 +190,21 @@ describe('useExchangeForm', () => {
             );
         });
 
-        it('should set quote to undefined when no quotes are available', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
+        it('should set quote to undefined when no quotes are available', async () => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes([]));
             });
 
             expect(result.current.getValues('quote')).toBeUndefined();
         });
 
-        it('should set receiveCryptoAmount based on selected quote', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
+        it('should set receiveCryptoAmount based on selected quote', async () => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('receiveAsset', btcAsset);
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
@@ -213,25 +213,25 @@ describe('useExchangeForm', () => {
             expect(result.current.getValues('receiveCryptoAmount')).toBe('0.00089118');
         });
 
-        it('should clear receiveCryptoAmount when receive asset does not match selected quote', () => {
-            const { result } = renderUseExchangeForm();
-            act(() => {
+        it('should clear receiveCryptoAmount when receive asset does not match selected quote', async () => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('receiveAsset', btcAsset);
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('receiveAsset', ethAsset);
             });
 
             expect(result.current.getValues('receiveCryptoAmount')).toBeUndefined();
         });
 
-        it('should set receiveCryptoAmount in sats when using BTC and amount in sats', () => {
+        it('should set receiveCryptoAmount in sats when using BTC and amount in sats', async () => {
             store = getInitializedStore(PROTO.AmountUnit.SATOSHI);
-            const { result } = renderUseExchangeForm();
-            act(() => {
+            const { result } = await renderUseExchangeForm();
+            await act(() => {
                 result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('receiveAsset', btcAsset);
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
@@ -240,9 +240,9 @@ describe('useExchangeForm', () => {
             expect(result.current.getValues('receiveCryptoAmount')).toBe('89118');
         });
 
-        it('should persist provider metadata to redux', () => {
-            renderUseExchangeForm();
-            act(() => {
+        it('should persist provider metadata to redux', async () => {
+            await renderUseExchangeForm();
+            await act(() => {
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
 
@@ -252,24 +252,24 @@ describe('useExchangeForm', () => {
         describe('when quote is selected and new quotes are fetched', () => {
             let form: ExchangeFormType;
 
-            beforeEach(() => {
-                const { result } = renderUseExchangeForm();
+            beforeEach(async () => {
+                const { result } = await renderUseExchangeForm();
                 form = result.current;
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingExchangeActions.saveQuotes([...exchangeQuotes]));
                 });
             });
 
-            it('should select quote with same Rate and Provider', () => {
-                act(() => {
+            it('should select quote with same Rate and Provider', async () => {
+                await act(() => {
                     form.setValue('quote', {
                         ...invityDexQuote,
                         quoteId: 'invity-dex-outdated',
                     });
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingExchangeActions.saveQuotes([...exchangeQuotes]));
                 });
 
@@ -280,15 +280,15 @@ describe('useExchangeForm', () => {
                 );
             });
 
-            it('should select quote with same Rate when same provider is not available', () => {
-                act(() => {
+            it('should select quote with same Rate when same provider is not available', async () => {
+                await act(() => {
                     form.setValue('quote', {
                         ...invityDexQuote,
                         quoteId: 'invity-dex-outdated',
                     });
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingExchangeActions.saveQuotes(exchangeQuotes.toSpliced(3, 1)),
                     );
@@ -301,15 +301,15 @@ describe('useExchangeForm', () => {
                 );
             });
 
-            it('should select floating quote when floating quote was previously selected', () => {
-                act(() => {
+            it('should select floating quote when floating quote was previously selected', async () => {
+                await act(() => {
                     form.setValue('quote', {
                         ...cexdirectFloatingQuote,
                         quoteId: 'cexdirect-floating-outdated',
                     });
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
                 });
 
@@ -334,7 +334,7 @@ describe('useExchangeForm', () => {
         } as ExchangeTrade;
 
         it('should confirm dex quote once selected in form', async () => {
-            renderUseExchangeForm();
+            await renderUseExchangeForm();
 
             await act(async () => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1AccountKey));
@@ -352,7 +352,7 @@ describe('useExchangeForm', () => {
         });
 
         it('should not confirm the same dex quote repeatedly', async () => {
-            renderUseExchangeForm();
+            await renderUseExchangeForm();
 
             await act(async () => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1AccountKey));
@@ -370,16 +370,16 @@ describe('useExchangeForm', () => {
     });
 
     describe('sendAccount', () => {
-        it('should be undefined by default', () => {
-            const { result } = renderUseExchangeForm();
+        it('should be undefined by default', async () => {
+            const { result } = await renderUseExchangeForm();
 
             expect(result.current.getValues('sendAccount')).toBeUndefined();
         });
 
-        it('should update sendAccount value when account in redux store is changed', () => {
-            const { result } = renderUseExchangeForm();
+        it('should update sendAccount value when account in redux store is changed', async () => {
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
             });
 
@@ -388,16 +388,16 @@ describe('useExchangeForm', () => {
     });
 
     describe('receiveAccount', () => {
-        it('should be undefined by default', () => {
-            const { result } = renderUseExchangeForm();
+        it('should be undefined by default', async () => {
+            const { result } = await renderUseExchangeForm();
 
             expect(result.current.getValues('receiveAccount')).toBeUndefined();
         });
 
-        it('should update receiveAccount value when account in redux store is changed', () => {
-            const { result } = renderUseExchangeForm();
+        it('should update receiveAccount value when account in redux store is changed', async () => {
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setReceiveAccountKey(btc1AccountKey));
             });
 
@@ -409,9 +409,9 @@ describe('useExchangeForm', () => {
         });
 
         it('should preselect receiveAccount when receiveAsset is selected', async () => {
-            const { result } = renderUseExchangeForm();
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('receiveAsset', btcAsset);
             });
 
@@ -431,9 +431,9 @@ describe('useExchangeForm', () => {
             ['100', 'Maximum is 50 BTC'],
             ['1', 'Insufficient funds'],
         ])('should display error for crypto amount %s BTC', async (amount, expectedValue) => {
-            const { result } = renderUseExchangeForm();
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('sendAsset', btcAsset);
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(
@@ -460,9 +460,9 @@ describe('useExchangeForm', () => {
             ['10000000', 'Insufficient funds'],
         ])('should display error for crypto amount %s SATS', async (amount, expectedValue) => {
             store = getInitializedStore(PROTO.AmountUnit.SATOSHI);
-            const { result } = renderUseExchangeForm();
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('sendAsset', btcAsset);
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(
@@ -485,9 +485,9 @@ describe('useExchangeForm', () => {
 
         it('should correctly compute balance with SATS', async () => {
             store = getInitializedStore(PROTO.AmountUnit.SATOSHI);
-            const { result } = renderUseExchangeForm();
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
                 result.current.setValue('sendAsset', btcAsset);
                 result.current.setValue('sendCryptoAmount', '10000');
@@ -504,9 +504,9 @@ describe('useExchangeForm', () => {
             ['1', false],
             ['2', true],
         ])('should use correct balance for USDC and amount %s', async (amount, expectedInvalid) => {
-            const { result } = renderUseExchangeForm();
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1AccountKey));
                 result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('sendCryptoAmount', amount);
@@ -520,14 +520,14 @@ describe('useExchangeForm', () => {
         });
 
         it('should trigger validation once limits are loaded', async () => {
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingExchangeActions.setAmountLimits(undefined));
                 store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
             });
 
-            const { result } = renderUseExchangeForm();
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('sendAsset', btcAsset);
                 result.current.setValue('sendCryptoAmount', '10');
             });
@@ -549,10 +549,10 @@ describe('useExchangeForm', () => {
         });
 
         describe('generalAlert', () => {
-            it('should be undefined by default', () => {
-                const { result } = renderUseExchangeForm();
+            it('should be undefined by default', async () => {
+                const { result } = await renderUseExchangeForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingExchangeActions.saveQuotes([] as ExchangeTrade[]));
                     store.dispatch(tradingExchangeActions.setAmountLimits(undefined));
                 });
@@ -560,10 +560,10 @@ describe('useExchangeForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be set when empty quotes are fetched and no limits are set', () => {
-                const { result } = renderUseExchangeForm();
+            it('should be set when empty quotes are fetched and no limits are set', async () => {
+                const { result } = await renderUseExchangeForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingExchangeActions.saveQuoteRequest({
                             send: btcAsset.cryptoId,
@@ -580,10 +580,10 @@ describe('useExchangeForm', () => {
                 );
             });
 
-            it('should be undefined when empty quotes are fetched and limits are set', () => {
-                const { result } = renderUseExchangeForm();
+            it('should be undefined when empty quotes are fetched and limits are set', async () => {
+                const { result } = await renderUseExchangeForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingExchangeActions.saveQuoteRequest({
                             send: btcAsset.cryptoId,
@@ -603,10 +603,10 @@ describe('useExchangeForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be undefined once quotes are fetched', () => {
-                const { result } = renderUseExchangeForm();
+            it('should be undefined once quotes are fetched', async () => {
+                const { result } = await renderUseExchangeForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingExchangeActions.saveQuoteRequest({
                             send: btcAsset.cryptoId,
@@ -621,10 +621,10 @@ describe('useExchangeForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be cleared once quotes are fetched', () => {
-                const { result } = renderUseExchangeForm();
+            it('should be cleared once quotes are fetched', async () => {
+                const { result } = await renderUseExchangeForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingExchangeActions.saveQuoteRequest({
                             send: btcAsset.cryptoId,
@@ -636,7 +636,7 @@ describe('useExchangeForm', () => {
                     store.dispatch(tradingExchangeActions.setAmountLimits(undefined));
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
                 });
 
@@ -646,17 +646,17 @@ describe('useExchangeForm', () => {
     });
 
     describe('clearExchangeFormQuoteData', () => {
-        it('should clear quote, sendCryptoAmount, receiveCryptoAmount and generalAlert data', () => {
-            const { result } = renderUseExchangeForm();
+        it('should clear quote, sendCryptoAmount, receiveCryptoAmount and generalAlert data', async () => {
+            const { result } = await renderUseExchangeForm();
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('quote', mercuryoFixedWorstQuote as ExchangeTrade);
                 result.current.setValue('sendCryptoAmount', '10');
                 result.current.setValue('receiveCryptoAmount', '10');
                 result.current.setValue('generalAlert', 'test');
             });
 
-            act(() => {
+            await act(() => {
                 clearExchangeFormQuoteData(result.current);
             });
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeIssue.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeIssue.test.ts
@@ -26,8 +26,8 @@ describe('useExchangeIssue', () => {
         mockUseCommonExchangeIssue.mockReturnValue(exchangeIssue);
     });
 
-    const renderUseExchangeIssue = (isRemoteFeatureEnabled?: boolean) =>
-        renderHookWithTradingProvider(() => useExchangeIssue(), {
+    const renderUseExchangeIssue = async (isRemoteFeatureEnabled?: boolean) =>
+        await renderHookWithTradingProvider(() => useExchangeIssue(), {
             tradeType: 'exchange',
             overrides: {
                 ...(isRemoteFeatureEnabled === undefined
@@ -48,8 +48,8 @@ describe('useExchangeIssue', () => {
             },
         });
 
-    it('passes the enabled native exchange context to the common hook', () => {
-        const { result } = renderUseExchangeIssue();
+    it('passes the enabled native exchange context to the common hook', async () => {
+        const { result } = await renderUseExchangeIssue();
 
         expect(mockUseCommonExchangeIssue).toHaveBeenCalledWith({
             account: btc1NormalAccount,
@@ -59,8 +59,8 @@ describe('useExchangeIssue', () => {
         expect(result.current).toBe(exchangeIssue);
     });
 
-    it('passes a disabled state when the message-system feature is disabled', () => {
-        renderUseExchangeIssue(false);
+    it('passes a disabled state when the message-system feature is disabled', async () => {
+        await renderUseExchangeIssue(false);
 
         expect(mockUseCommonExchangeIssue).toHaveBeenCalledWith({
             account: btc1NormalAccount,

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.test.ts
@@ -64,8 +64,8 @@ describe('useExchangeQuotes', () => {
             },
         });
 
-    const renderUseExchangeQuotes = (store: TestStore) =>
-        renderHookWithStoreProvider(
+    const renderUseExchangeQuotes = async (store: TestStore) =>
+        await renderHookWithStoreProvider(
             () => {
                 const form = useExchangeForm();
                 useExchangeQuotes(form);
@@ -82,7 +82,7 @@ describe('useExchangeQuotes', () => {
     it('should query quotes once all required data is selected', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         await act(async () => {
@@ -112,7 +112,7 @@ describe('useExchangeQuotes', () => {
     it('should respect sats setting', async () => {
         const store = getInitializedStore(PROTO.AmountUnit.SATOSHI);
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         await act(async () => {
@@ -133,7 +133,7 @@ describe('useExchangeQuotes', () => {
         async amount => {
             const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeQuotes(store);
+            const { result } = await renderUseExchangeQuotes(store);
             const { form } = result.current;
 
             await act(async () => {
@@ -155,17 +155,14 @@ describe('useExchangeQuotes', () => {
     it('should not query quotes when form contains error', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
-        act(() => {
+        await act(async () => {
             form.setValue('sendAsset', btcAsset);
             form.setValue('receiveAsset', ethAsset);
-            form.setValue('sendCryptoAmount', '10');
-            form.setError('receiveAsset', {
-                type: 'manual',
-                message: 'VALIDATION_ERROR',
-            });
+            form.setValue('sendCryptoAmount', 'invalid', { shouldValidate: true });
+            await form.trigger();
         });
 
         expect(dispatchSpy).not.toHaveBeenCalledWith(
@@ -173,21 +170,15 @@ describe('useExchangeQuotes', () => {
                 type: 'handleRequestThunkMock',
             }),
         );
-
-        // clean up form flush async validations
-        await act(async () => {
-            form.clearErrors();
-            await form.trigger();
-        });
     });
 
     it('should query quotes as soon as form contains no errors', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
-        act(() => {
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
             form.setValue('receiveAsset', btcAsset);
             form.setValue('sendCryptoAmount', '10');
@@ -209,13 +200,13 @@ describe('useExchangeQuotes', () => {
         );
     });
 
-    it('should clear exchange state on unmount', () => {
+    it('should clear exchange state on unmount', async () => {
         const store = getInitializedStore();
         store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { unmount } = renderUseExchangeQuotes(store);
+        const { unmount } = await renderUseExchangeQuotes(store);
 
-        unmount();
+        await unmount();
 
         expect(dispatchSpy).toHaveBeenCalledWith({
             payload: undefined,
@@ -237,7 +228,7 @@ describe('useExchangeQuotes', () => {
     ])('should refetch quotes on %s value change', async (field, value) => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         await act(async () => {
@@ -249,7 +240,7 @@ describe('useExchangeQuotes', () => {
 
         dispatchSpy.mockClear();
 
-        act(() => {
+        await act(() => {
             form.setValue(field, value);
         });
 
@@ -263,7 +254,7 @@ describe('useExchangeQuotes', () => {
     it('should not re-fetch quotes for BTC when address is not selected', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         await act(async () => {
@@ -275,7 +266,7 @@ describe('useExchangeQuotes', () => {
 
         dispatchSpy.mockClear();
 
-        act(() => {
+        await act(() => {
             form.setValue('receiveAccount', {
                 account: btc1NormalAccount,
             });
@@ -291,7 +282,7 @@ describe('useExchangeQuotes', () => {
     it('should re-fetch quotes when re-fetch time elapsed', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         await act(async () => {
@@ -301,7 +292,7 @@ describe('useExchangeQuotes', () => {
             await Promise.resolve();
         });
 
-        act(() => {
+        await act(() => {
             store.dispatch(
                 tradingActions.setRefetchQuotesTimestamp(
                     Date.now() - TRADE_API_RELOAD_QUOTES_AFTER_SECONDS * 1000,
@@ -324,14 +315,14 @@ describe('useExchangeQuotes', () => {
     it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
-        act(() => {
+        await act(() => {
             form.setValue('sendAsset', btcAsset);
         });
 
-        act(() => {
+        await act(() => {
             store.dispatch(
                 tradingActions.setRefetchQuotesTimestamp(
                     Date.now() - TRADE_API_RELOAD_QUOTES_AFTER_SECONDS * 1000,
@@ -352,7 +343,7 @@ describe('useExchangeQuotes', () => {
     it('should clear quotes when data in form becomes invalid', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         await act(async () => {
@@ -362,7 +353,7 @@ describe('useExchangeQuotes', () => {
             await Promise.resolve();
         });
         // handleRequestThunk is mocked, add quotes manually
-        act(() => {
+        await act(() => {
             store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
         });
 
@@ -389,7 +380,7 @@ describe('useExchangeQuotes', () => {
         const store = getInitializedStore();
 
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseExchangeQuotes(store);
+        const { result } = await renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         const receiveAccount: ReceiveAccount = {
@@ -433,7 +424,7 @@ describe('useExchangeQuotes', () => {
 
     describe('analytics', () => {
         const renderUseExchangeQuotesWithFilledForm = async (store: TestStore) => {
-            const { result } = renderUseExchangeQuotes(store);
+            const { result } = await renderUseExchangeQuotes(store);
             const { form } = result.current;
 
             mockReport.mockClear();

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.test.ts
@@ -99,11 +99,11 @@ describe('useExchangeSelectQuote', () => {
         });
     };
 
-    const renderExchangeForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), { store });
+    const renderExchangeForm = async () =>
+        await renderHookWithStoreProvider(() => useExchangeForm(), { store });
 
-    const renderUseExchangeSelectQuote = () => {
-        const hook = renderHookWithStoreProvider(
+    const renderUseExchangeSelectQuote = async () => {
+        const hook = await renderHookWithStoreProvider(
             () => useExchangeSelectQuoteWithReportSpy(exchangeForm),
             { store },
         );
@@ -119,38 +119,38 @@ describe('useExchangeSelectQuote', () => {
     });
 
     describe('while loading quotes', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             store = getInitializedStore({ isLoading: true });
 
-            const { result } = renderExchangeForm();
+            const { result } = await renderExchangeForm();
             exchangeForm = result.current;
         });
 
-        it('should canProceed be false when loading', () => {
-            const { result } = renderUseExchangeSelectQuote();
+        it('should canProceed be false when loading', async () => {
+            const { result } = await renderUseExchangeSelectQuote();
             expect(result.current.canProceed).toBe(false);
             expect(result.current.isLoading).toBe(true);
             expect(result.current.isDexQuoteApprovalPrefetchLoadingForCandidateQuote).toBe(false);
         });
 
-        it('selectQuote should not dispatch selectQuoteThunk when isLoading', () => {
+        it('selectQuote should not dispatch selectQuoteThunk when isLoading', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
             dispatchSpy.mockClear();
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
             expect(dispatchSpy).not.toHaveBeenCalled();
         });
 
-        it('selectQuoteForRevoke should not dispatch selectQuoteThunk when isLoading', () => {
+        it('selectQuoteForRevoke should not dispatch selectQuoteThunk when isLoading', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
             dispatchSpy.mockClear();
-            act(() => {
+            await act(() => {
                 result.current.selectQuoteForRevoke();
             });
 
@@ -159,22 +159,22 @@ describe('useExchangeSelectQuote', () => {
     });
 
     describe('while prefetching dex quote approval info', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             store = getInitializedStore({
                 isLoading: false,
                 dexQuoteApprovalPrefetchLoadingQuoteId: invityDexQuote.quoteId!,
             });
 
-            const { result } = renderExchangeForm();
+            const { result } = await renderExchangeForm();
             exchangeForm = result.current;
 
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', invityDexQuote);
             });
         });
 
         it('should canProceed be false while prefetch is loading for approval-required quote', async () => {
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
             await act(() => Promise.resolve());
 
@@ -183,12 +183,12 @@ describe('useExchangeSelectQuote', () => {
             expect(result.current.isDexQuoteApprovalPrefetchLoadingForCandidateQuote).toBe(true);
         });
 
-        it('should not dispatch selectQuoteThunk while prefetch is loading for approval-required quote', () => {
+        it('should not dispatch selectQuoteThunk while prefetch is loading for approval-required quote', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
             dispatchSpy.mockClear();
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -196,11 +196,11 @@ describe('useExchangeSelectQuote', () => {
         });
 
         it('should canProceed be true while prefetch is loading for quote without approval', async () => {
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', mercuryoFixedBestQuote);
             });
 
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
             await act(() => Promise.resolve());
 
@@ -208,26 +208,26 @@ describe('useExchangeSelectQuote', () => {
         });
 
         it('should canProceed be true when another approval-required quote is currently prefetched', async () => {
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', {
                     ...invityDexQuote,
                     quoteId: 'another-dex-quote-id',
                 });
             });
 
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
             await act(() => Promise.resolve());
 
             expect(result.current.canProceed).toBe(true);
         });
 
-        it('selectQuoteForRevoke should not dispatch selectQuoteThunk while prefetch is loading for approval-required quote', () => {
+        it('selectQuoteForRevoke should not dispatch selectQuoteThunk while prefetch is loading for approval-required quote', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
             dispatchSpy.mockClear();
-            act(() => {
+            await act(() => {
                 result.current.selectQuoteForRevoke();
             });
 
@@ -236,31 +236,31 @@ describe('useExchangeSelectQuote', () => {
     });
 
     describe('with quote loaded and selected', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             store = getInitializedStore({ isLoading: false });
 
-            const { result } = renderExchangeForm();
+            const { result } = await renderExchangeForm();
             exchangeForm = result.current;
 
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', mercuryoFixedBestQuote);
             });
         });
 
         it('should canProceed be true when not loading and quote exists', async () => {
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
             await act(() => Promise.resolve());
 
             expect(result.current.canProceed).toBe(true);
         });
 
-        it('should call selectQuoteThunk when selectQuote is called', () => {
+        it('should call selectQuoteThunk when selectQuote is called', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -276,17 +276,17 @@ describe('useExchangeSelectQuote', () => {
             );
         });
 
-        it('should apply default slippage when selecting a DEX quote without slippage', () => {
+        it('should apply default slippage when selecting a DEX quote without slippage', async () => {
             const quote = { ...invityDexQuote, swapSlippage: undefined };
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', quote);
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -299,7 +299,7 @@ describe('useExchangeSelectQuote', () => {
                 TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
             );
 
-            act(() => {
+            await act(() => {
                 selectQuoteAction.payload.nextStep();
             });
 
@@ -311,8 +311,8 @@ describe('useExchangeSelectQuote', () => {
             );
         });
 
-        it('should not call selectQuoteThunk when account is not fully selected', () => {
-            act(() => {
+        it('should not call selectQuoteThunk when account is not fully selected', async () => {
+            await act(() => {
                 [
                     tradingExchangeActions.setReceiveAccountKey(btcAccount.key),
                     tradingExchangeActions.setTradingAccountKey(ethAccount.key),
@@ -321,10 +321,10 @@ describe('useExchangeSelectQuote', () => {
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result, reportMock } = renderUseExchangeSelectQuote();
+            const { result, reportMock } = await renderUseExchangeSelectQuote();
 
             dispatchSpy.mockClear();
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -344,13 +344,13 @@ describe('useExchangeSelectQuote', () => {
             });
         });
 
-        it('should navigate to TradingExchangePreview when nextStep callback is executed', () => {
+        it('should navigate to TradingExchangePreview when nextStep callback is executed', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -360,7 +360,7 @@ describe('useExchangeSelectQuote', () => {
             const [dispatchCall] = firstCall;
             const { nextStep } = (dispatchCall as any).payload;
 
-            act(() => {
+            await act(() => {
                 nextStep();
             });
 
@@ -368,12 +368,12 @@ describe('useExchangeSelectQuote', () => {
         });
 
         describe('selectQuoteForRevoke', () => {
-            it('should call selectQuoteThunk when selectQuoteForRevoke is called', () => {
+            it('should call selectQuoteThunk when selectQuoteForRevoke is called', async () => {
                 const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-                const { result } = renderUseExchangeSelectQuote();
+                const { result } = await renderUseExchangeSelectQuote();
 
-                act(() => {
+                await act(() => {
                     result.current.selectQuoteForRevoke();
                 });
 
@@ -389,8 +389,8 @@ describe('useExchangeSelectQuote', () => {
                 );
             });
 
-            it('should not call selectQuoteThunk when account is not fully selected', () => {
-                act(() => {
+            it('should not call selectQuoteThunk when account is not fully selected', async () => {
+                await act(() => {
                     [
                         tradingExchangeActions.setReceiveAccountKey(btcAccount.key),
                         tradingExchangeActions.setTradingAccountKey(ethAccount.key),
@@ -399,10 +399,10 @@ describe('useExchangeSelectQuote', () => {
                 });
 
                 const dispatchSpy = jest.spyOn(store, 'dispatch');
-                const { result, reportMock } = renderUseExchangeSelectQuote();
+                const { result, reportMock } = await renderUseExchangeSelectQuote();
 
                 dispatchSpy.mockClear();
-                act(() => {
+                await act(() => {
                     result.current.selectQuoteForRevoke();
                 });
 
@@ -425,25 +425,25 @@ describe('useExchangeSelectQuote', () => {
     });
 
     describe('navigation based on approval status', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             store = getInitializedStore({ isLoading: false });
 
-            const { result } = renderExchangeForm();
+            const { result } = await renderExchangeForm();
             exchangeForm = result.current;
         });
 
-        it('should navigate to TradingExchangePreview when quote status is CONFIRM', () => {
+        it('should navigate to TradingExchangePreview when quote status is CONFIRM', async () => {
             const quote = { ...mercuryoFixedBestQuote, status: 'CONFIRM' as const };
 
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', quote);
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -453,7 +453,7 @@ describe('useExchangeSelectQuote', () => {
             const [dispatchCall] = firstCall;
             const { nextStep } = (dispatchCall as any).payload;
 
-            act(() => {
+            await act(() => {
                 nextStep();
             });
 
@@ -466,18 +466,18 @@ describe('useExchangeSelectQuote', () => {
             expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
         });
 
-        it('should navigate to TradingExchangePreview when quote status is SIGN_DATA', () => {
+        it('should navigate to TradingExchangePreview when quote status is SIGN_DATA', async () => {
             const quote = { ...mercuryoFixedBestQuote, status: 'SIGN_DATA' as const };
 
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', quote);
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -487,7 +487,7 @@ describe('useExchangeSelectQuote', () => {
             const [dispatchCall] = firstCall;
             const { nextStep } = (dispatchCall as any).payload;
 
-            act(() => {
+            await act(() => {
                 nextStep();
             });
 
@@ -498,18 +498,18 @@ describe('useExchangeSelectQuote', () => {
             });
         });
 
-        it('should navigate to TradingExchangeApproval when quote status is APPROVAL_REQ with no preapproval', () => {
+        it('should navigate to TradingExchangeApproval when quote status is APPROVAL_REQ with no preapproval', async () => {
             const quote = { ...invityDexQuote, status: 'APPROVAL_REQ' as const };
 
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', quote);
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -519,7 +519,7 @@ describe('useExchangeSelectQuote', () => {
             const [dispatchCall] = firstCall;
             const { nextStep } = (dispatchCall as any).payload;
 
-            act(() => {
+            await act(() => {
                 nextStep();
             });
 
@@ -536,22 +536,22 @@ describe('useExchangeSelectQuote', () => {
             expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
         });
 
-        it('should navigate to TradingExchangeApproval with shouldIncreaseLimit when status is APPROVAL_REQ, preapproved, token supports increase', () => {
+        it('should navigate to TradingExchangeApproval with shouldIncreaseLimit when status is APPROVAL_REQ, preapproved, token supports increase', async () => {
             const quote = {
                 ...invityDexQuote,
                 status: 'APPROVAL_REQ' as const,
                 preapprovedStringAmount: '10',
             };
 
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', quote);
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -561,7 +561,7 @@ describe('useExchangeSelectQuote', () => {
             const [dispatchCall] = firstCall;
             const { nextStep } = (dispatchCall as any).payload;
 
-            act(() => {
+            await act(() => {
                 nextStep();
             });
 
@@ -579,7 +579,7 @@ describe('useExchangeSelectQuote', () => {
             expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
         });
 
-        it('should navigate to TradingExchangeRevoke with shouldIncreaseLimit when status is APPROVAL_REQ, preapproved, token does not support increase (USDT)', () => {
+        it('should navigate to TradingExchangeRevoke with shouldIncreaseLimit when status is APPROVAL_REQ, preapproved, token does not support increase (USDT)', async () => {
             const quote = {
                 ...invityDexQuote,
                 status: 'APPROVAL_REQ' as const,
@@ -588,15 +588,15 @@ describe('useExchangeSelectQuote', () => {
                 send: 'ethereum--0xdAC17F958D2ee523a2206206994597C13D831ec7' as any,
             };
 
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', quote);
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuote();
             });
 
@@ -606,7 +606,7 @@ describe('useExchangeSelectQuote', () => {
             const [dispatchCall] = firstCall;
             const { nextStep } = (dispatchCall as any).payload;
 
-            act(() => {
+            await act(() => {
                 nextStep();
             });
 
@@ -622,21 +622,21 @@ describe('useExchangeSelectQuote', () => {
             });
         });
 
-        it('selectQuoteForRevoke should navigate to TradingExchangeRevoke with shouldIncreaseLimit: false when quote has preapproval', () => {
+        it('selectQuoteForRevoke should navigate to TradingExchangeRevoke with shouldIncreaseLimit: false when quote has preapproval', async () => {
             const quote = {
                 ...invityDexQuote,
                 preapprovedStringAmount: '10',
             };
 
-            act(() => {
+            await act(() => {
                 exchangeForm.setValue('quote', quote);
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuoteForRevoke();
             });
 
@@ -646,7 +646,7 @@ describe('useExchangeSelectQuote', () => {
             const [dispatchCall] = firstCall;
             const { nextStep } = (dispatchCall as any).payload;
 
-            act(() => {
+            await act(() => {
                 nextStep();
             });
 
@@ -664,16 +664,16 @@ describe('useExchangeSelectQuote', () => {
             expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
         });
 
-        it('selectQuoteForRevoke should not navigate when quote has no preapproval', () => {
-            act(() => {
+        it('selectQuoteForRevoke should not navigate when quote has no preapproval', async () => {
+            await act(() => {
                 exchangeForm.setValue('quote', invityDexQuote);
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseExchangeSelectQuote();
+            const { result } = await renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 result.current.selectQuoteForRevoke();
             });
 
@@ -683,7 +683,7 @@ describe('useExchangeSelectQuote', () => {
             const [dispatchCall] = firstCall;
             const { nextStep } = (dispatchCall as any).payload;
 
-            act(() => {
+            await act(() => {
                 nextStep();
             });
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSignTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSignTransaction.test.ts
@@ -48,18 +48,18 @@ type RenderUseExchangeSignTransactionParams = {
     onSignTransactionNavigation?: () => void;
 };
 
-const renderUseExchangeSignTransaction = ({
+const renderUseExchangeSignTransaction = async ({
     overrides = {},
     onSignTransactionNavigation = jest.fn(),
 }: RenderUseExchangeSignTransactionParams = {}) => ({
     onSignTransactionNavigation,
-    ...renderHookWithTradingProvider(
+    ...(await renderHookWithTradingProvider(
         () => useExchangeSignTransaction({ onSignTransactionNavigation }),
         {
             tradeType: 'exchange',
             overrides: mergeDeepObject(baseOverrides, overrides),
         },
-    ),
+    )),
 });
 
 describe('useExchangeSignTransaction', () => {
@@ -73,8 +73,8 @@ describe('useExchangeSignTransaction', () => {
         });
     });
 
-    it('returns state derived from the exchange and transaction', () => {
-        const { result } = renderUseExchangeSignTransaction({
+    it('returns state derived from the exchange and transaction', async () => {
+        const { result } = await renderUseExchangeSignTransaction({
             overrides: {
                 wallet: {
                     trading: {
@@ -99,8 +99,8 @@ describe('useExchangeSignTransaction', () => {
         );
     });
 
-    it('navigates to outputs review with sign-data flow details', () => {
-        const { result, onSignTransactionNavigation } = renderUseExchangeSignTransaction({
+    it('navigates to outputs review with sign-data flow details', async () => {
+        const { result, onSignTransactionNavigation } = await renderUseExchangeSignTransaction({
             overrides: {
                 wallet: {
                     trading: {
@@ -112,7 +112,7 @@ describe('useExchangeSignTransaction', () => {
             },
         });
 
-        act(() => {
+        await act(() => {
             result.current.handleSignTransaction();
         });
 
@@ -125,9 +125,9 @@ describe('useExchangeSignTransaction', () => {
         expect(onSignTransactionNavigation).toHaveBeenCalledTimes(1);
     });
 
-    it('does not navigate when the quote is missing', () => {
+    it('does not navigate when the quote is missing', async () => {
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const { result, onSignTransactionNavigation } = renderUseExchangeSignTransaction({
+        const { result, onSignTransactionNavigation } = await renderUseExchangeSignTransaction({
             overrides: {
                 wallet: {
                     trading: {
@@ -139,7 +139,7 @@ describe('useExchangeSignTransaction', () => {
             },
         });
 
-        act(() => {
+        await act(() => {
             result.current.handleSignTransaction();
         });
 

--- a/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.test.ts
@@ -10,16 +10,16 @@ import {
 } from '../../../test-utils/tradingTestUtils';
 
 describe('useContextForTradingForm', () => {
-    const renderUseContextForTradingForm = (
+    const renderUseContextForTradingForm = async (
         limits: TradingAmountLimitProps | undefined,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = {},
     ) =>
-        renderHookWithTradingProvider(() => useContextForTradingForm(limits), {
+        await renderHookWithTradingProvider(() => useContextForTradingForm(limits), {
             overrides,
         });
 
-    it('should return base context without limits and balance on initial render', () => {
-        const { result } = renderUseContextForTradingForm(undefined);
+    it('should return base context without limits and balance on initial render', async () => {
+        const { result } = await renderUseContextForTradingForm(undefined);
 
         expect(result.current.context).toEqual({
             translate: expect.any(Function),
@@ -29,7 +29,7 @@ describe('useContextForTradingForm', () => {
         });
     });
 
-    it('should append limits to context when specified', () => {
+    it('should append limits to context when specified', async () => {
         const limits: TradingAmountLimitProps = {
             minCrypto: '0.0001',
             maxCrypto: '1',
@@ -38,15 +38,15 @@ describe('useContextForTradingForm', () => {
             currency: 'BTC',
         };
 
-        const { result } = renderUseContextForTradingForm(limits);
+        const { result } = await renderUseContextForTradingForm(limits);
 
         expect(result.current.context).toEqual(expect.objectContaining(limits));
     });
 
-    it('should append send asset data and balance when specified', () => {
-        const { result } = renderUseContextForTradingForm(undefined);
+    it('should append send asset data and balance when specified', async () => {
+        const { result } = await renderUseContextForTradingForm(undefined);
 
-        act(() => {
+        await act(() => {
             result.current.setBalance('0.5');
             result.current.setSendNetworkSymbol('eth');
             result.current.setSendAssetSymbol('USDT');

--- a/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.test.tsx
@@ -50,8 +50,8 @@ describe('useCountryChangeEffect', () => {
         }),
     } as const;
 
-    const renderUseCountryChangeEffect = (defaultValues: CountryFormValues) =>
-        renderHookWithStoreProvider(
+    const renderUseCountryChangeEffect = async (defaultValues: CountryFormValues) =>
+        await renderHookWithStoreProvider(
             () => {
                 const form = useForm<CountryFormValues>({
                     defaultValues,
@@ -68,8 +68,8 @@ describe('useCountryChangeEffect', () => {
         store = createLightStore({ reducer });
     });
 
-    it('should do nothing on mount', () => {
-        renderUseCountryChangeEffect({
+    it('should do nothing on mount', async () => {
+        await renderUseCountryChangeEffect({
             country: buildCountryOption('US'),
             countrySubdivision: undefined,
         });
@@ -77,31 +77,31 @@ describe('useCountryChangeEffect', () => {
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
     });
 
-    it('should update trading residence country on country change', () => {
-        const { result } = renderUseCountryChangeEffect({
+    it('should update trading residence country on country change', async () => {
+        const { result } = await renderUseCountryChangeEffect({
             country: buildCountryOption('US'),
             countrySubdivision: undefined,
         });
 
-        act(() => result.current.setValue('country', buildCountryOption('CA')));
+        await act(() => result.current.setValue('country', buildCountryOption('CA')));
 
         expect(selectTradingResidenceCountry(store.getState())).toBe('CA');
         expect(selectTradingResidenceCountrySubdivision(store.getState())).toBeUndefined();
     });
 
-    it('should not update when country becomes undefined', () => {
-        const { result } = renderUseCountryChangeEffect({
+    it('should not update when country becomes undefined', async () => {
+        const { result } = await renderUseCountryChangeEffect({
             country: buildCountryOption('US'),
             countrySubdivision: undefined,
         });
 
-        act(() => result.current.setValue('country', undefined));
+        await act(() => result.current.setValue('country', undefined));
 
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
     });
 
-    it('should update trading residence country subdivision on subdivision change', () => {
-        const { result } = renderUseCountryChangeEffect({
+    it('should update trading residence country subdivision on subdivision change', async () => {
+        const { result } = await renderUseCountryChangeEffect({
             country: buildCountryOption('US'),
             countrySubdivision: {
                 value: 'CA',
@@ -110,7 +110,7 @@ describe('useCountryChangeEffect', () => {
             },
         });
 
-        act(() =>
+        await act(() =>
             result.current.setValue('countrySubdivision', {
                 value: 'NY',
                 label: 'New York',

--- a/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.test.ts
@@ -30,8 +30,8 @@ jest.mock('@react-navigation/native', () => {
 describe('useProviderMetadataChangeEffect', () => {
     let store: TestStore;
 
-    const renderUseProviderMetadataChangeEffect = (exchange: string | undefined) =>
-        renderHookWithTradingProvider(
+    const renderUseProviderMetadataChangeEffect = async (exchange: string | undefined) =>
+        await renderHookWithTradingProvider(
             () => {
                 const form = useForm<ProviderFormValues>({
                     defaultValues: { quote: { exchange } },
@@ -48,24 +48,24 @@ describe('useProviderMetadataChangeEffect', () => {
         mockIsFocused = true;
     });
 
-    it('should set currentProviderMetadata when quote is set', () => {
-        const { result } = renderUseProviderMetadataChangeEffect('mercuryo');
+    it('should set currentProviderMetadata when quote is set', async () => {
+        const { result } = await renderUseProviderMetadataChangeEffect('mercuryo');
 
         expect(selectTradingProviderMetadata(store.getState())).toEqual(buyMercuryo);
         expect(result.current).toEqual(buyMercuryo);
     });
 
-    it('should clear currentProviderMetadata on unmount', () => {
-        const { unmount } = renderUseProviderMetadataChangeEffect('mercuryo');
+    it('should clear currentProviderMetadata on unmount', async () => {
+        const { unmount } = await renderUseProviderMetadataChangeEffect('mercuryo');
 
-        unmount();
+        await unmount();
 
         expect(selectTradingProviderMetadata(store.getState())).toBeUndefined();
     });
 
-    it('should not change provider metadata when screen is not focused', () => {
+    it('should not change provider metadata when screen is not focused', async () => {
         mockIsFocused = false;
-        renderUseProviderMetadataChangeEffect('mercuryo');
+        await renderUseProviderMetadataChangeEffect('mercuryo');
 
         expect(selectTradingProviderMetadata(store.getState())).toBeUndefined();
     });

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.test.ts
@@ -30,8 +30,8 @@ describe('useReceiveAccountChangeEffect', () => {
         }),
     } as const;
 
-    const renderUseReceiveAccountChangeEffect = () =>
-        renderHookWithStoreProvider(
+    const renderUseReceiveAccountChangeEffect = async () =>
+        await renderHookWithStoreProvider(
             () => useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount),
             { store },
         );
@@ -48,19 +48,19 @@ describe('useReceiveAccountChangeEffect', () => {
         setValue = jest.fn();
     });
 
-    it('should set receiveAccount based on store value', () => {
-        renderUseReceiveAccountChangeEffect();
+    it('should set receiveAccount based on store value', async () => {
+        await renderUseReceiveAccountChangeEffect();
 
         expect(setValue).toHaveBeenCalledTimes(1);
         expect(setValue).toHaveBeenCalledWith('receiveAccount', undefined);
     });
 
-    it('should set receiveAccount on change', () => {
+    it('should set receiveAccount on change', async () => {
         const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
-        renderUseReceiveAccountChangeEffect();
+        await renderUseReceiveAccountChangeEffect();
 
         setValue.mockClear();
-        act(() => {
+        await act(() => {
             store.dispatch(tradingExchangeActions.setReceiveAccountKey(btc1Account.key));
         });
 

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.test.ts
@@ -19,7 +19,7 @@ import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
 const btc1AccountKey = btc1NormalAccount.key;
 
 describe('useReceiveAccountPreselectionEffect', () => {
-    const renderUseReceiveAccountPreselectionEffect = ({
+    const renderUseReceiveAccountPreselectionEffect = async ({
         store,
         tradingType = 'buy',
         receiveAsset = btcAsset,
@@ -28,7 +28,7 @@ describe('useReceiveAccountPreselectionEffect', () => {
         tradingType?: 'buy' | 'exchange';
         receiveAsset?: TradeableAsset;
     }) =>
-        renderHookWithStoreProvider(
+        await renderHookWithStoreProvider(
             () =>
                 useReceiveAccountPreselectionEffect({
                     tradingType,
@@ -71,10 +71,10 @@ describe('useReceiveAccountPreselectionEffect', () => {
             },
         });
 
-    it('should dispatch buy actions when account is preselected', () => {
+    it('should dispatch buy actions when account is preselected', async () => {
         const store = createStore();
 
-        renderUseReceiveAccountPreselectionEffect({ store });
+        await renderUseReceiveAccountPreselectionEffect({ store });
 
         expect(store.getActions()).toEqual([
             tradingActions.setReceiveAccount({
@@ -85,10 +85,10 @@ describe('useReceiveAccountPreselectionEffect', () => {
         ]);
     });
 
-    it('should dispatch exchange actions when account is preselected', () => {
+    it('should dispatch exchange actions when account is preselected', async () => {
         const store = createStore({ tradeType: 'exchange' });
 
-        renderUseReceiveAccountPreselectionEffect({ store, tradingType: 'exchange' });
+        await renderUseReceiveAccountPreselectionEffect({ store, tradingType: 'exchange' });
 
         expect(store.getActions()).toEqual([
             tradingActions.setReceiveAccount({
@@ -99,18 +99,18 @@ describe('useReceiveAccountPreselectionEffect', () => {
         ]);
     });
 
-    it('should not dispatch actions when no preselected account can be found', () => {
+    it('should not dispatch actions when no preselected account can be found', async () => {
         const store = createStore();
 
-        renderUseReceiveAccountPreselectionEffect({ store, receiveAsset: adaAsset });
+        await renderUseReceiveAccountPreselectionEffect({ store, receiveAsset: adaAsset });
 
         expect(store.getActions()).toEqual([]);
     });
 
-    it('should not dispatch actions when selectedReceiveAccount already has account set', () => {
+    it('should not dispatch actions when selectedReceiveAccount already has account set', async () => {
         const store = createStore({ selectedReceiveAccountKey: btc1AccountKey });
 
-        renderUseReceiveAccountPreselectionEffect({ store });
+        await renderUseReceiveAccountPreselectionEffect({ store });
 
         expect(store.getActions()).toEqual([]);
     });

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.test.ts
@@ -17,8 +17,8 @@ type HookProps = {
     setAccountKey: (accountKey: AccountKey | undefined) => void;
 };
 describe('useSendAccountAssetBalance', () => {
-    const renderUseSendAccountAssetBalance = (initialProps: HookProps) =>
-        renderHookWithStoreProvider(
+    const renderUseSendAccountAssetBalance = async (initialProps: HookProps) =>
+        await renderHookWithStoreProvider(
             ({
                 sendAccount,
                 sendAsset,
@@ -47,13 +47,13 @@ describe('useSendAccountAssetBalance', () => {
             },
         );
 
-    it('should watch for balance and asset symbol', () => {
+    it('should watch for balance and asset symbol', async () => {
         const setBalance = jest.fn();
         const setSendNetworkSymbol = jest.fn();
         const setSendAssetSymbol = jest.fn();
         const setContractAddress = jest.fn();
         const setAccountKey = jest.fn();
-        renderUseSendAccountAssetBalance({
+        await renderUseSendAccountAssetBalance({
             sendAccount: getBtcAccount(),
             sendAsset: btcAsset,
             setBalance,
@@ -68,14 +68,14 @@ describe('useSendAccountAssetBalance', () => {
         expect(setSendAssetSymbol).toHaveBeenCalledWith('BTC');
     });
 
-    it('should set balance to undefined when account is undefined', () => {
+    it('should set balance to undefined when account is undefined', async () => {
         const setBalance = jest.fn();
         const setSendNetworkSymbol = jest.fn();
         const setSendAssetSymbol = jest.fn();
         const setContractAddress = jest.fn();
         const setAccountKey = jest.fn();
 
-        renderUseSendAccountAssetBalance({
+        await renderUseSendAccountAssetBalance({
             sendAccount: undefined,
             sendAsset: btcAsset,
             setBalance,
@@ -88,14 +88,14 @@ describe('useSendAccountAssetBalance', () => {
         expect(setBalance).toHaveBeenCalledWith(undefined);
     });
 
-    it('should set balance to undefined when symbol is undefined', () => {
+    it('should set balance to undefined when symbol is undefined', async () => {
         const setBalance = jest.fn();
         const setSendNetworkSymbol = jest.fn();
         const setSendAssetSymbol = jest.fn();
         const setContractAddress = jest.fn();
         const setAccountKey = jest.fn();
 
-        renderUseSendAccountAssetBalance({
+        await renderUseSendAccountAssetBalance({
             sendAccount: getBtcAccount(),
             sendAsset: undefined,
             setBalance,

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.test.ts
@@ -34,8 +34,8 @@ describe('useSendAccountChangeEffect', () => {
         }),
     } as const;
 
-    const renderUseSendAccountChangeEffect = () =>
-        renderHookWithStoreProvider(
+    const renderUseSendAccountChangeEffect = async () =>
+        await renderHookWithStoreProvider(
             () => {
                 useSendAccountChangeEffect(
                     setValue,
@@ -59,39 +59,39 @@ describe('useSendAccountChangeEffect', () => {
         onSendAssetCleared = jest.fn();
     });
 
-    it('should set sendAccount and sendAsset to undefined initially', () => {
-        renderUseSendAccountChangeEffect();
+    it('should set sendAccount and sendAsset to undefined initially', async () => {
+        await renderUseSendAccountChangeEffect();
 
         expect(setValue).toHaveBeenCalledTimes(2);
         expect(setValue).toHaveBeenCalledWith('sendAccount', undefined);
         expect(setValue).toHaveBeenCalledWith('sendAsset', undefined);
     });
 
-    it('should not fire onSendAssetCleared on initial mount when there was no account', () => {
-        renderUseSendAccountChangeEffect();
+    it('should not fire onSendAssetCleared on initial mount when there was no account', async () => {
+        await renderUseSendAccountChangeEffect();
 
         expect(onSendAssetCleared).not.toHaveBeenCalled();
     });
 
-    it('should fire onSendAssetCleared when a previously selected account disappears', () => {
-        renderUseSendAccountChangeEffect();
-        act(() => {
+    it('should fire onSendAssetCleared when a previously selected account disappears', async () => {
+        await renderUseSendAccountChangeEffect();
+        await act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1Account.key));
         });
 
         onSendAssetCleared.mockClear();
-        act(() => {
+        await act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(undefined));
         });
 
         expect(onSendAssetCleared).toHaveBeenCalledTimes(1);
     });
 
-    it('should set sendAccount when account is changed in store', () => {
-        renderUseSendAccountChangeEffect();
+    it('should set sendAccount when account is changed in store', async () => {
+        await renderUseSendAccountChangeEffect();
 
         setValue.mockClear();
-        act(() => {
+        await act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1Account.key));
         });
 
@@ -99,14 +99,14 @@ describe('useSendAccountChangeEffect', () => {
         expect(setValue).toHaveBeenCalledWith('sendAccount', btc1Account);
     });
 
-    it('should set sendAsset to undefined when no trading account is selected', () => {
-        renderUseSendAccountChangeEffect();
-        act(() => {
+    it('should set sendAsset to undefined when no trading account is selected', async () => {
+        await renderUseSendAccountChangeEffect();
+        await act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1Account.key));
         });
 
         setValue.mockClear();
-        act(() => {
+        await act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(undefined));
         });
 
@@ -115,14 +115,14 @@ describe('useSendAccountChangeEffect', () => {
         expect(setValue).toHaveBeenCalledWith('sendAsset', undefined);
     });
 
-    it('should not change sendAsset when trading account key changed', () => {
-        renderUseSendAccountChangeEffect();
-        act(() => {
+    it('should not change sendAsset when trading account key changed', async () => {
+        await renderUseSendAccountChangeEffect();
+        await act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1Account.key));
         });
 
         setValue.mockClear();
-        act(() => {
+        await act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(btc2Account.key));
         });
 

--- a/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.test.ts
@@ -36,12 +36,12 @@ describe('useTradeableAssetChange', () => {
         setSelectedValue = jest.fn();
     });
 
-    const renderChangeAsset = (
+    const renderChangeAsset = async (
         config: Omit<Partial<Parameters<typeof useTradeableAssetChange>[0]>, 'form'> & {
             form: MockForm;
         },
     ) => {
-        const { result } = renderHookWithStoreProvider(
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useTradeableAssetChange({
                     tradingType: 'exchange',
@@ -58,9 +58,9 @@ describe('useTradeableAssetChange', () => {
         return result.current;
     };
 
-    it('should not apply any change effects when the selected asset is unchanged (dedup guard)', () => {
+    it('should not apply any change effects when the selected asset is unchanged (dedup guard)', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const changeAsset = renderChangeAsset({
+        const changeAsset = await renderChangeAsset({
             form: createMockForm(),
             selectedValue: btcAsset,
         });
@@ -72,9 +72,9 @@ describe('useTradeableAssetChange', () => {
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should still set the trading account key before the dedup guard returns', () => {
+    it('should still set the trading account key before the dedup guard returns', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const changeAsset = renderChangeAsset({
+        const changeAsset = await renderChangeAsset({
             form: createMockForm(),
             selectedValue: btcAsset,
             getSetTradingAccountKeyAction: tradingExchangeActions.setTradingAccountKey,
@@ -88,10 +88,10 @@ describe('useTradeableAssetChange', () => {
         expect(setSelectedValue).not.toHaveBeenCalled();
     });
 
-    it('should clear the amount and dispatch the base action on a cross-network change', () => {
+    it('should clear the amount and dispatch the base action on a cross-network change', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const form = createMockForm();
-        const changeAsset = renderChangeAsset({
+        const changeAsset = await renderChangeAsset({
             form,
             selectedValue: btcAsset,
             amountField: 'sendCryptoAmount',
@@ -109,9 +109,9 @@ describe('useTradeableAssetChange', () => {
         expect(dispatchSpy).not.toHaveBeenCalledWith(exchangeActions.receiveTokenChanged());
     });
 
-    it('should dispatch the token action when the network symbol is unchanged', () => {
+    it('should dispatch the token action when the network symbol is unchanged', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const changeAsset = renderChangeAsset({
+        const changeAsset = await renderChangeAsset({
             form: createMockForm(),
             tradingType: 'buy',
             selectedValue: ethAsset,
@@ -126,8 +126,8 @@ describe('useTradeableAssetChange', () => {
         expect(dispatchSpy).not.toHaveBeenCalledWith(buyActions.assetChanged());
     });
 
-    it('should not report analytics when shouldReportAnalytics is false', () => {
-        const changeAsset = renderChangeAsset({
+    it('should not report analytics when shouldReportAnalytics is false', async () => {
+        const changeAsset = await renderChangeAsset({
             form: createMockForm(),
             selectedValue: btcAsset,
         });
@@ -138,10 +138,10 @@ describe('useTradeableAssetChange', () => {
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should clear the counterpart asset and dispatch its action on collision', () => {
+    it('should clear the counterpart asset and dispatch its action on collision', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const form = createMockForm(usdcAsset);
-        const changeAsset = renderChangeAsset({
+        const changeAsset = await renderChangeAsset({
             form,
             selectedValue: btcAsset,
             analyticsParameter: 'cryptoFrom',
@@ -163,10 +163,10 @@ describe('useTradeableAssetChange', () => {
         });
     });
 
-    it('should clear the counterpart amount without a counterpart action when omitted', () => {
+    it('should clear the counterpart amount without a counterpart action when omitted', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
         const form = createMockForm(usdcAsset);
-        const changeAsset = renderChangeAsset({
+        const changeAsset = await renderChangeAsset({
             form,
             selectedValue: btcAsset,
             analyticsParameter: 'cryptoTo',

--- a/suite-native/module-trading/src/hooks/general/useActiveTradingTypeReaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useActiveTradingTypeReaction.test.ts
@@ -44,101 +44,101 @@ describe('useActiveTradingTypeReaction', () => {
         }),
     } as const;
 
-    const renderUseActiveTradingTypeReaction = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useActiveTradingTypeReaction(), { store });
+    const renderUseActiveTradingTypeReaction = async (store: TestStore) =>
+        await renderHookWithStoreProvider(() => useActiveTradingTypeReaction(), { store });
 
     beforeEach(() => {
         castedSelectEnabledTradingTypes.mockReturnValue(['buy', 'exchange', 'sell']);
         mockUseRouteParams = {};
     });
 
-    it('should set buy active when only buy is allowed', () => {
+    it('should set buy active when only buy is allowed', async () => {
         castedSelectEnabledTradingTypes.mockReturnValue(['buy']);
         const store = createLightStore({ reducer });
 
-        renderUseActiveTradingTypeReaction(store);
+        await renderUseActiveTradingTypeReaction(store);
 
         expect(selectActiveTradingType(store.getState())).toBe('buy');
     });
 
-    it('should set exchange active when only exchange is allowed', () => {
+    it('should set exchange active when only exchange is allowed', async () => {
         castedSelectEnabledTradingTypes.mockReturnValue(['exchange']);
         const store = createLightStore({ reducer });
 
-        renderUseActiveTradingTypeReaction(store);
+        await renderUseActiveTradingTypeReaction(store);
 
         expect(selectActiveTradingType(store.getState())).toBe('exchange');
     });
 
-    it('should set sell active when only sell is allowed', () => {
+    it('should set sell active when only sell is allowed', async () => {
         castedSelectEnabledTradingTypes.mockReturnValue(['sell']);
         const store = createLightStore({ reducer });
 
-        renderUseActiveTradingTypeReaction(store);
+        await renderUseActiveTradingTypeReaction(store);
 
         expect(selectActiveTradingType(store.getState())).toBe('sell');
     });
 
-    it('should render with undefined navigation params', () => {
+    it('should render with undefined navigation params', async () => {
         (mockUseRouteParams as any) = undefined;
         const store = createLightStore({ reducer });
 
-        expect(() => renderUseActiveTradingTypeReaction(store)).not.toThrow();
+        await expect(renderUseActiveTradingTypeReaction(store)).resolves.toBeDefined();
     });
 
-    it('should clear activeTradingType on unmount', () => {
+    it('should clear activeTradingType on unmount', async () => {
         const store = createLightStore({ reducer });
-        const { unmount } = renderUseActiveTradingTypeReaction(store);
+        const { unmount } = await renderUseActiveTradingTypeReaction(store);
 
-        unmount();
+        await unmount();
 
         expect(selectActiveTradingType(store.getState())).toBeUndefined();
     });
 
     describe('with trading type specified by navigation params', () => {
-        it('should set buy active when buy is specified', () => {
+        it('should set buy active when buy is specified', async () => {
             mockUseRouteParams.tradingType = 'buy';
             const store = createLightStore({ reducer });
 
-            renderUseActiveTradingTypeReaction(store);
+            await renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('buy');
         });
 
-        it('should set exchange active when exchange is specified', () => {
+        it('should set exchange active when exchange is specified', async () => {
             mockUseRouteParams.tradingType = 'exchange';
             const store = createLightStore({ reducer });
 
-            renderUseActiveTradingTypeReaction(store);
+            await renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('exchange');
         });
 
-        it('should set sell active when sell is specified', () => {
+        it('should set sell active when sell is specified', async () => {
             mockUseRouteParams.tradingType = 'sell';
             const store = createLightStore({ reducer });
 
-            renderUseActiveTradingTypeReaction(store);
+            await renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('sell');
         });
 
-        it('should fallback to buy when navigating to exchange but exchange is disabled', () => {
+        it('should fallback to buy when navigating to exchange but exchange is disabled', async () => {
             castedSelectEnabledTradingTypes.mockReturnValue(['buy']);
             mockUseRouteParams.tradingType = 'exchange';
             const store = createLightStore({ reducer });
 
-            renderUseActiveTradingTypeReaction(store);
+            await renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('buy');
         });
 
-        it('should fallback to buy when navigating to sell but sell is disabled', () => {
+        it('should fallback to buy when navigating to sell but sell is disabled', async () => {
             mockUseRouteParams.tradingType = 'sell';
             castedSelectEnabledTradingTypes.mockReturnValue(['buy']);
             const store = createLightStore({ reducer });
 
-            renderUseActiveTradingTypeReaction(store);
+            await renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('buy');
         });

--- a/suite-native/module-trading/src/hooks/general/useAllTradesReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useAllTradesReloadTimer.test.ts
@@ -56,10 +56,10 @@ describe('useAllTradesReloadTimer', () => {
             },
         });
 
-    const renderUseAllTradesReloadTimer = (store: TestStore) =>
-        renderHookWithTradingProvider(() => useAllTradesReloadTimer(), { store });
+    const renderUseAllTradesReloadTimer = async (store: TestStore) =>
+        await renderHookWithTradingProvider(() => useAllTradesReloadTimer(), { store });
 
-    it('should enable reload timer when there are trades to watch', () => {
+    it('should enable reload timer when there are trades to watch', async () => {
         const mockTrades = [
             getBuyTrade({ status: 'SUBMITTED' }),
             getExchangeTrade({ status: 'CONVERTING' }),
@@ -78,7 +78,7 @@ describe('useAllTradesReloadTimer', () => {
         });
 
         const store = getInitializedStore({ trades: tradesWithAccounts });
-        renderUseAllTradesReloadTimer(store);
+        await renderUseAllTradesReloadTimer(store);
 
         expect(mockUseReloadTimer).toHaveBeenCalledWith({
             isEnabled: true, // Should be true when there are trades to watch
@@ -86,7 +86,7 @@ describe('useAllTradesReloadTimer', () => {
         });
     });
 
-    it('should return selected trades', () => {
+    it('should return selected trades', async () => {
         const mockTrades = [
             getBuyTrade({ status: 'SUBMITTED' }), // Should be watched
             getBuyTrade({ status: 'SUCCESS' }), // Should not be watched (final status)
@@ -100,7 +100,7 @@ describe('useAllTradesReloadTimer', () => {
         }));
 
         const store = getInitializedStore({ trades: tradesWithAccounts });
-        const { result } = renderUseAllTradesReloadTimer(store);
+        const { result } = await renderUseAllTradesReloadTimer(store);
 
         expect(result.current.tradesToWatch).toHaveLength(2);
         expect(result.current.tradesToWatch[0]?.data.status).toBe('SUBMITTED');
@@ -127,7 +127,7 @@ describe('useAllTradesReloadTimer', () => {
         }));
 
         const store = getInitializedStore({ trades: tradesWithAccounts });
-        const { result } = renderUseAllTradesReloadTimer(store);
+        const { result } = await renderUseAllTradesReloadTimer(store);
 
         // Call the refreshAllTrades function
         await act(async () => {
@@ -153,7 +153,7 @@ describe('useAllTradesReloadTimer', () => {
         ];
 
         const store = getInitializedStore({ trades: mockTrades });
-        const { result } = renderUseAllTradesReloadTimer(store);
+        const { result } = await renderUseAllTradesReloadTimer(store);
 
         await act(async () => {
             await result.current.refreshAllTrades();
@@ -178,7 +178,7 @@ describe('useAllTradesReloadTimer', () => {
         }));
 
         const store = getInitializedStore({ trades: tradesWithAccounts });
-        const { result } = renderUseAllTradesReloadTimer(store);
+        const { result } = await renderUseAllTradesReloadTimer(store);
 
         // Initially should be false
         expect(result.current.hasFetchedInitialTrades).toBe(false);
@@ -201,7 +201,7 @@ describe('useAllTradesReloadTimer', () => {
         });
 
         const store = getInitializedStore({ trades: [] });
-        const { result } = renderUseAllTradesReloadTimer(store);
+        const { result } = await renderUseAllTradesReloadTimer(store);
 
         expect(result.current.tradesToWatch).toHaveLength(0);
         expect(result.current.tradesByAccount).toHaveLength(0);
@@ -211,7 +211,7 @@ describe('useAllTradesReloadTimer', () => {
         expect(mockReset).not.toHaveBeenCalled();
     });
 
-    it('should handle trades with different trade types', () => {
+    it('should handle trades with different trade types', async () => {
         const mockTrades = [
             getBuyTrade({ status: 'SUBMITTED' }),
             getExchangeTrade({ status: 'CONVERTING' }),
@@ -224,15 +224,15 @@ describe('useAllTradesReloadTimer', () => {
         }));
 
         const store = getInitializedStore({ trades: tradesWithAccounts });
-        const { result } = renderUseAllTradesReloadTimer(store);
+        const { result } = await renderUseAllTradesReloadTimer(store);
 
         // All trades should be watched as they have non-final statuses
         expect(result.current.tradesToWatch).toHaveLength(3);
     });
 
-    it('should provide setIsFetching function', () => {
+    it('should provide setIsFetching function', async () => {
         const store = getInitializedStore();
-        const { result } = renderUseAllTradesReloadTimer(store);
+        const { result } = await renderUseAllTradesReloadTimer(store);
 
         expect(typeof result.current.setIsFetching).toBe('function');
 

--- a/suite-native/module-trading/src/hooks/general/useAmountInputDecimals.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useAmountInputDecimals.test.ts
@@ -23,49 +23,51 @@ jest.mock('@suite-native/tokens', () => ({
 }));
 
 describe('useAmountInputDecimals', () => {
-    const renderUseAmountInputDecimals = (account?: Account, contractAddress?: TokenAddress) =>
-        renderHookWithStoreProvider(() => useAmountInputDecimals(account, contractAddress));
+    const renderUseAmountInputDecimals = async (
+        account?: Account,
+        contractAddress?: TokenAddress,
+    ) => await renderHookWithStoreProvider(() => useAmountInputDecimals(account, contractAddress));
 
     beforeEach(() => {
         jest.clearAllMocks();
         mockSelectAccountTokenDecimals.mockReturnValue(6);
     });
 
-    it('should be undefined when account is not set', () => {
-        const { result } = renderUseAmountInputDecimals(undefined, undefined);
+    it('should be undefined when account is not set', async () => {
+        const { result } = await renderUseAmountInputDecimals(undefined, undefined);
 
         expect(result.current).toBeUndefined();
     });
 
-    it('should limit value to decimals based on network.decimals value for networks', () => {
+    it('should limit value to decimals based on network.decimals value for networks', async () => {
         const account = {
             key: mockAccountKey({ symbol: 'eth', descriptor: 'accountKey' }),
             symbol: 'eth',
         } as Account;
-        const { result } = renderUseAmountInputDecimals(account, undefined);
+        const { result } = await renderUseAmountInputDecimals(account, undefined);
 
         expect(result.current).toEqual(18);
     });
 
-    it('should limit value to decimals based on selectAccountTokenDecimals return value', () => {
+    it('should limit value to decimals based on selectAccountTokenDecimals return value', async () => {
         const account = {
             key: mockAccountKey({ symbol: 'eth', descriptor: 'accountKey' }),
             symbol: 'eth',
         } as Account;
         const contractAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress;
-        const { result } = renderUseAmountInputDecimals(account, contractAddress);
+        const { result } = await renderUseAmountInputDecimals(account, contractAddress);
 
         expect(result.current).toEqual(6);
     });
 
-    it('should return undefined when selectAccountTokenDecimals returns nullish value', () => {
+    it('should return undefined when selectAccountTokenDecimals returns nullish value', async () => {
         mockSelectAccountTokenDecimals.mockReturnValue(null);
         const account = {
             key: mockAccountKey({ symbol: 'eth', descriptor: 'accountKey' }),
             symbol: 'eth',
         } as Account;
         const contractAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress;
-        const { result } = renderUseAmountInputDecimals(account, contractAddress);
+        const { result } = await renderUseAmountInputDecimals(account, contractAddress);
 
         expect(result.current).toBeUndefined();
     });

--- a/suite-native/module-trading/src/hooks/general/useClearTradingStateOnUnmount.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useClearTradingStateOnUnmount.test.ts
@@ -13,14 +13,17 @@ describe('useClearTradingStateOnUnmount', () => {
         jest.clearAllMocks();
     });
 
-    it('clears trading state on unmount', () => {
-        const { unmount } = renderHookWithTradingProvider(() => useClearTradingStateOnUnmount(), {
-            tradeType: 'sell',
-        });
+    it('clears trading state on unmount', async () => {
+        const { unmount } = await renderHookWithTradingProvider(
+            () => useClearTradingStateOnUnmount(),
+            {
+                tradeType: 'sell',
+            },
+        );
 
         expect(mockClearTradingStateThunk).not.toHaveBeenCalled();
 
-        unmount();
+        await unmount();
 
         expect(mockClearTradingStateThunk).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.test.ts
@@ -71,10 +71,13 @@ describe('useComposeTradingTransaction', () => {
         });
     };
 
-    const renderUseComposeTradingTransaction = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useComposeTradingTransaction({ tradeType: 'exchange' }), {
-            store,
-        });
+    const renderUseComposeTradingTransaction = async (store: TestStore) =>
+        await renderHookWithStoreProvider(
+            () => useComposeTradingTransaction({ tradeType: 'exchange' }),
+            {
+                store,
+            },
+        );
 
     beforeEach(() => {
         mockComposeTradingTransactionThunk.mockClear();
@@ -83,9 +86,9 @@ describe('useComposeTradingTransaction', () => {
     it('should compose transaction with latest draft fee values from store', async () => {
         const store = getInitializedStore();
 
-        const { result } = renderUseComposeTradingTransaction(store);
+        const { result } = await renderUseComposeTradingTransaction(store);
 
-        act(() => {
+        await act(() => {
             store.dispatch(
                 formDraftActions.storeDraft({
                     key: exchangeFormDraftKey,

--- a/suite-native/module-trading/src/hooks/general/useConsent.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useConsent.test.ts
@@ -3,18 +3,18 @@ import { act, renderHook, waitFor } from '@suite-native/test-utils';
 import { useConsent } from './useConsent';
 
 describe('useConsent', () => {
-    const renderUseConsent = () => renderHook(() => useConsent());
+    const renderUseConsent = async () => await renderHook(() => useConsent());
 
-    it('should initialize with isConsentRequested as false', () => {
-        const { result } = renderUseConsent();
+    it('should initialize with isConsentRequested as false', async () => {
+        const { result } = await renderUseConsent();
 
         expect(result.current.isConsentRequested).toBe(false);
     });
 
     describe('waitForConsent', () => {
-        it('should return a promise', () => {
-            const { result } = renderUseConsent();
-            act(() => {
+        it('should return a promise', async () => {
+            const { result } = await renderUseConsent();
+            await act(() => {
                 const promise = result.current.waitForConsent();
 
                 expect(promise).toBeInstanceOf(Promise);
@@ -22,9 +22,9 @@ describe('useConsent', () => {
         });
 
         it('should set isConsentRequested to true when called', async () => {
-            const { result } = renderUseConsent();
+            const { result } = await renderUseConsent();
 
-            act(() => {
+            await act(() => {
                 result.current.waitForConsent();
             });
 
@@ -36,11 +36,11 @@ describe('useConsent', () => {
 
     describe('resolveConsent', () => {
         it('should resolve the promise with the provided value', async () => {
-            const { result } = renderUseConsent();
+            const { result } = await renderUseConsent();
 
             let resolvedValue: boolean | undefined;
 
-            act(() => {
+            await act(() => {
                 const promise = result.current.waitForConsent();
                 promise.then(value => {
                     resolvedValue = value;
@@ -51,7 +51,7 @@ describe('useConsent', () => {
                 expect(result.current.isConsentRequested).toBe(true);
             });
 
-            act(() => {
+            await act(() => {
                 result.current.resolveConsent(true);
             });
 
@@ -63,12 +63,12 @@ describe('useConsent', () => {
 
     describe('consent flow', () => {
         it('should handle complete consent flow', async () => {
-            const { result } = renderUseConsent();
+            const { result } = await renderUseConsent();
 
             let consentResult: boolean | undefined;
 
             // Start consent request
-            act(() => {
+            await act(() => {
                 const promise = result.current.waitForConsent();
                 promise.then(value => {
                     consentResult = value;
@@ -81,7 +81,7 @@ describe('useConsent', () => {
             });
 
             // Resolve consent
-            act(() => {
+            await act(() => {
                 result.current.resolveConsent(true);
             });
 
@@ -94,10 +94,10 @@ describe('useConsent', () => {
     });
 
     it('should handle unmounting gracefully', async () => {
-        const { result, unmount } = renderUseConsent();
+        const { result, unmount } = await renderUseConsent();
 
         // Start consent request
-        act(() => {
+        await act(() => {
             result.current.waitForConsent();
         });
 
@@ -107,7 +107,7 @@ describe('useConsent', () => {
         });
 
         // Unmount component
-        unmount();
+        await unmount();
 
         // Wait a bit for cleanup
         await new Promise(resolve => setTimeout(resolve, 0));

--- a/suite-native/module-trading/src/hooks/general/useConsentDenier.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useConsentDenier.test.ts
@@ -3,11 +3,11 @@ import { renderHook } from '@suite-native/test-utils';
 import { useConsentDenier } from './useConsentDenier';
 
 describe('useConsentDenier', () => {
-    const renderConsentDenierHook = <T>(
+    const renderConsentDenierHook = async <T>(
         initialValue: T,
         initialResolveConsent: (approved: false) => void,
     ) =>
-        renderHook<
+        await renderHook<
             ReturnType<typeof useConsentDenier<T>>,
             { watchedValue: T; resolveConsent: (approved: false) => void }
         >(({ watchedValue, resolveConsent }) => useConsentDenier<T>(watchedValue, resolveConsent), {
@@ -17,27 +17,27 @@ describe('useConsentDenier', () => {
             },
         });
 
-    it('should not call resolve callback on initial render', () => {
+    it('should not call resolve callback on initial render', async () => {
         const resolveConsentMock = jest.fn();
-        renderConsentDenierHook(1, resolveConsentMock);
+        await renderConsentDenierHook(1, resolveConsentMock);
 
         expect(resolveConsentMock).not.toHaveBeenCalled();
     });
 
-    it('should call resolveConsent with false when watchedValue changes', () => {
+    it('should call resolveConsent with false when watchedValue changes', async () => {
         const resolveConsentMock = jest.fn();
-        const { rerender } = renderConsentDenierHook(1, resolveConsentMock);
+        const { rerender } = await renderConsentDenierHook(1, resolveConsentMock);
 
-        rerender({ watchedValue: 2, resolveConsent: resolveConsentMock });
+        await rerender({ watchedValue: 2, resolveConsent: resolveConsentMock });
 
         expect(resolveConsentMock).toHaveBeenCalledWith(false);
     });
 
-    it('should not call resolveConsent when watchedValue remains the same', () => {
+    it('should not call resolveConsent when watchedValue remains the same', async () => {
         const resolveConsentMock = jest.fn();
-        const { rerender } = renderConsentDenierHook(1, resolveConsentMock);
+        const { rerender } = await renderConsentDenierHook(1, resolveConsentMock);
 
-        rerender({ watchedValue: 1, resolveConsent: resolveConsentMock });
+        await rerender({ watchedValue: 1, resolveConsent: resolveConsentMock });
 
         expect(resolveConsentMock).not.toHaveBeenCalled();
     });

--- a/suite-native/module-trading/src/hooks/general/useConvertFormValueToBaseUnit.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useConvertFormValueToBaseUnit.test.ts
@@ -5,17 +5,17 @@ import { PROTO } from '@trezor/connect';
 import { useConvertFormValueToBaseUnit } from './useConvertFormValueToBaseUnit';
 
 describe('useConvertFormValueToBaseUnit', () => {
-    const renderUseConvertApiToAppAmount = (bitcoinAmountUnit: PROTO.AmountUnit) => {
+    const renderUseConvertApiToAppAmount = async (bitcoinAmountUnit: PROTO.AmountUnit) => {
         const preloadedState = { wallet: { settings: { bitcoinAmountUnit } } };
 
-        return renderHookWithStoreProvider(() => useConvertFormValueToBaseUnit(), {
+        return await renderHookWithStoreProvider(() => useConvertFormValueToBaseUnit(), {
             preloadedState,
         });
     };
 
     describe('convertStrToBaseUnit', () => {
-        it('should return undefined when amount is undefined', () => {
-            const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+        it('should return undefined when amount is undefined', async () => {
+            const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
 
             expect(result.current.convertStrToBaseUnit(undefined, 'btc')).toEqual(undefined);
         });
@@ -25,8 +25,8 @@ describe('useConvertFormValueToBaseUnit', () => {
             ['eth', '1', '1'],
         ])(
             'should correctly convert %s with BTC as app unit',
-            (symbol, amountFromApi, expectedAmount) => {
-                const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
+            async (symbol, amountFromApi, expectedAmount) => {
+                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
 
                 expect(result.current.convertStrToBaseUnit(amountFromApi, symbol)).toEqual(
                     expectedAmount,
@@ -39,8 +39,8 @@ describe('useConvertFormValueToBaseUnit', () => {
             ['eth', '1', '1'],
         ])(
             'should correctly convert %s with SAT as app unit',
-            (symbol, amountFromApi, expectedAmount) => {
-                const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+            async (symbol, amountFromApi, expectedAmount) => {
+                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
 
                 expect(result.current.convertStrToBaseUnit(amountFromApi, symbol)).toEqual(
                     expectedAmount,
@@ -50,8 +50,8 @@ describe('useConvertFormValueToBaseUnit', () => {
     });
 
     describe('convertNumberToBaseUnit', () => {
-        it('should return undefined when amount is undefined', () => {
-            const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+        it('should return undefined when amount is undefined', async () => {
+            const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
 
             expect(result.current.convertNumberToBaseUnit(undefined, 'btc')).toEqual(undefined);
         });
@@ -61,8 +61,8 @@ describe('useConvertFormValueToBaseUnit', () => {
             ['eth', 1, 1],
         ])(
             'should correctly convert %s with BTC as app unit',
-            (symbol, amountFromApi, expectedAmount) => {
-                const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
+            async (symbol, amountFromApi, expectedAmount) => {
+                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
 
                 expect(result.current.convertNumberToBaseUnit(amountFromApi, symbol)).toEqual(
                     expectedAmount,
@@ -75,8 +75,8 @@ describe('useConvertFormValueToBaseUnit', () => {
             ['eth', 1, 1],
         ])(
             'should correctly convert %s with SAT as app unit',
-            (symbol, amountFromApi, expectedAmount) => {
-                const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+            async (symbol, amountFromApi, expectedAmount) => {
+                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
 
                 expect(result.current.convertNumberToBaseUnit(amountFromApi, symbol)).toEqual(
                     expectedAmount,

--- a/suite-native/module-trading/src/hooks/general/useFiatCurrencyFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useFiatCurrencyFilteredData.test.ts
@@ -22,11 +22,13 @@ const supportedFiatCurrencies: FiatCurrencyItem[] = [
 ];
 
 describe('useFiatCurrencyFilteredData', () => {
-    const renderUseFiatCurrencyFilteredData = () =>
-        renderHookWithBasicProvider(() => useFiatCurrencyFilteredData(supportedFiatCurrencies));
+    const renderUseFiatCurrencyFilteredData = async () =>
+        await renderHookWithBasicProvider(() =>
+            useFiatCurrencyFilteredData(supportedFiatCurrencies),
+        );
 
-    it('should return section list data structure', () => {
-        const { result } = renderUseFiatCurrencyFilteredData();
+    it('should return section list data structure', async () => {
+        const { result } = await renderUseFiatCurrencyFilteredData();
 
         expect(result.current.filteredData).toEqual([
             {
@@ -54,10 +56,10 @@ describe('useFiatCurrencyFilteredData', () => {
         ]);
     });
 
-    it('should filter by label case-insensitive', () => {
-        const { result } = renderUseFiatCurrencyFilteredData();
+    it('should filter by label case-insensitive', async () => {
+        const { result } = await renderUseFiatCurrencyFilteredData();
 
-        act(() => {
+        await act(() => {
             result.current.setFilterValue('unITed');
         });
 
@@ -66,10 +68,10 @@ describe('useFiatCurrencyFilteredData', () => {
         ]);
     });
 
-    it('should filter by value case-insensitive', () => {
-        const { result } = renderUseFiatCurrencyFilteredData();
+    it('should filter by value case-insensitive', async () => {
+        const { result } = await renderUseFiatCurrencyFilteredData();
 
-        act(() => {
+        await act(() => {
             result.current.setFilterValue('uSd');
         });
 
@@ -78,10 +80,10 @@ describe('useFiatCurrencyFilteredData', () => {
         ]);
     });
 
-    it('should return current filter value', () => {
-        const { result } = renderUseFiatCurrencyFilteredData();
+    it('should return current filter value', async () => {
+        const { result } = await renderUseFiatCurrencyFilteredData();
 
-        act(() => {
+        await act(() => {
             result.current.setFilterValue('usd');
         });
 

--- a/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.test.tsx
@@ -41,35 +41,35 @@ describe('useFocusedValueWatch', () => {
         },
     };
 
-    const renderForm = () =>
-        renderHookWithStoreProvider(() => useBuyForm(), {
+    const renderForm = async () =>
+        await renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });
 
-    const renderUseFocusedValueWatch = () =>
-        renderHookWithStoreProvider(({ control }) => useFocusedValueWatch(control), {
+    const renderUseFocusedValueWatch = async () =>
+        await renderHookWithStoreProvider(({ control }) => useFocusedValueWatch(control), {
             initialProps: { control: form.control },
             store,
         });
 
-    beforeEach(() => {
-        const { result } = renderForm();
+    beforeEach(async () => {
+        const { result } = await renderForm();
         form = result.current;
 
         store = createLightStore({ reducer, preloadedState });
     });
 
-    it('should return false by default', () => {
-        const { result } = renderUseFocusedValueWatch();
+    it('should return false by default', async () => {
+        const { result } = await renderUseFocusedValueWatch();
 
         expect(result.current).toEqual(false);
         expect(selectIsAmountInputActive(store.getState())).toBe(false);
     });
 
     it('should be false right after input is focused', async () => {
-        const { result } = renderUseFocusedValueWatch();
+        const { result } = await renderUseFocusedValueWatch();
 
-        act(() => {
+        await act(() => {
             form.setValue('focusedValue', 'fiatValue');
         });
 
@@ -81,7 +81,7 @@ describe('useFocusedValueWatch', () => {
     });
 
     it('should be true after 300ms of input focus', async () => {
-        const { result } = renderUseFocusedValueWatch();
+        const { result } = await renderUseFocusedValueWatch();
 
         await act(() => {
             form.setValue('focusedValue', 'fiatValue');
@@ -97,7 +97,7 @@ describe('useFocusedValueWatch', () => {
     });
 
     it('should set isAmountInputActive to false on unmount', async () => {
-        const { unmount } = renderUseFocusedValueWatch();
+        const { unmount } = await renderUseFocusedValueWatch();
         await act(() => {
             form.setValue('focusedValue', 'fiatValue');
         });
@@ -107,7 +107,7 @@ describe('useFocusedValueWatch', () => {
             await new Promise(resolve => setTimeout(resolve, 300));
         });
 
-        unmount();
+        await unmount();
 
         expect(selectIsAmountInputActive(store.getState())).toBe(false);
     });

--- a/suite-native/module-trading/src/hooks/general/useGeolocationCountryCode.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useGeolocationCountryCode.test.ts
@@ -39,22 +39,22 @@ describe('useGeolocationCountryCode', () => {
             },
         });
 
-    const renderUseGeolocationCountryCode = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useGeolocationCountryCode(), { store });
+    const renderUseGeolocationCountryCode = async (store: TestStore) =>
+        await renderHookWithStoreProvider(() => useGeolocationCountryCode(), { store });
 
-    it('should call geolocation thunk on mount', () => {
+    it('should call geolocation thunk on mount', async () => {
         const store = createGeolocationTestStore();
 
-        renderUseGeolocationCountryCode(store);
+        await renderUseGeolocationCountryCode(store);
 
         expect(selectCountryCode(store.getState())).toBe('US');
     });
 
-    it('should not call geolocation thunk if country code is already known', () => {
+    it('should not call geolocation thunk if country code is already known', async () => {
         const store = createGeolocationTestStore();
         store.dispatch(geolocationActions.setCountryCode('CZ'));
 
-        renderUseGeolocationCountryCode(store);
+        await renderUseGeolocationCountryCode(store);
 
         expect(selectCountryCode(store.getState())).toBe('CZ');
     });

--- a/suite-native/module-trading/src/hooks/general/useInputFieldControls.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useInputFieldControls.test.ts
@@ -26,24 +26,24 @@ describe('useInputFieldControls', () => {
         }));
     });
 
-    it('should return given value', () => {
-        const { result } = renderHook(() =>
+    it('should return given value', async () => {
+        const { result } = await renderHook(() =>
             useInputFieldControls('testField', 'testValue', jest.fn()),
         );
 
         expect(result.current.value).toBe('testValue');
     });
 
-    it('should return empty string when value is undefined', () => {
-        const { result } = renderHook(() =>
+    it('should return empty string when value is undefined', async () => {
+        const { result } = await renderHook(() =>
             useInputFieldControls('testField', undefined, jest.fn()),
         );
 
         expect(result.current.value).toBe('');
     });
 
-    it('should use onChange from useField', () => {
-        const { result } = renderHook(() =>
+    it('should use onChange from useField', async () => {
+        const { result } = await renderHook(() =>
             useInputFieldControls('testField', 'testValue', jest.fn()),
         );
 
@@ -51,8 +51,8 @@ describe('useInputFieldControls', () => {
         expect(mockOnChange).toHaveBeenCalledWith('newValue');
     });
 
-    it('should use onBlur from useField', () => {
-        const { result } = renderHook(() =>
+    it('should use onBlur from useField', async () => {
+        const { result } = await renderHook(() =>
             useInputFieldControls('testField', 'testValue', jest.fn()),
         );
 
@@ -60,9 +60,9 @@ describe('useInputFieldControls', () => {
         expect(mockOnBlur).toHaveBeenCalled();
     });
 
-    it('should set focusedValue on onFocus', () => {
+    it('should set focusedValue on onFocus', async () => {
         const mockSetValue = jest.fn();
-        const { result } = renderHook(() =>
+        const { result } = await renderHook(() =>
             useInputFieldControls('testField', 'testValue', mockSetValue),
         );
 
@@ -70,9 +70,9 @@ describe('useInputFieldControls', () => {
         expect(mockSetValue).toHaveBeenCalledWith('focusedValue', 'testField');
     });
 
-    it('should clear focusedValue and call onBlur on clearFocusedValueAndBlur', () => {
+    it('should clear focusedValue and call onBlur on clearFocusedValueAndBlur', async () => {
         const mockSetValue = jest.fn();
-        const { result } = renderHook(() =>
+        const { result } = await renderHook(() =>
             useInputFieldControls('testField', 'testValue', mockSetValue),
         );
 
@@ -82,18 +82,18 @@ describe('useInputFieldControls', () => {
         expect(mockOnBlur).toHaveBeenCalled();
     });
 
-    it('should return hasError from useField', () => {
+    it('should return hasError from useField', async () => {
         mockHasError = true;
-        const { result } = renderHook(() =>
+        const { result } = await renderHook(() =>
             useInputFieldControls('testField', 'testValue', jest.fn()),
         );
 
         expect(result.current.hasError).toBe(true);
     });
 
-    it('should keep focus callbacks stable when the value changes', () => {
+    it('should keep focus callbacks stable when the value changes', async () => {
         const mockSetValue = jest.fn();
-        const { result, rerender } = renderHook(
+        const { result, rerender } = await renderHook(
             ({ value }: { value: string }) =>
                 useInputFieldControls('testField', value, mockSetValue),
             { initialProps: { value: '1' } },
@@ -101,7 +101,7 @@ describe('useInputFieldControls', () => {
         const initialOnFocus = result.current.onFocus;
         const initialOnBlur = result.current.onBlur;
 
-        rerender({ value: '2' });
+        await rerender({ value: '2' });
 
         expect(result.current.onFocus).toBe(initialOnFocus);
         expect(result.current.onBlur).toBe(initialOnBlur);

--- a/suite-native/module-trading/src/hooks/general/useMountedRecentlyFlag.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useMountedRecentlyFlag.test.ts
@@ -5,8 +5,8 @@ import { RECENT_DURATION, useMountedRecentlyFlag } from './useMountedRecentlyFla
 jest.mock('./useMountedRecentlyFlag', () => jest.requireActual('./useMountedRecentlyFlag'));
 
 describe('useMountedRecentlyFlag', () => {
-    const renderUseMountedRecentlyFlag = () =>
-        renderHookWithBasicProvider(({ context }) => useMountedRecentlyFlag(context), {
+    const renderUseMountedRecentlyFlag = async () =>
+        await renderHookWithBasicProvider(({ context }) => useMountedRecentlyFlag(context), {
             initialProps: { context: 'context_1' },
         });
 
@@ -14,48 +14,48 @@ describe('useMountedRecentlyFlag', () => {
         jest.useFakeTimers();
     });
 
-    afterEach(() => {
-        act(() => {
+    afterEach(async () => {
+        await act(() => {
             jest.runOnlyPendingTimers();
         });
         jest.useRealTimers();
     });
 
-    it('should be true by default', () => {
-        const { result } = renderUseMountedRecentlyFlag();
+    it('should be true by default', async () => {
+        const { result } = await renderUseMountedRecentlyFlag();
 
         expect(result.current).toEqual(true);
     });
 
-    it('should be false after RECENT_DURATION time', () => {
-        const { result } = renderUseMountedRecentlyFlag();
+    it('should be false after RECENT_DURATION time', async () => {
+        const { result } = await renderUseMountedRecentlyFlag();
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(RECENT_DURATION);
         });
 
         expect(result.current).toEqual(false);
     });
 
-    it('should reset to true when context changes', () => {
-        const { result, rerender } = renderUseMountedRecentlyFlag();
-        act(() => {
+    it('should reset to true when context changes', async () => {
+        const { result, rerender } = await renderUseMountedRecentlyFlag();
+        await act(() => {
             jest.advanceTimersByTime(RECENT_DURATION);
         });
 
-        rerender({ context: 'context_2' });
+        await rerender({ context: 'context_2' });
 
         expect(result.current).toEqual(true);
     });
 
-    it('should re-run timer on context change', () => {
-        const { result, rerender } = renderUseMountedRecentlyFlag();
-        act(() => {
+    it('should re-run timer on context change', async () => {
+        const { result, rerender } = await renderUseMountedRecentlyFlag();
+        await act(() => {
             jest.advanceTimersByTime(RECENT_DURATION);
         });
-        rerender({ context: 'context_2' });
+        await rerender({ context: 'context_2' });
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(RECENT_DURATION);
         });
 

--- a/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.test.ts
@@ -86,15 +86,17 @@ const sections = [
 const preferredCurrencyUsdThreshold = asBaseCurrencyAmount(new BigNumber('0.1'));
 
 describe('useMyAssetsFilteredData', () => {
-    const renderFilter = (threshold: BaseCurrencyAmount | null = preferredCurrencyUsdThreshold) => {
+    const renderFilter = async (
+        threshold: BaseCurrencyAmount | null = preferredCurrencyUsdThreshold,
+    ) => {
         mockUseTradingMyAssets.mockReturnValue(sections);
         mockUsePreferredCurrencyUsdThreshold.mockReturnValue(threshold);
 
-        return renderHook(() => useMyAssetsFilteredData('sell'));
+        return await renderHook(() => useMyAssetsFilteredData('sell'));
     };
 
-    it('groups each account assets by tradeability and low balance', () => {
-        const { result } = renderFilter();
+    it('groups each account assets by tradeability and low balance', async () => {
+        const { result } = await renderFilter();
         const ethSection = result.current.filteredSections[1];
 
         expect(mockUseTradingMyAssets).toHaveBeenCalledWith('sell');
@@ -107,8 +109,8 @@ describe('useMyAssetsFilteredData', () => {
         expect(ethSection?.nonTradeableAssets).toEqual([nonTradeableLowBalanceAsset]);
     });
 
-    it('keeps all tradeable assets in the main list when the threshold is unavailable', () => {
-        const { result } = renderFilter(null);
+    it('keeps all tradeable assets in the main list when the threshold is unavailable', async () => {
+        const { result } = await renderFilter(null);
         const ethSection = result.current.filteredSections[1];
 
         expect(ethSection?.lowBalanceAssets).toEqual([]);
@@ -116,18 +118,18 @@ describe('useMyAssetsFilteredData', () => {
         expect(ethSection?.nonTradeableAssets).toEqual([nonTradeableLowBalanceAsset]);
     });
 
-    it('uses the supplied preferred-currency threshold', () => {
-        const { result } = renderFilter(asBaseCurrencyAmount(new BigNumber('0.09')));
+    it('uses the supplied preferred-currency threshold', async () => {
+        const { result } = await renderFilter(asBaseCurrencyAmount(new BigNumber('0.09')));
         const ethSection = result.current.filteredSections[1];
 
         expect(ethSection?.lowBalanceAssets).toEqual([]);
         expect(ethSection?.assets).toContain(lowBalanceAsset);
     });
 
-    it('searches all categories without flattening them', () => {
-        const { result } = renderFilter();
+    it('searches all categories without flattening them', async () => {
+        const { result } = await renderFilter();
 
-        act(() => result.current.setFilterValue('disabled low'));
+        await act(() => result.current.setFilterValue('disabled low'));
 
         expect(result.current.filteredSections).toHaveLength(1);
         expect(result.current.filteredSections[0]?.assets).toEqual([]);
@@ -137,10 +139,10 @@ describe('useMyAssetsFilteredData', () => {
         ]);
     });
 
-    it('combines case-insensitive search and network filters', () => {
-        const { result } = renderFilter();
+    it('combines case-insensitive search and network filters', async () => {
+        const { result } = await renderFilter();
 
-        act(() => {
+        await act(() => {
             result.current.setFilterSymbol('eth');
             result.current.setFilterValue('LOW USDC');
         });
@@ -149,12 +151,12 @@ describe('useMyAssetsFilteredData', () => {
         expect(result.current.filteredSections[0]?.lowBalanceAssets).toEqual([lowBalanceAsset]);
     });
 
-    it('updates the scroll reset key for both filters', () => {
-        const { result } = renderFilter();
+    it('updates the scroll reset key for both filters', async () => {
+        const { result } = await renderFilter();
 
         expect(result.current.scrollResetKey).toBe('Network:all;Search:');
 
-        act(() => {
+        await act(() => {
             result.current.setFilterSymbol('eth');
             result.current.setFilterValue('usd');
         });

--- a/suite-native/module-trading/src/hooks/general/useProviderFilters.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useProviderFilters.test.ts
@@ -12,8 +12,8 @@ type UseProviderFilterProps = {
     shouldShowFilters?: boolean;
 };
 describe('useProviderFilters', () => {
-    const renderUseProviderFilters = (initialProps: UseProviderFilterProps) =>
-        renderHookWithBasicProvider(
+    const renderUseProviderFilters = async (initialProps: UseProviderFilterProps) =>
+        await renderHookWithBasicProvider(
             ({ quotes = EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES, shouldShowFilters = true }) =>
                 useProviderFilters(quotes, shouldShowFilters),
             {
@@ -21,8 +21,8 @@ describe('useProviderFilters', () => {
             },
         );
 
-    it('filterItems should be stable', () => {
-        const { result, rerender } = renderUseProviderFilters({});
+    it('filterItems should be stable', async () => {
+        const { result, rerender } = await renderUseProviderFilters({});
 
         const initialFilterItems = result.current.filterItems;
 
@@ -32,13 +32,13 @@ describe('useProviderFilters', () => {
             { label: getTranslation('moduleTrading.providerSheet.filters.dex'), value: 'dex' },
         ]);
 
-        rerender({});
+        await rerender({});
 
         expect(result.current.filterItems).toEqual(initialFilterItems);
     });
 
-    it('should return all given sections even when empty when no filter is selected ', () => {
-        const { result } = renderUseProviderFilters({
+    it('should return all given sections even when empty when no filter is selected ', async () => {
+        const { result } = await renderUseProviderFilters({
             quotes: {
                 fixed: [],
                 float: [],
@@ -51,10 +51,10 @@ describe('useProviderFilters', () => {
         ]);
     });
 
-    it('should return all sections when "all" filter is selected', () => {
-        const { result } = renderUseProviderFilters({});
+    it('should return all sections when "all" filter is selected', async () => {
+        const { result } = await renderUseProviderFilters({});
 
-        act(() => {
+        await act(() => {
             result.current.setSelectedFilter('all');
         });
 
@@ -66,10 +66,10 @@ describe('useProviderFilters', () => {
         ]);
     });
 
-    it('should return fixed and float when CEX is selected', () => {
-        const { result } = renderUseProviderFilters({});
+    it('should return fixed and float when CEX is selected', async () => {
+        const { result } = await renderUseProviderFilters({});
 
-        act(() => {
+        await act(() => {
             result.current.setSelectedFilter('cex');
         });
 
@@ -80,10 +80,10 @@ describe('useProviderFilters', () => {
         ]);
     });
 
-    it('should return dex when DEX is selected', () => {
-        const { result } = renderUseProviderFilters({});
+    it('should return dex when DEX is selected', async () => {
+        const { result } = await renderUseProviderFilters({});
 
-        act(() => {
+        await act(() => {
             result.current.setSelectedFilter('dex');
         });
 
@@ -93,10 +93,10 @@ describe('useProviderFilters', () => {
         ]);
     });
 
-    it('should return all section when cex is selected but shouldShowFilters is false', () => {
-        const { result } = renderUseProviderFilters({ shouldShowFilters: false });
+    it('should return all section when cex is selected but shouldShowFilters is false', async () => {
+        const { result } = await renderUseProviderFilters({ shouldShowFilters: false });
 
-        act(() => {
+        await act(() => {
             result.current.setSelectedFilter('cex');
         });
 

--- a/suite-native/module-trading/src/hooks/general/useQuotesInvalidator.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useQuotesInvalidator.test.ts
@@ -12,7 +12,7 @@ import {
 describe('useQuotesInvalidator', () => {
     let store: TestStore;
 
-    const renderUseQuotesInvalidator = ({
+    const renderUseQuotesInvalidator = async ({
         isFormValid = false,
         isLoading = false,
         anyQuotesLoaded = false,
@@ -23,7 +23,7 @@ describe('useQuotesInvalidator', () => {
         })) as ActionCreatorWithoutPayload,
         getClearStateAction = (() => ({ type: 'clearStateAction' })) as ActionCreatorWithoutPayload,
     }: Partial<UseQuotesInvalidatorProps>) =>
-        renderHookWithTradingProvider(props => useQuotesInvalidator(props), {
+        await renderHookWithTradingProvider(props => useQuotesInvalidator(props), {
             store,
             initialProps: {
                 isFormValid,
@@ -40,18 +40,18 @@ describe('useQuotesInvalidator', () => {
         store = createTradingLightStore();
     });
 
-    it('should call debounce with empty method when form is not valid', () => {
+    it('should call debounce with empty method when form is not valid', async () => {
         const debounceMock = jest.fn();
-        renderUseQuotesInvalidator({
+        await renderUseQuotesInvalidator({
             debounce: debounceMock,
         });
 
         expect(debounceMock).toHaveBeenCalledWith(expect.any(Function));
     });
 
-    it('should not call debounce when form is valid', () => {
+    it('should not call debounce when form is valid', async () => {
         const debounceMock = jest.fn();
-        renderUseQuotesInvalidator({
+        await renderUseQuotesInvalidator({
             debounce: debounceMock,
             isFormValid: true,
         });
@@ -60,12 +60,12 @@ describe('useQuotesInvalidator', () => {
     });
 
     describe('promise aborting', () => {
-        it('should abort quotesPromise when form is invalid and quotes are loading', () => {
+        it('should abort quotesPromise when form is invalid and quotes are loading', async () => {
             const abortMock = jest.fn();
             const quotesPromiseRef = {
                 current: { abort: abortMock } as unknown as AbortablePromise,
             };
-            renderUseQuotesInvalidator({
+            await renderUseQuotesInvalidator({
                 isFormValid: false,
                 isLoading: true,
                 quotesPromiseRef,
@@ -74,27 +74,27 @@ describe('useQuotesInvalidator', () => {
             expect(abortMock).toHaveBeenCalledWith('Invalidating quotes');
         });
 
-        it('should abort quotesPromise on unmount', () => {
+        it('should abort quotesPromise on unmount', async () => {
             const abortMock = jest.fn();
             const quotesPromiseRef = {
                 current: { abort: abortMock } as unknown as AbortablePromise,
             };
-            const { unmount } = renderUseQuotesInvalidator({
+            const { unmount } = await renderUseQuotesInvalidator({
                 isFormValid: true,
                 quotesPromiseRef,
             });
 
-            unmount();
+            await unmount();
 
             expect(abortMock).toHaveBeenCalledWith('Component unmounted');
         });
 
-        it('should not abort quotesPromise when form is valid', () => {
+        it('should not abort quotesPromise when form is valid', async () => {
             const abortMock = jest.fn();
             const quotesPromiseRef = {
                 current: { abort: abortMock } as unknown as AbortablePromise,
             };
-            renderUseQuotesInvalidator({
+            await renderUseQuotesInvalidator({
                 isFormValid: true,
                 quotesPromiseRef,
             });
@@ -102,12 +102,12 @@ describe('useQuotesInvalidator', () => {
             expect(abortMock).not.toHaveBeenCalled();
         });
 
-        it('should not abort quotesPromise when form is invalid but quotes are not loading', () => {
+        it('should not abort quotesPromise when form is invalid but quotes are not loading', async () => {
             const abortMock = jest.fn();
             const quotesPromiseRef = {
                 current: { abort: abortMock } as unknown as AbortablePromise,
             };
-            renderUseQuotesInvalidator({
+            await renderUseQuotesInvalidator({
                 isFormValid: false,
                 isLoading: false,
                 quotesPromiseRef,
@@ -118,9 +118,9 @@ describe('useQuotesInvalidator', () => {
     });
 
     describe('getClearRequestAction', () => {
-        it('should dispatch clear request action', () => {
+        it('should dispatch clear request action', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            renderUseQuotesInvalidator({
+            await renderUseQuotesInvalidator({
                 isFormValid: false,
                 anyQuotesLoaded: true,
             });
@@ -128,9 +128,9 @@ describe('useQuotesInvalidator', () => {
             expect(dispatchSpy).toHaveBeenCalledWith({ type: 'clearRequestAction' });
         });
 
-        it('should not dispatch clear request when no quotes are loaded', () => {
+        it('should not dispatch clear request when no quotes are loaded', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            renderUseQuotesInvalidator({
+            await renderUseQuotesInvalidator({
                 isFormValid: false,
                 anyQuotesLoaded: false,
             });
@@ -138,9 +138,9 @@ describe('useQuotesInvalidator', () => {
             expect(dispatchSpy).not.toHaveBeenCalledWith({ type: 'clearStateAction' });
         });
 
-        it('should not dispatch clear request when form is valid', () => {
+        it('should not dispatch clear request when form is valid', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            renderUseQuotesInvalidator({
+            await renderUseQuotesInvalidator({
                 isFormValid: true,
                 anyQuotesLoaded: true,
             });
@@ -150,11 +150,11 @@ describe('useQuotesInvalidator', () => {
     });
 
     describe('getClearStateAction', () => {
-        it('should dispatch clear state action on unmount', () => {
+        it('should dispatch clear state action on unmount', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { unmount } = renderUseQuotesInvalidator({});
+            const { unmount } = await renderUseQuotesInvalidator({});
 
-            unmount();
+            await unmount();
 
             expect(dispatchSpy).toHaveBeenCalledWith({ type: 'clearStateAction' });
         });

--- a/suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.test.tsx
@@ -26,17 +26,17 @@ describe(useReceiveAccountsListData.name, () => {
         wallet: { accounts },
     };
 
-    const renderUseReceiveAccountsListData = (
+    const renderUseReceiveAccountsListData = async (
         symbol: NetworkSymbol,
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = defaultOverrides,
     ) =>
-        renderHookWithTradingProvider(
+        await renderHookWithTradingProvider(
             ({ networkSymbol }) => useReceiveAccountsListData({ symbol: networkSymbol }),
             { overrides, initialProps: { networkSymbol: symbol } },
         );
 
-    it('returns all visible accounts for the selected network', () => {
-        const { result } = renderUseReceiveAccountsListData('btc');
+    it('returns all visible accounts for the selected network', async () => {
+        const { result } = await renderUseReceiveAccountsListData('btc');
 
         expect(result.current).toEqual([
             {
@@ -51,10 +51,10 @@ describe(useReceiveAccountsListData.name, () => {
         ]);
     });
 
-    it('reacts to a network change', () => {
-        const { result, rerender } = renderUseReceiveAccountsListData('btc');
+    it('reacts to a network change', async () => {
+        const { result, rerender } = await renderUseReceiveAccountsListData('btc');
 
-        rerender({ networkSymbol: 'eth' });
+        await rerender({ networkSymbol: 'eth' });
 
         expect(result.current[0]?.data).toEqual([
             { account: expect.objectContaining({ key: eth1NormalAccount.key }) },
@@ -62,8 +62,8 @@ describe(useReceiveAccountsListData.name, () => {
         ]);
     });
 
-    it('returns an empty array when no matching account exists', () => {
-        const { result } = renderUseReceiveAccountsListData('btc', {
+    it('returns an empty array when no matching account exists', async () => {
+        const { result } = await renderUseReceiveAccountsListData('btc', {
             ...defaultOverrides,
             wallet: { accounts: [] },
         });

--- a/suite-native/module-trading/src/hooks/general/useReceiveAddressesListData.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/useReceiveAddressesListData.test.tsx
@@ -36,8 +36,8 @@ describe(useReceiveAddressesListData.name, () => {
         wallet: { accounts: [btc1NormalAccount] },
     };
 
-    const renderUseReceiveAddressesListData = (searchQuery = '') =>
-        renderHookWithTradingProvider(
+    const renderUseReceiveAddressesListData = async (searchQuery = '') =>
+        await renderHookWithTradingProvider(
             ({ query }) =>
                 useReceiveAddressesListData({
                     accountKey: btc1NormalAccount.key,
@@ -46,8 +46,8 @@ describe(useReceiveAddressesListData.name, () => {
             { overrides, initialProps: { query: searchQuery } },
         );
 
-    it('returns the first fresh address and all used addresses in separate sections', () => {
-        const { result } = renderUseReceiveAddressesListData();
+    it('returns the first fresh address and all used addresses in separate sections', async () => {
+        const { result } = await renderUseReceiveAddressesListData();
 
         expect(result.current).toEqual([
             expect.objectContaining({
@@ -74,8 +74,8 @@ describe(useReceiveAddressesListData.name, () => {
         ]);
     });
 
-    it('filters case-insensitively by full addresses without changing address order', () => {
-        const { result } = renderUseReceiveAddressesListData('used1');
+    it('filters case-insensitively by full addresses without changing address order', async () => {
+        const { result } = await renderUseReceiveAddressesListData('used1');
 
         expect(
             result.current.flatMap(section =>
@@ -84,8 +84,8 @@ describe(useReceiveAddressesListData.name, () => {
         ).toEqual(['UNUSED1', 'USED1']);
     });
 
-    it('filters by a Suite Sync label', () => {
-        const { result } = renderUseReceiveAddressesListData('savings');
+    it('filters by a Suite Sync label', async () => {
+        const { result } = await renderUseReceiveAddressesListData('savings');
 
         expect(result.current).toEqual([
             expect.objectContaining({
@@ -99,8 +99,8 @@ describe(useReceiveAddressesListData.name, () => {
         ]);
     });
 
-    it('returns no sections when the query does not match', () => {
-        const { result } = renderUseReceiveAddressesListData('missing');
+    it('returns no sections when the query does not match', async () => {
+        const { result } = await renderUseReceiveAddressesListData('missing');
 
         expect(result.current).toEqual([]);
     });

--- a/suite-native/module-trading/src/hooks/general/useReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useReloadTimer.test.ts
@@ -12,8 +12,8 @@ jest.mock('@trezor/react-utils', () => ({
 }));
 
 describe('useReloadTimer', () => {
-    const renderUseReloadTimer = (initialEnabled: boolean = true) =>
-        renderHook<ReturnType<typeof useReloadTimer>, { isEnabled: boolean }>(
+    const renderUseReloadTimer = async (initialEnabled: boolean = true) =>
+        await renderHook<ReturnType<typeof useReloadTimer>, { isEnabled: boolean }>(
             ({ isEnabled }) => useReloadTimer({ isEnabled }),
             {
                 initialProps: { isEnabled: initialEnabled },
@@ -32,99 +32,99 @@ describe('useReloadTimer', () => {
         };
     });
 
-    it('should return running timer and shouldReload equal false', () => {
-        const { result } = renderUseReloadTimer();
+    it('should return running timer and shouldReload equal false', async () => {
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.shouldReload).toBe(false);
         expect(result.current.timer.stop).not.toHaveBeenCalled();
     });
 
-    it('should stop timer when reset count is equal to 40', () => {
+    it('should stop timer when reset count is equal to 40', async () => {
         mockTimerReturn.resetCount = MAX_RESET_COUNT;
 
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.timer.stop).toHaveBeenCalled();
     });
 
-    it('should stop timer when reset count is greater than 40', () => {
+    it('should stop timer when reset count is greater than 40', async () => {
         mockTimerReturn.resetCount = MAX_RESET_COUNT + 1;
 
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.timer.stop).toHaveBeenCalled();
     });
 
-    it('should set shouldReload to true when time spent is equal to TRADE_API_RELOAD_QUOTES_AFTER_SECONDS', () => {
+    it('should set shouldReload to true when time spent is equal to TRADE_API_RELOAD_QUOTES_AFTER_SECONDS', async () => {
         mockTimerReturn.timeSpent.seconds = TRADE_API_RELOAD_QUOTES_AFTER_SECONDS;
 
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.shouldReload).toBe(true);
     });
 
-    it('should set shouldReload to true when time spent is greater than TRADE_API_RELOAD_QUOTES_AFTER_SECONDS', () => {
+    it('should set shouldReload to true when time spent is greater than TRADE_API_RELOAD_QUOTES_AFTER_SECONDS', async () => {
         mockTimerReturn.timeSpent.seconds = TRADE_API_RELOAD_QUOTES_AFTER_SECONDS + 1;
 
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.shouldReload).toBe(true);
     });
 
-    it('should not call stop when isStopped is true', () => {
+    it('should not call stop when isStopped is true', async () => {
         mockTimerReturn.timeSpent.seconds = TRADE_API_RELOAD_QUOTES_AFTER_SECONDS + 1;
         mockTimerReturn.isStopped = true;
 
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.shouldReload).toBe(false);
         expect(result.current.timer.stop).not.toHaveBeenCalled();
     });
 
-    it('should not call stop when isLoading is true', () => {
+    it('should not call stop when isLoading is true', async () => {
         mockTimerReturn.timeSpent.seconds = TRADE_API_RELOAD_QUOTES_AFTER_SECONDS + 1;
         mockTimerReturn.isLoading = true;
 
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.shouldReload).toBe(false);
         expect(result.current.timer.stop).not.toHaveBeenCalled();
     });
 
-    it('should stop timer when isEnabled is false', () => {
-        const { result } = renderUseReloadTimer(false);
+    it('should stop timer when isEnabled is false', async () => {
+        const { result } = await renderUseReloadTimer(false);
 
         expect(result.current.timer.stop).toHaveBeenCalled();
         expect(result.current.shouldReload).toBe(false);
     });
 
-    it('should return shouldReload false when timer is not enabled even when reload time is reached', () => {
+    it('should return shouldReload false when timer is not enabled even when reload time is reached', async () => {
         mockTimerReturn.timeSpent.seconds = TRADE_API_RELOAD_QUOTES_AFTER_SECONDS + 1;
-        const { result } = renderUseReloadTimer(false);
+        const { result } = await renderUseReloadTimer(false);
 
         expect(result.current.timer.stop).toHaveBeenCalled();
         expect(result.current.shouldReload).toBe(false);
     });
 
-    it('should reset timer when enabled but stopped', () => {
+    it('should reset timer when enabled but stopped', async () => {
         mockTimerReturn.isStopped = true;
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.timer.reset).toHaveBeenCalled();
     });
 
-    it('should not reset timer when isStopped and isLoading', () => {
+    it('should not reset timer when isStopped and isLoading', async () => {
         mockTimerReturn.isStopped = true;
         mockTimerReturn.isLoading = true;
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.timer.reset).not.toHaveBeenCalled();
     });
 
-    it('should not reset timer when stopped and MAX_RESET_COUNT is reached', () => {
+    it('should not reset timer when stopped and MAX_RESET_COUNT is reached', async () => {
         mockTimerReturn.isStopped = true;
         mockTimerReturn.resetCount = MAX_RESET_COUNT + 1;
-        const { result } = renderUseReloadTimer();
+        const { result } = await renderUseReloadTimer();
 
         expect(result.current.timer.reset).not.toHaveBeenCalled();
     });

--- a/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.test.ts
@@ -33,18 +33,18 @@ const mockAssets: TradeableAsset[] = [
 ];
 
 describe('useTradeableAssetsFilteredData', () => {
-    const renderUseTradeableAssetsFilteredData = () =>
-        renderHook(() => useTradeableAssetsFilteredData({ assets: mockAssets }));
+    const renderUseTradeableAssetsFilteredData = async () =>
+        await renderHook(() => useTradeableAssetsFilteredData({ assets: mockAssets }));
 
-    it('should return all assets when no filter is applied', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
+    it('should return all assets when no filter is applied', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
         expect(result.current.filteredData).toEqual(mockAssets);
     });
 
-    it('should filter assets by network symbol', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
+    it('should filter assets by network symbol', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
 
-        act(() => {
+        await act(() => {
             result.current.setFilterValue('btc' as NetworkSymbol);
         });
 
@@ -52,10 +52,10 @@ describe('useTradeableAssetsFilteredData', () => {
         expect(result.current.filteredData[0]?.networkId).toBe('bitcoin');
     });
 
-    it('should filter assets by network name', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
+    it('should filter assets by network name', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
 
-        act(() => {
+        await act(() => {
             result.current.setFilterValue('bnb' as NetworkSymbol);
         });
 
@@ -63,28 +63,28 @@ describe('useTradeableAssetsFilteredData', () => {
         expect(result.current.filteredData[0]?.networkId).toBe('binance-smart-chain');
     });
 
-    it('should filter assets by name', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
-        act(() => {
+    it('should filter assets by name', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
+        await act(() => {
             result.current.setFilterValue('rock');
         });
         expect(result.current.filteredData).toHaveLength(1);
         expect(result.current.filteredData[0]?.name).toBe('Rocket Pool ETH');
     });
 
-    it('should filter assets by contract address', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
-        act(() => {
+    it('should filter assets by contract address', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
+        await act(() => {
             result.current.setFilterValue('0xa0b');
         });
         expect(result.current.filteredData).toHaveLength(1);
         expect(result.current.filteredData[0]?.contractAddress).toBeTruthy();
     });
 
-    it('should filter assets by filter symbol', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
+    it('should filter assets by filter symbol', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
 
-        act(() => {
+        await act(() => {
             result.current.setFilterSymbol('btc' as NetworkSymbol);
         });
 
@@ -93,9 +93,9 @@ describe('useTradeableAssetsFilteredData', () => {
         expect(result.current.filteredData[0]?.networkId).toBe('bitcoin');
     });
 
-    it('should combine network symbol filter with search query', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
-        act(() => {
+    it('should combine network symbol filter with search query', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
+        await act(() => {
             result.current.setFilterSymbol('eth' as NetworkSymbol);
             result.current.setFilterValue('usd');
         });
@@ -103,9 +103,9 @@ describe('useTradeableAssetsFilteredData', () => {
         expect(result.current.filteredData[0]?.name).toBe('USDC');
     });
 
-    it('should handle case-insensitive search', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
-        act(() => {
+    it('should handle case-insensitive search', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
+        await act(() => {
             result.current.setFilterValue('usDT');
         });
         expect(result.current.filteredData).toHaveLength(2);
@@ -116,16 +116,16 @@ describe('useTradeableAssetsFilteredData', () => {
         ).toBe(true);
     });
 
-    it('should return empty array when no matches found', () => {
-        const { result } = renderUseTradeableAssetsFilteredData();
-        act(() => {
+    it('should return empty array when no matches found', async () => {
+        const { result } = await renderUseTradeableAssetsFilteredData();
+        await act(() => {
             result.current.setFilterValue('NonExistentAsset');
         });
         expect(result.current.filteredData).toHaveLength(0);
     });
 
     describe('sort order', () => {
-        it('puts the five featured assets first in their fixed order', () => {
+        it('puts the five featured assets first in their fixed order', async () => {
             const solAsset: TradeableAsset = {
                 ...unknownAsset,
                 cryptoId: 'solana' as CryptoId,
@@ -134,7 +134,7 @@ describe('useTradeableAssetsFilteredData', () => {
                 name: 'Solana',
             };
             const assets = [usdcAsset, solAsset, ethAsset, usdtAsset, btcAsset];
-            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+            const { result } = await renderHook(() => useTradeableAssetsFilteredData({ assets }));
 
             expect(result.current.filteredData).toEqual([
                 btcAsset,
@@ -145,7 +145,7 @@ describe('useTradeableAssetsFilteredData', () => {
             ]);
         });
 
-        it('puts owned assets over the USD threshold next, ordered by fiat value', () => {
+        it('puts owned assets over the USD threshold next, ordered by fiat value', async () => {
             const assetBalances = new Map([
                 [
                     jitoOnSolanaAsset.cryptoId,
@@ -170,7 +170,7 @@ describe('useTradeableAssetsFilteredData', () => {
                 ],
             ]);
             const assets = [rethOnBaseAsset, jitoOnSolanaAsset, jupOnSolanaAsset];
-            const { result } = renderHook(() =>
+            const { result } = await renderHook(() =>
                 useTradeableAssetsFilteredData({
                     assets,
                     assetBalances,
@@ -185,12 +185,12 @@ describe('useTradeableAssetsFilteredData', () => {
             ]);
         });
 
-        it('should rank exact name match before name-startsWith', () => {
+        it('should rank exact name match before name-startsWith', async () => {
             // tronTetherAsset.name = 'Tether' (exact match), usdtAsset.name = 'Tether USDT' (startsWith)
             const assets = [usdtAsset, tronTetherAsset];
-            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+            const { result } = await renderHook(() => useTradeableAssetsFilteredData({ assets }));
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterValue('tether');
             });
 
@@ -198,7 +198,7 @@ describe('useTradeableAssetsFilteredData', () => {
             expect(result.current.filteredData[1]).toBe(usdtAsset);
         });
 
-        it('should rank exact symbol match before symbol-startsWith', () => {
+        it('should rank exact symbol match before symbol-startsWith', async () => {
             // Inline asset with symbol starting with 'usd' but not exact; usdcAsset.symbol = 'USDC' also startsWith.
             // We create an asset with symbol exactly 'USD' to compare against 'USDC'.
             const usdExactAsset: TradeableAsset = {
@@ -207,9 +207,9 @@ describe('useTradeableAssetsFilteredData', () => {
                 name: 'US Dollar',
             };
             const assets = [usdcAsset, usdExactAsset];
-            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+            const { result } = await renderHook(() => useTradeableAssetsFilteredData({ assets }));
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterValue('usd');
             });
 
@@ -219,14 +219,14 @@ describe('useTradeableAssetsFilteredData', () => {
             expect(result.current.filteredData[1]).toBe(usdcAsset);
         });
 
-        it('should rank name-startsWith before name-contains', () => {
+        it('should rank name-startsWith before name-contains', async () => {
             // ethAsset.name = 'Ethereum' → startsWith 'et' → weight 2
             // rethOnBaseAsset.name = 'Rocket Pool ETH' → contains 'et' but not startsWith → weight 4
             // Also: ethAsset.symbol = 'ETH' → 'eth' !== 'et', so no symbol exact match; name check wins at weight 2
             const assets = [rethOnBaseAsset, ethAsset];
-            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+            const { result } = await renderHook(() => useTradeableAssetsFilteredData({ assets }));
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterValue('et');
             });
 
@@ -234,13 +234,13 @@ describe('useTradeableAssetsFilteredData', () => {
             expect(result.current.filteredData[1]).toBe(rethOnBaseAsset);
         });
 
-        it('should rank asset name/symbol matches before network name matches', () => {
+        it('should rank asset name/symbol matches before network name matches', async () => {
             // ethAsset.name = 'Ethereum' → exact name match → weight 0
             // usdcAsset.networkId = 'ethereum' → network name 'Ethereum' exact match → weight 6
             const assets = [usdcAsset, ethAsset];
-            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+            const { result } = await renderHook(() => useTradeableAssetsFilteredData({ assets }));
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterValue('ethereum');
             });
 
@@ -248,14 +248,14 @@ describe('useTradeableAssetsFilteredData', () => {
             expect(result.current.filteredData[1]).toBe(usdcAsset);
         });
 
-        it('should rank contract address matches after name/symbol matches', () => {
+        it('should rank contract address matches after name/symbol matches', async () => {
             // Inline asset with '0xa0b' in its name → name startsWith → weight 2
             // usdcAsset.contractAddress starts with '0xa0b' → weight 12
             const contractNameAsset: TradeableAsset = { ...unknownAsset, name: '0xa0b Token' };
             const assets = [usdcAsset, contractNameAsset];
-            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+            const { result } = await renderHook(() => useTradeableAssetsFilteredData({ assets }));
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterValue('0xa0b');
             });
 
@@ -263,20 +263,20 @@ describe('useTradeableAssetsFilteredData', () => {
             expect(result.current.filteredData[1]).toBe(usdcAsset);
         });
 
-        it('should not change order when filter is empty', () => {
+        it('should not change order when filter is empty', async () => {
             const assets = [btcAsset, ethAsset, usdcAsset];
-            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+            const { result } = await renderHook(() => useTradeableAssetsFilteredData({ assets }));
 
             // No filter set — original order should be preserved
             expect(result.current.filteredData).toEqual(assets);
         });
 
-        it('should order match on token address as last', () => {
+        it('should order match on token address as last', async () => {
             const assets = [btcAsset, ethAsset, usdcAsset, tronTetherAsset] as TradeableAsset[];
 
-            const { result } = renderHook(() => useTradeableAssetsFilteredData({ assets }));
+            const { result } = await renderHook(() => useTradeableAssetsFilteredData({ assets }));
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterValue('tc');
             });
 
@@ -285,36 +285,36 @@ describe('useTradeableAssetsFilteredData', () => {
     });
 
     describe('filterValue', () => {
-        it('should have correct value for empty filter', () => {
-            const { result } = renderUseTradeableAssetsFilteredData();
+        it('should have correct value for empty filter', async () => {
+            const { result } = await renderUseTradeableAssetsFilteredData();
 
             expect(result.current.filterValue).toEqual('Network:all;Search:');
         });
 
-        it('should be affected by search value', () => {
-            const { result } = renderUseTradeableAssetsFilteredData();
+        it('should be affected by search value', async () => {
+            const { result } = await renderUseTradeableAssetsFilteredData();
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterValue('search text');
             });
 
             expect(result.current.filterValue).toEqual('Network:all;Search:search text');
         });
 
-        it('should be affected by network selection', () => {
-            const { result } = renderUseTradeableAssetsFilteredData();
+        it('should be affected by network selection', async () => {
+            const { result } = await renderUseTradeableAssetsFilteredData();
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterSymbol('eth' as NetworkSymbol);
             });
 
             expect(result.current.filterValue).toEqual('Network:eth;Search:');
         });
 
-        it('should be affected by both search value and network selection', () => {
-            const { result } = renderUseTradeableAssetsFilteredData();
+        it('should be affected by both search value and network selection', async () => {
+            const { result } = await renderUseTradeableAssetsFilteredData();
 
-            act(() => {
+            await act(() => {
                 result.current.setFilterValue('search text');
                 result.current.setFilterSymbol('eth' as NetworkSymbol);
             });

--- a/suite-native/module-trading/src/hooks/general/useTradingFiatValues.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingFiatValues.test.ts
@@ -40,7 +40,7 @@ const renderUseTradingFiatValues = async (
     cryptoId: CryptoId | undefined,
     overrides: PreloadedStatePartial<TradingTestPreloadedState> = getOverrides(),
 ) => {
-    const res = renderHookWithTradingProvider(() => useTradingFiatValues(amount, cryptoId), {
+    const res = await renderHookWithTradingProvider(() => useTradingFiatValues(amount, cryptoId), {
         overrides,
     });
 

--- a/suite-native/module-trading/src/hooks/general/useTradingReceiveAccountSelection.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingReceiveAccountSelection.test.ts
@@ -8,15 +8,15 @@ import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
 describe('useTradingReceiveAccountSelection', () => {
     it.each(['buy', 'exchange'] as const)(
         'should select the %s receive account with one action',
-        tradingType => {
+        async tradingType => {
             const store = createTradingLightStore({ tradeType: tradingType });
             const address = btc1NormalAccount.addresses?.unused[0];
-            const { result } = renderHookWithStoreProvider(
+            const { result } = await renderHookWithStoreProvider(
                 () => useTradingReceiveAccountSelection(tradingType),
                 { store },
             );
 
-            act(() => {
+            await act(() => {
                 result.current({ account: btc1NormalAccount, address });
             });
 
@@ -30,7 +30,7 @@ describe('useTradingReceiveAccountSelection', () => {
         },
     );
 
-    it('should not expose a stale address when switching exchange accounts', () => {
+    it('should not expose a stale address when switching exchange accounts', async () => {
         const store = createTradingLightStore({
             tradeType: 'exchange',
             overrides: {
@@ -49,13 +49,13 @@ describe('useTradingReceiveAccountSelection', () => {
             selectExchangeSelectedReceiveAccount(store.getState()),
         );
         const unsubscribe = store.subscribe(selectReceiveAccount);
-        const { result } = renderHookWithStoreProvider(
+        const { result } = await renderHookWithStoreProvider(
             () => useTradingReceiveAccountSelection('exchange'),
             { store },
         );
 
-        expect(() => {
-            act(() => {
+        expect(async () => {
+            await act(() => {
                 result.current({ account: btc2legacyAccount });
             });
         }).not.toThrow();

--- a/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.test.ts
@@ -58,12 +58,12 @@ const RECEIVE_CRYPTO_ID = 'stellar:USDC' as CryptoId;
 const TOKEN_CONTRACT = 'USDC-GA123';
 const ACCOUNT_KEY = 'xlm-account-key';
 
-const renderUseTradingStellarActivateToken = (options?: {
+const renderUseTradingStellarActivateToken = async (options?: {
     quote?: ExchangeTrade | BuyTrade;
     receiveCryptoId?: CryptoId;
     buttonTestId?: string;
 }) =>
-    renderHook(() =>
+    await renderHook(() =>
         useTradingStellarActivateToken({
             quote: options?.quote,
             receiveCryptoId: options?.receiveCryptoId,
@@ -72,24 +72,19 @@ const renderUseTradingStellarActivateToken = (options?: {
     );
 
 const getButtonProps = (
-    result: ReturnType<typeof renderUseTradingStellarActivateToken>['result'],
+    result: Awaited<ReturnType<typeof renderUseTradingStellarActivateToken>>['result'],
 ) => result.current.activateButtonElement?.props.children.props;
 
 const onActivateButtonPressStart = (
-    result: ReturnType<typeof renderUseTradingStellarActivateToken>['result'],
+    result: Awaited<ReturnType<typeof renderUseTradingStellarActivateToken>>['result'],
 ) => {
     const onPress = getButtonProps(result)?.onPress as (() => Promise<void>) | undefined;
-    let onPressPromise: Promise<void> | undefined;
 
-    act(() => {
-        onPressPromise = onPress?.();
-    });
-
-    return onPressPromise;
+    return onPress?.();
 };
 
 const onActivateButtonPress = async (
-    result: ReturnType<typeof renderUseTradingStellarActivateToken>['result'],
+    result: Awaited<ReturnType<typeof renderUseTradingStellarActivateToken>>['result'],
 ) => {
     const onPressPromise = onActivateButtonPressStart(result);
     await act(async () => await onPressPromise);
@@ -117,8 +112,8 @@ describe('useTradingStellarActivateToken', () => {
         }));
     });
 
-    it('returns activate button when receiving inactive Stellar token', () => {
-        const { result } = renderUseTradingStellarActivateToken({
+    it('returns activate button when receiving inactive Stellar token', async () => {
+        const { result } = await renderUseTradingStellarActivateToken({
             quote: { receive: 'USDC' } as ExchangeTrade,
             receiveCryptoId: RECEIVE_CRYPTO_ID,
             buttonTestId: 'activate-stellar-token',
@@ -129,12 +124,12 @@ describe('useTradingStellarActivateToken', () => {
         expect(getButtonProps(result)?.testID).toBe('activate-stellar-token');
     });
 
-    it('does not return activate button when token is already active', () => {
+    it('does not return activate button when token is already active', async () => {
         mockUseInactiveStellarTokens.mockReturnValue({
             inactiveTokens: [{ contract: 'AQUA-GB456' }],
         });
 
-        const { result } = renderUseTradingStellarActivateToken({
+        const { result } = await renderUseTradingStellarActivateToken({
             quote: { receive: 'USDC' } as ExchangeTrade,
             receiveCryptoId: RECEIVE_CRYPTO_ID,
         });
@@ -149,7 +144,7 @@ describe('useTradingStellarActivateToken', () => {
             meta: { requestStatus: 'fulfilled' },
         });
 
-        const { result } = renderUseTradingStellarActivateToken({
+        const { result } = await renderUseTradingStellarActivateToken({
             quote: { receive: 'USDC' } as ExchangeTrade,
             receiveCryptoId: RECEIVE_CRYPTO_ID,
         });
@@ -177,7 +172,7 @@ describe('useTradingStellarActivateToken', () => {
             meta: { requestStatus: 'rejected' },
         });
 
-        const { result } = renderUseTradingStellarActivateToken({
+        const { result } = await renderUseTradingStellarActivateToken({
             quote: { receive: 'USDC' } as ExchangeTrade,
             receiveCryptoId: RECEIVE_CRYPTO_ID,
         });
@@ -202,7 +197,7 @@ describe('useTradingStellarActivateToken', () => {
                 }),
         );
 
-        const { result } = renderUseTradingStellarActivateToken({
+        const { result } = await renderUseTradingStellarActivateToken({
             quote: { receive: 'USDC' } as ExchangeTrade,
             receiveCryptoId: RECEIVE_CRYPTO_ID,
         });
@@ -211,7 +206,7 @@ describe('useTradingStellarActivateToken', () => {
 
         await waitFor(() => expect(getButtonProps(result)?.isLoading).toBe(true));
 
-        act(() => {
+        await act(() => {
             resolveDispatch?.({
                 type: 'module-stellar-token-management/composeStellarTrustlineFeesThunk/fulfilled',
                 meta: { requestStatus: 'fulfilled' },

--- a/suite-native/module-trading/src/hooks/general/useTradingTradeableAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTradeableAssetsFilteredData.test.ts
@@ -20,8 +20,8 @@ jest.mock('../exchange/useExchangeFormContext', () => ({
 }));
 
 describe('useTradingTradeableAssetsFilteredData', () => {
-    const renderUseTradingTradeableAssetsFilteredData = () =>
-        renderHookWithTradingProvider(
+    const renderUseTradingTradeableAssetsFilteredData = async () =>
+        await renderHookWithTradingProvider(
             () => useTradingTradeableAssetsFilteredData(selectExchangeBuyTradeableAssets),
             { tradeType: 'exchange' },
         );
@@ -30,10 +30,10 @@ describe('useTradingTradeableAssetsFilteredData', () => {
         jest.clearAllMocks();
     });
 
-    it('returns assets selected by the supplied selector', () => {
+    it('returns assets selected by the supplied selector', async () => {
         mockUseWatch.mockReturnValue(undefined);
 
-        const { result } = renderUseTradingTradeableAssetsFilteredData();
+        const { result } = await renderUseTradingTradeableAssetsFilteredData();
 
         expect(result.current.filteredData).toEqual([
             expect.objectContaining({ cryptoId: btcAsset.cryptoId }),
@@ -42,12 +42,12 @@ describe('useTradingTradeableAssetsFilteredData', () => {
         ]);
     });
 
-    it('filters the selected assets by search text', () => {
+    it('filters the selected assets by search text', async () => {
         mockUseWatch.mockReturnValue(undefined);
 
-        const { result } = renderUseTradingTradeableAssetsFilteredData();
+        const { result } = await renderUseTradingTradeableAssetsFilteredData();
 
-        act(() => {
+        await act(() => {
             result.current.setFilterValue('usdc');
         });
 

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.test.ts
@@ -98,10 +98,13 @@ describe('useTradingTransaction', () => {
         });
     };
 
-    const renderUseTradingTransaction = ({ store }: { store: TestStore }) =>
-        renderHookWithTradingProvider(() => useTradingTransaction({ tradeType: 'exchange' }), {
-            store,
-        });
+    const renderUseTradingTransaction = async ({ store }: { store: TestStore }) =>
+        await renderHookWithTradingProvider(
+            () => useTradingTransaction({ tradeType: 'exchange' }),
+            {
+                store,
+            },
+        );
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -139,7 +142,7 @@ describe('useTradingTransaction', () => {
         it('should call composeTradingTransaction', async () => {
             const store = getInitializedStore();
 
-            const { result } = renderUseTradingTransaction({ store });
+            const { result } = await renderUseTradingTransaction({ store });
 
             await act(async () => {
                 await result.current.composeTradingTransaction();
@@ -155,7 +158,7 @@ describe('useTradingTransaction', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const mockNextStep = jest.fn();
 
-            const { result } = renderUseTradingTransaction({ store });
+            const { result } = await renderUseTradingTransaction({ store });
 
             await act(async () => {
                 await result.current.signAndSendTransaction({
@@ -188,7 +191,7 @@ describe('useTradingTransaction', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const mockNextStep = jest.fn();
 
-            const { result } = renderUseTradingTransaction({ store });
+            const { result } = await renderUseTradingTransaction({ store });
 
             await act(async () => {
                 await result.current.signAndSendTransaction({
@@ -210,7 +213,7 @@ describe('useTradingTransaction', () => {
         it('should set isConsentRequested to false and resolve the promise', async () => {
             const store = getInitializedStore();
 
-            const { result } = renderUseTradingTransaction({ store });
+            const { result } = await renderUseTradingTransaction({ store });
 
             // First, trigger the signAndSendTransaction to set up the promise
             const originalSendTransactionThunk =
@@ -228,7 +231,7 @@ describe('useTradingTransaction', () => {
             });
 
             // Now resolve the push consent
-            act(() => {
+            await act(() => {
                 result.current.resolveTransactionSendConsent(true);
             });
 
@@ -241,16 +244,16 @@ describe('useTradingTransaction', () => {
     });
 
     describe('useEffect cleanup', () => {
-        it('should call TrezorConnect.cancel on unmount', () => {
+        it('should call TrezorConnect.cancel on unmount', async () => {
             const store = getInitializedStore();
-            const { unmount } = renderUseTradingTransaction({ store });
+            const { unmount } = await renderUseTradingTransaction({ store });
 
             // Get the mocked TrezorConnect.cancel function
             const TrezorConnect = require('@trezor/connect');
             const mockCancel = TrezorConnect.cancel;
 
             // Unmount the component to trigger the cleanup useEffect
-            unmount();
+            await unmount();
 
             // Verify that TrezorConnect.cancel was called
             expect(mockCancel).toHaveBeenCalled();

--- a/suite-native/module-trading/src/hooks/general/useTransactionStateChangeAnalyticsReporting.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTransactionStateChangeAnalyticsReporting.test.ts
@@ -29,8 +29,8 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
     const activeSpies: ReportSpy[] = [];
     let reportMock: jest.Mock;
 
-    const setup = (initialTrades: TradingTransaction[]) => {
-        const hook = renderHookWithBasicProvider(
+    const setup = async (initialTrades: TradingTransaction[]) => {
+        const hook = await renderHookWithBasicProvider(
             ({ trades }: Props) => useHookWithReportSpy(trades),
             { initialProps: { trades: initialTrades } },
         );
@@ -55,33 +55,33 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         reportMock = undefined as unknown as jest.Mock;
     });
 
-    it('should not report analytics when deviceTrades is empty', () => {
-        setup([]);
+    it('should not report analytics when deviceTrades is empty', async () => {
+        await setup([]);
 
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should not report analytics when deviceTrades is undefined', () => {
-        expect(() => {
-            renderHook(() => useTransactionStateChangeAnalyticsReporting(undefined as any));
-        }).toThrow();
+    it('should not report analytics when deviceTrades is undefined', async () => {
+        await expect(
+            renderHook(() => useTransactionStateChangeAnalyticsReporting(undefined as any)),
+        ).rejects.toThrow('useServices must be used within a ServicesProvider');
     });
 
-    it('should not report analytics on first render for buy trade', () => {
+    it('should not report analytics on first render for buy trade', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        setup([buyTrade]);
+        await setup([buyTrade]);
 
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should report analytics for trade status change', () => {
+    it('should report analytics for trade status change', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { rerender } = setup([buyTrade]);
+        const { rerender } = await setup([buyTrade]);
 
         const updatedBuyTrade = getBuyTrade({ status: 'SUCCESS' });
-        rerender({ trades: [updatedBuyTrade] });
+        await rerender({ trades: [updatedBuyTrade] });
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingStatusEvent.name,
@@ -90,27 +90,27 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         expect(reportMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should not report analytics when status remains the same', () => {
+    it('should not report analytics when status remains the same', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { rerender } = setup([buyTrade]);
+        const { rerender } = await setup([buyTrade]);
 
-        rerender({ trades: [buyTrade] });
+        await rerender({ trades: [buyTrade] });
 
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should handle multiple trades with different status changes', () => {
+    it('should handle multiple trades with different status changes', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
 
-        const { rerender } = setup([buyTrade, exchangeTrade]);
+        const { rerender } = await setup([buyTrade, exchangeTrade]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
         const updatedBuyTrade = getBuyTrade({ status: 'SUCCESS' });
         const updatedExchangeTrade = getExchangeTrade({ status: 'SUCCESS' });
-        rerender({ trades: [updatedBuyTrade, updatedExchangeTrade] });
+        await rerender({ trades: [updatedBuyTrade, updatedExchangeTrade] });
 
         expect(reportMock).toHaveBeenCalledTimes(2);
         expect(reportMock).toHaveBeenNthCalledWith(1, {
@@ -123,7 +123,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         });
     });
 
-    it('should handle trade with unknown key and not report analytics', () => {
+    it('should handle trade with unknown key and not report analytics', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const tradeWithoutKeys = {
             ...buyTrade,
@@ -135,7 +135,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
             },
         } as TradingTransaction;
 
-        const { rerender } = setup([tradeWithoutKeys]);
+        const { rerender } = await setup([tradeWithoutKeys]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
@@ -143,16 +143,16 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
             ...tradeWithoutKeys,
             data: { ...tradeWithoutKeys.data, status: 'SUCCESS' },
         } as TradingTransaction;
-        rerender({ trades: [updatedTrade] });
+        await rerender({ trades: [updatedTrade] });
 
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should handle trade with orderId as fallback key', () => {
+    it('should handle trade with orderId as fallback key', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const tradeWithOrderId = { ...buyTrade, key: undefined } as TradingTransaction;
 
-        const { rerender } = setup([tradeWithOrderId]);
+        const { rerender } = await setup([tradeWithOrderId]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
@@ -160,7 +160,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
             ...tradeWithOrderId,
             data: { ...tradeWithOrderId.data, status: 'SUCCESS' },
         } as TradingTransaction;
-        rerender({ trades: [updatedTrade] });
+        await rerender({ trades: [updatedTrade] });
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingStatusEvent.name,
@@ -169,7 +169,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         expect(reportMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle trade with paymentId as fallback key', () => {
+    it('should handle trade with paymentId as fallback key', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const tradeWithPaymentId = {
             ...buyTrade,
@@ -177,7 +177,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
             data: { ...buyTrade.data, orderId: undefined },
         } as TradingTransaction;
 
-        const { rerender } = setup([tradeWithPaymentId]);
+        const { rerender } = await setup([tradeWithPaymentId]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
@@ -185,7 +185,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
             ...tradeWithPaymentId,
             data: { ...tradeWithPaymentId.data, status: 'SUCCESS' },
         } as TradingTransaction;
-        rerender({ trades: [updatedTrade] });
+        await rerender({ trades: [updatedTrade] });
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingStatusEvent.name,
@@ -194,28 +194,28 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         expect(reportMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle trade with undefined status and not report analytics', () => {
+    it('should handle trade with undefined status and not report analytics', async () => {
         const buyTrade = getBuyTrade({ status: undefined });
 
-        const { rerender } = setup([buyTrade]);
+        const { rerender } = await setup([buyTrade]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
         const updatedTrade = getBuyTrade({ status: 'SUCCESS' });
-        rerender({ trades: [updatedTrade] });
+        await rerender({ trades: [updatedTrade] });
 
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should handle trade status transitions correctly', () => {
+    it('should handle trade status transitions correctly', async () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
 
-        const { rerender } = setup([exchangeTrade]);
+        const { rerender } = await setup([exchangeTrade]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
         const kycTrade = getExchangeTrade({ status: 'KYC' });
-        rerender({ trades: [kycTrade] });
+        await rerender({ trades: [kycTrade] });
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingStatusEvent.name,
             payload: { type: 'exchange', status: 'kyc' },
@@ -223,7 +223,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         expect(reportMock).toHaveBeenCalledTimes(1);
 
         const successTrade = getExchangeTrade({ status: 'SUCCESS' });
-        rerender({ trades: [successTrade] });
+        await rerender({ trades: [successTrade] });
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingStatusEvent.name,
             payload: { type: 'exchange', status: 'success' },
@@ -231,15 +231,15 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         expect(reportMock).toHaveBeenCalledTimes(2);
     });
 
-    it('should handle error statuses correctly', () => {
+    it('should handle error statuses correctly', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { rerender } = setup([buyTrade]);
+        const { rerender } = await setup([buyTrade]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
         const errorTrade = getBuyTrade({ status: 'ERROR' });
-        rerender({ trades: [errorTrade] });
+        await rerender({ trades: [errorTrade] });
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingStatusEvent.name,
             payload: { type: 'buy', status: 'error' },
@@ -247,18 +247,18 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         expect(reportMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should maintain previous statuses across re-renders', () => {
+    it('should maintain previous statuses across re-renders', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { rerender } = setup([buyTrade]);
+        const { rerender } = await setup([buyTrade]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
         const successTrade = getBuyTrade({ status: 'SUCCESS' });
-        rerender({ trades: [successTrade] });
+        await rerender({ trades: [successTrade] });
         expect(reportMock).toHaveBeenCalledTimes(1);
 
-        rerender({ trades: [buyTrade] });
+        await rerender({ trades: [buyTrade] });
         expect(reportMock).toHaveBeenCalledTimes(2);
         expect(reportMock).toHaveBeenNthCalledWith(2, {
             type: events.tradingStatusEvent.name,
@@ -266,7 +266,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         });
     });
 
-    it('should handle trade with all fallback keys undefined and not report analytics', () => {
+    it('should handle trade with all fallback keys undefined and not report analytics', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const tradeWithoutKeys = {
             ...buyTrade,
@@ -278,7 +278,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
             },
         } as TradingTransaction;
 
-        const { rerender } = setup([tradeWithoutKeys]);
+        const { rerender } = await setup([tradeWithoutKeys]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
@@ -286,24 +286,24 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
             ...tradeWithoutKeys,
             data: { ...tradeWithoutKeys.data, status: 'SUCCESS' },
         } as TradingTransaction;
-        rerender({ trades: [updatedTrade] });
+        await rerender({ trades: [updatedTrade] });
 
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should handle trades being removed from the list', () => {
+    it('should handle trades being removed from the list', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
 
-        const { rerender } = setup([buyTrade, exchangeTrade]);
+        const { rerender } = await setup([buyTrade, exchangeTrade]);
 
         expect(reportMock).not.toHaveBeenCalled();
 
-        rerender({ trades: [buyTrade] });
+        await rerender({ trades: [buyTrade] });
         expect(reportMock).not.toHaveBeenCalled();
 
         const updatedBuyTrade = getBuyTrade({ status: 'SUCCESS' });
-        rerender({ trades: [updatedBuyTrade] });
+        await rerender({ trades: [updatedBuyTrade] });
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingStatusEvent.name,

--- a/suite-native/module-trading/src/hooks/general/useWatchAllTrades.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchAllTrades.test.ts
@@ -64,12 +64,12 @@ describe('useWatchAllTrades', () => {
             },
         });
 
-    const renderUseWatchAllTrades = (store: TestStore) =>
-        renderHookWithTradingProvider(() => useWatchAllTrades(), { store });
+    const renderUseWatchAllTrades = async (store: TestStore) =>
+        await renderHookWithTradingProvider(() => useWatchAllTrades(), { store });
 
-    it('should return empty arrays when no trades', () => {
+    it('should return empty arrays when no trades', async () => {
         const store = getInitializedStore();
-        const { result } = renderUseWatchAllTrades(store);
+        const { result } = await renderUseWatchAllTrades(store);
 
         expect(result.current.allTrades).toEqual([]);
         expect(result.current.tradesToWatch).toEqual([]);
@@ -77,7 +77,7 @@ describe('useWatchAllTrades', () => {
         expect(result.current.tradesWatching).toBe(0);
     });
 
-    it('should return trades for the current device', () => {
+    it('should return trades for the current device', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
         const sellTrade = getSellTrade({ status: 'SEND_CRYPTO' });
@@ -85,13 +85,13 @@ describe('useWatchAllTrades', () => {
         const store = getInitializedStore({
             trades: [buyTrade, exchangeTrade, sellTrade],
         });
-        const { result } = renderUseWatchAllTrades(store);
+        const { result } = await renderUseWatchAllTrades(store);
 
         expect(result.current.allTrades).toHaveLength(3);
         expect(result.current.totalTrades).toBe(3);
     });
 
-    it('should return trades to watch from useAllTradesReloadTimer', () => {
+    it('should return trades to watch from useAllTradesReloadTimer', async () => {
         const mockTradesToWatch = [
             getBuyTrade({ status: 'SUBMITTED' }),
             getExchangeTrade({ status: 'CONVERTING' }),
@@ -107,7 +107,7 @@ describe('useWatchAllTrades', () => {
         });
 
         const store = getInitializedStore();
-        const { result } = renderUseWatchAllTrades(store);
+        const { result } = await renderUseWatchAllTrades(store);
 
         expect(result.current.tradesToWatch).toEqual(mockTradesToWatch);
         expect(result.current.tradesWatching).toBe(2);
@@ -127,7 +127,7 @@ describe('useWatchAllTrades', () => {
         });
 
         const store = getInitializedStore();
-        renderUseWatchAllTrades(store);
+        await renderUseWatchAllTrades(store);
 
         // Wait for the effect to run
         await new Promise(resolve => setTimeout(resolve, 0));
@@ -150,7 +150,7 @@ describe('useWatchAllTrades', () => {
         });
 
         const store = getInitializedStore();
-        renderUseWatchAllTrades(store);
+        await renderUseWatchAllTrades(store);
 
         // Wait for the effect to run
         await new Promise(resolve => setTimeout(resolve, 0));
@@ -172,7 +172,7 @@ describe('useWatchAllTrades', () => {
         });
 
         const store = getInitializedStore();
-        renderUseWatchAllTrades(store);
+        await renderUseWatchAllTrades(store);
 
         // Wait for the effect to run
         await new Promise(resolve => setTimeout(resolve, 0));

--- a/suite-native/module-trading/src/hooks/general/useWatchTrade.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchTrade.test.ts
@@ -100,18 +100,18 @@ describe('useWatchTrade', () => {
             },
         });
 
-    const renderUseWatchTrade = (
+    const renderUseWatchTrade = async (
         store: TestStore,
         props: { accountKey?: AccountKey; orderId?: string; isInProgress?: boolean },
     ) =>
-        renderHookWithTradingProvider(() => useWatchTradeWithReportSpy(props), {
+        await renderHookWithTradingProvider(() => useWatchTradeWithReportSpy(props), {
             store,
         });
 
     describe('Trade Watching Behavior', () => {
-        it('should not dispatch watch trade thunk when no trade is found', () => {
+        it('should not dispatch watch trade thunk when no trade is found', async () => {
             const store = getInitializedStore();
-            renderUseWatchTrade(store, {
+            await renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: 'non-existent-order',
             });
@@ -119,13 +119,13 @@ describe('useWatchTrade', () => {
             expect(mockWatchTradeThunk).not.toHaveBeenCalled();
         });
 
-        it('should not dispatch watch trade thunk when no account is found', () => {
+        it('should not dispatch watch trade thunk when no account is found', async () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
             const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            renderUseWatchTrade(store, {
+            await renderUseWatchTrade(store, {
                 accountKey: mockAccountKey({ descriptor: 'nonExistentAccount' }),
                 orderId: buyTrade.data.orderId,
             });
@@ -133,13 +133,13 @@ describe('useWatchTrade', () => {
             expect(mockWatchTradeThunk).not.toHaveBeenCalled();
         });
 
-        it('should dispatch watch trade thunk when trade and account are found', () => {
+        it('should dispatch watch trade thunk when trade and account are found', async () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
             const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            renderUseWatchTrade(store, {
+            await renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });
@@ -151,7 +151,7 @@ describe('useWatchTrade', () => {
             });
         });
 
-        it('should dispatch watch trade thunk when shouldReload is true', () => {
+        it('should dispatch watch trade thunk when shouldReload is true', async () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
             const store = getInitializedStore({
                 trades: [buyTrade],
@@ -165,7 +165,7 @@ describe('useWatchTrade', () => {
                 resetCount: 1,
             });
 
-            renderUseWatchTrade(store, {
+            await renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });
@@ -177,13 +177,13 @@ describe('useWatchTrade', () => {
             });
         });
 
-        it('should not dispatch watch trade thunk when trade is in final status', () => {
+        it('should not dispatch watch trade thunk when trade is in final status', async () => {
             const buyTrade = getBuyTrade({ status: 'SUCCESS' });
             const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            renderUseWatchTrade(store, {
+            await renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });
@@ -193,13 +193,13 @@ describe('useWatchTrade', () => {
     });
 
     describe('Timer Management', () => {
-        it('should use faster refresh rate when trade is in progress', () => {
+        it('should use faster refresh rate when trade is in progress', async () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
             const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            renderUseWatchTrade(store, {
+            await renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
                 isInProgress: true,
@@ -211,13 +211,13 @@ describe('useWatchTrade', () => {
             });
         });
 
-        it('should use slower refresh rate when trade is not in progress', () => {
+        it('should use slower refresh rate when trade is not in progress', async () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
             const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            renderUseWatchTrade(store, {
+            await renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
                 isInProgress: false,
@@ -229,13 +229,13 @@ describe('useWatchTrade', () => {
             });
         });
 
-        it('should disable timer when trade is in final status', () => {
+        it('should disable timer when trade is in final status', async () => {
             const buyTrade = getBuyTrade({ status: 'SUCCESS' });
             const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            renderUseWatchTrade(store, {
+            await renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useDelayedReviewOutputListDisplayFlag.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useDelayedReviewOutputListDisplayFlag.test.ts
@@ -10,21 +10,21 @@ jest.mock('@suite-common/device', () => ({
 }));
 
 describe('useDelayedReviewOutputListDisplayFlag', () => {
-    const renderUseRequestDelayedNavigationToOutputsReview = () =>
-        renderHookWithStoreProvider(() => useDelayedReviewOutputListDisplayFlag());
+    const renderUseRequestDelayedNavigationToOutputsReview = async () =>
+        await renderHookWithStoreProvider(() => useDelayedReviewOutputListDisplayFlag());
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should became once there are any button requests', () => {
-        const { result, rerender } = renderUseRequestDelayedNavigationToOutputsReview();
+    it('should became once there are any button requests', async () => {
+        const { result, rerender } = await renderUseRequestDelayedNavigationToOutputsReview();
 
         expect(result.current).toBe(false);
 
         // we are using mocked selector, so we need to rerender the hook to get updated value
         mockSelectDeviceButtonRequestsCodes.mockReturnValue(['buttonRequestMock1']);
-        rerender({});
+        await rerender({});
 
         expect(result.current).toBe(true);
     });

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.test.tsx
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingContentBuilder.test.tsx
@@ -50,25 +50,25 @@ describe('useTradingContentBuilder', () => {
         return <>{contentBuilder({ ...baseProps, ...props })}</>;
     };
 
-    const renderContentBuilder = (props: Partial<ReviewOutputItemContentDataProps> = {}) =>
-        renderWithTradingProvider(<ContentBuilderWrapper props={props} />, {
+    const renderContentBuilder = async (props: Partial<ReviewOutputItemContentDataProps> = {}) =>
+        await renderWithTradingProvider(<ContentBuilderWrapper props={props} />, {
             tradeType: 'exchange',
         });
 
-    it('returns undefined for non-traded_assets output type', () => {
-        const { toJSON } = renderContentBuilder({ outputType: 'note' });
+    it('returns undefined for non-traded_assets output type', async () => {
+        const { toJSON } = await renderContentBuilder({ outputType: 'note' });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('returns undefined when send is missing', () => {
-        const { toJSON } = renderContentBuilder({ send: undefined });
+    it('returns undefined when send is missing', async () => {
+        const { toJSON } = await renderContentBuilder({ send: undefined });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('renders the send leg only for a partial swap (receive missing)', () => {
-        const { getByText, queryByText } = renderContentBuilder({ receive: undefined });
+    it('renders the send leg only for a partial swap (receive missing)', async () => {
+        const { getByText, queryByText } = await renderContentBuilder({ receive: undefined });
 
         expect(getByText('-1.22 BTC')).toBeOnTheScreen();
         expect(queryByText('+0.45796014 ETH')).toBeNull();
@@ -79,27 +79,27 @@ describe('useTradingContentBuilder', () => {
         ).toBeNull();
     });
 
-    it('returns undefined when receive is fiat (no cryptoId)', () => {
-        const { toJSON } = renderContentBuilder({ receive: mockReceiveFiat });
+    it('returns undefined when receive is fiat (no cryptoId)', async () => {
+        const { toJSON } = await renderContentBuilder({ receive: mockReceiveFiat });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('renders send amount with minus prefix', () => {
-        const { getByText } = renderContentBuilder();
+    it('renders send amount with minus prefix', async () => {
+        const { getByText } = await renderContentBuilder();
 
         expect(getByText('-1.22 BTC')).toBeOnTheScreen();
     });
 
-    it('renders receive amount adjusted by slippage with plus prefix', () => {
-        const { getByText } = renderContentBuilder();
+    it('renders receive amount adjusted by slippage with plus prefix', async () => {
+        const { getByText } = await renderContentBuilder();
 
         expect(getByText('+0.45796014 ETH')).toBeOnTheScreen();
     });
 
     describe('recipient row', () => {
-        it('renders recipient label and address when receive account is found', () => {
-            const { getByText } = renderContentBuilder({});
+        it('renders recipient label and address when receive account is found', async () => {
+            const { getByText } = await renderContentBuilder({});
 
             expect(
                 getByText(
@@ -109,8 +109,8 @@ describe('useTradingContentBuilder', () => {
             expect(getByText(btc1NormalAccount.descriptor)).toBeOnTheScreen();
         });
 
-        it('does not render recipient row when receive account is not found', () => {
-            const { queryByText } = renderContentBuilder({
+        it('does not render recipient row when receive account is not found', async () => {
+            const { queryByText } = await renderContentBuilder({
                 receive: {
                     ...mockReceiveCrypto,
                     accountKey: 'non-existent-account-key' as AccountKey,

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewErrorAlert.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewErrorAlert.test.ts
@@ -20,8 +20,8 @@ jest.mock('@suite-native/alerts', () => ({
 describe('useTradingOutputsReviewErrorAlert', () => {
     let store: TestStore;
 
-    const renderUseTradingOutputsReviewErrorAlert = (accountKey: AccountKey) =>
-        renderHookWithTradingProvider(() => useTradingOutputsReviewErrorAlert(accountKey), {
+    const renderUseTradingOutputsReviewErrorAlert = async (accountKey: AccountKey) =>
+        await renderHookWithTradingProvider(() => useTradingOutputsReviewErrorAlert(accountKey), {
             store,
         });
 
@@ -30,14 +30,14 @@ describe('useTradingOutputsReviewErrorAlert', () => {
         store = createTradingLightStore({ tradeType: 'exchange' });
     });
 
-    it('should show alert', () => {
+    it('should show alert', async () => {
         const mockOnRetry = jest.fn();
         const mockOnCancel = jest.fn();
-        const { result } = renderUseTradingOutputsReviewErrorAlert(
+        const { result } = await renderUseTradingOutputsReviewErrorAlert(
             mockAccountKey({ symbol: 'btc', descriptor: 'btc1normal' }),
         );
 
-        act(() => {
+        await act(() => {
             result.current(mockOnRetry, mockOnCancel);
         });
 
@@ -55,17 +55,17 @@ describe('useTradingOutputsReviewErrorAlert', () => {
         });
     });
 
-    it('should show special text fort solana', () => {
+    it('should show special text fort solana', async () => {
         const mockOnRetry = jest.fn();
         const mockOnCancel = jest.fn();
-        const { result } = renderUseTradingOutputsReviewErrorAlert(
+        const { result } = await renderUseTradingOutputsReviewErrorAlert(
             mockAccountKey({
                 symbol: 'sol',
                 descriptor: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
             }),
         );
 
-        act(() => {
+        await act(() => {
             result.current(mockOnRetry, mockOnCancel);
         });
 

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.test.ts
@@ -81,8 +81,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
         });
     };
 
-    const renderUseTradingOutputsReviewScreenControls = () =>
-        renderHookWithStoreProvider(
+    const renderUseTradingOutputsReviewScreenControls = async () =>
+        await renderHookWithStoreProvider(
             () =>
                 useTradingOutputsReviewScreenControls({
                     orderId: 'orderId',
@@ -100,8 +100,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
         store = createTestStore();
     });
 
-    it('should return confirmOnTrezorRef', () => {
-        const { result } = renderUseTradingOutputsReviewScreenControls();
+    it('should return confirmOnTrezorRef', async () => {
+        const { result } = await renderUseTradingOutputsReviewScreenControls();
 
         expect(result.current.confirmOnTrezorRef).toBe(
             mockUseConfirmOnTrezorController.confirmOnTrezorRef,
@@ -109,20 +109,20 @@ describe('useTradingOutputsReviewScreenControls', () => {
     });
 
     describe('without signed transaction', () => {
-        it('should call signAndSendTransaction on mount', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should call signAndSendTransaction on mount', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(1);
         });
 
-        it('should not call closeSheet', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should not call closeSheet', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockUseConfirmOnTrezorController.closeSheet).not.toHaveBeenCalled();
         });
 
-        it('should navigate to trade detail', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should navigate to trade detail', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -131,7 +131,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             );
 
             // call the nextStep callback to simulate thunk behavior
-            act(() => {
+            await act(() => {
                 const { nextStep } = (
                     mockSignAndSendTransaction.mock.lastCall as unknown as [
                         TradingExchangeSignAndSendTransactionProps,
@@ -144,9 +144,9 @@ describe('useTradingOutputsReviewScreenControls', () => {
             expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'continue');
         });
 
-        it('should navigate to trade detail and report sell analytics', () => {
+        it('should navigate to trade detail and report sell analytics', async () => {
             store = createTestStore('sell');
-            renderUseTradingOutputsReviewScreenControls();
+            await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -155,7 +155,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             );
 
             // call the nextStep callback to simulate thunk behavior
-            act(() => {
+            await act(() => {
                 const { nextStep } = (
                     mockSignAndSendTransaction.mock.lastCall as unknown as [
                         TradingExchangeSignAndSendTransactionProps,
@@ -168,8 +168,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
             expect(mockReportToAnalytics).toHaveBeenLastCalledWith('sign-and-send', 'continue');
         });
 
-        it('should display alert on thunk error', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should display alert on thunk error', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -178,7 +178,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             );
 
             // call the onError callback to simulate thunk behavior
-            act(() => {
+            await act(() => {
                 const { onError } = (
                     mockSignAndSendTransaction.mock.lastCall as unknown as [
                         TradingExchangeSignAndSendTransactionProps,
@@ -197,8 +197,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
             );
         });
 
-        it('should retry signing without leaving the outputs review', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should retry signing without leaving the outputs review', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -207,7 +207,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             );
 
             // call the onError callback to simulate thunk behavior
-            act(() => {
+            await act(() => {
                 const { onError } = (
                     mockSignAndSendTransaction.mock.lastCall as unknown as [
                         TradingExchangeSignAndSendTransactionProps,
@@ -221,7 +221,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
                 });
             });
 
-            act(() => {
+            await act(() => {
                 mockShowAlert.mock.calls[0][0].onPressPrimaryButton();
             });
 
@@ -229,10 +229,10 @@ describe('useTradingOutputsReviewScreenControls', () => {
             expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'retry');
         });
 
-        it('should leave the flow when error alert is canceled', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should leave the flow when error alert is canceled', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
-            act(() => {
+            await act(() => {
                 const { onError } = (
                     mockSignAndSendTransaction.mock.lastCall as unknown as [
                         TradingExchangeSignAndSendTransactionProps,
@@ -246,7 +246,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
                 });
             });
 
-            act(() => {
+            await act(() => {
                 mockShowAlert.mock.calls[0][0].onPressSecondaryButton();
             });
             expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'cancel');
@@ -256,8 +256,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
     });
 
     describe('with signed transaction', () => {
-        beforeEach(() => {
-            act(() => {
+        beforeEach(async () => {
+            await act(() => {
                 store.dispatch(
                     sendFormActions.storeSignedTransaction({
                         serializedTx: {
@@ -269,24 +269,24 @@ describe('useTradingOutputsReviewScreenControls', () => {
             });
         });
 
-        it('should not call signAndSendTransaction', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should not call signAndSendTransaction', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).not.toHaveBeenCalled();
         });
 
-        it('should closeSheet', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should closeSheet', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockUseConfirmOnTrezorController.closeSheet).toHaveBeenCalledTimes(1);
         });
     });
 
     describe('useOutputsReviewBackInterceptor', () => {
-        it('should be initialized with popToTop navigation callback and report cancel for exchange', () => {
-            renderUseTradingOutputsReviewScreenControls();
+        it('should be initialized with popToTop navigation callback and report cancel for exchange', async () => {
+            await renderUseTradingOutputsReviewScreenControls();
 
-            act(() => {
+            await act(() => {
                 const onReviewCanceled = mockUseOutputsReviewBackInterceptor.mock.lastCall?.[0];
                 onReviewCanceled();
             });
@@ -295,11 +295,11 @@ describe('useTradingOutputsReviewScreenControls', () => {
             expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'cancel');
         });
 
-        it('should report cancel for sell', () => {
+        it('should report cancel for sell', async () => {
             store = createTestStore('sell');
-            renderUseTradingOutputsReviewScreenControls();
+            await renderUseTradingOutputsReviewScreenControls();
 
-            act(() => {
+            await act(() => {
                 const onReviewCanceled = mockUseOutputsReviewBackInterceptor.mock.lastCall?.[0];
                 onReviewCanceled();
             });
@@ -309,8 +309,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
         });
     });
 
-    it('should report visit to analytics on mount for exchange', () => {
-        renderUseTradingOutputsReviewScreenControls();
+    it('should report visit to analytics on mount for exchange', async () => {
+        await renderUseTradingOutputsReviewScreenControls();
 
         expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'visit');
     });

--- a/suite-native/module-trading/src/hooks/sell/useComposeSellTransactionWhenRequired.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useComposeSellTransactionWhenRequired.test.ts
@@ -10,13 +10,13 @@ type TestProps = {
 };
 
 describe('useComposeSellTransactionWhenRequired', () => {
-    it('composes once for each order that reaches SEND_CRYPTO', () => {
+    it('composes once for each order that reaches SEND_CRYPTO', async () => {
         const composeTradingTransaction = jest.fn();
         const initialProps: TestProps = {
             orderId: 'order-1',
             status: 'PENDING',
         };
-        const { rerender } = renderHookWithBasicProvider(
+        const { rerender } = await renderHookWithBasicProvider(
             ({ orderId, status }: TestProps) =>
                 useComposeSellTransactionWhenRequired({
                     orderId,
@@ -28,12 +28,12 @@ describe('useComposeSellTransactionWhenRequired', () => {
 
         expect(composeTradingTransaction).not.toHaveBeenCalled();
 
-        rerender({ orderId: 'order-1', status: 'SEND_CRYPTO' });
-        rerender({ orderId: 'order-1', status: 'SEND_CRYPTO' });
+        await rerender({ orderId: 'order-1', status: 'SEND_CRYPTO' });
+        await rerender({ orderId: 'order-1', status: 'SEND_CRYPTO' });
 
         expect(composeTradingTransaction).toHaveBeenCalledTimes(1);
 
-        rerender({ orderId: 'order-2', status: 'SEND_CRYPTO' });
+        await rerender({ orderId: 'order-2', status: 'SEND_CRYPTO' });
 
         expect(composeTradingTransaction).toHaveBeenCalledTimes(2);
     });

--- a/suite-native/module-trading/src/hooks/sell/useSellBankAccountVerificationOnMount.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellBankAccountVerificationOnMount.test.ts
@@ -3,9 +3,9 @@ import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { useSellBankAccountVerificationOnMount } from './useSellBankAccountVerificationOnMount';
 
 describe('useSellBankAccountVerificationOnMount', () => {
-    it('checks bank account verification only on mount', () => {
+    it('checks bank account verification only on mount', async () => {
         const doBankAccountVerificationCheck = jest.fn();
-        const { rerender } = renderHookWithBasicProvider(
+        const { rerender } = await renderHookWithBasicProvider(
             () =>
                 useSellBankAccountVerificationOnMount({
                     doBankAccountVerificationCheck,
@@ -13,7 +13,7 @@ describe('useSellBankAccountVerificationOnMount', () => {
             { initialProps: {} },
         );
 
-        rerender({});
+        await rerender({});
 
         expect(doBankAccountVerificationCheck).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-trading/src/hooks/sell/useSellData.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/useSellData.test.tsx
@@ -41,7 +41,7 @@ describe('useSellData', () => {
         reloadRequestOrdinalInitialValue: number = 0,
         store?: TestStore,
     ) => {
-        const ret = renderHookWithStoreProvider(
+        const ret = await renderHookWithStoreProvider(
             ({ reloadRequestOrdinal }) => useSellData(reloadRequestOrdinal),
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
@@ -95,7 +95,7 @@ describe('useSellData', () => {
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
         const { rerender } = await renderUseSellData();
-        rerender({ reloadRequestOrdinal: 0 });
+        await rerender({ reloadRequestOrdinal: 0 });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
     });
@@ -106,7 +106,7 @@ describe('useSellData', () => {
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
         const { rerender } = await renderUseSellData();
-        rerender({ reloadRequestOrdinal: 1 });
+        await rerender({ reloadRequestOrdinal: 1 });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(2);
     });
@@ -127,7 +127,7 @@ describe('useSellData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc2Account.key));
             });
 
@@ -149,7 +149,7 @@ describe('useSellData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc2Account.key));
             });
 
@@ -168,7 +168,7 @@ describe('useSellData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc3Account.key));
             });
 
@@ -191,7 +191,7 @@ describe('useSellData', () => {
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(undefined));
             });
 

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.test.ts
@@ -69,7 +69,8 @@ const btc1AccountKey = btc1Account.key;
 describe('useSellFlow', () => {
     let store: TestStore;
 
-    const renderUseSellFlow = () => renderHookWithStoreProvider(() => useSellFlow(), { store });
+    const renderUseSellFlow = async () =>
+        await renderHookWithStoreProvider(() => useSellFlow(), { store });
 
     beforeEach(() => {
         store = createTradingLightStore({ tradeType: 'sell' });
@@ -86,12 +87,12 @@ describe('useSellFlow', () => {
             const trade = banxaCreditCardSellQuote;
 
             // Set up required state
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doSellTrade(trade);
@@ -116,13 +117,13 @@ describe('useSellFlow', () => {
             const trade = banxaCreditCardSellQuote;
 
             // Set up quote but not account
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
                 // Explicitly clear trading account key
                 store.dispatch(tradingSellActions.setTradingAccountKey(undefined));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doSellTrade(trade);
@@ -141,12 +142,12 @@ describe('useSellFlow', () => {
             const trade = banxaCreditCardSellQuote;
 
             // Set up account but not selectedQuote
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doSellTrade(trade);
@@ -169,12 +170,12 @@ describe('useSellFlow', () => {
             const bankAccount = verifiedBankAccount;
 
             // Set up required state
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.confirmTrade(bankAccount);
@@ -200,12 +201,12 @@ describe('useSellFlow', () => {
             const bankAccount = verifiedBankAccount;
 
             // Set up account but not quote
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.confirmTrade(bankAccount);
@@ -224,12 +225,12 @@ describe('useSellFlow', () => {
             const bankAccount = verifiedBankAccount;
 
             // Set up quote but not account
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
                 store.dispatch(tradingSellActions.setTradingAccountKey(undefined));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.confirmTrade(bankAccount);
@@ -252,12 +253,12 @@ describe('useSellFlow', () => {
                 quoteId: undefined,
             };
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doBankAccountVerificationCheck();
@@ -275,12 +276,12 @@ describe('useSellFlow', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const trade = { ...banxaCreditCardSellQuote, quoteId: '' };
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doBankAccountVerificationCheck();
@@ -299,12 +300,12 @@ describe('useSellFlow', () => {
             // Use a trade with a quoteId to avoid triggering doSellTrade
             const trade = { ...banxaCreditCardSellQuote, quoteId: 'test-quote-id' };
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doBankAccountVerificationCheck();
@@ -320,12 +321,12 @@ describe('useSellFlow', () => {
         it('should not call doSellTrade if selectedQuote is missing', async () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doBankAccountVerificationCheck();
@@ -343,12 +344,12 @@ describe('useSellFlow', () => {
         it('should navigate to browser when processResponseData is called with form data', async () => {
             const trade = banxaCreditCardSellQuote;
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1AccountKey));
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = renderUseSellFlow();
+            const { result } = await renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doSellTrade(trade);
@@ -370,7 +371,7 @@ describe('useSellFlow', () => {
 
             // Call processResponseData - capturedHandleTradeArgs is set during mock
             expect(capturedHandleTradeArgs).toBeTruthy();
-            act(() => {
+            await act(() => {
                 capturedHandleTradeArgs!.processResponseData(mockResponse);
             });
 

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.test.tsx
@@ -32,7 +32,8 @@ const eth1Account = getEthAccount({ descriptor: asAccountDescriptor('eth1normal'
 describe('useSellForm', () => {
     let store: TestStore;
 
-    const renderUseSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
+    const renderUseSellForm = async () =>
+        await renderHookWithStoreProvider(() => useSellForm(), { store });
 
     const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
         createTradingLightStore({
@@ -46,21 +47,21 @@ describe('useSellForm', () => {
         store = getInitializedStore();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
     describe('sendAccount', () => {
-        it('should be undefined by default', () => {
-            const { result } = renderUseSellForm();
+        it('should be undefined by default', async () => {
+            const { result } = await renderUseSellForm();
 
             expect(result.current.getValues('sendAccount')).toBeUndefined();
         });
 
-        it('should update sendAccount value when account in redux store is changed', () => {
-            const { result } = renderUseSellForm();
+        it('should update sendAccount value when account in redux store is changed', async () => {
+            const { result } = await renderUseSellForm();
 
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1Account.key));
             });
 
@@ -75,8 +76,8 @@ describe('useSellForm', () => {
                 ['100', 'Maximum is 50 BTC'],
                 ['1', 'Insufficient funds'],
             ])('should display error for crypto amount %s BTC', async (amount, expectedValue) => {
-                const { result } = renderUseSellForm();
-                act(() => {
+                const { result } = await renderUseSellForm();
+                await act(() => {
                     store.dispatch(tradingSellActions.setTradingAccountKey(btc1Account.key));
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('sendAsset', btcAsset);
@@ -103,8 +104,8 @@ describe('useSellForm', () => {
                 ['10000000', 'Insufficient funds'],
             ])('should display error for crypto amount %s SATS', async (amount, expectedValue) => {
                 store = getInitializedStore(PROTO.AmountUnit.SATOSHI);
-                const { result } = renderUseSellForm();
-                act(() => {
+                const { result } = await renderUseSellForm();
+                await act(() => {
                     store.dispatch(tradingSellActions.setTradingAccountKey(btc1Account.key));
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('sendAsset', btcAsset);
@@ -131,8 +132,8 @@ describe('useSellForm', () => {
             ])(
                 'should use correct balance for USDC and amount %s',
                 async (amount, expectedInvalid) => {
-                    const { result } = renderUseSellForm();
-                    act(() => {
+                    const { result } = await renderUseSellForm();
+                    await act(() => {
                         store.dispatch(tradingSellActions.setTradingAccountKey(eth1Account.key));
                         result.current.setValue('amountInCrypto', true);
                         result.current.setValue('sendAsset', usdcAsset);
@@ -147,8 +148,8 @@ describe('useSellForm', () => {
             );
 
             it("should be validated once the quote is selected and it changes it's value", async () => {
-                const { result } = renderUseSellForm();
-                act(() => {
+                const { result } = await renderUseSellForm();
+                await act(() => {
                     store.dispatch(tradingSellActions.setTradingAccountKey(eth1Account.key));
                     result.current.setValue('amountInCrypto', false);
                     result.current.setValue('sendAsset', usdcAsset);
@@ -180,8 +181,8 @@ describe('useSellForm', () => {
                 ['10', 'Minimum is $1,000.00'],
                 ['3000', 'Maximum is $2,000.00'],
             ])('should display fiat error for amount %s', async (amount, expectedValue) => {
-                const { result } = renderUseSellForm();
-                act(() => {
+                const { result } = await renderUseSellForm();
+                await act(() => {
                     store.dispatch(tradingSellActions.setTradingAccountKey(btc1Account.key));
                     result.current.setValue('amountInCrypto', false);
                     result.current.setValue('sendAsset', btcAsset);
@@ -204,18 +205,18 @@ describe('useSellForm', () => {
         });
 
         it('should trigger validation once limits are loaded', async () => {
-            act(() => {
+            await act(() => {
                 store.dispatch(tradingSellActions.setAmountLimits(undefined));
                 store.dispatch(tradingSellActions.setTradingAccountKey(btc1Account.key));
             });
-            const { result } = renderUseSellForm();
-            act(() => {
+            const { result } = await renderUseSellForm();
+            await act(() => {
                 result.current.setValue('sendAsset', btcAsset);
                 result.current.setValue('amountInCrypto', true);
                 result.current.setValue('cryptoStringAmount', '10');
             });
 
-            act(() => {
+            await act(() => {
                 store.dispatch(
                     tradingSellActions.setAmountLimits({ maxCrypto: '5', currency: 'BTC' }),
                 );
@@ -228,10 +229,10 @@ describe('useSellForm', () => {
         });
 
         describe('generalAlert', () => {
-            it('should be undefined by default', () => {
-                const { result } = renderUseSellForm();
+            it('should be undefined by default', async () => {
+                const { result } = await renderUseSellForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes([] as SellFiatTrade[]));
                     store.dispatch(tradingSellActions.setAmountLimits(undefined));
                 });
@@ -239,10 +240,10 @@ describe('useSellForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be set when empty quotes are fetched and no limits are set', () => {
-                const { result } = renderUseSellForm();
+            it('should be set when empty quotes are fetched and no limits are set', async () => {
+                const { result } = await renderUseSellForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingSellActions.saveQuoteRequest({
                             cryptoCurrency: btcAsset.cryptoId,
@@ -259,10 +260,10 @@ describe('useSellForm', () => {
                 );
             });
 
-            it('should be undefined when empty quotes are fetched and limits are set', () => {
-                const { result } = renderUseSellForm();
+            it('should be undefined when empty quotes are fetched and limits are set', async () => {
+                const { result } = await renderUseSellForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingSellActions.saveQuoteRequest({
                             cryptoCurrency: btcAsset.cryptoId,
@@ -282,10 +283,10 @@ describe('useSellForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be undefined once quotes are fetched', () => {
-                const { result } = renderUseSellForm();
+            it('should be undefined once quotes are fetched', async () => {
+                const { result } = await renderUseSellForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingSellActions.saveQuoteRequest({
                             cryptoCurrency: btcAsset.cryptoId,
@@ -300,10 +301,10 @@ describe('useSellForm', () => {
                 expect(result.current.getValues('generalAlert')).toBeUndefined();
             });
 
-            it('should be cleared once quotes are fetched', () => {
-                const { result } = renderUseSellForm();
+            it('should be cleared once quotes are fetched', async () => {
+                const { result } = await renderUseSellForm();
 
-                act(() => {
+                await act(() => {
                     store.dispatch(
                         tradingSellActions.saveQuoteRequest({
                             cryptoCurrency: btcAsset.cryptoId,
@@ -315,7 +316,7 @@ describe('useSellForm', () => {
                     store.dispatch(tradingSellActions.setAmountLimits(undefined));
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
                 });
 
@@ -325,14 +326,14 @@ describe('useSellForm', () => {
     });
 
     describe('on quotes change', () => {
-        const initFormAndQuoteRequest = (form: SellFormType) => {
-            act(() => {
+        const initFormAndQuoteRequest = async (form: SellFormType) => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('sendAccount', btc1Account);
                 form.setValue('amountInCrypto', false);
                 form.setValue('fiatStringAmount', '10');
             });
-            act(() => {
+            await act(() => {
                 store.dispatch(
                     tradingSellActions.saveQuoteRequest({
                         cryptoCurrency: btcAsset.cryptoId,
@@ -343,22 +344,22 @@ describe('useSellForm', () => {
             });
         };
 
-        it('if no quote is selected should select best rated quote with bankTransfer payment method', () => {
-            const { result } = renderUseSellForm();
+        it('if no quote is selected should select best rated quote with bankTransfer payment method', async () => {
+            const { result } = await renderUseSellForm();
 
-            initFormAndQuoteRequest(result.current);
-            act(() => {
+            await initFormAndQuoteRequest(result.current);
+            await act(() => {
                 store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
             });
 
             expect(result.current.getValues('quote')).toEqual(banxaBankTransferSellQuote);
         });
 
-        it('if no quote is selected and no bankTransferQuote is available should select first quote', () => {
-            const { result } = renderUseSellForm();
-            initFormAndQuoteRequest(result.current);
+        it('if no quote is selected and no bankTransferQuote is available should select first quote', async () => {
+            const { result } = await renderUseSellForm();
+            await initFormAndQuoteRequest(result.current);
 
-            act(() => {
+            await act(() => {
                 store.dispatch(
                     tradingSellActions.saveQuotes([
                         banxaCreditCardSellQuote,
@@ -371,112 +372,112 @@ describe('useSellForm', () => {
         });
 
         describe('when quote is selected and new quotes are fetched', () => {
-            it('should set quote to undefined when no quotes are available', () => {
-                const { result } = renderUseSellForm();
-                initFormAndQuoteRequest(result.current);
+            it('should set quote to undefined when no quotes are available', async () => {
+                const { result } = await renderUseSellForm();
+                await initFormAndQuoteRequest(result.current);
 
-                act(() => {
+                await act(() => {
                     result.current.setValue('quote', banxaCreditCardSellQuote);
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes([]));
                 });
 
                 expect(result.current.getValues('quote')).toBeUndefined();
             });
 
-            it('should select quote with same payment method and provider', () => {
-                const { result } = renderUseSellForm();
-                initFormAndQuoteRequest(result.current);
+            it('should select quote with same payment method and provider', async () => {
+                const { result } = await renderUseSellForm();
+                await initFormAndQuoteRequest(result.current);
 
-                act(() => {
+                await act(() => {
                     result.current.setValue('quote', {
                         ...moonpayCreditCardSellQuote,
                         orderId: 'test1',
                     });
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
                 });
 
                 expect(result.current.getValues('quote')).toEqual(moonpayCreditCardSellQuote);
             });
 
-            it('should select quote with same payment method if provider is not available', () => {
-                const { result } = renderUseSellForm();
-                initFormAndQuoteRequest(result.current);
+            it('should select quote with same payment method if provider is not available', async () => {
+                const { result } = await renderUseSellForm();
+                await initFormAndQuoteRequest(result.current);
 
-                act(() => {
+                await act(() => {
                     result.current.setValue('quote', {
                         ...moonpayCreditCardSellQuote,
                         orderId: 'test1',
                     });
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes(sellQuotes.slice(0, 2)));
                 });
 
                 expect(result.current.getValues('quote')).toEqual(banxaCreditCardSellQuote);
             });
 
-            it('should select best rated quote if neither same payment method nor provider are available', () => {
-                const { result } = renderUseSellForm();
-                initFormAndQuoteRequest(result.current);
+            it('should select best rated quote if neither same payment method nor provider are available', async () => {
+                const { result } = await renderUseSellForm();
+                await initFormAndQuoteRequest(result.current);
 
-                act(() => {
+                await act(() => {
                     result.current.setValue('quote', {
                         ...moonpayCreditCardSellQuote,
                         orderId: 'test1',
                     });
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes([banxaBankTransferSellQuote]));
                 });
 
                 expect(result.current.getValues('quote')).toEqual(banxaBankTransferSellQuote);
             });
 
-            it('should update cryptoValue when selected quote is changed and truncate it to 9 decimals', () => {
-                const { result } = renderUseSellForm();
-                initFormAndQuoteRequest(result.current);
-                act(() => {
+            it('should update cryptoValue when selected quote is changed and truncate it to 9 decimals', async () => {
+                const { result } = await renderUseSellForm();
+                await initFormAndQuoteRequest(result.current);
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
                 });
 
-                act(() => {
+                await act(() => {
                     result.current.setValue('quote', banxaBankTransferSellQuote);
                 });
 
                 expect(result.current.getValues('cryptoStringAmount')).toBe('0.025396001');
             });
-            it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount and truncate it to 3 decimals', () => {
-                const { result } = renderUseSellForm();
-                initFormAndQuoteRequest(result.current);
-                act(() => {
+            it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount and truncate it to 3 decimals', async () => {
+                const { result } = await renderUseSellForm();
+                await initFormAndQuoteRequest(result.current);
+                await act(() => {
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('cryptoStringAmount', '0.1');
                     store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
                 });
 
-                act(() => {
+                await act(() => {
                     result.current.setValue('quote', moonpayCreditCardSellQuote);
                 });
 
                 expect(result.current.getValues('fiatStringAmount')).toBe('100.062');
             });
 
-            it('should clear cryptoValue when no quotes are available and user inserted fiatValue', () => {
-                const { result } = renderUseSellForm();
-                initFormAndQuoteRequest(result.current);
-                act(() => {
+            it('should clear cryptoValue when no quotes are available and user inserted fiatValue', async () => {
+                const { result } = await renderUseSellForm();
+                await initFormAndQuoteRequest(result.current);
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes([]));
                 });
 
@@ -484,16 +485,16 @@ describe('useSellForm', () => {
                 expect(result.current.getValues('fiatStringAmount')).toBe('10');
             });
 
-            it('should clear fiatValue when no quotes are available and user inserted cryptoValue', () => {
-                const { result } = renderUseSellForm();
-                initFormAndQuoteRequest(result.current);
-                act(() => {
+            it('should clear fiatValue when no quotes are available and user inserted cryptoValue', async () => {
+                const { result } = await renderUseSellForm();
+                await initFormAndQuoteRequest(result.current);
+                await act(() => {
                     result.current.setValue('amountInCrypto', true);
                     result.current.setValue('cryptoStringAmount', '0.1');
                     store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
                 });
 
-                act(() => {
+                await act(() => {
                     store.dispatch(tradingSellActions.saveQuotes([]));
                 });
 
@@ -504,10 +505,10 @@ describe('useSellForm', () => {
     });
 
     describe('on country change', () => {
-        it('should set country to redux on change', () => {
-            const { result } = renderUseSellForm();
+        it('should set country to redux on change', async () => {
+            const { result } = await renderUseSellForm();
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('country', {
                     value: 'CA',
                     label: '🇨🇦 Canada',

--- a/suite-native/module-trading/src/hooks/sell/useSellInputFormControls.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/useSellInputFormControls.test.tsx
@@ -9,31 +9,31 @@ import { renderHookWithTradingProvider } from '../../test-utils/tradingTestUtils
 describe('useSellInputFormControls', () => {
     let form: SellFormType;
 
-    const renderSellFormHook = () =>
-        renderHookWithTradingProvider(() => useSellForm(), { tradeType: 'sell' });
+    const renderSellFormHook = async () =>
+        await renderHookWithTradingProvider(() => useSellForm(), { tradeType: 'sell' });
 
-    const renderUseSellInputFormControls = (
+    const renderUseSellInputFormControls = async (
         name: 'fiatStringAmount' | 'cryptoStringAmount' = 'fiatStringAmount',
     ) =>
-        renderHookWithBasicProvider(() => useSellInputFormControls(name), {
+        await renderHookWithBasicProvider(() => useSellInputFormControls(name), {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(() => {
-        const { result } = renderSellFormHook();
+    beforeEach(async () => {
+        const { result } = await renderSellFormHook();
         form = result.current;
     });
 
-    it('should use value from given form field', () => {
+    it('should use value from given form field', async () => {
         form.setValue('fiatStringAmount', '123');
 
-        const { result } = renderUseSellInputFormControls();
+        const { result } = await renderUseSellInputFormControls();
 
         expect(result.current.value).toEqual('123');
     });
 
-    it('should return correct structure', () => {
-        const { result } = renderUseSellInputFormControls();
+    it('should return correct structure', async () => {
+        const { result } = await renderUseSellInputFormControls();
 
         expect(result.current).toEqual(
             expect.objectContaining({
@@ -45,33 +45,33 @@ describe('useSellInputFormControls', () => {
         );
     });
 
-    it('should keep onChangeText stable when the value changes', () => {
-        const { result } = renderUseSellInputFormControls();
+    it('should keep onChangeText stable when the value changes', async () => {
+        const { result } = await renderUseSellInputFormControls();
         const initialOnChangeText = result.current.onChangeText;
 
-        act(() => form.setValue('fiatStringAmount', '123'));
+        await act(() => form.setValue('fiatStringAmount', '123'));
 
         expect(result.current.onChangeText).toBe(initialOnChangeText);
     });
 
-    it('should switch to fiat amount and clear crypto amount on fiat input change', () => {
+    it('should switch to fiat amount and clear crypto amount on fiat input change', async () => {
         form.setValue('amountInCrypto', true);
         form.setValue('cryptoStringAmount', '0.1');
-        const { result } = renderUseSellInputFormControls('fiatStringAmount');
+        const { result } = await renderUseSellInputFormControls('fiatStringAmount');
 
-        act(() => result.current.onChangeText('100'));
+        await act(() => result.current.onChangeText('100'));
 
         expect(form.getValues('fiatStringAmount')).toBe('100');
         expect(form.getValues('cryptoStringAmount')).toBeUndefined();
         expect(form.getValues('amountInCrypto')).toBe(false);
     });
 
-    it('should switch to crypto amount and clear fiat amount on crypto input change', () => {
+    it('should switch to crypto amount and clear fiat amount on crypto input change', async () => {
         form.setValue('amountInCrypto', false);
         form.setValue('fiatStringAmount', '100');
-        const { result } = renderUseSellInputFormControls('cryptoStringAmount');
+        const { result } = await renderUseSellInputFormControls('cryptoStringAmount');
 
-        act(() => result.current.onChangeText('0.1'));
+        await act(() => result.current.onChangeText('0.1'));
 
         expect(form.getValues('cryptoStringAmount')).toBe('0.1');
         expect(form.getValues('fiatStringAmount')).toBeUndefined();

--- a/suite-native/module-trading/src/hooks/sell/useSellPreviewFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellPreviewFlow.test.ts
@@ -23,7 +23,7 @@ describe('useSellPreviewFlow', () => {
         jest.clearAllMocks();
     });
 
-    it('reports preview continue and replaces the route', () => {
+    it('reports preview continue and replaces the route', async () => {
         const store = createTradingLightStore({
             tradeType: 'sell',
             overrides: {
@@ -37,12 +37,12 @@ describe('useSellPreviewFlow', () => {
                 },
             },
         });
-        const { result } = renderHookWithStoreProvider(() => useSellPreviewFlow(), {
+        const { result } = await renderHookWithStoreProvider(() => useSellPreviewFlow(), {
             store,
             services,
         });
 
-        act(() => result.current.continueToProvider());
+        await act(() => result.current.continueToProvider());
 
         expect(mockReplace).toHaveBeenCalledWith('TradingSellCompletion');
         expect(mockReport).toHaveBeenCalledWith({

--- a/suite-native/module-trading/src/hooks/sell/useSellQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellQuotes.test.ts
@@ -54,8 +54,8 @@ describe('useSellQuotes', () => {
             },
         });
 
-    const renderUseSellQuotes = (store: TestStore) =>
-        renderHookWithStoreProvider(
+    const renderUseSellQuotes = async (store: TestStore) =>
+        await renderHookWithStoreProvider(
             () => {
                 const form = useSellForm();
                 useSellQuotes(form);
@@ -72,9 +72,9 @@ describe('useSellQuotes', () => {
     it('should query quotes once all required data is selected', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseSellQuotes(store);
+        const { result } = await renderUseSellQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('amountInCrypto', true);
@@ -97,9 +97,9 @@ describe('useSellQuotes', () => {
         async amount => {
             const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseSellQuotes(store);
+            const { result } = await renderUseSellQuotes(store);
 
-            act(() => {
+            await act(() => {
                 result.current.setValue('sendAsset', bnbAsset);
                 result.current.setValue('fiatCurrency', 'usd');
             });
@@ -120,9 +120,9 @@ describe('useSellQuotes', () => {
     it('should accept amount in fiat when requested', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseSellQuotes(store);
+        const { result } = await renderUseSellQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('amountInCrypto', false);
@@ -140,13 +140,13 @@ describe('useSellQuotes', () => {
         );
     });
 
-    it('should clear sell state on unmount', () => {
+    it('should clear sell state on unmount', async () => {
         const store = getInitializedStore();
         store.dispatch(tradingSellActions.saveQuotes(sellQuotes));
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { unmount } = renderUseSellQuotes(store);
+        const { unmount } = await renderUseSellQuotes(store);
 
-        unmount();
+        await unmount();
 
         expect(dispatchSpy).toHaveBeenCalledWith({
             payload: undefined,
@@ -163,8 +163,8 @@ describe('useSellQuotes', () => {
         async (field, value) => {
             const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = renderUseSellQuotes(store);
-            act(() => {
+            const { result } = await renderUseSellQuotes(store);
+            await act(() => {
                 result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('fiatCurrency', 'usd');
             });
@@ -175,7 +175,7 @@ describe('useSellQuotes', () => {
             });
 
             dispatchSpy.mockClear();
-            act(() => {
+            await act(() => {
                 result.current.setValue(field, value);
             });
 
@@ -191,8 +191,8 @@ describe('useSellQuotes', () => {
         jest.useFakeTimers();
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseSellQuotes(store);
-        act(() => {
+        const { result } = await renderUseSellQuotes(store);
+        await act(() => {
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
         });
@@ -203,12 +203,12 @@ describe('useSellQuotes', () => {
             await Promise.resolve();
         });
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
         });
         dispatchSpy.mockClear();
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(TRADE_API_RELOAD_QUOTES_AFTER_SECONDS * 1000);
         });
 
@@ -220,22 +220,22 @@ describe('useSellQuotes', () => {
         );
     });
 
-    it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', () => {
+    it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', async () => {
         jest.useFakeTimers();
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result, unmount } = renderUseSellQuotes(store);
+        const { result, unmount } = await renderUseSellQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('fiatCurrency', 'usd');
         });
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
         });
         dispatchSpy.mockClear();
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(TRADE_API_RELOAD_QUOTES_AFTER_SECONDS * 1000);
         });
 
@@ -243,15 +243,15 @@ describe('useSellQuotes', () => {
             expect.objectContaining({ type: 'handleRequestThunkMock' }),
         );
 
-        unmount();
+        await unmount();
     });
 
     it('should clear quotes when data in form becomes invalid', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result, unmount } = renderUseSellQuotes(store);
+        const { result, unmount } = await renderUseSellQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('fiatStringAmount', '100');
@@ -265,7 +265,7 @@ describe('useSellQuotes', () => {
 
         dispatchSpy.mockClear();
         // clear some value to make form invalid
-        act(() => {
+        await act(() => {
             result.current.setValue('fiatStringAmount', undefined);
         });
 
@@ -276,7 +276,7 @@ describe('useSellQuotes', () => {
         expect(store.getState().wallet.trading.sell.quotes).toEqual([]);
 
         // unmount hook to avoid unintentional rerenders
-        unmount();
+        await unmount();
     });
 
     it('should not clear quotes when error is from quote', async () => {
@@ -286,9 +286,9 @@ describe('useSellQuotes', () => {
         };
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseSellQuotes(store);
+        const { result } = await renderUseSellQuotes(store);
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingSellActions.setTradingAccountKey(eth1Account.key));
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
@@ -316,9 +316,9 @@ describe('useSellQuotes', () => {
     it('should not clear quotes when fiat quote exceeds max spendable amount', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseSellQuotes(store);
+        const { result } = await renderUseSellQuotes(store);
 
-        act(() => {
+        await act(() => {
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
             result.current.setValue('amountInCrypto', false);
@@ -350,7 +350,7 @@ describe('useSellQuotes', () => {
     it('should not query quotes when form contains error', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseSellQuotes(store);
+        const { result } = await renderUseSellQuotes(store);
 
         await act(async () => {
             result.current.setValue('sendAsset', usdcAsset);

--- a/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.test.ts
@@ -1,8 +1,12 @@
 import { tradingSellActions } from '@suite-common/trading';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import {
+    type TestStore,
+    act,
+    renderHookWithStoreProvider,
+    waitFor,
+} from '@suite-native/test-utils-store';
 import { banxaCreditCardSellQuote } from '@suite-native/trading-fixtures';
-import { type SellFormType } from '@suite-native/trading-types';
 
 import { useSellForm } from './useSellForm';
 import { useSellSelectQuote } from './useSellSelectQuote';
@@ -17,68 +21,73 @@ jest.mock('@suite-common/trading', () => ({
 
 describe('useSellSelectQuote', () => {
     let store: TestStore;
-    let sellForm: SellFormType;
 
-    const renderSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
+    const renderUseSellSelectQuote = async () =>
+        await renderHookWithStoreProvider(
+            () => {
+                const form = useSellForm();
 
-    const renderUseSellSelectQuote = () =>
-        renderHookWithStoreProvider(() => useSellSelectQuote(sellForm), { store });
+                return { form, ...useSellSelectQuote(form) };
+            },
+            { store },
+        );
 
     beforeEach(() => {
         store = createTradingLightStore({ tradeType: 'sell' });
-
-        const { result } = renderSellForm();
-        sellForm = result.current;
     });
 
     describe('canProceed', () => {
-        it('should be false when no quote is selected in form', () => {
-            const { result } = renderUseSellSelectQuote();
+        it('should be false when no quote is selected in form', async () => {
+            const { result } = await renderUseSellSelectQuote();
 
             expect(result.current.canProceed).toEqual(false);
         });
 
-        it('should be false when quotes are being fetched', () => {
-            act(() => {
-                sellForm.setValue('quote', banxaCreditCardSellQuote);
+        it('should be false when quotes are being fetched', async () => {
+            const { result } = await renderUseSellSelectQuote();
+
+            await act(() => {
+                result.current.form.setValue('quote', banxaCreditCardSellQuote);
                 store.dispatch(tradingSellActions.setIsLoading(true));
             });
 
-            const { result } = renderUseSellSelectQuote();
-
             expect(result.current.canProceed).toEqual(false);
         });
 
-        it('should be false when form contains error', () => {
-            act(() => {
+        it('should be false when form contains error', async () => {
+            const { result, rerender } = await renderUseSellSelectQuote();
+            const { form } = result.current;
+            form.register('cryptoStringAmount');
+
+            await act(() => {
                 store.dispatch(
                     tradingSellActions.setTradingAccountKey(
                         mockAccountKey({ symbol: 'btc', descriptor: 'btc1normal' }),
                     ),
                 );
-                sellForm.setValue('quote', banxaCreditCardSellQuote);
-                sellForm.setError('cryptoStringAmount', {
-                    type: 'manual',
-                    message: 'VALIDATION_ERROR',
-                });
+                form.setValue('quote', banxaCreditCardSellQuote);
             });
 
-            const { result } = renderUseSellSelectQuote();
+            await act(async () => {
+                form.setValue('cryptoStringAmount', '-1', { shouldValidate: true });
+                await form.trigger('cryptoStringAmount');
+            });
+            await rerender(undefined);
 
-            expect(result.current.canProceed).toEqual(false);
+            await waitFor(() => expect(result.current.canProceed).toEqual(false));
         });
 
-        it('should be true when quote is selected', () => {
-            act(() => {
-                sellForm.setValue('quote', banxaCreditCardSellQuote);
+        it('should be true when quote is selected', async () => {
+            const { result } = await renderUseSellSelectQuote();
+
+            await act(() => {
+                result.current.form.setValue('quote', banxaCreditCardSellQuote);
                 store.dispatch(
                     tradingSellActions.setTradingAccountKey(
                         mockAccountKey({ symbol: 'btc', descriptor: 'btc1normal' }),
                     ),
                 );
             });
-
-            const { result } = renderUseSellSelectQuote();
 
             expect(result.current.canProceed).toEqual(true);
         });

--- a/suite-native/module-trading/src/navigation/TradingStackNavigator.test.tsx
+++ b/suite-native/module-trading/src/navigation/TradingStackNavigator.test.tsx
@@ -15,8 +15,8 @@ jest.mock('../hooks/buy/useBuyData', () => ({
 }));
 
 describe('TradingStackNavigator', () => {
-    it('should render', () => {
-        const { getByTestId } = renderWithTradingProvider(<TradingStackNavigator />, {
+    it('should render', async () => {
+        const { getByTestId } = await renderWithTradingProvider(<TradingStackNavigator />, {
             overrides: {
                 featureFlags: createTradingFeatureFlags({}),
                 messageSystem: mockMessageSystemStateWithFeatureFlags({}),
@@ -26,8 +26,8 @@ describe('TradingStackNavigator', () => {
         expect(getByTestId('@screen/Trading')).toBeTruthy();
     });
 
-    it('should not render when all feature flags are disabled', () => {
-        const { queryByTestId } = renderWithTradingProvider(<TradingStackNavigator />, {
+    it('should not render when all feature flags are disabled', async () => {
+        const { queryByTestId } = await renderWithTradingProvider(<TradingStackNavigator />, {
             overrides: {
                 featureFlags: createTradingFeatureFlags({}),
                 messageSystem: mockMessageSystemStateWithFeatureFlags({

--- a/suite-native/module-trading/src/screens/TradingBuyPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingBuyPreviewScreen.test.tsx
@@ -30,7 +30,7 @@ describe('TradingBuyPreviewScreen', () => {
         jest.clearAllMocks();
     });
 
-    const renderTradingBuyPreviewScreen = ({
+    const renderTradingBuyPreviewScreen = async ({
         providerMetadata,
         selectedQuote,
     }: {
@@ -41,30 +41,30 @@ describe('TradingBuyPreviewScreen', () => {
         tradingState.currentProviderMetadata = providerMetadata;
         tradingState.buy.selectedQuote = selectedQuote;
 
-        return renderWithTradingProvider(<TradingBuyPreviewScreen />, {
+        return await renderWithTradingProvider(<TradingBuyPreviewScreen />, {
             tradeType: 'buy',
             overrides: { wallet: { trading: tradingState } },
         });
     };
 
-    it('displays error when providerMetadata is missing', () => {
-        const { getByText } = renderTradingBuyPreviewScreen({
+    it('displays error when providerMetadata is missing', async () => {
+        const { getByText } = await renderTradingBuyPreviewScreen({
             selectedQuote: mercuryoApplePayBuyQuote,
         });
 
         expect(getByText(getTranslation('generic.unknownError'))).toBeOnTheScreen();
     });
 
-    it('displays error when quote is missing', () => {
-        const { getByText } = renderTradingBuyPreviewScreen({
+    it('displays error when quote is missing', async () => {
+        const { getByText } = await renderTradingBuyPreviewScreen({
             providerMetadata: buyMercuryo,
         });
 
         expect(getByText(getTranslation('generic.unknownError'))).toBeOnTheScreen();
     });
 
-    it('renders screen title with company name when all data is provided', () => {
-        const { getByText } = renderTradingBuyPreviewScreen({
+    it('renders screen title with company name when all data is provided', async () => {
+        const { getByText } = await renderTradingBuyPreviewScreen({
             selectedQuote: mercuryoApplePayBuyQuote,
             providerMetadata: buyMercuryo,
         });
@@ -78,8 +78,8 @@ describe('TradingBuyPreviewScreen', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should report buy-preview visit on mount', () => {
-        renderTradingBuyPreviewScreen({
+    it('should report buy-preview visit on mount', async () => {
+        await renderTradingBuyPreviewScreen({
             selectedQuote: mercuryoApplePayBuyQuote,
             providerMetadata: buyMercuryo,
         });

--- a/suite-native/module-trading/src/screens/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingConfirmingScreen.test.tsx
@@ -100,7 +100,7 @@ const mockUseAllowanceTxTracking = useAllowanceTxTracking as jest.Mock;
 describe('TradingConfirmingScreen', () => {
     let store: TestStore;
 
-    const renderScreen = (
+    const renderScreen = async (
         routeProps: Partial<RootStackParamList[RootStackRoutes.TradingConfirming]> = {},
     ) => {
         routeParams = {
@@ -108,7 +108,7 @@ describe('TradingConfirmingScreen', () => {
             ...routeProps,
         };
 
-        return renderWithStoreProvider(
+        return await renderWithStoreProvider(
             <TradingConfirmingScreen navigation={mockNavigation} route={mockUseRoute()} />,
             { store },
         );
@@ -138,8 +138,8 @@ describe('TradingConfirmingScreen', () => {
         setApprovalTxid: jest.fn(),
     };
 
-    it('should render approve header when variant is approve', () => {
-        const { getByTestId } = renderScreen({ flowType: 'approve' });
+    it('should render approve header when variant is approve', async () => {
+        const { getByTestId } = await renderScreen({ flowType: 'approve' });
 
         expect(getByTestId('@screen/sub-header/title')).toHaveTextContent(
             getTranslation('moduleTrading.tradingConfirmationScreen.approveHeaderTitle', {
@@ -148,8 +148,8 @@ describe('TradingConfirmingScreen', () => {
         );
     });
 
-    it('should render revoke header when variant is revoke', () => {
-        const { getByTestId } = renderScreen({ flowType: 'revoke' });
+    it('should render revoke header when variant is revoke', async () => {
+        const { getByTestId } = await renderScreen({ flowType: 'revoke' });
 
         expect(getByTestId('@screen/sub-header/title')).toHaveTextContent(
             getTranslation('moduleTrading.tradingConfirmationScreen.revokeHeaderTitle', {
@@ -158,22 +158,22 @@ describe('TradingConfirmingScreen', () => {
         );
     });
 
-    it('should not navigate when transaction is not confirmed', () => {
-        renderScreen();
+    it('should not navigate when transaction is not confirmed', async () => {
+        await renderScreen();
 
         expect(mockNavigation.popToTop).not.toHaveBeenCalled();
         expect(mockNavigation.push).not.toHaveBeenCalled();
     });
 
-    it('approve: navigates to TradingExchangePreview when the quote status becomes CONFIRM', () => {
+    it('approve: navigates to TradingExchangePreview when the quote status becomes CONFIRM', async () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
-        renderScreen({ flowType: 'approve' });
+        await renderScreen({ flowType: 'approve' });
 
         expect(mockNavigation.push).not.toHaveBeenCalled();
 
         // Simulate the backend advancing the status (what the watch poll saves).
-        act(() => {
+        await act(() => {
             store.dispatch(
                 tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'CONFIRM' }),
             );
@@ -185,19 +185,19 @@ describe('TradingConfirmingScreen', () => {
         });
     });
 
-    it('approve: does not navigate while status stays APPROVAL_PENDING', () => {
+    it('approve: does not navigate while status stays APPROVAL_PENDING', async () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
         store.dispatch(
             tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'APPROVAL_PENDING' }),
         );
 
-        renderScreen({ flowType: 'approve' });
+        await renderScreen({ flowType: 'approve' });
 
         expect(mockNavigation.popToTop).not.toHaveBeenCalled();
         expect(mockNavigation.push).not.toHaveBeenCalled();
     });
 
-    it('revoke-and-approve: navigates to TradingExchangeApproval and strips revoke-tx artifacts from selectedQuote', () => {
+    it('revoke-and-approve: navigates to TradingExchangeApproval and strips revoke-tx artifacts from selectedQuote', async () => {
         // Seed selectedQuote with revoke artifacts that the post-revoke confirmExchangeTradeThunk would have written.
         store.dispatch(
             tradingExchangeActions.saveSelectedQuote({
@@ -209,12 +209,12 @@ describe('TradingConfirmingScreen', () => {
         );
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
-        renderScreen({ flowType: 'revoke-and-approve' });
+        await renderScreen({ flowType: 'revoke-and-approve' });
 
         expect(mockNavigation.push).not.toHaveBeenCalled();
 
         // Simulate the backend reporting the follow-up approval is required.
-        act(() => {
+        await act(() => {
             store.dispatch(
                 tradingExchangeActions.saveSelectedQuote({
                     ...testQuote,
@@ -236,18 +236,18 @@ describe('TradingConfirmingScreen', () => {
         expect(persisted?.status).toBe('APPROVAL_REQ');
     });
 
-    it('revoke: pops to top and clears selectedQuote', () => {
+    it('revoke: pops to top and clears selectedQuote', async () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
-        renderScreen({ flowType: 'revoke' });
+        await renderScreen({ flowType: 'revoke' });
 
         expect(mockNavigation.popToTop).toHaveBeenCalled();
         expect(mockNavigation.push).not.toHaveBeenCalled();
         expect(selectTradingExchangeSelectedQuote(store.getState())).toBeUndefined();
     });
 
-    it('should render the explore in blockchain button', () => {
-        const { getByText } = renderScreen();
+    it('should render the explore in blockchain button', async () => {
+        const { getByText } = await renderScreen();
 
         expect(
             getByText(
@@ -256,7 +256,7 @@ describe('TradingConfirmingScreen', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render date when transaction has blockTime', () => {
+    it('should render date when transaction has blockTime', async () => {
         mockUseTransactionDetails.mockReturnValue({
             transaction: mockTransaction,
             openInBlockchain: mockOpenInBlockchain,
@@ -265,15 +265,15 @@ describe('TradingConfirmingScreen', () => {
             explorerUrl: 'https://etherscan.io/tx/test-txid',
         });
 
-        const { getByText } = renderScreen();
+        const { getByText } = await renderScreen();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingConfirmationScreen.date')),
         ).toBeOnTheScreen();
     });
 
-    it('should clear selected quote on back navigation', () => {
-        renderScreen();
+    it('should clear selected quote on back navigation', async () => {
+        await renderScreen();
 
         const interceptorOptions = mockUseNavigationRemoveInterceptorAlert.mock.calls.at(-1)?.[0];
 
@@ -283,7 +283,7 @@ describe('TradingConfirmingScreen', () => {
 
         const { onRemoveConfirmed } = interceptorOptions;
 
-        act(() => {
+        await act(() => {
             onRemoveConfirmed();
         });
 
@@ -292,14 +292,14 @@ describe('TradingConfirmingScreen', () => {
         expect(mockNavigation.goBack).toHaveBeenCalled();
     });
 
-    it('should allow leaving without confirmation when approval transaction fails', () => {
+    it('should allow leaving without confirmation when approval transaction fails', async () => {
         mockUseAllowanceTxTracking.mockReturnValue({
             status: { isConfirmed: false, isFailed: true, isPending: false } as TransactionStatus,
             approvalTxid: 'some-txid',
             setApprovalTxid: jest.fn(),
         });
 
-        renderScreen();
+        await renderScreen();
 
         expect(mockUseNavigationRemoveInterceptorAlert).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -308,11 +308,11 @@ describe('TradingConfirmingScreen', () => {
         );
     });
 
-    it('surfaces a backend error status and allows leaving without confirmation', () => {
+    it('surfaces a backend error status and allows leaving without confirmation', async () => {
         mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
         store.dispatch(tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'ERROR' }));
 
-        renderScreen({ flowType: 'approve' });
+        await renderScreen({ flowType: 'approve' });
 
         expect(mockUseNavigationRemoveInterceptorAlert).toHaveBeenCalledWith(
             expect.objectContaining({ shouldPrevent: false }),
@@ -321,16 +321,16 @@ describe('TradingConfirmingScreen', () => {
     });
 
     describe('analytics', () => {
-        it('should report approval-confirming visit ', () => {
-            renderScreen();
+        it('should report approval-confirming visit ', async () => {
+            await renderScreen();
 
             expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-confirming', 'visit');
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
-        it('should report approval-confirming cancel on back navigation', () => {
+        it('should report approval-confirming cancel on back navigation', async () => {
             store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
-            renderScreen();
+            await renderScreen();
 
             const interceptorOptions =
                 mockUseNavigationRemoveInterceptorAlert.mock.calls.at(-1)?.[0];
@@ -341,7 +341,7 @@ describe('TradingConfirmingScreen', () => {
 
             const { onRemoveConfirmed } = interceptorOptions;
 
-            act(() => {
+            await act(() => {
                 onRemoveConfirmed();
             });
 
@@ -349,19 +349,19 @@ describe('TradingConfirmingScreen', () => {
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(2);
         });
 
-        it('should report revoke-confirming visit for revoke', () => {
-            renderScreen({ flowType: 'revoke' });
+        it('should report revoke-confirming visit for revoke', async () => {
+            await renderScreen({ flowType: 'revoke' });
 
             expect(mockAnalyticsReport).toHaveBeenCalledWith('revoke-confirming', 'visit');
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
-        it('should report continue when on navigation to next screen', () => {
+        it('should report continue when on navigation to next screen', async () => {
             mockUseAllowanceTxTracking.mockReturnValue(confirmedStatus);
 
-            renderScreen({ flowType: 'approve' });
+            await renderScreen({ flowType: 'approve' });
 
-            act(() => {
+            await act(() => {
                 store.dispatch(
                     tradingExchangeActions.saveSelectedQuote({ ...testQuote, status: 'CONFIRM' }),
                 );

--- a/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.test.tsx
@@ -99,8 +99,8 @@ describe('TradingExchangeApprovalScreen', () => {
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const renderScreen = (params: Record<string, unknown> = {}) => {
-        const result = renderWithTradingProvider(
+    const renderScreen = async (params: Record<string, unknown> = {}) => {
+        const result = await renderWithTradingProvider(
             <TradingExchangeApprovalScreen
                 route={{ params } as any}
                 navigation={{ dispatch: mockNavigationDispatch } as any}
@@ -123,15 +123,15 @@ describe('TradingExchangeApprovalScreen', () => {
         store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1NormalAccount.key));
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         if (unmount) {
-            unmount();
+            await unmount();
             unmount = undefined;
         }
     });
 
-    it('should confirm approval on mount', () => {
-        renderScreen();
+    it('should confirm approval on mount', async () => {
+        await renderScreen();
 
         expect(mockConfirmApproval).toHaveBeenCalledTimes(1);
         expect(mockConfirmApproval).toHaveBeenCalledWith(
@@ -139,41 +139,41 @@ describe('TradingExchangeApprovalScreen', () => {
         );
     });
 
-    it('should render the approval screen with quote details', () => {
-        const { getByText } = renderScreen();
+    it('should render the approval screen with quote details', async () => {
+        const { getByText } = await renderScreen();
 
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
         expect(errorSpy).not.toHaveBeenCalled();
     });
 
-    it('should display provider information correctly', () => {
-        const { getByText } = renderScreen();
+    it('should display provider information correctly', async () => {
+        const { getByText } = await renderScreen();
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
     it('should open bottom sheet when limit row is pressed', async () => {
-        const { findByText } = renderScreen();
+        const { findByText } = await renderScreen();
 
         const pressableElement = await findByText(
             getTranslation('moduleTrading.tradingExchangeApprovalScreen.limitLabel'),
         );
 
-        fireEvent.press(pressableElement);
+        await fireEvent.press(pressableElement);
         expect(mockShowSheet).toHaveBeenCalledTimes(1);
     });
 
-    it('should render continue button', () => {
-        const { getByText } = renderScreen();
+    it('should render continue button', async () => {
+        const { getByText } = await renderScreen();
 
         expect(getByText(getTranslation('generic.buttons.continue'))).toBeOnTheScreen();
     });
 
-    it('should render alert when no quote is provided', () => {
+    it('should render alert when no quote is provided', async () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { getByText, queryByText } = renderScreen();
+        const { getByText, queryByText } = await renderScreen();
 
         expect(
             getByText(
@@ -185,9 +185,9 @@ describe('TradingExchangeApprovalScreen', () => {
         expect(errorSpy).toHaveBeenCalledWith('No quote to confirm approval');
     });
 
-    it('should clear selected quote on back navigation', () => {
+    it('should clear selected quote on back navigation', async () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
-        renderScreen();
+        await renderScreen();
 
         const backAction: NavigationAction = { type: 'GO_BACK' };
 
@@ -198,8 +198,8 @@ describe('TradingExchangeApprovalScreen', () => {
         expect(mockNavigationDispatch).toHaveBeenCalledWith(backAction);
     });
 
-    it('should render revoke success alert when isRevoked is true', () => {
-        const { getByText } = renderScreen({ isRevoked: true });
+    it('should render revoke success alert when isRevoked is true', async () => {
+        const { getByText } = await renderScreen({ isRevoked: true });
 
         expect(
             getByText(
@@ -208,10 +208,10 @@ describe('TradingExchangeApprovalScreen', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should display device guard when device is not connected', () => {
+    it('should display device guard when device is not connected', async () => {
         mockIsDeviceConnected = false;
 
-        const { getByText } = renderScreen();
+        const { getByText } = await renderScreen();
 
         expect(
             getByText(getTranslation('moduleConnectDevice.connectAndUnlockScreen.title')),
@@ -219,16 +219,16 @@ describe('TradingExchangeApprovalScreen', () => {
     });
 
     describe('analytics', () => {
-        it('should report approval-preview visit ', () => {
-            renderScreen();
+        it('should report approval-preview visit ', async () => {
+            await renderScreen();
 
             expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-preview', 'visit');
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
-        it('should report approval-preview cancel on back navigation', () => {
+        it('should report approval-preview cancel on back navigation', async () => {
             store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
-            renderScreen();
+            await renderScreen();
 
             triggerPreventNavigationRemove({ type: 'GO_BACK' });
 

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx
@@ -155,7 +155,7 @@ describe('TradingExchangePreviewScreen', () => {
     let consoleErrorSpy: jest.SpyInstance;
     let unmount: (() => void) | undefined;
 
-    const renderTradingExchangePreviewScreen = (
+    const renderTradingExchangePreviewScreen = async (
         isApproved: boolean = false,
         customStore?: TestStore,
     ) => {
@@ -166,7 +166,7 @@ describe('TradingExchangePreviewScreen', () => {
         };
         jest.clearAllMocks();
 
-        const result = renderWithStoreProvider(
+        const result = await renderWithStoreProvider(
             <TradingExchangePreviewScreen
                 navigation={createNavigationProps()}
                 route={createRouteProps(isApproved)}
@@ -201,38 +201,38 @@ describe('TradingExchangePreviewScreen', () => {
         store = createStore();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         consoleErrorSpy.mockRestore();
         if (unmount) {
-            unmount();
+            await unmount();
             unmount = undefined;
         }
     });
 
-    it('should display device guard when device is not connected', () => {
+    it('should display device guard when device is not connected', async () => {
         mockIsDeviceConnected = false;
-        const { result } = renderTradingExchangePreviewScreen();
+        const { result } = await renderTradingExchangePreviewScreen();
         expect(
             result.getByText(getTranslation('moduleConnectDevice.connectAndUnlockScreen.title')),
         ).toBeOnTheScreen();
     });
 
-    it('should render continue button', () => {
-        const { result } = renderTradingExchangePreviewScreen();
+    it('should render continue button', async () => {
+        const { result } = await renderTradingExchangePreviewScreen();
 
         expect(result.getByText(getTranslation('generic.buttons.continue'))).toBeOnTheScreen();
     });
 
-    it('should render screen title correctly', () => {
-        const { result } = renderTradingExchangePreviewScreen();
+    it('should render screen title correctly', async () => {
+        const { result } = await renderTradingExchangePreviewScreen();
 
         expect(
             result.getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.title')),
         ).toBeOnTheScreen();
     });
 
-    it('should render from and to account labels', () => {
-        const { result } = renderTradingExchangePreviewScreen();
+    it('should render from and to account labels', async () => {
+        const { result } = await renderTradingExchangePreviewScreen();
 
         expect(
             result.getByText(
@@ -246,10 +246,10 @@ describe('TradingExchangePreviewScreen', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render transaction details section', () => {
+    it('should render transaction details section', async () => {
         const {
             result: { getByText },
-        } = renderTradingExchangePreviewScreen();
+        } = await renderTradingExchangePreviewScreen();
 
         // 1st line of trade info is provider
         expect(getByText(getTranslation('moduleTrading.tradingScreen.provider'))).toBeOnTheScreen();
@@ -259,7 +259,7 @@ describe('TradingExchangePreviewScreen', () => {
         it('should show error alert when trade confirmation errors', async () => {
             mockConfirmTrade.mockRejectedValueOnce(new Error('Trade confirmation failed'));
 
-            renderTradingExchangePreviewScreen();
+            await renderTradingExchangePreviewScreen();
 
             await waitFor(
                 () => {
@@ -278,7 +278,7 @@ describe('TradingExchangePreviewScreen', () => {
                 .mockRejectedValueOnce(new Error('Trade confirmation failed'))
                 .mockResolvedValueOnce(true);
 
-            const { reportMock } = renderTradingExchangePreviewScreen();
+            const { reportMock } = await renderTradingExchangePreviewScreen();
 
             await waitFor(() => {
                 expect(mockShowAlert).toHaveBeenCalled();
@@ -302,7 +302,7 @@ describe('TradingExchangePreviewScreen', () => {
         it('should navigate to top when cancel button is pressed', async () => {
             mockConfirmTrade.mockRejectedValueOnce(new Error('Trade confirmation failed'));
 
-            const { reportMock } = renderTradingExchangePreviewScreen();
+            const { reportMock } = await renderTradingExchangePreviewScreen();
 
             await waitFor(() => {
                 expect(mockShowAlert).toHaveBeenCalled();
@@ -326,7 +326,7 @@ describe('TradingExchangePreviewScreen', () => {
         it('should not show error alert when trade confirmation succeeds', async () => {
             mockConfirmTrade.mockResolvedValue(true);
 
-            renderTradingExchangePreviewScreen();
+            await renderTradingExchangePreviewScreen();
 
             await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -334,8 +334,8 @@ describe('TradingExchangePreviewScreen', () => {
         });
     });
 
-    it('should report to analytics on mount', () => {
-        const { reportMock } = renderTradingExchangePreviewScreen();
+    it('should report to analytics on mount', async () => {
+        const { reportMock } = await renderTradingExchangePreviewScreen();
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
@@ -347,7 +347,7 @@ describe('TradingExchangePreviewScreen', () => {
         });
     });
 
-    it('reports a validation risk as a high-risk issue', () => {
+    it('reports a validation risk as a high-risk issue', async () => {
         mockUseExchangeIssue.mockReturnValue({
             isSimulationEnabled: true,
             isSimulationLoading: false,
@@ -363,7 +363,7 @@ describe('TradingExchangePreviewScreen', () => {
             },
         });
 
-        const { reportMock } = renderTradingExchangePreviewScreen();
+        const { reportMock } = await renderTradingExchangePreviewScreen();
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingExchangeIssueEvent.name,
@@ -374,7 +374,7 @@ describe('TradingExchangePreviewScreen', () => {
         });
     });
 
-    it('reports a returned simulation failure as a slippage-too-low issue', () => {
+    it('reports a returned simulation failure as a slippage-too-low issue', async () => {
         mockUseExchangeIssue.mockReturnValue({
             isSimulationEnabled: true,
             isSimulationLoading: false,
@@ -385,7 +385,7 @@ describe('TradingExchangePreviewScreen', () => {
             },
         });
 
-        const { reportMock } = renderTradingExchangePreviewScreen();
+        const { reportMock } = await renderTradingExchangePreviewScreen();
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingExchangeIssueEvent.name,
@@ -401,7 +401,7 @@ describe('TradingExchangePreviewScreen', () => {
         [0.2, 'price-impact-critical', true],
     ] as const)(
         'reports deviation %s as %s with isSimulation=%s',
-        (deviation, issue, isSimulation) => {
+        async (deviation, issue, isSimulation) => {
             mockUseExchangeIssue.mockReturnValue({
                 isSimulationEnabled: true,
                 isSimulationLoading: false,
@@ -419,7 +419,7 @@ describe('TradingExchangePreviewScreen', () => {
                 data: isSimulation ? createSimulationResult() : undefined,
             });
 
-            const { reportMock } = renderTradingExchangePreviewScreen();
+            const { reportMock } = await renderTradingExchangePreviewScreen();
 
             expect(reportMock).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -430,7 +430,7 @@ describe('TradingExchangePreviewScreen', () => {
         },
     );
 
-    it('does not report an equivalent exchange issue twice', () => {
+    it('does not report an equivalent exchange issue twice', async () => {
         const firstIssue = {
             type: 'slippage-too-low' as const,
             severity: 'warning' as const,
@@ -442,7 +442,7 @@ describe('TradingExchangePreviewScreen', () => {
             issue: firstIssue,
         });
 
-        const { result, reportMock } = renderTradingExchangePreviewScreen();
+        const { result, reportMock } = await renderTradingExchangePreviewScreen();
         const countIssueEvents = () =>
             reportMock.mock.calls.filter(
                 ([event]) => event.type === events.tradingExchangeIssueEvent.name,
@@ -450,7 +450,7 @@ describe('TradingExchangePreviewScreen', () => {
 
         expect(countIssueEvents()).toBe(1);
 
-        result.rerender(
+        await result.rerender(
             <TradingExchangePreviewScreen
                 navigation={createNavigationProps()}
                 route={createRouteProps()}
@@ -464,7 +464,7 @@ describe('TradingExchangePreviewScreen', () => {
             isSimulation: true,
             issue: { ...firstIssue },
         });
-        result.rerender(
+        await result.rerender(
             <TradingExchangePreviewScreen
                 navigation={createNavigationProps()}
                 route={createRouteProps()}
@@ -474,23 +474,23 @@ describe('TradingExchangePreviewScreen', () => {
         expect(countIssueEvents()).toBe(1);
     });
 
-    it('should abort confirm trade on unmount', () => {
-        const { result } = renderTradingExchangePreviewScreen();
+    it('should abort confirm trade on unmount', async () => {
+        const { result } = await renderTradingExchangePreviewScreen();
 
         expect(mockAbortConfirmTrade).not.toHaveBeenCalled();
 
-        result.unmount();
+        await result.unmount();
         unmount = undefined;
 
         expect(mockAbortConfirmTrade).toHaveBeenCalledTimes(1);
     });
 
-    it('should clear trading state on unmount', () => {
-        const { result } = renderTradingExchangePreviewScreen();
+    it('should clear trading state on unmount', async () => {
+        const { result } = await renderTradingExchangePreviewScreen();
 
         expect(store.getState().wallet.trading.exchange.selectedQuote).toBeDefined();
 
-        result.unmount();
+        await result.unmount();
         unmount = undefined;
 
         expect(store.getState().wallet.trading.exchange.selectedQuote).toBeUndefined();
@@ -498,7 +498,7 @@ describe('TradingExchangePreviewScreen', () => {
     });
 
     it('should report to analytics on Continue press', async () => {
-        const { result, reportMock } = renderTradingExchangePreviewScreen();
+        const { result, reportMock } = await renderTradingExchangePreviewScreen();
         reportMock.mockClear();
 
         await userEvent.press(
@@ -523,7 +523,7 @@ describe('TradingExchangePreviewScreen', () => {
             };
             const testStore = createStore(approvalReqQuote);
 
-            renderTradingExchangePreviewScreen(false, testStore);
+            await renderTradingExchangePreviewScreen(false, testStore);
 
             await waitFor(() => {
                 expect(mockNavigate).toHaveBeenCalledTimes(1);
@@ -533,15 +533,15 @@ describe('TradingExchangePreviewScreen', () => {
     });
 
     describe('Error String Fallback Logic', () => {
-        it('should use txnErrorString when provided', () => {
+        it('should use txnErrorString when provided', async () => {
             mockTxnErrorString = 'Transaction error occurred';
 
-            const { result } = renderTradingExchangePreviewScreen();
+            const { result } = await renderTradingExchangePreviewScreen();
 
             expect(result.getByText('Transaction error occurred')).toBeOnTheScreen();
         });
 
-        it('should fall back to quote.error when txnErrorString is null', () => {
+        it('should fall back to quote.error when txnErrorString is null', async () => {
             mockTxnErrorString = null;
 
             const quoteWithError = {
@@ -550,12 +550,12 @@ describe('TradingExchangePreviewScreen', () => {
             };
 
             const testStore = createStore(quoteWithError);
-            const { result } = renderTradingExchangePreviewScreen(false, testStore);
+            const { result } = await renderTradingExchangePreviewScreen(false, testStore);
 
             expect(result.getByText('Quote error message')).toBeOnTheScreen();
         });
 
-        it('should not show error when both txnErrorString and quote.error are null', () => {
+        it('should not show error when both txnErrorString and quote.error are null', async () => {
             mockTxnErrorString = null;
 
             const quoteWithoutError = {
@@ -564,13 +564,13 @@ describe('TradingExchangePreviewScreen', () => {
             };
 
             const testStore = createStore(quoteWithoutError);
-            const { result } = renderTradingExchangePreviewScreen(false, testStore);
+            const { result } = await renderTradingExchangePreviewScreen(false, testStore);
 
             expect(result.queryByText('Transaction error occurred')).toBeNull();
             expect(result.queryByText('Quote error message')).toBeNull();
         });
 
-        it('should prioritize txnErrorString over quote.error', () => {
+        it('should prioritize txnErrorString over quote.error', async () => {
             mockTxnErrorString = 'Transaction error takes priority';
 
             const quoteWithError = {
@@ -579,13 +579,13 @@ describe('TradingExchangePreviewScreen', () => {
             };
 
             const testStore = createStore(quoteWithError);
-            const { result } = renderTradingExchangePreviewScreen(false, testStore);
+            const { result } = await renderTradingExchangePreviewScreen(false, testStore);
 
             expect(result.getByText('Transaction error takes priority')).toBeOnTheScreen();
             expect(result.queryByText('Quote error message')).toBeNull();
         });
 
-        it('should not show errors for quote with SIGN_DATA status and EIP-712 data', () => {
+        it('should not show errors for quote with SIGN_DATA status and EIP-712 data', async () => {
             mockTxnErrorString = 'Transaction error occurred';
 
             const quoteWithEip712SignData = {
@@ -594,13 +594,13 @@ describe('TradingExchangePreviewScreen', () => {
             };
 
             const testStore = createStore(quoteWithEip712SignData);
-            const { result } = renderTradingExchangePreviewScreen(false, testStore);
+            const { result } = await renderTradingExchangePreviewScreen(false, testStore);
 
             expect(result.queryByText('Transaction error occurred')).toBeNull();
             expect(result.queryByText('Quote error message')).toBeNull();
         });
 
-        it('should show errors for quote with SIGN_DATA status and non-EIP-712 data', () => {
+        it('should show errors for quote with SIGN_DATA status and non-EIP-712 data', async () => {
             mockTxnErrorString = 'Transaction error occurred';
 
             const quoteWithNonEip712SignData = {
@@ -614,7 +614,7 @@ describe('TradingExchangePreviewScreen', () => {
             };
 
             const testStore = createStore(quoteWithNonEip712SignData);
-            const { result } = renderTradingExchangePreviewScreen(false, testStore);
+            const { result } = await renderTradingExchangePreviewScreen(false, testStore);
 
             expect(result.getByText('Transaction error occurred')).toBeOnTheScreen();
             expect(result.queryByText('Quote error message')).toBeNull();
@@ -624,7 +624,7 @@ describe('TradingExchangePreviewScreen', () => {
     it('should preserve quote slippage when confirming a DEX quote', async () => {
         const testStore = createStore({ ...mercuryoDexQuote, swapSlippage: '0.5' });
 
-        renderTradingExchangePreviewScreen(false, testStore);
+        await renderTradingExchangePreviewScreen(false, testStore);
 
         await waitFor(() => {
             expect(mockConfirmTrade).toHaveBeenCalledTimes(1);
@@ -641,7 +641,7 @@ describe('TradingExchangePreviewScreen', () => {
 
     it('should confirm the trade again with user-confirmed slippage', async () => {
         const testStore = createStore(mercuryoDexQuote);
-        const { result } = renderTradingExchangePreviewScreen(false, testStore);
+        const { result } = await renderTradingExchangePreviewScreen(false, testStore);
 
         await waitFor(() => {
             expect(mockConfirmTrade).toHaveBeenCalledTimes(1);

--- a/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.test.tsx
@@ -97,8 +97,8 @@ describe('TradingExchangeRevokeScreen', () => {
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const renderScreen = (params: Record<string, unknown> = {}) => {
-        const result = renderWithTradingProvider(
+    const renderScreen = async (params: Record<string, unknown> = {}) => {
+        const result = await renderWithTradingProvider(
             <TradingExchangeRevokeScreen
                 route={{ params } as any}
                 navigation={{ dispatch: mockNavigationDispatch } as any}
@@ -121,15 +121,15 @@ describe('TradingExchangeRevokeScreen', () => {
         store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1NormalAccount.key));
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         if (unmount) {
-            unmount();
+            await unmount();
             unmount = undefined;
         }
     });
 
-    it('should confirm revoke with ZERO approval type', () => {
-        renderScreen();
+    it('should confirm revoke with ZERO approval type', async () => {
+        await renderScreen();
 
         expect(mockConfirmApproval).toHaveBeenCalledTimes(1);
         expect(mockConfirmApproval).toHaveBeenCalledWith(
@@ -137,30 +137,30 @@ describe('TradingExchangeRevokeScreen', () => {
         );
     });
 
-    it('should render the revoke screen with quote details', () => {
-        const { getByText } = renderScreen();
+    it('should render the revoke screen with quote details', async () => {
+        const { getByText } = await renderScreen();
 
         expect(getByText('ETH Account #1')).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
         expect(errorSpy).not.toHaveBeenCalled();
     });
 
-    it('should display provider information correctly', () => {
-        const { getByText } = renderScreen();
+    it('should display provider information correctly', async () => {
+        const { getByText } = await renderScreen();
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should render continue button', () => {
-        const { getByText } = renderScreen();
+    it('should render continue button', async () => {
+        const { getByText } = await renderScreen();
 
         expect(getByText(getTranslation('generic.buttons.continue'))).toBeOnTheScreen();
     });
 
-    it('should render alert when no quote is provided', () => {
+    it('should render alert when no quote is provided', async () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { getByText, queryByText } = renderScreen();
+        const { getByText, queryByText } = await renderScreen();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingExchangeRevokeScreen.revokeErrorAlert')),
@@ -170,9 +170,9 @@ describe('TradingExchangeRevokeScreen', () => {
         expect(errorSpy).toHaveBeenCalledWith('No quote to revoke approval');
     });
 
-    it('should clear selected quote on back navigation', () => {
+    it('should clear selected quote on back navigation', async () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
-        renderScreen();
+        await renderScreen();
 
         const backAction: NavigationAction = { type: 'GO_BACK' };
 
@@ -183,8 +183,8 @@ describe('TradingExchangeRevokeScreen', () => {
         expect(mockNavigationDispatch).toHaveBeenCalledWith(backAction);
     });
 
-    it('should render low limit info alert when shouldIncreaseLimit is true', () => {
-        const { getByText } = renderScreen({ shouldIncreaseLimit: true });
+    it('should render low limit info alert when shouldIncreaseLimit is true', async () => {
+        const { getByText } = await renderScreen({ shouldIncreaseLimit: true });
 
         expect(
             getByText(
@@ -193,10 +193,10 @@ describe('TradingExchangeRevokeScreen', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should display device guard when device is not connected', () => {
+    it('should display device guard when device is not connected', async () => {
         mockIsDeviceConnected = false;
 
-        const { getByText } = renderScreen();
+        const { getByText } = await renderScreen();
 
         expect(
             getByText(getTranslation('moduleConnectDevice.connectAndUnlockScreen.title')),
@@ -204,16 +204,16 @@ describe('TradingExchangeRevokeScreen', () => {
     });
 
     describe('analytics', () => {
-        it('should report revoke-preview visit ', () => {
-            renderScreen();
+        it('should report revoke-preview visit ', async () => {
+            await renderScreen();
 
             expect(mockAnalyticsReport).toHaveBeenCalledWith('revoke-preview', 'visit');
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
-        it('should report revoke-preview cancel on back navigation', () => {
+        it('should report revoke-preview cancel on back navigation', async () => {
             store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
-            renderScreen();
+            await renderScreen();
 
             triggerPreventNavigationRemove({ type: 'GO_BACK' });
 

--- a/suite-native/module-trading/src/screens/TradingMyAssetScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingMyAssetScreen.test.tsx
@@ -67,12 +67,12 @@ describe('TradingMyAssetScreen', () => {
 
     it.each(['sell', 'exchange'] as const)(
         'returns the selected asset and account to the %s form',
-        tradingType => {
-            const { getByText } = renderWithTradingProvider(
+        async tradingType => {
+            const { getByText } = await renderWithTradingProvider(
                 <TradingMyAssetScreen navigation={navigation} route={createRoute(tradingType)} />,
             );
 
-            fireEvent.press(getByText('BTC'));
+            await fireEvent.press(getByText('BTC'));
 
             expect(mockUseTradingMyAssets).toHaveBeenCalledWith(tradingType);
             expect(navigation.popTo).toHaveBeenCalledWith(RootStackRoutes.AppTabs, {

--- a/suite-native/module-trading/src/screens/TradingOutputsReviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingOutputsReviewScreen.test.tsx
@@ -127,21 +127,21 @@ describe('TradingSellOutputsReviewScreen', () => {
     let store: TestStore;
     let unmount: (() => void) | undefined;
 
-    afterEach(() => {
+    afterEach(async () => {
         if (unmount) {
-            unmount();
+            await unmount();
             unmount = undefined;
         }
     });
 
     describe('TradingSellOutputsReviewScreen', () => {
-        const renderScreen = (
+        const renderScreen = async (
             route: StackProps<
                 RootStackParamList,
                 RootStackRoutes.TradingSellOutputsReview
             >['route'],
         ) => {
-            const result = renderWithTradingProvider(
+            const result = await renderWithTradingProvider(
                 <TradingSellOutputsReviewScreen route={route} navigation={mockNavigation} />,
                 { store },
             );
@@ -159,11 +159,11 @@ describe('TradingSellOutputsReviewScreen', () => {
             mockNavigation.popToTop.mockClear();
         });
 
-        it('should render TradingSellOutputsReviewScreen', () => {
+        it('should render TradingSellOutputsReviewScreen', async () => {
             const params = createSellRouteParams();
             const route = createSellRoute(params);
 
-            const { toJSON } = renderScreen(route);
+            const { toJSON } = await renderScreen(route);
 
             expect(toJSON()).not.toBeNull();
             expect(mockUseSellFlowFn).toHaveBeenCalled();
@@ -178,13 +178,13 @@ describe('TradingSellOutputsReviewScreen', () => {
     });
 
     describe('TradingExchangeOutputsReviewScreen', () => {
-        const renderScreen = (
+        const renderScreen = async (
             route: StackProps<
                 RootStackParamList,
                 RootStackRoutes.TradingExchangeOutputsReview
             >['route'],
         ) => {
-            const result = renderWithTradingProvider(
+            const result = await renderWithTradingProvider(
                 <TradingExchangeOutputsReviewScreen route={route} navigation={mockNavigation} />,
                 { store },
             );
@@ -202,11 +202,11 @@ describe('TradingSellOutputsReviewScreen', () => {
             mockNavigation.popToTop.mockClear();
         });
 
-        it('should render TradingExchangeOutputsReviewScreen', () => {
+        it('should render TradingExchangeOutputsReviewScreen', async () => {
             const params = createExchangeRouteParams();
             const route = createExchangeRoute(params);
 
-            const { toJSON } = renderScreen(route);
+            const { toJSON } = await renderScreen(route);
 
             expect(toJSON()).not.toBeNull();
             expect(mockUseExchangeFlowFn).toHaveBeenCalled();
@@ -219,11 +219,11 @@ describe('TradingSellOutputsReviewScreen', () => {
             );
         });
 
-        it('should pass signDataAndConfirm when flowType is sign-data', () => {
+        it('should pass signDataAndConfirm when flowType is sign-data', async () => {
             const params = createExchangeRouteParams(undefined, 'sign-data');
             const route = createExchangeRoute(params);
 
-            renderScreen(route);
+            await renderScreen(route);
 
             expect(mockUseTradingOutputsReviewScreenControls).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -232,11 +232,11 @@ describe('TradingSellOutputsReviewScreen', () => {
             );
         });
 
-        it('should pass signAndSendTransaction when flowType is swap', () => {
+        it('should pass signAndSendTransaction when flowType is swap', async () => {
             const params = createExchangeRouteParams(undefined, 'swap');
             const route = createExchangeRoute(params);
 
-            renderScreen(route);
+            await renderScreen(route);
 
             expect(mockUseTradingOutputsReviewScreenControls).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/suite-native/module-trading/src/screens/TradingReceiveAccountsPickerScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingReceiveAccountsPickerScreen.test.tsx
@@ -48,8 +48,8 @@ const overridesWithAccounts = (
 describe('TradingReceiveAccountsPickerScreen', () => {
     let unmount: (() => void) | undefined;
 
-    const renderScreen = (overrides: PreloadedStatePartial<TradingTestPreloadedState>) => {
-        const result = renderWithTradingProvider(<TradingReceiveAccountsPickerScreen />, {
+    const renderScreen = async (overrides: PreloadedStatePartial<TradingTestPreloadedState>) => {
+        const result = await renderWithTradingProvider(<TradingReceiveAccountsPickerScreen />, {
             tradeType: mockRouteParams.tradingType,
             overrides,
         });
@@ -59,53 +59,53 @@ describe('TradingReceiveAccountsPickerScreen', () => {
         return result;
     };
 
-    afterEach(() => {
+    afterEach(async () => {
         if (unmount) {
-            unmount();
+            await unmount();
             unmount = undefined;
         }
     });
 
-    it('should render the empty-state title when no account exists', () => {
+    it('should render the empty-state title when no account exists', async () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 
-        const { getByText } = renderScreen(overridesWithAccounts([]));
+        const { getByText } = await renderScreen(overridesWithAccounts([]));
 
         expect(
             getByText(getTranslation('moduleTrading.accountScreen.accountEmpty.title')),
         ).toBeTruthy();
     });
 
-    it('should render account list with accounts', () => {
+    it('should render account list with accounts', async () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 
-        const { getByText } = renderScreen(overridesWithAccounts(accounts));
+        const { getByText } = await renderScreen(overridesWithAccounts(accounts));
 
         expect(getByText(accounts[0]?.accountLabel ?? '')).toBeTruthy();
     });
 
-    it('should render account list with accounts for exchange', () => {
+    it('should render account list with accounts for exchange', async () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'exchange' };
 
-        const { getByText } = renderScreen(overridesWithAccounts(accounts));
+        const { getByText } = await renderScreen(overridesWithAccounts(accounts));
 
         expect(getByText(accounts[0]?.accountLabel ?? '')).toBeTruthy();
     });
 
-    it('should render empty state when no account exist', () => {
+    it('should render empty state when no account exist', async () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 
-        const { getByText } = renderScreen(overridesWithAccounts([]));
+        const { getByText } = await renderScreen(overridesWithAccounts([]));
 
         expect(
             getByText(getTranslation('moduleTrading.accountScreen.accountEmpty.title')),
         ).toBeTruthy();
     });
 
-    it('should render the activation button when no account exists', () => {
+    it('should render the activation button when no account exists', async () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 
-        const { getByText } = renderScreen(overridesWithAccounts([]));
+        const { getByText } = await renderScreen(overridesWithAccounts([]));
 
         expect(
             getByText(

--- a/suite-native/module-trading/src/screens/TradingReceiveAddressPickerScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingReceiveAddressPickerScreen.test.tsx
@@ -52,12 +52,14 @@ describe(TradingReceiveAddressPickerScreen.name, () => {
         wallet: { accounts: [btc1NormalAccount] },
     };
 
-    const renderScreen = () => {
+    const renderScreen = async () => {
         const store = createTradingLightStore({
             tradeType: mockRouteParams.tradingType,
             overrides,
         });
-        const result = renderWithStoreProvider(<TradingReceiveAddressPickerScreen />, { store });
+        const result = await renderWithStoreProvider(<TradingReceiveAddressPickerScreen />, {
+            store,
+        });
 
         return { ...result, store };
     };
@@ -72,8 +74,8 @@ describe(TradingReceiveAddressPickerScreen.name, () => {
         mockRouteParams = { accountKey: btc1NormalAccount.key, tradingType: 'buy' };
     });
 
-    it('renders the compact title, search input, and address sections', () => {
-        const { getByPlaceholderText, getByText } = renderScreen();
+    it('renders the compact title, search input, and address sections', async () => {
+        const { getByPlaceholderText, getByText } = await renderScreen();
 
         expect(
             getByText(getTranslation('moduleTrading.accountScreen.receiveAddressTitle')),
@@ -86,19 +88,19 @@ describe(TradingReceiveAddressPickerScreen.name, () => {
     });
 
     it('filters addresses and renders the no-results state', async () => {
-        const { getByPlaceholderText, getByText, queryByText } = renderScreen();
+        const { getByPlaceholderText, getByText, queryByText } = await renderScreen();
         const searchInput = getByPlaceholderText(
             getTranslation('moduleTrading.accountScreen.searchPlaceholder'),
         );
 
-        fireEvent.changeText(searchInput, 'USED1');
+        await fireEvent.changeText(searchInput, 'USED1');
 
         await waitFor(() => {
             expect(getByText('USED1')).toBeTruthy();
             expect(queryByText('USED2')).toBeNull();
         });
 
-        fireEvent.changeText(searchInput, 'missing');
+        await fireEvent.changeText(searchInput, 'missing');
 
         await waitFor(() => {
             expect(
@@ -107,10 +109,10 @@ describe(TradingReceiveAddressPickerScreen.name, () => {
         });
     });
 
-    it('atomically selects a buy account and address', () => {
-        const { getByText, store } = renderScreen();
+    it('atomically selects a buy account and address', async () => {
+        const { getByText, store } = await renderScreen();
 
-        fireEvent.press(getByText('UNUSED1'));
+        await fireEvent.press(getByText('UNUSED1'));
 
         expect(selectBuySelectedReceiveAccount(store.getState())).toEqual({
             account: btc1NormalAccount,
@@ -119,11 +121,11 @@ describe(TradingReceiveAddressPickerScreen.name, () => {
         expect(navigationPopToTop).toHaveBeenCalledTimes(1);
     });
 
-    it('atomically selects an exchange account and address', () => {
+    it('atomically selects an exchange account and address', async () => {
         mockRouteParams = { accountKey: btc1NormalAccount.key, tradingType: 'exchange' };
-        const { getByText, store } = renderScreen();
+        const { getByText, store } = await renderScreen();
 
-        fireEvent.press(getByText('USED1'));
+        await fireEvent.press(getByText('USED1'));
 
         expect(selectExchangeSelectedReceiveAccount(store.getState())).toEqual({
             account: btc1NormalAccount,
@@ -132,15 +134,15 @@ describe(TradingReceiveAddressPickerScreen.name, () => {
         expect(navigationPopToTop).toHaveBeenCalledTimes(1);
     });
 
-    it('preserves the previous selection when navigating back', () => {
-        const { getByTestId, store } = renderScreen();
+    it('preserves the previous selection when navigating back', async () => {
+        const { getByTestId, store } = await renderScreen();
         const previousAddress = btc1NormalAccount.addresses?.used[1];
 
         store.dispatch(tradingBuyActions.setTradingAccountKey(btc1NormalAccount.key));
         store.dispatch(tradingBuyActions.setReceiveAccountKey(btc1NormalAccount.key));
         store.dispatch(tradingBuyActions.setReceiveAddress(previousAddress?.address));
 
-        fireEvent.press(getByTestId('@screen/sub-header/go-back-button'));
+        await fireEvent.press(getByTestId('@screen/sub-header/go-back-button'));
 
         expect(selectBuySelectedReceiveAccount(store.getState())).toEqual({
             account: btc1NormalAccount,

--- a/suite-native/module-trading/src/screens/TradingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingScreen.test.tsx
@@ -61,29 +61,31 @@ const overridesWithDisabledTrading: PreloadedStatePartial<TradingTestPreloadedSt
 describe('TradingScreen', () => {
     let unmount: (() => void) | undefined;
 
-    const renderTradingScreen = (overrides?: PreloadedStatePartial<TradingTestPreloadedState>) => {
-        const result = renderWithTradingProvider(<TradingScreen />, { overrides });
+    const renderTradingScreen = async (
+        overrides?: PreloadedStatePartial<TradingTestPreloadedState>,
+    ) => {
+        const result = await renderWithTradingProvider(<TradingScreen />, { overrides });
 
         ({ unmount } = result);
 
         return result;
     };
 
-    afterEach(() => {
+    afterEach(async () => {
         if (unmount) {
-            unmount();
+            await unmount();
             unmount = undefined;
         }
     });
 
-    it('should render nothing when trading feature flag is not enabled', () => {
-        const { toJSON } = renderTradingScreen(overridesWithDisabledTrading);
+    it('should render nothing when trading feature flag is not enabled', async () => {
+        const { toJSON } = await renderTradingScreen(overridesWithDisabledTrading);
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render Buy form by default', () => {
-        const { getByText } = renderTradingScreen({
+    it('should render Buy form by default', async () => {
+        const { getByText } = await renderTradingScreen({
             featureFlags: createTradingFeatureFlags({}),
         });
 

--- a/suite-native/module-trading/src/screens/TradingSellCompletionScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellCompletionScreen.test.tsx
@@ -79,7 +79,7 @@ describe('TradingSellCompletionScreen', () => {
         tradingState.currentProviderMetadata = sellMoonpay;
         tradingState.providerConfirmationStatus = providerConfirmationStatus;
 
-        const result = renderWithTradingProvider(<TradingSellCompletionScreen />, {
+        const result = await renderWithTradingProvider(<TradingSellCompletionScreen />, {
             tradeType: 'sell',
             overrides: {
                 wallet: {
@@ -176,7 +176,7 @@ describe('TradingSellCompletionScreen', () => {
         const { rerender } = await renderScreen({ status: 'SEND_CRYPTO' });
 
         await waitFor(() => expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1));
-        rerender(<TradingSellCompletionScreen />);
+        await rerender(<TradingSellCompletionScreen />);
 
         expect(mockComposeTradingTransaction).toHaveBeenCalledTimes(1);
     });
@@ -205,7 +205,7 @@ describe('TradingSellCompletionScreen', () => {
         const { unmount } = await renderScreen();
 
         expect(mockClearTradingStateThunk).not.toHaveBeenCalled();
-        unmount();
+        await unmount();
 
         expect(mockClearTradingStateThunk).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.test.tsx
@@ -26,26 +26,26 @@ describe('TradingSellPreviewScreen', () => {
         jest.clearAllMocks();
     });
 
-    const renderScreen = ({ withQuote = true, withProvider = true } = {}) => {
+    const renderScreen = async ({ withQuote = true, withProvider = true } = {}) => {
         const tradingState = getInitializedTradingState('sell');
         tradingState.sell.selectedQuote = withQuote ? moonpayCreditCardSellQuote : undefined;
         tradingState.sell.tradingAccountKey = eth1NormalAccount.key;
         tradingState.currentProviderMetadata = withProvider ? sellMoonpay : undefined;
 
-        return renderWithTradingProvider(<TradingSellPreviewScreen />, {
+        return await renderWithTradingProvider(<TradingSellPreviewScreen />, {
             tradeType: 'sell',
             overrides: { wallet: { trading: tradingState } },
         });
     };
 
-    it('shows a general error without quote or provider metadata', () => {
-        const { getByText } = renderScreen({ withQuote: false });
+    it('shows a general error without quote or provider metadata', async () => {
+        const { getByText } = await renderScreen({ withQuote: false });
 
         expect(getByText(getTranslation('generic.unknownError'))).toBeOnTheScreen();
     });
 
-    it('renders provider title and sell summary', () => {
-        const { getByText } = renderScreen();
+    it('renders provider title and sell summary', async () => {
+        const { getByText } = await renderScreen();
 
         expect(
             getByText(
@@ -65,8 +65,8 @@ describe('TradingSellPreviewScreen', () => {
         ).toBeOnTheScreen();
     });
 
-    it('reports a transaction-preview visit', () => {
-        renderScreen();
+    it('reports a transaction-preview visit', async () => {
+        await renderScreen();
 
         expect(mockAnalyticsReport).toHaveBeenCalledWith('transaction-preview', 'visit');
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);

--- a/suite-native/module-trading/src/screens/TradingTradeableAssetScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingTradeableAssetScreen.test.tsx
@@ -65,35 +65,38 @@ describe('TradingTradeableAssetScreen', () => {
     it.each([
         ['buy', 'BTC', btcAsset.cryptoId],
         ['exchange', 'USDC', usdcAsset.cryptoId],
-    ] as const)('renders and selects the %s asset data', (tradingType, assetSymbol, cryptoId) => {
-        mockUseTradingTradeableAssetsFilteredData.mockReturnValue(
-            tradingType === 'buy' ? mockBuyFilteredData : mockExchangeFilteredData,
-        );
+    ] as const)(
+        'renders and selects the %s asset data',
+        async (tradingType, assetSymbol, cryptoId) => {
+            mockUseTradingTradeableAssetsFilteredData.mockReturnValue(
+                tradingType === 'buy' ? mockBuyFilteredData : mockExchangeFilteredData,
+            );
 
-        const { getByLabelText, getByText } = renderWithTradingProvider(
-            <TradingTradeableAssetScreen
-                navigation={navigation}
-                route={createRoute(tradingType)}
-            />,
-        );
+            const { getByLabelText, getByText } = await renderWithTradingProvider(
+                <TradingTradeableAssetScreen
+                    navigation={navigation}
+                    route={createRoute(tradingType)}
+                />,
+            );
 
-        const assetElement =
-            tradingType === 'buy' ? getByText(assetSymbol) : getByLabelText(assetSymbol);
-        fireEvent.press(assetElement);
+            const assetElement =
+                tradingType === 'buy' ? getByText(assetSymbol) : getByLabelText(assetSymbol);
+            await fireEvent.press(assetElement);
 
-        expect(mockUseTradingTradeableAssetsFilteredData).toHaveBeenCalledWith(
-            tradingType === 'buy' ? selectBuyTradeableAssets : selectExchangeBuyTradeableAssets,
-        );
+            expect(mockUseTradingTradeableAssetsFilteredData).toHaveBeenCalledWith(
+                tradingType === 'buy' ? selectBuyTradeableAssets : selectExchangeBuyTradeableAssets,
+            );
 
-        expect(navigation.popTo).toHaveBeenCalledWith(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.TradeStack,
-            params: {
-                screen: TradingStackRoutes.Trading,
+            expect(navigation.popTo).toHaveBeenCalledWith(RootStackRoutes.AppTabs, {
+                screen: AppTabsRoutes.TradeStack,
                 params: {
-                    tradingType,
-                    selectedTradeableAssetCryptoId: cryptoId,
+                    screen: TradingStackRoutes.Trading,
+                    params: {
+                        tradingType,
+                        selectedTradeableAssetCryptoId: cryptoId,
+                    },
                 },
-            },
-        });
-    });
+            });
+        },
+    );
 });

--- a/suite-native/module-trading/src/test-utils/tradingTestUtils.ts
+++ b/suite-native/module-trading/src/test-utils/tradingTestUtils.ts
@@ -159,7 +159,7 @@ type RenderHookWithTradingProviderOptions<Props> = TradingProviderOptions &
 export const renderWithTradingProvider = (
     element: ReactElement,
     { overrides, tradeType, ...options }: RenderWithTradingProviderOptions = {},
-): RenderResult =>
+): Promise<RenderResult> =>
     renderWithStoreProvider(element, {
         preloadedState: createTradingPreloadedState({ overrides, tradeType }),
         ...options,
@@ -168,7 +168,7 @@ export const renderWithTradingProvider = (
 export const renderHookWithTradingProvider = <Result, Props>(
     callback: (props: Props) => Result,
     { overrides, tradeType, ...options }: RenderHookWithTradingProviderOptions<Props> = {},
-): RenderHookResult<Result, Props> =>
+): Promise<RenderHookResult<Result, Props>> =>
     renderHookWithStoreProvider<Result, Props>(callback, {
         preloadedState: createTradingPreloadedState({ overrides, tradeType }),
         ...options,

--- a/suite-native/module-trading/src/utils/buy/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/buy/quotesUtils.test.ts
@@ -18,16 +18,16 @@ import { useBuyForm } from '../../hooks/buy/useBuyForm';
 describe('quotesUtils', () => {
     let form: BuyFormType;
 
-    const renderUseTradingBuyForm = () =>
-        renderHookWithStoreProvider(() => useBuyForm(), {
+    const renderUseTradingBuyForm = async () =>
+        await renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState: {
                 device: deviceInitialState,
                 wallet: { trading: getInitializedTradingState() },
             },
         });
 
-    beforeEach(() => {
-        const { result } = renderUseTradingBuyForm();
+    beforeEach(async () => {
+        const { result } = await renderUseTradingBuyForm();
         form = result.current;
     });
 
@@ -36,8 +36,8 @@ describe('quotesUtils', () => {
             expect(getPaymentMethodFromBuyForm(form)).toBeUndefined();
         });
 
-        it('should return TradingPaymentMethodListProps object when quote is set', () => {
-            act(() => {
+        it('should return TradingPaymentMethodListProps object when quote is set', async () => {
+            await act(() => {
                 form.setValue('quote', mercuryoApplePayBuyQuote);
             });
 
@@ -56,8 +56,8 @@ describe('quotesUtils', () => {
         });
 
         describe('with buy form populated', () => {
-            beforeEach(() => {
-                act(() => {
+            beforeEach(async () => {
+                await act(() => {
                     form.setValue('fiatValue', '100');
                     form.setValue('asset', btcAsset);
                     form.setValue('country', {
@@ -126,8 +126,8 @@ describe('quotesUtils', () => {
                 });
             });
 
-            it('should set receiveAddress from address', () => {
-                act(() => {
+            it('should set receiveAddress from address', async () => {
+                await act(() => {
                     form.setValue('receiveAccount', {
                         account: btc1NormalAccount,
                         address: btc1NormalAccount.addresses!.unused[0],
@@ -143,8 +143,8 @@ describe('quotesUtils', () => {
                 );
             });
 
-            it('should set paymentMethod to undefined when provided quote is not complete', () => {
-                act(() => {
+            it('should set paymentMethod to undefined when provided quote is not complete', async () => {
+                await act(() => {
                     form.setValue('quote', {
                         ...mercuryoApplePayBuyQuote,
                         paymentMethodName: undefined,

--- a/suite-native/module-trading/src/utils/exchange/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/exchange/quotesUtils.test.ts
@@ -23,13 +23,13 @@ import { renderHookWithTradingProvider } from '../../test-utils/tradingTestUtils
 describe('quotesUtils', () => {
     let form: ExchangeFormType;
 
-    const renderUseTradingBuyForm = () =>
-        renderHookWithTradingProvider(() => useExchangeForm(), {
+    const renderUseTradingBuyForm = async () =>
+        await renderHookWithTradingProvider(() => useExchangeForm(), {
             overrides: { wallet: { trading: getInitializedTradingState() } },
         });
 
-    beforeEach(() => {
-        const { result } = renderUseTradingBuyForm();
+    beforeEach(async () => {
+        const { result } = await renderUseTradingBuyForm();
         form = result.current;
     });
 
@@ -40,8 +40,8 @@ describe('quotesUtils', () => {
             );
         });
 
-        it('should throw when receiveAsset is not specified', () => {
-            act(() => {
+        it('should throw when receiveAsset is not specified', async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
             });
 
@@ -50,8 +50,8 @@ describe('quotesUtils', () => {
             );
         });
 
-        it('should throw when sendCryptoAmount is not specified', () => {
-            act(() => {
+        it('should throw when sendCryptoAmount is not specified', async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('receiveAsset', ethAsset);
             });
@@ -61,8 +61,8 @@ describe('quotesUtils', () => {
             );
         });
 
-        it('should return correct TradingExchangeFormProps when all values are set', () => {
-            act(() => {
+        it('should return correct TradingExchangeFormProps when all values are set', async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('receiveAsset', ethAsset);
                 form.setValue('sendCryptoAmount', '1');
@@ -75,8 +75,8 @@ describe('quotesUtils', () => {
             } satisfies MinimalExchangeFormProps);
         });
 
-        it('should include fromAddress when provided', () => {
-            act(() => {
+        it('should include fromAddress when provided', async () => {
+            await act(() => {
                 form.setValue('sendAsset', ethAsset);
                 form.setValue('receiveAsset', btcAsset);
                 form.setValue('sendCryptoAmount', '1');
@@ -91,8 +91,8 @@ describe('quotesUtils', () => {
             } satisfies MinimalExchangeFormProps);
         });
 
-        it('should not use btc account descriptor', () => {
-            act(() => {
+        it('should not use btc account descriptor', async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('receiveAsset', ethAsset);
                 form.setValue('sendCryptoAmount', '1');
@@ -106,14 +106,14 @@ describe('quotesUtils', () => {
             } satisfies MinimalExchangeFormProps);
         });
 
-        it('should make address lower case for eth based assets', () => {
+        it('should make address lower case for eth based assets', async () => {
             const alteredUsdcAsset = {
                 ...usdcAsset,
                 cryptoId: 'ethereum--0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48' as CryptoId,
                 contractAddress: usdcAsset.contractAddress!.toUpperCase() as TokenAddress,
             };
 
-            act(() => {
+            await act(() => {
                 form.setValue('sendAsset', alteredUsdcAsset);
                 form.setValue('receiveAsset', alteredUsdcAsset);
                 form.setValue('sendCryptoAmount', '1');
@@ -130,7 +130,7 @@ describe('quotesUtils', () => {
             } satisfies MinimalExchangeFormProps);
         });
 
-        it('should include receiveAddress when receiveAccount has an address', () => {
+        it('should include receiveAddress when receiveAccount has an address', async () => {
             const receiveAccount: ReceiveAccount = {
                 account: btc1NormalAccount,
                 address: {
@@ -143,7 +143,7 @@ describe('quotesUtils', () => {
                 },
             };
 
-            act(() => {
+            await act(() => {
                 form.setValue('sendAsset', ethAsset);
                 form.setValue('receiveAsset', btcAsset);
                 form.setValue('sendCryptoAmount', '1');
@@ -159,12 +159,12 @@ describe('quotesUtils', () => {
             } satisfies MinimalExchangeFormProps);
         });
 
-        it('should not fall back to account descriptor for BTC when no address is set', () => {
+        it('should not fall back to account descriptor for BTC when no address is set', async () => {
             const receiveAccount: ReceiveAccount = {
                 account: btc1NormalAccount,
             };
 
-            act(() => {
+            await act(() => {
                 form.setValue('sendAsset', ethAsset);
                 form.setValue('receiveAsset', btcAsset);
                 form.setValue('sendCryptoAmount', '1');
@@ -179,12 +179,12 @@ describe('quotesUtils', () => {
             } satisfies MinimalExchangeFormProps);
         });
 
-        it('should use  account descriptor for non-btc like networks', () => {
+        it('should use  account descriptor for non-btc like networks', async () => {
             const receiveAccount: ReceiveAccount = {
                 account: eth1NormalAccount,
             };
 
-            act(() => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('receiveAsset', ethAsset);
                 form.setValue('sendCryptoAmount', '1');
@@ -200,8 +200,8 @@ describe('quotesUtils', () => {
             } satisfies MinimalExchangeFormProps);
         });
 
-        it('should not make address lower case for SOL based assets', () => {
-            act(() => {
+        it('should not make address lower case for SOL based assets', async () => {
+            await act(() => {
                 form.setValue('sendAsset', jupOnSolanaAsset);
                 form.setValue('receiveAsset', jitoOnSolanaAsset);
                 form.setValue('sendCryptoAmount', '1');

--- a/suite-native/module-trading/src/utils/general/validationSchemes.test.ts
+++ b/suite-native/module-trading/src/utils/general/validationSchemes.test.ts
@@ -14,8 +14,8 @@ import {
 
 let formatters: ReturnType<typeof useFormatters>;
 
-beforeAll(() => {
-    const { result } = renderHookWithBasicProvider(() => useFormatters());
+beforeAll(async () => {
+    const { result } = await renderHookWithBasicProvider(() => useFormatters());
     formatters = result.current;
 });
 

--- a/suite-native/module-trading/src/utils/sell/quoteUtils.test.ts
+++ b/suite-native/module-trading/src/utils/sell/quoteUtils.test.ts
@@ -11,13 +11,13 @@ import { useSellForm } from '../../hooks/sell/useSellForm';
 describe('quoteUtils', () => {
     let form: SellFormType;
 
-    const renderUseTradingSellForm = () =>
-        renderHookWithStoreProvider(() => useSellForm(), {
+    const renderUseTradingSellForm = async () =>
+        await renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) },
         });
 
-    beforeEach(() => {
-        const { result } = renderUseTradingSellForm();
+    beforeEach(async () => {
+        const { result } = await renderUseTradingSellForm();
         form = result.current;
     });
 
@@ -28,8 +28,8 @@ describe('quoteUtils', () => {
             );
         });
 
-        it('should throw when amountInCrypto is true and cryptoStringAmount is not specified', () => {
-            act(() => {
+        it('should throw when amountInCrypto is true and cryptoStringAmount is not specified', async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('amountInCrypto', true);
             });
@@ -39,8 +39,8 @@ describe('quoteUtils', () => {
             );
         });
 
-        it('should throw when amountInCrypto is false and fiatStringAmount is not specified', () => {
-            act(() => {
+        it('should throw when amountInCrypto is false and fiatStringAmount is not specified', async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('amountInCrypto', false);
             });
@@ -50,8 +50,8 @@ describe('quoteUtils', () => {
             );
         });
 
-        it('should return correct MinimalSellFormProps when all values are specified and amountInCrypto is true', () => {
-            act(() => {
+        it('should return correct MinimalSellFormProps when all values are specified and amountInCrypto is true', async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('amountInCrypto', true);
                 form.setValue('cryptoStringAmount', '0.1');
@@ -80,8 +80,8 @@ describe('quoteUtils', () => {
             } satisfies MinimalSellFormProps);
         });
 
-        it('should return correct MinimalSellFormProps when all values are specified and amountInCrypto is false', () => {
-            act(() => {
+        it('should return correct MinimalSellFormProps when all values are specified and amountInCrypto is false', async () => {
+            await act(() => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('amountInCrypto', false);
                 form.setValue('fiatStringAmount', '1000');

--- a/suite-native/module-transactions/src/hooks/useCancelEvmTransaction.test.tsx
+++ b/suite-native/module-transactions/src/hooks/useCancelEvmTransaction.test.tsx
@@ -96,8 +96,8 @@ const selectDeviceButtonRequestsCodesMock = selectDeviceButtonRequestsCodes as u
 // Stable references so react-redux's reference-equality useSelector doesn't re-render every tick.
 const EMPTY_BUTTON_REQUEST_CODES: number[] = [];
 
-const renderCancelHook = (transaction: WalletAccountTransaction = pendingEvmTx) =>
-    renderHookWithStoreProvider(() =>
+const renderCancelHook = async (transaction: WalletAccountTransaction = pendingEvmTx) =>
+    await renderHookWithStoreProvider(() =>
         useCancelEvmTransaction({ accountKey: ethAccount.key, transaction }),
     );
 
@@ -111,8 +111,8 @@ describe('useCancelEvmTransaction', () => {
         selectDeviceButtonRequestsCodesMock.mockReturnValue(EMPTY_BUTTON_REQUEST_CODES);
     });
 
-    it('is cancellable for a pending EVM tx with rbf params and a live (non-stuck) nonce', () => {
-        const { result } = renderCancelHook();
+    it('is cancellable for a pending EVM tx with rbf params and a live (non-stuck) nonce', async () => {
+        const { result } = await renderCancelHook();
 
         expect(result.current.isCancellable).toBe(true);
         // sanity: nothing composed/signing yet
@@ -122,34 +122,34 @@ describe('useCancelEvmTransaction', () => {
         expect(result.current.isSigning).toBe(false);
     });
 
-    it('is not cancellable when the account is not an EVM account', () => {
+    it('is not cancellable when the account is not an EVM account', async () => {
         selectAccountByKeyMock.mockReturnValue(btcAccount);
 
-        const { result } = renderCancelHook();
+        const { result } = await renderCancelHook();
 
         expect(result.current.isCancellable).toBe(false);
     });
 
-    it('is not cancellable when the transaction is no longer pending', () => {
+    it('is not cancellable when the transaction is no longer pending', async () => {
         selectIsTransactionPendingMock.mockReturnValue(false);
 
-        const { result } = renderCancelHook();
+        const { result } = await renderCancelHook();
 
         expect(result.current.isCancellable).toBe(false);
     });
 
-    it("is not cancellable when the tx's own nonce is stuck (superseded/gapped)", () => {
+    it("is not cancellable when the tx's own nonce is stuck (superseded/gapped)", async () => {
         useEvmNonceInfoMock.mockReturnValue({ nonceInfo: stuckNonceInfo });
 
-        const { result } = renderCancelHook();
+        const { result } = await renderCancelHook();
 
         expect(result.current.isCancellable).toBe(false);
     });
 
-    it('is not cancellable for a tx without ethereum rbf params', () => {
+    it('is not cancellable for a tx without ethereum rbf params', async () => {
         const txWithoutRbf = { ...pendingEvmTx, rbfParams: undefined } as WalletAccountTransaction;
 
-        const { result } = renderCancelHook(txWithoutRbf);
+        const { result } = await renderCancelHook(txWithoutRbf);
 
         expect(result.current.isCancellable).toBe(false);
     });

--- a/suite-native/module-transactions/src/hooks/useDeviceGuardedSign.test.tsx
+++ b/suite-native/module-transactions/src/hooks/useDeviceGuardedSign.test.tsx
@@ -45,8 +45,8 @@ const cancelNavigationTarget = {
     name: RootStackRoutes.TransactionDetailStack,
 } as unknown as NavigateParameters<RootStackParamList>;
 
-const renderGuardedSign = (sign: () => Promise<void>) =>
-    renderHookWithStoreProvider(() => useDeviceGuardedSign({ sign, cancelNavigationTarget }));
+const renderGuardedSign = async (sign: () => Promise<void>) =>
+    await renderHookWithStoreProvider(() => useDeviceGuardedSign({ sign, cancelNavigationTarget }));
 
 describe('useDeviceGuardedSign', () => {
     beforeEach(() => {
@@ -56,10 +56,10 @@ describe('useDeviceGuardedSign', () => {
         selectDeviceButtonRequestsCodesMock.mockReturnValue(NO_BUTTON_REQUESTS);
     });
 
-    it('routes requestSign through the device-connection guard, forwarding the cancel target', () => {
-        const { result } = renderGuardedSign(jest.fn().mockResolvedValue(undefined));
+    it('routes requestSign through the device-connection guard, forwarding the cancel target', async () => {
+        const { result } = await renderGuardedSign(jest.fn().mockResolvedValue(undefined));
 
-        act(() => result.current.requestSign());
+        await act(() => result.current.requestSign());
 
         expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.AuthorizeDeviceStack, {
             screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
@@ -69,9 +69,9 @@ describe('useDeviceGuardedSign', () => {
 
     it('runs the pending sign when the screen regains focus with an authorized device', async () => {
         const sign = jest.fn().mockResolvedValue(undefined);
-        const { result } = renderGuardedSign(sign);
+        const { result } = await renderGuardedSign(sign);
 
-        act(() => result.current.requestSign());
+        await act(() => result.current.requestSign());
         await act(async () => {
             capturedFocusHandler?.();
             await Promise.resolve();
@@ -83,9 +83,9 @@ describe('useDeviceGuardedSign', () => {
     it('does not sign on focus when the device is not authorized', async () => {
         selectIsDeviceConnectedAndAuthorizedMock.mockReturnValue(false);
         const sign = jest.fn().mockResolvedValue(undefined);
-        const { result } = renderGuardedSign(sign);
+        const { result } = await renderGuardedSign(sign);
 
-        act(() => result.current.requestSign());
+        await act(() => result.current.requestSign());
         await act(async () => {
             capturedFocusHandler?.();
             await Promise.resolve();
@@ -96,7 +96,7 @@ describe('useDeviceGuardedSign', () => {
 
     it('does not sign on focus when no sign was requested', async () => {
         const sign = jest.fn().mockResolvedValue(undefined);
-        renderGuardedSign(sign);
+        await renderGuardedSign(sign);
 
         await act(async () => {
             capturedFocusHandler?.();
@@ -115,12 +115,12 @@ describe('useDeviceGuardedSign', () => {
                     resolveSign = resolve;
                 }),
         );
-        const { result } = renderGuardedSign(sign);
+        const { result } = await renderGuardedSign(sign);
 
         expect(result.current.isSigning).toBe(false);
         expect(result.current.isWaitingForDevice).toBe(false);
 
-        act(() => result.current.requestSign());
+        await act(() => result.current.requestSign());
         await act(async () => {
             capturedFocusHandler?.();
             await Promise.resolve();

--- a/suite-native/navigation/src/hooks/useNavigationRemoveActionInterceptor.test.ts
+++ b/suite-native/navigation/src/hooks/useNavigationRemoveActionInterceptor.test.ts
@@ -33,11 +33,11 @@ describe('useNavigationRemoveActionInterceptor', () => {
         jest.clearAllMocks();
     });
 
-    it('calls onInterceptedAction when action type is included in actionTypes', () => {
+    it('calls onInterceptedAction when action type is included in actionTypes', async () => {
         const onInterceptedAction = jest.fn();
         const action: NavigationAction = { type: 'GO_BACK' };
 
-        renderHookWithBasicProvider(() =>
+        await renderHookWithBasicProvider(() =>
             useNavigationRemoveActionInterceptor({
                 interceptedActionTypes: ['GO_BACK'],
                 onInterceptedAction,
@@ -49,12 +49,12 @@ describe('useNavigationRemoveActionInterceptor', () => {
         expect(mockDispatch).not.toHaveBeenCalled();
     });
 
-    it('does not call onInterceptedAction when action type is not included in actionTypes', () => {
+    it('does not call onInterceptedAction when action type is not included in actionTypes', async () => {
         const onInterceptedAction = jest.fn();
         const onAllowedAction = jest.fn();
         const action: NavigationAction = { type: 'POP' };
 
-        renderHookWithBasicProvider(() =>
+        await renderHookWithBasicProvider(() =>
             useNavigationRemoveActionInterceptor({
                 interceptedActionTypes: ['GO_BACK'],
                 onInterceptedAction,

--- a/suite-native/test-utils-store/package.json
+++ b/suite-native/test-utils-store/package.json
@@ -14,10 +14,11 @@
         "@reduxjs/toolkit": "2.12.0",
         "@suite-native/formatters-config": "workspace:*",
         "@suite-native/test-utils": "workspace:*",
-        "@testing-library/react-native": "13.3.3",
+        "@testing-library/react-native": "14.0.1",
         "@trezor/utils": "workspace:*",
         "react": "19.2.3",
         "react-native": "0.86.0",
-        "react-redux": "9.3.0"
+        "react-redux": "9.3.0",
+        "test-renderer": "1.2.0"
     }
 }

--- a/suite-native/test-utils-store/src/renderWithStore.tsx
+++ b/suite-native/test-utils-store/src/renderWithStore.tsx
@@ -23,11 +23,11 @@ export type RenderHookOptionsExtended<Props> = RenderHookOptions<Props> & {
     store?: TestStore;
 };
 
-export const renderWithStoreProvider = (
+export const renderWithStoreProvider = async (
     element: ReactElement,
     { preloadedState, services, wrapper: Wrapper, store, ...options }: RenderOptionsExtended = {},
-): RenderResult =>
-    render(element, {
+): Promise<RenderResult> =>
+    await render(element, {
         wrapper: ({ children }) => (
             <StoreProviderForTests
                 preloadedState={preloadedState}
@@ -40,7 +40,7 @@ export const renderWithStoreProvider = (
         ...options,
     });
 
-export const renderHookWithStoreProvider = <Result = unknown, Props = unknown>(
+export const renderHookWithStoreProvider = async <Result = unknown, Props = unknown>(
     callback: (props: Props) => Result,
     {
         preloadedState,
@@ -49,8 +49,8 @@ export const renderHookWithStoreProvider = <Result = unknown, Props = unknown>(
         store,
         ...options
     }: RenderHookOptionsExtended<Props> = {},
-): RenderHookResult<Result, Props> =>
-    renderHook(callback, {
+): Promise<RenderHookResult<Result, Props>> =>
+    await renderHook(callback, {
         wrapper: ({ children }) => (
             <StoreProviderForTests
                 preloadedState={preloadedState}

--- a/suite-native/test-utils/package.json
+++ b/suite-native/test-utils/package.json
@@ -23,7 +23,7 @@
         "@suite-native/analytics": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/services": "workspace:*",
-        "@testing-library/react-native": "13.3.3",
+        "@testing-library/react-native": "14.0.1",
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",
         "react": "19.2.3",
@@ -33,6 +33,7 @@
         "react-native-permissions": "5.4.4",
         "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
-        "react-native-worklets": "0.10.0"
+        "react-native-worklets": "0.10.0",
+        "test-renderer": "1.2.0"
     }
 }

--- a/suite-native/test-utils/src/renderBasic.tsx
+++ b/suite-native/test-utils/src/renderBasic.tsx
@@ -13,7 +13,7 @@ import type { FormatterProviderConfig } from '@suite-common/formatters';
 
 import { BasicProviderForTests } from './BasicProviderForTests';
 
-export const renderWithBasicProvider = <Props,>(
+export const renderWithBasicProvider = async <Props,>(
     element: ReactElement<Props>,
     {
         formattersConfig,
@@ -24,8 +24,8 @@ export const renderWithBasicProvider = <Props,>(
         formattersConfig?: FormatterProviderConfig;
         services?: Record<string, unknown>;
     } = {},
-): RenderResult =>
-    render(element, {
+): Promise<RenderResult> =>
+    await render(element, {
         wrapper: ({ children }) => (
             <BasicProviderForTests formattersConfig={formattersConfig} services={services}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
@@ -34,7 +34,7 @@ export const renderWithBasicProvider = <Props,>(
         ...options,
     });
 
-export const renderHookWithBasicProvider = <Result, Props>(
+export const renderHookWithBasicProvider = async <Result, Props>(
     callback: (props: Props) => Result,
     {
         formattersConfig,
@@ -45,8 +45,8 @@ export const renderHookWithBasicProvider = <Result, Props>(
         formattersConfig?: FormatterProviderConfig;
         services?: Record<string, unknown>;
     } = {},
-): RenderHookResult<Result, Props> =>
-    renderHook(callback, {
+): Promise<RenderHookResult<Result, Props>> =>
+    await renderHook(callback, {
         wrapper: ({ children }) => (
             <BasicProviderForTests formattersConfig={formattersConfig} services={services}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}

--- a/suite-native/trading-analytics/src/hooks/useBuyAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/useBuyAnalyticReportCallback.test.ts
@@ -28,14 +28,14 @@ describe('useBuyAnalyticReportCallback', () => {
     ): BuyAnalyticsPreloadedState =>
         mergePreloadedState({ wallet: getWalletState({ tradeType: 'buy' }) }, overrides);
 
-    const renderUseBuyAnalyticReportCallback = ({
+    const renderUseBuyAnalyticReportCallback = async ({
         candidateQuote: initialCandidateQuote,
         preloadedState = createPreloadedState(),
     }: {
         candidateQuote?: Parameters<typeof useBuyAnalyticReportCallback>[0];
         preloadedState?: BuyAnalyticsPreloadedState;
     } = {}) =>
-        renderHookWithStoreProvider(
+        await renderHookWithStoreProvider(
             ({ candidateQuote }) => useBuyAnalyticReportCallback(candidateQuote),
             {
                 preloadedState,
@@ -50,8 +50,8 @@ describe('useBuyAnalyticReportCallback', () => {
         jest.clearAllMocks();
     });
 
-    it('should call analytics with correct payload when persisted quote and coinInfo are present', () => {
-        const { result } = renderUseBuyAnalyticReportCallback({
+    it('should call analytics with correct payload when persisted quote and coinInfo are present', async () => {
+        const { result } = await renderUseBuyAnalyticReportCallback({
             preloadedState: createPreloadedState({
                 wallet: {
                     trading: {
@@ -76,8 +76,8 @@ describe('useBuyAnalyticReportCallback', () => {
         });
     });
 
-    it('should prefer candidateQuote over persisted quote', () => {
-        const { result } = renderUseBuyAnalyticReportCallback({
+    it('should prefer candidateQuote over persisted quote', async () => {
+        const { result } = await renderUseBuyAnalyticReportCallback({
             candidateQuote: cexdirectCreditCardBuyQuote,
             preloadedState: createPreloadedState({
                 wallet: {

--- a/suite-native/trading-analytics/src/hooks/useBuyAnalyticsStepReport.test.ts
+++ b/suite-native/trading-analytics/src/hooks/useBuyAnalyticsStepReport.test.ts
@@ -13,8 +13,8 @@ describe('useBuyAnalyticsStepReport', () => {
         jest.clearAllMocks();
     });
 
-    it('should pass the step and action to the underlying callback', () => {
-        const { result } = renderHookWithBasicProvider(() =>
+    it('should pass the step and action to the underlying callback', async () => {
+        const { result } = await renderHookWithBasicProvider(() =>
             useBuyAnalyticsStepReport('buy-preview'),
         );
 

--- a/suite-native/trading-analytics/src/hooks/useExchangeAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/useExchangeAnalyticReportCallback.test.ts
@@ -30,14 +30,14 @@ describe('useExchangeAnalyticReportCallback', () => {
     ): ExchangeAnalyticsPreloadedState =>
         mergePreloadedState({ wallet: getWalletState({ tradeType: 'exchange' }) }, overrides);
 
-    const renderUseExchangeAnalyticReportCallback = ({
+    const renderUseExchangeAnalyticReportCallback = async ({
         candidateQuote: initialCandidateQuote,
         preloadedState = createPreloadedState(),
     }: {
         candidateQuote?: Parameters<typeof useExchangeAnalyticReportCallback>[0];
         preloadedState?: ExchangeAnalyticsPreloadedState;
     } = {}) =>
-        renderHookWithStoreProvider(
+        await renderHookWithStoreProvider(
             ({ candidateQuote }) => useExchangeAnalyticReportCallback(candidateQuote),
             {
                 preloadedState,
@@ -52,8 +52,8 @@ describe('useExchangeAnalyticReportCallback', () => {
         jest.clearAllMocks();
     });
 
-    it('should call analytics on mount', () => {
-        const { result } = renderUseExchangeAnalyticReportCallback({
+    it('should call analytics on mount', async () => {
+        const { result } = await renderUseExchangeAnalyticReportCallback({
             preloadedState: createPreloadedState({
                 wallet: {
                     trading: {
@@ -77,8 +77,8 @@ describe('useExchangeAnalyticReportCallback', () => {
         });
     });
 
-    it('should work without quote', () => {
-        const { result } = renderUseExchangeAnalyticReportCallback();
+    it('should work without quote', async () => {
+        const { result } = await renderUseExchangeAnalyticReportCallback();
 
         result.current('exchange-form', 'continue');
 
@@ -91,8 +91,8 @@ describe('useExchangeAnalyticReportCallback', () => {
         });
     });
 
-    it('should allow to specify quote as parameter', () => {
-        const { result } = renderUseExchangeAnalyticReportCallback({
+    it('should allow to specify quote as parameter', async () => {
+        const { result } = await renderUseExchangeAnalyticReportCallback({
             candidateQuote: invityDexQuote,
             preloadedState: createPreloadedState({
                 wallet: {
@@ -121,8 +121,8 @@ describe('useExchangeAnalyticReportCallback', () => {
     it.each([
         [{ ...mercuryoFixedWorstQuote, send: 'unknown_cryptoID' as CryptoId }],
         [{ ...mercuryoFixedWorstQuote, receive: 'unknown_cryptoID' as CryptoId }],
-    ])('should work with unknown quote values', quote => {
-        const { result } = renderUseExchangeAnalyticReportCallback({
+    ])('should work with unknown quote values', async quote => {
+        const { result } = await renderUseExchangeAnalyticReportCallback({
             candidateQuote: quote,
         });
 
@@ -137,13 +137,13 @@ describe('useExchangeAnalyticReportCallback', () => {
         });
     });
 
-    it('should be stable even when quote changes', () => {
-        const { result, rerender } = renderUseExchangeAnalyticReportCallback({
+    it('should be stable even when quote changes', async () => {
+        const { result, rerender } = await renderUseExchangeAnalyticReportCallback({
             candidateQuote: mercuryoFixedWorstQuote,
         });
         const firstCallback = result.current;
 
-        rerender({ candidateQuote: invityDexQuote });
+        await rerender({ candidateQuote: invityDexQuote });
 
         expect(result.current).toBe(firstCallback);
     });

--- a/suite-native/trading-analytics/src/hooks/useExchangeAnalyticsStepReport.test.ts
+++ b/suite-native/trading-analytics/src/hooks/useExchangeAnalyticsStepReport.test.ts
@@ -16,8 +16,8 @@ describe('useExchangeAnalyticsStepReport', () => {
         jest.clearAllMocks();
     });
 
-    it('should report correct data on callback execution', () => {
-        const { result } = renderHookWithStoreProvider(
+    it('should report correct data on callback execution', async () => {
+        const { result } = await renderHookWithStoreProvider(
             () => useExchangeAnalyticsStepReport('exchange-form'),
             { preloadedState },
         );

--- a/suite-native/trading-analytics/src/hooks/useExchangeIssueAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/useExchangeIssueAnalyticReportCallback.test.ts
@@ -14,13 +14,13 @@ describe('useExchangeIssueAnalyticReportCallback', () => {
         jest.clearAllMocks();
     });
 
-    it('reports an exchange issue', () => {
-        const { result } = renderHookWithBasicProvider(
+    it('reports an exchange issue', async () => {
+        const { result } = await renderHookWithBasicProvider(
             () => useExchangeIssueAnalyticReportCallback(),
             { services },
         );
 
-        act(() => {
+        await act(() => {
             result.current('high-risk', true);
         });
 

--- a/suite-native/trading-analytics/src/hooks/useTradingAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/useTradingAnalyticReportCallback.test.ts
@@ -44,8 +44,8 @@ describe('useTradingAnalyticReportCallback', () => {
             };
         });
 
-        it('should return sell analytics callback', () => {
-            const { result } = renderHookWithStoreProvider(
+        it('should return sell analytics callback', async () => {
+            const { result } = await renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('sell'),
                 { preloadedState, services },
             );
@@ -81,8 +81,8 @@ describe('useTradingAnalyticReportCallback', () => {
             };
         });
 
-        it('should return exchange analytics callback', () => {
-            const { result } = renderHookWithStoreProvider(
+        it('should return exchange analytics callback', async () => {
+            const { result } = await renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('exchange'),
                 { preloadedState, services },
             );
@@ -110,8 +110,8 @@ describe('useTradingAnalyticReportCallback', () => {
             };
         });
 
-        it('should return null action (no analytics)', () => {
-            const { result } = renderHookWithStoreProvider(
+        it('should return null action (no analytics)', async () => {
+            const { result } = await renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback(undefined),
                 { preloadedState, services },
             );
@@ -129,8 +129,8 @@ describe('useTradingAnalyticReportCallback', () => {
             };
         });
 
-        it('should return null action (no analytics)', () => {
-            const { result } = renderHookWithStoreProvider(
+        it('should return null action (no analytics)', async () => {
+            const { result } = await renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('buy'),
                 { preloadedState, services },
             );

--- a/suite-native/trading-atoms/src/components/AmountEditingDoneButton.test.tsx
+++ b/suite-native/trading-atoms/src/components/AmountEditingDoneButton.test.tsx
@@ -6,11 +6,11 @@ import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 import { AmountEditingDoneButton } from './AmountEditingDoneButton';
 
 describe('AmountEditingDoneButton', () => {
-    it('should remove focus from active input', () => {
+    it('should remove focus from active input', async () => {
         const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
-        const { getByText } = renderWithBasicProvider(<AmountEditingDoneButton />);
+        const { getByText } = await renderWithBasicProvider(<AmountEditingDoneButton />);
 
-        fireEvent.press(getByText(getTranslation('generic.buttons.done')));
+        await fireEvent.press(getByText(getTranslation('generic.buttons.done')));
 
         expect(keyboardDismissSpy).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/trading-atoms/src/components/BottomSheetSearchInputWithCancel.test.tsx
+++ b/suite-native/trading-atoms/src/components/BottomSheetSearchInputWithCancel.test.tsx
@@ -17,8 +17,8 @@ jest.mock('@trezor/react-utils', () => {
 });
 
 describe('SearchInputWithCancel', () => {
-    const renderSearchInputWithCancel = (props: Partial<BottomSheetSearchInputProps>) =>
-        renderWithBasicProvider(
+    const renderSearchInputWithCancel = async (props: Partial<BottomSheetSearchInputProps>) =>
+        await renderWithBasicProvider(
             <BottomSheetSearchInputWithCancel onChange={jest.fn()} {...props} />,
         );
 
@@ -28,48 +28,48 @@ describe('SearchInputWithCancel', () => {
         expect(queryByText(getTranslation('generic.buttons.cancel'))).toBeNull();
     });
 
-    it('should call onChange callback when text is typed', () => {
+    it('should call onChange callback when text is typed', async () => {
         const changeMock = jest.fn();
-        const { getByPlaceholderText } = renderSearchInputWithCancel({
+        const { getByPlaceholderText } = await renderSearchInputWithCancel({
             onChange: changeMock,
         });
 
-        fireEvent.changeText(getByPlaceholderText('Search'), 'test');
+        await fireEvent.changeText(getByPlaceholderText('Search'), 'test');
 
         expect(changeMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should call onFocus and display "Cancel" button on input focus', () => {
+    it('should call onFocus and display "Cancel" button on input focus', async () => {
         const focusMock = jest.fn();
-        const { getByText, getByPlaceholderText } = renderSearchInputWithCancel({
+        const { getByText, getByPlaceholderText } = await renderSearchInputWithCancel({
             onFocus: focusMock,
         });
 
-        fireEvent(getByPlaceholderText('Search'), 'focus');
+        await fireEvent(getByPlaceholderText('Search'), 'focus');
 
         expect(getByText(getTranslation('generic.buttons.cancel'))).toBeTruthy();
         expect(focusMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should call onChange with empty value on unmount', () => {
+    it('should call onChange with empty value on unmount', async () => {
         const onChangeMock = jest.fn();
-        const { unmount } = renderSearchInputWithCancel({
+        const { unmount } = await renderSearchInputWithCancel({
             onChange: onChangeMock,
         });
 
-        unmount();
+        await unmount();
 
         expect(onChangeMock).toHaveBeenCalledWith('');
     });
 
-    it('should call onChange with empty value when Cancel is pressed', () => {
+    it('should call onChange with empty value when Cancel is pressed', async () => {
         const onChangeMock = jest.fn();
-        const { getByPlaceholderText, getByText } = renderSearchInputWithCancel({
+        const { getByPlaceholderText, getByText } = await renderSearchInputWithCancel({
             onChange: onChangeMock,
         });
 
-        fireEvent(getByPlaceholderText('Search'), 'focus');
-        fireEvent.press(getByText(getTranslation('generic.buttons.cancel')));
+        await fireEvent(getByPlaceholderText('Search'), 'focus');
+        await fireEvent.press(getByText(getTranslation('generic.buttons.cancel')));
 
         expect(onChangeMock).toHaveBeenCalledWith('');
     });

--- a/suite-native/trading-atoms/src/components/EmptyComponent.test.tsx
+++ b/suite-native/trading-atoms/src/components/EmptyComponent.test.tsx
@@ -3,8 +3,8 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { EmptyComponent } from './EmptyComponent';
 
 describe('EmptyComponent', () => {
-    it('should render given title and description', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should render given title and description', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <EmptyComponent title="TITLE" description="DESCRIPTION" />,
         );
 

--- a/suite-native/trading-atoms/src/components/Error/ServerOffline.test.tsx
+++ b/suite-native/trading-atoms/src/components/Error/ServerOffline.test.tsx
@@ -4,17 +4,17 @@ import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-util
 import { ServerOffline, type ServerOfflineProps } from './ServerOffline';
 
 describe('ServerOffline', () => {
-    const renderServerOffline = (props: Partial<ServerOfflineProps>) =>
-        renderWithBasicProvider(<ServerOffline onRetryPress={jest.fn()} {...props} />);
+    const renderServerOffline = async (props: Partial<ServerOfflineProps>) =>
+        await renderWithBasicProvider(<ServerOffline onRetryPress={jest.fn()} {...props} />);
 
-    it('should call onRetryPress when "Try again" button is pressed', () => {
+    it('should call onRetryPress when "Try again" button is pressed', async () => {
         const retryPressMock = jest.fn();
-        const { getByText } = renderServerOffline({ onRetryPress: retryPressMock });
+        const { getByText } = await renderServerOffline({ onRetryPress: retryPressMock });
 
         const retryButton = getByText(getTranslation('tradingAtoms.error.serverOfflineRetry'));
 
-        act(() => {
-            fireEvent.press(retryButton);
+        await act(async () => {
+            await fireEvent.press(retryButton);
         });
 
         expect(retryPressMock).toHaveBeenCalledTimes(1);

--- a/suite-native/trading-atoms/src/components/FiatCurrencyIcon.test.tsx
+++ b/suite-native/trading-atoms/src/components/FiatCurrencyIcon.test.tsx
@@ -3,8 +3,8 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { FiatCurrencyIcon } from './FiatCurrencyIcon';
 
 describe('FiatCurrencyIcon', () => {
-    it('should render a mapped fiat currency flag', () => {
-        const { getByLabelText, queryByText } = renderWithBasicProvider(
+    it('should render a mapped fiat currency flag', async () => {
+        const { getByLabelText, queryByText } = await renderWithBasicProvider(
             <FiatCurrencyIcon size="medium" value="usd" />,
         );
 
@@ -12,8 +12,8 @@ describe('FiatCurrencyIcon', () => {
         expect(queryByText('coin')).toBeNull();
     });
 
-    it('should render fallback coin icon when fiat currency is missing', () => {
-        const { queryByTestId } = renderWithBasicProvider(<FiatCurrencyIcon size="medium" />);
+    it('should render fallback coin icon when fiat currency is missing', async () => {
+        const { queryByTestId } = await renderWithBasicProvider(<FiatCurrencyIcon size="medium" />);
 
         expect(queryByTestId('@trading/fiat-currency-icon-fallback')).toBeTruthy();
         expect(queryByTestId('@atom/flag')).toBeNull();

--- a/suite-native/trading-atoms/src/components/IconByCryptoId.test.tsx
+++ b/suite-native/trading-atoms/src/components/IconByCryptoId.test.tsx
@@ -13,7 +13,7 @@ const networkIconHint = 'Network Icon';
 
 describe('IconByCryptoId', () => {
     const renderIcon = async (props: IconByCryptoIdProps) => {
-        const result = renderWithBasicProvider(<IconByCryptoId {...props} />);
+        const result = await renderWithBasicProvider(<IconByCryptoId {...props} />);
         await act(async () => {});
 
         return result;

--- a/suite-native/trading-atoms/src/components/IconWithSpinner.test.tsx
+++ b/suite-native/trading-atoms/src/components/IconWithSpinner.test.tsx
@@ -3,23 +3,23 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { IconWithSpinner, type IconWithSpinnerProps } from './IconWithSpinner';
 
 describe('IconWithSpinner', () => {
-    const renderIconWithSpinner = (props: Partial<IconWithSpinnerProps> = {}) =>
-        renderWithBasicProvider(<IconWithSpinner iconName="check" {...props} />);
+    const renderIconWithSpinner = async (props: Partial<IconWithSpinnerProps> = {}) =>
+        await renderWithBasicProvider(<IconWithSpinner iconName="check" {...props} />);
 
-    it('should render spinner when isInProgress is true by default', () => {
-        const { getByTestId } = renderIconWithSpinner();
+    it('should render spinner when isInProgress is true by default', async () => {
+        const { getByTestId } = await renderIconWithSpinner();
 
         expect(getByTestId('@circular-spinner')).toBeOnTheScreen();
     });
 
-    it('should not render spinner when isInProgress is false', () => {
-        const { queryByTestId } = renderIconWithSpinner({ isInProgress: false });
+    it('should not render spinner when isInProgress is false', async () => {
+        const { queryByTestId } = await renderIconWithSpinner({ isInProgress: false });
 
         expect(queryByTestId('@circular-spinner')).toBeNull();
     });
 
-    it('should render spinner when isInProgress is explicitly true', () => {
-        const { getByTestId } = renderIconWithSpinner({ isInProgress: true });
+    it('should render spinner when isInProgress is explicitly true', async () => {
+        const { getByTestId } = await renderIconWithSpinner({ isInProgress: true });
 
         expect(getByTestId('@circular-spinner')).toBeOnTheScreen();
     });

--- a/suite-native/trading-atoms/src/components/KYCWarning.test.tsx
+++ b/suite-native/trading-atoms/src/components/KYCWarning.test.tsx
@@ -4,8 +4,8 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { KYCWarning } from './KYCWarning';
 
 describe('KYCWarning', () => {
-    it('should render KYC info ', () => {
-        const { getByText } = renderWithBasicProvider(<KYCWarning />);
+    it('should render KYC info ', async () => {
+        const { getByText } = await renderWithBasicProvider(<KYCWarning />);
 
         expect(
             getByText(getTranslation('moduleTrading.tradingScreen.kycRequired')),

--- a/suite-native/trading-atoms/src/components/NetworkBadge.test.tsx
+++ b/suite-native/trading-atoms/src/components/NetworkBadge.test.tsx
@@ -5,11 +5,11 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { NetworkBadge } from './NetworkBadge';
 
 describe('NetworkBadge', () => {
-    const renderPlatformBadge = (symbol: NetworkSymbol) =>
-        renderWithBasicProvider(<NetworkBadge symbol={symbol} />);
+    const renderPlatformBadge = async (symbol: NetworkSymbol) =>
+        await renderWithBasicProvider(<NetworkBadge symbol={symbol} />);
 
-    it('should render badge with platform name', () => {
-        const { getByLabelText } = renderPlatformBadge('eth');
+    it('should render badge with platform name', async () => {
+        const { getByLabelText } = await renderPlatformBadge('eth');
 
         expect(getByLabelText(getTranslation('moduleTrading.networkName'))).toHaveTextContent(
             'Ethereum',

--- a/suite-native/trading-atoms/src/components/OverviewRow.test.tsx
+++ b/suite-native/trading-atoms/src/components/OverviewRow.test.tsx
@@ -25,7 +25,7 @@ describe('OverviewRow', () => {
 
         await fireEvent.press(getByText('Title'));
 
-        expect(onPress).toHaveBeenCalledWith();
+        expect(onPress).toHaveBeenCalledTimes(1);
     });
 
     it('should render warning when added', async () => {

--- a/suite-native/trading-atoms/src/components/OverviewRow.test.tsx
+++ b/suite-native/trading-atoms/src/components/OverviewRow.test.tsx
@@ -4,8 +4,8 @@ import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 import { OverviewRow } from './OverviewRow';
 
 describe('OverviewRow', () => {
-    it('should use title as left text as well as a11yLabel', () => {
-        const { getByText, getByLabelText } = renderWithBasicProvider(
+    it('should use title as left text as well as a11yLabel', async () => {
+        const { getByText, getByLabelText } = await renderWithBasicProvider(
             <OverviewRow title="Title" onPress={jest.fn()}>
                 <Text>Child</Text>
             </OverviewRow>,
@@ -15,21 +15,21 @@ describe('OverviewRow', () => {
         expect(getByLabelText('Title')).toBeTruthy();
     });
 
-    it('should call onPress callback when clicked', () => {
+    it('should call onPress callback when clicked', async () => {
         const onPress = jest.fn();
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = await renderWithBasicProvider(
             <OverviewRow title="Title" onPress={onPress}>
                 <Text>Child</Text>
             </OverviewRow>,
         );
 
-        fireEvent.press(getByText('Title'));
+        await fireEvent.press(getByText('Title'));
 
         expect(onPress).toHaveBeenCalledWith();
     });
 
-    it('should render warning when added', () => {
-        const { queryByHintText } = renderWithBasicProvider(
+    it('should render warning when added', async () => {
+        const { queryByHintText } = await renderWithBasicProvider(
             <OverviewRow title="Title" warning="Warning message">
                 <Text>Child</Text>
             </OverviewRow>,
@@ -38,8 +38,8 @@ describe('OverviewRow', () => {
         expect(queryByHintText('Warning')).toHaveTextContent(/^.Warning message$/);
     });
 
-    it('should not render warning when not added', () => {
-        const { queryByHintText } = renderWithBasicProvider(
+    it('should not render warning when not added', async () => {
+        const { queryByHintText } = await renderWithBasicProvider(
             <OverviewRow title="Title">
                 <Text>Child</Text>
             </OverviewRow>,

--- a/suite-native/trading-atoms/src/components/PaymentMethodTranslation.test.tsx
+++ b/suite-native/trading-atoms/src/components/PaymentMethodTranslation.test.tsx
@@ -8,15 +8,15 @@ import {
 } from './PaymentMethodTranslation';
 
 describe('PaymentMethodTranslation', () => {
-    const renderPaymentMethodTranslation = (props: PaymentMethodTranslationProps) =>
-        renderWithBasicProvider(
+    const renderPaymentMethodTranslation = async (props: PaymentMethodTranslationProps) =>
+        await renderWithBasicProvider(
             <Text>
                 <PaymentMethodTranslation {...props} />
             </Text>,
         );
 
-    it('should render known payment method translation', () => {
-        const { getByText } = renderPaymentMethodTranslation({
+    it('should render known payment method translation', async () => {
+        const { getByText } = await renderPaymentMethodTranslation({
             paymentMethod: 'creditCard',
         });
 
@@ -25,8 +25,8 @@ describe('PaymentMethodTranslation', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render payment method name when payment method is unknown', () => {
-        const { getByText } = renderPaymentMethodTranslation({
+    it('should render payment method name when payment method is unknown', async () => {
+        const { getByText } = await renderPaymentMethodTranslation({
             paymentMethod: 'customMethod',
             paymentMethodName: 'Custom Method',
         });
@@ -34,8 +34,8 @@ describe('PaymentMethodTranslation', () => {
         expect(getByText('Custom Method')).toBeOnTheScreen();
     });
 
-    it('should render payment method when payment method name is missing', () => {
-        const { getByText } = renderPaymentMethodTranslation({
+    it('should render payment method when payment method name is missing', async () => {
+        const { getByText } = await renderPaymentMethodTranslation({
             paymentMethod: 'customMethod',
             paymentMethodName: '',
         });
@@ -43,8 +43,8 @@ describe('PaymentMethodTranslation', () => {
         expect(getByText('customMethod')).toBeOnTheScreen();
     });
 
-    it('should render empty string when no payment method or name is provided', () => {
-        const { getByText } = renderPaymentMethodTranslation({});
+    it('should render empty string when no payment method or name is provided', async () => {
+        const { getByText } = await renderPaymentMethodTranslation({});
 
         expect(getByText('')).toBeOnTheScreen();
     });

--- a/suite-native/trading-atoms/src/components/TradeInfo/NetworkAndAccountCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/NetworkAndAccountCard.test.tsx
@@ -29,8 +29,8 @@ describe('NetworkAndAccountCard', () => {
         }),
     } as const;
 
-    const renderNetworkAndAccountCard = (props: Partial<NetworkAndAccountCardProps>) =>
-        renderWithStoreProvider(
+    const renderNetworkAndAccountCard = async (props: Partial<NetworkAndAccountCardProps>) =>
+        await renderWithStoreProvider(
             <NetworkAndAccountCard title="TITLE" account={btc1NormalAccount} {...props} />,
             {
                 store: createLightStore({
@@ -44,16 +44,16 @@ describe('NetworkAndAccountCard', () => {
             },
         );
 
-    it('should render title, network name and account label', () => {
-        const { getByText, getByHintText } = renderNetworkAndAccountCard({});
+    it('should render title, network name and account label', async () => {
+        const { getByText, getByHintText } = await renderNetworkAndAccountCard({});
 
         expect(getByText('TITLE')).toBeOnTheScreen();
         expect(getByHintText('Network Icon')).toBeOnTheScreen();
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
     });
 
-    it('should render children', () => {
-        const { getByText } = renderNetworkAndAccountCard({
+    it('should render children', async () => {
+        const { getByText } = await renderNetworkAndAccountCard({
             children: <Text>CHILDREN</Text>,
         });
 

--- a/suite-native/trading-atoms/src/components/TradeInfo/TradeInfoHeader.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/TradeInfoHeader.test.tsx
@@ -6,17 +6,17 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { TradeInfoHeader } from './TradeInfoHeader';
 
 describe('TradeInfoHeader', () => {
-    const renderTradeInfoRow = (title: string, props = {}) =>
-        renderWithBasicProvider(<TradeInfoHeader title={title} {...props} />);
+    const renderTradeInfoRow = async (title: string, props = {}) =>
+        await renderWithBasicProvider(<TradeInfoHeader title={title} {...props} />);
 
-    it('should render title', () => {
-        const { getByText } = renderTradeInfoRow('Test Title', {});
+    it('should render title', async () => {
+        const { getByText } = await renderTradeInfoRow('Test Title', {});
 
         expect(getByText('Test Title')).toBeTruthy();
     });
 
-    it('should render rightContent when provided', () => {
-        const { getByText } = renderTradeInfoRow('Test Title', {
+    it('should render rightContent when provided', async () => {
+        const { getByText } = await renderTradeInfoRow('Test Title', {
             rightContent: <Text>Right Content</Text>,
         });
 

--- a/suite-native/trading-atoms/src/components/TradeInfo/TradeInfoRow.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/TradeInfoRow.test.tsx
@@ -6,16 +6,17 @@ import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
 import { TradeInfoRow } from './TradeInfoRow';
 
 describe('TradeInfoRow', () => {
-    const renderTradeInfoRow = (props = {}) => renderWithBasicProvider(<TradeInfoRow {...props} />);
+    const renderTradeInfoRow = async (props = {}) =>
+        await renderWithBasicProvider(<TradeInfoRow {...props} />);
 
-    it('should render children content', () => {
-        const { getByText } = renderTradeInfoRow({ children: <Text>Test Content</Text> });
+    it('should render children content', async () => {
+        const { getByText } = await renderTradeInfoRow({ children: <Text>Test Content</Text> });
 
         expect(getByText('Test Content')).toBeTruthy();
     });
 
-    it('should render multiple children', () => {
-        const { getByText } = renderTradeInfoRow({
+    it('should render multiple children', async () => {
+        const { getByText } = await renderTradeInfoRow({
             children: (
                 <>
                     <Text>First Child</Text>
@@ -32,7 +33,7 @@ describe('TradeInfoRow', () => {
 
     it('should call onPress when pressed', async () => {
         const mockOnPress = jest.fn();
-        const { getByTestId } = renderTradeInfoRow({
+        const { getByTestId } = await renderTradeInfoRow({
             onPress: mockOnPress,
             testID: 'trade-info-row',
         });

--- a/suite-native/trading-atoms/src/components/TradeInfo/TradeSideCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/TradeSideCard.test.tsx
@@ -31,8 +31,8 @@ describe('TradeSideCard', () => {
         }),
     } as const;
 
-    const renderTradeSideCard = (props: Partial<TradeSideCardProps>) =>
-        renderWithStoreProvider(
+    const renderTradeSideCard = async (props: Partial<TradeSideCardProps>) =>
+        await renderWithStoreProvider(
             <TradeSideCard
                 account={btc1NormalAccount}
                 amount={<Text>AMOUNT</Text>}
@@ -51,22 +51,22 @@ describe('TradeSideCard', () => {
             },
         );
 
-    it('should render nothing when no cryptoId is specified', () => {
-        const { toJSON } = renderTradeSideCard({});
+    it('should render nothing when no cryptoId is specified', async () => {
+        const { toJSON } = await renderTradeSideCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render title, amount and account label', () => {
-        const { getByText } = renderTradeSideCard({ cryptoId: 'bitcoin' as CryptoId });
+    it('should render title, amount and account label', async () => {
+        const { getByText } = await renderTradeSideCard({ cryptoId: 'bitcoin' as CryptoId });
 
         expect(getByText('TITLE')).toBeOnTheScreen();
         expect(getByText('AMOUNT')).toBeOnTheScreen();
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
     });
 
-    it('should render children when provided', () => {
-        const { getByText } = renderTradeSideCard({
+    it('should render children when provided', async () => {
+        const { getByText } = await renderTradeSideCard({
             cryptoId: 'bitcoin' as CryptoId,
             children: <Text>CHILDREN</Text>,
         });

--- a/suite-native/trading-atoms/src/components/WaitingCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/WaitingCard.test.tsx
@@ -5,18 +5,18 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { WaitingCard, type WaitingCardProps } from './WaitingCard';
 
 describe('ProviderWaitingCard', () => {
-    const renderProviderWaitingCard = (props: Partial<WaitingCardProps>) =>
-        renderWithBasicProvider(<WaitingCard title="TITLE" subtitle="SUBTITLE" {...props} />);
+    const renderProviderWaitingCard = async (props: Partial<WaitingCardProps>) =>
+        await renderWithBasicProvider(<WaitingCard title="TITLE" subtitle="SUBTITLE" {...props} />);
 
-    it('should render', () => {
-        const { getByText } = renderProviderWaitingCard({});
+    it('should render', async () => {
+        const { getByText } = await renderProviderWaitingCard({});
 
         expect(getByText('TITLE')).toBeOnTheScreen();
         expect(getByText('SUBTITLE')).toBeOnTheScreen();
     });
 
-    it('should render with children', () => {
-        const { getByText } = renderProviderWaitingCard({
+    it('should render with children', async () => {
+        const { getByText } = await renderProviderWaitingCard({
             children: <Text>CHILDREN</Text>,
         });
 

--- a/suite-native/trading-atoms/src/hooks/useFormatCryptoValue.test.ts
+++ b/suite-native/trading-atoms/src/hooks/useFormatCryptoValue.test.ts
@@ -8,8 +8,8 @@ import { useFormatCryptoValue } from './useFormatCryptoValue';
 describe('useFormatCryptoValue', () => {
     const getPreloadedState = () => ({ wallet: { trading: getInitializedTradingState() } });
 
-    const renderUseFormatCryptoValue = () =>
-        renderHookWithStoreProvider(() => useFormatCryptoValue(), {
+    const renderUseFormatCryptoValue = async () =>
+        await renderHookWithStoreProvider(() => useFormatCryptoValue(), {
             preloadedState: getPreloadedState(),
         });
 
@@ -17,8 +17,8 @@ describe('useFormatCryptoValue', () => {
         [undefined, 'bitcoin' as CryptoId],
         ['1.5', undefined],
         ['1', 'unknown-crypto' as CryptoId],
-    ])('returns undefined for value=%s cryptoId=%s', (value, cryptoId) => {
-        const { result } = renderUseFormatCryptoValue();
+    ])('returns undefined for value=%s cryptoId=%s', async (value, cryptoId) => {
+        const { result } = await renderUseFormatCryptoValue();
 
         expect(result.current(value, cryptoId)).toBeUndefined();
     });
@@ -30,8 +30,8 @@ describe('useFormatCryptoValue', () => {
             'solana--jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL' as CryptoId,
             '10.1232 JTO',
         ],
-    ])('formats %s %s as "%s"', (value, cryptoId, expected) => {
-        const { result } = renderUseFormatCryptoValue();
+    ])('formats %s %s as "%s"', async (value, cryptoId, expected) => {
+        const { result } = await renderUseFormatCryptoValue();
 
         expect(result.current(value, cryptoId)).toBe(expected);
     });
@@ -45,8 +45,8 @@ describe('useFormatCryptoValue', () => {
             'solana--jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL' as CryptoId,
             '0.1234567890123457 JTO',
         ],
-    ])('respects network decimal precision for %s %s', (value, cryptoId, expected) => {
-        const { result } = renderUseFormatCryptoValue();
+    ])('respects network decimal precision for %s %s', async (value, cryptoId, expected) => {
+        const { result } = await renderUseFormatCryptoValue();
 
         expect(result.current(value, cryptoId)).toBe(expected);
     });

--- a/suite-native/trading-atoms/src/hooks/useSectionList.test.tsx
+++ b/suite-native/trading-atoms/src/hooks/useSectionList.test.tsx
@@ -4,10 +4,10 @@ import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 
 import { type UseSectionListProps, useSectionList } from './useSectionList';
 
-const renderUseSectionListHook = <T, U = undefined>(
+const renderUseSectionListHook = async <T, U = undefined>(
     initialProps: Partial<UseSectionListProps<T, U>>,
 ) =>
-    renderHookWithBasicProvider(
+    await renderHookWithBasicProvider(
         ({
             data = [],
             noSingletonSectionHeader = false,
@@ -72,8 +72,8 @@ describe('useSectionList', () => {
     const mockData = [section1, section2, section3];
 
     describe('data transformation', () => {
-        it('should correctly transform data with section headers', () => {
-            const { result } = renderUseSectionListHook({
+        it('should correctly transform data with section headers', async () => {
+            const { result } = await renderUseSectionListHook({
                 data: mockData,
             });
 
@@ -162,8 +162,8 @@ describe('useSectionList', () => {
         });
 
         describe('with noSingletonSectionHeader', () => {
-            it('should handle single section', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle single section', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [section1],
                     noSingletonSectionHeader: true,
                 });
@@ -194,8 +194,8 @@ describe('useSectionList', () => {
                 expect(result.current.data).toEqual(expectedTransformedData);
             });
 
-            it('should handle empty data', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle empty data', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [],
                     noSingletonSectionHeader: true,
                 });
@@ -203,8 +203,8 @@ describe('useSectionList', () => {
                 expect(result.current.data).toEqual([]);
             });
 
-            it('should handle empty sections', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle empty sections', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [section4],
                     noSingletonSectionHeader: true,
                 });
@@ -212,8 +212,8 @@ describe('useSectionList', () => {
                 expect(result.current.data).toEqual([]);
             });
 
-            it('should handle empty section even with renderEmptySectionContent specified', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle empty section even with renderEmptySectionContent specified', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [section4],
                     noSingletonSectionHeader: true,
                     SectionEmptyComponent: <Text>Empty Section Placeholder</Text>,
@@ -222,8 +222,8 @@ describe('useSectionList', () => {
                 expect(result.current.data).toEqual([]);
             });
 
-            it('should handle multiple sections with SectionEmptyComponent specified', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle multiple sections with SectionEmptyComponent specified', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [section3, section4],
                     SectionEmptyComponent: <Text>Empty Section Placeholder</Text>,
                     noSingletonSectionHeader: true,
@@ -262,8 +262,8 @@ describe('useSectionList', () => {
         });
 
         describe('without noSingletonSectionHeader', () => {
-            it('should handle single section', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle single section', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [section1],
                 });
 
@@ -299,16 +299,16 @@ describe('useSectionList', () => {
                 expect(result.current.data).toEqual(expectedTransformedData);
             });
 
-            it('should handle empty data', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle empty data', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [],
                 });
 
                 expect(result.current.data).toEqual([]);
             });
 
-            it('should handle empty sections', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle empty sections', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [section4],
                 });
 
@@ -322,8 +322,8 @@ describe('useSectionList', () => {
                 ]);
             });
 
-            it('should handle empty section even with SectionEmptyComponent specified', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle empty section even with SectionEmptyComponent specified', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [section4],
                     SectionEmptyComponent: <Text>Empty Section Placeholder</Text>,
                 });
@@ -348,8 +348,8 @@ describe('useSectionList', () => {
                 ]);
             });
 
-            it('should handle multiple sections with SectionEmptyComponent specified', () => {
-                const { result } = renderUseSectionListHook({
+            it('should handle multiple sections with SectionEmptyComponent specified', async () => {
+                const { result } = await renderUseSectionListHook({
                     data: [section3, section4],
                     SectionEmptyComponent: <Text>Empty Section Placeholder</Text>,
                 });
@@ -388,22 +388,22 @@ describe('useSectionList', () => {
     });
 
     describe('sections and items count', () => {
-        it('should correctly calculate sectionsCount', () => {
-            const { result } = renderUseSectionListHook({ data: mockData });
+        it('should correctly calculate sectionsCount', async () => {
+            const { result } = await renderUseSectionListHook({ data: mockData });
 
             expect(result.current.sectionsCount).toBe(3);
         });
 
-        it('should correctly calculate itemsCount', () => {
-            const { result } = renderUseSectionListHook({ data: mockData });
+        it('should correctly calculate itemsCount', async () => {
+            const { result } = await renderUseSectionListHook({ data: mockData });
 
             expect(result.current.itemsCount).toBe(6);
         });
     });
 
     describe('isEnabled property handling', () => {
-        it('should correctly handle items with explicit or undefined isEnabled property', () => {
-            const { result } = renderUseSectionListHook({ data: [sectionWithDisabledItems] });
+        it('should correctly handle items with explicit or undefined isEnabled property', async () => {
+            const { result } = await renderUseSectionListHook({ data: [sectionWithDisabledItems] });
 
             const transformedData = result.current.data;
             const items = transformedData.filter(item => item.type === 'item');

--- a/suite-native/trading-browser-auth/src/components/ConfirmationFailed.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/ConfirmationFailed.test.tsx
@@ -13,12 +13,13 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('ConfirmationFailed', () => {
-    const renderConfirmationFailed = () => renderWithBasicProvider(<ConfirmationFailed />);
+    const renderConfirmationFailed = async () =>
+        await renderWithBasicProvider(<ConfirmationFailed />);
 
-    it('should navigate back on button press', () => {
-        const { getByText } = renderConfirmationFailed();
+    it('should navigate back on button press', async () => {
+        const { getByText } = await renderConfirmationFailed();
 
-        fireEvent.press(
+        await fireEvent.press(
             getByText(
                 getTranslation(
                     'moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.button',

--- a/suite-native/trading-browser-auth/src/components/ProviderConfirmationStatusInfo.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderConfirmationStatusInfo.test.tsx
@@ -11,22 +11,29 @@ jest.mock('../hooks/useProviderConfirmationStatus', () => ({
 }));
 
 describe('ProviderConfirmationStatusInfo', () => {
-    const renderProviderConfirmationStatusInfo = (onConfirmationComplete?: jest.Mock) =>
-        renderWithBasicProvider(
+    const renderProviderConfirmationStatusInfo = async (onConfirmationComplete?: jest.Mock) =>
+        await renderWithBasicProvider(
             <ProviderConfirmationStatusInfo
                 companyName="MoonPay"
                 onConfirmationComplete={onConfirmationComplete}
             />,
         );
 
-    const finishSpinnerAnimation = (
-        getByProps: ReturnType<typeof renderProviderConfirmationStatusInfo>['UNSAFE_getByProps'],
+    const finishSpinnerAnimation = async (
+        container: Awaited<ReturnType<typeof renderProviderConfirmationStatusInfo>>['container'],
     ) => {
-        const spinner = getByProps({ loop: false, speed: 1.5 });
+        const [spinner] = container.queryAll(
+            instance => instance.props.loop === false && instance.props.speed === 1.5,
+        );
 
-        fireEvent(spinner, 'animationFinish');
-        fireEvent(spinner, 'animationFinish');
-        fireEvent(spinner, 'animationFinish');
+        if (!spinner) {
+            throw new Error('Spinner animation was not rendered.');
+        }
+
+        const event = { nativeEvent: { isCancelled: false } };
+        await fireEvent(spinner, 'animationFinish', event);
+        await fireEvent(spinner, 'animationFinish', event);
+        await fireEvent(spinner, 'animationFinish', event);
     };
 
     beforeEach(() => {
@@ -35,10 +42,10 @@ describe('ProviderConfirmationStatusInfo', () => {
 
     it.each<ProviderConfirmationStatus>(['inactive', 'confirmation_success', 'window_opened'])(
         'should render nothing when providerConfirmationStatus is [%s]',
-        providerConfirmationStatus => {
+        async providerConfirmationStatus => {
             mockUseProviderConfirmationStatus = providerConfirmationStatus;
 
-            const { toJSON } = renderProviderConfirmationStatusInfo();
+            const { toJSON } = await renderProviderConfirmationStatusInfo();
 
             expect(toJSON()).toBeNull();
         },
@@ -65,23 +72,23 @@ describe('ProviderConfirmationStatusInfo', () => {
         ],
     ])(
         'should render "%s" when providerConfirmationStatus is [%s]',
-        (expectedTitle, providerConfirmationStatus) => {
+        async (expectedTitle, providerConfirmationStatus) => {
             mockUseProviderConfirmationStatus = providerConfirmationStatus;
 
-            const { getByText } = renderProviderConfirmationStatusInfo();
+            const { getByText } = await renderProviderConfirmationStatusInfo();
 
             expect(getByText(expectedTitle)).toBeTruthy();
         },
     );
 
-    it('should show the success animation before hiding the confirmation status', () => {
+    it('should show the success animation before hiding the confirmation status', async () => {
         mockUseProviderConfirmationStatus = 'window_closed_with_success';
         const onConfirmationComplete = jest.fn();
-        const { getByText, queryByText, rerender, UNSAFE_getByProps } =
-            renderProviderConfirmationStatusInfo(onConfirmationComplete);
+        const { container, getByText, queryByText, rerender } =
+            await renderProviderConfirmationStatusInfo(onConfirmationComplete);
 
         mockUseProviderConfirmationStatus = 'confirmation_success';
-        rerender(
+        await rerender(
             <ProviderConfirmationStatusInfo
                 companyName="MoonPay"
                 onConfirmationComplete={onConfirmationComplete}
@@ -97,7 +104,7 @@ describe('ProviderConfirmationStatusInfo', () => {
         ).toBeTruthy();
         expect(onConfirmationComplete).not.toHaveBeenCalled();
 
-        finishSpinnerAnimation(UNSAFE_getByProps);
+        await finishSpinnerAnimation(container);
 
         expect(
             queryByText(
@@ -109,22 +116,22 @@ describe('ProviderConfirmationStatusInfo', () => {
         expect(onConfirmationComplete).toHaveBeenCalledWith('success');
     });
 
-    it('should complete immediately when there is no success animation to show', () => {
+    it('should complete immediately when there is no success animation to show', async () => {
         mockUseProviderConfirmationStatus = 'confirmation_success';
         const onConfirmationComplete = jest.fn();
 
-        renderProviderConfirmationStatusInfo(onConfirmationComplete);
+        await renderProviderConfirmationStatusInfo(onConfirmationComplete);
 
         expect(onConfirmationComplete).toHaveBeenCalledWith('success');
     });
 
-    it('should show the failure animation before rendering the failure status', () => {
+    it('should show the failure animation before rendering the failure status', async () => {
         mockUseProviderConfirmationStatus = 'window_closed_incomplete';
-        const { getByText, queryByText, rerender, UNSAFE_getByProps } =
-            renderProviderConfirmationStatusInfo();
+        const { container, getByText, queryByText, rerender } =
+            await renderProviderConfirmationStatusInfo();
 
         mockUseProviderConfirmationStatus = 'confirmation_failed';
-        rerender(<ProviderConfirmationStatusInfo companyName="MoonPay" />);
+        await rerender(<ProviderConfirmationStatusInfo companyName="MoonPay" />);
 
         const failureTitle = getTranslation(
             'moduleTrading.tradingSellPreviewScreen.providerStatus.cannotBeCompletedAlert.title',
@@ -132,15 +139,15 @@ describe('ProviderConfirmationStatusInfo', () => {
 
         expect(queryByText(failureTitle)).toBeNull();
 
-        finishSpinnerAnimation(UNSAFE_getByProps);
+        await finishSpinnerAnimation(container);
 
         expect(getByText(failureTitle)).toBeTruthy();
     });
 
-    it('should render a quote error immediately', () => {
+    it('should render a quote error immediately', async () => {
         mockUseProviderConfirmationStatus = 'window_closed_incomplete';
 
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = await renderWithBasicProvider(
             <ProviderConfirmationStatusInfo companyName="MoonPay" quoteStatus="ERROR" />,
         );
 

--- a/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.test.tsx
@@ -18,8 +18,8 @@ import { ProviderStatusDevButtons } from './ProviderStatusDevButtons';
 describe('ProviderStatusDevButtons', () => {
     let store: TestStore;
 
-    const renderProviderStatusDevButtons = () =>
-        renderWithStoreProvider(<ProviderStatusDevButtons />, { store });
+    const renderProviderStatusDevButtons = async () =>
+        await renderWithStoreProvider(<ProviderStatusDevButtons />, { store });
 
     beforeEach(() => {
         store = createLightStore({
@@ -34,15 +34,15 @@ describe('ProviderStatusDevButtons', () => {
         });
     });
 
-    it('should display nothing without debug mode', () => {
-        const { toJSON } = renderProviderStatusDevButtons();
+    it('should display nothing without debug mode', async () => {
+        const { toJSON } = await renderProviderStatusDevButtons();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display current status', () => {
+    it('should display current status', async () => {
         store.dispatch(toggleFeatureFlag({ featureFlag: FeatureFlag.IsTradingDebugEnabled }));
-        const { getByText } = renderProviderStatusDevButtons();
+        const { getByText } = await renderProviderStatusDevButtons();
 
         expect(getByText('Current status:')).toBeOnTheScreen();
         expect(getByText('inactive')).toBeOnTheScreen();
@@ -50,7 +50,7 @@ describe('ProviderStatusDevButtons', () => {
 
     it('should change state on buttons press', async () => {
         store.dispatch(toggleFeatureFlag({ featureFlag: FeatureFlag.IsTradingDebugEnabled }));
-        const { getByText } = renderProviderStatusDevButtons();
+        const { getByText } = await renderProviderStatusDevButtons();
 
         await userEvent.press(getByText('restart flow'));
         expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.test.ts
@@ -60,8 +60,8 @@ jest.mock('./useOnForegroundCallback', () => ({
 describe('useBrowserAuth', () => {
     let store: TestStore;
 
-    const renderUseBrowserAuth = (tradingType: TradingType = 'sell') =>
-        renderHookWithStoreProvider(() => useBrowserAuth(tradingType), { store });
+    const renderUseBrowserAuth = async (tradingType: TradingType = 'sell') =>
+        await renderHookWithStoreProvider(() => useBrowserAuth(tradingType), { store });
 
     const defaultWalletState = getWalletState();
 
@@ -93,8 +93,8 @@ describe('useBrowserAuth', () => {
         });
     });
 
-    it('should return openBrowser callback', () => {
-        const { result } = renderUseBrowserAuth();
+    it('should return openBrowser callback', async () => {
+        const { result } = await renderUseBrowserAuth();
 
         expect(result.current.openBrowser).toBeInstanceOf(Function);
     });
@@ -103,7 +103,7 @@ describe('useBrowserAuth', () => {
         it('should log error to sentry and return early when called with undefined tradingType', async () => {
             const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
-            const { result } = renderHookWithStoreProvider(() => useBrowserAuth(undefined), {
+            const { result } = await renderHookWithStoreProvider(() => useBrowserAuth(undefined), {
                 store,
             });
 
@@ -124,11 +124,11 @@ describe('useBrowserAuth', () => {
             );
         });
 
-        it('should call openBrowserAsync', () => {
+        it('should call openBrowserAsync', async () => {
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
-            const { result } = renderUseBrowserAuth();
+            const { result } = await renderUseBrowserAuth();
 
-            act(() => {
+            await act(() => {
                 result.current.openBrowser('URL', 'CALLBACK_URL');
             });
 
@@ -141,7 +141,7 @@ describe('useBrowserAuth', () => {
             'should call handleBrowserClosed when openBrowserAsync resolves with %s',
             async type => {
                 mockOpenBrowserAsync.mockResolvedValue({ type });
-                const { result } = renderUseBrowserAuth();
+                const { result } = await renderUseBrowserAuth();
 
                 await act(async () => {
                     await result.current.openBrowser('URL', 'CALLBACK_URL');
@@ -155,7 +155,7 @@ describe('useBrowserAuth', () => {
 
         it('should call setShouldWatchForForeground when openBrowserAsync resolves with opened', async () => {
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
-            const { result } = renderUseBrowserAuth();
+            const { result } = await renderUseBrowserAuth();
 
             await act(async () => {
                 await result.current.openBrowser('URL', 'CALLBACK_URL');
@@ -168,7 +168,7 @@ describe('useBrowserAuth', () => {
 
         it('should set last error message when openBrowserAsync resolves with locked', async () => {
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.LOCKED });
-            const { result } = renderUseBrowserAuth();
+            const { result } = await renderUseBrowserAuth();
 
             await act(async () => {
                 await result.current.openBrowser('URL', 'CALLBACK_URL');
@@ -185,7 +185,7 @@ describe('useBrowserAuth', () => {
             const error = new Error('Browser error');
 
             mockOpenBrowserAsync.mockRejectedValue(error);
-            const { result } = renderUseBrowserAuth();
+            const { result } = await renderUseBrowserAuth();
 
             await act(async () => {
                 await result.current.openBrowser('URL', 'CALLBACK_URL');
@@ -204,21 +204,21 @@ describe('useBrowserAuth', () => {
             store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
         });
 
-        it('should do nothing when url is empty', () => {
+        it('should do nothing when url is empty', async () => {
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.CANCEL });
-            renderUseBrowserAuth();
+            await renderUseBrowserAuth();
 
             expect(selectTradeToBeOpened(store.getState())).toBeUndefined();
             expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
             expect(mockDismissBrowser).not.toHaveBeenCalled();
         });
 
-        it('should do nothing when url is not closeCallbackUrl', () => {
+        it('should do nothing when url is not closeCallbackUrl', async () => {
             mockLinkingURL = 'https://some.other.url';
-            mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.CANCEL });
-            const { result } = renderUseBrowserAuth();
+            mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
+            const { result } = await renderUseBrowserAuth();
 
-            act(() => {
+            await act(() => {
                 result.current.openBrowser('URL', 'CALLBACK_URL');
             });
 
@@ -227,12 +227,12 @@ describe('useBrowserAuth', () => {
             expect(mockDismissBrowser).not.toHaveBeenCalled();
         });
 
-        it('should call dismissBrowser and handleBrowserSuccess for sell tradingType when url matches closeCallbackUrl ', () => {
+        it('should call dismissBrowser and handleBrowserSuccess for sell tradingType when url matches closeCallbackUrl ', async () => {
             mockLinkingURL = TRADING_URL_DEFAULT_BACK;
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.CANCEL });
-            const { result } = renderUseBrowserAuth();
+            const { result } = await renderUseBrowserAuth();
 
-            act(() => {
+            await act(() => {
                 result.current.openBrowser('URL', TRADING_URL_DEFAULT_BACK);
             });
 
@@ -243,12 +243,12 @@ describe('useBrowserAuth', () => {
             expect(mockDismissBrowser).toHaveBeenCalledTimes(1);
         });
 
-        it('should call handleBrowserSuccess and set tradeToBeOpened for buy ', () => {
+        it('should call handleBrowserSuccess and set tradeToBeOpened for buy ', async () => {
             mockLinkingURL = TRADING_URL_DEFAULT_BACK;
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.CANCEL });
-            const { result } = renderUseBrowserAuth('buy');
+            const { result } = await renderUseBrowserAuth('buy');
 
-            act(() => {
+            await act(() => {
                 result.current.openBrowser('URL', TRADING_URL_DEFAULT_BACK, 'trade-order-id-1');
             });
 
@@ -260,13 +260,13 @@ describe('useBrowserAuth', () => {
             expect(mockDismissBrowser).toHaveBeenCalledTimes(1);
         });
 
-        it('should handle dismissBrowser returning undefined', () => {
+        it('should handle dismissBrowser returning undefined', async () => {
             mockLinkingURL = TRADING_URL_DEFAULT_BACK;
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.CANCEL });
             mockDismissBrowser.mockReturnValue(undefined);
-            const { result } = renderUseBrowserAuth();
+            const { result } = await renderUseBrowserAuth();
 
-            act(() => {
+            await act(() => {
                 result.current.openBrowser('URL', TRADING_URL_DEFAULT_BACK);
             });
 
@@ -278,11 +278,11 @@ describe('useBrowserAuth', () => {
     });
 
     describe('openBrowserForFormData', () => {
-        it('should call openBrowserAsync with URL extracted from formData', () => {
+        it('should call openBrowserAsync with URL extracted from formData', async () => {
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
-            const { result } = renderUseBrowserAuth();
+            const { result } = await renderUseBrowserAuth();
 
-            act(() => {
+            await act(() => {
                 result.current.openBrowserForFormData(
                     {
                         formMethod: 'GET',
@@ -298,12 +298,12 @@ describe('useBrowserAuth', () => {
             expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
         });
 
-        it('should log error and dispatch error message when method is not supported', () => {
+        it('should log error and dispatch error message when method is not supported', async () => {
             const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
-            const { result } = renderUseBrowserAuth();
+            const { result } = await renderUseBrowserAuth();
 
-            act(() => {
+            await act(() => {
                 result.current.openBrowserForFormData(
                     {
                         formMethod: 'IFRAME',
@@ -326,12 +326,12 @@ describe('useBrowserAuth', () => {
             );
         });
 
-        it('should call handleBrowserSuccess and set tradeToBeOpened for buy ', () => {
+        it('should call handleBrowserSuccess and set tradeToBeOpened for buy ', async () => {
             mockLinkingURL = TRADING_URL_DEFAULT_BACK;
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.CANCEL });
-            const { result } = renderUseBrowserAuth('buy');
+            const { result } = await renderUseBrowserAuth('buy');
 
-            act(() => {
+            await act(() => {
                 result.current.openBrowserForFormData(
                     {
                         formMethod: 'GET',

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserStateChangeCallbacks.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserStateChangeCallbacks.test.ts
@@ -25,8 +25,8 @@ jest.mock('@suite-native/trading-analytics', () => ({
 describe('useBrowserStateChangeCallbacks', () => {
     let store: TestStore;
 
-    const renderUseBrowserwStateChangeCallbacks = (tradingType: TradingType | undefined) =>
-        renderHookWithStoreProvider(() => useBrowserStateChangeCallbacks(tradingType), {
+    const renderUseBrowserwStateChangeCallbacks = async (tradingType: TradingType | undefined) =>
+        await renderHookWithStoreProvider(() => useBrowserStateChangeCallbacks(tradingType), {
             store,
         });
 
@@ -44,20 +44,20 @@ describe('useBrowserStateChangeCallbacks', () => {
     });
 
     describe('handleBrowserOpened', () => {
-        it('should set correct confirmation status', () => {
-            const { result } = renderUseBrowserwStateChangeCallbacks('sell');
+        it('should set correct confirmation status', async () => {
+            const { result } = await renderUseBrowserwStateChangeCallbacks('sell');
 
-            act(() => {
+            await act(() => {
                 result.current.handleBrowserOpened();
             });
 
             expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
         });
 
-        it('should report browser open to analytics', () => {
-            const { result } = renderUseBrowserwStateChangeCallbacks('sell');
+        it('should report browser open to analytics', async () => {
+            const { result } = await renderUseBrowserwStateChangeCallbacks('sell');
 
-            act(() => {
+            await act(() => {
                 result.current.handleBrowserOpened();
             });
 
@@ -66,10 +66,10 @@ describe('useBrowserStateChangeCallbacks', () => {
     });
 
     describe('handleBrowserClosed', () => {
-        it('should set correct confirmation status', () => {
-            const { result } = renderUseBrowserwStateChangeCallbacks('sell');
+        it('should set correct confirmation status', async () => {
+            const { result } = await renderUseBrowserwStateChangeCallbacks('sell');
 
-            act(() => {
+            await act(() => {
                 result.current.handleBrowserOpened();
                 result.current.handleBrowserClosed();
             });
@@ -81,10 +81,10 @@ describe('useBrowserStateChangeCallbacks', () => {
     });
 
     describe('handleBrowserSuccess', () => {
-        it('should set correct confirmation status', () => {
-            const { result } = renderUseBrowserwStateChangeCallbacks('sell');
+        it('should set correct confirmation status', async () => {
+            const { result } = await renderUseBrowserwStateChangeCallbacks('sell');
 
-            act(() => {
+            await act(() => {
                 result.current.handleBrowserOpened();
                 result.current.handleBrowserSuccess();
             });
@@ -97,12 +97,12 @@ describe('useBrowserStateChangeCallbacks', () => {
 
     it.each<TradingType>(['buy', 'exchange'])(
         'should not dispatch confirmation status change for tradingType [%s]',
-        tradingType => {
-            const { result } = renderUseBrowserwStateChangeCallbacks(tradingType);
+        async tradingType => {
+            const { result } = await renderUseBrowserwStateChangeCallbacks(tradingType);
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-            act(() => {
+            await act(() => {
                 result.current.handleBrowserOpened();
                 result.current.handleBrowserClosed();
                 result.current.handleBrowserSuccess();
@@ -115,12 +115,12 @@ describe('useBrowserStateChangeCallbacks', () => {
         },
     );
 
-    it('should do nothing when trading type is undefined', () => {
-        const { result } = renderUseBrowserwStateChangeCallbacks(undefined);
+    it('should do nothing when trading type is undefined', async () => {
+        const { result } = await renderUseBrowserwStateChangeCallbacks(undefined);
 
         const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-        act(() => {
+        await act(() => {
             result.current.handleBrowserOpened();
             result.current.handleBrowserClosed();
             result.current.handleBrowserSuccess();

--- a/suite-native/trading-browser-auth/src/hooks/useDispatchProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useDispatchProviderConfirmationStatus.test.ts
@@ -17,8 +17,8 @@ import { useDispatchProviderConfirmationStatus } from './useDispatchProviderConf
 describe('useDispatchProviderConfirmationStatus', () => {
     let store: TestStore;
 
-    const renderUseDispatchProviderConfirmationStatus = () =>
-        renderHookWithStoreProvider(() => useDispatchProviderConfirmationStatus(), { store });
+    const renderUseDispatchProviderConfirmationStatus = async () =>
+        await renderHookWithStoreProvider(() => useDispatchProviderConfirmationStatus(), { store });
 
     beforeEach(() => {
         store = createLightStore({
@@ -32,10 +32,10 @@ describe('useDispatchProviderConfirmationStatus', () => {
         });
     });
 
-    it('should provide callback for dispatching setProviderConfirmationStatus trading action', () => {
-        const { result } = renderUseDispatchProviderConfirmationStatus();
+    it('should provide callback for dispatching setProviderConfirmationStatus trading action', async () => {
+        const { result } = await renderUseDispatchProviderConfirmationStatus();
 
-        act(() => {
+        await act(() => {
             result.current('window_opened');
         });
 

--- a/suite-native/trading-browser-auth/src/hooks/useOnForegroundCallback.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useOnForegroundCallback.test.ts
@@ -25,30 +25,30 @@ describe('useOnForegroundCallback', () => {
     const mockCallback = jest.fn();
     const appStateSpy = jest.spyOn(AppState, 'addEventListener');
 
-    const renderUseOnFocusCallback = () =>
-        renderHookWithBasicProvider(() => useOnForegroundCallback(mockCallback), {});
+    const renderUseOnFocusCallback = async () =>
+        await renderHookWithBasicProvider(() => useOnForegroundCallback(mockCallback), {});
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should only subscribe for app state changes on mount', () => {
-        const { result } = renderUseOnFocusCallback();
+    it('should only subscribe for app state changes on mount', async () => {
+        const { result } = await renderUseOnFocusCallback();
 
         expect(appStateSpy).toHaveBeenCalledWith('change', expect.any(Function));
         expect(result.current.shouldWatchForForeground).toBe(false);
         expect(mockCallback).toHaveBeenCalledTimes(0);
     });
 
-    it('should call callback once when app state is active and shouldWatchForForeground is set to true', () => {
-        const { result } = renderUseOnFocusCallback();
+    it('should call callback once when app state is active and shouldWatchForForeground is set to true', async () => {
+        const { result } = await renderUseOnFocusCallback();
         const changeHandler = getChangeHandler(appStateSpy);
 
-        act(() => {
+        await act(() => {
             // simulate app being in foreground
             changeHandler('active');
             result.current.setShouldWatchForForeground(true);
@@ -58,11 +58,11 @@ describe('useOnForegroundCallback', () => {
         expect(result.current.shouldWatchForForeground).toBe(false);
     });
 
-    it('should not call callback when app is on background and shouldWatchForForeground is set to true ', () => {
-        const { result } = renderUseOnFocusCallback();
+    it('should not call callback when app is on background and shouldWatchForForeground is set to true ', async () => {
+        const { result } = await renderUseOnFocusCallback();
         const changeHandler = getChangeHandler(appStateSpy);
 
-        act(() => {
+        await act(() => {
             // simulate app going to background
             changeHandler('active');
             changeHandler('background');
@@ -74,11 +74,11 @@ describe('useOnForegroundCallback', () => {
         expect(result.current.shouldWatchForForeground).toBe(true);
     });
 
-    it('should react to app state changes', () => {
-        const { result } = renderUseOnFocusCallback();
+    it('should react to app state changes', async () => {
+        const { result } = await renderUseOnFocusCallback();
         const changeHandler = getChangeHandler(appStateSpy);
 
-        act(() => {
+        await act(() => {
             // simulate app going to background
             changeHandler('active');
             changeHandler('background');
@@ -94,7 +94,7 @@ describe('useOnForegroundCallback', () => {
 
     it('should catch errors in callback', async () => {
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const { result } = renderUseOnFocusCallback();
+        const { result } = await renderUseOnFocusCallback();
         const changeHandler = getChangeHandler(appStateSpy);
         const error = new Error('Test error');
 

--- a/suite-native/trading-browser-auth/src/hooks/useProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useProviderConfirmationStatus.test.ts
@@ -22,8 +22,8 @@ import { useProviderConfirmationStatus } from './useProviderConfirmationStatus';
 describe('useProviderConfirmationStatus', () => {
     let store: TestStore;
 
-    const renderUseProviderConfirmationStatus = () =>
-        renderHookWithStoreProvider(() => useProviderConfirmationStatus(), {
+    const renderUseProviderConfirmationStatus = async () =>
+        await renderHookWithStoreProvider(() => useProviderConfirmationStatus(), {
             store,
         });
 
@@ -44,34 +44,34 @@ describe('useProviderConfirmationStatus', () => {
         jest.useRealTimers();
     });
 
-    it('should return current status', () => {
+    it('should return current status', async () => {
         store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
-        const { result } = renderUseProviderConfirmationStatus();
+        const { result } = await renderUseProviderConfirmationStatus();
 
         expect(result.current).toEqual('window_opened');
     });
 
-    it('should clear tradingProviderConfirmationStatus on unmount', () => {
+    it('should clear tradingProviderConfirmationStatus on unmount', async () => {
         store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
-        const { unmount } = renderUseProviderConfirmationStatus();
+        const { unmount } = await renderUseProviderConfirmationStatus();
 
-        unmount();
+        await unmount();
 
         expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
     });
 
-    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_incomplete" is set', () => {
-        renderUseProviderConfirmationStatus();
+    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_incomplete" is set', async () => {
+        await renderUseProviderConfirmationStatus();
         jest.useFakeTimers();
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
             store.dispatch(
                 tradingActions.setProviderConfirmationStatus('window_closed_incomplete'),
             );
         });
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(30_000);
         });
 
@@ -80,18 +80,18 @@ describe('useProviderConfirmationStatus', () => {
         );
     });
 
-    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_with_success" is set', () => {
-        renderUseProviderConfirmationStatus();
+    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_with_success" is set', async () => {
+        await renderUseProviderConfirmationStatus();
         jest.useFakeTimers();
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
             store.dispatch(
                 tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
             );
         });
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(30_000);
         });
 
@@ -100,26 +100,26 @@ describe('useProviderConfirmationStatus', () => {
         );
     });
 
-    it('should not set tradingProviderConfirmationStatus to "confirmation_failed" when status changes', () => {
-        renderUseProviderConfirmationStatus();
+    it('should not set tradingProviderConfirmationStatus to "confirmation_failed" when status changes', async () => {
+        await renderUseProviderConfirmationStatus();
         jest.useFakeTimers();
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
             store.dispatch(
                 tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
             );
         });
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(15_000);
         });
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setProviderConfirmationStatus('confirmation_success'));
         });
 
-        act(() => {
+        await act(() => {
             jest.advanceTimersByTime(30_000);
         });
 
@@ -128,10 +128,10 @@ describe('useProviderConfirmationStatus', () => {
         );
     });
 
-    it('should set tradingProviderConfirmationStatus to "confirmation_success" when isTradeFinalized becomes truthy', () => {
-        renderUseProviderConfirmationStatus();
+    it('should set tradingProviderConfirmationStatus to "confirmation_success" when isTradeFinalized becomes truthy', async () => {
+        await renderUseProviderConfirmationStatus();
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
             store.dispatch(
                 tradingActions.setProviderConfirmationStatus('window_closed_with_success'),
@@ -148,10 +148,10 @@ describe('useProviderConfirmationStatus', () => {
         );
     });
 
-    it('should wait for the browser to close before setting "confirmation_success"', () => {
-        renderUseProviderConfirmationStatus();
+    it('should wait for the browser to close before setting "confirmation_success"', async () => {
+        await renderUseProviderConfirmationStatus();
 
-        act(() => {
+        await act(() => {
             store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
             store.dispatch(
                 sendFormActions.storePrecomposedTransaction({
@@ -162,7 +162,7 @@ describe('useProviderConfirmationStatus', () => {
 
         expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
 
-        act(() => {
+        await act(() => {
             store.dispatch(
                 tradingActions.setProviderConfirmationStatus('window_closed_incomplete'),
             );

--- a/suite-native/trading-debug/src/components/CopyableText.test.tsx
+++ b/suite-native/trading-debug/src/components/CopyableText.test.tsx
@@ -9,15 +9,15 @@ jest.mock('@suite-native/clipboard', () => ({
 }));
 
 describe('CopyableText', () => {
-    const renderCopyableText = (props: Partial<CopyableTextProps>) =>
-        renderWithBasicProvider(<CopyableText text="TEST TEXT" {...props} />);
+    const renderCopyableText = async (props: Partial<CopyableTextProps>) =>
+        await renderWithBasicProvider(<CopyableText text="TEST TEXT" {...props} />);
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should render title, text and copy button', () => {
-        const { getByText, getByLabelText } = renderCopyableText({
+    it('should render title, text and copy button', async () => {
+        const { getByText, getByLabelText } = await renderCopyableText({
             title: 'Title',
         });
 
@@ -26,10 +26,10 @@ describe('CopyableText', () => {
         expect(getByLabelText('Copy to clipboard')).toBeOnTheScreen();
     });
 
-    it('should handle copy to clipboard press', () => {
-        const { getByLabelText } = renderCopyableText({});
+    it('should handle copy to clipboard press', async () => {
+        const { getByLabelText } = await renderCopyableText({});
 
-        fireEvent.press(getByLabelText('Copy to clipboard'));
+        await fireEvent.press(getByLabelText('Copy to clipboard'));
 
         expect(mockCopyToClipboard).toHaveBeenCalledWith('TEST TEXT');
     });

--- a/suite-native/trading-debug/src/components/DebugModeView.test.tsx
+++ b/suite-native/trading-debug/src/components/DebugModeView.test.tsx
@@ -10,8 +10,8 @@ jest.mock('../hooks/useTradingDebugModeFlag', () => ({
 }));
 
 describe('DebugModeView', () => {
-    const renderDebugModeView = () =>
-        renderWithBasicProvider(
+    const renderDebugModeView = async () =>
+        await renderWithBasicProvider(
             <DebugModeView>
                 <Text>TEST TEXT</Text>
             </DebugModeView>,
@@ -21,15 +21,15 @@ describe('DebugModeView', () => {
         mockDebugMode = false;
     });
 
-    it('should render nothing when debug mode is disabled', () => {
-        const { toJSON } = renderDebugModeView();
+    it('should render nothing when debug mode is disabled', async () => {
+        const { toJSON } = await renderDebugModeView();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render children when debug mode is enabled', () => {
+    it('should render children when debug mode is enabled', async () => {
         mockDebugMode = true;
-        const { getByText } = renderDebugModeView();
+        const { getByText } = await renderDebugModeView();
 
         expect(getByText('TEST TEXT')).toBeOnTheScreen();
     });

--- a/suite-native/trading-debug/src/components/TradingEnvironmentWarning.test.tsx
+++ b/suite-native/trading-debug/src/components/TradingEnvironmentWarning.test.tsx
@@ -22,10 +22,10 @@ describe('TradingEnvironmentWarning', () => {
         }),
     } as const;
 
-    const renderTradingEnvironmentWarning = (
+    const renderTradingEnvironmentWarning = async (
         tradingEnvironment: TradingState['tradingEnvironment'],
     ) =>
-        renderWithStoreProvider(<TradingEnvironmentWarning />, {
+        await renderWithStoreProvider(<TradingEnvironmentWarning />, {
             store: createLightStore({
                 reducer,
                 preloadedState: {
@@ -39,16 +39,16 @@ describe('TradingEnvironmentWarning', () => {
             }),
         });
 
-    it('should render nothing when tradingEnvironment is [production]', () => {
-        const { toJSON } = renderTradingEnvironmentWarning('production');
+    it('should render nothing when tradingEnvironment is [production]', async () => {
+        const { toJSON } = await renderTradingEnvironmentWarning('production');
 
         expect(toJSON()).toBeNull();
     });
 
     it.each<TradingState['tradingEnvironment']>(['staging', 'dev', 'localhost'])(
         'should render warning for tradingEnvironment [%s]',
-        tradingEnvironment => {
-            const { getByText } = renderTradingEnvironmentWarning(tradingEnvironment);
+        async tradingEnvironment => {
+            const { getByText } = await renderTradingEnvironmentWarning(tradingEnvironment);
 
             expect(getByText(`Trading environment: ${tradingEnvironment}`)).toBeOnTheScreen();
         },

--- a/suite-native/trading-debug/src/hooks/useTradingDebugModeFlag.test.ts
+++ b/suite-native/trading-debug/src/hooks/useTradingDebugModeFlag.test.ts
@@ -4,11 +4,11 @@ import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { useTradingDebugModeFlag } from './useTradingDebugModeFlag';
 
 describe('useTradingDebugModeFlag', () => {
-    const renderUseDebugModeFlag = (preloadedState = {}) =>
-        renderHookWithStoreProvider(() => useTradingDebugModeFlag(), { preloadedState });
+    const renderUseDebugModeFlag = async (preloadedState = {}) =>
+        await renderHookWithStoreProvider(() => useTradingDebugModeFlag(), { preloadedState });
 
-    it.each([true, false])('should respect FF [%s]', ffValue => {
-        const { result } = renderUseDebugModeFlag({
+    it.each([true, false])('should respect FF [%s]', async ffValue => {
+        const { result } = await renderUseDebugModeFlag({
             featureFlags: {
                 ...featureFlagsInitialState,
                 isTradingDebugEnabled: ffValue,

--- a/suite-native/trading-debug/src/hooks/useTransactionStatusOverride.test.ts
+++ b/suite-native/trading-debug/src/hooks/useTransactionStatusOverride.test.ts
@@ -20,16 +20,16 @@ describe('useTransactionStatusOverride', () => {
             mockIsDebugMode = false;
         });
 
-        it('returns the original status unchanged', () => {
-            const { result } = renderHook(() => useTransactionStatusOverride(pendingStatus));
+        it('returns the original status unchanged', async () => {
+            const { result } = await renderHook(() => useTransactionStatusOverride(pendingStatus));
 
             expect(result.current.status).toEqual(pendingStatus);
         });
 
-        it('forceStatus is a noop that does not change the output', () => {
-            const { result } = renderHook(() => useTransactionStatusOverride(noStatus));
+        it('forceStatus is a noop that does not change the output', async () => {
+            const { result } = await renderHook(() => useTransactionStatusOverride(noStatus));
 
-            act(() => {
+            await act(() => {
                 result.current.forceStatus('isPending');
             });
 
@@ -42,16 +42,16 @@ describe('useTransactionStatusOverride', () => {
             mockIsDebugMode = true;
         });
 
-        it('returns the original status when no override is set', () => {
-            const { result } = renderHook(() => useTransactionStatusOverride(pendingStatus));
+        it('returns the original status when no override is set', async () => {
+            const { result } = await renderHook(() => useTransactionStatusOverride(pendingStatus));
 
             expect(result.current.status).toEqual(pendingStatus);
         });
 
-        it('returns the real forceStatus setter so an override can be selected', () => {
-            const { result } = renderHook(() => useTransactionStatusOverride(noStatus));
+        it('returns the real forceStatus setter so an override can be selected', async () => {
+            const { result } = await renderHook(() => useTransactionStatusOverride(noStatus));
 
-            act(() => {
+            await act(() => {
                 result.current.forceStatus('isPending');
             });
 
@@ -67,23 +67,23 @@ describe('useTransactionStatusOverride', () => {
             ['isFailed', { isPending: false, isConfirmed: false, isFailed: true }],
             ['isConfirmed', { isPending: false, isConfirmed: true, isFailed: false }],
             ['none', { isPending: false, isConfirmed: false, isFailed: false }],
-        ] as const)('forces status to %s', (override, expectedStatus) => {
-            const { result } = renderHook(() => useTransactionStatusOverride(noStatus));
+        ] as const)('forces status to %s', async (override, expectedStatus) => {
+            const { result } = await renderHook(() => useTransactionStatusOverride(noStatus));
 
-            act(() => {
+            await act(() => {
                 result.current.forceStatus(override);
             });
 
             expect(result.current.status).toEqual(expectedStatus);
         });
 
-        it('resets to original status after forceStatus is called with no-override', () => {
-            const { result } = renderHook(() => useTransactionStatusOverride(pendingStatus));
+        it('resets to original status after forceStatus is called with no-override', async () => {
+            const { result } = await renderHook(() => useTransactionStatusOverride(pendingStatus));
 
-            act(() => {
+            await act(() => {
                 result.current.forceStatus('isFailed');
             });
-            act(() => {
+            await act(() => {
                 result.current.forceStatus('no-override');
             });
 

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAlert.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAlert.test.tsx
@@ -54,14 +54,14 @@ const alertLabelsCases: AlertLabelsCase[] = [
     },
 ];
 
-const renderAlert = ({
+const renderAlert = async ({
     alertType,
     trade = getBuyTrade({ status: 'SUBMITTED' }),
 }: {
     alertType: TradeStatusStep;
     trade?: TradingTransaction;
 }) =>
-    renderWithStoreProvider(
+    await renderWithStoreProvider(
         <TradeDetailAlert alertType={alertType} orderId={trade.data.orderId} />,
         {
             preloadedState: {
@@ -82,16 +82,16 @@ describe('TradeDetailAlert', () => {
 
     it.each(alertLabelsCases)(
         'should render translated labels for $alertType alert',
-        ({ alertType, titleKey, descriptionKey }) => {
-            const { getByText } = renderAlert({ alertType });
+        async ({ alertType, titleKey, descriptionKey }) => {
+            const { getByText } = await renderAlert({ alertType });
 
             expect(getByText(getTranslation(titleKey))).toBeOnTheScreen();
             expect(getByText(getTranslation(descriptionKey))).toBeOnTheScreen();
         },
     );
 
-    it('should render proceed payment button for waiting alert', () => {
-        const { getByText } = renderAlert({ alertType: 'waiting' });
+    it('should render proceed payment button for waiting alert', async () => {
+        const { getByText } = await renderAlert({ alertType: 'waiting' });
 
         expect(
             getByText(getTranslation('moduleTrading.tradeHistory.detail.waitingAlert.button')),
@@ -111,8 +111,8 @@ describe('TradeDetailAlert', () => {
             getExchangeTrade({ status: 'ERROR' }),
             'moduleTrading.tradeHistory.detail.errorAlert.swapDescription',
         ],
-    ] as const)('should use trade-specific error description key', (trade, key) => {
-        const { getByText } = renderAlert({ alertType: 'error', trade });
+    ] as const)('should use trade-specific error description key', async (trade, key) => {
+        const { getByText } = await renderAlert({ alertType: 'error', trade });
 
         expect(getByText(getTranslation(key))).toBeOnTheScreen();
     });

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAmountStack.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAmountStack.test.tsx
@@ -4,8 +4,8 @@ import { btcAsset } from '@suite-native/trading-fixtures';
 import { TradeDetailAmountStack } from './TradeDetailAmountStack';
 
 describe('TradeDetailAmountStack', () => {
-    it('should render fiat amount without crypto icon and fiat badge', () => {
-        const { getByText, queryByText } = renderWithBasicProvider(
+    it('should render fiat amount without crypto icon and fiat badge', async () => {
+        const { getByText, queryByText } = await renderWithBasicProvider(
             <TradeDetailAmountStack
                 isCrypto={false}
                 amountString="$100.00"
@@ -18,8 +18,8 @@ describe('TradeDetailAmountStack', () => {
         expect(queryByText(/0.002/)).toBeNull();
     });
 
-    it('should render crypto amount with fiat badge', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should render crypto amount with fiat badge', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <TradeDetailAmountStack
                 isCrypto={true}
                 amountString="0.5 BTC"

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailFooter.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailFooter.test.tsx
@@ -25,10 +25,10 @@ describe('TradeDetailFooter', () => {
         jest.clearAllMocks();
     });
 
-    it('should not render when trade is not found', () => {
+    it('should not render when trade is not found', async () => {
         const preloadedState = getPreloadedState([]);
 
-        const { toJSON } = renderWithStoreProvider(
+        const { toJSON } = await renderWithStoreProvider(
             <TradeDetailFooter orderId="nonexistent_order_id" />,
             { preloadedState },
         );
@@ -36,16 +36,16 @@ describe('TradeDetailFooter', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should handle copy order ID press', () => {
+    it('should handle copy order ID press', async () => {
         const sellTrade = getSellTrade({ status: 'ERROR' });
         const preloadedState = getPreloadedState([sellTrade]);
 
-        const { getByText } = renderWithStoreProvider(
+        const { getByText } = await renderWithStoreProvider(
             <TradeDetailFooter orderId={sellTrade.data.orderId!} />,
             { preloadedState },
         );
 
-        fireEvent.press(getByText(getTranslation('generic.buttons.copy')));
+        await fireEvent.press(getByText(getTranslation('generic.buttons.copy')));
 
         expect(mockCopyToClipboard).toHaveBeenCalledWith(
             sellTrade.data.orderId!,

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailHeader.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailHeader.test.tsx
@@ -24,58 +24,58 @@ describe('TradeDetailHeader', () => {
         jest.clearAllMocks();
     });
 
-    const renderHeader = (orderId: string, trades: TradingTransaction[] = []) =>
-        renderWithTradingHistoryProvider(
+    const renderHeader = async (orderId: string, trades: TradingTransaction[] = []) =>
+        await renderWithTradingHistoryProvider(
             <TradeDetailHeader orderId={orderId} onOpenedBrowser={jest.fn()} />,
             { overrides: createOverrides(trades) },
         );
 
     describe('Trade Not Found', () => {
-        it('should not render when trade is not found', () => {
-            const { toJSON } = renderHeader('nonexistent_order_id');
+        it('should not render when trade is not found', async () => {
+            const { toJSON } = await renderHeader('nonexistent_order_id');
 
             expect(toJSON()).toBeNull();
         });
     });
 
     describe('Success Status', () => {
-        it('should render header with spinner for in-progress pending trade', () => {
+        it('should render header with spinner for in-progress pending trade', async () => {
             const sellTrade = getSellTrade({ status: 'PENDING' });
-            const { getByTestId } = renderHeader(sellTrade.data.orderId!, [sellTrade]);
+            const { getByTestId } = await renderHeader(sellTrade.data.orderId!, [sellTrade]);
 
             expect(getByTestId('@circular-spinner')).toBeTruthy();
         });
 
-        it('should render header without spinner for final success status', () => {
+        it('should render header without spinner for final success status', async () => {
             const sellTrade = getSellTrade({ status: 'SUCCESS' });
-            const { queryByTestId } = renderHeader(sellTrade.data.orderId!, [sellTrade]);
+            const { queryByTestId } = await renderHeader(sellTrade.data.orderId!, [sellTrade]);
 
             expect(queryByTestId('@circular-spinner')).toBeNull();
         });
     });
 
     describe('Alert Rendering', () => {
-        it('should render error alert for buy trade error status', () => {
+        it('should render error alert for buy trade error status', async () => {
             const buyTrade = getBuyTrade({ status: 'ERROR' });
-            const { getByText } = renderHeader(buyTrade.data.orderId!, [buyTrade]);
+            const { getByText } = await renderHeader(buyTrade.data.orderId!, [buyTrade]);
 
             expect(
                 getByText(getTranslation('moduleTrading.tradeHistory.detail.errorAlert.title')),
             ).toBeTruthy();
         });
 
-        it('should render waiting alert for buy trade submitted status', () => {
+        it('should render waiting alert for buy trade submitted status', async () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const { getByText } = renderHeader(buyTrade.data.orderId!, [buyTrade]);
+            const { getByText } = await renderHeader(buyTrade.data.orderId!, [buyTrade]);
 
             expect(
                 getByText(getTranslation('moduleTrading.tradeHistory.detail.waitingAlert.title')),
             ).toBeTruthy();
         });
 
-        it('should render converting alert for exchange converting status', () => {
+        it('should render converting alert for exchange converting status', async () => {
             const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
-            const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
+            const { getByText } = await renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
             expect(
                 getByText(
@@ -84,18 +84,18 @@ describe('TradeDetailHeader', () => {
             ).toBeTruthy();
         });
 
-        it('should render kyc alert for exchange kyc status', () => {
+        it('should render kyc alert for exchange kyc status', async () => {
             const exchangeTrade = getExchangeTrade({ status: 'KYC' });
-            const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
+            const { getByText } = await renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
             expect(
                 getByText(getTranslation('moduleTrading.tradeHistory.detail.kycAlert.title')),
             ).toBeTruthy();
         });
 
-        it('should render sending alert for exchange sending status', () => {
+        it('should render sending alert for exchange sending status', async () => {
             const exchangeTrade = getExchangeTrade({ status: 'SENDING' });
-            const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
+            const { getByText } = await renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
             expect(
                 getByText(getTranslation('moduleTrading.tradeHistory.detail.sendingAlert.title')),

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailInfo.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailInfo.test.tsx
@@ -19,10 +19,10 @@ const getPreloadedState = (trades: TradingTransaction[]) => ({
 });
 
 describe('TradeDetailInfo', () => {
-    it('should not render when trade is not found', () => {
+    it('should not render when trade is not found', async () => {
         const preloadedState = getPreloadedState([]);
 
-        const { toJSON } = renderWithStoreProvider(
+        const { toJSON } = await renderWithStoreProvider(
             <TradeDetailInfo orderId="nonexistent_order_id" />,
             { preloadedState },
         );
@@ -30,12 +30,12 @@ describe('TradeDetailInfo', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render buy trade info correctly', () => {
+    it('should render buy trade info correctly', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
         const preloadedState = getPreloadedState([buyTrade]);
 
-        const { getByText } = renderWithStoreProvider(
+        const { getByText } = await renderWithStoreProvider(
             <TradeDetailInfo orderId={buyTrade.data.orderId!} />,
             { preloadedState },
         );
@@ -47,12 +47,12 @@ describe('TradeDetailInfo', () => {
         expect(getByText(/[0-9]{1,2}:21/)).toBeTruthy();
     });
 
-    it('should render exchange trade info correctly', () => {
+    it('should render exchange trade info correctly', async () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
 
         const preloadedState = getPreloadedState([exchangeTrade]);
 
-        const { getByText, queryByText } = renderWithStoreProvider(
+        const { getByText, queryByText } = await renderWithStoreProvider(
             <TradeDetailInfo orderId={exchangeTrade.data.orderId!} />,
             { preloadedState },
         );

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailProviderCard.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailProviderCard.test.tsx
@@ -34,8 +34,8 @@ const getTrade = ({ shouldIncludeStatusUrl = false } = {}) => {
     };
 };
 
-const renderProviderCard = (trade = getTrade()) =>
-    renderWithStoreProvider(<TradeDetailProviderCard orderId={trade.data.orderId!} />, {
+const renderProviderCard = async (trade = getTrade()) =>
+    await renderWithStoreProvider(<TradeDetailProviderCard orderId={trade.data.orderId!} />, {
         preloadedState: getPreloadedState([trade]),
     });
 
@@ -47,7 +47,7 @@ describe('TradeDetailProviderCard', () => {
     });
 
     it('should show status url when it is defined and open it on press', async () => {
-        const { getByText } = renderProviderCard(getTrade({ shouldIncludeStatusUrl: true }));
+        const { getByText } = await renderProviderCard(getTrade({ shouldIncludeStatusUrl: true }));
         const statusLink = getByText(
             getTranslation('moduleTrading.tradeHistory.detail.checkOrderStatus'),
         );
@@ -61,8 +61,8 @@ describe('TradeDetailProviderCard', () => {
         });
     });
 
-    it('should not show status url when it is not defined', () => {
-        const { queryByText } = renderProviderCard();
+    it('should not show status url when it is not defined', async () => {
+        const { queryByText } = await renderProviderCard();
 
         expect(
             queryByText(getTranslation('moduleTrading.tradeHistory.detail.checkOrderStatus')),
@@ -70,7 +70,7 @@ describe('TradeDetailProviderCard', () => {
     });
 
     it('should show support url when it is defined and open it on press', async () => {
-        const { getByText } = renderProviderCard();
+        const { getByText } = await renderProviderCard();
 
         const supportLink = getByText(
             getTranslation('moduleTrading.tradeHistory.detail.providerSupport'),

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailTransactionInfo.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailTransactionInfo.test.tsx
@@ -66,24 +66,24 @@ const getOverrides = (
 });
 
 describe('TradeDetailTransactionInfo', () => {
-    const renderComponent = (
+    const renderComponent = async (
         orderId: TradeDetailTransactionInfoProps['orderId'],
         overrides = getOverrides([]),
     ) =>
-        renderWithTradingHistoryProvider(<TradeDetailTransactionInfo orderId={orderId} />, {
+        await renderWithTradingHistoryProvider(<TradeDetailTransactionInfo orderId={orderId} />, {
             overrides,
         });
 
-    it('should not render when trade is not found', () => {
-        const { toJSON } = renderComponent('nonexistent_order_id', getOverrides([]));
+    it('should not render when trade is not found', async () => {
+        const { toJSON } = await renderComponent('nonexistent_order_id', getOverrides([]));
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render buy trade transaction info correctly', () => {
+    it('should render buy trade transaction info correctly', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { getByText, queryByText } = renderComponent(
+        const { getByText, queryByText } = await renderComponent(
             buyTrade.data.orderId!,
             getOverrides([buyTrade]),
         );
@@ -95,18 +95,21 @@ describe('TradeDetailTransactionInfo', () => {
         ).toBeNull();
     });
 
-    it('should render correct account name for buy trade', () => {
+    it('should render correct account name for buy trade', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { getByText } = renderComponent(buyTrade.data.orderId!, getOverrides([buyTrade]));
+        const { getByText } = await renderComponent(
+            buyTrade.data.orderId!,
+            getOverrides([buyTrade]),
+        );
 
         expect(getByText('ETH Account #1')).toBeTruthy();
     });
 
-    it('should render exchange trade transaction info correctly', () => {
+    it('should render exchange trade transaction info correctly', async () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
 
-        const { getByText } = renderComponent(
+        const { getByText } = await renderComponent(
             exchangeTrade.data.orderId!,
             getOverrides([exchangeTrade]),
         );
@@ -115,10 +118,10 @@ describe('TradeDetailTransactionInfo', () => {
         expect(getByText('0.462586 SOL')).toBeTruthy();
     });
 
-    it('should render correct account name for exchange trade', () => {
+    it('should render correct account name for exchange trade', async () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
 
-        const { getAllByText } = renderComponent(
+        const { getAllByText } = await renderComponent(
             exchangeTrade.data.orderId!,
             getOverrides([exchangeTrade]),
         );
@@ -127,12 +130,12 @@ describe('TradeDetailTransactionInfo', () => {
         expect(getAllByText('SOL Account #1')).toHaveLength(2);
     });
 
-    it('should render exchange trade even when accounts are not found', () => {
+    it('should render exchange trade even when accounts are not found', async () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
         const overridesState = getOverrides([exchangeTrade]);
         overridesState!.wallet!.accounts = []; // remove all accounts
 
-        const { getByText, getAllByText } = renderComponent(
+        const { getByText, getAllByText } = await renderComponent(
             exchangeTrade.data.orderId!,
             overridesState,
         );
@@ -142,22 +145,22 @@ describe('TradeDetailTransactionInfo', () => {
         expect(getAllByText('Solana')).toHaveLength(2);
     });
 
-    it('should render "Unknown" when asset network is not found', () => {
+    it('should render "Unknown" when asset network is not found', async () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
         exchangeTrade.data.send = 'unknown-asset' as any;
         exchangeTrade.data.receive = 'unknown-asset' as any;
         const overridesState = getOverrides([exchangeTrade]);
         overridesState!.wallet!.accounts = []; // remove all accounts
 
-        const { getAllByText } = renderComponent(exchangeTrade.data.orderId!, overridesState);
+        const { getAllByText } = await renderComponent(exchangeTrade.data.orderId!, overridesState);
 
         expect(getAllByText(getTranslation('generic.unknown'))).toHaveLength(2);
     });
 
-    it('should render sell trade transaction info correctly', () => {
+    it('should render sell trade transaction info correctly', async () => {
         const sellTrade = getSellTrade({ status: 'SEND_CRYPTO' });
 
-        const { getByText, queryByText } = renderComponent(
+        const { getByText, queryByText } = await renderComponent(
             sellTrade.data.orderId!,
             getOverrides([sellTrade]),
         );
@@ -169,10 +172,13 @@ describe('TradeDetailTransactionInfo', () => {
         ).toBeTruthy();
     });
 
-    it('should render correct account name for sell trade', () => {
+    it('should render correct account name for sell trade', async () => {
         const sellTrade = getSellTrade({ status: 'SEND_CRYPTO' });
 
-        const { getByText } = renderComponent(sellTrade.data.orderId!, getOverrides([sellTrade]));
+        const { getByText } = await renderComponent(
+            sellTrade.data.orderId!,
+            getOverrides([sellTrade]),
+        );
 
         expect(getByText('BTC Account #1')).toBeTruthy();
     });

--- a/suite-native/trading-history/src/components/TradeHistoryListItem/TradeHistoryListItem.test.tsx
+++ b/suite-native/trading-history/src/components/TradeHistoryListItem/TradeHistoryListItem.test.tsx
@@ -18,15 +18,16 @@ jest.mock('@suite-native/trading-atoms', () => {
 });
 
 describe('TradeHistoryListItem', () => {
-    const renderTradeHistoryListItem = (transaction: TradingTransaction) =>
-        renderWithTradingHistoryProvider(
+    const renderTradeHistoryListItem = async (transaction: TradingTransaction) =>
+        await renderWithTradingHistoryProvider(
             <TradeHistoryListItem transaction={transaction} onPress={jest.fn()} />,
         );
 
-    it('should render a buy trade with fiat and crypto icons', () => {
+    it('should render a buy trade with fiat and crypto icons', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { getByLabelText, getByText, queryByText } = renderTradeHistoryListItem(buyTrade);
+        const { getByLabelText, getByText, queryByText } =
+            await renderTradeHistoryListItem(buyTrade);
 
         expect(getByLabelText('flag-US')).toBeTruthy();
         expect(getByLabelText('ethereum')).toBeTruthy();
@@ -36,40 +37,40 @@ describe('TradeHistoryListItem', () => {
         expect(queryByText(/d3ef3451/)).toBeNull();
     });
 
-    it('should render exchange and sell trade directions', () => {
+    it('should render exchange and sell trade directions', async () => {
         const exchangeTrade = getExchangeTrade({ status: 'SUCCESS' });
         const sellTrade = getSellTrade({ status: 'ERROR' });
 
-        const exchangeResult = renderTradeHistoryListItem(exchangeTrade);
+        const exchangeResult = await renderTradeHistoryListItem(exchangeTrade);
 
         expect(exchangeResult.getByText('10.1232 JTO')).toBeTruthy();
         expect(exchangeResult.getByText('0.462586 SOL')).toBeTruthy();
-        exchangeResult.unmount();
+        await exchangeResult.unmount();
 
-        const sellResult = renderTradeHistoryListItem(sellTrade);
+        const sellResult = await renderTradeHistoryListItem(sellTrade);
 
         expect(sellResult.getByText('1.22 BTC')).toBeTruthy();
         expect(sellResult.getByText('$100.00')).toBeTruthy();
         expect(sellResult.getByLabelText('flag-US')).toBeTruthy();
     });
 
-    it('should render date and accessible status', () => {
+    it('should render date and accessible status', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { getByLabelText, getByText } = renderTradeHistoryListItem(buyTrade);
+        const { getByLabelText, getByText } = await renderTradeHistoryListItem(buyTrade);
 
         expect(getByText(/0[45]\/10\/2025,.*21/)).toBeTruthy();
         expect(getByLabelText('Trade in progress')).toBeTruthy();
     });
 
-    it('should call onPress when pressed', () => {
+    it('should call onPress when pressed', async () => {
         const onPress = jest.fn();
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-        const { getByText } = renderWithTradingHistoryProvider(
+        const { getByText } = await renderWithTradingHistoryProvider(
             <TradeHistoryListItem transaction={buyTrade} onPress={onPress} />,
         );
 
-        fireEvent.press(getByText('$1,234.00'));
+        await fireEvent.press(getByText('$1,234.00'));
 
         expect(onPress).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/trading-history/src/components/TradeHistoryListItem/TradeStatusIcon.test.tsx
+++ b/suite-native/trading-history/src/components/TradeHistoryListItem/TradeStatusIcon.test.tsx
@@ -38,10 +38,12 @@ describe('TradeStatusIcon', () => {
         });
     });
 
-    it('renders no icon for an undefined status', () => {
+    it('renders no icon for an undefined status', async () => {
         expect(getTradeStatusIconConfig(undefined)).toBeUndefined();
 
-        const { toJSON } = renderWithTradingHistoryProvider(<TradeStatusIcon status={undefined} />);
+        const { toJSON } = await renderWithTradingHistoryProvider(
+            <TradeStatusIcon status={undefined} />,
+        );
 
         expect(toJSON()).toBeNull();
     });
@@ -51,8 +53,8 @@ describe('TradeStatusIcon', () => {
         ['ERROR', 'moduleTrading.tradeHistory.statusIcon.error'],
         ['CANCELLED', 'moduleTrading.tradeHistory.statusIcon.warning'],
         ['SUBMITTED', 'moduleTrading.tradeHistory.statusIcon.pending'],
-    ] as const)('provides an accessible label for %s', (status, labelId) => {
-        const { getByLabelText } = renderWithTradingHistoryProvider(
+    ] as const)('provides an accessible label for %s', async (status, labelId) => {
+        const { getByLabelText } = await renderWithTradingHistoryProvider(
             <TradeStatusIcon status={status} />,
         );
 

--- a/suite-native/trading-history/src/components/TradeHistoryListItem/TradingDetailFeedback.test.tsx
+++ b/suite-native/trading-history/src/components/TradeHistoryListItem/TradingDetailFeedback.test.tsx
@@ -18,30 +18,33 @@ const reportMock = jest.fn();
 const services: NativeAnalyticsDep = { analytics: mockNativeAnalytics(reportMock) };
 
 describe('TradingDetailFeedback', () => {
-    const renderTradingDetailFeedback = (
+    const renderTradingDetailFeedback = async (
         props: Partial<Parameters<typeof TradingDetailFeedback>[0]> = {},
     ) =>
-        renderWithTradingHistoryProvider(<TradingDetailFeedback type="exchange" {...props} />, {
-            services,
-            overrides: {
-                geolocation: { countryCode: 'CZ' },
-                analytics: { instanceId: 'test-instance' },
+        await renderWithTradingHistoryProvider(
+            <TradingDetailFeedback type="exchange" {...props} />,
+            {
+                services,
+                overrides: {
+                    geolocation: { countryCode: 'CZ' },
+                    analytics: { instanceId: 'test-instance' },
+                },
             },
-        });
+        );
 
     beforeEach(() => {
         sendFeedbackActionMock.mockClear();
         reportMock.mockClear();
     });
 
-    it('renders the feedback card heading', () => {
-        renderTradingDetailFeedback();
+    it('renders the feedback card heading', async () => {
+        await renderTradingDetailFeedback();
 
         expect(screen.getByText(getTranslation('feedbackForm.title'))).toBeOnTheScreen();
     });
 
-    it('sends a trade feedback with the selected rating and typed description on submit', () => {
-        renderTradingDetailFeedback({
+    it('sends a trade feedback with the selected rating and typed description on submit', async () => {
+        await renderTradingDetailFeedback({
             status: 'CONFIRMED',
             provider: 'changelly',
             id: 'order-1',
@@ -50,9 +53,12 @@ describe('TradingDetailFeedback', () => {
             country: 'US',
         });
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
-        fireEvent.changeText(screen.getByTestId('@feedback-form/description-input'), 'Great!');
-        fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.changeText(
+            screen.getByTestId('@feedback-form/description-input'),
+            'Great!',
+        );
+        await fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
 
         expect(sendFeedbackActionMock).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -73,11 +79,11 @@ describe('TradingDetailFeedback', () => {
         );
     });
 
-    it('does not send feedback until a rating and description are provided', () => {
-        renderTradingDetailFeedback();
+    it('does not send feedback until a rating and description are provided', async () => {
+        await renderTradingDetailFeedback();
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
-        fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
 
         expect(sendFeedbackActionMock).not.toHaveBeenCalled();
         expect(reportMock).not.toHaveBeenCalledWith(
@@ -85,10 +91,10 @@ describe('TradingDetailFeedback', () => {
         );
     });
 
-    it('reports the rating selected event with the rating, category, trade context and provider', () => {
-        renderTradingDetailFeedback({ provider: 'changelly' });
+    it('reports the rating selected event with the rating, category, trade context and provider', async () => {
+        await renderTradingDetailFeedback({ provider: 'changelly' });
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.feedbackRatingSelectedEvent.name,
@@ -96,12 +102,15 @@ describe('TradingDetailFeedback', () => {
         });
     });
 
-    it('reports the feedback sent event on submit', () => {
-        renderTradingDetailFeedback({ provider: 'changelly' });
+    it('reports the feedback sent event on submit', async () => {
+        await renderTradingDetailFeedback({ provider: 'changelly' });
 
-        fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
-        fireEvent.changeText(screen.getByTestId('@feedback-form/description-input'), 'Great!');
-        fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
+        await fireEvent.press(screen.getByTestId('@feedback-form/rating/4'));
+        await fireEvent.changeText(
+            screen.getByTestId('@feedback-form/description-input'),
+            'Great!',
+        );
+        await fireEvent.press(screen.getByTestId('@feedback-form/submit-button'));
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.feedbackSentEvent.name,

--- a/suite-native/trading-history/src/components/TradeStatusBadge.test.tsx
+++ b/suite-native/trading-history/src/components/TradeStatusBadge.test.tsx
@@ -7,8 +7,8 @@ import { TradeStatusBadge, getBadgeIconName, getBadgeVariant } from './TradeStat
 import { renderWithTradingHistoryProvider } from '../test-utils/tradingHistoryTestUtils';
 
 describe('TradeStatusBadge', () => {
-    it('should render nothing when status is undefined', () => {
-        const { toJSON } = renderWithTradingHistoryProvider(
+    it('should render nothing when status is undefined', async () => {
+        const { toJSON } = await renderWithTradingHistoryProvider(
             <TradeStatusBadge status={undefined} />,
         );
 
@@ -26,9 +26,9 @@ describe('TradeStatusBadge', () => {
         ['WAITING_FOR_USER', 'waitingForUser'],
     ] as const)(
         'should render badge with correct text for buy trade and status %s',
-        (status, statusKey) => {
+        async (status, statusKey) => {
             const buyTrade = getBuyTrade({ status });
-            const { getByAccessibilityHint } = renderWithTradingHistoryProvider(
+            const { getByAccessibilityHint } = await renderWithTradingHistoryProvider(
                 <TradeStatusBadge status={buyTrade.data.status} />,
             );
             const expectedText = new RegExp(
@@ -52,9 +52,9 @@ describe('TradeStatusBadge', () => {
         ['SIGN_DATA', 'signData'],
     ] as const)(
         'should render badge with correct text for exchange trade and status %s',
-        (status, statusKey) => {
+        async (status, statusKey) => {
             const exchangeTrade = getExchangeTrade({ status });
-            const { getByAccessibilityHint } = renderWithTradingHistoryProvider(
+            const { getByAccessibilityHint } = await renderWithTradingHistoryProvider(
                 <TradeStatusBadge status={exchangeTrade.data.status} />,
             );
             const expectedText = new RegExp(
@@ -76,9 +76,9 @@ describe('TradeStatusBadge', () => {
         ['SUBMITTED', 'submitted'],
     ] as const)(
         'should render badge with correct text for sell trade and status %s',
-        (status, statusKey) => {
+        async (status, statusKey) => {
             const sellTrade = getSellTrade({ status });
-            const { getByAccessibilityHint } = renderWithTradingHistoryProvider(
+            const { getByAccessibilityHint } = await renderWithTradingHistoryProvider(
                 <TradeStatusBadge status={sellTrade.data.status} />,
             );
             const expectedText = new RegExp(

--- a/suite-native/trading-history/src/components/TradingHistory.test.tsx
+++ b/suite-native/trading-history/src/components/TradingHistory.test.tsx
@@ -84,12 +84,12 @@ const defaultTrades = [
 describe('TradingHistoryScreen', () => {
     let unmount: (() => void) | undefined;
 
-    const renderTradingHistory = ({
+    const renderTradingHistory = async ({
         trades = defaultTrades,
     }: {
         trades?: TradingTestPreloadedState['wallet']['trading']['trades'];
     } = {}) => {
-        const result = renderWithTradingHistoryProvider(<TradingHistory />, {
+        const result = await renderWithTradingHistoryProvider(<TradingHistory />, {
             overrides: getOverrides(trades),
         });
 
@@ -101,15 +101,15 @@ describe('TradingHistoryScreen', () => {
         jest.clearAllMocks();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         if (unmount) {
-            unmount();
+            await unmount();
             unmount = undefined;
         }
     });
 
-    it('should render list of trades', () => {
-        const { getByText } = renderTradingHistory();
+    it('should render list of trades', async () => {
+        const { getByText } = await renderTradingHistory();
 
         expect(getByText('$1,234.00')).toBeTruthy();
         expect(getByText('0.462586 ETH')).toBeTruthy();
@@ -122,10 +122,10 @@ describe('TradingHistoryScreen', () => {
         ).toBeTruthy();
     });
 
-    it('should show bottom sheet when trade item is clicked', () => {
-        const { getByText, queryAllByText } = renderTradingHistory();
+    it('should show bottom sheet when trade item is clicked', async () => {
+        const { getByText, queryAllByText } = await renderTradingHistory();
 
-        fireEvent.press(getByText('$1,234.00'));
+        await fireEvent.press(getByText('$1,234.00'));
 
         expect(mockShowSheet).toHaveBeenCalledTimes(1);
 
@@ -134,23 +134,25 @@ describe('TradingHistoryScreen', () => {
         expect(queryAllByText('0.462586 ETH').length).toBe(2);
     });
 
-    it('should filter trades by type', () => {
-        const { getByText, queryByText } = renderTradingHistory();
+    it('should filter trades by type', async () => {
+        const { getByText, queryByText } = await renderTradingHistory();
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradeHistory.tabs.exchange')));
+        await fireEvent.press(
+            getByText(getTranslation('moduleTrading.tradeHistory.tabs.exchange')),
+        );
 
         expect(getByText('10.1232 JTO')).toBeTruthy();
         expect(queryByText('$1,234.00')).toBeNull();
         expect(queryByText('1.22 BTC')).toBeNull();
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradeHistory.tabs.sell')));
+        await fireEvent.press(getByText(getTranslation('moduleTrading.tradeHistory.tabs.sell')));
 
         expect(getByText('1.22 BTC')).toBeTruthy();
         expect(queryByText('10.1232 JTO')).toBeNull();
     });
 
     it('should show the first trade after scrolling and changing the filter', async () => {
-        const { getByTestId, getByText } = renderTradingHistory();
+        const { getByTestId, getByText } = await renderTradingHistory();
         const list = getByTestId('@trading/history/list');
 
         await userEvent.scrollTo(list, {
@@ -166,11 +168,13 @@ describe('TradingHistoryScreen', () => {
         expect(getByText('10.1232 JTO')).toBeVisible();
     });
 
-    it('should show filtered empty state and return to all trades', () => {
+    it('should show filtered empty state and return to all trades', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-        const { getByText, queryByText } = renderTradingHistory({ trades: [buyTrade] });
+        const { getByText, queryByText } = await renderTradingHistory({ trades: [buyTrade] });
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradeHistory.tabs.exchange')));
+        await fireEvent.press(
+            getByText(getTranslation('moduleTrading.tradeHistory.tabs.exchange')),
+        );
 
         expect(
             getByText(getTranslation('moduleTrading.tradeHistory.filteredEmptyState.exchange')),
@@ -182,15 +186,15 @@ describe('TradingHistoryScreen', () => {
             ),
         ).toBeTruthy();
 
-        fireEvent.press(
+        await fireEvent.press(
             getByText(getTranslation('moduleTrading.tradeHistory.filteredEmptyState.showAll')),
         );
 
         expect(getByText('$1,234.00')).toBeTruthy();
     });
 
-    it('should show global empty state and return to the trade form', () => {
-        const { getByTestId, getByText, queryByText } = renderTradingHistory({
+    it('should show global empty state and return to the trade form', async () => {
+        const { getByTestId, getByText, queryByText } = await renderTradingHistory({
             trades: [],
         });
 
@@ -205,7 +209,9 @@ describe('TradingHistoryScreen', () => {
             ),
         ).toBeNull();
 
-        fireEvent.press(getByText(getTranslation('moduleTrading.tradeHistory.emptyState.button')));
+        await fireEvent.press(
+            getByText(getTranslation('moduleTrading.tradeHistory.emptyState.button')),
+        );
 
         expect(mockGoBack).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailHeader.test.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailHeader.test.tsx
@@ -79,20 +79,21 @@ describe('TradingHistoryDetailHeader', () => {
 
     it.each(testCases)(
         'should render the header for $titleId',
-        ({ trade, titleId, descriptionId, artwork }) => {
+        async ({ trade, titleId, descriptionId, artwork }) => {
             const orderId = trade.data.orderId ?? 'missing-order-id';
-            const { getByText, getByTestId, queryByTestId } = renderWithTradingHistoryProvider(
-                <TradingHistoryDetailHeader orderId={orderId} />,
-                {
-                    overrides: {
-                        wallet: {
-                            trading: {
-                                trades: [trade],
+            const { getByText, getByTestId, queryByTestId } =
+                await renderWithTradingHistoryProvider(
+                    <TradingHistoryDetailHeader orderId={orderId} />,
+                    {
+                        overrides: {
+                            wallet: {
+                                trading: {
+                                    trades: [trade],
+                                },
                             },
                         },
                     },
-                },
-            );
+                );
             const translationValues = { providerName: 'Mercuryo' };
 
             expect(getByText(getTranslation(titleId, translationValues))).toBeOnTheScreen();
@@ -132,9 +133,9 @@ describe('TradingHistoryDetailHeader', () => {
             titleId: 'moduleTrading.tradeHistory.detail.header.exchange.kyc.title' as const,
             trade: getExchangeTrade({ status: 'KYC' }),
         },
-    ])('renders $artwork artwork in compact content', ({ artwork, titleId, trade }) => {
+    ])('renders $artwork artwork in compact content', async ({ artwork, titleId, trade }) => {
         const orderId = trade.data.orderId ?? 'missing-order-id';
-        const { getByText, getByTestId } = renderWithTradingHistoryProvider(
+        const { getByText, getByTestId } = await renderWithTradingHistoryProvider(
             <TradingHistoryDetailCompactHeader orderId={orderId} />,
             {
                 overrides: {

--- a/suite-native/trading-history/src/components/TradingHistoryExportButton.test.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryExportButton.test.tsx
@@ -48,17 +48,17 @@ const getOverrides = (
 });
 
 describe('TradingHistoryExportButton', () => {
-    const renderExportButton = ({
+    const renderExportButton = async ({
         trades = [getBuyTrade({ status: 'SUCCESS' })],
     }: {
         trades?: TradingTestPreloadedState['wallet']['trading']['trades'];
     } = {}) =>
-        renderWithTradingHistoryProvider(<TradingHistoryExportButton />, {
+        await renderWithTradingHistoryProvider(<TradingHistoryExportButton />, {
             overrides: getOverrides(trades),
         });
 
     const confirmExport = async () => {
-        fireEvent.press(screen.getByTestId('@trading/history/export-button'));
+        await fireEvent.press(screen.getByTestId('@trading/history/export-button'));
         await act(() => mockShowAlert.mock.calls[0]![0].onPressPrimaryButton());
     };
 
@@ -67,22 +67,22 @@ describe('TradingHistoryExportButton', () => {
         mockExportTradingHistoryCsv.mockResolvedValue({ success: true });
     });
 
-    it('renders nothing when the device has no trades', () => {
-        renderExportButton({ trades: [] });
+    it('renders nothing when the device has no trades', async () => {
+        await renderExportButton({ trades: [] });
 
         expect(screen.queryByTestId('@trading/history/export-button')).toBeNull();
     });
 
-    it('renders the export button when the device has trades', () => {
-        renderExportButton();
+    it('renders the export button when the device has trades', async () => {
+        await renderExportButton();
 
         expect(screen.getByTestId('@trading/history/export-button')).toBeOnTheScreen();
     });
 
-    it('opens a confirmation alert instead of exporting immediately', () => {
-        renderExportButton();
+    it('opens a confirmation alert instead of exporting immediately', async () => {
+        await renderExportButton();
 
-        fireEvent.press(screen.getByTestId('@trading/history/export-button'));
+        await fireEvent.press(screen.getByTestId('@trading/history/export-button'));
 
         expect(mockShowAlert).toHaveBeenCalledTimes(1);
         expect(mockExportTradingHistoryCsv).not.toHaveBeenCalled();
@@ -99,7 +99,7 @@ describe('TradingHistoryExportButton', () => {
     });
 
     it('exports the CSV and shows a success toast when the download is confirmed', async () => {
-        renderExportButton();
+        await renderExportButton();
 
         await confirmExport();
 
@@ -117,7 +117,7 @@ describe('TradingHistoryExportButton', () => {
 
     it('shows a critical toast when the export fails', async () => {
         mockExportTradingHistoryCsv.mockResolvedValue({ success: false, reason: 'exportFailed' });
-        renderExportButton();
+        await renderExportButton();
 
         await confirmExport();
 
@@ -129,7 +129,7 @@ describe('TradingHistoryExportButton', () => {
 
     it('shows a critical toast when the export throws an error', async () => {
         mockExportTradingHistoryCsv.mockRejectedValue(new Error('unexpected failure'));
-        renderExportButton();
+        await renderExportButton();
 
         await confirmExport();
 
@@ -144,7 +144,7 @@ describe('TradingHistoryExportButton', () => {
             success: false,
             reason: 'fileSavingNotSupported',
         });
-        renderExportButton();
+        await renderExportButton();
 
         await confirmExport();
 
@@ -156,7 +156,7 @@ describe('TradingHistoryExportButton', () => {
 
     it('shows no toast when the export is cancelled by dismissing the directory picker', async () => {
         mockExportTradingHistoryCsv.mockResolvedValue({ success: false, reason: 'cancelled' });
-        renderExportButton();
+        await renderExportButton();
 
         await confirmExport();
 
@@ -164,10 +164,10 @@ describe('TradingHistoryExportButton', () => {
         expect(mockShowToast).not.toHaveBeenCalled();
     });
 
-    it('dismisses the alert without exporting when cancelled', () => {
-        renderExportButton();
+    it('dismisses the alert without exporting when cancelled', async () => {
+        await renderExportButton();
 
-        fireEvent.press(screen.getByTestId('@trading/history/export-button'));
+        await fireEvent.press(screen.getByTestId('@trading/history/export-button'));
         mockShowAlert.mock.calls[0]![0].onPressSecondaryButton();
 
         expect(mockHideAlert).toHaveBeenCalledTimes(1);

--- a/suite-native/trading-history/src/hooks/useSymbolExtractor.test.ts
+++ b/suite-native/trading-history/src/hooks/useSymbolExtractor.test.ts
@@ -6,8 +6,8 @@ import { getInitializedTradingState } from '@suite-native/trading-fixtures';
 import { useSymbolExtractor } from './useSymbolExtractor';
 
 describe('useSymbolExtractor', () => {
-    it('should return symbol for known cryptoId', () => {
-        const { result } = renderHookWithStoreProvider(
+    it('should return symbol for known cryptoId', async () => {
+        const { result } = await renderHookWithStoreProvider(
             () => useSymbolExtractor('bitcoin' as CryptoId),
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
@@ -15,8 +15,8 @@ describe('useSymbolExtractor', () => {
         expect(result.current).toBe('BTC');
     });
 
-    it('should return original cryptoId for unknown cryptoId', () => {
-        const { result } = renderHookWithStoreProvider(
+    it('should return original cryptoId for unknown cryptoId', async () => {
+        const { result } = await renderHookWithStoreProvider(
             () => useSymbolExtractor('unknown-crypto' as CryptoId),
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
@@ -24,8 +24,8 @@ describe('useSymbolExtractor', () => {
         expect(result.current).toBe('unknown-crypto');
     });
 
-    it('should handle undefined cryptoId', () => {
-        const { result } = renderHookWithStoreProvider(() => useSymbolExtractor(undefined), {
+    it('should handle undefined cryptoId', async () => {
+        const { result } = await renderHookWithStoreProvider(() => useSymbolExtractor(undefined), {
             preloadedState: { wallet: { trading: getInitializedTradingState() } },
         });
 

--- a/suite-native/trading-history/src/test-utils/tradingHistoryTestUtils.ts
+++ b/suite-native/trading-history/src/test-utils/tradingHistoryTestUtils.ts
@@ -50,7 +50,7 @@ type RenderWithTradingProviderOptions = TradingProviderOptions &
 export const renderWithTradingHistoryProvider = (
     element: ReactElement,
     { overrides, ...options }: RenderWithTradingProviderOptions = {},
-): RenderResult =>
+): Promise<RenderResult> =>
     renderWithStoreProvider(element, {
         preloadedState: createTradingPreloadedState({ overrides }),
         ...options,

--- a/suite-native/trading-provider-utils/src/components/Footer.test.tsx
+++ b/suite-native/trading-provider-utils/src/components/Footer.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@suite-native/atoms', () => ({
 describe('Footer', () => {
     const mockOpenLink = jest.spyOn(Linking, 'openURL');
 
-    const renderFooter = (overrides: Partial<TradingState>) => {
+    const renderFooter = async (overrides: Partial<TradingState>) => {
         const walletState = getWalletState();
         const preloadedState = {
             wallet: {
@@ -34,15 +34,15 @@ describe('Footer', () => {
             },
         };
 
-        return renderWithStoreProvider(<Footer />, { preloadedState });
+        return await renderWithStoreProvider(<Footer />, { preloadedState });
     };
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should render footer info', () => {
-        const { getByText } = renderFooter({});
+    it('should render footer info', async () => {
+        const { getByText } = await renderFooter({});
 
         expect(
             getByText(
@@ -56,14 +56,14 @@ describe('Footer', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render nothing when isAmountInputActive is true', () => {
-        const { toJSON } = renderFooter({ isAmountInputActive: true });
+    it('should render nothing when isAmountInputActive is true', async () => {
+        const { toJSON } = await renderFooter({ isAmountInputActive: true });
 
         expect(toJSON()).toBeNull();
     });
 
     it("should render provider's Terms & Conditions link when quote and provider infos are provided", async () => {
-        const { getByText } = renderFooter({ currentProviderMetadata: exchangeCexdirect });
+        const { getByText } = await renderFooter({ currentProviderMetadata: exchangeCexdirect });
 
         expect(getByText(/Cexdirect/)).toBeOnTheScreen();
         await userEvent.press(
@@ -75,7 +75,7 @@ describe('Footer', () => {
     });
 
     it('pressing link should open sheet', async () => {
-        const { getByText } = renderFooter({});
+        const { getByText } = await renderFooter({});
 
         await userEvent.press(
             getByText(

--- a/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.test.tsx
+++ b/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.test.tsx
@@ -14,8 +14,8 @@ const mockCloseModal = jest.fn();
 describe('HowTradingWorksSheet', () => {
     const mockOpenLink = jest.spyOn(Linking, 'openURL');
 
-    const renderHowTradingWorksSheet = () =>
-        renderWithBasicProvider(
+    const renderHowTradingWorksSheet = async () =>
+        await renderWithBasicProvider(
             <HowTradingWorksSheet
                 ref={createRef<BottomSheetModalMethods>()}
                 closeModal={mockCloseModal}
@@ -27,7 +27,7 @@ describe('HowTradingWorksSheet', () => {
     });
 
     it('should open links on press', async () => {
-        const { getByText } = renderHowTradingWorksSheet();
+        const { getByText } = await renderHowTradingWorksSheet();
 
         await userEvent.press(
             getByText(
@@ -46,7 +46,7 @@ describe('HowTradingWorksSheet', () => {
     });
 
     it('should close sheet on got it button press', async () => {
-        const { getByText } = renderHowTradingWorksSheet();
+        const { getByText } = await renderHowTradingWorksSheet();
 
         await userEvent.press(getByText(getTranslation('generic.buttons.gotIt')));
 

--- a/suite-native/trading-provider-utils/src/components/KycPolicyWarning.test.tsx
+++ b/suite-native/trading-provider-utils/src/components/KycPolicyWarning.test.tsx
@@ -19,8 +19,8 @@ describe('KycPolicyWarning', () => {
             kycPolicyType: 'KYC-yesrefund' as const,
             expected: "KYC is only required in exceptional cases. It's not needed for refunds.",
         },
-    ])('renders correct translation for $kycPolicyType', ({ kycPolicyType, expected }) => {
-        const { getByText } = renderWithBasicProvider(
+    ])('renders correct translation for $kycPolicyType', async ({ kycPolicyType, expected }) => {
+        const { getByText } = await renderWithBasicProvider(
             <Text>
                 <KycPolicyWarning kycPolicyType={kycPolicyType} />
             </Text>,
@@ -33,8 +33,8 @@ describe('KycPolicyWarning', () => {
         { kycPolicyType: 'noKYC' as const },
         { kycPolicyType: undefined },
         { kycPolicyType: 'UNKNOWN_TYPE' as ExchangeKYCType },
-    ])('renders nothing for $kycPolicyType', ({ kycPolicyType }) => {
-        const { queryByText } = renderWithBasicProvider(
+    ])('renders nothing for $kycPolicyType', async ({ kycPolicyType }) => {
+        const { queryByText } = await renderWithBasicProvider(
             <Text>
                 <KycPolicyWarning kycPolicyType={kycPolicyType} />
             </Text>,

--- a/suite-native/trading-quote-utils/src/components/CryptoToFiatValueBadge.test.tsx
+++ b/suite-native/trading-quote-utils/src/components/CryptoToFiatValueBadge.test.tsx
@@ -16,7 +16,7 @@ describe('CryptoToFiatValueBadge', () => {
     });
 
     const renderCryptoToFiatValueBadge = async (props: CryptoToFiatValueBadgeProps) => {
-        const res = renderWithStoreProvider(<CryptoToFiatValueBadge {...props} />, {
+        const res = await renderWithStoreProvider(<CryptoToFiatValueBadge {...props} />, {
             preloadedState: getPreloadedState(),
         });
 

--- a/suite-native/trading-quote-utils/src/hooks/useChangeStringsExtractor.test.ts
+++ b/suite-native/trading-quote-utils/src/hooks/useChangeStringsExtractor.test.ts
@@ -12,14 +12,14 @@ import { useChangeStringsExtractor } from './useChangeStringsExtractor';
 describe('useChangeStringsExtractor', () => {
     const getPreloadedState = () => ({ wallet: { trading: getInitializedTradingState() } });
 
-    const renderUseChangeStringsExtractor = (data: TradingTradeType | undefined) =>
-        renderHookWithStoreProvider(() => useChangeStringsExtractor(data), {
+    const renderUseChangeStringsExtractor = async (data: TradingTradeType | undefined) =>
+        await renderHookWithStoreProvider(() => useChangeStringsExtractor(data), {
             preloadedState: getPreloadedState(),
         });
 
-    it('should extract strings for buy trade', () => {
+    it('should extract strings for buy trade', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-        const { result } = renderUseChangeStringsExtractor(buyTrade.data);
+        const { result } = await renderUseChangeStringsExtractor(buyTrade.data);
 
         expect(result.current).toEqual({
             fromCurrency: 'USD',
@@ -34,9 +34,9 @@ describe('useChangeStringsExtractor', () => {
         });
     });
 
-    it('should extract strings for sell trade', () => {
+    it('should extract strings for sell trade', async () => {
         const sellTrade = getSellTrade({ status: 'SUBMITTED' });
-        const { result } = renderUseChangeStringsExtractor(sellTrade.data);
+        const { result } = await renderUseChangeStringsExtractor(sellTrade.data);
 
         expect(result.current).toEqual({
             fromCurrency: 'bitcoin',
@@ -51,9 +51,9 @@ describe('useChangeStringsExtractor', () => {
         });
     });
 
-    it('should extract strings for exchange trade', () => {
+    it('should extract strings for exchange trade', async () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONFIRM' });
-        const { result } = renderUseChangeStringsExtractor(exchangeTrade.data);
+        const { result } = await renderUseChangeStringsExtractor(exchangeTrade.data);
 
         expect(result.current).toEqual({
             fromCurrency: 'solana--jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL',
@@ -68,8 +68,8 @@ describe('useChangeStringsExtractor', () => {
         });
     });
 
-    it('should handle undefined trade', () => {
-        const { result } = renderUseChangeStringsExtractor(undefined);
+    it('should handle undefined trade', async () => {
+        const { result } = await renderUseChangeStringsExtractor(undefined);
 
         expect(result.current).toEqual({
             fromCurrency: undefined,
@@ -84,7 +84,7 @@ describe('useChangeStringsExtractor', () => {
         });
     });
 
-    it('should handle trade with missing values', () => {
+    it('should handle trade with missing values', async () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const tradeWithMissingValues = {
             ...buyTrade.data,
@@ -92,7 +92,7 @@ describe('useChangeStringsExtractor', () => {
             receiveStringAmount: undefined,
         };
 
-        const { result } = renderUseChangeStringsExtractor(tradeWithMissingValues);
+        const { result } = await renderUseChangeStringsExtractor(tradeWithMissingValues);
 
         expect(result.current).toEqual({
             fromCurrency: 'USD',

--- a/suite-native/trading-quote-utils/src/hooks/useReceiveAmountMultiplier.test.ts
+++ b/suite-native/trading-quote-utils/src/hooks/useReceiveAmountMultiplier.test.ts
@@ -10,8 +10,8 @@ const getPreloadedState = (swapSlippage: string | undefined) => {
     return { wallet: { trading } };
 };
 
-const renderUseReceiveAmountMultiplier = (swapSlippage: string | undefined) =>
-    renderHookWithStoreProvider(() => useReceiveAmountMultiplier(), {
+const renderUseReceiveAmountMultiplier = async (swapSlippage: string | undefined) =>
+    await renderHookWithStoreProvider(() => useReceiveAmountMultiplier(), {
         preloadedState: getPreloadedState(swapSlippage),
     });
 
@@ -22,8 +22,8 @@ describe('useReceiveAmountMultiplier', () => {
         ['5', '0.95'],
     ])(
         'applies slippage multiplier for selected quote swapSlippage=%s',
-        (swapSlippage, expectedAmount) => {
-            const { result } = renderUseReceiveAmountMultiplier(swapSlippage);
+        async (swapSlippage, expectedAmount) => {
+            const { result } = await renderUseReceiveAmountMultiplier(swapSlippage);
 
             expect(result.current('1')).toBe(expectedAmount);
         },

--- a/suite-native/trading-quote-utils/src/utils/utils.test.ts
+++ b/suite-native/trading-quote-utils/src/utils/utils.test.ts
@@ -118,9 +118,9 @@ describe('utils', () => {
             ['Buy', 'buy'],
             ['Sell', 'sell'],
             ['Swap', 'exchange'],
-        ])('should return "%s" for [%s] tradeType', (expectedTitle, tradeType) => {
+        ])('should return "%s" for [%s] tradeType', async (expectedTitle, tradeType) => {
             const trade = { tradeType } as TradingTransaction;
-            const { result } = renderHookWithBasicProvider(() => useTranslate());
+            const { result } = await renderHookWithBasicProvider(() => useTranslate());
 
             expect(getTradeTitle(trade, result.current.translate)).toBe(expectedTitle);
         });

--- a/suite-native/trading-residence/src/components/ConfirmLocationButton.test.tsx
+++ b/suite-native/trading-residence/src/components/ConfirmLocationButton.test.tsx
@@ -103,8 +103,8 @@ const LocationFormWithCountrySubdivisionPickerControls = ({
 describe('ConfirmLocationButton', () => {
     let store: TestStore;
 
-    const renderConfirmLocationButton = (props: Partial<ConfirmLocationButtonProps>) =>
-        renderWithStoreProvider(<ConfirmLocationButton afterConfirm={jest.fn} {...props} />, {
+    const renderConfirmLocationButton = async (props: Partial<ConfirmLocationButtonProps>) =>
+        await renderWithStoreProvider(<ConfirmLocationButton afterConfirm={jest.fn} {...props} />, {
             wrapper: LocationForm,
             store,
         });
@@ -124,11 +124,11 @@ describe('ConfirmLocationButton', () => {
         });
     });
 
-    it('should set location and call afterConfirmMock on press', () => {
+    it('should set location and call afterConfirmMock on press', async () => {
         const afterConfirmMock = jest.fn();
 
-        const { getByText } = renderConfirmLocationButton({ afterConfirm: afterConfirmMock });
-        fireEvent.press(
+        const { getByText } = await renderConfirmLocationButton({ afterConfirm: afterConfirmMock });
+        await fireEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
         );
 
@@ -138,9 +138,9 @@ describe('ConfirmLocationButton', () => {
         expect(afterConfirmMock).toHaveBeenCalled();
     });
 
-    it('should log submitDefault event on press', () => {
-        const { getByText } = renderConfirmLocationButton({});
-        fireEvent.press(
+    it('should log submitDefault event on press', async () => {
+        const { getByText } = await renderConfirmLocationButton({});
+        await fireEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
         );
 
@@ -148,13 +148,16 @@ describe('ConfirmLocationButton', () => {
         expect(mockAnalyticsReport).toHaveBeenCalledWith('submitDefault');
     });
 
-    it('should log submitCustom when selected value does not match the default one', () => {
-        const { getByText } = renderWithStoreProvider(<ConfirmLocationButtonWithChangedCountry />, {
-            wrapper: LocationForm,
-            store,
-        });
+    it('should log submitCustom when selected value does not match the default one', async () => {
+        const { getByText } = await renderWithStoreProvider(
+            <ConfirmLocationButtonWithChangedCountry />,
+            {
+                wrapper: LocationForm,
+                store,
+            },
+        );
 
-        fireEvent.press(
+        await fireEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
         );
 
@@ -164,7 +167,7 @@ describe('ConfirmLocationButton', () => {
 
     it('should open subdivision picker and not confirm when subdivision is required but missing', async () => {
         const afterConfirmMock = jest.fn();
-        const { getByText, queryByText } = renderWithStoreProvider(
+        const { getByText, queryByText } = await renderWithStoreProvider(
             <ConfirmLocationButtonWithUSCountry afterConfirm={afterConfirmMock} />,
             {
                 wrapper: LocationFormWithCountrySubdivisionPickerControls,
@@ -189,9 +192,9 @@ describe('ConfirmLocationButton', () => {
         expect(afterConfirmMock).not.toHaveBeenCalled();
     });
 
-    it('should persist subdivision when required subdivision is selected', () => {
+    it('should persist subdivision when required subdivision is selected', async () => {
         const afterConfirmMock = jest.fn();
-        const { getByText } = renderWithStoreProvider(
+        const { getByText } = await renderWithStoreProvider(
             <ConfirmLocationButtonWithUSCountry
                 afterConfirm={afterConfirmMock}
                 countrySubdivision={{
@@ -206,7 +209,7 @@ describe('ConfirmLocationButton', () => {
             },
         );
 
-        fireEvent.press(
+        await fireEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
         );
 

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryListItem.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryListItem.test.tsx
@@ -6,21 +6,23 @@ import { CountryListItem, type CountryListItemProps } from './CountryListItem';
 describe('CountryListItem', () => {
     const usData = nonSanctionedRegional.countriesOptionsMap.get('US')!;
 
-    const renderCountryListItem = (props: Partial<CountryListItemProps>) =>
-        renderWithBasicProvider(<CountryListItem onPress={jest.fn()} {...usData} {...props} />);
+    const renderCountryListItem = async (props: Partial<CountryListItemProps>) =>
+        await renderWithBasicProvider(
+            <CountryListItem onPress={jest.fn()} {...usData} {...props} />,
+        );
 
-    it('should render flag and name', () => {
-        const { getByLabelText, getByText } = renderCountryListItem({});
+    it('should render flag and name', async () => {
+        const { getByLabelText, getByText } = await renderCountryListItem({});
 
         expect(getByLabelText('flag-US')).toBeOnTheScreen();
         expect(getByText('United States of America')).toBeOnTheScreen();
     });
 
-    it('should call onPress callback on item press', () => {
+    it('should call onPress callback on item press', async () => {
         const onPress = jest.fn();
-        const { getByLabelText } = renderCountryListItem({ onPress });
+        const { getByLabelText } = await renderCountryListItem({ onPress });
 
-        fireEvent.press(getByLabelText('flag-US'));
+        await fireEvent.press(getByLabelText('flag-US'));
 
         expect(onPress).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.test.tsx
@@ -64,18 +64,20 @@ describe('CountryOfResidencePicker', () => {
         (useCountryFilteredData as jest.Mock).mockImplementation(mockUseCountryFilteredData);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         // make sure component is unmounted (FlashList otherwise might try to do some magic)
-        screen.unmount();
+        await screen.unmount();
     });
 
-    const renderCountryOfResidencePicker = (props: Partial<CountryOfResidencePickerProps> = {}) => {
-        const { result } = renderHookWithStoreProvider(() => useLocationForm(), {
+    const renderCountryOfResidencePicker = async (
+        props: Partial<CountryOfResidencePickerProps> = {},
+    ) => {
+        const { result } = await renderHookWithStoreProvider(() => useLocationForm(), {
             services,
             store: createTradingResidenceStore(),
         });
 
-        return renderWithBasicProvider(
+        return await renderWithBasicProvider(
             <CountryOfResidencePicker testID="TEST_ID" context="settings" {...props} />,
             {
                 services,
@@ -84,8 +86,8 @@ describe('CountryOfResidencePicker', () => {
         );
     };
 
-    it('should display value from expo-localization (Poland) when in default state', () => {
-        const { getByLabelText } = renderCountryOfResidencePicker();
+    it('should display value from expo-localization (Poland) when in default state', async () => {
+        const { getByLabelText } = await renderCountryOfResidencePicker();
 
         expect(
             getByLabelText(
@@ -95,7 +97,7 @@ describe('CountryOfResidencePicker', () => {
     });
 
     it('should allow to select country', async () => {
-        const { getByText, getByLabelText } = renderCountryOfResidencePicker();
+        const { getByText, getByLabelText } = await renderCountryOfResidencePicker();
 
         await userEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
@@ -110,7 +112,7 @@ describe('CountryOfResidencePicker', () => {
     });
 
     it('should clear selected subdivision when country changes', async () => {
-        const form = renderHookWithBasicProvider(
+        const form = await renderHookWithBasicProvider(
             () =>
                 useForm<TradingLocationFormValues>({
                     defaultValues: {
@@ -133,7 +135,7 @@ describe('CountryOfResidencePicker', () => {
             { services },
         );
 
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = await renderWithBasicProvider(
             <CountryOfResidencePicker testID="TEST_ID" context="settings" />,
             {
                 services,
@@ -156,7 +158,7 @@ describe('CountryOfResidencePicker', () => {
             setFilterValue: jest.fn(),
         }));
 
-        const { getByText } = renderCountryOfResidencePicker();
+        const { getByText } = await renderCountryOfResidencePicker();
         await userEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
         );
@@ -168,7 +170,7 @@ describe('CountryOfResidencePicker', () => {
     });
 
     it('should report to analytics after country changed', async () => {
-        const { getByText } = renderCountryOfResidencePicker();
+        const { getByText } = await renderCountryOfResidencePicker();
 
         await userEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
@@ -179,7 +181,7 @@ describe('CountryOfResidencePicker', () => {
     });
 
     it('should not report to analytics when user selects already selected country', async () => {
-        const { getByText } = renderCountryOfResidencePicker();
+        const { getByText } = await renderCountryOfResidencePicker();
 
         await userEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
@@ -195,13 +197,13 @@ describe('CountryOfResidencePicker', () => {
         expect(reportMock).not.toHaveBeenCalled();
     });
 
-    it('should render even when no value is selected', () => {
-        const formWithoutCountrySet = renderHookWithBasicProvider(
+    it('should render even when no value is selected', async () => {
+        const formWithoutCountrySet = await renderHookWithBasicProvider(
             () => useForm<TradingLocationFormValues>({ validation: locationFormValidationSchema }),
             { services },
         );
 
-        const { getByLabelText } = renderWithBasicProvider(
+        const { getByLabelText } = await renderWithBasicProvider(
             <CountryOfResidencePicker testID="TEST_ID" context="settings" />,
             {
                 services,

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionListItem.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionListItem.test.tsx
@@ -14,20 +14,22 @@ describe('CountrySubdivisionListItem', () => {
         name: 'California',
     } satisfies TradingCountrySubdivisionOption;
 
-    const renderCountrySubdivisionListItem = (props: Partial<CountrySubdivisionListItemProps>) =>
-        renderWithBasicProvider(
+    const renderCountrySubdivisionListItem = async (
+        props: Partial<CountrySubdivisionListItemProps>,
+    ) =>
+        await renderWithBasicProvider(
             <CountrySubdivisionListItem onPress={jest.fn()} {...subdivisionData} {...props} />,
         );
 
-    it('should render the name', () => {
-        const { getByText } = renderCountrySubdivisionListItem({});
+    it('should render the name', async () => {
+        const { getByText } = await renderCountrySubdivisionListItem({});
 
         expect(getByText('California')).toBeOnTheScreen();
     });
 
     it('should call onPress on item press', async () => {
         const onPress = jest.fn();
-        const { getByText } = renderCountrySubdivisionListItem({ onPress });
+        const { getByText } = await renderCountrySubdivisionListItem({ onPress });
 
         await userEvent.press(getByText('California'));
 

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.test.tsx
@@ -45,19 +45,19 @@ const TestCountrySubdivisionPickerControlsProvider = ({ children }: { children: 
 };
 
 describe('CountrySubdivisionPicker', () => {
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    const renderCountrySubdivisionPicker = (defaultValues: TradingLocationFormValues) => {
-        const form = renderHookWithBasicProvider(() =>
+    const renderCountrySubdivisionPicker = async (defaultValues: TradingLocationFormValues) => {
+        const form = await renderHookWithBasicProvider(() =>
             useForm<TradingLocationFormValues>({
                 defaultValues,
                 validation: locationFormValidationSchema,
             }),
         );
 
-        const renderResult = renderWithBasicProvider(
+        const renderResult = await renderWithBasicProvider(
             <CountrySubdivisionPicker testID="TEST_ID" noBottomBorder />,
             {
                 wrapper: ({ children }) => (
@@ -74,8 +74,8 @@ describe('CountrySubdivisionPicker', () => {
         };
     };
 
-    it('should render nothing when selected country does not require subdivision', () => {
-        const { queryByText } = renderCountrySubdivisionPicker({
+    it('should render nothing when selected country does not require subdivision', async () => {
+        const { queryByText } = await renderCountrySubdivisionPicker({
             country: czechiaCountry,
         });
 
@@ -84,8 +84,8 @@ describe('CountrySubdivisionPicker', () => {
         ).toBeNull();
     });
 
-    it('should render empty value when selected country requires subdivision', () => {
-        const { getByLabelText } = renderCountrySubdivisionPicker({
+    it('should render empty value when selected country requires subdivision', async () => {
+        const { getByLabelText } = await renderCountrySubdivisionPicker({
             country: usaCountry,
         });
 
@@ -96,8 +96,8 @@ describe('CountrySubdivisionPicker', () => {
         ).toHaveTextContent(getTranslation('tradingResidence.locationSettings.notSelected'));
     });
 
-    it('should display selected subdivision', () => {
-        const { getByLabelText } = renderCountrySubdivisionPicker({
+    it('should display selected subdivision', async () => {
+        const { getByLabelText } = await renderCountrySubdivisionPicker({
             country: usaCountry,
             countrySubdivision: {
                 value: 'CA',
@@ -114,7 +114,7 @@ describe('CountrySubdivisionPicker', () => {
     });
 
     it('should allow to select subdivision', async () => {
-        const { getByText, getByLabelText } = renderCountrySubdivisionPicker({
+        const { getByText, getByLabelText } = await renderCountrySubdivisionPicker({
             country: usaCountry,
         });
 

--- a/suite-native/trading-residence/src/components/OnboardingButtons.test.tsx
+++ b/suite-native/trading-residence/src/components/OnboardingButtons.test.tsx
@@ -21,8 +21,8 @@ import { OnboardingButtons, type OnboardingButtonsProps } from './OnboardingButt
 describe('OnboardingButtons', () => {
     let store: TestStore;
 
-    const renderOnboardingButtons = (props: OnboardingButtonsProps) =>
-        renderWithStoreProvider(<OnboardingButtons {...props} />, {
+    const renderOnboardingButtons = async (props: OnboardingButtonsProps) =>
+        await renderWithStoreProvider(<OnboardingButtons {...props} />, {
             wrapper: LocationForm,
             store,
         });
@@ -41,8 +41,8 @@ describe('OnboardingButtons', () => {
         });
     });
 
-    it('should render correctly', () => {
-        const { getByText } = renderOnboardingButtons({ afterPress: () => {} });
+    it('should render correctly', async () => {
+        const { getByText } = await renderOnboardingButtons({ afterPress: () => {} });
 
         expect(
             getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
@@ -56,11 +56,11 @@ describe('OnboardingButtons', () => {
         expect(selectWasTradingResidenceOnboardingVisited(store.getState())).toBe(false);
     });
 
-    it('should dispatch setResidenceCountry and setOnboardingVisited on `Confirm location` press', () => {
+    it('should dispatch setResidenceCountry and setOnboardingVisited on `Confirm location` press', async () => {
         const afterPressMock = jest.fn();
-        const { getByText } = renderOnboardingButtons({ afterPress: afterPressMock });
+        const { getByText } = await renderOnboardingButtons({ afterPress: afterPressMock });
 
-        fireEvent.press(
+        await fireEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
         );
 
@@ -70,11 +70,13 @@ describe('OnboardingButtons', () => {
         expect(afterPressMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should dispatch only setOnboardingVisited on `Not now` press', () => {
+    it('should dispatch only setOnboardingVisited on `Not now` press', async () => {
         const afterPressMock = jest.fn();
-        const { getByText } = renderOnboardingButtons({ afterPress: afterPressMock });
+        const { getByText } = await renderOnboardingButtons({ afterPress: afterPressMock });
 
-        fireEvent.press(getByText(getTranslation('tradingResidence.locationSettings.skipButton')));
+        await fireEvent.press(
+            getByText(getTranslation('tradingResidence.locationSettings.skipButton')),
+        );
 
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
         expect(selectWasTradingResidenceOnboardingVisited(store.getState())).toBe(true);

--- a/suite-native/trading-residence/src/components/SkipButton.test.tsx
+++ b/suite-native/trading-residence/src/components/SkipButton.test.tsx
@@ -10,25 +10,29 @@ jest.mock('../hooks/useCountrySelectionAnalyticsReport', () => ({
 }));
 
 describe('SkipButton', () => {
-    const renderSkipButton = (props: Partial<SkipButtonProps>) =>
-        renderWithBasicProvider(<SkipButton onPress={jest.fn()} {...props} />);
+    const renderSkipButton = async (props: Partial<SkipButtonProps>) =>
+        await renderWithBasicProvider(<SkipButton onPress={jest.fn()} {...props} />);
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should call onPress callback when pressed', () => {
+    it('should call onPress callback when pressed', async () => {
         const onPressMock = jest.fn();
 
-        const { getByText } = renderSkipButton({ onPress: onPressMock });
-        fireEvent.press(getByText(getTranslation('tradingResidence.locationSettings.skipButton')));
+        const { getByText } = await renderSkipButton({ onPress: onPressMock });
+        await fireEvent.press(
+            getByText(getTranslation('tradingResidence.locationSettings.skipButton')),
+        );
 
         expect(onPressMock).toHaveBeenCalled();
     });
 
-    it('should log cancel event on press', () => {
-        const { getByText } = renderSkipButton({});
-        fireEvent.press(getByText(getTranslation('tradingResidence.locationSettings.skipButton')));
+    it('should log cancel event on press', async () => {
+        const { getByText } = await renderSkipButton({});
+        await fireEvent.press(
+            getByText(getTranslation('tradingResidence.locationSettings.skipButton')),
+        );
 
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         expect(mockAnalyticsReport).toHaveBeenCalledWith('cancel');

--- a/suite-native/trading-residence/src/components/TradingAvailability.test.tsx
+++ b/suite-native/trading-residence/src/components/TradingAvailability.test.tsx
@@ -10,22 +10,23 @@ jest.mock('../hooks/useIsTradingAvailableForForm', () => ({
 }));
 
 describe('TradingAvailability', () => {
-    const renderTradingAvailability = () => renderWithBasicProvider(<TradingAvailability />);
+    const renderTradingAvailability = async () =>
+        await renderWithBasicProvider(<TradingAvailability />);
 
-    it('should render negative message when selected country is not whitelisted', () => {
+    it('should render negative message when selected country is not whitelisted', async () => {
         mockIsTradingAvailableForForm = false;
 
-        const { getByText } = renderTradingAvailability();
+        const { getByText } = await renderTradingAvailability();
 
         expect(
             getByText(getTranslation('tradingResidence.locationSettings.tradingUnavailable')),
         ).toBeOnTheScreen();
     });
 
-    it('should render positive message when selected country is whitelisted', () => {
+    it('should render positive message when selected country is whitelisted', async () => {
         mockIsTradingAvailableForForm = true;
 
-        const { getByText } = renderTradingAvailability();
+        const { getByText } = await renderTradingAvailability();
 
         expect(
             getByText(getTranslation('tradingResidence.locationSettings.tradingAvailable')),

--- a/suite-native/trading-residence/src/components/TradingLocationSettings.test.tsx
+++ b/suite-native/trading-residence/src/components/TradingLocationSettings.test.tsx
@@ -40,20 +40,20 @@ describe('TradingLocationSettings', () => {
             },
         });
 
-    const renderTradingLocationSettings = (props: TradingLocationSettingsProps) =>
-        renderWithStoreProvider(<TradingLocationSettings {...props} />, { store });
+    const renderTradingLocationSettings = async (props: TradingLocationSettingsProps) =>
+        await renderWithStoreProvider(<TradingLocationSettings {...props} />, { store });
 
     beforeEach(() => {
         store = createStore();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         // make sure component is unmounted (FlashList otherwise might try to do some magic)
-        screen.unmount();
+        await screen.unmount();
     });
 
-    it('should render all components', () => {
-        const { getByText } = renderTradingLocationSettings({
+    it('should render all components', async () => {
+        const { getByText } = await renderTradingLocationSettings({
             context: 'settings',
             children: <Text>Test Children</Text>,
         });
@@ -68,14 +68,14 @@ describe('TradingLocationSettings', () => {
         expect(getByText('POL')).toBeOnTheScreen();
     });
 
-    it('should show trading as unavailable when required subdivision is missing', () => {
+    it('should show trading as unavailable when required subdivision is missing', async () => {
         store = createStore({
             country: 'US',
             countrySubdivision: undefined,
             wasOnboardingVisited: false,
         });
 
-        const { getByText } = renderTradingLocationSettings({
+        const { getByText } = await renderTradingLocationSettings({
             context: 'settings',
             children: <Text>Test Children</Text>,
         });

--- a/suite-native/trading-residence/src/hooks/useAvailableScreenSquare.test.ts
+++ b/suite-native/trading-residence/src/hooks/useAvailableScreenSquare.test.ts
@@ -21,25 +21,27 @@ describe('useAvailableScreenSquare', () => {
             nativeEvent: { layout: { height, width, x: 0, y: 0 } },
         }) as LayoutChangeEvent;
 
-    const renderUseAvailableScreenSpace = (maximumSize = MAXIMUM_SIZE) =>
-        renderHookWithBasicProvider(() => useAvailableScreenSquare(MINIMUM_SIZE, maximumSize));
+    const renderUseAvailableScreenSpace = async (maximumSize = MAXIMUM_SIZE) =>
+        await renderHookWithBasicProvider(() =>
+            useAvailableScreenSquare(MINIMUM_SIZE, maximumSize),
+        );
 
-    it('should return MAXIMUM_SIZE when totalAvailableHeight is larger than MAXIMUM_SIZE', () => {
+    it('should return MAXIMUM_SIZE when totalAvailableHeight is larger than MAXIMUM_SIZE', async () => {
         // totalAvailableHeight = 1334 - 100 = 1234 which is > MAXIMUM_SIZE = 300
 
-        const { result } = renderUseAvailableScreenSpace();
+        const { result } = await renderUseAvailableScreenSpace();
 
         expect(result.current.squareSize).toBe(MAXIMUM_SIZE);
     });
 
-    it('should return total available height when it is between MINIMUM_SIZE and MAXIMUM_SIZE', () => {
+    it('should return total available height when it is between MINIMUM_SIZE and MAXIMUM_SIZE', async () => {
         // contentHeight = 1000 => totalAvailableHeight = 1334 - 100 - 1000 = 234
         // 234 > 50 (MINIMUM_SIZE) && 234 < 300 (MAXIMUM_SIZE)
         const contentHeight = 1000;
 
-        const { result } = renderUseAvailableScreenSpace();
+        const { result } = await renderUseAvailableScreenSpace();
 
-        act(() => {
+        await act(() => {
             result.current.handleContentLayout(mockLayoutEvent(contentHeight));
         });
 
@@ -48,22 +50,22 @@ describe('useAvailableScreenSquare', () => {
         expect(result.current.squareSize).toBe(expectedHeight);
     });
 
-    it('should return MINIMUM_SIZE when totalAvailableHeight is below MINIMUM_SIZE', () => {
+    it('should return MINIMUM_SIZE when totalAvailableHeight is below MINIMUM_SIZE', async () => {
         // contentHeight = 1185 => totalAvailableHeight = 1334 - 100 - 1185 = 49 which is < 50 (MINIMUM_SIZE)
         const contentHeight = 1185;
 
-        const { result } = renderUseAvailableScreenSpace();
+        const { result } = await renderUseAvailableScreenSpace();
 
-        act(() => {
+        await act(() => {
             result.current.handleContentLayout(mockLayoutEvent(contentHeight));
         });
 
         expect(result.current.squareSize).toBe(MINIMUM_SIZE);
     });
 
-    it('should cap squareSize to totalAvailableWidth when height exceeds it', () => {
+    it('should cap squareSize to totalAvailableWidth when height exceeds it', async () => {
         // MAXIMUM_SIZE = 800 > totalAvailableWidth = 730 => squareSize should be 730
-        const { result } = renderUseAvailableScreenSpace(800);
+        const { result } = await renderUseAvailableScreenSpace(800);
 
         expect(result.current.squareSize).toBe(MOCKED_SCREEN_WIDTH - HORIZONTAL_MARGIN);
     });

--- a/suite-native/trading-residence/src/hooks/useCountrySelectionAnalyticsReport.test.ts
+++ b/suite-native/trading-residence/src/hooks/useCountrySelectionAnalyticsReport.test.ts
@@ -10,17 +10,17 @@ describe('useCountrySelectionAnalyticsReport', () => {
         analytics: mockNativeAnalytics(reportMock),
     };
 
-    const renderUseCountrySelectionAnalyticsReport = () =>
-        renderHookWithBasicProvider(() => useCountrySelectionAnalyticsReport(), { services });
+    const renderUseCountrySelectionAnalyticsReport = async () =>
+        await renderHookWithBasicProvider(() => useCountrySelectionAnalyticsReport(), { services });
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should report event to analytics', () => {
-        const { result } = renderUseCountrySelectionAnalyticsReport();
+    it('should report event to analytics', async () => {
+        const { result } = await renderUseCountrySelectionAnalyticsReport();
 
-        act(() => {
+        await act(() => {
             result.current('submitCustom');
         });
 

--- a/suite-native/trading-residence/src/hooks/useFormCountryCode.test.tsx
+++ b/suite-native/trading-residence/src/hooks/useFormCountryCode.test.tsx
@@ -18,8 +18,8 @@ import { useLocationForm } from './useLocationForm';
 import { type TradingLocationFormType } from '../types/tradingLocationForm';
 
 describe('useFormCountryCode', () => {
-    const renderLocationForm = () =>
-        renderHookWithStoreProvider(() => useLocationForm(), {
+    const renderLocationForm = async () =>
+        await renderHookWithStoreProvider(() => useLocationForm(), {
             store: createLightStore({
                 reducer: {
                     locale: localeReducer,
@@ -33,26 +33,29 @@ describe('useFormCountryCode', () => {
             }),
         });
 
-    const renderUseFormCountryCode = (locationForm: TradingLocationFormType) =>
-        renderHookWithBasicProvider(() => useFormCountryCode(), {
+    const renderUseFormCountryCode = async (locationForm: TradingLocationFormType) =>
+        await renderHookWithBasicProvider(() => useFormCountryCode(), {
             wrapper: ({ children }) => <Form form={locationForm}>{children}</Form>,
         });
 
-    it.each<TradingCountryCode>(['US', 'unknown'])('should reflect country for %s', country => {
-        const { result: formResult } = renderLocationForm();
+    it.each<TradingCountryCode>(['US', 'unknown'])(
+        'should reflect country for %s',
+        async country => {
+            const { result: formResult } = await renderLocationForm();
 
-        act(() => {
-            formResult.current.setValue('country', {
-                value: country,
-                codeAlpha3: 'USA',
-                flag: 'Flag',
-                name: 'Country long name',
-                label: 'Country label',
-                shortLabel: 'Short label',
+            await act(() => {
+                formResult.current.setValue('country', {
+                    value: country,
+                    codeAlpha3: 'USA',
+                    flag: 'Flag',
+                    name: 'Country long name',
+                    label: 'Country label',
+                    shortLabel: 'Short label',
+                });
             });
-        });
-        const { result } = renderUseFormCountryCode(formResult.current);
+            const { result } = await renderUseFormCountryCode(formResult.current);
 
-        expect(result.current).toEqual(country);
-    });
+            expect(result.current).toEqual(country);
+        },
+    );
 });

--- a/suite-native/trading-residence/src/hooks/useIsTradingAvailableForForm.test.tsx
+++ b/suite-native/trading-residence/src/hooks/useIsTradingAvailableForForm.test.tsx
@@ -5,8 +5,8 @@ import { useIsTradingAvailableForForm } from './useIsTradingAvailableForForm';
 import { LocationForm } from '../components/LocationForm';
 
 describe('useIsTradingAvailableForForm', () => {
-    const renderUseIsTradingAvailableForForm = (preloadedState: Record<string, unknown>) =>
-        renderHookWithStoreProvider(() => useIsTradingAvailableForForm(), {
+    const renderUseIsTradingAvailableForForm = async (preloadedState: Record<string, unknown>) =>
+        await renderHookWithStoreProvider(() => useIsTradingAvailableForForm(), {
             wrapper: LocationForm,
             preloadedState,
         });
@@ -25,12 +25,12 @@ describe('useIsTradingAvailableForForm', () => {
         [true, 'US', 'CA'],
     ])(
         'should be [%s] for country [%s] and subdivision [%s]',
-        (expectedValue, country, countrySubdivision) => {
+        async (expectedValue, country, countrySubdivision) => {
             const preloadedState = {
                 wallet: { trading: { residence: { country, countrySubdivision } } },
             };
 
-            const { result } = renderUseIsTradingAvailableForForm(preloadedState);
+            const { result } = await renderUseIsTradingAvailableForForm(preloadedState);
 
             expect(result.current).toEqual(expectedValue);
         },

--- a/suite-native/trading-residence/src/hooks/useLocationForm.test.ts
+++ b/suite-native/trading-residence/src/hooks/useLocationForm.test.ts
@@ -17,8 +17,8 @@ import { useLocationForm } from './useLocationForm';
 describe('useLocationForm', () => {
     let store: TestStore;
 
-    const renderUseLocationForm = () =>
-        renderHookWithStoreProvider(() => useLocationForm(), { store });
+    const renderUseLocationForm = async () =>
+        await renderHookWithStoreProvider(() => useLocationForm(), { store });
 
     beforeEach(() => {
         store = createLightStore({
@@ -34,8 +34,8 @@ describe('useLocationForm', () => {
         });
     });
 
-    it('should use default subdivision value from redux state', () => {
-        act(() => {
+    it('should use default subdivision value from redux state', async () => {
+        await act(() => {
             store.dispatch(
                 residenceActions.setResidenceCountry({
                     country: 'US',
@@ -44,7 +44,7 @@ describe('useLocationForm', () => {
             );
         });
 
-        const { result } = renderUseLocationForm();
+        const { result } = await renderUseLocationForm();
 
         expect(result.current.getValues('country')).toEqual(
             expect.objectContaining({
@@ -58,8 +58,8 @@ describe('useLocationForm', () => {
         });
     });
 
-    it('should ignore persisted subdivision when it does not belong to country', () => {
-        act(() => {
+    it('should ignore persisted subdivision when it does not belong to country', async () => {
+        await act(() => {
             store.dispatch(
                 residenceActions.setResidenceCountry({
                     country: 'CZ',
@@ -68,13 +68,13 @@ describe('useLocationForm', () => {
             );
         });
 
-        const { result } = renderUseLocationForm();
+        const { result } = await renderUseLocationForm();
 
         expect(result.current.getValues('countrySubdivision')).toBeUndefined();
     });
 
-    it('should use value from expo-localization when country is not set in store', () => {
-        const { result } = renderUseLocationForm();
+    it('should use value from expo-localization when country is not set in store', async () => {
+        const { result } = await renderUseLocationForm();
 
         expect(result.current.getValues('country')).toEqual(
             expect.objectContaining({
@@ -83,7 +83,7 @@ describe('useLocationForm', () => {
         );
     });
 
-    it('should fallback to worldwide when country is not set in store and expo-localization country is not supported', () => {
+    it('should fallback to worldwide when country is not set in store and expo-localization country is not supported', async () => {
         jest.spyOn(Localization, 'getLocales').mockReturnValue([
             {
                 languageTag: 'es-CU',
@@ -99,7 +99,7 @@ describe('useLocationForm', () => {
             } as unknown as Locale,
         ]);
 
-        const { result } = renderUseLocationForm();
+        const { result } = await renderUseLocationForm();
 
         expect(result.current.getValues('country')).toEqual(
             expect.objectContaining({

--- a/suite-native/trading-residence/src/screens/SettingsTradingLocationScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/SettingsTradingLocationScreen.test.tsx
@@ -37,8 +37,8 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('TradingLocationSettingsScreen', () => {
-    const renderTradingLocationSettingsScreen = () =>
-        renderWithStoreProvider(<SettingsTradingLocationScreen />, {
+    const renderTradingLocationSettingsScreen = async () =>
+        await renderWithStoreProvider(<SettingsTradingLocationScreen />, {
             services,
             store: createLightStore({
                 reducer: {
@@ -58,12 +58,13 @@ describe('TradingLocationSettingsScreen', () => {
         jest.clearAllMocks();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render all components', () => {
-        const { getByText, queryByText, getByLabelText } = renderTradingLocationSettingsScreen();
+    it('should render all components', async () => {
+        const { getByText, queryByText, getByLabelText } =
+            await renderTradingLocationSettingsScreen();
 
         expect(
             getByText(getTranslation('tradingResidence.locationSettings.title')),
@@ -79,7 +80,7 @@ describe('TradingLocationSettingsScreen', () => {
     });
 
     it('should goBack on `Confirm location` press', async () => {
-        const { getByText } = renderTradingLocationSettingsScreen();
+        const { getByText } = await renderTradingLocationSettingsScreen();
 
         await userEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.confirmButton')),
@@ -89,7 +90,7 @@ describe('TradingLocationSettingsScreen', () => {
     });
 
     it('should log analytics event on country change', async () => {
-        const { getByText } = renderTradingLocationSettingsScreen();
+        const { getByText } = await renderTradingLocationSettingsScreen();
 
         await userEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
@@ -107,7 +108,7 @@ describe('TradingLocationSettingsScreen', () => {
     });
 
     it('should go back and log analytics event on back button press', async () => {
-        const { getByLabelText } = renderTradingLocationSettingsScreen();
+        const { getByLabelText } = await renderTradingLocationSettingsScreen();
 
         await userEvent.press(getByLabelText(getTranslation('generic.buttons.goBack')));
 

--- a/suite-native/trading-residence/src/screens/TradingLocationModalScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/TradingLocationModalScreen.test.tsx
@@ -45,8 +45,8 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('TradingLocationModalScreen', () => {
-    const renderTradingLocationModalScreen = () =>
-        renderWithStoreProvider(
+    const renderTradingLocationModalScreen = async () =>
+        await renderWithStoreProvider(
             <TradingLocationModalScreen
                 navigation={
                     {
@@ -76,12 +76,12 @@ describe('TradingLocationModalScreen', () => {
         jest.clearAllMocks();
     });
 
-    afterEach(() => {
-        screen.unmount();
+    afterEach(async () => {
+        await screen.unmount();
     });
 
-    it('should render all components', () => {
-        const { getByText, queryByLabelText } = renderTradingLocationModalScreen();
+    it('should render all components', async () => {
+        const { getByText, queryByLabelText } = await renderTradingLocationModalScreen();
 
         expect(
             getByText(getTranslation('tradingResidence.locationSettings.title')),
@@ -97,7 +97,7 @@ describe('TradingLocationModalScreen', () => {
     });
 
     it('should log analytics event on country change', async () => {
-        const { getByText } = renderTradingLocationModalScreen();
+        const { getByText } = await renderTradingLocationModalScreen();
 
         await userEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.countryOfResidence')),
@@ -115,7 +115,7 @@ describe('TradingLocationModalScreen', () => {
     });
 
     it('should reset navigation on button press', async () => {
-        const { getByText } = renderTradingLocationModalScreen();
+        const { getByText } = await renderTradingLocationModalScreen();
 
         await userEvent.press(
             getByText(getTranslation('tradingResidence.locationSettings.skipButton')),

--- a/suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx
@@ -19,7 +19,7 @@ const mockOnSlippageConfirmed = jest.fn();
 
 describe('SlippageBottomSheet', () => {
     const renderSlippageBottomSheet = async (store: TestStore) => {
-        const result = renderWithSlippageTestProvider(
+        const result = await renderWithSlippageTestProvider(
             <SlippageBottomSheet
                 isVisible={false}
                 onClose={mockOnClose}

--- a/suite-native/trading-slippage/src/components/SlippagePicker.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippagePicker.test.tsx
@@ -27,7 +27,7 @@ describe('SlippagePicker', () => {
     });
 
     const renderSlippagePicker = async (quote: ExchangeTrade = mercuryoDexQuote) => {
-        const result = renderWithSlippageTestProvider(
+        const result = await renderWithSlippageTestProvider(
             <SlippagePicker onSlippageConfirmed={mockOnSlippageConfirmed} />,
             { quote },
         );

--- a/suite-native/trading-slippage/src/components/SlippageSummary.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageSummary.test.tsx
@@ -24,12 +24,12 @@ const TestWrapper = ({ slippage = '1' }: { slippage?: string }) => {
     );
 };
 
-const renderSlippageSummary = (slippage?: string, quote?: ExchangeTrade) =>
-    renderWithSlippageTestProvider(<TestWrapper slippage={slippage} />, { quote });
+const renderSlippageSummary = async (slippage?: string, quote?: ExchangeTrade) =>
+    await renderWithSlippageTestProvider(<TestWrapper slippage={slippage} />, { quote });
 
 describe('SlippageSummary', () => {
-    it('should render all row labels', () => {
-        const { getByText } = renderSlippageSummary();
+    it('should render all row labels', async () => {
+        const { getByText } = await renderSlippageSummary();
 
         expect(
             getByText(getTranslation('moduleTrading.slippage.summary.offered')),
@@ -42,46 +42,46 @@ describe('SlippageSummary', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should show offered amount and symbol from the quote', () => {
-        const { getByText } = renderSlippageSummary();
+    it('should show offered amount and symbol from the quote', async () => {
+        const { getByText } = await renderSlippageSummary();
 
         expect(getByText(`${mercuryoDexQuote.receiveStringAmount} BTC`)).toBeOnTheScreen();
     });
 
-    it('should calculate deduction and minimum receive from slippage', () => {
-        const { getByText } = renderSlippageSummary('1');
+    it('should calculate deduction and minimum receive from slippage', async () => {
+        const { getByText } = await renderSlippageSummary('1');
 
         expect(getByText('-0.00000836 BTC')).toBeOnTheScreen();
         expect(getByText('0.00082718 BTC')).toBeOnTheScreen();
     });
 
-    it('should use swapSlippage from the quote when form value is empty', () => {
-        const { getByText } = renderSlippageSummary('');
+    it('should use swapSlippage from the quote when form value is empty', async () => {
+        const { getByText } = await renderSlippageSummary('');
 
         expect(getByText('-0.00000836 BTC')).toBeOnTheScreen();
         expect(getByText('0.00082718 BTC')).toBeOnTheScreen();
     });
 
-    it('should recalculate values when slippage changes', () => {
-        const { getByText } = renderSlippageSummary('3');
+    it('should recalculate values when slippage changes', async () => {
+        const { getByText } = await renderSlippageSummary('3');
 
         expect(getByText('-0.00002507 BTC')).toBeOnTheScreen();
         expect(getByText('0.00081047 BTC')).toBeOnTheScreen();
     });
 
     describe('quote validation', () => {
-        it('should throw when swapSlippage is undefined', () => {
+        it('should throw when swapSlippage is undefined', async () => {
             const quote = { ...mercuryoDexQuote, swapSlippage: undefined };
 
-            expect(() => renderSlippageSummary(undefined, quote)).toThrow(
+            await expect(renderSlippageSummary(undefined, quote)).rejects.toThrow(
                 'swapSlippage is required in quote for SlippageSummary',
             );
         });
 
-        it('should throw when receiveStringAmount is undefined', () => {
+        it('should throw when receiveStringAmount is undefined', async () => {
             const quote = { ...mercuryoDexQuote, receiveStringAmount: undefined };
 
-            expect(() => renderSlippageSummary(undefined, quote)).toThrow(
+            await expect(renderSlippageSummary(undefined, quote)).rejects.toThrow(
                 'receiveStringAmount is required in quote for SlippageSummary',
             );
         });

--- a/suite-native/trading-slippage/src/hooks/useSlippageForm.test.ts
+++ b/suite-native/trading-slippage/src/hooks/useSlippageForm.test.ts
@@ -10,7 +10,9 @@ import { renderHookWithSlippageTestProvider } from '../test-utils/testUtils';
 
 describe('useSlippageForm', () => {
     const renderUseSlippageForm = async (initialSlippage?: string) => {
-        const ret = renderHookWithSlippageTestProvider(() => useSlippageForm(initialSlippage));
+        const ret = await renderHookWithSlippageTestProvider(() =>
+            useSlippageForm(initialSlippage),
+        );
         // wait for form validation
         await act(() => Promise.resolve());
 

--- a/suite-native/trading-slippage/src/test-utils/testUtils.ts
+++ b/suite-native/trading-slippage/src/test-utils/testUtils.ts
@@ -51,7 +51,7 @@ export const createSlippageTestStore = (quote: ExchangeTrade | undefined = mercu
 export const renderWithSlippageTestProvider = (
     element: ReactElement,
     { store, quote }: SlippageTestOptions = {},
-): RenderResult => {
+): Promise<RenderResult> => {
     const preloadedState = store ? undefined : getSlippageTestPreloadedState(quote);
 
     return renderWithStoreProvider(element, { preloadedState, store });
@@ -60,7 +60,7 @@ export const renderWithSlippageTestProvider = (
 export const renderHookWithSlippageTestProvider = <Result>(
     callback: () => Result,
     { store, quote }: SlippageTestOptions = {},
-): RenderHookResult<Result, unknown> => {
+): Promise<RenderHookResult<Result, unknown>> => {
     const preloadedState = store ? undefined : getSlippageTestPreloadedState(quote);
 
     return renderHookWithStoreProvider(callback, { preloadedState, store });

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputHexData.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputHexData.test.tsx
@@ -10,24 +10,24 @@ jest.mock('@suite-native/clipboard', () => ({
 }));
 
 describe('ReviewOutputHexData', () => {
-    const renderHexData = (value: string) =>
-        renderWithBasicProvider(<ReviewOutputHexData value={value} />);
+    const renderHexData = async (value: string) =>
+        await renderWithBasicProvider(<ReviewOutputHexData value={value} />);
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should render empty-state translation when value is empty', () => {
-        const { getByText } = renderHexData('');
+    it('should render empty-state translation when value is empty', async () => {
+        const { getByText } = await renderHexData('');
 
         expect(
             getByText(getTranslation('transactionManagement.review.outputs.transactionDataEmpty')),
         ).toBeOnTheScreen();
     });
 
-    it('should render full value when length is at most 300 characters', () => {
+    it('should render full value when length is at most 300 characters', async () => {
         const value = 'a'.repeat(300);
-        const { getByText, queryByText } = renderHexData(value);
+        const { getByText, queryByText } = await renderHexData(value);
 
         expect(getByText(value)).toBeOnTheScreen();
         expect(
@@ -47,7 +47,7 @@ describe('ReviewOutputHexData', () => {
             'transactionManagement.review.outputs.transactionDataShowLess',
         );
 
-        const { getByText, queryByText } = renderHexData(value);
+        const { getByText, queryByText } = await renderHexData(value);
 
         expect(getByText(truncated)).toBeOnTheScreen();
         expect(queryByText(value)).toBeNull();
@@ -71,7 +71,7 @@ describe('ReviewOutputHexData', () => {
             'transactionManagement.review.outputs.transactionDataShowLess',
         );
 
-        const { getByText } = renderHexData(value);
+        const { getByText } = await renderHexData(value);
 
         await userEvent.press(getByText(truncated));
 
@@ -81,7 +81,7 @@ describe('ReviewOutputHexData', () => {
 
     it('should copy full value on long press of the data control', async () => {
         const value = '0xcafe';
-        const { getAllByRole } = renderHexData(value);
+        const { getAllByRole } = await renderHexData(value);
 
         const button = getAllByRole('button')?.[0];
         if (!button) {

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.test.tsx
@@ -22,8 +22,8 @@ jest.mock('./ReviewOutputItemValues', () => ({
 }));
 
 describe('ReviewOutputItem', () => {
-    const renderReviewOutputItem = (props: Partial<ReviewOutputItemProps>) =>
-        renderWithStoreProvider(
+    const renderReviewOutputItem = async (props: Partial<ReviewOutputItemProps>) =>
+        await renderWithStoreProvider(
             <ReviewOutputItem
                 accountKey={ETH_ACCOUNT_KEY}
                 onLayout={jest.fn()}
@@ -64,11 +64,11 @@ describe('ReviewOutputItem', () => {
             getTranslation('transactionManagement.review.outputs.tradedAssetsOutputLabel'),
         ],
         ['swap_intent', getTranslation('transactionManagement.review.outputs.swapIntentLabel')],
-    ])('should display title based on type [%s]', (type, expectedTitle) => {
+    ])('should display title based on type [%s]', async (type, expectedTitle) => {
         // Suppress console warnings for unsupported types
         jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-        const { getByTestId } = renderReviewOutputItem({
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type,
                 value: 'mockvalue',
@@ -79,8 +79,8 @@ describe('ReviewOutputItem', () => {
         expect(getByTestId('review-output-card/title')).toHaveTextContent(expectedTitle);
     });
 
-    it('should render ReviewOutputItemValues component for type "amount"', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render ReviewOutputItemValues component for type "amount"', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'amount',
                 value: 'mockvalue',
@@ -94,8 +94,8 @@ describe('ReviewOutputItem', () => {
         );
     });
 
-    it('should not render output card for type "rewards"', () => {
-        const { queryByTestId } = renderReviewOutputItem({
+    it('should not render output card for type "rewards"', async () => {
+        const { queryByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'rewards',
                 rewards: [],
@@ -106,8 +106,8 @@ describe('ReviewOutputItem', () => {
         expect(queryByTestId('review-output-card/title')).toBeNull();
     });
 
-    it('should render value for type "destination-tag" and value set', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render value for type "destination-tag" and value set', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'destination-tag',
                 value: 'mockvalue',
@@ -118,8 +118,8 @@ describe('ReviewOutputItem', () => {
         expect(getByTestId('review-output-card/content')).toHaveTextContent('mockvalue');
     });
 
-    it('should render tag not set placeholder for type "destination-tag" and empty value', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render tag not set placeholder for type "destination-tag" and empty value', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'destination-tag',
                 value: '',
@@ -137,8 +137,8 @@ describe('ReviewOutputItem', () => {
         'regular_legacy',
         'contract',
         'signing-with',
-    ])('should render chunked value for type "%s"', type => {
-        const { getByTestId } = renderReviewOutputItem({
+    ])('should render chunked value for type "%s"', async type => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type,
                 value: '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe',
@@ -151,8 +151,8 @@ describe('ReviewOutputItem', () => {
         );
     });
 
-    it('should render "No restriction" for type "timebounds"', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render "No restriction" for type "timebounds"', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'timebounds',
                 value: '',
@@ -165,8 +165,8 @@ describe('ReviewOutputItem', () => {
         );
     });
 
-    it('should render Testnet info for type "network"', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render Testnet info for type "network"', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'network',
                 value: '',
@@ -179,8 +179,8 @@ describe('ReviewOutputItem', () => {
         );
     });
 
-    it('should render transaction data for type "data"', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render transaction data for type "data"', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'data',
                 value: '0xabcd',
@@ -191,10 +191,10 @@ describe('ReviewOutputItem', () => {
         expect(getByTestId('review-output-card/content')).toHaveTextContent('0xabcd');
     });
 
-    it('should render long transaction data truncated with show-more control', () => {
+    it('should render long transaction data truncated with show-more control', async () => {
         const longHex = 'd'.repeat(301);
         const truncated = 'd'.repeat(300);
-        const { getByTestId } = renderReviewOutputItem({
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'data',
                 value: longHex,
@@ -211,8 +211,8 @@ describe('ReviewOutputItem', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render empty transaction data placeholder for type "data" with empty value', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render empty transaction data placeholder for type "data" with empty value', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'data',
                 value: '',
@@ -225,8 +225,8 @@ describe('ReviewOutputItem', () => {
         );
     });
 
-    it('should render recipient name for type "recipient_name"', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render recipient name for type "recipient_name"', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'recipient_name',
                 value: 'mockvalue',
@@ -237,8 +237,8 @@ describe('ReviewOutputItem', () => {
         expect(getByTestId('review-output-card/content')).toHaveTextContent('mockvalue');
     });
 
-    it('should render traded assets when send and receive are crypto', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render traded assets when send and receive are crypto', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'traded_assets',
                 value: '',
@@ -266,8 +266,8 @@ describe('ReviewOutputItem', () => {
         );
     });
 
-    it('should render the send leg only for a partial clear-signed swap (receive missing)', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render the send leg only for a partial clear-signed swap (receive missing)', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'traded_assets',
                 value: '',
@@ -292,8 +292,8 @@ describe('ReviewOutputItem', () => {
         );
     });
 
-    it('should render traded assets when receive is fiat', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render traded assets when receive is fiat', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'traded_assets',
                 value: '',
@@ -319,8 +319,8 @@ describe('ReviewOutputItem', () => {
         );
     });
 
-    it('should render empty content for type "traded_assets" when send or receive is missing', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render empty content for type "traded_assets" when send or receive is missing', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'traded_assets',
                 value: '',
@@ -332,8 +332,8 @@ describe('ReviewOutputItem', () => {
         expect(getByTestId('review-output-card/content')).toHaveTextContent('');
     });
 
-    it('should render "Swap" for "swap_intent"', () => {
-        const { getByTestId } = renderReviewOutputItem({
+    it('should render "Swap" for "swap_intent"', async () => {
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type: 'swap_intent',
                 value: 'swap',
@@ -352,9 +352,9 @@ describe('ReviewOutputItem', () => {
         'txid',
         'gas',
         'approve_data',
-    ])('should render no content for type', type => {
+    ])('should render no content for type', async type => {
         const warningSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const { getByTestId } = renderReviewOutputItem({
+        const { getByTestId } = await renderReviewOutputItem({
             reviewOutput: {
                 type,
                 value: 'mockvalue',
@@ -369,8 +369,8 @@ describe('ReviewOutputItem', () => {
     });
 
     describe('exchange approval flow', () => {
-        it('should render Token approval for type "address"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render Token approval for type "address"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     type: 'address',
                     value: '0x1234567890abcdef1234567890abcdef12345678',
@@ -387,8 +387,8 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('should render "Approve to" for type "contract"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render "Approve to" for type "contract"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     type: 'contract',
@@ -405,8 +405,8 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('should render Approve info for type "approve_data"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render Approve info for type "approve_data"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     token: {
@@ -443,9 +443,9 @@ describe('ReviewOutputItem', () => {
             expect(within(content).getByText('Ethereum')).toBeTruthy();
         });
 
-        it('should render unlimited allowance for max uint256 approve_data', () => {
+        it('should render unlimited allowance for max uint256 approve_data', async () => {
             const maxUint256 = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
-            const { getByTestId } = renderReviewOutputItem({
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     token: {
@@ -472,8 +472,8 @@ describe('ReviewOutputItem', () => {
             ).toBeOnTheScreen();
         });
 
-        it('should not render Chain row for type "approve_data" when value2 is absent', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should not render Chain row for type "approve_data" when value2 is absent', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     token: {
@@ -506,8 +506,8 @@ describe('ReviewOutputItem', () => {
     });
 
     describe('exchange swap flow', () => {
-        it('should render "Recipient address" for type "address"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render "Recipient address" for type "address"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     type: 'address',
                     value: '0x1234567890abcdef1234567890abcdef12345678',
@@ -524,8 +524,8 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('should render swap contract label and formatted contract address for type "contract"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render swap contract label and formatted contract address for type "contract"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     type: 'contract',
@@ -544,8 +544,8 @@ describe('ReviewOutputItem', () => {
     });
 
     describe('exchange revoke-and-approve flow', () => {
-        it('should render Token revoke for type "address"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render Token revoke for type "address"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     type: 'address',
                     value: '0x1234567890abcdef1234567890abcdef12345678',
@@ -562,8 +562,8 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('should render "Revoke approval from" for type "contract"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render "Revoke approval from" for type "contract"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     type: 'contract',
@@ -580,8 +580,8 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('should render Revoke info for type "approve_data"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render Revoke info for type "approve_data"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     token: {
@@ -620,8 +620,8 @@ describe('ReviewOutputItem', () => {
     });
 
     describe('exchange revoke flow', () => {
-        it('should render Token revoke for type "address"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render Token revoke for type "address"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     type: 'address',
                     value: '0x1234567890abcdef1234567890abcdef12345678',
@@ -638,8 +638,8 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('should render "Approve to" for type "contract"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render "Approve to" for type "contract"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     type: 'contract',
@@ -656,8 +656,8 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('should render Revoke info for type "approve_data"', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render Revoke info for type "approve_data"', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     token: {
@@ -694,8 +694,8 @@ describe('ReviewOutputItem', () => {
             expect(within(content).getByText('Ethereum')).toBeTruthy();
         });
 
-        it('should not render Chain row for type "approve_data" when value2 is absent', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should not render Chain row for type "approve_data" when value2 is absent', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     token: {
@@ -728,19 +728,19 @@ describe('ReviewOutputItem', () => {
     });
 
     describe('contentBuilder prop', () => {
-        it('renders content returned by contentBuilder instead of default', () => {
+        it('renders content returned by contentBuilder instead of default', async () => {
             const contentBuilder = jest.fn().mockReturnValue(<Text>Custom Content</Text>);
 
-            const { getByText } = renderReviewOutputItem({ contentBuilder });
+            const { getByText } = await renderReviewOutputItem({ contentBuilder });
 
             expect(getByText('Custom Content')).toBeOnTheScreen();
             expect(() => getByText('mockvalue')).toThrow();
         });
 
-        it('passes all data props to contentBuilder', () => {
+        it('passes all data props to contentBuilder', async () => {
             const contentBuilder = jest.fn().mockReturnValue(undefined);
 
-            renderReviewOutputItem({
+            await renderReviewOutputItem({
                 contentBuilder,
                 reviewOutput: { type: 'note', value: 'some value', state: 'active' },
             });
@@ -753,10 +753,10 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('falls back to default rendering when contentBuilder returns undefined', () => {
+        it('falls back to default rendering when contentBuilder returns undefined', async () => {
             const contentBuilder = jest.fn().mockReturnValue(undefined);
 
-            const { getByTestId } = renderReviewOutputItem({
+            const { getByTestId } = await renderReviewOutputItem({
                 contentBuilder,
                 reviewOutput: { type: 'note', value: 'fallback note text', state: 'active' },
             });
@@ -768,9 +768,9 @@ describe('ReviewOutputItem', () => {
     });
 
     describe('ReviewOutputItemContent approve_data edge cases', () => {
-        it('should warn and render no content for approve_data when exchange flow is swap', () => {
+        it('should warn and render no content for approve_data when exchange flow is swap', async () => {
             const warningSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-            const { getByTestId } = renderReviewOutputItem({
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     type: 'approve_data',
@@ -785,8 +785,8 @@ describe('ReviewOutputItem', () => {
             );
         });
 
-        it('should render raw allowance value for approve_data on approve flow without token', () => {
-            const { getByTestId } = renderReviewOutputItem({
+        it('should render raw allowance value for approve_data on approve flow without token', async () => {
+            const { getByTestId } = await renderReviewOutputItem({
                 reviewOutput: {
                     state: undefined,
                     type: 'approve_data',

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.test.tsx
@@ -30,8 +30,8 @@ jest.mock('../../selectors', () => {
 });
 
 describe('ReviewOutputItemList', () => {
-    const renderReviewOutputItemList = (props: Partial<ReviewOutputItemListProps> = {}) =>
-        renderWithStoreProvider(
+    const renderReviewOutputItemList = async (props: Partial<ReviewOutputItemListProps> = {}) =>
+        await renderWithStoreProvider(
             <ReviewOutputItemList prefix="send" accountKey={ETH_ACCOUNT_KEY} {...props} />,
             { preloadedState: { wallet: getWalletState() } },
         );
@@ -53,8 +53,8 @@ describe('ReviewOutputItemList', () => {
         mockSelectIsTransactionAlreadySignedValue = false;
     });
 
-    it('should render Error when account is not found', () => {
-        const { getByText } = renderReviewOutputItemList({
+    it('should render Error when account is not found', async () => {
+        const { getByText } = await renderReviewOutputItemList({
             accountKey: mockAccountKey({ symbol: btcSymbol, descriptor: 'btcAccount3' }),
         });
 
@@ -63,8 +63,8 @@ describe('ReviewOutputItemList', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render outputs list', () => {
-        const { getByText } = renderReviewOutputItemList({});
+    it('should render outputs list', async () => {
+        const { getByText } = await renderReviewOutputItemList({});
 
         expect(
             getByText(getTranslation('transactionManagement.review.outputs.addressLabel')),
@@ -84,9 +84,9 @@ describe('ReviewOutputItemList', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render empty list when reviewOutputs are undefined', () => {
+    it('should render empty list when reviewOutputs are undefined', async () => {
         mockSelectTransactionReviewOutputsFromDraftReturnValue = null;
-        const { queryByText } = renderReviewOutputItemList({});
+        const { queryByText } = await renderReviewOutputItemList({});
 
         expect(
             queryByText(getTranslation('transactionManagement.review.outputs.addressLabel')),
@@ -103,21 +103,21 @@ describe('ReviewOutputItemList', () => {
     });
 
     describe('SlidingFooterOverlay', () => {
-        it('should render when transaction is not signed', () => {
-            const { getByTestId } = renderReviewOutputItemList({});
+        it('should render when transaction is not signed', async () => {
+            const { getByTestId } = await renderReviewOutputItemList({});
 
             expect(getByTestId('sliding-footer-overlay')).toBeOnTheScreen();
         });
 
-        it('should render when transaction is already signed', () => {
+        it('should render when transaction is already signed', async () => {
             mockSelectIsTransactionAlreadySignedValue = true;
-            const { queryByTestId } = renderReviewOutputItemList({});
+            const { queryByTestId } = await renderReviewOutputItemList({});
 
             expect(queryByTestId('sliding-footer-overlay')).toBeNull();
         });
 
-        it('should not render for Solana accounts', () => {
-            const { queryByTestId } = renderReviewOutputItemList({
+        it('should not render for Solana accounts', async () => {
+            const { queryByTestId } = await renderReviewOutputItemList({
                 accountKey: SOL_ACCOUNT_KEY,
             });
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.test.tsx
@@ -8,11 +8,11 @@ import { ETH_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState'
 const oneUsdc = '1000000'; // 1 USDC in smallest unit
 
 describe('ReviewOutputItemValues', () => {
-    const renderReviewOutputItemValues = (
+    const renderReviewOutputItemValues = async (
         props: Partial<ReviewOutputItemValuesProps> = {},
         preloadedState = {},
     ) =>
-        renderWithStoreProvider(
+        await renderWithStoreProvider(
             <ReviewOutputItemValues
                 accountKey={ETH_ACCOUNT_KEY}
                 value={oneUsdc}
@@ -24,16 +24,16 @@ describe('ReviewOutputItemValues', () => {
             },
         );
 
-    it('should render translated title', () => {
-        const { getByText } = renderReviewOutputItemValues({}, { wallet: getWalletState() });
+    it('should render translated title', async () => {
+        const { getByText } = await renderReviewOutputItemValues({}, { wallet: getWalletState() });
 
         expect(
             getByText(getTranslation('transactionManagement.review.outputs.summary.totalAmount')),
         ).toBeOnTheScreen();
     });
 
-    it('should render token balance', () => {
-        const { getByText } = renderReviewOutputItemValues(
+    it('should render token balance', async () => {
+        const { getByText } = await renderReviewOutputItemValues(
             {
                 tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
             },

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.test.tsx
@@ -35,8 +35,8 @@ jest.mock('./ReviewOutputItemValues', () => ({
 }));
 
 describe('ReviewOutputSummaryItem', () => {
-    const renderReviewOutputSummaryItem = (props: Partial<ReviewOutputSummaryItemProps>) =>
-        renderWithStoreProvider(
+    const renderReviewOutputSummaryItem = async (props: Partial<ReviewOutputSummaryItemProps>) =>
+        await renderWithStoreProvider(
             <ReviewOutputSummaryItem
                 accountKey={ETH_ACCOUNT_KEY}
                 symbol={btcSymbol}
@@ -51,14 +51,14 @@ describe('ReviewOutputSummaryItem', () => {
         mockSelectIsClearSignedTradingSwap.mockReturnValue(false);
     });
 
-    it('should render nothing when summaryOutput is not specified', () => {
-        const { toJSON } = renderReviewOutputSummaryItem({});
+    it('should render nothing when summaryOutput is not specified', async () => {
+        const { toJSON } = await renderReviewOutputSummaryItem({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render "total amount" and "fee" for BTC', () => {
-        const { getByText } = renderReviewOutputSummaryItem({
+    it('should render "total amount" and "fee" for BTC', async () => {
+        const { getByText } = await renderReviewOutputSummaryItem({
             summaryOutput: {
                 totalSpent: '1000',
                 fee: '10',
@@ -83,8 +83,8 @@ describe('ReviewOutputSummaryItem', () => {
         ).toBeTruthy();
     });
 
-    it('should render "amount" and "max fee" for ETH', () => {
-        const { getByText } = renderReviewOutputSummaryItem({
+    it('should render "amount" and "max fee" for ETH', async () => {
+        const { getByText } = await renderReviewOutputSummaryItem({
             summaryOutput: {
                 totalSpent: '1000',
                 fee: '10',
@@ -114,8 +114,8 @@ describe('ReviewOutputSummaryItem', () => {
         'approve',
         'revoke',
         'revoke-and-approve',
-    ])('should not render "amount" for flowType "%s"', flowType => {
-        const { getByText, queryByText } = renderReviewOutputSummaryItem({
+    ])('should not render "amount" for flowType "%s"', async flowType => {
+        const { getByText, queryByText } = await renderReviewOutputSummaryItem({
             summaryOutput: {
                 totalSpent: '1000',
                 fee: '10',
@@ -137,8 +137,8 @@ describe('ReviewOutputSummaryItem', () => {
         ).toBeTruthy();
     });
 
-    it('should render "amount" and "max fee" for USDC', () => {
-        const { getByText } = renderReviewOutputSummaryItem({
+    it('should render "amount" and "max fee" for USDC', async () => {
+        const { getByText } = await renderReviewOutputSummaryItem({
             summaryOutput: {
                 totalSpent: '1000',
                 fee: '10',
@@ -165,10 +165,10 @@ describe('ReviewOutputSummaryItem', () => {
         ).toBeTruthy();
     });
 
-    it('should not render "amount" if transaction is clear-signed', () => {
+    it('should not render "amount" if transaction is clear-signed', async () => {
         mockSelectIsClearSignedTradingSwap.mockReturnValue(true);
 
-        const { queryByText, getByText } = renderReviewOutputSummaryItem({
+        const { queryByText, getByText } = await renderReviewOutputSummaryItem({
             summaryOutput: {
                 totalSpent: '1000',
                 fee: '10',

--- a/suite-native/transaction-management/src/components/SlidingFooterOverlay.test.tsx
+++ b/suite-native/transaction-management/src/components/SlidingFooterOverlay.test.tsx
@@ -4,8 +4,8 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { SlidingFooterOverlay } from './SlidingFooterOverlay';
 
 describe('SlidingFooterOverlay', () => {
-    it('should render children', () => {
-        const { getByText, getByTestId } = renderWithBasicProvider(
+    it('should render children', async () => {
+        const { getByText, getByTestId } = await renderWithBasicProvider(
             <SlidingFooterOverlay activeStepOffset={123}>
                 <Text>CHILDREN</Text>
             </SlidingFooterOverlay>,
@@ -17,8 +17,8 @@ describe('SlidingFooterOverlay', () => {
         });
     });
 
-    it('should render without children', () => {
-        const { getByTestId } = renderWithBasicProvider(
+    it('should render without children', async () => {
+        const { getByTestId } = await renderWithBasicProvider(
             <SlidingFooterOverlay activeStepOffset={321} />,
         );
 

--- a/suite-native/transaction-management/src/components/TxValidityTimer.test.tsx
+++ b/suite-native/transaction-management/src/components/TxValidityTimer.test.tsx
@@ -16,34 +16,34 @@ describe('TxValidityTimer', () => {
         onRetry: jest.fn(),
     };
 
-    const renderTimer = (props: Partial<React.ComponentProps<typeof TxValidityTimer>> = {}) =>
-        renderWithBasicProvider(<TxValidityTimer {...defaultProps} {...props} />);
+    const renderTimer = async (props: Partial<React.ComponentProps<typeof TxValidityTimer>> = {}) =>
+        await renderWithBasicProvider(<TxValidityTimer {...defaultProps} {...props} />);
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     describe('label', () => {
-        it('should show the remaining seconds countdown by default', () => {
-            const { getByText } = renderTimer({ secondsLeft: 42 });
+        it('should show the remaining seconds countdown by default', async () => {
+            const { getByText } = await renderTimer({ secondsLeft: 42 });
 
             expect(getByText(getCountdownLabel(42))).toBeOnTheScreen();
         });
 
-        it('should show the expired label when past the deadline', () => {
-            const { getByText } = renderTimer({ isPastDeadline: true });
+        it('should show the expired label when past the deadline', async () => {
+            const { getByText } = await renderTimer({ isPastDeadline: true });
 
             expect(getByText(expiredLabel)).toBeOnTheScreen();
         });
 
-        it('should show the confirming label while broadcasting', () => {
-            const { getByText } = renderTimer({ isBroadcasting: true });
+        it('should show the confirming label while broadcasting', async () => {
+            const { getByText } = await renderTimer({ isBroadcasting: true });
 
             expect(getByText(confirmingLabel)).toBeOnTheScreen();
         });
 
-        it('should prioritize the confirming label over the expired label while broadcasting', () => {
-            const { getByText, queryByText } = renderTimer({
+        it('should prioritize the confirming label over the expired label while broadcasting', async () => {
+            const { getByText, queryByText } = await renderTimer({
                 isBroadcasting: true,
                 isPastDeadline: true,
             });
@@ -54,35 +54,35 @@ describe('TxValidityTimer', () => {
     });
 
     describe('retry button', () => {
-        it('should call onRetry when the retry button is pressed', () => {
+        it('should call onRetry when the retry button is pressed', async () => {
             const onRetry = jest.fn();
-            const { getByText } = renderTimer({ onRetry });
+            const { getByText } = await renderTimer({ onRetry });
 
-            fireEvent.press(getByText(tryAgainLabel));
+            await fireEvent.press(getByText(tryAgainLabel));
 
             expect(onRetry).toHaveBeenCalledTimes(1);
         });
 
-        it('should keep the retry button enabled by default', () => {
-            const { getByText } = renderTimer();
+        it('should keep the retry button enabled by default', async () => {
+            const { getByText } = await renderTimer();
 
             expect(getByText(tryAgainLabel)).toBeEnabled();
         });
 
-        it('should disable the retry button when retry is on cooldown', () => {
-            const { getByText } = renderTimer({ isRetryDisabled: true });
+        it('should disable the retry button when retry is on cooldown', async () => {
+            const { getByText } = await renderTimer({ isRetryDisabled: true });
 
             expect(getByText(tryAgainLabel)).toBeDisabled();
         });
 
-        it('should disable the retry button and not call onRetry while broadcasting', () => {
+        it('should disable the retry button and not call onRetry while broadcasting', async () => {
             const onRetry = jest.fn();
-            const { getByText } = renderTimer({ isBroadcasting: true, onRetry });
+            const { getByText } = await renderTimer({ isBroadcasting: true, onRetry });
 
             const retryButton = getByText(tryAgainLabel);
             expect(retryButton).toBeDisabled();
 
-            fireEvent.press(retryButton);
+            await fireEvent.press(retryButton);
             expect(onRetry).not.toHaveBeenCalled();
         });
     });

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.test.tsx
@@ -45,8 +45,8 @@ describe('CustomFee', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = (accountKey: AccountKey = ETH_ACCOUNT_KEY) => {
-        const { result } = renderHookWithStoreProvider(
+    const renderUseFeesForm = async (accountKey: AccountKey = ETH_ACCOUNT_KEY) => {
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -60,7 +60,7 @@ describe('CustomFee', () => {
         return result.current;
     };
 
-    const renderCustomFee = ({
+    const renderCustomFee = async ({
         form,
         props,
     }: {
@@ -85,7 +85,7 @@ describe('CustomFee', () => {
             formDraft: mockFormDraft,
         };
 
-        return renderWithStoreProvider(<CustomFee {...finalProps} />, {
+        return await renderWithStoreProvider(<CustomFee {...finalProps} />, {
             preloadedState: defaultState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
@@ -105,9 +105,9 @@ describe('CustomFee', () => {
         jest.clearAllMocks();
     });
 
-    it('should render custom fee button when custom fee is not selected', () => {
-        const form = renderUseFeesForm();
-        const { getByTestId, getByText } = renderCustomFee({
+    it('should render custom fee button when custom fee is not selected', async () => {
+        const form = await renderUseFeesForm();
+        const { getByTestId, getByText } = await renderCustomFee({
             form,
         });
 
@@ -117,15 +117,15 @@ describe('CustomFee', () => {
         ).toBeTruthy();
     });
 
-    it('should render custom fee card when custom fee is selected', () => {
-        const form = renderUseFeesForm();
+    it('should render custom fee card when custom fee is selected', async () => {
+        const form = await renderUseFeesForm();
 
         // Set fee level to custom
-        act(() => {
+        await act(() => {
             form.setValue('feeLevel', 'custom');
         });
 
-        const { getByText } = renderCustomFee({
+        const { getByText } = await renderCustomFee({
             form,
         });
 
@@ -134,9 +134,9 @@ describe('CustomFee', () => {
         expect(getByText(getTranslation('generic.buttons.edit'))).toBeTruthy();
     });
 
-    it('should not render for solana network', () => {
-        const form = renderUseFeesForm();
-        const { toJSON } = renderCustomFee({
+    it('should not render for solana network', async () => {
+        const form = await renderUseFeesForm();
+        const { toJSON } = await renderCustomFee({
             form,
             props: {
                 symbol: 'sol' as NetworkSymbol,
@@ -146,13 +146,13 @@ describe('CustomFee', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should not call useCustomFee hook for solana network', () => {
-        const form = renderUseFeesForm();
+    it('should not call useCustomFee hook for solana network', async () => {
+        const form = await renderUseFeesForm();
 
         // Clear any previous calls
         mockUseCustomFee.mockClear();
 
-        renderCustomFee({
+        await renderCustomFee({
             form,
             props: {
                 symbol: 'sol' as NetworkSymbol,
@@ -163,13 +163,13 @@ describe('CustomFee', () => {
         expect(mockUseCustomFee).not.toHaveBeenCalled();
     });
 
-    it('should call useCustomFee hook for ethereum network', () => {
-        const form = renderUseFeesForm();
+    it('should call useCustomFee hook for ethereum network', async () => {
+        const form = await renderUseFeesForm();
 
         // Clear any previous calls
         mockUseCustomFee.mockClear();
 
-        renderCustomFee({
+        await renderCustomFee({
             form,
             props: {
                 symbol: 'eth' as NetworkSymbol,
@@ -183,9 +183,9 @@ describe('CustomFee', () => {
         });
     });
 
-    it('should render for bitcoin network', () => {
-        const form = renderUseFeesForm();
-        const { getByTestId } = renderCustomFee({
+    it('should render for bitcoin network', async () => {
+        const form = await renderUseFeesForm();
+        const { getByTestId } = await renderCustomFee({
             form,
             props: {
                 symbol: 'btc' as NetworkSymbol,
@@ -195,9 +195,9 @@ describe('CustomFee', () => {
         expect(getByTestId('@transactionManagement/fees-level-custom')).toBeTruthy();
     });
 
-    it('should render for ethereum network', () => {
-        const form = renderUseFeesForm();
-        const { getByTestId } = renderCustomFee({
+    it('should render for ethereum network', async () => {
+        const form = await renderUseFeesForm();
+        const { getByTestId } = await renderCustomFee({
             form,
             props: {
                 symbol: 'eth' as NetworkSymbol,
@@ -208,14 +208,14 @@ describe('CustomFee', () => {
     });
 
     it('should open bottom sheet when edit button is pressed', async () => {
-        const form = renderUseFeesForm();
+        const form = await renderUseFeesForm();
 
         // Set fee level to custom to show the card
-        act(() => {
+        await act(() => {
             form.setValue('feeLevel', 'custom');
         });
 
-        const { getByText } = renderCustomFee({
+        const { getByText } = await renderCustomFee({
             form,
         });
 
@@ -228,9 +228,9 @@ describe('CustomFee', () => {
         ).toBeTruthy();
     });
 
-    it('should handle different account keys', () => {
-        const form = renderUseFeesForm(BTC_ACCOUNT_KEY);
-        const { getByTestId } = renderCustomFee({
+    it('should handle different account keys', async () => {
+        const form = await renderUseFeesForm(BTC_ACCOUNT_KEY);
+        const { getByTestId } = await renderCustomFee({
             form,
             props: {
                 accountKey: BTC_ACCOUNT_KEY,

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeCard.test.tsx
@@ -28,8 +28,8 @@ describe('CustomFeeCard', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = (accountKey: AccountKey = ETH_ACCOUNT_KEY) => {
-        const { result } = renderHookWithStoreProvider(
+    const renderUseFeesForm = async (accountKey: AccountKey = ETH_ACCOUNT_KEY) => {
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -43,7 +43,7 @@ describe('CustomFeeCard', () => {
         return result.current;
     };
 
-    const renderCustomFeeCard = ({
+    const renderCustomFeeCard = async ({
         form,
         props,
     }: {
@@ -52,7 +52,7 @@ describe('CustomFeeCard', () => {
     }) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return renderWithStoreProvider(<CustomFeeCard {...finalProps} />, {
+        return await renderWithStoreProvider(<CustomFeeCard {...finalProps} />, {
             preloadedState: defaultState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
@@ -63,9 +63,9 @@ describe('CustomFeeCard', () => {
     });
 
     describe('Rendering', () => {
-        it('should render custom fee card when custom fee transaction is available', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeCard({
+        it('should render custom fee card when custom fee transaction is available', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeCard({
                 form,
             });
 
@@ -74,28 +74,28 @@ describe('CustomFeeCard', () => {
             expect(getByText(getTranslation('generic.buttons.edit'))).toBeTruthy();
         });
 
-        it('should display fee amount correctly', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeCard({
+        it('should display fee amount correctly', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeCard({
                 form,
             });
 
             expect(getByText('0.000000426691398 ETH')).toBeTruthy();
         });
 
-        it('should display price and limit correctly', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeCard({
+        it('should display price and limit correctly', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeCard({
                 form,
             });
 
             expect(getByText('1.00 Gwei')).toBeTruthy();
         });
 
-        it('should not render if using wrong accountKey', () => {
+        it('should not render if using wrong accountKey', async () => {
             const accountKey = mockAccountKey({ descriptor: 'wrongKey' });
-            const form = renderUseFeesForm(accountKey);
-            const { toJSON } = renderCustomFeeCard({
+            const form = await renderUseFeesForm(accountKey);
+            const { toJSON } = await renderCustomFeeCard({
                 form,
                 props: {
                     accountKey,
@@ -108,8 +108,8 @@ describe('CustomFeeCard', () => {
 
     describe('Interaction', () => {
         it('should call onEdit when edit button is pressed', async () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeCard({
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeCard({
                 form,
             });
 
@@ -119,8 +119,8 @@ describe('CustomFeeCard', () => {
         });
 
         it('should call onCancel when cancel button is pressed', async () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeCard({
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeCard({
                 form,
             });
 
@@ -130,10 +130,10 @@ describe('CustomFeeCard', () => {
         });
     });
 
-    it('should render for bitcoin network', () => {
+    it('should render for bitcoin network', async () => {
         const accountKey = BTC_ACCOUNT_KEY;
-        const form = renderUseFeesForm(accountKey);
-        const { getByText } = renderCustomFeeCard({
+        const form = await renderUseFeesForm(accountKey);
+        const { getByText } = await renderCustomFeeCard({
             form,
             props: {
                 accountKey,

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.test.tsx
@@ -37,8 +37,8 @@ describe('CustomFeeInputs', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = (accountKey: AccountKey = ETH_ACCOUNT_KEY) => {
-        const { result } = renderHookWithStoreProvider(
+    const renderUseFeesForm = async (accountKey: AccountKey = ETH_ACCOUNT_KEY) => {
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -53,7 +53,7 @@ describe('CustomFeeInputs', () => {
         return result.current;
     };
 
-    const renderCustomFeeInputs = ({
+    const renderCustomFeeInputs = async ({
         form,
         props,
     }: {
@@ -62,7 +62,7 @@ describe('CustomFeeInputs', () => {
     }) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return renderWithStoreProvider(<CustomFeeInputs {...finalProps} />, {
+        return await renderWithStoreProvider(<CustomFeeInputs {...finalProps} />, {
             preloadedState: defaultState,
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
@@ -81,9 +81,9 @@ describe('CustomFeeInputs', () => {
         jest.clearAllMocks();
     });
     describe('Rendering', () => {
-        it('should render fee per unit input for bitcoin', () => {
-            const form = renderUseFeesForm();
-            const { getByText, getByTestId } = renderCustomFeeInputs({
+        it('should render fee per unit input for bitcoin', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText, getByTestId } = await renderCustomFeeInputs({
                 form,
             });
             expect(
@@ -94,9 +94,9 @@ describe('CustomFeeInputs', () => {
             expect(getByTestId('@transactionManagement/customFeePerUnit-input')).toBeTruthy();
         });
 
-        it('should render fee per unit input for ethereum', () => {
-            const form = renderUseFeesForm();
-            const { getByText, getByTestId } = renderCustomFeeInputs({
+        it('should render fee per unit input for ethereum', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText, getByTestId } = await renderCustomFeeInputs({
                 form,
                 props: { symbol: ethSymbol },
             });
@@ -109,9 +109,9 @@ describe('CustomFeeInputs', () => {
             expect(getByTestId('@transactionManagement/customFeePerUnit-input')).toBeTruthy();
         });
 
-        it('should render fee limit input for ethereum', () => {
-            const form = renderUseFeesForm();
-            const { getByText, getByTestId } = renderCustomFeeInputs({
+        it('should render fee limit input for ethereum', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText, getByTestId } = await renderCustomFeeInputs({
                 form,
                 props: { symbol: ethSymbol },
             });
@@ -124,9 +124,9 @@ describe('CustomFeeInputs', () => {
             expect(getByTestId('@transactionManagement/customFeeLimit-input')).toBeTruthy();
         });
 
-        it('should not render fee limit input for bitcoin', () => {
-            const form = renderUseFeesForm();
-            const { queryByText, queryByTestId } = renderCustomFeeInputs({
+        it('should not render fee limit input for bitcoin', async () => {
+            const form = await renderUseFeesForm();
+            const { queryByText, queryByTestId } = await renderCustomFeeInputs({
                 form,
                 props: { symbol: btcSymbol },
             });
@@ -138,24 +138,24 @@ describe('CustomFeeInputs', () => {
             expect(queryByTestId('@transactionManagement/customFeeLimit-input')).toBeNull();
         });
 
-        it('should display correct units for different networks', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeInputs({
+        it('should display correct units for different networks', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeInputs({
                 form,
                 props: { symbol: btcSymbol },
             });
             expect(getByText('sat/vB')).toBeTruthy();
 
-            const { getByText: getByText2 } = renderCustomFeeInputs({
+            const { getByText: getByText2 } = await renderCustomFeeInputs({
                 form,
                 props: { symbol: ethSymbol },
             });
             expect(getByText2('Gwei')).toBeTruthy();
         });
 
-        it('should show minimum fee hint for bitcoin', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeInputs({
+        it('should show minimum fee hint for bitcoin', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeInputs({
                 form,
                 props: { symbol: btcSymbol },
             });
@@ -168,9 +168,9 @@ describe('CustomFeeInputs', () => {
             ).toBeTruthy();
         });
 
-        it('should not show minimum fee hint for ethereum', () => {
-            const form = renderUseFeesForm();
-            const { queryByText } = renderCustomFeeInputs({
+        it('should not show minimum fee hint for ethereum', async () => {
+            const form = await renderUseFeesForm();
+            const { queryByText } = await renderCustomFeeInputs({
                 form,
                 props: { symbol: ethSymbol },
             });

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeLabel.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeLabel.test.tsx
@@ -17,8 +17,8 @@ describe('CustomFeeLabel', () => {
         wallet: getWalletState(),
     };
 
-    const renderUseFeesForm = () => {
-        const { result } = renderHookWithStoreProvider(
+    const renderUseFeesForm = async () => {
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey: mockAccountKey({ descriptor: 'testAccountKey' }),
@@ -32,22 +32,22 @@ describe('CustomFeeLabel', () => {
         return result.current;
     };
 
-    const renderCustomFeeLabel = ({
+    const renderCustomFeeLabel = async ({
         networkType,
         form,
     }: {
         networkType: NetworkTypeConfig;
         form: FeesFormType;
     }) =>
-        renderWithStoreProvider(<CustomFeeLabel networkType={networkType} />, {
+        await renderWithStoreProvider(<CustomFeeLabel networkType={networkType} />, {
             preloadedState: defaultState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
     describe('Bitcoin Network', () => {
-        it('should render custom fee label for bitcoin', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeLabel({
+        it('should render custom fee label for bitcoin', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeLabel({
                 networkType: 'bitcoin',
                 form,
             });
@@ -55,21 +55,21 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Custom/)).toBeTruthy();
         });
 
-        it('should display fee per unit with correct units', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeLabel({ networkType: 'bitcoin', form });
+        it('should display fee per unit with correct units', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeLabel({ networkType: 'bitcoin', form });
 
             expect(getByText(/sat\/vB/)).toBeTruthy();
         });
 
-        it('should handle different fee per unit values', () => {
-            const form = renderUseFeesForm();
+        it('should handle different fee per unit values', async () => {
+            const form = await renderUseFeesForm();
 
-            act(() => {
+            await act(() => {
                 form.setValue('customFeePerUnit', '50');
             });
 
-            const { getByText } = renderCustomFeeLabel({
+            const { getByText } = await renderCustomFeeLabel({
                 networkType: 'bitcoin',
                 form,
             });
@@ -79,9 +79,9 @@ describe('CustomFeeLabel', () => {
     });
 
     describe('Ethereum Network', () => {
-        it('should render custom fee label for ethereum', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeLabel({
+        it('should render custom fee label for ethereum', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeLabel({
                 networkType: 'ethereum',
                 form,
             });
@@ -89,9 +89,9 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Custom/)).toBeTruthy();
         });
 
-        it('should display gas price and gas limit for ethereum', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeLabel({
+        it('should display gas price and gas limit for ethereum', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeLabel({
                 networkType: 'ethereum',
                 form,
             });
@@ -99,9 +99,9 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Gwei/)).toBeTruthy();
         });
 
-        it('should display fee per unit with Gwei units for ethereum', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeLabel({
+        it('should display fee per unit with Gwei units for ethereum', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeLabel({
                 networkType: 'ethereum',
                 form,
             });
@@ -109,15 +109,15 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Gwei/)).toBeTruthy();
         });
 
-        it('should handle different gas price and gas limit values', () => {
-            const form = renderUseFeesForm();
+        it('should handle different gas price and gas limit values', async () => {
+            const form = await renderUseFeesForm();
 
-            act(() => {
+            await act(() => {
                 form.setValue('customFeePerUnit', '25');
                 form.setValue('customFeeLimit', '50000');
             });
 
-            const { getByText } = renderCustomFeeLabel({
+            const { getByText } = await renderCustomFeeLabel({
                 networkType: 'ethereum',
                 form,
             });
@@ -127,9 +127,9 @@ describe('CustomFeeLabel', () => {
     });
 
     describe('Other Networks', () => {
-        it('should render custom fee label for other networks', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeLabel({
+        it('should render custom fee label for other networks', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeLabel({
                 networkType: 'ripple',
                 form,
             });
@@ -137,9 +137,9 @@ describe('CustomFeeLabel', () => {
             expect(getByText(/Custom/)).toBeTruthy();
         });
 
-        it('should display fee per unit with appropriate units for other networks', () => {
-            const form = renderUseFeesForm();
-            const { getByText } = renderCustomFeeLabel({
+        it('should display fee per unit with appropriate units for other networks', async () => {
+            const form = await renderUseFeesForm();
+            const { getByText } = await renderCustomFeeLabel({
                 networkType: 'ripple',
                 form,
             });

--- a/suite-native/transaction-management/src/components/fees/FeeLabelTranslation.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeLabelTranslation.test.tsx
@@ -6,15 +6,15 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { FeeLabelTranslation } from './FeeLabelTranslation';
 
 describe('FeeLabelTranslation', () => {
-    const renderFeeLabelTranslation = (networkType: NetworkType) =>
-        renderWithBasicProvider(
+    const renderFeeLabelTranslation = async (networkType: NetworkType) =>
+        await renderWithBasicProvider(
             <Text>
                 <FeeLabelTranslation networkType={networkType} />
             </Text>,
         );
 
-    it('should render "Maximum fee" for [ethereum]', () => {
-        const { getByText } = renderFeeLabelTranslation('ethereum');
+    it('should render "Maximum fee" for [ethereum]', async () => {
+        const { getByText } = await renderFeeLabelTranslation('ethereum');
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.ethereum')),
@@ -23,8 +23,8 @@ describe('FeeLabelTranslation', () => {
 
     it.each<NetworkType>(['bitcoin', 'cardano', 'solana'])(
         'should render "Transaction fee" for [%s]',
-        networkType => {
-            const { getByText } = renderFeeLabelTranslation(networkType);
+        async networkType => {
+            const { getByText } = await renderFeeLabelTranslation(networkType);
 
             expect(
                 getByText(getTranslation('transactionManagement.fees.description.title.general')),

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.test.tsx
@@ -71,11 +71,11 @@ describe('FeeOption', () => {
         wallet: getWalletState(),
     });
 
-    const renderFeeOption = (props = {}) => {
+    const renderFeeOption = async (props = {}) => {
         const finalProps = { ...defaultProps, ...props };
         mockOnSelectedFeeLevel = finalProps.onSelectedFeeLevel;
 
-        return renderWithStoreProvider(
+        return await renderWithStoreProvider(
             <TestFormWrapper>
                 <FeeOption {...finalProps} />
             </TestFormWrapper>,
@@ -103,35 +103,35 @@ describe('FeeOption', () => {
             ['normal', /Normal/],
             ['economy', /Low/],
             ['high', /High/],
-        ])('should render %s fee level with correct label', (feeKey, expectedLabel) => {
-            const { getByText } = renderFeeOption({ feeKey });
+        ])('should render %s fee level with correct label', async (feeKey, expectedLabel) => {
+            const { getByText } = await renderFeeOption({ feeKey });
 
             expect(getByText(expectedLabel)).toBeTruthy();
         });
 
-        it('should display fee information correctly', () => {
-            const { getByText } = renderFeeOption();
+        it('should display fee information correctly', async () => {
+            const { getByText } = await renderFeeOption();
 
             expect(getByText('4 sat/vB')).toBeTruthy();
             expect(getByText('~ ~10 minutes')).toBeTruthy();
         });
 
-        it('should show radio button when interactive', () => {
-            const { getByTestId } = renderFeeOption();
+        it('should show radio button when interactive', async () => {
+            const { getByTestId } = await renderFeeOption();
 
             expect(getByTestId('@transactionManagement/fees-level-radio-normal')).toBeTruthy();
         });
 
-        it('should not show radio button when not interactive', () => {
-            const { queryByTestId } = renderFeeOption({
+        it('should not show radio button when not interactive', async () => {
+            const { queryByTestId } = await renderFeeOption({
                 isInteractive: false,
             });
 
             expect(queryByTestId('@transactionManagement/fees-level-radio-normal')).toBeNull();
         });
 
-        it('should show loading skeleton when isLoading is true', () => {
-            const { queryAllByTestId } = renderFeeOption({
+        it('should show loading skeleton when isLoading is true', async () => {
+            const { queryAllByTestId } = await renderFeeOption({
                 isLoading: true,
             });
 
@@ -141,7 +141,7 @@ describe('FeeOption', () => {
 
     describe('Interaction', () => {
         it('should call onSelectedFeeLevel when pressed', async () => {
-            const { getByTestId } = renderFeeOption({
+            const { getByTestId } = await renderFeeOption({
                 feeKey: 'high',
             });
 
@@ -151,7 +151,7 @@ describe('FeeOption', () => {
         });
 
         it('should not call onSelectedFeeLevel when not interactive', async () => {
-            const { getByTestId } = renderFeeOption({
+            const { getByTestId } = await renderFeeOption({
                 isInteractive: false,
             });
 
@@ -163,7 +163,7 @@ describe('FeeOption', () => {
         });
 
         it('should handle different fee levels correctly', async () => {
-            const { getByTestId } = renderFeeOption({
+            const { getByTestId } = await renderFeeOption({
                 feeKey: 'economy',
             });
 
@@ -174,8 +174,8 @@ describe('FeeOption', () => {
     });
 
     describe('Fee calculation', () => {
-        it('should calculate fee per unit correctly for bitcoin', () => {
-            const { getByText } = renderFeeOption({
+        it('should calculate fee per unit correctly for bitcoin', async () => {
+            const { getByText } = await renderFeeOption({
                 symbol: 'btc',
                 feeLevel: defaultProps.feeLevel,
                 transactionBytes: 250,
@@ -185,8 +185,8 @@ describe('FeeOption', () => {
             expect(getByText('4 sat/vB')).toBeTruthy();
         });
 
-        it('should use feePerByte for non-bitcoin networks', () => {
-            const { getByText } = renderFeeOption({
+        it('should use feePerByte for non-bitcoin networks', async () => {
+            const { getByText } = await renderFeeOption({
                 symbol: 'eth',
                 feeLevel: defaultProps.feeLevel,
                 transactionBytes: 250,

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionErrorMessage.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionErrorMessage.test.tsx
@@ -4,18 +4,18 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { FeeOptionErrorMessage } from './FeeOptionErrorMessage';
 
 describe('FeeOptionErrorMessage', () => {
-    const renderFeeOptionErrorMessage = (isVisible: boolean) =>
-        renderWithBasicProvider(<FeeOptionErrorMessage isVisible={isVisible} />);
+    const renderFeeOptionErrorMessage = async (isVisible: boolean) =>
+        await renderWithBasicProvider(<FeeOptionErrorMessage isVisible={isVisible} />);
 
-    it('should render error message when visible', () => {
-        const { getByText, queryByTestId } = renderFeeOptionErrorMessage(true);
+    it('should render error message when visible', async () => {
+        const { getByText, queryByTestId } = await renderFeeOptionErrorMessage(true);
 
         expect(getByText(getTranslation('transactionManagement.fees.error'))).toBeOnTheScreen();
         expect(queryByTestId('@transactionManagement/fee-option-error-message')).toBeOnTheScreen();
     });
 
-    it('should have height 0 when not visible', () => {
-        const { queryByTestId } = renderFeeOptionErrorMessage(false);
+    it('should have height 0 when not visible', async () => {
+        const { queryByTestId } = await renderFeeOptionErrorMessage(false);
 
         expect(queryByTestId('@transactionManagement/fee-option-error-message')).toBeNull();
     });

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.test.tsx
@@ -75,12 +75,12 @@ describe('FeeOptionsList', () => {
             preloadedState,
         });
 
-    const renderUseFeesForm = (
+    const renderUseFeesForm = async (
         store: ReturnType<typeof createFeeOptionsStore>,
         accountKey: AccountKey = ETH_ACCOUNT_KEY,
         defaultFeePerUnit?: string,
     ) => {
-        const { result } = renderHookWithStoreProvider(
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -94,7 +94,7 @@ describe('FeeOptionsList', () => {
         return result.current;
     };
 
-    const renderFeeOptionsList = ({
+    const renderFeeOptionsList = async ({
         preloadedState,
         props,
     }: {
@@ -103,9 +103,9 @@ describe('FeeOptionsList', () => {
     }) => {
         const finalProps = { ...defaultProps, ...props };
         const store = createFeeOptionsStore(preloadedState);
-        const form = renderUseFeesForm(store);
+        const form = await renderUseFeesForm(store);
 
-        const view = renderWithStoreProvider(<FeeOptionsList {...finalProps} />, {
+        const view = await renderWithStoreProvider(<FeeOptionsList {...finalProps} />, {
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
@@ -124,16 +124,16 @@ describe('FeeOptionsList', () => {
     });
 
     describe('Rendering', () => {
-        it('should render all fee options', () => {
-            const { getByText } = renderFeeOptionsList({});
+        it('should render all fee options', async () => {
+            const { getByText } = await renderFeeOptionsList({});
 
             expect(getByText(/Low/)).toBeTruthy();
             expect(getByText(/Normal/)).toBeTruthy();
             expect(getByText(/High/)).toBeTruthy();
         });
 
-        it('should show loading state when isLoading is true', () => {
-            const { queryAllByTestId } = renderFeeOptionsList({
+        it('should show loading state when isLoading is true', async () => {
+            const { queryAllByTestId } = await renderFeeOptionsList({
                 props: { isLoading: true },
             });
 
@@ -141,14 +141,14 @@ describe('FeeOptionsList', () => {
             expect(queryAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);
         });
 
-        it('should filter out custom and low fee levels for btc network', () => {
+        it('should filter out custom and low fee levels for btc network', async () => {
             const feeLevels = {
                 ...createMockFeeLevels(),
                 custom: createFeeLevel(),
                 low: createFeeLevel(),
             };
 
-            const { getByText, queryByText } = renderFeeOptionsList({
+            const { getByText, queryByText } = await renderFeeOptionsList({
                 props: { feeLevels, symbol: btcSymbol },
             });
 
@@ -160,14 +160,14 @@ describe('FeeOptionsList', () => {
             expect(queryByText(/Custom/)).toBeNull();
         });
 
-        it('should work with economy if there is no normal', () => {
+        it('should work with economy if there is no normal', async () => {
             const all = createMockFeeLevels();
             const feeLevels = {
                 economy: all.economy,
                 high: all.high,
             };
 
-            const { getByText, queryByText } = renderFeeOptionsList({
+            const { getByText, queryByText } = await renderFeeOptionsList({
                 props: { feeLevels },
             });
 
@@ -179,7 +179,7 @@ describe('FeeOptionsList', () => {
 
     describe('Interaction', () => {
         it('should call onSelectedFeeLevel when a fee option is selected', async () => {
-            const { getByTestId } = renderFeeOptionsList({});
+            const { getByTestId } = await renderFeeOptionsList({});
 
             await userEvent.press(getByTestId('@transactionManagement/fees-level-radio-normal'));
 
@@ -187,7 +187,7 @@ describe('FeeOptionsList', () => {
         });
 
         it('should handle different fee level selections', async () => {
-            const { getByTestId } = renderFeeOptionsList({});
+            const { getByTestId } = await renderFeeOptionsList({});
 
             await userEvent.press(getByTestId('@transactionManagement/fees-level-radio-economy'));
             expect(defaultProps.onSelectedFeeLevel).toHaveBeenCalledWith('economy');
@@ -197,8 +197,8 @@ describe('FeeOptionsList', () => {
         });
 
         it('should update the visually selected fee option', async () => {
-            const { getByTestId, form } = renderFeeOptionsList({});
-            act(() => form.setValue('feeLevel', 'normal'));
+            const { getByTestId, form } = await renderFeeOptionsList({});
+            await act(() => form.setValue('feeLevel', 'normal'));
 
             expect(getByTestId('@transactionManagement/fees-level-radio-normal')).toHaveProp(
                 'accessibilityState',
@@ -222,8 +222,8 @@ describe('FeeOptionsList', () => {
             );
         });
 
-        it('should make options interactive when multiple options are available', () => {
-            const { getByTestId } = renderFeeOptionsList({});
+        it('should make options interactive when multiple options are available', async () => {
+            const { getByTestId } = await renderFeeOptionsList({});
 
             // Should have radio buttons when multiple options are available
             expect(getByTestId('@transactionManagement/fees-level-radio-normal')).toBeTruthy();
@@ -231,12 +231,12 @@ describe('FeeOptionsList', () => {
             expect(getByTestId('@transactionManagement/fees-level-radio-high')).toBeTruthy();
         });
 
-        it('should make options non-interactive when only one option is available', () => {
+        it('should make options non-interactive when only one option is available', async () => {
             const singleFeeLevel = {
                 normal: createFeeLevel(),
             };
 
-            const { queryByTestId } = renderFeeOptionsList({
+            const { queryByTestId } = await renderFeeOptionsList({
                 props: { feeLevels: singleFeeLevel },
             });
 

--- a/suite-native/transaction-management/src/components/fees/FeeSelectorRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSelectorRow.test.tsx
@@ -14,8 +14,8 @@ describe('FeeSelectorRow', () => {
         wallet: getWalletState(),
     });
 
-    const renderRow = () =>
-        renderWithStoreProvider(
+    const renderRow = async () =>
+        await renderWithStoreProvider(
             <FeeSelectorRow
                 accountKey={BTC_ACCOUNT_KEY}
                 updateThunk={noopThunk}
@@ -25,25 +25,25 @@ describe('FeeSelectorRow', () => {
             { preloadedState: getPreloadedState() },
         );
 
-    it('should render the fee row with its testID for a Bitcoin account', () => {
-        const { getByTestId } = renderRow();
+    it('should render the fee row with its testID for a Bitcoin account', async () => {
+        const { getByTestId } = await renderRow();
 
         expect(getByTestId('@transactionManagement/fee-selector-row')).toBeOnTheScreen();
     });
 
-    it('should render the crypto fee amount formatter', () => {
-        const { getByTestId } = renderRow();
+    it('should render the crypto fee amount formatter', async () => {
+        const { getByTestId } = await renderRow();
 
         expect(getByTestId('@transactionManagement/fee-crypto-amount')).toBeOnTheScreen();
     });
 
-    it('should render nothing when the account is not in the store', () => {
+    it('should render nothing when the account is not in the store', async () => {
         const missingAccountKey = mockAccountKey({
             symbol: btcSymbol,
             descriptor: 'unknownAccount',
         });
 
-        const { toJSON } = renderWithStoreProvider(
+        const { toJSON } = await renderWithStoreProvider(
             <FeeSelectorRow
                 accountKey={missingAccountKey}
                 updateThunk={noopThunk}
@@ -56,7 +56,7 @@ describe('FeeSelectorRow', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render an alert when fees are unavailable and a form draft is set', () => {
+    it('should render an alert when fees are unavailable and a form draft is set', async () => {
         const baseWalletState = getWalletState();
         const preloadedState = {
             wallet: {
@@ -74,7 +74,7 @@ describe('FeeSelectorRow', () => {
             },
         };
 
-        const { queryByTestId, getByText } = renderWithStoreProvider(
+        const { queryByTestId, getByText } = await renderWithStoreProvider(
             <FeeSelectorRow
                 accountKey={BTC_ACCOUNT_KEY}
                 updateThunk={noopThunk}

--- a/suite-native/transaction-management/src/components/fees/FeeSummaryCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSummaryCard.test.tsx
@@ -22,29 +22,29 @@ describe('FeeSummaryCard', () => {
         wallet: getWalletState(),
     });
 
-    const renderCard = (props: Partial<typeof defaultProps> = {}) =>
-        renderWithStoreProvider(<FeeSummaryCard {...defaultProps} {...props} />, {
+    const renderCard = async (props: Partial<typeof defaultProps> = {}) =>
+        await renderWithStoreProvider(<FeeSummaryCard {...defaultProps} {...props} />, {
             preloadedState: getPreloadedState(),
         });
 
-    it('should render fee label for bitcoin', () => {
-        const { getByText } = renderCard();
+    it('should render fee label for bitcoin', async () => {
+        const { getByText } = await renderCard();
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.general')),
         ).toBeTruthy();
     });
 
-    it('should render ethereum-specific label for ethereum network', () => {
-        const { getByText } = renderCard({ networkType: 'ethereum', symbol: ethSymbol });
+    it('should render ethereum-specific label for ethereum network', async () => {
+        const { getByText } = await renderCard({ networkType: 'ethereum', symbol: ethSymbol });
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.ethereum')),
         ).toBeTruthy();
     });
 
-    it('should render pressable card with testID', () => {
-        const { getByTestId } = renderCard();
+    it('should render pressable card with testID', async () => {
+        const { getByTestId } = await renderCard();
 
         expect(getByTestId('@test/fee-summary-card')).toBeTruthy();
     });

--- a/suite-native/transaction-management/src/components/fees/FeeSummaryRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSummaryRow.test.tsx
@@ -20,29 +20,29 @@ describe('FeeSummaryRow', () => {
         wallet: getWalletState(),
     });
 
-    const renderRow = (props: Partial<FeeSummaryRowProps> = {}) =>
-        renderWithStoreProvider(<FeeSummaryRow {...defaultProps} {...props} />, {
+    const renderRow = async (props: Partial<FeeSummaryRowProps> = {}) =>
+        await renderWithStoreProvider(<FeeSummaryRow {...defaultProps} {...props} />, {
             preloadedState: getPreloadedState(),
         });
 
-    it('should render fee label for bitcoin', () => {
-        const { getByText } = renderRow();
+    it('should render fee label for bitcoin', async () => {
+        const { getByText } = await renderRow();
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.general')),
         ).toBeOnTheScreen();
     });
 
-    it('should render ethereum-specific label for ethereum network', () => {
-        const { getByText } = renderRow({ networkType: 'ethereum', symbol: ethSymbol });
+    it('should render ethereum-specific label for ethereum network', async () => {
+        const { getByText } = await renderRow({ networkType: 'ethereum', symbol: ethSymbol });
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.ethereum')),
         ).toBeOnTheScreen();
     });
 
-    it('should render custom label when provided', () => {
-        const { getByText, queryByText } = renderRow({ label: 'Network fee' });
+    it('should render custom label when provided', async () => {
+        const { getByText, queryByText } = await renderRow({ label: 'Network fee' });
 
         expect(getByText('Network fee')).toBeOnTheScreen();
         expect(
@@ -50,8 +50,8 @@ describe('FeeSummaryRow', () => {
         ).toBeNull();
     });
 
-    it('should render fee amount via the crypto amount formatter', () => {
-        const { getByTestId } = renderRow();
+    it('should render fee amount via the crypto amount formatter', async () => {
+        const { getByTestId } = await renderRow();
 
         expect(getByTestId('@transactionManagement/fee-crypto-amount')).toBeOnTheScreen();
     });

--- a/suite-native/transaction-management/src/components/fees/FeesContent.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesContent.test.tsx
@@ -62,10 +62,10 @@ describe('FeesContent', () => {
         wallet: getWalletState(),
     });
 
-    const renderFeesContent = (props: Partial<FeesContentProps> = {}) => {
+    const renderFeesContent = async (props: Partial<FeesContentProps> = {}) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return renderWithStoreProvider(
+        return await renderWithStoreProvider(
             <TestFormWrapper>
                 <FeesContent {...finalProps} />
             </TestFormWrapper>,
@@ -79,8 +79,8 @@ describe('FeesContent', () => {
         jest.clearAllMocks();
     });
 
-    it('should render title and description', () => {
-        const { getByText } = renderFeesContent();
+    it('should render title and description', async () => {
+        const { getByText } = await renderFeesContent();
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.general')),
@@ -90,46 +90,46 @@ describe('FeesContent', () => {
         ).toBeTruthy();
     });
 
-    it('should render fee options list when selected fee level is not custom', () => {
-        const { getByTestId } = renderFeesContent({
+    it('should render fee options list when selected fee level is not custom', async () => {
+        const { getByTestId } = await renderFeesContent({
             selectedFeeLevel: 'normal',
         });
 
         expect(getByTestId('@transactionManagement/fees-level-container-normal')).toBeTruthy();
     });
 
-    it('should not render fee options list when selected fee level is custom', () => {
-        const { queryByTestId } = renderFeesContent({
+    it('should not render fee options list when selected fee level is custom', async () => {
+        const { queryByTestId } = await renderFeesContent({
             selectedFeeLevel: 'custom',
         });
 
         expect(queryByTestId('@transactionManagement/fees-level-container-normal')).toBeNull();
     });
 
-    it('should always render custom fee component', () => {
-        const { getByTestId } = renderFeesContent();
+    it('should always render custom fee component', async () => {
+        const { getByTestId } = await renderFeesContent();
 
         expect(getByTestId('@transactionManagement/fees-level-custom')).toBeTruthy();
     });
 
-    it('should render all three fee level options', () => {
-        const { getByTestId } = renderFeesContent();
+    it('should render all three fee level options', async () => {
+        const { getByTestId } = await renderFeesContent();
 
         expect(getByTestId('@transactionManagement/fees-level-container-economy')).toBeTruthy();
         expect(getByTestId('@transactionManagement/fees-level-container-normal')).toBeTruthy();
         expect(getByTestId('@transactionManagement/fees-level-container-high')).toBeTruthy();
     });
 
-    it('should handle loading state', () => {
-        const { getByTestId } = renderFeesContent({
+    it('should handle loading state', async () => {
+        const { getByTestId } = await renderFeesContent({
             areFeesLoading: true,
         });
 
         expect(getByTestId('@transactionManagement/fees-level-custom')).toBeTruthy();
     });
 
-    it('should work with different network symbols', () => {
-        const { getByText } = renderFeesContent({
+    it('should work with different network symbols', async () => {
+        const { getByText } = await renderFeesContent({
             symbol: ethSymbol,
         });
 
@@ -138,13 +138,13 @@ describe('FeesContent', () => {
         ).toBeTruthy();
     });
 
-    it('should render with form draft data', () => {
+    it('should render with form draft data', async () => {
         const mockFormDraft = {
             selectedFee: 'high',
             feePerUnit: '10',
         } as FormState;
 
-        const { getByTestId } = renderFeesContent({
+        const { getByTestId } = await renderFeesContent({
             selectedFeeLevel: 'high',
             formDraft: mockFormDraft,
         });

--- a/suite-native/transaction-management/src/components/fees/FeesFooter.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesFooter.test.tsx
@@ -72,11 +72,11 @@ describe('FeesFooter', () => {
         wallet: getWalletState(),
     });
 
-    const renderFeesFooter = (props = {}) => {
+    const renderFeesFooter = async (props = {}) => {
         const finalProps = { ...defaultProps, ...props };
         mockOnSubmit = finalProps.onSubmit;
 
-        return renderWithStoreProvider(
+        return await renderWithStoreProvider(
             <TestFormWrapper>
                 {/*
                   FeesFooterProps expects withSubmitButton: true when present.
@@ -105,14 +105,14 @@ describe('FeesFooter', () => {
         jest.clearAllMocks();
     });
 
-    it('should render mainnet summary when no token contract is provided', () => {
-        const { getByText } = renderFeesFooter();
+    it('should render mainnet summary when no token contract is provided', async () => {
+        const { getByText } = await renderFeesFooter();
 
         expect(getByText(getTranslation('transactionManagement.fees.totalAmount'))).toBeTruthy();
     });
 
-    it('should render token summary when token contract is provided', () => {
-        const { getByText } = renderFeesFooter({
+    it('should render token summary when token contract is provided', async () => {
+        const { getByText } = await renderFeesFooter({
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
 
@@ -120,24 +120,24 @@ describe('FeesFooter', () => {
         expect(getByText(getTranslation('transactions.detail.feeLabel'))).toBeTruthy();
     });
 
-    it('should display total amount correctly', () => {
-        const { getByText } = renderFeesFooter({
+    it('should display total amount correctly', async () => {
+        const { getByText } = await renderFeesFooter({
             totalAmount: '5000000',
         });
 
         expect(getByText('0.05 BTC')).toBeTruthy();
     });
 
-    it('should show submit button when isSubmittable is true', () => {
-        const { getByTestId } = renderFeesFooter({
+    it('should show submit button when isSubmittable is true', async () => {
+        const { getByTestId } = await renderFeesFooter({
             isSubmittable: true,
         });
 
         expect(getByTestId('@transactionManagement/fees-submit-button')).toBeTruthy();
     });
 
-    it('should not show submit button when isSubmittable is false', () => {
-        const { queryByTestId } = renderFeesFooter({
+    it('should not show submit button when isSubmittable is false', async () => {
+        const { queryByTestId } = await renderFeesFooter({
             isSubmittable: false,
         });
 
@@ -145,7 +145,7 @@ describe('FeesFooter', () => {
     });
 
     it('should call onSubmit when submit button is pressed', async () => {
-        const { getByTestId } = renderFeesFooter({
+        const { getByTestId } = await renderFeesFooter({
             isSubmittable: true,
         });
 
@@ -154,20 +154,20 @@ describe('FeesFooter', () => {
         expect(mockOnSubmit).toHaveBeenCalledTimes(1);
     });
 
-    it('should display token symbol correctly', () => {
+    it('should display token symbol correctly', async () => {
         mockSelectAccountTokenSymbol.mockReturnValue('USDC');
 
-        const { getByText } = renderFeesFooter({
+        const { getByText } = await renderFeesFooter({
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
 
         expect(getByText(/USDC/)).toBeTruthy();
     });
 
-    it('should display token amount with correct decimals', () => {
+    it('should display token amount with correct decimals', async () => {
         mockSelectAccountTokenDecimals.mockReturnValue(6);
 
-        const { getByText } = renderFeesFooter({
+        const { getByText } = await renderFeesFooter({
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
             totalAmount: '1000', // 1 USDC with 6 decimals
         });
@@ -175,18 +175,18 @@ describe('FeesFooter', () => {
         expect(getByText('0.001 USDC')).toBeTruthy();
     });
 
-    it('should handle different token contracts', () => {
+    it('should handle different token contracts', async () => {
         mockSelectAccountTokenSymbol.mockReturnValue('DAI');
 
-        const { getByText } = renderFeesFooter({
+        const { getByText } = await renderFeesFooter({
             tokenContract: '0x6b175474e89094c44da98b954eedeac495271d0f' as TokenAddress,
         });
 
         expect(getByText(/DAI/)).toBeTruthy();
     });
 
-    it('should show submit button when withSubmitButton is true and isSubmittable is true', () => {
-        const { getByText } = renderFeesFooter({
+    it('should show submit button when withSubmitButton is true and isSubmittable is true', async () => {
+        const { getByText } = await renderFeesFooter({
             isSubmittable: true,
             withSubmitButton: true,
         });
@@ -200,8 +200,8 @@ describe('FeesFooter', () => {
         { isSubmittable: false, withSubmitButton: false },
     ])(
         'should not show submit button when withSubmitButton is $withSubmitButton even if isSubmittable is $isSubmittable',
-        props => {
-            const { queryByText } = renderFeesFooter(props);
+        async props => {
+            const { queryByText } = await renderFeesFooter(props);
 
             expect(
                 queryByText(getTranslation('transactionManagement.fees.submitButton')),
@@ -209,8 +209,8 @@ describe('FeesFooter', () => {
         },
     );
 
-    it('should default withSubmitButton to true when not provided', () => {
-        const { getByText } = renderFeesFooter({
+    it('should default withSubmitButton to true when not provided', async () => {
+        const { getByText } = await renderFeesFooter({
             isSubmittable: true,
             // withSubmitButton not provided, should default to true
         });

--- a/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard/TronFeeSummaryRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard/TronFeeSummaryRow.test.tsx
@@ -21,35 +21,35 @@ describe('TronFeeSummaryRow', () => {
         wallet: getWalletState(),
     });
 
-    const renderRow = (props: Partial<TronFeeSummaryRowProps> = {}) =>
-        renderWithStoreProvider(<TronFeeSummaryRow {...defaultProps} {...props} />, {
+    const renderRow = async (props: Partial<TronFeeSummaryRowProps> = {}) =>
+        await renderWithStoreProvider(<TronFeeSummaryRow {...defaultProps} {...props} />, {
             preloadedState: getPreloadedState(),
         });
 
-    it('should render the non-adjustable Tron fee label by default', () => {
-        const { getByText } = renderRow();
+    it('should render the non-adjustable Tron fee label by default', async () => {
+        const { getByText } = await renderRow();
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.tron')),
         ).toBeOnTheScreen();
     });
 
-    it('should render the adjustable (Maximum fee) label when supportsAdjustableFees is true', () => {
-        const { getByText } = renderRow({ supportsAdjustableFees: true });
+    it('should render the adjustable (Maximum fee) label when supportsAdjustableFees is true', async () => {
+        const { getByText } = await renderRow({ supportsAdjustableFees: true });
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.ethereum')),
         ).toBeOnTheScreen();
     });
 
-    it('should render the resource coverage line when trxBurned and a resourceLabel are present', () => {
-        const { getByText } = renderRow({ resourceLabel: '120 Energy' });
+    it('should render the resource coverage line when trxBurned and a resourceLabel are present', async () => {
+        const { getByText } = await renderRow({ resourceLabel: '120 Energy' });
 
         expect(getByText('+ 120 Energy')).toBeOnTheScreen();
     });
 
-    it('should NOT render the resource coverage line when trxBurned is null', () => {
-        const { queryByText } = renderRow({ trxBurned: null, resourceLabel: '120 Energy' });
+    it('should NOT render the resource coverage line when trxBurned is null', async () => {
+        const { queryByText } = await renderRow({ trxBurned: null, resourceLabel: '120 Energy' });
 
         expect(queryByText('+ 120 Energy')).toBeNull();
     });

--- a/suite-native/transaction-management/src/hooks/fees/useFeesFetching.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesFetching.test.ts
@@ -42,7 +42,7 @@ describe('useFeesFetching', () => {
         ...overrides,
     });
 
-    const renderUseFeesFetching = ({
+    const renderUseFeesFetching = async ({
         store,
         networkSymbol,
         isRefetchDisabled = false,
@@ -51,9 +51,12 @@ describe('useFeesFetching', () => {
         networkSymbol?: NetworkSymbol;
         isRefetchDisabled?: boolean;
     }) =>
-        renderHookWithStoreProvider(() => useFeesFetching({ networkSymbol, isRefetchDisabled }), {
-            store,
-        });
+        await renderHookWithStoreProvider(
+            () => useFeesFetching({ networkSymbol, isRefetchDisabled }),
+            {
+                store,
+            },
+        );
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -63,9 +66,9 @@ describe('useFeesFetching', () => {
         mockSelectAreFeesLoading.mockReturnValue(false);
     });
 
-    it('should select account by key from state', () => {
+    it('should select account by key from state', async () => {
         const store = createStoreFromPreloadedState(createMockState());
-        const { result } = renderUseFeesFetching({ store, networkSymbol: btcSymbol });
+        const { result } = await renderUseFeesFetching({ store, networkSymbol: btcSymbol });
 
         expect(result.current.areFeesLoading).toBe(false);
         expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: btcSymbol });
@@ -75,10 +78,10 @@ describe('useFeesFetching', () => {
         });
     });
 
-    it('should handle loading state correctly', () => {
+    it('should handle loading state correctly', async () => {
         mockSelectAreFeesLoading.mockReturnValue(true);
         const store = createStoreFromPreloadedState(createMockState());
-        const { result } = renderUseFeesFetching({ store, networkSymbol: btcSymbol });
+        const { result } = await renderUseFeesFetching({ store, networkSymbol: btcSymbol });
 
         expect(result.current.areFeesLoading).toBe(true);
         expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: btcSymbol });
@@ -88,9 +91,9 @@ describe('useFeesFetching', () => {
         });
     });
 
-    it('should handle refetch disabled correctly', () => {
+    it('should handle refetch disabled correctly', async () => {
         const store = createStoreFromPreloadedState(createMockState());
-        const { result } = renderUseFeesFetching({
+        const { result } = await renderUseFeesFetching({
             store,
             networkSymbol: btcSymbol,
             isRefetchDisabled: true,
@@ -104,9 +107,9 @@ describe('useFeesFetching', () => {
         });
     });
 
-    it('should handle undefined networkSymbol gracefully', () => {
+    it('should handle undefined networkSymbol gracefully', async () => {
         const store = createStoreFromPreloadedState(createMockState());
-        const { result } = renderUseFeesFetching({
+        const { result } = await renderUseFeesFetching({
             store,
             networkSymbol: undefined,
         });

--- a/suite-native/transaction-management/src/hooks/fees/useFeesForm.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesForm.test.ts
@@ -14,8 +14,8 @@ describe('useFeesForm', () => {
         defaultFeePerUnit: '20000000000', // 20 gwei
     };
 
-    const renderUseFeesForm = (props: UseFeesFormProps = mockProps) =>
-        renderHookWithStoreProvider(() => useFeesForm(props), {
+    const renderUseFeesForm = async (props: UseFeesFormProps = mockProps) =>
+        await renderHookWithStoreProvider(() => useFeesForm(props), {
             preloadedState: {
                 wallet: {
                     fees: {},
@@ -71,8 +71,8 @@ describe('useFeesForm', () => {
             },
         });
 
-    it('should initialize with default values', () => {
-        const { result } = renderUseFeesForm();
+    it('should initialize with default values', async () => {
+        const { result } = await renderUseFeesForm();
 
         expect(result.current.getValues()).toEqual({
             feeLevel: 'normal',
@@ -81,38 +81,38 @@ describe('useFeesForm', () => {
         });
     });
 
-    it('should update fee level when changed', () => {
-        const { result } = renderUseFeesForm();
+    it('should update fee level when changed', async () => {
+        const { result } = await renderUseFeesForm();
 
-        act(() => {
+        await act(() => {
             result.current.setValue('feeLevel', 'high');
         });
 
         expect(result.current.getValues('feeLevel')).toBe('high');
     });
 
-    it('should update custom fee per unit when changed', () => {
-        const { result } = renderUseFeesForm();
+    it('should update custom fee per unit when changed', async () => {
+        const { result } = await renderUseFeesForm();
 
-        act(() => {
+        await act(() => {
             result.current.setValue('customFeePerUnit', '30000000000');
         });
 
         expect(result.current.getValues('customFeePerUnit')).toBe('30000000000');
     });
 
-    it('should update custom fee limit when changed', () => {
-        const { result } = renderUseFeesForm();
+    it('should update custom fee limit when changed', async () => {
+        const { result } = await renderUseFeesForm();
 
-        act(() => {
+        await act(() => {
             result.current.setValue('customFeeLimit', '21000');
         });
 
         expect(result.current.getValues('customFeeLimit')).toBe('21000');
     });
 
-    it('should handle empty fee levels without crashing', () => {
-        const { result } = renderHookWithStoreProvider(() => useFeesForm(mockProps), {
+    it('should handle empty fee levels without crashing', async () => {
+        const { result } = await renderHookWithStoreProvider(() => useFeesForm(mockProps), {
             preloadedState: {
                 wallet: {
                     fees: {},
@@ -141,14 +141,14 @@ describe('useFeesForm', () => {
         expect(result.current.getValues('customFeeLimit')).toBeUndefined();
     });
 
-    it('should initialize with custom default values', () => {
+    it('should initialize with custom default values', async () => {
         const customProps: UseFeesFormProps = {
             accountKey: ETH_ACCOUNT_KEY,
             defaultFeeLevel: 'high',
             defaultFeePerUnit: '15000000000',
         };
 
-        const { result } = renderUseFeesForm(customProps);
+        const { result } = await renderUseFeesForm(customProps);
 
         expect(result.current.getValues()).toEqual({
             feeLevel: 'high',

--- a/suite-native/transaction-management/src/hooks/fees/useTronFeeBreakdown.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useTronFeeBreakdown.test.ts
@@ -47,8 +47,8 @@ describe('useTronFeeBreakdown', () => {
         };
     };
 
-    it('should return null for a non-Tron account', () => {
-        const { result } = renderHookWithStoreProvider(
+    it('should return null for a non-Tron account', async () => {
+        const { result } = await renderHookWithStoreProvider(
             () => useTronFeeBreakdown({ accountKey: ETH_ACCOUNT_KEY }),
             { preloadedState: getPreloadedStateWith() },
         );
@@ -56,8 +56,8 @@ describe('useTronFeeBreakdown', () => {
         expect(result.current).toBeNull();
     });
 
-    it('should return null for a missing account', () => {
-        const { result } = renderHookWithStoreProvider(
+    it('should return null for a missing account', async () => {
+        const { result } = await renderHookWithStoreProvider(
             () =>
                 useTronFeeBreakdown({
                     accountKey: mockAccountKey({
@@ -71,8 +71,8 @@ describe('useTronFeeBreakdown', () => {
         expect(result.current).toBeNull();
     });
 
-    it('should return a breakdown for a Tron account', () => {
-        const { result } = renderHookWithStoreProvider(
+    it('should return a breakdown for a Tron account', async () => {
+        const { result } = await renderHookWithStoreProvider(
             () => useTronFeeBreakdown({ accountKey: TRON_ACCOUNT_KEY }),
             { preloadedState: getPreloadedStateWith([getTronAccount()]) },
         );

--- a/suite-native/transaction-management/src/hooks/useActiveStepOffset.test.ts
+++ b/suite-native/transaction-management/src/hooks/useActiveStepOffset.test.ts
@@ -8,31 +8,31 @@ describe('useActiveStepOffset', () => {
     const getLayoutEvent = (height: number) =>
         ({ nativeEvent: { layout: { height } } }) as LayoutChangeEvent;
 
-    const renderUseReviewOutputItemListHeights = (initialActiveStep: number) =>
-        renderHookWithBasicProvider(({ activeStep }) => useActiveStepOffset(activeStep), {
+    const renderUseReviewOutputItemListHeights = async (initialActiveStep: number) =>
+        await renderHookWithBasicProvider(({ activeStep }) => useActiveStepOffset(activeStep), {
             initialProps: { activeStep: initialActiveStep },
         });
 
-    it('should return 0 on initial render', () => {
-        const { result } = renderUseReviewOutputItemListHeights(0);
+    it('should return 0 on initial render', async () => {
+        const { result } = await renderUseReviewOutputItemListHeights(0);
 
         expect(result.current.activeStepBottomOffset).toEqual(0);
     });
 
-    it('should use heights from layout events to compute offset to bottom of active item', () => {
-        const { result } = renderUseReviewOutputItemListHeights(1);
+    it('should use heights from layout events to compute offset to bottom of active item', async () => {
+        const { result } = await renderUseReviewOutputItemListHeights(1);
 
-        act(() => {
+        await act(() => {
             result.current.handleReadListItemHeight(getLayoutEvent(100), 0);
         });
-        act(() => {
+        await act(() => {
             result.current.handleReadListItemHeight(getLayoutEvent(200), 1);
         });
-        act(() => {
+        await act(() => {
             result.current.handleReadListItemHeight(getLayoutEvent(300), 2);
         });
         // rewrite already set height for index 1
-        act(() => {
+        await act(() => {
             result.current.handleReadListItemHeight(getLayoutEvent(150), 1);
         });
 

--- a/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.test.ts
+++ b/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.test.ts
@@ -34,91 +34,102 @@ describe('useIsNetworkReserveBannerVisible', () => {
         });
     });
 
-    const renderHook = (params: Parameters<typeof useIsNetworkReserveBannerVisible>[0]) =>
-        renderHookWithStoreProvider(() => useIsNetworkReserveBannerVisible(params), { store });
+    const renderHook = async (params: Parameters<typeof useIsNetworkReserveBannerVisible>[0]) =>
+        await renderHookWithStoreProvider(() => useIsNetworkReserveBannerVisible(params), {
+            store,
+        });
 
-    it('returns false for null symbol, null amount, null balance, or no-reserve network', () => {
-        expect(renderHook({ symbol: undefined, amount: '1', balance: '2' }).result.current).toBe(
-            false,
-        );
-        expect(renderHook({ symbol: solSymbol, amount: null, balance: '1' }).result.current).toBe(
-            false,
-        );
-        expect(renderHook({ symbol: solSymbol, amount: '1', balance: null }).result.current).toBe(
-            false,
-        );
-        expect(renderHook({ symbol: btcSymbol, amount: '0.5', balance: '1' }).result.current).toBe(
-            false,
-        );
-    });
-
-    it('returns false for tokens (contractAddress set)', () => {
+    it('returns false for null symbol, null amount, null balance, or no-reserve network', async () => {
         expect(
-            renderHook({
-                symbol: solSymbol,
-                contractAddress: 'some-token-contract',
-                amount: '0.998',
-                balance: '1.0',
-            }).result.current,
+            (await renderHook({ symbol: undefined, amount: '1', balance: '2' })).result.current,
+        ).toBe(false);
+        expect(
+            (await renderHook({ symbol: solSymbol, amount: null, balance: '1' })).result.current,
+        ).toBe(false);
+        expect(
+            (await renderHook({ symbol: solSymbol, amount: '1', balance: null })).result.current,
+        ).toBe(false);
+        expect(
+            (await renderHook({ symbol: btcSymbol, amount: '0.5', balance: '1' })).result.current,
         ).toBe(false);
     });
 
-    it('shows banner when remainder is at or below static network reserve (no maxAmount)', () => {
+    it('returns false for tokens (contractAddress set)', async () => {
+        expect(
+            (
+                await renderHook({
+                    symbol: solSymbol,
+                    contractAddress: 'some-token-contract',
+                    amount: '0.998',
+                    balance: '1.0',
+                })
+            ).result.current,
+        ).toBe(false);
+    });
+
+    it('shows banner when remainder is at or below static network reserve (no maxAmount)', async () => {
         // remainder = 1.0 - 0.997 = 0.003 = SOL reserve
         expect(
-            renderHook({ symbol: solSymbol, amount: '0.997', balance: '1.0' }).result.current,
+            (await renderHook({ symbol: solSymbol, amount: '0.997', balance: '1.0' })).result
+                .current,
         ).toBe(true);
         // remainder = 1.0 - 0.998 = 0.002 < 0.003
         expect(
-            renderHook({ symbol: solSymbol, amount: '0.998', balance: '1.0' }).result.current,
+            (await renderHook({ symbol: solSymbol, amount: '0.998', balance: '1.0' })).result
+                .current,
         ).toBe(true);
     });
 
-    it('hides banner when amount is below reserve zone', () => {
+    it('hides banner when amount is below reserve zone', async () => {
         expect(
-            renderHook({ symbol: solSymbol, amount: '0.5', balance: '1.0' }).result.current,
+            (await renderHook({ symbol: solSymbol, amount: '0.5', balance: '1.0' })).result.current,
         ).toBe(false);
     });
 
-    it('hides banner when amount exceeds balance', () => {
+    it('hides banner when amount exceeds balance', async () => {
         expect(
-            renderHook({ symbol: solSymbol, amount: '1.1', balance: '1.0' }).result.current,
+            (await renderHook({ symbol: solSymbol, amount: '1.1', balance: '1.0' })).result.current,
         ).toBe(false);
     });
 
-    it('hides banner for zero amount', () => {
-        expect(renderHook({ symbol: solSymbol, amount: '0', balance: '1.0' }).result.current).toBe(
-            false,
-        );
+    it('hides banner for zero amount', async () => {
+        expect(
+            (await renderHook({ symbol: solSymbol, amount: '0', balance: '1.0' })).result.current,
+        ).toBe(false);
     });
 
-    it('shows banner when amount equals composed maxAmount (send / fee path)', () => {
+    it('shows banner when amount equals composed maxAmount (send / fee path)', async () => {
         // feeWithReserve = balance - maxAmount = 0.01; remainder = 0.01
         expect(
-            renderHook({
-                symbol: solSymbol,
-                amount: '0.99',
-                balance: '1.0',
-                maxAmount: '0.99',
-            }).result.current,
+            (
+                await renderHook({
+                    symbol: solSymbol,
+                    amount: '0.99',
+                    balance: '1.0',
+                    maxAmount: '0.99',
+                })
+            ).result.current,
         ).toBe(true);
     });
 
-    it('hides banner when below composed maxAmount threshold', () => {
+    it('hides banner when below composed maxAmount threshold', async () => {
         expect(
-            renderHook({
-                symbol: solSymbol,
-                amount: '0.5',
-                balance: '1.0',
-                maxAmount: '0.99',
-            }).result.current,
+            (
+                await renderHook({
+                    symbol: solSymbol,
+                    amount: '0.5',
+                    balance: '1.0',
+                    maxAmount: '0.99',
+                })
+            ).result.current,
         ).toBe(false);
     });
 
-    it('shows banner on base network at reserve boundary', () => {
+    it('shows banner on base network at reserve boundary', async () => {
         // remainder = 0.1 - 0.0999 = 0.0001 <= base reserve 0.0002
         expect(
-            renderHook({ symbol: baseSymbol, amount: '0.0999', balance: '0.1' }).result.current,
+            (await renderHook({ symbol: baseSymbol, amount: '0.0999', balance: '0.1' })).result
+                .current,
         ).toBe(true);
     });
 });

--- a/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.test.ts
+++ b/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.test.ts
@@ -50,13 +50,13 @@ describe('useMaxSpendableAmount', () => {
         selectedUtxos: [],
     };
 
-    const renderUseMaxSpendableAmount = ({
+    const renderUseMaxSpendableAmount = async ({
         accountKey,
         tokenContract,
         formState,
         symbol,
     }: Parameters<typeof useMaxSpendableAmount>[0]) =>
-        renderHookWithStoreProvider(
+        await renderHookWithStoreProvider(
             () =>
                 useMaxSpendableAmount({
                     accountKey,
@@ -92,15 +92,15 @@ describe('useMaxSpendableAmount', () => {
         jest.clearAllMocks();
     });
 
-    it('should keep max spendable amount undefined without account key', () => {
-        const { result } = renderUseMaxSpendableAmount({ symbol: null });
+    it('should keep max spendable amount undefined without account key', async () => {
+        const { result } = await renderUseMaxSpendableAmount({ symbol: null });
 
         expect(result.current.maxSpendableAmount).toBeUndefined();
         expect(mockCalculateFeeLevelsMaxAmountThunk).not.toHaveBeenCalled();
     });
 
     it('should use token balance when token balance is available', async () => {
-        const { result } = renderUseMaxSpendableAmount({
+        const { result } = await renderUseMaxSpendableAmount({
             accountKey: ethAccountKey,
             tokenContract: usdcTokenContract,
             symbol: etcSymbol,
@@ -115,7 +115,7 @@ describe('useMaxSpendableAmount', () => {
 
     it('should calculate max spendable amount for native asset with default form state', async () => {
         mockMaxAmountThunkResult({ normal: '0.009', economy: '0.008' });
-        const { result } = renderUseMaxSpendableAmount({
+        const { result } = await renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
             symbol: btcSymbol,
         });
@@ -128,7 +128,7 @@ describe('useMaxSpendableAmount', () => {
     it('should calculate max spendable amount with provided form state', async () => {
         mockMaxAmountThunkResult({ normal: '0.009', economy: '0.008' });
 
-        const { result } = renderUseMaxSpendableAmount({
+        const { result } = await renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
             formState: customFormState,
             symbol: btcSymbol,
@@ -149,7 +149,7 @@ describe('useMaxSpendableAmount', () => {
     it('should fall back to economy fee level when normal max amount is missing', async () => {
         mockMaxAmountThunkResult({ normal: undefined, economy: '0.008' });
 
-        const { result } = renderUseMaxSpendableAmount({
+        const { result } = await renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
             symbol: btcSymbol,
         });
@@ -159,8 +159,8 @@ describe('useMaxSpendableAmount', () => {
         });
     });
 
-    it('should skip native asset calculation when calculation is disabled', () => {
-        const { result } = renderUseMaxSpendableAmount({
+    it('should skip native asset calculation when calculation is disabled', async () => {
+        const { result } = await renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
             symbol: btcSymbol,
             enabled: false,

--- a/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.test.ts
+++ b/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.test.ts
@@ -54,6 +54,7 @@ describe('useMaxSpendableAmount', () => {
         accountKey,
         tokenContract,
         formState,
+        enabled,
         symbol,
     }: Parameters<typeof useMaxSpendableAmount>[0]) =>
         await renderHookWithStoreProvider(
@@ -62,6 +63,7 @@ describe('useMaxSpendableAmount', () => {
                     accountKey,
                     tokenContract,
                     formState,
+                    enabled,
                     symbol,
                 }),
             {

--- a/suite-native/transaction-management/src/hooks/useNavigationRemoveInterceptorAlert.test.ts
+++ b/suite-native/transaction-management/src/hooks/useNavigationRemoveInterceptorAlert.test.ts
@@ -26,13 +26,13 @@ const mockedUseNavigationRemoveActionInterceptor = jest.mocked(
     useNavigationRemoveActionInterceptor,
 );
 
-const renderUseNavigationRemoveInterceptorAlert = ({
+const renderUseNavigationRemoveInterceptorAlert = async ({
     onRemoveConfirmed = jest.fn(),
     onStayConfirmed,
     shouldPrevent,
     alertOptions,
 }: RenderUseNavigationRemoveInterceptorAlertOptions = {}) =>
-    renderHookWithBasicProvider(() =>
+    await renderHookWithBasicProvider(() =>
         useNavigationRemoveInterceptorAlert({
             onRemoveConfirmed,
             onStayConfirmed,
@@ -49,14 +49,14 @@ describe('useNavigationRemoveInterceptorAlert', () => {
         jest.clearAllMocks();
     });
 
-    it('should show stay on screen alert on prevented remove action', () => {
+    it('should show stay on screen alert on prevented remove action', async () => {
         const onRemoveConfirmed = jest.fn();
         const onStayConfirmed = jest.fn();
         const alertOptions = {
             title: 'Leave this screen?',
         };
 
-        renderUseNavigationRemoveInterceptorAlert({
+        await renderUseNavigationRemoveInterceptorAlert({
             onRemoveConfirmed,
             onStayConfirmed,
             alertOptions,
@@ -72,16 +72,16 @@ describe('useNavigationRemoveInterceptorAlert', () => {
         });
     });
 
-    it('should hide stay on screen alert on allowed remove action', () => {
-        renderUseNavigationRemoveInterceptorAlert();
+    it('should hide stay on screen alert on allowed remove action', async () => {
+        await renderUseNavigationRemoveInterceptorAlert();
 
         getPreventNavigationRemoveProps()?.onAllowedAction?.({ type: 'PUSH' });
 
         expect(mockHideStayOnScreenAlert).toHaveBeenCalledTimes(1);
     });
 
-    it('should pass shouldPrevent to useNavigationRemoveActionInterceptor', () => {
-        renderUseNavigationRemoveInterceptorAlert({ shouldPrevent: false });
+    it('should pass shouldPrevent to useNavigationRemoveActionInterceptor', async () => {
+        await renderUseNavigationRemoveInterceptorAlert({ shouldPrevent: false });
 
         expect(mockedUseNavigationRemoveActionInterceptor).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/suite-native/transaction-management/src/hooks/useOutputsReviewBackInterceptor.test.ts
+++ b/suite-native/transaction-management/src/hooks/useOutputsReviewBackInterceptor.test.ts
@@ -18,8 +18,9 @@ jest.mock('./useShowReviewCancellationAlert', () => ({
 }));
 
 describe('useOutputsReviewBackInterceptor', () => {
-    const renderUseOutputsReviewBackInterceptor = (onReviewCanceled: () => void = jest.fn()) =>
-        renderHookWithBasicProvider(() => useOutputsReviewBackInterceptor(onReviewCanceled));
+    const renderUseOutputsReviewBackInterceptor = async (
+        onReviewCanceled: () => void = jest.fn(),
+    ) => await renderHookWithBasicProvider(() => useOutputsReviewBackInterceptor(onReviewCanceled));
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -28,8 +29,8 @@ describe('useOutputsReviewBackInterceptor', () => {
         );
     });
 
-    it('should call showReviewCancellationAlert onBack action', () => {
-        renderUseOutputsReviewBackInterceptor();
+    it('should call showReviewCancellationAlert onBack action', async () => {
+        await renderUseOutputsReviewBackInterceptor();
 
         expect(mockShowReviewCancellationAlert).toHaveBeenCalledTimes(1);
     });
@@ -37,7 +38,7 @@ describe('useOutputsReviewBackInterceptor', () => {
     it('should call onReviewCanceled if review was canceled', async () => {
         const mockOnReviewCanceled = jest.fn();
 
-        renderUseOutputsReviewBackInterceptor(mockOnReviewCanceled);
+        await renderUseOutputsReviewBackInterceptor(mockOnReviewCanceled);
 
         await waitFor(() => {
             expect(mockOnReviewCanceled).toHaveBeenCalledTimes(1);
@@ -49,7 +50,7 @@ describe('useOutputsReviewBackInterceptor', () => {
         mockShowReviewCancellationAlert.mockReturnValue(
             Promise.resolve({ wasReviewCanceled: false }),
         );
-        renderUseOutputsReviewBackInterceptor(mockOnReviewCanceled);
+        await renderUseOutputsReviewBackInterceptor(mockOnReviewCanceled);
 
         await Promise.resolve(); // wait for the promise in the hook to resolve
         expect(mockOnReviewCanceled).toHaveBeenCalledTimes(0);

--- a/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.test.tsx
+++ b/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.test.tsx
@@ -28,8 +28,8 @@ describe('usePrecomposedTransactionError', () => {
 
     it.each([[null], [undefined], ['INVALID_ERROR'], ['']])(
         'should return null when error is %s',
-        error => {
-            const { result } = renderHookWithBasicProvider(() =>
+        async error => {
+            const { result } = await renderHookWithBasicProvider(() =>
                 usePrecomposedTransactionError({ error, networkSymbol }),
             );
 
@@ -89,16 +89,16 @@ describe('usePrecomposedTransactionError', () => {
                 'transactionManagement.precomposedTransaction.errors.stakeNotEnoughFunds',
             ),
         },
-    ])('should return correct translation data for $error', ({ error, expectedErrorMsg }) => {
-        const { getByText } = renderWithBasicProvider(
+    ])('should return correct translation data for $error', async ({ error, expectedErrorMsg }) => {
+        const { getByText } = await renderWithBasicProvider(
             <ErrorText error={error} networkSymbol={networkSymbol} />,
         );
 
         expect(getByText(expectedErrorMsg)).toBeOnTheScreen();
     });
 
-    it('should handle context without network symbol', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should handle context without network symbol', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <ErrorText error="AMOUNT_NOT_ENOUGH_CURRENCY_FEE" />,
         );
 
@@ -112,8 +112,8 @@ describe('usePrecomposedTransactionError', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should handle different network symbols', () => {
-        const { getByText } = renderWithBasicProvider(
+    it('should handle different network symbols', async () => {
+        const { getByText } = await renderWithBasicProvider(
             <ErrorText error="AMOUNT_NOT_ENOUGH_CURRENCY_FEE" networkSymbol={ethSymbol} />,
         );
 

--- a/suite-native/transaction-management/src/hooks/useShowReviewCancellationAlert.test.ts
+++ b/suite-native/transaction-management/src/hooks/useShowReviewCancellationAlert.test.ts
@@ -24,28 +24,28 @@ jest.mock('@suite-common/wallet-core', () => ({
 describe('useShowReviewCancellationAlert', () => {
     let store: TestStore;
 
-    const renderUseShowReviewCancellationAlert = () =>
-        renderHookWithStoreProvider(() => useShowReviewCancellationAlert(), { store });
+    const renderUseShowReviewCancellationAlert = async () =>
+        await renderHookWithStoreProvider(() => useShowReviewCancellationAlert(), { store });
 
     beforeEach(() => {
         mockShowAlert.mockClear();
         store = createStoreFromPreloadedState();
     });
 
-    it('should return stable callback', () => {
-        const { result, rerender } = renderUseShowReviewCancellationAlert();
+    it('should return stable callback', async () => {
+        const { result, rerender } = await renderUseShowReviewCancellationAlert();
 
         const firstCallback = result.current;
 
-        rerender({});
+        await rerender({});
 
         const secondCallback = result.current;
 
         expect(firstCallback).toBe(secondCallback);
     });
 
-    it('should call showAlert on callback execution', () => {
-        const { result } = renderUseShowReviewCancellationAlert();
+    it('should call showAlert on callback execution', async () => {
+        const { result } = await renderUseShowReviewCancellationAlert();
 
         result.current();
 
@@ -54,7 +54,7 @@ describe('useShowReviewCancellationAlert', () => {
 
     it('should resolve with wasReviewCanceled true when primary button is pressed', async () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = renderUseShowReviewCancellationAlert();
+        const { result } = await renderUseShowReviewCancellationAlert();
         const promise = result.current();
         const alertConfig = mockShowAlert.mock.calls[0][0];
 
@@ -68,7 +68,7 @@ describe('useShowReviewCancellationAlert', () => {
     });
 
     it('should resolve with wasReviewCanceled false when secondary button is pressed', async () => {
-        const { result } = renderUseShowReviewCancellationAlert();
+        const { result } = await renderUseShowReviewCancellationAlert();
         const promise = result.current();
         const alertConfig = mockShowAlert.mock.calls[0][0];
 

--- a/suite-native/transaction-management/src/hooks/useSubscribeForSolanaBlockUpdates.test.ts
+++ b/suite-native/transaction-management/src/hooks/useSubscribeForSolanaBlockUpdates.test.ts
@@ -16,14 +16,14 @@ describe('useSubscribeForSolanaBlockUpdates', () => {
         jest.clearAllMocks();
     });
 
-    it('should subscribe to Solana block updates when Solana account is provided', () => {
+    it('should subscribe to Solana block updates when Solana account is provided', async () => {
         const solanaAccount = {
             key: 'sol-account-1',
             symbol: 'sol',
             networkType: 'solana',
         } as unknown as Account;
 
-        renderHook(() => useSubscribeForSolanaBlockUpdates(solanaAccount));
+        await renderHook(() => useSubscribeForSolanaBlockUpdates(solanaAccount));
 
         const mockBlockchainSubscribe = TrezorConnect.blockchainSubscribe;
 
@@ -33,34 +33,36 @@ describe('useSubscribeForSolanaBlockUpdates', () => {
         });
     });
 
-    it('should not subscribe when non-Solana account is provided', () => {
+    it('should not subscribe when non-Solana account is provided', async () => {
         const btcAccount = {
             key: 'btc-account-1',
             symbol: 'btc',
             networkType: 'bitcoin',
         } as unknown as Account;
 
-        renderHook(() => useSubscribeForSolanaBlockUpdates(btcAccount));
+        await renderHook(() => useSubscribeForSolanaBlockUpdates(btcAccount));
         const mockBlockchainSubscribe = TrezorConnect.blockchainSubscribe;
 
         expect(mockBlockchainSubscribe).not.toHaveBeenCalled();
     });
 
-    it('should not subscribe when account is null', () => {
-        renderHook(() => useSubscribeForSolanaBlockUpdates(null));
+    it('should not subscribe when account is null', async () => {
+        await renderHook(() => useSubscribeForSolanaBlockUpdates(null));
         const mockBlockchainSubscribe = TrezorConnect.blockchainSubscribe;
 
         expect(mockBlockchainSubscribe).not.toHaveBeenCalled();
     });
 
-    it('should unsubscribe when component unmounts with Solana account', () => {
+    it('should unsubscribe when component unmounts with Solana account', async () => {
         const solanaAccount = {
             key: 'sol-account-1',
             symbol: 'sol',
             networkType: 'solana',
         } as unknown as Account;
 
-        const { unmount } = renderHook(() => useSubscribeForSolanaBlockUpdates(solanaAccount));
+        const { unmount } = await renderHook(() =>
+            useSubscribeForSolanaBlockUpdates(solanaAccount),
+        );
 
         const mockBlockchainSubscribe = TrezorConnect.blockchainSubscribe;
 
@@ -70,7 +72,7 @@ describe('useSubscribeForSolanaBlockUpdates', () => {
         });
 
         const mockBlockchainUnsubscribe = TrezorConnect.blockchainUnsubscribe;
-        unmount();
+        await unmount();
 
         expect(mockBlockchainUnsubscribe).toHaveBeenCalledWith({
             coin: 'sol',

--- a/suite-native/transaction-management/src/hooks/useTransactionDetails.test.ts
+++ b/suite-native/transaction-management/src/hooks/useTransactionDetails.test.ts
@@ -55,11 +55,11 @@ const buildPreloadedState = (
     },
 });
 
-const renderUseTransactionDetails = (
+const renderUseTransactionDetails = async (
     params: Parameters<typeof useTransactionDetails>[0],
     transactions?: WalletAccountTransaction[],
 ) =>
-    renderHookWithStoreProvider(() => useTransactionDetails(params), {
+    await renderHookWithStoreProvider(() => useTransactionDetails(params), {
         preloadedState: buildPreloadedState(transactions),
     });
 
@@ -69,27 +69,33 @@ describe('useTransactionDetails', () => {
     });
 
     describe('transaction', () => {
-        it('returns undefined when accountKey is null', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: null, txid: TXID });
+        it('returns undefined when accountKey is null', async () => {
+            const { result } = await renderUseTransactionDetails({ accountKey: null, txid: TXID });
 
             expect(result.current.transaction).toBeUndefined();
         });
 
-        it('returns undefined when txid is null', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: ACCOUNT_KEY, txid: null });
+        it('returns undefined when txid is null', async () => {
+            const { result } = await renderUseTransactionDetails({
+                accountKey: ACCOUNT_KEY,
+                txid: null,
+            });
 
             expect(result.current.transaction).toBeUndefined();
         });
 
-        it('returns the transaction matching accountKey and txid', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: ACCOUNT_KEY, txid: TXID });
+        it('returns the transaction matching accountKey and txid', async () => {
+            const { result } = await renderUseTransactionDetails({
+                accountKey: ACCOUNT_KEY,
+                txid: TXID,
+            });
 
             expect(result.current.transaction?.txid).toBe(TXID);
             expect(result.current.transaction?.symbol).toBe(mockTransaction.symbol);
         });
 
-        it('returns null when no transaction matches the txid', () => {
-            const { result } = renderUseTransactionDetails({
+        it('returns null when no transaction matches the txid', async () => {
+            const { result } = await renderUseTransactionDetails({
                 accountKey: ACCOUNT_KEY,
                 txid: 'nonexistent-txid',
             });
@@ -99,14 +105,17 @@ describe('useTransactionDetails', () => {
     });
 
     describe('isPending', () => {
-        it('returns false for a confirmed transaction', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: ACCOUNT_KEY, txid: TXID });
+        it('returns false for a confirmed transaction', async () => {
+            const { result } = await renderUseTransactionDetails({
+                accountKey: ACCOUNT_KEY,
+                txid: TXID,
+            });
 
             expect(result.current.isPending).toBe(false);
         });
 
-        it('returns true for a pending transaction (blockHeight 0)', () => {
-            const { result } = renderUseTransactionDetails(
+        it('returns true for a pending transaction (blockHeight 0)', async () => {
+            const { result } = await renderUseTransactionDetails(
                 { accountKey: ACCOUNT_KEY, txid: TXID },
                 [pendingTransaction],
             );
@@ -114,22 +123,25 @@ describe('useTransactionDetails', () => {
             expect(result.current.isPending).toBe(true);
         });
 
-        it('returns false when accountKey is null', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: null, txid: TXID });
+        it('returns false when accountKey is null', async () => {
+            const { result } = await renderUseTransactionDetails({ accountKey: null, txid: TXID });
 
             expect(result.current.isPending).toBe(false);
         });
     });
 
     describe('tokenTransfer', () => {
-        it('returns undefined when tokenContract is not provided', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: ACCOUNT_KEY, txid: TXID });
+        it('returns undefined when tokenContract is not provided', async () => {
+            const { result } = await renderUseTransactionDetails({
+                accountKey: ACCOUNT_KEY,
+                txid: TXID,
+            });
 
             expect(result.current.tokenTransfer).toBeUndefined();
         });
 
-        it('returns the matching token transfer when tokenContract matches', () => {
-            const { result } = renderUseTransactionDetails(
+        it('returns the matching token transfer when tokenContract matches', async () => {
+            const { result } = await renderUseTransactionDetails(
                 { accountKey: ACCOUNT_KEY, txid: TXID, tokenContract: TOKEN_CONTRACT },
                 [transactionWithToken],
             );
@@ -138,8 +150,8 @@ describe('useTransactionDetails', () => {
             expect(result.current.tokenTransfer?.symbol).toBe('usdc');
         });
 
-        it('returns undefined when tokenContract does not match any token', () => {
-            const { result } = renderUseTransactionDetails(
+        it('returns undefined when tokenContract does not match any token', async () => {
+            const { result } = await renderUseTransactionDetails(
                 { accountKey: ACCOUNT_KEY, txid: TXID, tokenContract: '0xnonexistent' },
                 [transactionWithToken],
             );
@@ -149,15 +161,18 @@ describe('useTransactionDetails', () => {
     });
 
     describe('explorerUrl', () => {
-        it('returns a URL containing the txid when transaction exists', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: ACCOUNT_KEY, txid: TXID });
+        it('returns a URL containing the txid when transaction exists', async () => {
+            const { result } = await renderUseTransactionDetails({
+                accountKey: ACCOUNT_KEY,
+                txid: TXID,
+            });
 
             expect(result.current.explorerUrl).not.toBeNull();
             expect(result.current.explorerUrl).toContain(TXID);
         });
 
-        it('returns null when transaction does not exist', () => {
-            const { result } = renderUseTransactionDetails({
+        it('returns null when transaction does not exist', async () => {
+            const { result } = await renderUseTransactionDetails({
                 accountKey: ACCOUNT_KEY,
                 txid: 'nonexistent-txid',
             });
@@ -165,18 +180,21 @@ describe('useTransactionDetails', () => {
             expect(result.current.explorerUrl).toBeNull();
         });
 
-        it('returns null when accountKey is null', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: null, txid: TXID });
+        it('returns null when accountKey is null', async () => {
+            const { result } = await renderUseTransactionDetails({ accountKey: null, txid: TXID });
 
             expect(result.current.explorerUrl).toBeNull();
         });
     });
 
     describe('openInBlockchain', () => {
-        it('calls openLink with the explorerUrl when transaction exists', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: ACCOUNT_KEY, txid: TXID });
+        it('calls openLink with the explorerUrl when transaction exists', async () => {
+            const { result } = await renderUseTransactionDetails({
+                accountKey: ACCOUNT_KEY,
+                txid: TXID,
+            });
 
-            act(() => {
+            await act(() => {
                 result.current.openInBlockchain();
             });
 
@@ -184,23 +202,23 @@ describe('useTransactionDetails', () => {
             expect(mockOpenLink).toHaveBeenCalledWith(result.current.explorerUrl);
         });
 
-        it('does not call openLink when transaction does not exist', () => {
-            const { result } = renderUseTransactionDetails({
+        it('does not call openLink when transaction does not exist', async () => {
+            const { result } = await renderUseTransactionDetails({
                 accountKey: ACCOUNT_KEY,
                 txid: 'nonexistent-txid',
             });
 
-            act(() => {
+            await act(() => {
                 result.current.openInBlockchain();
             });
 
             expect(mockOpenLink).not.toHaveBeenCalled();
         });
 
-        it('does not call openLink when accountKey is null', () => {
-            const { result } = renderUseTransactionDetails({ accountKey: null, txid: TXID });
+        it('does not call openLink when accountKey is null', async () => {
+            const { result } = await renderUseTransactionDetails({ accountKey: null, txid: TXID });
 
-            act(() => {
+            await act(() => {
                 result.current.openInBlockchain();
             });
 

--- a/suite-native/transaction-management/src/hooks/useTxValidityTimer.test.tsx
+++ b/suite-native/transaction-management/src/hooks/useTxValidityTimer.test.tsx
@@ -50,9 +50,11 @@ describe('useTxValidityTimer', () => {
         onCancel: jest.fn(),
     });
 
-    const renderTimer = (overrides: Partial<Params> = {}) => {
+    const renderTimer = async (overrides: Partial<Params> = {}) => {
         const initialProps = { ...getBaseParams(now), ...overrides };
-        const view = renderHook((props: Params) => useTxValidityTimer(props), { initialProps });
+        const view = await renderHook((props: Params) => useTxValidityTimer(props), {
+            initialProps,
+        });
 
         return { ...view, initialProps };
     };
@@ -76,93 +78,93 @@ describe('useTxValidityTimer', () => {
     });
 
     describe('timer relevance', () => {
-        it('should show the timer for a Solana transaction with a creation timestamp', () => {
-            const { result } = renderTimer();
+        it('should show the timer for a Solana transaction with a creation timestamp', async () => {
+            const { result } = await renderTimer();
 
             expect(result.current.showTimer).toBe(true);
         });
 
         it.each(['ethereum', 'bitcoin', 'ripple'] as NetworkType[])(
             'should not show the timer for a %s transaction',
-            networkType => {
-                const { result } = renderTimer({ networkType });
+            async networkType => {
+                const { result } = await renderTimer({ networkType });
 
                 expect(result.current.showTimer).toBe(false);
             },
         );
 
-        it('should not show the timer when the creation timestamp is missing', () => {
-            const { result } = renderTimer({ createdTimestamp: 0 });
+        it('should not show the timer when the creation timestamp is missing', async () => {
+            const { result } = await renderTimer({ createdTimestamp: 0 });
 
             expect(result.current.showTimer).toBe(false);
         });
 
-        it('should not show the timer when the network type is unknown', () => {
-            const { result } = renderTimer({ networkType: undefined });
+        it('should not show the timer when the network type is unknown', async () => {
+            const { result } = await renderTimer({ networkType: undefined });
 
             expect(result.current.showTimer).toBe(false);
         });
     });
 
     describe('countdown', () => {
-        it('should derive the remaining seconds from the countdown duration', () => {
+        it('should derive the remaining seconds from the countdown duration', async () => {
             mockUseCountdownTimer.mockReturnValue({
                 duration: { minutes: 1, seconds: 5 },
                 isPastDeadline: false,
             });
 
-            const { result } = renderTimer();
+            const { result } = await renderTimer();
 
             expect(result.current.secondsLeft).toBe(65);
         });
 
-        it('should default the remaining seconds to zero for an empty duration', () => {
+        it('should default the remaining seconds to zero for an empty duration', async () => {
             mockUseCountdownTimer.mockReturnValue({ duration: {}, isPastDeadline: false });
 
-            const { result } = renderTimer();
+            const { result } = await renderTimer();
 
             expect(result.current.secondsLeft).toBe(0);
         });
 
-        it('should pass the broadcasting flag through', () => {
-            const { result } = renderTimer({ isBroadcasting: true });
+        it('should pass the broadcasting flag through', async () => {
+            const { result } = await renderTimer({ isBroadcasting: true });
 
             expect(result.current.isBroadcasting).toBe(true);
         });
     });
 
     describe('expiration', () => {
-        it('should report past deadline when relevant, not broadcasting, and the countdown elapsed', () => {
+        it('should report past deadline when relevant, not broadcasting, and the countdown elapsed', async () => {
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
 
-            const { result } = renderTimer();
+            const { result } = await renderTimer();
 
             expect(result.current.isPastDeadline).toBe(true);
         });
 
-        it('should not report past deadline while broadcasting', () => {
+        it('should not report past deadline while broadcasting', async () => {
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
 
-            const { result } = renderTimer({ isBroadcasting: true });
+            const { result } = await renderTimer({ isBroadcasting: true });
 
             expect(result.current.isPastDeadline).toBe(false);
         });
 
-        it('should not report past deadline when the timer is irrelevant', () => {
+        it('should not report past deadline when the timer is irrelevant', async () => {
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
 
-            const { result } = renderTimer({ networkType: 'ethereum' });
+            const { result } = await renderTimer({ networkType: 'ethereum' });
 
             expect(result.current.isPastDeadline).toBe(false);
         });
     });
 
     describe('retry', () => {
-        it('should route onRetry through the click cooldown', () => {
+        it('should route onRetry through the click cooldown', async () => {
             const onRetry = jest.fn();
-            const { result } = renderTimer({ onRetry });
+            const { result } = await renderTimer({ onRetry });
 
-            act(() => {
+            await act(() => {
                 result.current.onRetry();
             });
 
@@ -170,23 +172,23 @@ describe('useTxValidityTimer', () => {
             expect(onRetry).toHaveBeenCalledTimes(1);
         });
 
-        it('should reflect the cooldown disabled state', () => {
+        it('should reflect the cooldown disabled state', async () => {
             mockUseClickCooldown.mockReturnValue({
                 handleClick: mockHandleRetryClick,
                 disabled: true,
             });
 
-            const { result } = renderTimer();
+            const { result } = await renderTimer();
 
             expect(result.current.isRetryDisabled).toBe(true);
         });
     });
 
     describe('expiration alert', () => {
-        it('should show the expired alert once the transaction expires', () => {
+        it('should show the expired alert once the transaction expires', async () => {
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
 
-            renderTimer();
+            await renderTimer();
 
             expect(mockShowAlert).toHaveBeenCalledTimes(1);
             expect(mockShowAlert).toHaveBeenCalledWith(
@@ -194,59 +196,59 @@ describe('useTxValidityTimer', () => {
             );
         });
 
-        it('should not show an alert while the transaction is still valid', () => {
+        it('should not show an alert while the transaction is still valid', async () => {
             mockUseCountdownTimer.mockReturnValue(NOT_EXPIRED);
 
-            renderTimer();
+            await renderTimer();
 
             expect(mockShowAlert).not.toHaveBeenCalled();
         });
 
-        it('should not show an alert when expiry happens during broadcasting', () => {
+        it('should not show an alert when expiry happens during broadcasting', async () => {
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
 
-            renderTimer({ isBroadcasting: true });
+            await renderTimer({ isBroadcasting: true });
 
             expect(mockShowAlert).not.toHaveBeenCalled();
         });
 
-        it('should show the alert only once while it remains expired', () => {
+        it('should show the alert only once while it remains expired', async () => {
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
 
-            const { rerender, initialProps } = renderTimer();
-            rerender(initialProps);
+            const { rerender, initialProps } = await renderTimer();
+            await rerender(initialProps);
 
             expect(mockShowAlert).toHaveBeenCalledTimes(1);
         });
 
-        it('should show the alert again after the transaction recovers and expires again', () => {
+        it('should show the alert again after the transaction recovers and expires again', async () => {
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
-            const { rerender, initialProps } = renderTimer();
+            const { rerender, initialProps } = await renderTimer();
             expect(mockShowAlert).toHaveBeenCalledTimes(1);
 
             mockUseCountdownTimer.mockReturnValue(NOT_EXPIRED);
-            rerender(initialProps);
+            await rerender(initialProps);
             expect(mockShowAlert).toHaveBeenCalledTimes(1);
 
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
-            rerender(initialProps);
+            await rerender(initialProps);
             expect(mockShowAlert).toHaveBeenCalledTimes(2);
         });
 
-        it('should wire the alert primary button to retry and the secondary button to cancel', () => {
+        it('should wire the alert primary button to retry and the secondary button to cancel', async () => {
             const onRetry = jest.fn();
             const onCancel = jest.fn();
             mockUseCountdownTimer.mockReturnValue(EXPIRED);
 
-            renderTimer({ onRetry, onCancel });
+            await renderTimer({ onRetry, onCancel });
             const alertConfig = mockShowAlert.mock.calls[0][0];
 
-            act(() => {
+            await act(() => {
                 alertConfig.onPressPrimaryButton();
             });
             expect(onRetry).toHaveBeenCalledTimes(1);
 
-            act(() => {
+            await act(() => {
                 alertConfig.onPressSecondaryButton();
             });
             expect(onCancel).toHaveBeenCalledTimes(1);
@@ -254,26 +256,26 @@ describe('useTxValidityTimer', () => {
     });
 
     describe('Trezor request cancellation', () => {
-        it('should cancel the Trezor request once the validity window elapses', () => {
-            renderTimer();
+        it('should cancel the Trezor request once the validity window elapses', async () => {
+            await renderTimer();
 
             expect(mockTrezorConnectCancel).not.toHaveBeenCalled();
 
-            act(() => {
+            await act(() => {
                 jest.advanceTimersByTime(1_000);
             });
             expect(mockTrezorConnectCancel).not.toHaveBeenCalled();
 
-            act(() => {
+            await act(() => {
                 jest.advanceTimersByTime(SOLANA_TIMEOUT_MS);
             });
             expect(mockTrezorConnectCancel).toHaveBeenCalledWith('tx-timeout');
         });
 
-        it('should not schedule cancellation when the deadline has already passed', () => {
-            renderTimer({ createdTimestamp: now - SOLANA_TIMEOUT_MS - 1_000 });
+        it('should not schedule cancellation when the deadline has already passed', async () => {
+            await renderTimer({ createdTimestamp: now - SOLANA_TIMEOUT_MS - 1_000 });
 
-            act(() => {
+            await act(() => {
                 jest.advanceTimersByTime(SOLANA_TIMEOUT_MS * 2);
             });
 
@@ -289,22 +291,25 @@ describe('useTxValidityTimer', () => {
             { name: 'for non-solana networks', overrides: { networkType: 'ethereum' } },
         ];
 
-        it.each(noCancelScenarios)('should not schedule cancellation $name', ({ overrides }) => {
-            renderTimer(overrides);
+        it.each(noCancelScenarios)(
+            'should not schedule cancellation $name',
+            async ({ overrides }) => {
+                await renderTimer(overrides);
 
-            act(() => {
-                jest.advanceTimersByTime(SOLANA_TIMEOUT_MS * 2);
-            });
+                await act(() => {
+                    jest.advanceTimersByTime(SOLANA_TIMEOUT_MS * 2);
+                });
 
-            expect(mockTrezorConnectCancel).not.toHaveBeenCalled();
-        });
+                expect(mockTrezorConnectCancel).not.toHaveBeenCalled();
+            },
+        );
 
-        it('should clear the scheduled cancellation on unmount', () => {
-            const { unmount } = renderTimer();
+        it('should clear the scheduled cancellation on unmount', async () => {
+            const { unmount } = await renderTimer();
 
-            unmount();
+            await unmount();
 
-            act(() => {
+            await act(() => {
                 jest.advanceTimersByTime(SOLANA_TIMEOUT_MS * 2);
             });
 

--- a/suite-native/transaction-management/src/hooks/useWaitForButtonRequest.test.ts
+++ b/suite-native/transaction-management/src/hooks/useWaitForButtonRequest.test.ts
@@ -10,8 +10,8 @@ jest.mock('@suite-common/device', () => ({
 }));
 
 describe('useWaitForButtonRequest.ts', () => {
-    const renderUseWaitForButtonRequest = (initialCallback: jest.Mock) =>
-        renderHookWithStoreProvider(
+    const renderUseWaitForButtonRequest = async (initialCallback: jest.Mock) =>
+        await renderHookWithStoreProvider(
             ({ onButtonRequest }) => useWaitForButtonRequest(onButtonRequest),
             {
                 initialProps: {
@@ -24,11 +24,11 @@ describe('useWaitForButtonRequest.ts', () => {
         jest.clearAllMocks();
     });
 
-    it('should call callback once there are any button requests', () => {
+    it('should call callback once there are any button requests', async () => {
         const callback = jest.fn();
-        const { result, rerender } = renderUseWaitForButtonRequest(callback);
+        const { result, rerender } = await renderUseWaitForButtonRequest(callback);
 
-        act(() => {
+        await act(() => {
             result.current();
         });
 
@@ -36,27 +36,27 @@ describe('useWaitForButtonRequest.ts', () => {
 
         // we are use mock, we need to rerender manually
         mockSelectDeviceButtonRequestsCodes.mockReturnValue(['buttonRequestMock1']);
-        rerender({ onButtonRequest: callback });
+        await rerender({ onButtonRequest: callback });
 
         expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    it('should not call callback multiple times', () => {
+    it('should not call callback multiple times', async () => {
         const callback = jest.fn();
-        const { result, rerender } = renderUseWaitForButtonRequest(callback);
+        const { result, rerender } = await renderUseWaitForButtonRequest(callback);
 
-        act(() => {
+        await act(() => {
             result.current();
         });
 
         // we are use mock, we need to rerender manually
         mockSelectDeviceButtonRequestsCodes.mockReturnValue(['buttonRequestMock1']);
-        rerender({ onButtonRequest: callback });
+        await rerender({ onButtonRequest: callback });
         mockSelectDeviceButtonRequestsCodes.mockReturnValue([
             'buttonRequestMock1',
             'buttonRequestMock2',
         ]);
-        rerender({ onButtonRequest: callback });
+        await rerender({ onButtonRequest: callback });
 
         expect(callback).toHaveBeenCalledTimes(1);
     });

--- a/suite-native/transactions/src/components/TransactionName.test.tsx
+++ b/suite-native/transactions/src/components/TransactionName.test.tsx
@@ -26,16 +26,16 @@ const unwrapTx = {
 } as unknown as WalletAccountTransaction;
 
 describe('TransactionName - WETH wrap/unwrap label', () => {
-    it('labels a wrap with the native symbol and the wrapped amount', () => {
-        const { getByText } = renderWithStoreProvider(
+    it('labels a wrap with the native symbol and the wrapped amount', async () => {
+        const { getByText } = await renderWithStoreProvider(
             <TransactionName transaction={wrapTx} isPending={false} />,
         );
 
         expect(getByText('Wrap ETH into 1 WETH')).toBeTruthy();
     });
 
-    it('labels an unwrap with the wrapped amount and the native symbol', () => {
-        const { getByText } = renderWithStoreProvider(
+    it('labels an unwrap with the wrapped amount and the native symbol', async () => {
+        const { getByText } = await renderWithStoreProvider(
             <TransactionName transaction={unwrapTx} isPending={false} />,
         );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14409,11 +14409,12 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.12.0"
     "@suite-native/formatters-config": "workspace:*"
     "@suite-native/test-utils": "workspace:*"
-    "@testing-library/react-native": "npm:13.3.3"
+    "@testing-library/react-native": "npm:14.0.1"
     "@trezor/utils": "workspace:*"
     react: "npm:19.2.3"
     react-native: "npm:0.86.0"
     react-redux: "npm:9.3.0"
+    test-renderer: "npm:1.2.0"
   languageName: unknown
   linkType: soft
 
@@ -14433,7 +14434,7 @@ __metadata:
     "@suite-native/analytics": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/services": "workspace:*"
-    "@testing-library/react-native": "npm:13.3.3"
+    "@testing-library/react-native": "npm:14.0.1"
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"
     react: "npm:19.2.3"
@@ -14444,6 +14445,7 @@ __metadata:
     react-native-reanimated: "npm:4.5.0"
     react-native-safe-area-context: "npm:~5.7.0"
     react-native-worklets: "npm:0.10.0"
+    test-renderer: "npm:1.2.0"
   languageName: unknown
   linkType: soft
 
@@ -16480,23 +16482,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react-native@npm:13.3.3":
-  version: 13.3.3
-  resolution: "@testing-library/react-native@npm:13.3.3"
+"@testing-library/react-native@npm:14.0.1":
+  version: 14.0.1
+  resolution: "@testing-library/react-native@npm:14.0.1"
   dependencies:
-    jest-matcher-utils: "npm:^30.0.5"
+    jest-matcher-utils: "npm:^30.4.1"
     picocolors: "npm:^1.1.1"
-    pretty-format: "npm:^30.0.5"
+    pretty-format: "npm:^30.4.1"
     redent: "npm:^3.0.0"
   peerDependencies:
     jest: ">=29.0.0"
-    react: ">=18.2.0"
-    react-native: ">=0.71"
-    react-test-renderer: ">=18.2.0"
+    react: ">=19.0.0"
+    react-native: ">=0.78"
+    test-renderer: ^1.0.0
   peerDependenciesMeta:
     jest:
       optional: true
-  checksum: 10/06aaddabbba401f9f322607aba5db859e25aab0007366bab5f540199af3c6e479b4920acf95433153a3a3c557ab008374bb86de2c94c5489159ab8f0b9576a09
+  checksum: 10/6f65b9566cce6f9737c3fff8beb0b6e7b623f3e440f286b0d652e2a8ae58eec854ec455ac297f6c736a3f7c289869c5f9fe07eddf4286f95751934a4fd27c3ee
   languageName: node
   linkType: hard
 
@@ -19132,6 +19134,15 @@ __metadata:
   peerDependencies:
     "@types/react": ^19.2.0
   checksum: 10/616c4a8aee250ea05fb1e7b98e7e00475dd3a6c1c30d7be18b4b93caba832f4203106b3a496a6b147e5acc2da14575eca47bce234c633bca1f8430ef8ffb234a
+  languageName: node
+  linkType: hard
+
+"@types/react-reconciler@npm:~0.33.0":
+  version: 0.33.0
+  resolution: "@types/react-reconciler@npm:0.33.0"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10/b65408e08f9e9924a6040fb7a4820ed12efdad598dccb9e08efc70a7101199cce4a5aa1f8695a82d8efe7b503bd9b8dc5122db8a23bac39f9bc473d595873ba4
   languageName: node
   linkType: hard
 
@@ -33100,7 +33111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:30.4.1, jest-matcher-utils@npm:^30.0.5":
+"jest-matcher-utils@npm:30.4.1, jest-matcher-utils@npm:^30.4.1":
   version: 30.4.1
   resolution: "jest-matcher-utils@npm:30.4.1"
   dependencies:
@@ -40101,7 +40112,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:30.4.1, pretty-format@npm:^30.0.0, pretty-format@npm:^30.0.5":
+"pretty-format@npm:30.4.1, pretty-format@npm:^30.0.0, pretty-format@npm:^30.4.1":
   version: 30.4.1
   resolution: "pretty-format@npm:30.4.1"
   dependencies:
@@ -41375,6 +41386,17 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
   checksum: 10/e7235fa08947296c2084a89dc264651fd7cb9dc3a26c3b132b84ecf2a30c46b9b98cd004c30adfe2a24741cd1e49a618858a48080008ce2b4e964a2c4233041e
+  languageName: node
+  linkType: hard
+
+"react-reconciler@npm:~0.33.0":
+  version: 0.33.0
+  resolution: "react-reconciler@npm:0.33.0"
+  dependencies:
+    scheduler: "npm:^0.27.0"
+  peerDependencies:
+    react: ^19.2.0
+  checksum: 10/eb8ddb8b5cfe850e022379df5330fad1871ab75dd7bc3a4e4c4fef7aa1b951b4cd784263186a0e5b01313de91b389499f95fc616f96b7d9e5dd33c13bdacb014
   languageName: node
   linkType: hard
 
@@ -45221,6 +45243,18 @@ __metadata:
     glob: "npm:^7.1.4"
     minimatch: "npm:^3.0.4"
   checksum: 10/8fccb2cb6c8fcb6bb4115394feb833f8b6cf4b9503ec2485c2c90febf435cac62abe882a0c5c51a37b9bbe70640cdd05acf5f45e486ac4583389f4b0855f69e5
+  languageName: node
+  linkType: hard
+
+"test-renderer@npm:1.2.0":
+  version: 1.2.0
+  resolution: "test-renderer@npm:1.2.0"
+  dependencies:
+    "@types/react-reconciler": "npm:~0.33.0"
+    react-reconciler: "npm:~0.33.0"
+  peerDependencies:
+    react: ^19.0.0
+  checksum: 10/65be16c35ce1e0e2cef6b6f28043de96954077c303016fad98feee5d8fafd81ca62c215d566780e99b0f80064c40a92364122fbc96ec672e647f3f40fc365830
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bumps @testing-library/react-native to 14.0.1. Upstream v14 makes render/hook/event/lifecycle APIs async, uses test-renderer for React 19.2, removes unsafe aliases, and tightens text/event validation. Risk is medium for native test/CI stability due to the broad migration, with no runtime impact. Test affected lint/type-check and requirements, rerun native units, and manually verify async press/input/animation plus rerender/unmount paths. Tracks https://github.com/trezor/trezor-suite/issues/30670

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deps-30670-testing-library-react-native/web/](https://dev.suite.sldev.cz/suite-web/chore/deps-30670-testing-library-react-native/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deps-30670-testing-library-react-native&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deps-30670-testing-library-react-native&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/deps-30670-testing-library-react-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T21:55:18.463Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T21:55:54.021Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->