### PR TITLE
Redact account data from Sentry reports and staking error toasts

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -40,6 +40,7 @@ import {
 } from '@suite-common/wallet-types';
 import {
     asAmountSubunit,
+    createSafeConnectError,
     getAddressParameters,
     getCardanoAccountPoolId,
     getDelegationCertificates,
@@ -60,7 +61,7 @@ import {
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type FeeLevel, PROTO } from '@trezor/connect';
 import type { EstimatedFee } from '@trezor/network-solana/types'; // TODO should be Cardano instead?
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, redactSensitiveDataFromString } from '@trezor/utils';
 
 const calculateTransaction = (
     availableBalance: string,
@@ -203,7 +204,8 @@ export const prepareTxPlan = async ({
         testnet: isTestnet(account.symbol),
     });
 
-    if (!response.success) throw new Error(response.error.message);
+    if (!response.success)
+        throw createSafeConnectError(response.error, 'cardanoComposeTransaction');
 
     return { txPlan: response.payload[0], certificates, withdrawals, selectedPool };
 };
@@ -382,12 +384,27 @@ export const signTransaction =
             return;
         }
 
-        const txData = await getTransactionData(
-            formValues,
-            selectedAccount,
-            cardanoPools,
-            stake.votingDelegation,
-        );
+        let txData;
+        try {
+            txData = await getTransactionData(
+                formValues,
+                selectedAccount,
+                cardanoPools,
+                stake.votingDelegation,
+            );
+        } catch (error) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'sign-tx-error',
+                    error:
+                        error instanceof Error
+                            ? redactSensitiveDataFromString(error.message)
+                            : 'Compose failed',
+                }),
+            );
+
+            return;
+        }
 
         if (!txData) {
             dispatch(
@@ -450,7 +467,7 @@ export const signTransaction =
                 dispatch(
                     notificationsActions.addToast({
                         type: 'sign-tx-error',
-                        error: signedTx.error.message,
+                        error: redactSensitiveDataFromString(signedTx.error.message),
                     }),
                 );
             }

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -45,6 +45,7 @@ import {
     getAccountIdentity,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type FeeLevel } from '@trezor/connect';
+import { redactSensitiveDataFromString } from '@trezor/utils';
 
 const calculateStakingTransaction = (
     availableBalance: string,
@@ -257,7 +258,7 @@ export const signTransaction =
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',
-                    error: signedTx.error.message,
+                    error: redactSensitiveDataFromString(signedTx.error.message),
                 }),
             );
 

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -21,6 +21,7 @@ import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 import { getSuiteVersion } from '@trezor/env-utils';
 import solana from '@trezor/network-solana/runtime';
+import { redactSensitiveDataFromString } from '@trezor/utils';
 
 const getSolanaUserAgent = () => `Trezor Suite ${getSuiteVersion()}`;
 
@@ -156,7 +157,7 @@ export const signTransaction =
                 dispatch(
                     notificationsActions.addToast({
                         type: 'sign-tx-error',
-                        error: signedTx.error.message,
+                        error: redactSensitiveDataFromString(signedTx.error.message),
                     }),
                 );
             }

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -51,7 +51,7 @@ import TrezorConnect from '@trezor/connect';
 import { asCoinSymbol } from '@trezor/connect-common';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { type Err } from '@trezor/type-utils';
-import { BigNumber } from '@trezor/utils';
+import { BigNumber, redactSensitiveDataFromString } from '@trezor/utils';
 
 import * as stakeFormCardanoActions from './stake/stakeFormCardanoActions';
 import * as stakeFormEthereumActions from './stake/stakeFormEthereumActions';
@@ -258,7 +258,7 @@ const pushTransaction =
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',
-                    error: sentTx.error.message,
+                    error: redactSensitiveDataFromString(sentTx.error.message),
                 }),
             );
 

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -52,6 +52,7 @@ export const useCardanoStaking = (): CardanoStaking => {
             if (!account) return;
 
             setLoading(true);
+
             try {
                 const composeRes = await prepareTxPlan({
                     account,
@@ -59,12 +60,15 @@ export const useCardanoStaking = (): CardanoStaking => {
                     cardanoPools,
                     votingDelegation,
                 });
+
                 if (composeRes?.txPlan) {
                     if (composeRes.txPlan.type === 'error') {
                         throw new Error(composeRes.txPlan.error);
                     }
+
                     setFee(composeRes.txPlan.fee);
                     setDeposit(composeRes.txPlan.deposit);
+
                     const actionAvailability: ActionAvailability =
                         composeRes.txPlan.type === 'final'
                             ? {
@@ -74,6 +78,7 @@ export const useCardanoStaking = (): CardanoStaking => {
                                   status: false,
                                   reason: 'TX_NOT_FINAL',
                               };
+
                     setDelegatingAvailable(actionAvailability);
                     seWithdrawingAvailable(actionAvailability);
                 }
@@ -85,6 +90,7 @@ export const useCardanoStaking = (): CardanoStaking => {
                     status: false,
                     reason: err.message,
                 };
+
                 setDelegatingAvailable(actionAvailability);
                 seWithdrawingAvailable(actionAvailability);
             }

--- a/packages/suite/src/hooks/earn/useClaimForm.ts
+++ b/packages/suite/src/hooks/earn/useClaimForm.ts
@@ -124,10 +124,14 @@ export const useClaimForm = ({ account }: UseClaimFormsProps): ClaimContextValue
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(signTransaction(values, composedTx));
+            try {
+                const result = await dispatch(signTransaction(values, composedTx));
 
-            if (result?.success) {
-                clearForm();
+                if (result?.success) {
+                    clearForm();
+                }
+            } catch (error) {
+                console.warn('Sign transaction unexpected error', error);
             }
         }
     }, [getValues, composedLevels, dispatch, clearForm, selectedFee]);

--- a/packages/suite/src/hooks/earn/useStakeForm.ts
+++ b/packages/suite/src/hooks/earn/useStakeForm.ts
@@ -351,11 +351,16 @@ export const useStakeForm = ({ account }: UseStakeFormProps): StakeContextValues
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
             setIsLoading(true);
-            const result = await dispatch(signTransaction(values, composedTx));
+            try {
+                const result = await dispatch(signTransaction(values, composedTx));
 
-            setIsLoading(false);
-            if (result?.success) {
-                clearForm();
+                if (result?.success) {
+                    clearForm();
+                }
+            } catch (error) {
+                console.warn('Sign transaction unexpected error', error);
+            } finally {
+                setIsLoading(false);
             }
         }
     }, [getValues, composedLevels, dispatch, clearForm, selectedFee]);

--- a/packages/suite/src/hooks/earn/useWithdrawalForm.ts
+++ b/packages/suite/src/hooks/earn/useWithdrawalForm.ts
@@ -274,10 +274,14 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(signTransaction(values, composedTx));
+            try {
+                const result = await dispatch(signTransaction(values, composedTx));
 
-            if (result?.success) {
-                clearForm();
+                if (result?.success) {
+                    clearForm();
+                }
+            } catch (error) {
+                console.warn('Sign transaction unexpected error', error);
             }
         }
     }, [getValues, composedLevels, dispatch, clearForm, selectedFee]);

--- a/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
@@ -70,15 +70,25 @@ export const useStakeCompose = <TFieldValues extends StakeFormState>({
 
             // store current request ID before async debounced process and compare it later. see explanation below
             const resultID = composeRequestIDRef.current;
-            const result = await debounce(() => {
-                if (Object.keys(errors).length > 0) {
-                    return Promise.resolve(undefined);
+            let result;
+            try {
+                result = await debounce(() => {
+                    if (Object.keys(errors).length > 0) {
+                        return Promise.resolve(undefined);
+                    }
+
+                    const values = getValues();
+
+                    return dispatch(composeTransaction(values, state));
+                });
+            } catch (error) {
+                console.warn('Compose unexpected error', error);
+                if (resultID === composeRequestIDRef.current) {
+                    setLoading(false);
                 }
 
-                const values = getValues();
-
-                return dispatch(composeTransaction(values, state));
-            });
+                return;
+            }
 
             // RACE-CONDITION NOTE:
             // resultID could be outdated when composeRequestID was updated by another upcoming/pending composeRequest and render tick didn't process it yet,

--- a/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
+++ b/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
@@ -110,10 +110,14 @@ export const useChangeDelegateForm = ({
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(signTransaction(values, composedTx));
+            try {
+                const result = await dispatch(signTransaction(values, composedTx));
 
-            if (result?.success) {
-                clearForm();
+                if (result?.success) {
+                    clearForm();
+                }
+            } catch (error) {
+                console.warn('Sign transaction unexpected error', error);
             }
         }
     }, [getValues, composedLevels, dispatch, clearForm, selectedFee]);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -52,6 +52,7 @@ export * from './objectPartition';
 export * from './parseElectrumUrl';
 export * from './parseHostname';
 export * from './promiseAllSequence';
+export * from './redactSensitiveData';
 export * from './redactUserPath';
 export * from './resolveAfter';
 export * from './safeParseUrl';

--- a/packages/utils/src/redactSensitiveData.test.ts
+++ b/packages/utils/src/redactSensitiveData.test.ts
@@ -1,0 +1,41 @@
+import { redactSensitiveDataFromString } from './redactSensitiveData';
+
+describe('redactSensitiveDataFromString', () => {
+    it('redacts a JSON payload embedded in an invalid parameter error', () => {
+        const message =
+            'Invalid parameter "account.utxo" (= [{"txid":"1f0e3dad99908345f7439f8ffabdffc4","address":"addr1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wxhxx9r9y","amount":"1000000"}]): Expected array';
+
+        expect(redactSensitiveDataFromString(message)).toBe(
+            'Invalid parameter "account.utxo" (= [redacted]): Expected array',
+        );
+    });
+
+    it('keeps bracketed text that carries no payload', () => {
+        expect(redactSensitiveDataFromString('[Info] device disconnected')).toBe(
+            '[Info] device disconnected',
+        );
+    });
+
+    it.each([
+        ['bech32 address', 'addr1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wxhxx9r9y'],
+        ['bitcoin address', 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'],
+        ['stake address', 'stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw'],
+        [
+            'extended public key',
+            'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL',
+        ],
+        ['ethereum address', '0x71C7656EC7ab88b098defB751B7401B5f6d8976F'],
+        ['transaction id', '1f0e3dad99908345f7439f8ffabdffc41f0e3dad99908345f7439f8ffabdffc4'],
+        ['solana address', '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM'],
+    ])('redacts %s', (_name, value) => {
+        expect(redactSensitiveDataFromString(`failed for ${value} at block 42`)).toBe(
+            'failed for [redacted] at block 42',
+        );
+    });
+
+    it('keeps messages without any account data intact', () => {
+        expect(redactSensitiveDataFromString('Device disconnected during action')).toBe(
+            'Device disconnected during action',
+        );
+    });
+});

--- a/packages/utils/src/redactSensitiveData.ts
+++ b/packages/utils/src/redactSensitiveData.ts
@@ -1,0 +1,18 @@
+const REDACTED = '[redacted]';
+
+// Only JSON-looking blobs are redacted, so that prose such as `[Info] failed` stays readable.
+const jsonBlobRegex = /[[{][\s\S]*[\]}]/g;
+const jsonBlobContentRegex = /["\d]/;
+
+const bech32Regex = /\b(?:addr_test1|addr1|stake_test1|stake1|bc1|tb1|ltc1)[02-9ac-hj-np-z]{10,}/gi;
+const extendedKeyRegex = /\b[xyztuv](?:pub|prv)[1-9A-HJ-NP-Za-km-z]{20,}/g;
+const longHexRegex = /\b(?:0x)?[0-9a-f]{40,}\b/gi;
+const base58Regex = /\b[1-9A-HJ-NP-Za-km-z]{32,}\b/g;
+
+export const redactSensitiveDataFromString = (text: string) =>
+    text
+        .replace(jsonBlobRegex, blob => (jsonBlobContentRegex.test(blob) ? REDACTED : blob))
+        .replace(extendedKeyRegex, REDACTED)
+        .replace(bech32Regex, REDACTED)
+        .replace(longHexRegex, REDACTED)
+        .replace(base58Regex, REDACTED);

--- a/suite-common/sentry/jest.config.js
+++ b/suite-common/sentry/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/sentry/package.json
+++ b/suite-common/sentry/package.json
@@ -8,9 +8,11 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@sentry/core": "10.69.0"
+        "@sentry/core": "10.69.0",
+        "@trezor/utils": "workspace:*"
     }
 }

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -1,4 +1,5 @@
 export * from './constants';
 export { ignoreErrorsCommon } from './ignoreErrors';
+export { redactSensitiveEventData } from './redactSensitiveEventData';
 export { redactSentryEvent } from './redactSentryEvent';
 export type { ChainableBeforeSend } from './types';

--- a/suite-common/sentry/src/redactSensitiveEventData.test.ts
+++ b/suite-common/sentry/src/redactSensitiveEventData.test.ts
@@ -1,0 +1,51 @@
+import { redactSensitiveEventData } from './redactSensitiveEventData';
+
+const descriptor =
+    'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL';
+
+describe('redactSensitiveEventData', () => {
+    it('redacts the payload embedded in an exception message', () => {
+        const event = redactSensitiveEventData({
+            type: undefined,
+            exception: {
+                values: [
+                    {
+                        type: 'Error',
+                        value: `Invalid parameter "account.utxo" (= [{"address":"addr1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wxhxx9r9y"}]): Expected array`,
+                    },
+                ],
+            },
+        });
+
+        expect(event?.exception?.values?.[0]?.value).toBe(
+            'Invalid parameter "account.utxo" (= [redacted]): Expected array',
+        );
+    });
+
+    it('redacts arguments captured from a console call', () => {
+        const event = redactSensitiveEventData({
+            type: undefined,
+            extra: { arguments: [{ message: `compose failed for ${descriptor}` }] },
+        });
+
+        expect(event?.extra).toEqual({ arguments: [{ message: 'compose failed for [redacted]' }] });
+    });
+
+    it('redacts the event message and breadcrumbs', () => {
+        const event = redactSensitiveEventData({
+            type: undefined,
+            message: `push failed: ${descriptor}`,
+            breadcrumbs: [{ message: `fetching ${descriptor}`, data: { descriptor } }],
+        });
+
+        expect(event?.message).toBe('push failed: [redacted]');
+        expect(event?.breadcrumbs?.[0]).toEqual({
+            message: 'fetching [redacted]',
+            data: { descriptor: '[redacted]' },
+        });
+    });
+
+    it('passes a filtered out event through', () => {
+        expect(redactSensitiveEventData(null)).toBeNull();
+    });
+});

--- a/suite-common/sentry/src/redactSensitiveEventData.ts
+++ b/suite-common/sentry/src/redactSensitiveEventData.ts
@@ -1,0 +1,68 @@
+import type { Breadcrumb, ErrorEvent } from '@sentry/core';
+
+import { redactSensitiveDataFromString } from '@trezor/utils';
+
+import { type ChainableBeforeSend } from './types';
+
+// Sentry normalizes captured objects to `normalizeDepth`, so deeper walking finds nothing.
+const MAX_DEPTH = 5;
+
+const redactValue = (value: unknown, depth = 0): unknown => {
+    if (typeof value === 'string') {
+        return redactSensitiveDataFromString(value);
+    }
+
+    if (value === null || typeof value !== 'object' || depth === MAX_DEPTH) {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(item => redactValue(item, depth + 1));
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [key, redactValue(item, depth + 1)]),
+    );
+};
+
+const redactBreadcrumb = (breadcrumb: Breadcrumb): Breadcrumb => ({
+    ...breadcrumb,
+    ...(breadcrumb.message === undefined
+        ? {}
+        : { message: redactSensitiveDataFromString(breadcrumb.message) }),
+    ...(breadcrumb.data === undefined
+        ? {}
+        : { data: redactValue(breadcrumb.data) as Breadcrumb['data'] }),
+});
+
+export const redactSensitiveEventData: ChainableBeforeSend = event => {
+    if (event === null) return null;
+
+    return {
+        ...event,
+        ...(typeof event.message === 'string'
+            ? { message: redactSensitiveDataFromString(event.message) }
+            : {}),
+        ...(event.exception === undefined
+            ? {}
+            : {
+                  exception: {
+                      ...event.exception,
+                      values: event.exception.values?.map(exceptionValue =>
+                          exceptionValue.value === undefined
+                              ? exceptionValue
+                              : {
+                                    ...exceptionValue,
+                                    value: redactSensitiveDataFromString(exceptionValue.value),
+                                },
+                      ),
+                  },
+              }),
+        ...(event.breadcrumbs === undefined
+            ? {}
+            : { breadcrumbs: event.breadcrumbs.map(redactBreadcrumb) }),
+        ...(event.extra === undefined
+            ? {}
+            : { extra: redactValue(event.extra) as ErrorEvent['extra'] }),
+    };
+};

--- a/suite-common/sentry/src/redactSentryEvent.ts
+++ b/suite-common/sentry/src/redactSentryEvent.ts
@@ -1,4 +1,5 @@
 import { ALLOW_REPORT_TAG, MAX_EVENTS_INTERVAL_LENGTH, MAX_EVENTS_PER_INTERVAL } from './constants';
+import { redactSensitiveEventData } from './redactSensitiveEventData';
 import { type ChainableBeforeSend } from './types';
 
 let eventCountThisSession = 0;
@@ -41,5 +42,5 @@ export const redactSentryEvent: ChainableBeforeSend = event => {
     }
 
     // whole event is sent after user confirms analytics (or a past decision is loaded)
-    return event;
+    return redactSensitiveEventData(event);
 };

--- a/suite-common/sentry/tsconfig.json
+++ b/suite-common/sentry/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": []
+    "references": [
+        { "path": "../../packages/utils" }
+    ]
 }

--- a/suite-common/wallet-utils/src/connectErrorUtils.test.ts
+++ b/suite-common/wallet-utils/src/connectErrorUtils.test.ts
@@ -1,0 +1,26 @@
+import { createSafeConnectError } from './connectErrorUtils';
+
+describe('createSafeConnectError', () => {
+    it('keeps the error code and drops the raw TrezorConnect message', () => {
+        const error = createSafeConnectError(
+            {
+                message:
+                    'Invalid parameter "account.utxo" (= [{"address":"addr1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wxhxx9r9y"}]): Expected array',
+                code: 'Method_InvalidParameter',
+            },
+            'cardanoComposeTransaction',
+        );
+
+        expect(error.message).toBe('cardanoComposeTransaction failed: Method_InvalidParameter');
+        expect(error.cause).toBe('Method_InvalidParameter');
+    });
+
+    it('names the method that failed', () => {
+        const error = createSafeConnectError(
+            { message: 'Device disconnected', code: 'Device_Disconnected' },
+            'cardanoSignTransaction',
+        );
+
+        expect(error.message).toBe('cardanoSignTransaction failed: Device_Disconnected');
+    });
+});

--- a/suite-common/wallet-utils/src/connectErrorUtils.ts
+++ b/suite-common/wallet-utils/src/connectErrorUtils.ts
@@ -1,0 +1,4 @@
+import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
+
+export const createSafeConnectError = (error: SerializedError, method: string) =>
+    new Error(`${method} failed: ${error.code}`, { cause: error.code });

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -34,6 +34,7 @@ export * from './wrappedNativePendingTxUtils';
 export * from './AmountTypes';
 export * from './baseCurrency';
 export * from './cardanoStakingUtils';
+export * from './connectErrorUtils';
 export * from './amountUtils';
 export * from './bigNumberUtils';
 export * from './feeUnitUtils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11142,6 +11142,7 @@ __metadata:
   resolution: "@suite-common/sentry@workspace:suite-common/sentry"
   dependencies:
     "@sentry/core": "npm:10.69.0"
+    "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Uncaught staking compose/sign failures rethrew TrezorConnect's raw error message, so account data could reach Sentry verbatim. The forms now report a safe error code instead, and Sentry events are scrubbed of addresses, keys and txids before leaving the app.

## Related Issue

Resolve (https://github.com/trezor/trezor-suite/issues/30046)