### PR TITLE
fix(suite-native-31828): fix E2E receive account selection

### DIFF
--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -84,7 +84,7 @@ export abstract class TradingFormActions extends TradingActions {
             .withTimeout(this.SHORT_TIMEOUT);
     }
 
-    async selectReceiveAccount(accountName: string, derivationPath?: string) {
+    async selectReceiveAccount(accountName: string, shouldSelectFreshAddress = false) {
         const receiveAccountPicker = this.getElementById('receive-account');
         await waitForVisible(receiveAccountPicker, { timeout: this.SHORT_TIMEOUT });
         await receiveAccountPicker.tap();
@@ -92,9 +92,11 @@ export abstract class TradingFormActions extends TradingActions {
         await waitForVisible(by.text(accountName));
         await element(by.text(accountName)).tap();
 
-        if (derivationPath) {
-            await waitForVisible(by.text(derivationPath));
-            await element(by.text(derivationPath)).tap();
+        if (shouldSelectFreshAddress) {
+            const freshAddressMatcher = by.id('@trading/account-list/fresh-address');
+
+            await waitForVisible(freshAddressMatcher);
+            await element(freshAddressMatcher).tap();
         }
 
         await detoxExpect(this.getElementById('receive-account/selected-account')).toHaveText(
@@ -102,8 +104,8 @@ export abstract class TradingFormActions extends TradingActions {
         );
     }
 
-    async selectBtcReceiveAccount(accountName: string, derivationPath: string) {
-        await this.selectReceiveAccount(accountName, derivationPath);
+    async selectBtcFreshAddress(accountName: string) {
+        await this.selectReceiveAccount(accountName, true);
         await this.expectReceiveAccountBalance('0 BTC');
     }
 

--- a/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingBuyFlow.test.ts
@@ -23,7 +23,7 @@ describe('Trade Buy [@noDevice]', () => {
 
     it('Basic buy for 100 PLN flow', async () => {
         await tradingBuyActions.selectReceiveAsset('BTC', undefined, 'Bitcoin');
-        await tradingBuyActions.selectBtcReceiveAccount('BTC SegWit', "m/84'/0'/0'/0/0");
+        await tradingBuyActions.selectBtcFreshAddress('BTC SegWit');
         await tradingBuyActions.selectFiatCurrency('PLN');
         await tradingBuyActions.setFiatAmount('100');
         await tradingBuyActions.selectCountry('Polan', 'Poland', 'POL');

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListBaseItem.tsx
@@ -94,6 +94,7 @@ export const AccountListBaseItem = ({
             onPress={onPress}
             accessibilityRole="button"
             accessibilityLabel={accountLabel}
+            testID={isFreshAddress ? '@trading/account-list/fresh-address' : undefined}
         >
             <HStack
                 alignItems="center"


### PR DESCRIPTION
## Description

- Add a stable test ID for the fresh-address option in the trading account list.
- Fix e2e

## Notes for QA

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31828

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31828-fix-e2e-receive-acc-select&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->