### PR TITLE
chore(suite-native): update expo prebuild default for SDK 57

### DIFF
--- a/.github/workflows/chore-purge-android-e2e-build.yml
+++ b/.github/workflows/chore-purge-android-e2e-build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app
-        run: yarn prebuild --platform android --clean
+        run: yarn prebuild --platform android
 
       - name: Sign message system config
         working-directory: ./suite-common/message-system

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app
-        run: yarn prebuild --platform android --clean
+        run: yarn prebuild --platform android
 
       - name: Sign message system config
         working-directory: ./suite-common/message-system

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Prebuild native expo project
         working-directory: ./suite-native/app
-        run: yarn prebuild --platform ios --clean
+        run: yarn prebuild --platform ios
 
       # Detox runtime may indirectly import the built config, and that would crash if message-system is not built
       - name: Sign message system config

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "native:android": "yarn workspace @suite-native/app android",
         "native:ios": "yarn workspace @suite-native/app ios",
         "native:prebuild": "yarn workspace @suite-native/app prebuild",
-        "native:prebuild:clean": "yarn workspace @suite-native/app prebuild:clean",
+        "native:prebuild:no-clean": "yarn workspace @suite-native/app prebuild:no-clean",
         "native:reverse-ports": "yarn workspace @suite-native/app reverse-ports",
         "ws": "./scripts/workspace-run.sh",
         "_______ Aliases _______": "Aliases for longer commands which we often have to run manually. Names don't have to be pretty or make total sense.",

--- a/suite-native/app/README.md
+++ b/suite-native/app/README.md
@@ -27,9 +27,9 @@ nix develop .#use_android
 
 ## Before you run the app
 
-1. Run `yarn native:prebuild:clean` to generate `ios/` and `android/` directories.
-    - You can prebuild for specific platform if you setup only Android/iOS: `yarn prebuild:clean --platform [android|ios]`
-    - It's necessary to re-run faster version of this command `yarn native:prebuild` (shortcut `yarn p`) on any change in native code (when you change branch/pull/rebase).
+1. Run `yarn native:prebuild` (shortcut `yarn p`) to generate `ios/` and `android/` directories.
+    - You can prebuild for specific platform if you setup only Android/iOS: `yarn prebuild --platform [android|ios]`
+    - It's necessary to re-run faster version of this command `yarn native:prebuild:no-clean` on any change in native code (when you change branch/pull/rebase).
 
 ## Running app on Android
 
@@ -107,7 +107,7 @@ Whenever you do a change in a native code (updating native dependency and so on)
 ## Troubleshooting
 
 1. For any issues with the build, try to clean the project and rebuild it:
-    - `yarn native:prebuild:clean`
+    - `yarn native:prebuild`
     - `yarn native:android` or `yarn native:ios`
 2. In case of issues with the packager, try to restart it with `--reset-cache` i.e (`yarn s --reset-cache`).
 3. If metro crashes after running `yarn start` on iOS, try running `watchman watch-del-all` to clear stale file‑watch state.

--- a/suite-native/app/e2e/README.md
+++ b/suite-native/app/e2e/README.md
@@ -21,7 +21,7 @@ To run the tests locally, you need to have the following installed:
 With the debug config, the app is running in Expo dev-client and the JavaScript bundle is served from the local Metro server. This configuration is suitable for development and testing purposes because the Metro hot reloads make it easy to debug the test scenarios. To run the tests in debug mode, follow these steps:
 
 1. Navigate to the `suite-native/app` folder
-2. generate Expo native code with `yarn prebuild:clean`
+2. generate Expo native code with `yarn prebuild`
 3. Create a debug build:
     - (**Android**) `yarn build:e2e android.emu.debug`
     - (**iOS**) `yarn build:e2e ios.sim.debug`
@@ -37,7 +37,7 @@ With the debug config, the app is running in Expo dev-client and the JavaScript 
 To test the app in the release mode, you need to build the app with the release configuration. The JavaScript bundle is bundled within the app and the app is running in the standalone mode. To run the tests in the release mode, follow these steps:
 
 1. Navigate to the `suite-native/app` folder
-2. generate Expo native code with `yarn prebuild:clean`
+2. generate Expo native code with `yarn prebuild`
 3. Create a release build:
     - (**Android**) `yarn build:e2e android.emu.release`
     - (**iOS**) `yarn build:e2e ios.sim.release`
@@ -152,7 +152,7 @@ To run specific files in CI you can temporarily change the GH workflow `template
 
 #### How to make prebuild for one platform only?
 
-`yarn prebuild:clean --platform android`
+`yarn prebuild --platform android`
 
 #### How to find testIDs for screens?
 

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -25,7 +25,7 @@
         "prebuild": "expo prebuild",
         "eas-build-post-install": "yarn workspace @suite-common/message-system sign-config",
         "eas-build-on-success": "./eas-post-success.sh",
-        "prebuild:clean": "expo prebuild --clean",
+        "prebuild:no-clean": "expo prebuild --no-clean",
         "build:e2e": "detox build --configuration",
         "test:e2e": "node ./scripts/cleanArtifacts.js && tsx e2e/trezorDetoxRunner/index.ts",
         "test:e2e:android": "node ./scripts/cleanArtifacts.js && tsx e2e/trezorDetoxRunner/index.ts --config=e2e/trezorDetoxRunner/config/runner-android.config.js",


### PR DESCRIPTION
## Description

Expo SDK 57 (already in use, `expo: ~57.0.8`) flipped the `expo prebuild` default:

> `expo prebuild`: now clears and regenerates the native `android` and `ios` directories by default; pass `--no-clean` to apply changes to the existing folders instead

So `--clean` is now redundant, and the incremental variant needs to be opted into explicitly.

## Changes

- Dropped `--clean` from all `expo prebuild` calls (Android/iOS e2e app-build workflows + the Android e2e build purge job).
- Renamed `prebuild:clean` → `prebuild:no-clean` (`expo prebuild --no-clean`) and its root wrapper `native:prebuild:clean` → `native:prebuild:no-clean`.
- Updated `suite-native/app/README.md` and `suite-native/app/e2e/README.md` accordingly.

The `yarn p` alias stays mapped to `native:prebuild`, so it now follows the new default and does the full clean regeneration. The incremental variant is available explicitly as `yarn native:prebuild:no-clean`.

## Related Issue

n/a

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/matejrkiz/expo-prebuild-no-clean/web/](https://dev.suite.sldev.cz/suite-web/matejrkiz/expo-prebuild-no-clean/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=matejrkiz/expo-prebuild-no-clean&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=matejrkiz/expo-prebuild-no-clean&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejrkiz/expo-prebuild-no-clean&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T08:03:43.739Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-28T08:02:26.844Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->