### PR TITLE
chore(eslint): adopt remaining v10 recommended rules

### DIFF
--- a/networks/solana/network-solana/src/runtime/connect.ts
+++ b/networks/solana/network-solana/src/runtime/connect.ts
@@ -410,7 +410,7 @@ export const sendAndConfirmTransaction = async (rawTx: string, api: SolanaAPI) =
     } catch (error) {
         const errorMessage = getSendErrorMessage(error);
         if (errorMessage) {
-            throw new Error(errorMessage);
+            throw new Error(errorMessage, { cause: error });
         }
         throw error;
     }

--- a/networks/solana/network-solana/src/runtime/staking.ts
+++ b/networks/solana/network-solana/src/runtime/staking.ts
@@ -170,6 +170,7 @@ export const stake = async ({
     } catch (error) {
         throw new Error(
             `Solana staking: staking failed - ${error instanceof Error ? error.message : serializeError(error)}`,
+            { cause: error },
         );
     }
 };
@@ -336,6 +337,7 @@ export const unstake = async ({
     } catch (error) {
         throw new Error(
             `Solana staking: unstaking failed - ${error instanceof Error ? error.message : serializeError(error)}`,
+            { cause: error },
         );
     }
 };
@@ -403,6 +405,7 @@ export const claim = async ({
     } catch (error) {
         throw new Error(
             `Solana staking: claiming failed - ${error instanceof Error ? error.message : serializeError(error)}`,
+            { cause: error },
         );
     }
 };

--- a/packages/blockchain-link/src/workers/electrum/client/electrum.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/electrum.ts
@@ -69,7 +69,7 @@ export class ElectrumClient extends BatchingJsonRpcClient implements ElectrumAPI
             this.lastBlock = await (this as ElectrumAPI).request('blockchain.headers.subscribe');
         } catch (err) {
             this.socket = undefined;
-            throw new Error(`Communication with Electrum server failed: [${err}]`);
+            throw new Error(`Communication with Electrum server failed: [${err}]`, { cause: err });
         }
 
         this.keepAlive();

--- a/packages/blockchain-link/src/workers/electrum/client/electrum.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/electrum.ts
@@ -69,7 +69,9 @@ export class ElectrumClient extends BatchingJsonRpcClient implements ElectrumAPI
             this.lastBlock = await (this as ElectrumAPI).request('blockchain.headers.subscribe');
         } catch (err) {
             this.socket = undefined;
-            throw new Error(`Communication with Electrum server failed: [${err}]`, { cause: err });
+            throw Object.assign(new Error(`Communication with Electrum server failed: [${err}]`), {
+                cause: err,
+            });
         }
 
         this.keepAlive();

--- a/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
@@ -27,7 +27,7 @@ export class JsonRpcClient {
             await this.socket.connect(this);
         } catch (err) {
             this.socket = undefined;
-            throw new Error(`JSON RPC connection failed: [${err}]`);
+            throw new Error(`JSON RPC connection failed: [${err}]`, { cause: err });
         }
     }
 

--- a/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
@@ -27,7 +27,7 @@ export class JsonRpcClient {
             await this.socket.connect(this);
         } catch (err) {
             this.socket = undefined;
-            throw new Error(`JSON RPC connection failed: [${err}]`, { cause: err });
+            throw Object.assign(new Error(`JSON RPC connection failed: [${err}]`), { cause: err });
         }
     }
 

--- a/packages/blockchain-link/src/workers/stellar/index.ts
+++ b/packages/blockchain-link/src/workers/stellar/index.ts
@@ -327,8 +327,10 @@ const pushTransaction = async (
             e?.response?.data?.extras?.result_codes?.transaction || 'unknown';
         const opResultCode: string =
             e?.response?.data?.extras?.result_codes?.operations?.[0] || 'unknown';
-        throw new Error(
-            `transaction result code: ${txResultCode}, operation result code: ${opResultCode}`,
+        throw Object.assign(
+            new Error(
+                `transaction result code: ${txResultCode}, operation result code: ${opResultCode}`,
+            ),
             { cause: e },
         );
     }

--- a/packages/blockchain-link/src/workers/stellar/index.ts
+++ b/packages/blockchain-link/src/workers/stellar/index.ts
@@ -329,6 +329,7 @@ const pushTransaction = async (
             e?.response?.data?.extras?.result_codes?.operations?.[0] || 'unknown';
         throw new Error(
             `transaction result code: ${txResultCode}, operation result code: ${opResultCode}`,
+            { cause: e },
         );
     }
 };

--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -221,7 +221,7 @@ export class Status extends TypedEmitter<StatusEvents> {
             return this.processStatus(status);
         } catch (error) {
             this.log('error', `Status processing ${error.message}`);
-            throw new Error(`Status processing ${error.message}`);
+            throw new Error(`Status processing ${error.message}`, { cause: error });
         }
     }
 

--- a/packages/connect-common/src/data/thpSettings.test.ts
+++ b/packages/connect-common/src/data/thpSettings.test.ts
@@ -69,9 +69,9 @@ describe('data/thpSettings', () => {
         result = parseThpSettings({ manifest, thp: { pairingMethods: 1 } });
         expect(result).toEqual({ appName, pairingMethods });
         // @ts-expect-error invalid pairingMethods
-        result = parseThpSettings({ manifest, thp: { pairingMethods: ['Foo'] } });
+        parseThpSettings({ manifest, thp: { pairingMethods: ['Foo'] } });
         // @ts-expect-error invalid pairingMethods
-        result = parseThpSettings({ manifest, thp: { pairingMethods: [0] } });
+        parseThpSettings({ manifest, thp: { pairingMethods: [0] } });
 
         // @ts-expect-error invalid appName
         result = parseThpSettings({ thp: { appName: {} } });

--- a/packages/connect-examples/update-webextensions-sw.js
+++ b/packages/connect-examples/update-webextensions-sw.js
@@ -26,7 +26,7 @@ if (buildFolderIndex > -1) {
 
 rootPaths.forEach(dir => {
     const rootPath = path.join(__dirname, dir);
-    const buildPath = path.join(rootPath, 'build');
+    const buildPath = path.join(rootPath, buildFolder);
 
     fs.readdirSync(buildPath).forEach(p => {
         // Skip TypeScript source files - they should no longer exist

--- a/packages/connect-web/src/bootstrap/bootstrap.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap.ts
@@ -60,7 +60,7 @@ const getParams = () => {
 // ✅ Chrome 125+ / Opera 111+
 // ❌ Firefox / Safari / many WebViews / some Chromium forks
 const getUnpartitionedBroadcastChannel = async (channelName: string): Promise<BroadcastChannel> => {
-    let handle: { BroadcastChannel?: (name: string) => BroadcastChannel } | null = null;
+    let handle: { BroadcastChannel?: (name: string) => BroadcastChannel } | null;
     try {
         // @ts-expect-error - requestStorageAccess params not yet lib.dom.d.ts
         handle = await document.requestStorageAccess({ BroadcastChannel: true });

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -56,7 +56,7 @@ export const createPendingTransaction = (
             sequence: ins.sequence,
         })),
         vout: outputs.map((out, n) => {
-            let transformedAddresses: string[] = [];
+            let transformedAddresses: string[];
 
             if (out.address) {
                 transformedAddresses = [out.address];

--- a/packages/connect/src/api/firmware/parseFirmwareHeaders.ts
+++ b/packages/connect/src/api/firmware/parseFirmwareHeaders.ts
@@ -7,7 +7,7 @@ import type { VersionArray } from '@trezor/utils/src/versionUtils';
  */
 export const parseFirmwareHeaders = (buff: Buffer) => {
     const vendorHeader = buff.subarray(0, 4).toString('utf8');
-    let trezorImageHeader = '';
+    let trezorImageHeader: string;
 
     let restbuff: Buffer | undefined;
     if (vendorHeader === 'TRZV') {

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -470,8 +470,8 @@ export const getReleaseInfo = ({
 
     const changelog = getChangelog(releasesOfDevice, features);
 
-    let isNewer = false;
-    let requiresIntermediary = false;
+    let isNewer: boolean;
+    let requiresIntermediary: boolean;
 
     if (features.bootloader_mode && release.bootloader_version) {
         // Some old version of T1B1 do not report FW version in bootloader mode and some other devices do not

--- a/packages/connect/src/device/DeviceList.test.ts
+++ b/packages/connect/src/device/DeviceList.test.ts
@@ -267,7 +267,7 @@ describe('DeviceList', () => {
         let readCount = 0;
         const transport = createTestTransport({
             read: () => {
-                let res = '';
+                let res: string;
                 if (readCount === 0) {
                     // cancel response
                     res = '3f2323000300000000000000000000000000000000';

--- a/packages/connect/src/utils/accountUtils.ts
+++ b/packages/connect/src/utils/accountUtils.ts
@@ -100,7 +100,7 @@ export const getAccountLabel = (path: number[], coinInfo: CoinInfo) => {
 
 export const getPublicKeyLabel = (path: number[], coinInfo?: BitcoinNetworkInfo) => {
     let hasSegwit = false;
-    let coinLabel = 'Unknown coin';
+    let coinLabel: string;
     if (coinInfo) {
         coinLabel = coinInfo.label;
         hasSegwit = coinInfo.segwit;

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -122,6 +122,7 @@ const fetchRemoteJws = async (firmwareChannel?: FirmwareChannel): Promise<JwsInf
     } catch (error) {
         throw new Error(
             `Failed to fetch remote JWS: ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error },
         );
     }
 };

--- a/packages/device-authenticity/src/x509certificate.ts
+++ b/packages/device-authenticity/src/x509certificate.ts
@@ -72,7 +72,7 @@ const derToAsn1 = (byteArray: Uint8Array): Asn1 => {
     }
 
     function getLength() {
-        let length = 0;
+        let length: number;
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const positionByte: number = byteArray[position];
 

--- a/packages/e2e-utils/src/testCoverage/selectTestsByChangedFiles.ts
+++ b/packages/e2e-utils/src/testCoverage/selectTestsByChangedFiles.ts
@@ -63,6 +63,7 @@ const downloadCoverageMap = async (localFile: string): Promise<void> => {
         } else {
             throw new Error(
                 `Failed to download coverage map: ${err instanceof Error ? err.message : err}`,
+                { cause: err },
             );
         }
     }

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -124,10 +124,6 @@ export const javascriptConfig = [
 
             // Offs
             'no-undef': 'off', // Todo: write description
-            // New in ESLint 10 recommended config; adopt separately from the dependency upgrade.
-            'no-useless-assignment': 'off',
-            'preserve-caught-error': 'off',
-
             // Offs for Node.js
             'no-sync': 'off', // disallow use of synchronous methods (off by default)
             'no-process-exit': 'off', // disallow process.exit() (on by default in the node environment)

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -586,7 +586,7 @@ const checkReferer = ({
 }) => {
     const { referer } = request.headers;
     const referers = allowedReferer ?? [];
-    let isRefererAllowed = false;
+    let isRefererAllowed: boolean;
     // Allow all origins
     if (referers.includes('*')) {
         isRefererAllowed = true;

--- a/packages/node-utils/src/validateJsonSchema.ts
+++ b/packages/node-utils/src/validateJsonSchema.ts
@@ -16,13 +16,13 @@ export const validateJsonSchema = (config: string, schema: string) => {
     try {
         parsedConfig = JSON.parse(config);
     } catch (err) {
-        throw Error(`Invalid config JSON format: ${err.message}`);
+        throw Error(`Invalid config JSON format: ${err.message}`, { cause: err });
     }
 
     try {
         parsedSchema = JSON.parse(schema);
     } catch (err) {
-        throw Error(`Invalid schema JSON format: ${err.message}`);
+        throw Error(`Invalid schema JSON format: ${err.message}`, { cause: err });
     }
 
     const validate = ajv.compile(parsedSchema);

--- a/packages/protocol/src/protocol-thp/crypto/curve25519.ts
+++ b/packages/protocol/src/protocol-thp/crypto/curve25519.ts
@@ -177,8 +177,8 @@ export function curve25519(privateKey: Uint8Array, publicKey: Uint8Array): Buffe
         [x2, z2, x3, z3] = ladderOperation(ctx, x1, x2, z2, x3, z3);
     }
 
-    [x2, x3] = conditionalSwap(x2, x3, Boolean(swap));
-    [z2, z3] = conditionalSwap(z2, z3, Boolean(swap));
+    [x2] = conditionalSwap(x2, x3, Boolean(swap));
+    [z2] = conditionalSwap(z2, z3, Boolean(swap));
 
     const x = (pow(z2, p - 2n, p) * x2) % p;
 

--- a/packages/protocol/src/protocol-thp/crypto/curve25519.ts
+++ b/packages/protocol/src/protocol-thp/crypto/curve25519.ts
@@ -177,8 +177,10 @@ export function curve25519(privateKey: Uint8Array, publicKey: Uint8Array): Buffe
         [x2, z2, x3, z3] = ladderOperation(ctx, x1, x2, z2, x3, z3);
     }
 
-    [x2] = conditionalSwap(x2, x3, Boolean(swap));
-    [z2] = conditionalSwap(z2, z3, Boolean(swap));
+    // eslint-disable-next-line no-useless-assignment -- RFC 7748 assigns both outputs in the final swap.
+    [x2, x3] = conditionalSwap(x2, x3, Boolean(swap));
+    // eslint-disable-next-line no-useless-assignment -- RFC 7748 assigns both outputs in the final swap.
+    [z2, z3] = conditionalSwap(z2, z3, Boolean(swap));
 
     const x = (pow(z2, p - 2n, p) * x2) % p;
 

--- a/packages/requirements/src/workspaces.ts
+++ b/packages/requirements/src/workspaces.ts
@@ -32,7 +32,7 @@ export const listAllWorkspaces = (repoRoot: string): ReadonlyArray<WorkspaceEntr
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
 
-        throw new Error(`Failed to list workspaces in ${cacheKey}: ${message}`);
+        throw new Error(`Failed to list workspaces in ${cacheKey}: ${message}`, { cause: error });
     }
 
     const workspaces = rawOutput

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -252,7 +252,9 @@ export const createHttpReceiver = (options?: {
             } catch (error) {
                 const template = applyTemplate('Error');
                 response.end(template);
-                throw new Error(`Could not handle buy post request at ${request.url} : ${error}`);
+                throw new Error(`Could not handle buy post request at ${request.url} : ${error}`, {
+                    cause: error,
+                });
             }
         },
     ]);

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -154,6 +154,7 @@ const initModulesInner = <
 
                     throw new Error(
                         `Check if there is another instance of the Suite app running. ${err}`,
+                        { cause: err },
                     );
                 }
             }),

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -214,7 +214,7 @@ export const useTradingReceiveAddress = ({
         }
 
         if (!isNewAsset && persistedReceiveAddress && canUseNonSuiteAccount && symbol) {
-            let isValidForCurrentSymbol = false;
+            let isValidForCurrentSymbol: boolean;
 
             try {
                 isValidForCurrentSymbol = addressValidator.isAddressValid(

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx
@@ -43,7 +43,7 @@ export const TradingReceiveAddressModal = () => {
             if (cryptoId) {
                 const symbol =
                     cryptoIdToNetwork(cryptoId)?.symbol ?? cryptoIdToNativeCoinSymbol(cryptoId);
-                let isValid = true;
+                let isValid: boolean;
 
                 try {
                     isValid =

--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -74,7 +74,7 @@ export const SummaryCards = ({
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
 
     // Aggregate values from shown graph data.
-    const txsFromData = data.reduce((acc, d) => (acc += d.txs), 0);
+    const txsFromData = data.reduce((acc, d) => acc + d.txs, 0);
     // only fall back to account.history.total before graph data has loaded.
     const numOfTransactions = isGraphDataLoaded
         ? txsFromData

--- a/packages/transport-test/e2e/api/shared.ts
+++ b/packages/transport-test/e2e/api/shared.ts
@@ -28,6 +28,6 @@ export const sharedTest = async (description: string, callback: () => any) => {
         ]);
         success(description);
     } catch (e) {
-        throw new Error(error(e));
+        throw new Error(error(e), { cause: e });
     }
 };

--- a/packages/utils/src/typedObjectKeys.type-test.ts
+++ b/packages/utils/src/typedObjectKeys.type-test.ts
@@ -4,11 +4,8 @@ type AB = { a: 'A'; b: 'B' } | { b: 'BB' };
 
 type ExpectedType = 'a' | 'b';
 
-let _assertExpectedType: ExpectedType[];
+const assertExpectedType1: ExpectedType[] = typedObjectKeys({ b: 'BB' } satisfies AB);
+const assertExpectedType2: ExpectedType[] = typedObjectKeys({ a: 'A', b: 'B' } satisfies AB);
 
-const test1 = typedObjectKeys({ b: 'BB' } satisfies AB);
-_assertExpectedType = test1;
-const test2 = typedObjectKeys({ a: 'A', b: 'B' } satisfies AB);
-_assertExpectedType = test2;
-
-void _assertExpectedType;
+void assertExpectedType1;
+void assertExpectedType2;

--- a/packages/utils/src/typedObjectValues.type-test.ts
+++ b/packages/utils/src/typedObjectValues.type-test.ts
@@ -4,11 +4,8 @@ type AB = { a: 'A'; b: 'B' } | { b: 'BB' };
 
 type ExpectedType = 'BB' | 'B' | 'A';
 
-let _assertExpectedType: ExpectedType[];
+const assertExpectedType1: ExpectedType[] = typedObjectValues({ b: 'BB' } satisfies AB);
+const assertExpectedType2: ExpectedType[] = typedObjectValues({ a: 'A', b: 'B' } satisfies AB);
 
-const test1 = typedObjectValues({ b: 'BB' } satisfies AB);
-_assertExpectedType = test1;
-const test2 = typedObjectValues({ a: 'A', b: 'B' } satisfies AB);
-_assertExpectedType = test2;
-
-void _assertExpectedType;
+void assertExpectedType1;
+void assertExpectedType2;

--- a/packages/utxo-lib/src/payments/p2tr.ts
+++ b/packages/utxo-lib/src/payments/p2tr.ts
@@ -146,7 +146,6 @@ export function p2tr(a: Payment, opts?: PaymentOpts): Payment {
         if (a.pubkey) {
             const pkh = tapTweakPubkey(liftX(a.pubkey)).pubkey;
             if (hash.length > 0 && !hash.equals(pkh)) throw new TypeError('Hash mismatch');
-            else hash = pkh;
             if (!ecc.isPoint(Buffer.concat([EVEN_Y_COORD_PREFIX, liftX(a.pubkey)])))
                 throw new TypeError('Invalid pubkey for p2tr');
         }

--- a/packages/utxo-lib/src/payments/p2wsh.ts
+++ b/packages/utxo-lib/src/payments/p2wsh.ts
@@ -196,7 +196,6 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
                 // match hash against other sources
                 const hash2 = bcrypto.sha256(a.redeem.output);
                 if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
-                else hash = hash2;
             }
 
             if (a.redeem.input && !bscript.isPushOnly(_rchunks()))

--- a/packages/utxo-lib/src/txWeightCalculator.ts
+++ b/packages/utxo-lib/src/txWeightCalculator.ts
@@ -85,10 +85,8 @@ export class TxWeightCalculator {
             const n = input.multisig.nodes
                 ? input.multisig.nodes.length
                 : input.multisig.pubkeys.length;
-            let multisig_script_size = _TXSIZE_MULTISIGSCRIPT + n * (1 + _TXSIZE_PUBKEY);
-            if (SEGWIT_INPUT_SCRIPT_TYPES.includes(input.script_type)) {
-                multisig_script_size += getVarIntSize(multisig_script_size);
-            } else {
+            if (!SEGWIT_INPUT_SCRIPT_TYPES.includes(input.script_type)) {
+                let multisig_script_size = _TXSIZE_MULTISIGSCRIPT + n * (1 + _TXSIZE_PUBKEY);
                 multisig_script_size += getOpPushSize(multisig_script_size);
                 input_script_size =
                     1 + // the OP_FALSE bug in multisig

--- a/packages/utxo-lib/src/txWeightCalculator.ts
+++ b/packages/utxo-lib/src/txWeightCalculator.ts
@@ -85,8 +85,11 @@ export class TxWeightCalculator {
             const n = input.multisig.nodes
                 ? input.multisig.nodes.length
                 : input.multisig.pubkeys.length;
-            if (!SEGWIT_INPUT_SCRIPT_TYPES.includes(input.script_type)) {
-                let multisig_script_size = _TXSIZE_MULTISIGSCRIPT + n * (1 + _TXSIZE_PUBKEY);
+            let multisig_script_size = _TXSIZE_MULTISIGSCRIPT + n * (1 + _TXSIZE_PUBKEY);
+            if (SEGWIT_INPUT_SCRIPT_TYPES.includes(input.script_type)) {
+                // eslint-disable-next-line no-useless-assignment -- Fixed separately in #31838.
+                multisig_script_size += getVarIntSize(multisig_script_size);
+            } else {
                 multisig_script_size += getOpPushSize(multisig_script_size);
                 input_script_size =
                     1 + // the OP_FALSE bug in multisig

--- a/scripts/ci/npm-reserve-package.js
+++ b/scripts/ci/npm-reserve-package.js
@@ -134,7 +134,7 @@ const removeLatestDistTag = packageName => {
         { encoding: 'utf-8' },
     );
 
-    let distTags = {};
+    let distTags;
     try {
         distTags = JSON.parse(stdout);
     } catch {

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -210,6 +210,6 @@ export const connectInitThunk = createThunk<
         } else {
             formattedError = error.code ? `${error.code}: ${error.message}` : error.message;
         }
-        throw new Error(formattedError);
+        throw new Error(formattedError, { cause: error });
     }
 });

--- a/suite-common/staking/src/ethereumStaking.ts
+++ b/suite-common/staking/src/ethereumStaking.ts
@@ -358,7 +358,7 @@ export const stake = async ({
             data,
         };
     } catch (e) {
-        throw new Error(e);
+        throw new Error(e, { cause: e });
     }
 };
 
@@ -429,7 +429,7 @@ export const unstake = async ({
             data,
         };
     } catch (error) {
-        throw new Error(error);
+        throw new Error(error, { cause: error });
     }
 };
 
@@ -492,7 +492,7 @@ export const claimWithdrawRequest = async ({
             data,
         };
     } catch (error) {
-        throw new Error(error);
+        throw new Error(error, { cause: error });
     }
 };
 

--- a/suite-common/suite-utils/src/date.ts
+++ b/suite-common/suite-utils/src/date.ts
@@ -18,12 +18,10 @@ export const formatDurationStrict = (seconds: number, locale?: Locale) =>
     formatDistanceStrict(0, seconds * 1000, { locale });
 
 export const calcTicks = (startDate: Date, endDate: Date) => {
-    let timestamps = [];
-    if (differenceInMonths(endDate, startDate) <= 1) {
-        timestamps = eachDayOfInterval({ start: startDate, end: endDate });
-    } else {
-        timestamps = eachMonthOfInterval({ start: startDate, end: endDate });
-    }
+    const timestamps =
+        differenceInMonths(endDate, startDate) <= 1
+            ? eachDayOfInterval({ start: startDate, end: endDate })
+            : eachMonthOfInterval({ start: startDate, end: endDate });
 
     return timestamps;
 };

--- a/suite-common/token-definitions/scripts/utils/fetchCoins.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchCoins.ts
@@ -247,7 +247,7 @@ export const fetchAllCoins = async (): Promise<CoinData[]> => {
         return data;
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        throw new Error(`fetchAllCoins error: ${message}`);
+        throw new Error(`fetchAllCoins error: ${message}`, { cause: err });
     }
 };
 

--- a/suite-common/token-definitions/scripts/utils/fetchNft.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchNft.ts
@@ -32,7 +32,7 @@ const fetchNftPage = async (page: number, assetPlatformId: string): Promise<NftD
 
         return await response.json();
     } catch (error) {
-        throw new Error(error);
+        throw new Error(error, { cause: error });
     }
 };
 

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -130,7 +130,7 @@ export const handleExchangeRequestThunk = createThunk<
             dispatch(tradingExchangeActions.clearQuotes());
         }
 
-        let allQuotes: ExchangeTrade[] = [];
+        let allQuotes: ExchangeTrade[];
         let requestSucceeded = false;
         try {
             allQuotes = (await getQuotesRequest({ requestData, signal })) ?? [];

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -109,7 +109,7 @@ export const handleSellRequestThunk = createThunk<
             return rejectWithValue('Invalid request data');
         }
 
-        let allQuotes: SellFiatTrade[] = [];
+        let allQuotes: SellFiatTrade[];
         let requestSucceeded = false;
         try {
             allQuotes = (await getQuotesRequest({ requestData, signal })) ?? [];

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -102,7 +102,7 @@ const createAccount = createAction(
             return { payload };
         } catch (error) {
             console.error('Error creating account payload:', error);
-            throw new Error('Failed to create account payload');
+            throw new Error('Failed to create account payload', { cause: error });
         }
     },
 );

--- a/suite-native/firmware/src/components/FirmwareChangelog.tsx
+++ b/suite-native/firmware/src/components/FirmwareChangelog.tsx
@@ -39,12 +39,10 @@ export const FirmwareChangelog = ({ ref, onClose }: FirmwareChangelogProps) => {
             );
         }
 
-        let firmwareChangelogLines: string[] = [];
-        if (typeof firmwareChangelog === 'string') {
-            firmwareChangelogLines = firmwareChangelog.split('\n');
-        } else {
-            firmwareChangelogLines = firmwareChangelog;
-        }
+        const firmwareChangelogLines =
+            typeof firmwareChangelog === 'string'
+                ? firmwareChangelog.split('\n')
+                : firmwareChangelog;
 
         return firmwareChangelogLines.map((text, index) => {
             const key = text + index;

--- a/suite-native/intl/src/utils.ts
+++ b/suite-native/intl/src/utils.ts
@@ -108,7 +108,6 @@ export const deleteNestedTranslationKey = (obj: Record<string, any>, path: strin
             break;
         }
 
-        currentNode = node;
         parent = parents.pop();
     }
 };

--- a/suite/e2e/support/device.ts
+++ b/suite/e2e/support/device.ts
@@ -174,7 +174,7 @@ export class DeviceFixture {
             raw = JSON.parse(debugState.tokens.join(''));
         } catch (error) {
             throw new Error(`Failed to parse display content JSON: ${debugState.tokens.join('')}`, {
-                cause: error as Error,
+                cause: error,
             });
         }
 


### PR DESCRIPTION
## Description

Enable ESLint 10's no-useless-assignment and preserve-caught-error recommended rules, resolving the existing findings. Risk is medium because dead-store cleanup touches crypto and transaction code while preserved causes can change error observability; review confidential-data reporting and run affected lint, type checks, and focused protocol, UTXO, and Connect tests. This is stacked on #31823 and tracks https://github.com/trezor/trezor-suite/issues/30670.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/eslint-adopt-v10-recommended-rules/web/](https://dev.suite.sldev.cz/suite-web/chore/eslint-adopt-v10-recommended-rules/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/eslint-adopt-v10-recommended-rules&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/eslint-adopt-v10-recommended-rules&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/eslint-adopt-v10-recommended-rules&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T11:32:11.052Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T11:32:13.549Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->