### PR TITLE
WIP: diagnose hanging Android E2E open handles

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -38,6 +38,7 @@ on:
 jobs:
   run_android_e2e_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +129,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Run Detox E2E Android tests
+        timeout-minutes: 50
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
         env:
           RUNNER_TEMP: /tmp

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TEST_GROUP: [0, 1, 2, 3, 4]
+        TEST_GROUP: [0]
 
     steps:
       - name: Checkout project
@@ -157,7 +157,7 @@ jobs:
           cores: 4
           heap-size: 512M
           script: |
-            yarn test:e2e --config=${{ inputs.runner_config }} --shard=${{ matrix.TEST_GROUP }} --totalShards=5 --headless --quarantine
+            yarn test:e2e --config=${{ inputs.runner_config }} --project=T3T1 --headless e2e/tests/tradingExchangeFlow.test.ts
 
       - name: Post Currents link
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}

--- a/suite-native/app/e2e/trezorDetoxRunner/detox.ts
+++ b/suite-native/app/e2e/trezorDetoxRunner/detox.ts
@@ -37,6 +37,7 @@ const runDetox = (
         if (testFiles && testFiles.length > 0) {
             args.push(...testFiles);
         }
+        args.push('--', '--detectOpenHandles');
 
         const child = spawn('npx', args, { stdio: 'inherit', env });
 


### PR DESCRIPTION
# DO NOT MERGE

## Description

Diagnostic-only PR for collecting evidence about the Android E2E process that sometimes remains alive after Jest prints its summary.

- Runs only e2e/tests/tradingExchangeFlow.test.ts for the T3T1 project.
- Reduces the Android matrix to one job.
- Passes --detectOpenHandles through Detox to Jest.
- Keeps the 50-minute step and 60-minute job timeouts from the base branch.

The goal is to identify the asynchronous handle preventing Jest and the custom runner from exiting. The changes are intentionally hardcoded and must not be merged.

## Notes for QA

No product QA is needed. Inspect the Android E2E CI log for the open-handle report. If the intermittent failure does not reproduce, rerun the job.

## Related Issue

N/A

## Screenshots

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/wip-mobile-e2e-detect-open-handles&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->