### PR TITLE
refactor(redux): add WithServices dependency contracts

### DIFF
--- a/eslint-local-rules/no-unused-intersection-members/README.md
+++ b/eslint-local-rules/no-unused-intersection-members/README.md
@@ -25,22 +25,25 @@ without it.
 3. **Account for structural composition.** A required type can be satisfied by properties spread
    across multiple intersection members. The rule recursively compares their combined properties
    rather than checking each member only in isolation.
-4. **Include transitive thunk requirements.** Dispatching a child thunk implicitly requires the
+4. **Look through service containers.** `WithServices<LoggerDep & StorageDep>` moves the intersection
+   below the `services` property but does not make it a single capability. The inner dependency
+   members are checked against usages such as `deps.services.logger` and child-thunk requirements.
+5. **Include transitive thunk requirements.** Dispatching a child thunk implicitly requires the
    child's `state` and `extra` types. Those requirements count even if the parent thunk never calls
    `getState()` or reads `extra` itself.
-5. **Prefer false negatives over false positives.** When the analysis cannot prove which member is
+6. **Prefer false negatives over false positives.** When the analysis cannot prove which member is
    needed, it keeps the whole contract. The rule should suggest a removal only when that removal is
    demonstrably safe for every usage visible in the file.
-6. **Stay local and predictable.** Candidates are direct type aliases in the current source file,
-   must be intersections, and must end in `State` or `Deps`. Usage collection is file-local: a
-   consumer needing an additional capability should declare it at the consumer instead of relying on
-   a broader upstream alias. This avoids turning lint into an open-ended whole-program dependency
-   analysis.
+7. **Stay local and predictable.** Candidates are type aliases in the current source file, must end
+   in `State` or `Deps`, and must contain either a direct intersection or an intersection inside a
+   transparent `services` container. Usage collection is file-local: a consumer needing an
+   additional capability should declare it at the consumer instead of relying on a broader upstream
+   alias. This avoids turning lint into an open-ended whole-program dependency analysis.
 
 ### Analysis stages
 
-1. At `Program:exit`, collect matching aliases and resolve every intersection member with the
-   TypeScript type checker.
+1. At `Program:exit`, collect matching aliases and resolve every direct or service-wrapped
+   intersection member with the TypeScript type checker.
 2. Mark contracts as opaque when they enter a generic context that the rule cannot safely interpret.
 3. Read `createThunk` configuration and add the state/dependency requirements of dispatched child
    thunks.

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -51,6 +51,20 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
         {
             filename: typeAwareTestFilename,
             code: `
+                    type WithServices<Services extends object> = { services: Services };
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunDeps = WithServices<LoggerDep & StorageDep>;
+
+                    const run = (deps: RunDeps) => {
+                        deps.services.logger.log();
+                        deps.services.storage.save();
+                    };
+                `,
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
                     type AccountsRootState = { accounts: { selected: string } };
                     type SettingsRootState = { settings: { enabled: boolean } };
                     type RunState = AccountsRootState & SettingsRootState;
@@ -173,6 +187,66 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                     );
                 `,
         },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type WithServices<Services extends object> = { services: Services };
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type ParentDeps = WithServices<LoggerDep & StorageDep>;
+                    type ChildAction = (
+                        dispatch: unknown,
+                        getState: () => unknown,
+                        extra: WithServices<StorageDep>,
+                    ) => void;
+
+                    declare const childThunk: () => ChildAction;
+                    declare const createThunk: <Result, Payload, Config>(
+                        name: string,
+                        callback: (
+                            payload: Payload,
+                            api: {
+                                dispatch: (action: ChildAction) => unknown;
+                                extra: Config extends { extra: infer Deps } ? Deps : never;
+                            },
+                        ) => Result,
+                    ) => unknown;
+
+                    createThunk<void, void, { extra: ParentDeps }>(
+                        'parent',
+                        (_, { dispatch, extra }) => {
+                            extra.services.logger.log();
+                            dispatch(childThunk());
+                        },
+                    );
+                `,
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type WithServices<Services extends object> = { services: Services };
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type ParentDeps = WithServices<LoggerDep & StorageDep>;
+                    type ChildAction = (
+                        dispatch: unknown,
+                        getState: () => unknown,
+                        extra: WithServices<StorageDep>,
+                    ) => void;
+
+                    declare const childThunk: () => ChildAction;
+
+                    const parentThunk = () =>
+                        (
+                            dispatch: (action: ChildAction) => unknown,
+                            _getState: () => unknown,
+                            extra: ParentDeps,
+                        ) => {
+                            extra.services.logger.log();
+                            dispatch(childThunk());
+                        };
+                `,
+        },
     ],
     invalid: [
         {
@@ -224,6 +298,45 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
                     messageId: 'unusedIntersectionMember',
                     data: { memberName: 'AnalyticsDep', typeName: 'RunDeps' },
                 },
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDep', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type WithServices<Services extends object> = { services: Services };
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunDeps = WithServices<LoggerDep & StorageDep>;
+
+                    const run = (deps: RunDeps) => deps.services.logger.log();
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'StorageDep', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            filename: typeAwareTestFilename,
+            code: `
+                    type WithServices<Services extends object> = { services: Services };
+                    type LoggerDep = { logger: { log: () => void } };
+                    type StorageDep = { storage: { save: () => void } };
+                    type RunDeps = WithServices<LoggerDep & StorageDep> & {
+                        thunks: { finish: () => void };
+                    };
+
+                    const run = (deps: RunDeps) => {
+                        deps.services.logger.log();
+                        deps.thunks.finish();
+                    };
+                `,
+            errors: [
                 {
                     messageId: 'unusedIntersectionMember',
                     data: { memberName: 'StorageDep', typeName: 'RunDeps' },

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -26,6 +26,7 @@ type IntersectionContract = {
     isOpaque: boolean;
     members: IntersectionMember[];
     name: string;
+    rootPath: string[];
     symbol: ts.Symbol;
     usages: ContractUsage[];
 };
@@ -50,15 +51,18 @@ const isNodeDeclarationName = (node: ts.Node) =>
     !ts.isShorthandPropertyAssignment(node.parent) &&
     (node.parent as ts.Node & { name?: ts.Node }).name === node;
 
-const getAliasedContract = (
+const getAliasedContracts = (
     node: ts.Expression,
-    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract>,
+    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
     checker: ts.TypeChecker,
 ) => {
     const type = checker.getTypeAtLocation(node);
 
-    return type.aliasSymbol === undefined ? undefined : contractsBySymbol.get(type.aliasSymbol);
+    return type.aliasSymbol === undefined ? [] : (contractsBySymbol.get(type.aliasSymbol) ?? []);
 };
+
+const doesPathStartWith = (path: readonly string[], prefix: readonly string[]) =>
+    prefix.every((part, index) => path[index] === part);
 
 const getExpectedArgumentType = (
     callExpression: ts.CallExpression | ts.NewExpression,
@@ -90,6 +94,82 @@ const isTransparentExpression = (node: ts.Node, expression: ts.Expression) =>
         ts.isAwaitExpression(node)) &&
     node.expression === expression;
 
+const getPropertyType = (type: ts.Type, propertyName: string, checker: ts.TypeChecker) => {
+    const property = checker.getPropertyOfType(type, propertyName);
+
+    if (property === undefined) {
+        return undefined;
+    }
+
+    const declaration =
+        property.valueDeclaration ?? property.declarations?.[0] ?? type.symbol?.valueDeclaration;
+
+    return declaration === undefined
+        ? undefined
+        : checker.getTypeOfSymbolAtLocation(property, declaration);
+};
+
+const getTypeAtPath = (type: ts.Type, path: readonly string[], checker: ts.TypeChecker) => {
+    let currentType: ts.Type | undefined = type;
+
+    for (const propertyName of path) {
+        currentType = getPropertyType(currentType, propertyName, checker);
+
+        if (currentType === undefined) {
+            return undefined;
+        }
+    }
+
+    return currentType;
+};
+
+const normalizeContractUsage = (
+    usage: ContractUsage,
+    contract: IntersectionContract,
+    checker: ts.TypeChecker,
+): ContractUsage | undefined => {
+    if (doesPathStartWith(usage.path, contract.rootPath)) {
+        return {
+            path: usage.path.slice(contract.rootPath.length),
+            requiredType: usage.requiredType,
+        };
+    }
+
+    if (!doesPathStartWith(contract.rootPath, usage.path)) {
+        return undefined;
+    }
+
+    const remainingRootPath = contract.rootPath.slice(usage.path.length);
+    const { requiredType } = usage;
+
+    if (requiredType === undefined) {
+        return undefined;
+    }
+
+    if ((requiredType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0) {
+        // An untyped receiver could inspect any nested capability, so keep every member.
+        return { path: [], requiredType };
+    }
+
+    const requiredTypeAtRoot = getTypeAtPath(requiredType, remainingRootPath, checker);
+
+    return requiredTypeAtRoot === undefined
+        ? undefined
+        : { path: [], requiredType: requiredTypeAtRoot };
+};
+
+const recordContractUsage = (
+    usage: ContractUsage,
+    contract: IntersectionContract,
+    checker: ts.TypeChecker,
+) => {
+    const normalizedUsage = normalizeContractUsage(usage, contract, checker);
+
+    if (normalizedUsage !== undefined) {
+        contract.usages.push(normalizedUsage);
+    }
+};
+
 const addContractUsage = (
     rootExpression: ts.Expression,
     contract: IntersectionContract,
@@ -119,8 +199,14 @@ const addContractUsage = (
                 continue;
             }
 
-            // A runtime key can reach any part of the contract, so no member is provably unused.
-            contract.isOpaque = true;
+            // A runtime key can reach any part below its current path. It makes this contract
+            // opaque only when that path contains, or could still reach, the contract root.
+            if (
+                doesPathStartWith(path, contract.rootPath) ||
+                doesPathStartWith(contract.rootPath, path)
+            ) {
+                contract.isOpaque = true;
+            }
 
             return;
         }
@@ -147,7 +233,7 @@ const addContractUsage = (
             return;
         }
 
-        contract.usages.push({ path, requiredType });
+        recordContractUsage({ path, requiredType }, contract, checker);
 
         return;
     }
@@ -163,10 +249,14 @@ const addContractUsage = (
             return;
         }
 
-        contract.usages.push({
-            path,
-            requiredType: checker.getTypeAtLocation(terminalExpression),
-        });
+        recordContractUsage(
+            {
+                path,
+                requiredType: checker.getTypeAtLocation(terminalExpression),
+            },
+            contract,
+            checker,
+        );
 
         return;
     }
@@ -178,22 +268,7 @@ const addContractUsage = (
         return;
     }
 
-    contract.usages.push({ path });
-};
-
-const getPropertyType = (type: ts.Type, propertyName: string, checker: ts.TypeChecker) => {
-    const property = checker.getPropertyOfType(type, propertyName);
-
-    if (property === undefined) {
-        return undefined;
-    }
-
-    const declaration =
-        property.valueDeclaration ?? property.declarations?.[0] ?? type.symbol?.valueDeclaration;
-
-    return declaration === undefined
-        ? undefined
-        : checker.getTypeOfSymbolAtLocation(property, declaration);
+    recordContractUsage({ path }, contract, checker);
 };
 
 const getTypesAtPath = (
@@ -328,18 +403,18 @@ const isCreateThunkCall = (node: ts.CallExpression) =>
 // property path. createThunk is excluded because its state and extra contracts are handled below.
 const markContractsUsedByGenericCallsAsOpaque = (
     sourceFile: ts.SourceFile,
-    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract>,
+    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
     checker: ts.TypeChecker,
 ) => {
     const visitTypeNode = (node: ts.Node) => {
         if (ts.isTypeReferenceNode(node)) {
             const type = checker.getTypeFromTypeNode(node);
-            const contract =
+            const contracts =
                 type.aliasSymbol === undefined
-                    ? undefined
-                    : contractsBySymbol.get(type.aliasSymbol);
+                    ? []
+                    : (contractsBySymbol.get(type.aliasSymbol) ?? []);
 
-            if (contract !== undefined) {
+            for (const contract of contracts) {
                 contract.isOpaque = true;
             }
         }
@@ -362,16 +437,16 @@ const markContractsUsedByGenericCallsAsOpaque = (
     ts.forEachChild(sourceFile, visitNode);
 };
 
-const getConfigContract = (
+const getConfigContracts = (
     createThunkCall: ts.CallExpression,
     propertyName: 'extra' | 'state',
-    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract>,
+    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
     checker: ts.TypeChecker,
 ) => {
     const configTypeNode = createThunkCall.typeArguments?.[2];
 
     if (configTypeNode === undefined || !ts.isTypeLiteralNode(configTypeNode)) {
-        return undefined;
+        return [];
     }
 
     const property = configTypeNode.members.find(
@@ -386,14 +461,14 @@ const getConfigContract = (
         !ts.isPropertySignature(property) ||
         property.type === undefined
     ) {
-        return undefined;
+        return [];
     }
 
     const propertyType = checker.getTypeFromTypeNode(property.type);
 
     return propertyType.aliasSymbol === undefined
-        ? undefined
-        : contractsBySymbol.get(propertyType.aliasSymbol);
+        ? []
+        : (contractsBySymbol.get(propertyType.aliasSymbol) ?? []);
 };
 
 const getObjectBindingIdentifier = (parameter: ts.ParameterDeclaration, propertyName: string) => {
@@ -433,85 +508,192 @@ const getDispatchedThunkRequirements = (action: ts.Expression, checker: ts.TypeC
     });
 };
 
-// A dispatched child thunk introduces transitive state and dependency requirements even though the
-// parent callback never accesses those values directly.
-const addDispatchedThunkUsages = (
-    sourceFile: ts.SourceFile,
-    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract>,
+const getContractsForType = (
+    type: ts.Type | undefined,
+    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
+) => (type?.aliasSymbol === undefined ? [] : (contractsBySymbol.get(type.aliasSymbol) ?? []));
+
+const addRequirementsFromDispatches = (
+    body: ts.Node,
+    dispatchSymbol: ts.Symbol,
+    stateContracts: readonly IntersectionContract[],
+    depsContracts: readonly IntersectionContract[],
     checker: ts.TypeChecker,
 ) => {
     const visitNode = (node: ts.Node) => {
-        if (!ts.isCallExpression(node) || !isCreateThunkCall(node)) {
-            ts.forEachChild(node, visitNode);
-
-            return;
-        }
-
-        const callback = node.arguments[1];
-        const callbackFunction =
-            callback !== undefined &&
-            (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))
-                ? callback
-                : undefined;
-        const apiParameter =
-            callbackFunction === undefined ? undefined : callbackFunction.parameters[1];
-        const dispatchIdentifier =
-            apiParameter === undefined
-                ? undefined
-                : getObjectBindingIdentifier(apiParameter, 'dispatch');
-        const dispatchSymbol =
-            dispatchIdentifier === undefined
-                ? undefined
-                : checker.getSymbolAtLocation(dispatchIdentifier);
-
         if (
-            callbackFunction === undefined ||
-            apiParameter === undefined ||
-            dispatchSymbol === undefined
+            ts.isCallExpression(node) &&
+            ts.isIdentifier(node.expression) &&
+            checker.getSymbolAtLocation(node.expression) === dispatchSymbol
         ) {
-            ts.forEachChild(node, visitNode);
+            const action = node.arguments[0];
 
-            return;
-        }
-
-        const stateContract = getConfigContract(node, 'state', contractsBySymbol, checker);
-        const depsContract = getConfigContract(node, 'extra', contractsBySymbol, checker);
-
-        const visitCallbackNode = (callbackNode: ts.Node) => {
-            if (
-                ts.isCallExpression(callbackNode) &&
-                ts.isIdentifier(callbackNode.expression) &&
-                checker.getSymbolAtLocation(callbackNode.expression) === dispatchSymbol
-            ) {
-                const action = callbackNode.arguments[0];
-
-                if (action !== undefined) {
-                    for (const requirement of getDispatchedThunkRequirements(action, checker)) {
-                        if (requirement.stateType !== undefined && stateContract !== undefined) {
-                            stateContract.usages.push({
-                                path: [],
-                                requiredType: requirement.stateType,
-                            });
+            if (action !== undefined) {
+                for (const requirement of getDispatchedThunkRequirements(action, checker)) {
+                    if (requirement.stateType !== undefined) {
+                        for (const stateContract of stateContracts) {
+                            recordContractUsage(
+                                { path: [], requiredType: requirement.stateType },
+                                stateContract,
+                                checker,
+                            );
                         }
+                    }
 
-                        if (requirement.extraType !== undefined && depsContract !== undefined) {
-                            depsContract.usages.push({
-                                path: [],
-                                requiredType: requirement.extraType,
-                            });
+                    if (requirement.extraType !== undefined) {
+                        for (const depsContract of depsContracts) {
+                            recordContractUsage(
+                                { path: [], requiredType: requirement.extraType },
+                                depsContract,
+                                checker,
+                            );
                         }
                     }
                 }
             }
+        }
 
-            ts.forEachChild(callbackNode, visitCallbackNode);
-        };
+        ts.forEachChild(node, visitNode);
+    };
 
-        ts.forEachChild(callbackFunction.body, visitCallbackNode);
+    ts.forEachChild(body, visitNode);
+};
+
+const addVanillaThunkUsages = (
+    node: ts.FunctionLikeDeclaration,
+    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
+    checker: ts.TypeChecker,
+) => {
+    const dispatchParameter = node.parameters[0];
+    const getStateParameter = node.parameters[1];
+    const extraParameter = node.parameters[2];
+
+    if (
+        node.body === undefined ||
+        dispatchParameter === undefined ||
+        !ts.isIdentifier(dispatchParameter.name)
+    ) {
+        return;
+    }
+
+    const dispatchSymbol = checker.getSymbolAtLocation(dispatchParameter.name);
+
+    if (dispatchSymbol === undefined) {
+        return;
+    }
+
+    const getStateType =
+        getStateParameter === undefined
+            ? undefined
+            : checker.getTypeAtLocation(getStateParameter.name);
+    const stateType = getStateType
+        ? checker
+              .getSignaturesOfType(getStateType, ts.SignatureKind.Call)
+              .map(signature => signature.getReturnType())[0]
+        : undefined;
+    const extraType =
+        extraParameter === undefined ? undefined : checker.getTypeAtLocation(extraParameter.name);
+    const stateContracts = getContractsForType(stateType, contractsBySymbol);
+    const depsContracts = getContractsForType(extraType, contractsBySymbol);
+
+    if (stateContracts.length === 0 && depsContracts.length === 0) {
+        return;
+    }
+
+    addRequirementsFromDispatches(
+        node.body,
+        dispatchSymbol,
+        stateContracts,
+        depsContracts,
+        checker,
+    );
+};
+
+// A dispatched child thunk introduces transitive state and dependency requirements even though the
+// parent callback never accesses those values directly.
+const addDispatchedThunkUsages = (
+    sourceFile: ts.SourceFile,
+    contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
+    checker: ts.TypeChecker,
+) => {
+    const visitNode = (node: ts.Node) => {
+        if (ts.isFunctionLike(node)) {
+            addVanillaThunkUsages(node, contractsBySymbol, checker);
+        }
+
+        if (ts.isCallExpression(node) && isCreateThunkCall(node)) {
+            const callback = node.arguments[1];
+            const callbackFunction =
+                callback !== undefined &&
+                (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))
+                    ? callback
+                    : undefined;
+            const apiParameter = callbackFunction?.parameters[1];
+            const dispatchIdentifier =
+                apiParameter === undefined
+                    ? undefined
+                    : getObjectBindingIdentifier(apiParameter, 'dispatch');
+            const dispatchSymbol =
+                dispatchIdentifier === undefined
+                    ? undefined
+                    : checker.getSymbolAtLocation(dispatchIdentifier);
+
+            if (callbackFunction !== undefined && dispatchSymbol !== undefined) {
+                addRequirementsFromDispatches(
+                    callbackFunction.body,
+                    dispatchSymbol,
+                    getConfigContracts(node, 'state', contractsBySymbol, checker),
+                    getConfigContracts(node, 'extra', contractsBySymbol, checker),
+                    checker,
+                );
+            }
+        }
+
         ts.forEachChild(node, visitNode);
     };
 
     ts.forEachChild(sourceFile, visitNode);
+};
+
+const getWrappedServicesIntersection = (node: ts.TypeNode, checker: ts.TypeChecker) => {
+    if (
+        !ts.isTypeReferenceNode(node) ||
+        node.typeArguments?.length !== 1 ||
+        !ts.isIntersectionTypeNode(node.typeArguments[0])
+    ) {
+        return undefined;
+    }
+
+    const servicesIntersection = node.typeArguments[0];
+    const wrapperType = checker.getTypeFromTypeNode(node);
+    const wrapperProperties = checker.getPropertiesOfType(wrapperType);
+
+    if (wrapperProperties.length !== 1 || wrapperProperties[0].name !== 'services') {
+        return undefined;
+    }
+
+    const wrappedServicesType = getPropertyType(wrapperType, 'services', checker);
+    const intersectionType = checker.getTypeFromTypeNode(servicesIntersection);
+
+    if (
+        wrappedServicesType === undefined ||
+        !checker.isTypeAssignableTo(wrappedServicesType, intersectionType) ||
+        !checker.isTypeAssignableTo(intersectionType, wrappedServicesType)
+    ) {
+        return undefined;
+    }
+
+    return servicesIntersection;
+};
+
+const getWrappedServicesIntersections = (node: ts.TypeNode, checker: ts.TypeChecker) => {
+    const possibleWrappers = ts.isIntersectionTypeNode(node) ? node.types : [node];
+
+    return possibleWrappers.flatMap(possibleWrapper => {
+        const servicesIntersection = getWrappedServicesIntersection(possibleWrapper, checker);
+
+        return servicesIntersection === undefined ? [] : [servicesIntersection];
+    });
 };
 
 /**
@@ -556,14 +738,11 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                     return;
                 }
 
-                const contractsBySymbol = new Map<ts.Symbol, IntersectionContract>();
+                const contractsBySymbol = new Map<ts.Symbol, IntersectionContract[]>();
 
-                // Restricting candidates to direct aliases with explicit intersections keeps each
-                // proof tied to a concrete member list that can be reported and edited reliably.
                 for (const statement of sourceFile.statements) {
                     if (
                         !ts.isTypeAliasDeclaration(statement) ||
-                        !ts.isIntersectionTypeNode(statement.type) ||
                         !contractTypeNamePattern.test(statement.name.text)
                     ) {
                         continue;
@@ -575,17 +754,53 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                         continue;
                     }
 
-                    contractsBySymbol.set(symbol, {
-                        isOpaque: false,
-                        members: statement.type.types.map(memberNode => ({
-                            name: memberNode.getText(sourceFile),
-                            node: memberNode,
-                            type: checker.getTypeFromTypeNode(memberNode),
-                        })),
-                        name: statement.name.text,
-                        symbol,
-                        usages: [],
-                    });
+                    const contracts: IntersectionContract[] = [];
+
+                    // Direct intersections remain independently editable top-level members.
+                    if (ts.isIntersectionTypeNode(statement.type)) {
+                        contracts.push({
+                            isOpaque: false,
+                            members: statement.type.types.map(memberNode => ({
+                                name: memberNode.getText(sourceFile),
+                                node: memberNode,
+                                type: checker.getTypeFromTypeNode(memberNode),
+                            })),
+                            name: statement.name.text,
+                            rootPath: [],
+                            symbol,
+                            usages: [],
+                        });
+                    }
+
+                    const wrappedServicesIntersections = getWrappedServicesIntersections(
+                        statement.type,
+                        checker,
+                    );
+                    const wrappedServiceMembers = wrappedServicesIntersections.flatMap(
+                        intersection => intersection.types,
+                    );
+
+                    if (wrappedServiceMembers.length > 0) {
+                        // WithServices moves a dependency intersection below the `services` key.
+                        // Analyze those inner members as another local contract while retaining the
+                        // outer contract above for any non-service intersection members.
+                        contracts.push({
+                            isOpaque: false,
+                            members: wrappedServiceMembers.map(memberNode => ({
+                                name: memberNode.getText(sourceFile),
+                                node: memberNode,
+                                type: checker.getTypeFromTypeNode(memberNode),
+                            })),
+                            name: statement.name.text,
+                            rootPath: ['services'],
+                            symbol,
+                            usages: [],
+                        });
+                    }
+
+                    if (contracts.length > 0) {
+                        contractsBySymbol.set(symbol, contracts);
+                    }
                 }
 
                 if (contractsBySymbol.size === 0) {
@@ -603,9 +818,9 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
                         !isNodeDeclarationName(node) &&
                         !isInsideTypeNode(node)
                     ) {
-                        const contract = getAliasedContract(node, contractsBySymbol, checker);
+                        const contracts = getAliasedContracts(node, contractsBySymbol, checker);
 
-                        if (contract !== undefined) {
+                        for (const contract of contracts) {
                             addContractUsage(node, contract, checker);
                         }
                     }
@@ -615,7 +830,7 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
 
                 ts.forEachChild(sourceFile, visitNode);
 
-                for (const contract of contractsBySymbol.values()) {
+                for (const contract of [...contractsBySymbol.values()].flat()) {
                     if (contract.isOpaque || contract.usages.length === 0) {
                         continue;
                     }

--- a/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
+++ b/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
@@ -1,14 +1,12 @@
 import { METADATA } from '@suite/metadata';
 import { type Bip329Dep } from '@suite-common/bip329-types';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { triggerWebDownloadFile } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type Account } from '@suite-common/wallet-types';
 import { sanitizeFilename } from '@trezor/utils';
 
-type ExportMetadataToBip329FileThunkDeps = {
-    services: Bip329Dep;
-};
+type ExportMetadataToBip329FileThunkDeps = WithServices<Bip329Dep>;
 
 export const exportMetadataToBip329File = createThunk<
     void,

--- a/packages/suite/src/actions/labels/moveLabelsForRbfThunk.ts
+++ b/packages/suite/src/actions/labels/moveLabelsForRbfThunk.ts
@@ -6,6 +6,7 @@ import {
 } from '@suite/metadata';
 import { type DeviceRootState } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
+import { type WithServices } from '@suite-common/redux-utils';
 import { findLabelsToBeMovedOrDeleted } from '@suite-common/suite-rbf-labels-migrations';
 import { type MigrateSuiteSyncLabelsForRbfTransactionDep } from '@suite-common/suite-rbf-labels-migrations-types';
 import { type WithSuiteSyncState, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
@@ -30,9 +31,7 @@ export type MoveLabelsForRbfThunkState = DeviceRootState &
     MessageSystemRootState &
     MoveLabelsForRbfOldMetadataThunkState &
     WithSuiteSyncState;
-export type MoveLabelsForRbfThunkDeps = {
-    services: MigrateSuiteSyncLabelsForRbfTransactionDep;
-};
+export type MoveLabelsForRbfThunkDeps = WithServices<MigrateSuiteSyncLabelsForRbfTransactionDep>;
 type MoveLabelsForRbfThunkDispatch = ThunkDispatch<
     MoveLabelsForRbfThunkState,
     MoveLabelsForRbfThunkDeps,

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -21,6 +21,7 @@ import {
     selectHasBitcoinOnlyFirmware,
     selectSelectedDevice,
 } from '@suite-common/device';
+import { type WithServices } from '@suite-common/redux-utils';
 import { type BackupType } from '@suite-common/suite-types';
 import {
     type StartDiscoveryThunkDeps,
@@ -101,9 +102,8 @@ type GoToSuiteState = DeviceRootState &
     OnboardingRootState &
     StartDiscoveryThunkState &
     WalletSettingsRootState;
-type GoToSuiteDeps = {
-    services: DesktopAnalyticsDep & SuiteRouterHistoryDep;
-} & StartDiscoveryThunkDeps;
+type GoToSuiteDeps = WithServices<DesktopAnalyticsDep & SuiteRouterHistoryDep> &
+    StartDiscoveryThunkDeps;
 
 export type GoToSuiteOptions = {
     skipDeviceSetupCompletedEvent?: boolean;

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -17,6 +17,7 @@ import {
     selectIsAnalyticsEnabled,
     selectLoggerEnabled,
 } from '@suite-common/analytics-redux';
+import { type WithServices } from '@suite-common/redux-utils';
 import { type InitOptions, getTrackingRandomId } from '@trezor/analytics-uploader';
 import { getCommitHash, getEnvironment, isCodesignBuild } from '@trezor/env-utils';
 
@@ -26,7 +27,7 @@ type SendReportProps = {
     sendReport: boolean;
 };
 
-type EnableAnalyticsThunkDeps = { services: DesktopAnalyticsDep };
+type EnableAnalyticsThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const enableAnalyticsThunk =
     ({ sendReport }: SendReportProps) =>
@@ -46,7 +47,7 @@ export const enableAnalyticsThunk =
         dispatch(analyticsActions.enableAnalytics());
     };
 
-type DisableAnalyticsThunkDeps = { services: DesktopAnalyticsDep };
+type DisableAnalyticsThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const disableAnalyticsThunk =
     ({ sendReport }: SendReportProps) =>
@@ -67,7 +68,7 @@ export const disableAnalyticsThunk =
     };
 
 type InitAnalyticsThunkState = AnalyticsRootState;
-type InitAnalyticsThunkDeps = { services: DesktopAnalyticsDep };
+type InitAnalyticsThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 /**
  * Init analytics, should be always run on application start (see suiteMiddleware). It:

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -13,6 +13,7 @@ import {
 } from '@suite/router';
 import { handleCoinProtocolUri } from '@suite/transfer-uri';
 import type { FindNetworkSymbolForProtocolDep } from '@suite-common/networks';
+import { type WithServices } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type WalletConnectInitThunkDeps,
@@ -40,9 +41,9 @@ export const fillSendForm = createAction<boolean>(PROTOCOL.FILL_SEND_FORM);
 
 export const resetProtocol = createAction(PROTOCOL.RESET);
 
-export type HandleProtocolRequestDeps = {
-    services: DesktopAnalyticsDep & FindNetworkSymbolForProtocolDep & SuiteRouterHistoryDep;
-};
+export type HandleProtocolRequestDeps = WithServices<
+    DesktopAnalyticsDep & FindNetworkSymbolForProtocolDep & SuiteRouterHistoryDep
+>;
 
 export type HandleProtocolRequestState = GotoThunkState & WalletConnectInitThunkState;
 type HandleProtocolRequestDispatchDeps = HandleProtocolRequestDeps & WalletConnectInitThunkDeps;

--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -1,6 +1,6 @@
 import { type MetadataRootState } from '@suite/metadata';
 import { type AccountLabels } from '@suite-common/metadata-types';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type TokenDefinitionsRootState,
     selectNetworkTokenDefinitions,
@@ -36,11 +36,9 @@ type ExportTransactionsThunkState = FiatRatesRootState &
     TokenDefinitionsRootState &
     TransactionsRootState &
     WalletSettingsRootState;
-type ExportTransactionsThunkDeps = {
-    services: {
-        saveAs: (data: Blob, fileName: string) => void;
-    };
-};
+type ExportTransactionsThunkDeps = WithServices<{
+    saveAs: (data: Blob, fileName: string) => void;
+}>;
 
 const selectMetadataState = (state: MetadataRootState) => state.metadata;
 

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -14,7 +14,7 @@ import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device
 import { type MessageSystemRootState } from '@suite-common/message-system';
 import { type MetadataAddPayload } from '@suite-common/metadata-types';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type WithSuiteSyncState, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import {
@@ -159,7 +159,7 @@ type ApplySendFormMetadataLabelsThunkState = DeviceRootState &
     MetadataRootState &
     SendRootState &
     WithSuiteSyncState;
-type ApplySendFormMetadataLabelsThunkDeps = { services: SuiteSyncDep };
+type ApplySendFormMetadataLabelsThunkDeps = WithServices<SuiteSyncDep>;
 
 const applySendFormMetadataLabelsThunk = createThunk<
     void,
@@ -251,7 +251,8 @@ type SignAndPushSendFormTransactionThunkState = ApplySendFormMetadataLabelsThunk
 type SignAndPushSendFormTransactionThunkDeps = ApplySendFormMetadataLabelsThunkDeps &
     CancelSignSendFormTransactionThunkDeps &
     PushSendFormTransactionThunkDeps &
-    UpdateRbfLabelsThunkDeps & { services: DesktopAnalyticsDep };
+    UpdateRbfLabelsThunkDeps &
+    WithServices<DesktopAnalyticsDep>;
 
 export const signAndPushSendFormTransactionThunk = createThunk<
     any,

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -8,6 +8,7 @@ import {
 } from '@suite/analytics';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { type AdaPools } from '@suite-common/earn-staking-api';
+import { type WithServices } from '@suite-common/redux-utils';
 import {
     calculate,
     composeStakingTransaction,
@@ -339,8 +340,8 @@ const getPoolDelegation = (
     };
 };
 
-type SignTransactionThunkDeps = { services: DesktopAnalyticsDep };
 type SignTransactionThunkState = DeviceRootState & SelectedAccountRootState & StakeRootState;
+type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -4,6 +4,7 @@ import { type ThunkDispatch } from 'redux-thunk';
 import { type SelectedAccountRootState } from '@suite/account';
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+import { type WithServices } from '@suite-common/redux-utils';
 import {
     getStakeTxGasLimit,
     prepareClaimEthTx,
@@ -119,11 +120,11 @@ export const composeTransaction =
         );
     };
 
-type SignTransactionThunkDeps = { services: DesktopAnalyticsDep };
 type SignTransactionThunkState = DeviceRootState &
     EthereumGetCurrentNonceThunkState &
     SelectedAccountRootState &
     WalletSettingsRootState;
+type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -3,6 +3,7 @@ import { type Dispatch, type UnknownAction } from '@reduxjs/toolkit';
 import { type SelectedAccountRootState } from '@suite/account';
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+import { type WithServices } from '@suite-common/redux-utils';
 import { composeSolanaStakingTransaction, prepareSolanaStakeTxData } from '@suite-common/staking';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -46,11 +47,11 @@ export const composeTransaction =
         });
     };
 
-type SignTransactionThunkDeps = { services: DesktopAnalyticsDep };
 type SignTransactionThunkState = BlockchainRootState &
     DeviceRootState &
     SelectedAccountRootState &
     WalletSettingsRootState;
+type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -13,6 +13,7 @@ import {
     type MevProtectionRootState,
     selectIsMevProtectionFeatureEnabled,
 } from '@suite-common/mev';
+import { type WithServices } from '@suite-common/redux-utils';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -116,9 +117,8 @@ type PushTransactionThunkState = DeviceRootState &
     StakeRootState &
     SyncAccountsWithBlockchainThunkState &
     WalletSettingsRootState;
-type PushTransactionThunkDeps = {
-    services: DesktopAnalyticsDep;
-} & SyncAccountsWithBlockchainThunkDeps;
+type PushTransactionThunkDeps = WithServices<DesktopAnalyticsDep> &
+    SyncAccountsWithBlockchainThunkDeps;
 
 // private, called from signTransaction only
 const pushTransaction =

--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -2,7 +2,7 @@ import { type BuyTrade } from 'invity-api';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type TradingFormAccountRootState,
     buyThunks,
@@ -21,7 +21,7 @@ import { submitRequestForm } from '../tradingCommonActions';
 
 type SelectBuyQuoteThunkParams = { quote: BuyTrade };
 type SelectBuyQuoteThunkState = GotoThunkState & TradingFormAccountRootState;
-type SelectBuyQuoteThunkDeps = GotoThunkDeps & { services: DesktopAnalyticsDep };
+type SelectBuyQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;
 
 export const selectBuyQuoteThunk = createThunk<
     void,

--- a/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
@@ -2,7 +2,7 @@ import { type ExchangeTrade } from 'invity-api';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type TradingRootState,
     cryptoIdToNetworkSymbolAndContractAddress,
@@ -19,7 +19,7 @@ type SelectExchangeQuoteThunkProps = {
     fractionButton?: number;
 };
 type SelectExchangeQuoteThunkState = GotoThunkState & TradingRootState;
-type SelectExchangeQuoteThunkDeps = GotoThunkDeps & { services: DesktopAnalyticsDep };
+type SelectExchangeQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;
 
 export const selectExchangeQuoteThunk = createThunk<
     void,

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
@@ -2,7 +2,7 @@ import { type SellFiatTrade } from 'invity-api';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     cryptoIdToNetworkSymbolAndContractAddress,
     selectTradingSellInfo,
@@ -16,7 +16,7 @@ import { type RequestSellTradeThunkState, requestSellTradeThunk } from './reques
 
 type SelectSellQuoteThunkParams = { quote: SellFiatTrade; fractionButton?: number };
 type SelectSellQuoteThunkState = GotoThunkState & RequestSellTradeThunkState;
-type SelectSellQuoteThunkDeps = GotoThunkDeps & { services: DesktopAnalyticsDep };
+type SelectSellQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;
 
 export const selectSellQuoteThunk = createThunk<
     void,

--- a/packages/suite/src/hooks/suite/useDispatch.type-test.ts
+++ b/packages/suite/src/hooks/suite/useDispatch.type-test.ts
@@ -1,4 +1,4 @@
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type WalletSettingsRootState } from '@suite-common/wallet-core';
 
 import type { SuiteServices } from 'src/support/extraDependencies';
@@ -11,14 +11,10 @@ type UnavailableState = {
         value: string;
     };
 };
-type AvailableExtraDependencies = {
-    services: Pick<SuiteServices, 'getLanguage'>;
-};
-type UnavailableExtraDependencies = {
-    services: {
-        unavailableDependency: () => void;
-    };
-};
+type AvailableExtraDependencies = WithServices<Pick<SuiteServices, 'getLanguage'>>;
+type UnavailableExtraDependencies = WithServices<{
+    unavailableDependency: () => void;
+}>;
 
 const compatibleStateThunk = createThunk<void, void, { state: AvailableState }>(
     'test/compatibleStateThunk',

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -19,7 +19,7 @@ import {
 import { onSuiteReady } from '@suite/suite-lifecycle';
 import { deviceActions, selectDevices, selectDevicesCount } from '@suite-common/device';
 import { firmwareUpdate } from '@suite-common/firmware';
-import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import { type WithServices, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
 import {
     getIsDeviceDescriptorApiTypeBluetooth,
@@ -65,7 +65,7 @@ import { hasVisibleTokens } from 'src/utils/wallet/tokenUtils';
     - transport (webusb/bridge) and its version
     - backup type (shamir/bip39)
 */
-export type PrepareAnalyticsMiddlewareDeps = { services: DesktopAnalyticsDep };
+export type PrepareAnalyticsMiddlewareDeps = WithServices<DesktopAnalyticsDep>;
 
 type AnalyticsMiddlewareState = CoinjoinRootState &
     GetSuiteReadyPayloadState &

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -8,7 +8,7 @@ import { recoveryActions } from '@suite/recovery';
 import { type RouterRootState, goto, routerAppChanged } from '@suite/router';
 import { updateOnlineStatus } from '@suite/suite-lifecycle';
 import { deviceActions, isTrezorDeviceWithState } from '@suite-common/device';
-import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import { type WithServices, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -56,7 +56,7 @@ const isActionDeviceRelated = (action: UnknownAction): boolean => {
     return false;
 };
 
-export type PrepareSuiteMiddlewareDeps = { services: SuiteSyncDep };
+export type PrepareSuiteMiddlewareDeps = WithServices<SuiteSyncDep>;
 
 const createSuiteMiddleware = createMiddlewareWithExtraDeps<
     PrepareSuiteMiddlewareDeps,

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -53,6 +53,7 @@ import {
     type CommonServices,
     type ExtraDependenciesStatic,
 } from '@suite-common/redux-extra-dependencies';
+import { type WithServices } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
 import {
     createSuiteSyncWriteLabels,
@@ -113,7 +114,8 @@ export type SuiteServices = CommonServices &
     TransportsDep;
 
 export type ExtraDependenciesSuite = ExtraDependenciesStatic &
-    TokenDefinitionsMiddlewareDeps & { services: SuiteServices };
+    TokenDefinitionsMiddlewareDeps &
+    WithServices<SuiteServices>;
 
 export type StoreAPIDep = {
     getState: () => AppState;

--- a/suite-common/firmware-authenticity/src/reportSecurityCheckThunk.ts
+++ b/suite-common/firmware-authenticity/src/reportSecurityCheckThunk.ts
@@ -1,4 +1,4 @@
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type ReportSecurityCheckDep,
     type ReportSecurityCheckParams,
@@ -9,7 +9,7 @@ const FIRMWARE_AUTHENTICITY_MODULE_PREFIX = '@common/firmware-authenticity';
 /**
  * Wrapper thunk around extra.services.reportSecurityCheck
  */
-type ReportSecurityCheckThunkDeps = { services: ReportSecurityCheckDep };
+type ReportSecurityCheckThunkDeps = WithServices<ReportSecurityCheckDep>;
 
 export const reportSecurityCheckThunk = createThunk<
     void,

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -1,5 +1,5 @@
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type GetBinFilesBaseUrlDep,
     type GetLanguageDep,
@@ -27,9 +27,9 @@ export type FirmwareUpdateResult = {
     connectResponse?: Awaited<ReturnType<typeof TrezorConnect.firmwareUpdate>>;
 };
 
-export type FirmwareUpdateThunkDeps = {
-    services: GetBinFilesBaseUrlDep & GetLanguageDep & ReportSecurityCheckDep;
-};
+export type FirmwareUpdateThunkDeps = WithServices<
+    GetBinFilesBaseUrlDep & GetLanguageDep & ReportSecurityCheckDep
+>;
 export type FirmwareUpdateThunkState = DeviceRootState & FirmwareRootState;
 
 export const firmwareUpdate = createThunk<

--- a/suite-common/redux-extra-dependencies/src/extraDependenciesType.ts
+++ b/suite-common/redux-extra-dependencies/src/extraDependenciesType.ts
@@ -15,7 +15,7 @@ import type {
     NetworkModuleRepositoryDep,
 } from '@suite-common/networks';
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
-import { type SuiteCompatibleThunk } from '@suite-common/redux-utils';
+import { type SuiteCompatibleThunk, type WithServices } from '@suite-common/redux-utils';
 import { type MigrateSuiteSyncLabelsForRbfTransactionDep } from '@suite-common/suite-rbf-labels-migrations-types';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import {
@@ -135,4 +135,4 @@ export type ExtraDependenciesStatic = {
     };
 };
 
-export type ExtraDependencies = ExtraDependenciesStatic & { services: CommonServices };
+export type ExtraDependencies = ExtraDependenciesStatic & WithServices<CommonServices>;

--- a/suite-common/redux-utils/src/createMiddleware.type-test.ts
+++ b/suite-common/redux-utils/src/createMiddleware.type-test.ts
@@ -2,12 +2,11 @@ import { type UnknownAction } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from './createMiddleware';
 import { createThunk } from './createThunk';
+import { type WithServices } from './types';
 
-type SelectedExtraDependencies = {
-    services: {
-        selectedDependency: () => void;
-    };
-};
+type SelectedExtraDependencies = WithServices<{
+    selectedDependency: () => void;
+}>;
 
 type SelectedState = {
     selectedState: string;

--- a/suite-common/redux-utils/src/createSingleInstanceThunk.type-test.ts
+++ b/suite-common/redux-utils/src/createSingleInstanceThunk.type-test.ts
@@ -1,10 +1,9 @@
 import { createSingleInstanceThunk } from './createSingleInstanceThunk';
+import { type WithServices } from './types';
 
-type SelectedExtraDependencies = {
-    services: {
-        selectedDependency: () => void;
-    };
-};
+type SelectedExtraDependencies = WithServices<{
+    selectedDependency: () => void;
+}>;
 
 type SelectedState = {
     selected: {

--- a/suite-common/redux-utils/src/createThunk.type-test.ts
+++ b/suite-common/redux-utils/src/createThunk.type-test.ts
@@ -1,12 +1,11 @@
 import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
 
 import { createThunk } from './createThunk';
+import { type WithServices } from './types';
 
-type SelectedExtraDependencies = {
-    services: {
-        selectedDependency: () => void;
-    };
-};
+type SelectedExtraDependencies = WithServices<{
+    selectedDependency: () => void;
+}>;
 
 type SelectedState = {
     selected: {
@@ -88,11 +87,9 @@ type ChildThunkState = {
     };
 };
 
-type ChildThunkDeps = {
-    services: {
-        childDependency: () => void;
-    };
-};
+type ChildThunkDeps = WithServices<{
+    childDependency: () => void;
+}>;
 
 const selectChildValue = (state: ChildThunkState) => state.child.value;
 

--- a/suite-common/redux-utils/src/types.ts
+++ b/suite-common/redux-utils/src/types.ts
@@ -5,6 +5,10 @@ import {
     type UnknownAction,
 } from '@reduxjs/toolkit';
 
+export type WithServices<TServices extends object> = {
+    services: TServices;
+};
+
 /**
  * Original thunk type in Redux before redux-toolkit
  */

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -2,7 +2,7 @@ import { type UnknownAction, isAnyOf } from '@reduxjs/toolkit';
 
 import { deviceActions, isTrezorDeviceWithState } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
-import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import { type WithServices, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import { selectDeviceThunk } from '@suite-common/wallet-core';
 
@@ -12,7 +12,7 @@ import {
     selectIsSuiteSyncEnabled,
 } from './suiteSyncSelectors';
 
-type SuiteSyncMiddlewareDeps = { services: SuiteSyncDep };
+type SuiteSyncMiddlewareDeps = WithServices<SuiteSyncDep>;
 type SuiteSyncMiddlewareState = WithSuiteSyncAndDeviceState & MessageSystemRootState;
 
 export const prepareSuiteSyncMiddleware = createMiddlewareWithExtraDeps<

--- a/suite-common/test-utils/src/configureMockStore.type-test.ts
+++ b/suite-common/test-utils/src/configureMockStore.type-test.ts
@@ -1,15 +1,15 @@
 import { type UnknownAction } from '@reduxjs/toolkit';
 
+import { type WithServices } from '@suite-common/redux-utils';
+
 import { configureMockStore } from './configureMockStore';
 
 // Platform tests add thunk services that are intentionally unknown to suite-common. This
 // compile-only test guards the third generic that lets them supply those platform-specific
 // overrides; removing or narrowing that extension point must fail the package type-check.
-type PlatformExtraDependencies = {
-    services: {
-        platformOnlyService: () => void;
-    };
-};
+type PlatformExtraDependencies = WithServices<{
+    platformOnlyService: () => void;
+}>;
 
 const store = configureMockStore<{ value: number }, UnknownAction, PlatformExtraDependencies>({
     extra: {

--- a/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
@@ -1,6 +1,6 @@
 import { D } from '@mobily/ts-belt';
 
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TimerId } from '@trezor/type-utils';
 
@@ -39,9 +39,7 @@ export const getTokenDefinitionThunk = createThunk<
     },
 );
 
-export type InitTokenDefinitionsThunkDeps = {
-    services: GetTokenDefinitionsEnabledNetworksDep;
-};
+export type InitTokenDefinitionsThunkDeps = WithServices<GetTokenDefinitionsEnabledNetworksDep>;
 export type InitTokenDefinitionsThunkState = TokenDefinitionsRootState;
 
 export const initTokenDefinitionsThunk = createThunk<

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -1,4 +1,4 @@
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type SelectedAccountStatus } from '@suite-common/wallet-types';
 
 import {
@@ -31,12 +31,10 @@ export interface LoadInitialDataThunkProps {
 }
 
 type LoadInitialDataThunkState = TradingRootStateWithAccounts;
-type LoadInitialDataThunkDeps = {
-    services: {
-        getSelectedAccount: () => SelectedAccountStatus;
-        getTradingEnvironment: () => TradeServerEnvironment | undefined;
-    };
-};
+type LoadInitialDataThunkDeps = WithServices<{
+    getSelectedAccount: () => SelectedAccountStatus;
+    getTradingEnvironment: () => TradeServerEnvironment | undefined;
+}>;
 
 export const loadInitialDataThunk = createThunk<
     void,

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -1,7 +1,7 @@
 import { type ExchangeTrade, type ExchangeTradeQuoteRequest } from 'invity-api';
 
 import { type AddressValidatorDep } from '@suite-common/address';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type Network } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
@@ -76,9 +76,7 @@ export const getQuoteRequestData = ({
 };
 
 type HandleExchangeRequestThunkState = AccountsRootState & TradingRootState;
-type HandleExchangeRequestThunkDeps = {
-    services: AddressValidatorDep;
-};
+type HandleExchangeRequestThunkDeps = WithServices<AddressValidatorDep>;
 
 export const handleExchangeRequestThunk = createThunk<
     ExchangeTrade[],

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -1,6 +1,6 @@
 import { type AnalyticsDep, events } from '@suite-common/analytics';
 import { type DeviceRootState, selectDevices } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import {
     type NotificationsRootState,
@@ -102,9 +102,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
     return tokens;
 };
 
-export type ReportWalletBalanceThunkDeps = {
-    services: AnalyticsDep;
-};
+export type ReportWalletBalanceThunkDeps = WithServices<AnalyticsDep>;
 export type ReportWalletBalanceThunkState = AccountsRootState;
 
 export const reportWalletBalanceThunk = createThunk<
@@ -118,9 +116,7 @@ export const reportWalletBalanceThunk = createThunk<
     });
 });
 
-export type ReportAccountInfoThunkDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
-};
+export type ReportAccountInfoThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 export type ReportAccountInfoThunkState = AccountsRootState & TokenDefinitionsRootState;
 
 export const reportAccountInfoThunk = createThunk<
@@ -149,9 +145,7 @@ export const reportAccountInfoThunk = createThunk<
 
 // Left here for clarity, but shouldn't be called anywhere but in blockchainActions.syncAccounts
 // as we usually want to update all accounts for a single coin at once
-export type FetchAndUpdateAccountThunkDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
-};
+export type FetchAndUpdateAccountThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 export type FetchAndUpdateAccountThunkState = AccountsRootState &
     BlockchainRootState &
     DeviceRootState &

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -1,6 +1,6 @@
 import { type AnalyticsDep } from '@suite-common/analytics';
 import { type DeviceRootState, selectDevices } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type GetIsWindowVisibleDep } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -124,9 +124,7 @@ export const setCustomBackendThunk = createThunk<
 export type InitBlockchainThunkState = AccountsRootState &
     BlockchainRootState &
     WalletSettingsRootState;
-export type InitBlockchainThunkDeps = {
-    services: AnalyticsDep;
-};
+export type InitBlockchainThunkDeps = WithServices<AnalyticsDep>;
 
 export const initBlockchainThunk = createThunk<
     void,
@@ -277,9 +275,9 @@ const tryClearTimeout = (timeout?: TimerId) => {
     if (timeout) clearTimeout(timeout);
 };
 
-export type SyncAccountsWithBlockchainThunkDeps = {
-    services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
-};
+export type SyncAccountsWithBlockchainThunkDeps = WithServices<
+    AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
+>;
 export type SyncAccountsWithBlockchainThunkState = BlockchainRootState &
     FetchAndUpdateAccountThunkState;
 
@@ -333,9 +331,9 @@ export const syncAccountsWithBlockchainThunk = createThunk<
 
 type OnBlockchainConnectThunkState = SyncAccountsWithBlockchainThunkState &
     GetOrFetchRawFeeInfoThunkState;
-type OnBlockchainConnectThunkDeps = {
-    services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
-};
+type OnBlockchainConnectThunkDeps = WithServices<
+    AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
+>;
 
 export const onBlockchainConnectThunk = createThunk<
     void,
@@ -359,9 +357,9 @@ export const onBlockchainConnectThunk = createThunk<
 });
 
 type OnBlockMinedThunkState = SyncAccountsWithBlockchainThunkState;
-type OnBlockMinedThunkDeps = {
-    services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
-};
+type OnBlockMinedThunkDeps = WithServices<
+    AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
+>;
 
 export const onBlockMinedThunk = createThunk<
     unknown,
@@ -394,9 +392,9 @@ export const onBlockMinedThunk = createThunk<
 type OnBlockchainNotificationThunkState = DeviceRootState &
     SyncAccountsWithBlockchainThunkState &
     WalletSettingsRootState;
-type OnBlockchainNotificationThunkDeps = {
-    services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
-};
+type OnBlockchainNotificationThunkDeps = WithServices<
+    AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
+>;
 
 export const onBlockchainNotificationThunk = createThunk<
     void,
@@ -471,9 +469,9 @@ export const onBlockchainNotificationThunk = createThunk<
 });
 
 type OnBlockchainDisconnectThunkState = SyncAccountsWithBlockchainThunkState;
-type OnBlockchainDisconnectThunkDeps = {
-    services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
-};
+type OnBlockchainDisconnectThunkDeps = WithServices<
+    AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
+>;
 
 export const onBlockchainDisconnectThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -25,7 +25,7 @@ import {
     selectIsFirmwareInstallationRunning,
 } from '@suite-common/firmware';
 import { type FetchAndSaveMetadataDep } from '@suite-common/metadata-types';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type AcquiredDevice,
     type OpenModalDep,
@@ -206,8 +206,7 @@ type AcquireDeviceThunkParams = {
     startDiscovery?: boolean;
 };
 type AcquireDeviceThunkState = RunDiscoveryThunkState;
-type AcquireDeviceThunkDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
+type AcquireDeviceThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
 
@@ -341,8 +340,7 @@ type DeviceConnectThunksParams = {
     device: Device;
 };
 
-export type DeviceConnectThunkDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
+export type DeviceConnectThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
 

--- a/suite-common/wallet-core/src/device/entropyCheckThunks.ts
+++ b/suite-common/wallet-core/src/device/entropyCheckThunks.ts
@@ -3,7 +3,7 @@ import {
     deviceActions,
     getIsIgnoredEntropyCheckError,
 } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type AcquiredDevice, type ReportSecurityCheckDep } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import type TrezorConnect from '@trezor/connect';
@@ -15,7 +15,7 @@ type FailEntropyCheckParams = {
     error: SerializedError;
 };
 
-type FailEntropyCheckThunkDeps = { services: ReportSecurityCheckDep };
+type FailEntropyCheckThunkDeps = WithServices<ReportSecurityCheckDep>;
 
 const failEntropyCheckThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -11,7 +11,11 @@ import {
     shouldDeviceBeRemembered,
 } from '@suite-common/device';
 import { type FetchAndSaveMetadataDep } from '@suite-common/metadata-types';
-import { type SuiteCompatibleThunk, createThunk } from '@suite-common/redux-utils';
+import {
+    type SuiteCompatibleThunk,
+    type WithServices,
+    createThunk,
+} from '@suite-common/redux-utils';
 import {
     type AcquiredDevice,
     type AuthorizedDevice,
@@ -55,9 +59,7 @@ const USER_UI_CANCEL_CODE = 'USER_UI_CANCEL';
 const DEVICE_CANCELLATION_CODES = ['Method_Cancel', 'Failure_ActionCancelled'];
 
 type DiscoveryReportingThunkState = TokenDefinitionsRootState & WalletCoreCompoundRootState;
-type DiscoveryReportingDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
-};
+type DiscoveryReportingDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 
 type ProgressEvent = BundleProgress<DiscoverAccountsProgress>['payload'];
 
@@ -305,8 +307,7 @@ type RunDiscoveryParams = {
     callId?: string;
 };
 
-export type RunDiscoveryThunkDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
+export type RunDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
 export type RunDiscoveryThunkState = DiscoveryReportingThunkState;
@@ -623,8 +624,7 @@ type StartDiscoveryThunkParams = {
     useScopedCallIds?: boolean;
 };
 export type StartDiscoveryThunkState = RunDiscoveryThunkState;
-export type StartDiscoveryThunkDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
+export type StartDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
 
@@ -667,9 +667,7 @@ export const startDiscoveryThunk = createThunk<
 );
 
 type RunAdditionalDiscoveryThunkState = RunDiscoveryThunkState;
-type RunAdditionalDiscoveryThunkDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
-};
+type RunAdditionalDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 
 export const runAdditionalDiscoveryThunk = createThunk<
     void,
@@ -839,8 +837,7 @@ export const submitPassphrase = createThunk<
 );
 
 type StartOrRestartDiscoveryThunkState = RunDiscoveryThunkState;
-type StartOrRestartDiscoveryThunkDeps = {
-    services: AnalyticsDep & GetTradedAccountKeysDep;
+type StartOrRestartDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
 

--- a/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
@@ -1,6 +1,6 @@
 import { type AnalyticsDep } from '@suite-common/analytics';
 import { type FetchAndSaveMetadataDep } from '@suite-common/metadata-types';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type ConnectInitHooksDeps, type TrezorDevice } from '@suite-common/suite-types';
 import { type GetTradedAccountKeysDep } from '@suite-common/wallet-types';
 import TrezorConnect, { UI_EVENT, UI_REQUEST } from '@trezor/connect';
@@ -18,8 +18,9 @@ import {
 import { defaultTrezorUIEventHandlerThunk } from '../uiEvent/defaultTrezorUIEventHandlerThunk';
 import { registerScopedCallId, unregisterScopedCallId } from '../uiEvent/scopedCallIdRegistry';
 
-type RunPassphraseWalletAddingDiscoveryThunkDeps = {
-    services: AnalyticsDep & ConnectInitHooksDeps & GetTradedAccountKeysDep;
+type RunPassphraseWalletAddingDiscoveryThunkDeps = WithServices<
+    AnalyticsDep & ConnectInitHooksDeps & GetTradedAccountKeysDep
+> & {
     thunks: FetchAndSaveMetadataDep;
 };
 type RunPassphraseWalletAddingDiscoveryThunkState = RunDiscoveryThunkState;
@@ -69,8 +70,9 @@ type StartDiscoveryOfExistingPassphraseWalletThunkPayload = {
     useScopedCallIds?: boolean;
 };
 type StartDiscoveryOfExistingPassphraseWalletThunkState = RunDiscoveryThunkState;
-type StartDiscoveryOfExistingPassphraseWalletThunkDeps = {
-    services: AnalyticsDep & ConnectInitHooksDeps & GetTradedAccountKeysDep;
+type StartDiscoveryOfExistingPassphraseWalletThunkDeps = WithServices<
+    AnalyticsDep & ConnectInitHooksDeps & GetTradedAccountKeysDep
+> & {
     thunks: FetchAndSaveMetadataDep;
 };
 

--- a/suite-common/wallet-core/src/explorer/explorerThunks.ts
+++ b/suite-common/wallet-core/src/explorer/explorerThunks.ts
@@ -1,14 +1,12 @@
 import { type AnalyticsDep, events } from '@suite-common/analytics';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import type { Explorer, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { EXPLORER_MODULE_PREFIX, explorerActions } from './explorerActions';
 import { type ExplorerState } from './explorerReducer';
 import { selectNetworkExplorerType } from './explorerSelectors';
 
-type SetNetworkExplorerThunkDeps = {
-    services: AnalyticsDep;
-};
+type SetNetworkExplorerThunkDeps = WithServices<AnalyticsDep>;
 type SetNetworkExplorerThunkState = ExplorerState;
 type SetNetworkExplorerThunkParams = {
     symbol: NetworkSymbol;

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -3,7 +3,7 @@ import {
     fetchErc4626UnderlyingAsset,
     fetchLastWeekFiatRates,
 } from '@suite-common/fiat-services';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type GetIsWindowVisibleDep } from '@suite-common/suite-types';
 import {
     type TokenDefinitionsRootState,
@@ -385,9 +385,7 @@ type PeriodicFetchFiatRatesThunkPayload = {
     localCurrency: BaseCurrencyCode;
 };
 
-export type PeriodicFetchFiatRatesThunkDeps = {
-    services: GetIsWindowVisibleDep;
-};
+export type PeriodicFetchFiatRatesThunkDeps = WithServices<GetIsWindowVisibleDep>;
 export type PeriodicFetchFiatRatesThunkState = FetchFiatRatesThunkState;
 
 export const periodicFetchFiatRatesThunk = createThunk<

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -4,7 +4,11 @@ import { isRejected } from '@reduxjs/toolkit';
 import { type AnalyticsDep } from '@suite-common/analytics';
 import { Calldata } from '@suite-common/calldata';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
-import { type ActionsFromAsyncThunk, createThunk } from '@suite-common/redux-utils';
+import {
+    type ActionsFromAsyncThunk,
+    type WithServices,
+    createThunk,
+} from '@suite-common/redux-utils';
 import { type GetIsWindowVisibleDep, type OnModalCancelDep } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
@@ -303,9 +307,9 @@ type SynchronizeSentTransactionThunkParams = {
 export type SynchronizeSentTransactionThunkState = FeesRootState &
     SendRootState &
     SyncAccountsWithBlockchainThunkState;
-export type SynchronizeSentTransactionThunkDeps = {
-    services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
-};
+export type SynchronizeSentTransactionThunkDeps = WithServices<
+    AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
+>;
 
 export const synchronizeSentTransactionThunk = createThunk<
     void,
@@ -577,9 +581,9 @@ type PushSendFormRawTransactionThunkParams = {
     isMevProtectionEnabled: boolean;
 };
 type PushSendFormRawTransactionThunkState = DeviceRootState & SyncAccountsWithBlockchainThunkState;
-type PushSendFormRawTransactionThunkDeps = {
-    services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
-};
+type PushSendFormRawTransactionThunkDeps = WithServices<
+    AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
+>;
 
 export const pushSendFormRawTransactionThunk = createThunk<
     boolean,

--- a/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.ts
+++ b/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.ts
@@ -1,5 +1,5 @@
 import { type DeviceRootState, deviceActions, selectSelectedDevice } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type ConnectInitHooksDeps } from '@suite-common/suite-types';
 import { UI_REQUEST } from '@trezor/connect';
 import type { PopupEventMessage, UiEventMessage } from '@trezor/connect-common';
@@ -10,9 +10,7 @@ const MODULE = '@common/wallet-core/uiEvent';
 export type UiEventAction = Without<UiEventMessage | PopupEventMessage, 'event'>;
 
 export type DefaultTrezorUIEventHandlerThunkState = DeviceRootState;
-export type DefaultTrezorUIEventHandlerThunkDeps = {
-    services: ConnectInitHooksDeps;
-};
+export type DefaultTrezorUIEventHandlerThunkDeps = WithServices<ConnectInitHooksDeps>;
 
 export const defaultTrezorUIEventHandlerThunk = createThunk<
     void,

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -11,7 +11,7 @@ import {
 import { type AnalyticsDep, events } from '@suite-common/analytics';
 import * as trezorConnectPopupActions from '@suite-common/connect-popup';
 import { type DeviceRootState } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetwork } from '@suite-common/wallet-config';
@@ -132,9 +132,7 @@ const sessionAuthenticateThunk = createThunk<
 });
 
 type SessionProposalThunkState = SuccessfulAccountsThunkState;
-type SessionProposalThunkDeps = {
-    services: AnalyticsDep;
-};
+type SessionProposalThunkDeps = WithServices<AnalyticsDep>;
 
 const sessionProposalThunk = createThunk<
     void,
@@ -294,9 +292,7 @@ export const switchSelectedAccountThunk = createThunk<
 );
 
 type SessionProposalApproveThunkState = SuccessfulAccountsThunkState & WalletConnectStateRootState;
-type SessionProposalApproveThunkDeps = {
-    services: AnalyticsDep;
-};
+type SessionProposalApproveThunkDeps = WithServices<AnalyticsDep>;
 
 export const sessionProposalApproveThunk = createThunk<
     void,
@@ -378,9 +374,7 @@ export const sessionProposalApproveThunk = createThunk<
 );
 
 type SessionProposalRejectThunkState = WalletConnectStateRootState;
-type SessionProposalRejectThunkDeps = {
-    services: AnalyticsDep;
-};
+type SessionProposalRejectThunkDeps = WithServices<AnalyticsDep>;
 
 export const sessionProposalRejectThunk = createThunk<
     void,

--- a/suite-native/analytics-redux/src/analyticsThunks.ts
+++ b/suite-native/analytics-redux/src/analyticsThunks.ts
@@ -8,7 +8,7 @@ import {
     selectIsAnalyticsEnabled,
     selectLoggerEnabled,
 } from '@suite-common/analytics-redux';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { isProduction } from '@suite-native/config';
 import { allowSentryReport, setSentryUser } from '@suite-native/sentry';
@@ -17,7 +17,7 @@ import { getCommitHash } from '@trezor/env-utils';
 
 const ACTION_PREFIX = '@suite-native/analytics';
 
-type EnableAnalyticsThunkDeps = { services: NativeAnalyticsDep };
+type EnableAnalyticsThunkDeps = WithServices<NativeAnalyticsDep>;
 
 const enableAnalyticsThunk = createThunk<
     void,
@@ -32,7 +32,7 @@ const enableAnalyticsThunk = createThunk<
     dispatch(analyticsActions.enableAnalytics());
 });
 
-type DisableAnalyticsThunkDeps = { services: NativeAnalyticsDep };
+type DisableAnalyticsThunkDeps = WithServices<NativeAnalyticsDep>;
 
 const disableAnalyticsThunk = createThunk<
     void,
@@ -51,7 +51,7 @@ const disableAnalyticsThunk = createThunk<
 });
 
 export type InitAnalyticsThunkState = AnalyticsRootState;
-export type InitAnalyticsThunkDeps = { services: NativeAnalyticsDep };
+export type InitAnalyticsThunkDeps = WithServices<NativeAnalyticsDep>;
 
 export const initAnalyticsThunk = createThunk<
     void,

--- a/suite-native/biometrics/src/biometricsThunks.ts
+++ b/suite-native/biometrics/src/biometricsThunks.ts
@@ -4,7 +4,7 @@ import { isRejected } from '@reduxjs/toolkit';
 import * as LocalAuthentication from 'expo-local-authentication';
 import type { LocalAuthenticationResult } from 'expo-local-authentication';
 
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 
 import {
@@ -61,7 +61,7 @@ export const authenticateUserThunk = createThunk<
 });
 
 type ToggleBiometricsSettingsThunkState = BiometricsSliceRootState;
-type ToggleBiometricsSettingsThunkDeps = { services: NativeAnalyticsDep };
+type ToggleBiometricsSettingsThunkDeps = WithServices<NativeAnalyticsDep>;
 
 export const toggleBiometricsSettingsThunk = createThunk<
     BiometricsToggleFulfilledResult,

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -10,7 +10,7 @@ import {
     type MessageSystemRootState,
     selectIsFeatureEnabled,
 } from '@suite-common/message-system';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type BackupType, type ReportSecurityCheckDep } from '@suite-common/suite-types';
 import { processEntropyCheckResultThunk } from '@suite-common/wallet-core';
 import {
@@ -46,7 +46,7 @@ const getResetDeviceConfig = (walletBackupType: BackupType): PROTO.ResetDevice =
 };
 
 type CreateAndBackupWalletThunkState = DeviceRootState & MessageSystemRootState;
-type CreateAndBackupWalletThunkDeps = { services: ReportSecurityCheckDep };
+type CreateAndBackupWalletThunkDeps = WithServices<ReportSecurityCheckDep>;
 
 export const createAndBackupWalletThunk = createThunk<
     Err<SerializedError> | OkWithDevice<PROTO.Success>,

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -1,7 +1,7 @@
 import { type UnknownAction, isAnyOf } from '@reduxjs/toolkit';
 
 import { deviceActions, isTrezorDeviceWithState } from '@suite-common/device';
-import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import { type WithServices, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
 import {
@@ -43,7 +43,7 @@ const isActionDeviceRelated = (action: UnknownAction): boolean => {
     return isAnyDeviceEventAction(action);
 };
 
-type DeviceMiddlewareDeps = { services: SuiteSyncDep & NativeAnalyticsDep };
+type DeviceMiddlewareDeps = WithServices<SuiteSyncDep & NativeAnalyticsDep>;
 type DeviceMiddlewareState = AccountsRootState & DiscoveryRootState & NativeBluetoothRootState;
 
 export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps<

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -1,5 +1,5 @@
 import { PORTFOLIO_TRACKER_DEVICE_STATE } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type GetTokenDefinitionsEnabledNetworksDep,
     type TokenDefinitionsRootState,
@@ -45,7 +45,7 @@ const getAccountTypeFromDescriptor = (descriptor: string, symbol: NetworkSymbol)
 };
 
 type ImportAccountThunkState = AccountsRootState & TokenDefinitionsRootState;
-type ImportAccountThunkDeps = { services: GetTokenDefinitionsEnabledNetworksDep };
+type ImportAccountThunkDeps = WithServices<GetTokenDefinitionsEnabledNetworksDep>;
 
 export const importAccountThunk = createThunk<
     void,

--- a/suite-native/module-receive/src/receiveThunks.ts
+++ b/suite-native/module-receive/src/receiveThunks.ts
@@ -1,6 +1,6 @@
 import { getReceiveAddressForFlowEntry, getReceiveAddressToAdd } from '@suite-common/address';
 import { receiveActions, selectCurrentFreshAddress } from '@suite-common/receive';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 
@@ -52,7 +52,7 @@ export const setCurrentFreshAddressForFlowEntryThunk = createThunk<
 );
 
 export type AddReceiveAddressThunkState = ReceiveAddressListRootState;
-export type AddReceiveAddressThunkDeps = { services: NativeAnalyticsDep };
+export type AddReceiveAddressThunkDeps = WithServices<NativeAnalyticsDep>;
 
 export const addReceiveAddressThunk = createThunk<
     void,

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -5,7 +5,7 @@ import {
     type MevProtectionRootState,
     selectIsMevProtectionFeatureEnabled,
 } from '@suite-common/mev';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type AccountsRootState,
     type EnhancePrecomposedTransactionThunkState,
@@ -210,7 +210,8 @@ export type SendTransactionThunkState = MevProtectionRootState &
     PushSendFormTransactionThunkState &
     AddTransactionLabelingThunkState;
 export type SendTransactionThunkDeps = PushSendFormTransactionThunkDeps &
-    AddTransactionLabelingThunkDeps & { services: NativeAnalyticsDep };
+    AddTransactionLabelingThunkDeps &
+    WithServices<NativeAnalyticsDep>;
 
 export const sendTransactionThunk = createThunk<
     Ok<{ txid: string }>,

--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -11,6 +11,7 @@ import { type Persistor, persistStore } from 'redux-persist';
 import { logsMiddleware } from '@suite-common/logger';
 import {
     type ReducerState,
+    type WithServices,
     castExtraStore,
     createStoreWithExtraStoreMiddleware,
 } from '@suite-common/redux-utils';
@@ -78,9 +79,7 @@ export type StoreWithExtra = ReturnType<
 const ENABLE_REDUX_LOGGER = false;
 const enhancers: Array<StoreEnhancer<any, any>> = [];
 
-type GetMiddlewaresDeps = {
-    services: NativeAnalyticsDep & SuiteSyncDep;
-};
+type GetMiddlewaresDeps = WithServices<NativeAnalyticsDep & SuiteSyncDep>;
 
 const getMiddlewares = (getExtra: () => GetMiddlewaresDeps | null) => {
     const middlewares: Middleware[] = [

--- a/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
+++ b/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
@@ -1,5 +1,5 @@
 import { type MessageSystemRootState } from '@suite-common/message-system';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type WithSuiteSyncAndDeviceState,
     selectIsSuiteSyncEnabled,
@@ -25,7 +25,7 @@ type AddTransactionLabelingThunkParams = {
 export type AddTransactionLabelingThunkState = WithSuiteSyncAndDeviceState &
     MessageSystemRootState &
     SendRootState;
-export type AddTransactionLabelingThunkDeps = { services: SuiteSyncDep };
+export type AddTransactionLabelingThunkDeps = WithServices<SuiteSyncDep>;
 
 // Todo: This code below is kinda copy-paste from `applySendFormMetadataLabelsThunk` in Desktop.
 //       However, desktop code is polluted by Legacy Labeling (Metadata) so it cannot be easily reused.

--- a/suite/backup/src/backupDeviceThunk.ts
+++ b/suite/backup/src/backupDeviceThunk.ts
@@ -1,6 +1,6 @@
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import TrezorConnect from '@trezor/connect';
 
@@ -12,9 +12,7 @@ type BackupDeviceThunkParams = {
     skipSuccessToast?: boolean;
 };
 
-export type BackupDeviceThunkDeps = {
-    services: DesktopAnalyticsDep;
-};
+export type BackupDeviceThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export type BackupDeviceThunkState = DeviceRootState;
 

--- a/suite/desktop-update/src/desktopUpdateActionsThunks.ts
+++ b/suite/desktop-update/src/desktopUpdateActionsThunks.ts
@@ -1,6 +1,7 @@
 import { type Dispatch } from 'redux';
 
 import { AppUpdateEventStatus, type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { type WithServices } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type UpdateInfo, desktopApi } from '@trezor/suite-desktop-api';
 
@@ -13,7 +14,7 @@ import {
 
 type GetState = () => DesktopUpdateRootState;
 
-type AvailableThunkDeps = { services: DesktopAnalyticsDep };
+type AvailableThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const availableThunk =
     (info: UpdateInfo) => (dispatch: Dispatch, getState: GetState, extra: AvailableThunkDeps) => {
@@ -41,7 +42,7 @@ export const notAvailableThunk = (info: UpdateInfo) => (dispatch: Dispatch) => {
     dispatch(desktopUpdateActions.notAvailable(info));
 };
 
-type DownloadThunkDeps = { services: DesktopAnalyticsDep };
+type DownloadThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const downloadThunk =
     () => (dispatch: Dispatch, getState: GetState, extra: DownloadThunkDeps) => {
@@ -61,7 +62,7 @@ export const downloadThunk =
         dispatch(desktopUpdateActions.download());
     };
 
-type ReadyThunkDeps = { services: DesktopAnalyticsDep };
+type ReadyThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const readyThunk =
     (info: UpdateInfo) => (dispatch: Dispatch, getState: GetState, extra: ReadyThunkDeps) => {
@@ -83,7 +84,7 @@ export const readyThunk =
         dispatch(desktopUpdateActions.ready(info));
     };
 
-type InstallUpdateThunkDeps = { services: DesktopAnalyticsDep };
+type InstallUpdateThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const installUpdateThunk =
     ({ installNow }: { installNow: boolean }) =>
@@ -115,7 +116,7 @@ export const installUpdateThunk =
         }
     };
 
-type ErrorThunkDeps = { services: DesktopAnalyticsDep };
+type ErrorThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const errorThunk = () => (dispatch: Dispatch, getState: GetState, extra: ErrorThunkDeps) => {
     // eslint-disable-next-line no-restricted-syntax

--- a/suite/labeling/src/processLegacyMetadataIntoSuiteSyncThunk.ts
+++ b/suite/labeling/src/processLegacyMetadataIntoSuiteSyncThunk.ts
@@ -1,6 +1,6 @@
 import { featureUsed } from '@suite/feature-feedback';
 import { type MetadataAddPayload } from '@suite-common/metadata-types';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
 import {
     type EnsureWalletSuiteSyncOnErrors,
@@ -17,7 +17,7 @@ type ProcessMetadataMessageThunkParams = {
     value: string | undefined;
 };
 
-type ProcessLegacyMetadataIntoSuiteSyncThunkDeps = { services: SuiteSyncDep };
+type ProcessLegacyMetadataIntoSuiteSyncThunkDeps = WithServices<SuiteSyncDep>;
 
 /**
  * This is a compatibility thunk to map the old Metadata code to a new Evolu storage.

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -15,6 +15,7 @@ import {
     ProviderErrorAction,
     type WalletLabels,
 } from '@suite-common/metadata-types';
+import { type WithServices } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type Account } from '@suite-common/wallet-types';
 import TrezorConnect, { type StaticSessionId } from '@trezor/connect';
@@ -557,7 +558,7 @@ export const addMetadata =
         return result.success;
     };
 
-export type InitMetadataDeps = { services: DesktopAnalyticsDep };
+export type InitMetadataDeps = WithServices<DesktopAnalyticsDep>;
 
 /**
  * init - prepare everything needed to load + decrypt and upload + decrypt metadata. Note that this method

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -11,6 +11,7 @@ import {
     ProviderErrorAction,
     type Tokens,
 } from '@suite-common/metadata-types';
+import { type WithServices } from '@suite-common/redux-utils';
 import { triggerWebDownloadFile } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { exhaustive } from '@trezor/type-utils';
@@ -100,7 +101,7 @@ type DisconnectProviderParams = {
     removeMetadata?: boolean;
 };
 
-type DisconnectProviderDeps = { services: DesktopAnalyticsDep };
+type DisconnectProviderDeps = WithServices<DesktopAnalyticsDep>;
 
 export const disconnectProvider =
     ({ clientId, dataType, removeMetadata = true }: DisconnectProviderParams) =>
@@ -240,7 +241,7 @@ type ConnectProviderParams = {
     clientId?: string;
 };
 
-export type ConnectProviderDeps = { services: DesktopAnalyticsDep };
+export type ConnectProviderDeps = WithServices<DesktopAnalyticsDep>;
 
 export const connectProvider =
     ({ type, dataType = 'labels', clientId }: ConnectProviderParams) =>

--- a/suite/receive/package.json
+++ b/suite/receive/package.json
@@ -16,6 +16,7 @@
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/receive": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite/receive/src/address/revealNextAddressThunk.ts
+++ b/suite/receive/src/address/revealNextAddressThunk.ts
@@ -12,6 +12,7 @@ import {
     selectCurrentFreshAddress,
     selectTouchedAddresses,
 } from '@suite-common/receive';
+import { type WithServices } from '@suite-common/redux-utils';
 import {
     type AccountsRootState,
     type TransactionsRootState,
@@ -26,7 +27,7 @@ type RevealNextAddressState = AccountsRootState &
     ReceiveRootState &
     SelectLabeledUnusedAddressesState;
 
-type RevealNextAddressThunkDeps = { services: DesktopAnalyticsDep };
+type RevealNextAddressThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const revealNextAddressThunk =
     ({ accountKey }: { accountKey: AccountKey }) =>

--- a/suite/receive/src/verification/showAddressThunk.ts
+++ b/suite/receive/src/verification/showAddressThunk.ts
@@ -10,6 +10,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/device';
 import { type ReceiveRootState, selectCurrentFreshAddress } from '@suite-common/receive';
+import { type WithServices } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type WalletSettingsRootState,
@@ -19,7 +20,7 @@ import {
 } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
-type ShowAddressThunkDeps = { services: DesktopAnalyticsDep };
+type ShowAddressThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const showAddressThunk =
     ({ path }: { path: string }) =>

--- a/suite/receive/tsconfig.json
+++ b/suite/receive/tsconfig.json
@@ -9,6 +9,9 @@
         { "path": "../../suite-common/device" },
         { "path": "../../suite-common/receive" },
         {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
             "path": "../../suite-common/toast-notifications"
         },
         {

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -1,6 +1,6 @@
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import TrezorConnect, { PROTO, type RecoveryDevice } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -23,7 +23,7 @@ const recoveryInputTypeToInputMethod: Record<RecoveryInputType, PROTO.RecoveryDe
     advanced: PROTO.RecoveryDeviceInputMethod.Matrix,
 };
 
-type CheckSeedThunkDeps = { services: DesktopAnalyticsDep };
+type CheckSeedThunkDeps = WithServices<DesktopAnalyticsDep>;
 type CheckSeedThunkState = DeviceRootState & { recovery: RecoveryState };
 
 export const checkSeedThunk = createThunk<
@@ -123,7 +123,7 @@ export const recoverDeviceThunk = createThunk<void, void, { state: RecoverDevice
     },
 );
 
-type RecoveryRerunThunkDeps = { services: DesktopAnalyticsDep };
+type RecoveryRerunThunkDeps = WithServices<DesktopAnalyticsDep>;
 type RecoveryRerunThunkState = DeviceRootState & { recovery: RecoveryState };
 
 // Recovery mode is persistent on T2T1. This means that device stays in recovery mode even after reconnecting.

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -1,6 +1,6 @@
 import { type LocksRootState, lockRouter, selectIsRouterLocked } from '@suite/locks';
 import { type ModalRootState } from '@suite/modal';
-import { createThunk } from '@suite-common/redux-utils';
+import { type WithServices, createThunk } from '@suite-common/redux-utils';
 
 import { type AnchorType } from './anchors';
 import { type Route } from './route';
@@ -57,7 +57,7 @@ export const onLocationChange = createThunk<
  * Called from `@suite-middlewares/suiteMiddleware`
  */
 type RouterInitThunkState = LocksRootState & ModalRootState & RouterRootState;
-type RouterInitThunkDeps = { services: SuiteRouterHistoryDep };
+type RouterInitThunkDeps = WithServices<SuiteRouterHistoryDep>;
 
 export const routerInit = createThunk<
     void,
@@ -79,7 +79,7 @@ type GotoPayload = {
 };
 
 export type GotoThunkState = LocksRootState & ModalRootState & RouterRootState;
-export type GotoThunkDeps = { services: SuiteRouterHistoryDep };
+export type GotoThunkDeps = WithServices<SuiteRouterHistoryDep>;
 
 export const goto = createThunk<void, GotoPayload, { state: GotoThunkState; extra: GotoThunkDeps }>(
     '@router/goto',

--- a/suite/sign-verify/package.json
+++ b/suite/sign-verify/package.json
@@ -18,6 +18,7 @@
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/receive": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/validators": "workspace:*",

--- a/suite/sign-verify/src/signVerifyActions.ts
+++ b/suite/sign-verify/src/signVerifyActions.ts
@@ -2,6 +2,7 @@ import { type Dispatch } from 'redux';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+import { type WithServices } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type WalletSettingsRootState, selectAddressDisplayType } from '@suite-common/wallet-core';
@@ -24,7 +25,7 @@ export type SignVerifyRootState = DeviceRootState & WalletSettingsRootState;
 
 type GetState = () => SignVerifyRootState;
 
-type SignVerifyThunkDeps = { services: DesktopAnalyticsDep };
+type SignVerifyThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 const CANCEL_ERROR_CODES: ErrorCode[] = ['Method_Cancel', 'Failure_ActionCancelled'];
 

--- a/suite/sign-verify/tsconfig.json
+++ b/suite/sign-verify/tsconfig.json
@@ -9,6 +9,9 @@
         { "path": "../../suite-common/device" },
         { "path": "../../suite-common/receive" },
         {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
             "path": "../../suite-common/suite-types"
         },
         {

--- a/suite/tor-desktop/package.json
+++ b/suite/tor-desktop/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite/tor-desktop/src/toggleTorThunk.ts
+++ b/suite/tor-desktop/src/toggleTorThunk.ts
@@ -5,13 +5,14 @@ import { type ModalRootState, openDeferredModal, selectModalType } from '@suite/
 import { type RouterRootState, selectRouterUrl } from '@suite/router';
 import { type TorRootState, isOnionUrl, selectTorBootstrap, torActions } from '@suite/tor';
 import { TorStatus } from '@suite/tor-types';
+import { type WithServices } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type BlockchainRootState, selectBlockchainState } from '@suite-common/wallet-core';
 import { getCustomBackends } from '@suite-common/wallet-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 type ToggleTorRootState = TorRootState & ModalRootState & RouterRootState & BlockchainRootState;
-type ToggleTorDeps = { services: DesktopAnalyticsDep };
+type ToggleTorDeps = WithServices<DesktopAnalyticsDep>;
 
 export type ToggleTorDispatch = ThunkDispatch<ToggleTorRootState, ToggleTorDeps, UnknownAction>;
 

--- a/suite/tor-desktop/tsconfig.json
+++ b/suite/tor-desktop/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
             "path": "../../suite-common/suite-config"
         },
         {

--- a/suite/transfer-uri/package.json
+++ b/suite/transfer-uri/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
         "@suite-common/networks": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/transfer-uri": "workspace:*",
         "@suite/analytics": "workspace:*",

--- a/suite/transfer-uri/src/handleCoinProtocolUri.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.ts
@@ -2,6 +2,7 @@ import { type Dispatch, type UnknownAction } from '@reduxjs/toolkit';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import type { FindNetworkSymbolForProtocolDep } from '@suite-common/networks';
+import { type WithServices } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { isAmountPresent, parseTransferUri } from '@suite-common/transfer-uri';
 import type { Protocol } from '@trezor/network-module-suite-common-types';
@@ -18,9 +19,9 @@ export type CoinProtocol = {
 
 type SaveCoinProtocol = (coinProtocol: CoinProtocol) => UnknownAction;
 
-export type HandleCoinProtocolUriDeps = {
-    services: FindNetworkSymbolForProtocolDep & DesktopAnalyticsDep;
-};
+export type HandleCoinProtocolUriDeps = WithServices<
+    FindNetworkSymbolForProtocolDep & DesktopAnalyticsDep
+>;
 
 /**
  * Fire-and-forget thunk for an incoming transfer URI: decode it, report any

--- a/suite/transfer-uri/tsconfig.json
+++ b/suite/transfer-uri/tsconfig.json
@@ -4,6 +4,9 @@
     "references": [
         { "path": "../../suite-common/networks" },
         {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
             "path": "../../suite-common/toast-notifications"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15640,6 +15640,7 @@ __metadata:
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/receive": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
@@ -15749,6 +15750,7 @@ __metadata:
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/receive": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
@@ -15874,6 +15876,7 @@ __metadata:
   resolution: "@suite/tor-desktop@workspace:suite/tor-desktop"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -15954,6 +15957,7 @@ __metadata:
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
     "@suite-common/networks": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/transfer-uri": "workspace:*"
     "@suite-common/wallet-config": "workspace:^"


### PR DESCRIPTION
## Description

Add a shared WithServices helper for explicit Redux service dependencies and migrate existing contracts to it. Teach the unused-intersection ESLint rule to inspect service intersections through the wrapper, including dependencies required by dispatched child thunks.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/redux-with-services/web/](https://dev.suite.sldev.cz/suite-web/refactor/redux-with-services/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/redux-with-services&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/redux-with-services&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/redux-with-services&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T11:19:52.806Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T11:20:20.289Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->