### PR TITLE
fix(utxo-lib): count SegWit multisig witness weight

### DIFF
--- a/packages/utxo-lib/src/txWeightCalculator.ts
+++ b/packages/utxo-lib/src/txWeightCalculator.ts
@@ -76,7 +76,7 @@ export class TxWeightCalculator {
     addInput(input: Input) {
         this.inputs_count += 1;
 
-        let input_script_size = 0;
+        let inputScriptSize: number;
 
         if (input.multisig) {
             if (input.script_type === 'SPENDTAPROOT') {
@@ -85,28 +85,27 @@ export class TxWeightCalculator {
             const n = input.multisig.nodes
                 ? input.multisig.nodes.length
                 : input.multisig.pubkeys.length;
-            let multisig_script_size = _TXSIZE_MULTISIGSCRIPT + n * (1 + _TXSIZE_PUBKEY);
+            let multisigScriptSize = _TXSIZE_MULTISIGSCRIPT + n * (1 + _TXSIZE_PUBKEY);
             if (SEGWIT_INPUT_SCRIPT_TYPES.includes(input.script_type)) {
-                // eslint-disable-next-line no-useless-assignment -- Fixed separately in #31838.
-                multisig_script_size += getVarIntSize(multisig_script_size);
+                multisigScriptSize += getVarIntSize(multisigScriptSize);
             } else {
-                multisig_script_size += getOpPushSize(multisig_script_size);
-                input_script_size =
-                    1 + // the OP_FALSE bug in multisig
-                    input.multisig.m * (1 + _TXSIZE_DER_SIGNATURE) +
-                    multisig_script_size;
+                multisigScriptSize += getOpPushSize(multisigScriptSize);
             }
+            inputScriptSize =
+                1 + // the OP_FALSE bug in multisig
+                input.multisig.m * (1 + _TXSIZE_DER_SIGNATURE) +
+                multisigScriptSize;
         } else if (input.script_type === 'SPENDTAPROOT') {
-            input_script_size = 1 + _TXSIZE_SCHNORR_SIGNATURE;
+            inputScriptSize = 1 + _TXSIZE_SCHNORR_SIGNATURE;
         } else {
-            input_script_size = 1 + _TXSIZE_DER_SIGNATURE + 1 + _TXSIZE_PUBKEY;
+            inputScriptSize = 1 + _TXSIZE_DER_SIGNATURE + 1 + _TXSIZE_PUBKEY;
         }
 
         this.counter += 4 * _TXSIZE_INPUT;
 
         if (NONSEGWIT_INPUT_SCRIPT_TYPES.includes(input.script_type)) {
-            input_script_size += getVarIntSize(input_script_size);
-            this.counter += 4 * input_script_size;
+            inputScriptSize += getVarIntSize(inputScriptSize);
+            this.counter += 4 * inputScriptSize;
         } else if (SEGWIT_INPUT_SCRIPT_TYPES.includes(input.script_type)) {
             this.segwit_inputs_count += 1;
             if (input.script_type === 'SPENDP2SHWITNESS') {
@@ -119,7 +118,7 @@ export class TxWeightCalculator {
             } else {
                 this.counter += 4; // empty script_sig (1 byte)
             }
-            this.counter += 1 + input_script_size; // discounted witness
+            this.counter += 1 + inputScriptSize; // discounted witness
         } else if (input.script_type === 'EXTERNAL') {
             const witness_size = 0;
             const script_sig_size = 0;
@@ -145,7 +144,7 @@ export class TxWeightCalculator {
             throw new Error('unknown input script_type');
         }
 
-        this.inputs.push({ length: input_script_size });
+        this.inputs.push({ length: inputScriptSize });
     }
 
     addOutputByKey(key: keyof typeof OUTPUT_SCRIPT_LENGTH) {

--- a/packages/utxo-lib/src/txweight.test.ts
+++ b/packages/utxo-lib/src/txweight.test.ts
@@ -38,32 +38,30 @@ describe('TxWeightCalculator', () => {
         expect(c.getTotal()).toEqual(4 * 94 + 68);
     });
 
-    // multisig is not implemented
-    // eslint-disable-next-line jest/no-commented-out-tests
-    // it('legacy multisig', () => {
-    //     const c = new TxWeightCalculator();
-    //     c.addInput({
-    //         script_type: 'SPENDMULTISIG',
-    //         multisig: {
-    //             pubkeys: [{}, {}, {}],
-    //             m: 2,
-    //         },
-    //     });
-    //     c.addOutputByKey('p2pkh');
-    //     expect(c.getTotal()).toEqual(4 * 341);
-    // });
+    it('legacy multisig', () => {
+        const c = new TxWeightCalculator();
+        c.addInput({
+            script_type: 'SPENDMULTISIG',
+            multisig: {
+                pubkeys: [{}, {}, {}],
+                m: 2,
+            },
+        });
+        c.addOutputByKey('p2pkh');
+        expect(c.getTotal()).toEqual(4 * 341);
+    });
 
-    // eslint-disable-next-line jest/no-commented-out-tests
-    // it('segwit multisig', () => {
-    //     const c = new TxWeightCalculator();
-    //     c.addInput({
-    //         script_type: 'SPENDP2SHWITNESS',
-    //         multisig: {
-    //             pubkeys: [{}, {}, {}],
-    //             m: 2,
-    //         },
-    //     });
-    //     c.addOutputByKey('p2wpkh');
-    //     expect(c.getTotal()).toEqual(4 * 129 + 256);
-    // });
+    it('segwit multisig', () => {
+        const c = new TxWeightCalculator();
+        c.addInput({
+            script_type: 'SPENDP2SHWITNESS',
+            multisig: {
+                pubkeys: [{}, {}, {}],
+                m: 2,
+            },
+        });
+        // P2WSH output: OP_0, 32-byte witness program.
+        c.addOutput({ length: 34 });
+        expect(c.getTotal()).toEqual(4 * 129 + 256);
+    });
 });


### PR DESCRIPTION
## Description

`TxWeightCalculator.addInput()` previously left `input_script_size` at zero for SegWit multisig inputs. It calculated the multisig witness-script length and its CompactSize prefix, but never included the result in `input_script_size`; the later witness accounting therefore counted only the stack-item-count byte and omitted the dummy `OP_FALSE` item, signatures, and witness script. This path is reachable through `getTransactionVbytes()`, which forwards `input.multisig` to the calculator.

The issue surfaced when ESLint 10's `no-useless-assignment` rule identified the discarded calculation in #31832. With the corrected 34-byte P2WSH output fixture, the regression test expected 772 weight units but received 519, an undercount of 253 weight units and 63 virtual bytes for the tested 2-of-3 transaction. Underestimated virtual size can lead callers to underestimate the required transaction fee.

The fix mirrors [`trezor-firmware`](https://github.com/trezor/trezor-firmware/blob/main/core/src/apps/bitcoin/sign_tx/tx_weight.py): both legacy and SegWit multisig paths now calculate the full input stack size, using CompactSize encoding for the SegWit witness script and an opcode-push prefix for the legacy redeem script. It also activates the previously commented legacy and SegWit multisig tests and corrects the SegWit fixture from a 22-byte P2WPKH output to the 34-byte P2WSH output used by the firmware reference transaction.

Risk is medium and limited to transaction-size estimation for multisig inputs. SegWit multisig estimates increase to include the previously omitted witness data; legacy multisig, single-signature SegWit, Taproot, and transaction serialization/signing behavior remain unchanged.

Validated with the complete `@trezor/utxo-lib` unit suite (2,289 tests), the package type-check, focused ESLint, and Prettier. The regression was also confirmed red before the implementation (`519` received versus `772` expected).

Stacked on #31832. Tracks https://github.com/trezor/trezor-suite/issues/30670.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/utxo-lib-segwit-multisig-weight/web/](https://dev.suite.sldev.cz/suite-web/fix/utxo-lib-segwit-multisig-weight/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/utxo-lib-segwit-multisig-weight&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/utxo-lib-segwit-multisig-weight&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/utxo-lib-segwit-multisig-weight&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T12:08:39.693Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T12:08:41.594Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to txWeightCalculator.ts sits in a widely-shared UTXO utility, so the static mapping covers 136 tests. Most of those are transitive consumers that never actually construct or display a UTXO transaction. The recommended strategy is to run a small, targeted set of tests that directly exercise fee estimation, max-amount calculation, and on-device total/fee display for BTC, LTC, and DOGE, plus the BTC swap paths that depend on accurate weight computation. No broad regression run is needed.

<details><summary><b>Changed files (2)</b></summary>

- `packages/utxo-lib/src/txWeightCalculator.ts`
- `packages/utxo-lib/src/txweight.test.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test directly exercises a BTC swap with a custom fee rate and asserts that the total amount equals fee plus send amount and that the fee rate shown on the device prompt matches the input. This is one of the most direct end-to-end validations of txWeightCalculator behavior in transaction construction.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — The test constructs Bitcoin regtest transactions with multiple outputs, setMax amount, locktime, and OP_RETURN data. Each of these paths requires accurate transaction weight calculation to derive fees and the maximum spendable amount.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test fills the LTC send form, uses the setMax button, and attempts to spend a MimbleWimble peg-out output. Fee estimation and max-amount logic for LTC rely on txWeightCalculator.
- `suite/e2e/tests/wallet/send-doge.test.ts` — The test verifies the DOGE send flow and checks the amount, total, and fee shown on the device prompt. These displayed values are derived from transaction weight and fee calculation for Dogecoin.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The BTC sell flow constructs a Bitcoin transaction and calculates a network fee for the send step to the provider. A regression in txWeightCalculator could change the displayed or computed fee.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — This BTC swap flow requires building a Bitcoin transaction and verifying the total amount and fee on both the app confirmation modal and the hardware device display, which depend on correct transaction weight calculation.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/utxo-lib/src/txweight.test.ts`

_Updated: 2026-08-28T12:06:17.601Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->