### PR TITLE
fix(suite): reconnect after setting custom backend

### DIFF
--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts
@@ -1,0 +1,59 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import TrezorConnect from '@trezor/connect';
+
+import { blockchainInitialState, prepareBlockchainReducer } from './blockchainReducer';
+import { setCustomBackendThunk } from './blockchainThunks';
+
+const blockchainReducer = prepareBlockchainReducer(extraDependenciesCommonMock);
+const electrumUrl = '127.0.0.1:50001:t';
+
+const initStore = () =>
+    configureMockStore({
+        reducer: combineReducers({
+            wallet: combineReducers({
+                blockchain: blockchainReducer,
+            }),
+        }),
+        preloadedState: {
+            wallet: {
+                blockchain: {
+                    ...blockchainInitialState,
+                    btc: {
+                        ...blockchainInitialState.btc,
+                        backends: {
+                            selected: 'electrum' as const,
+                            urls: { electrum: [electrumUrl] },
+                        },
+                    },
+                },
+            },
+        },
+    });
+
+describe(setCustomBackendThunk.name, () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('requests a connection after applying a custom backend', async () => {
+        const setCustomBackend = jest
+            .spyOn(TrezorConnect, 'blockchainSetCustomBackend')
+            .mockResolvedValue({ success: true, payload: true });
+        const reconnect = jest
+            .spyOn(TrezorConnect, 'blockchainUnsubscribeFiatRates')
+            .mockResolvedValue({ success: true, payload: { subscribed: false } });
+        const store = initStore();
+
+        await store.dispatch(setCustomBackendThunk('btc'));
+
+        expect(setCustomBackend).toHaveBeenCalledWith({
+            coin: 'btc',
+            blockchainLink: { type: 'electrum', url: [electrumUrl] },
+        });
+        expect(reconnect).toHaveBeenCalledWith({ coin: 'btc', identity: undefined });
+        const setCustomBackendOrder =
+            setCustomBackend.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
+        const reconnectOrder = reconnect.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY;
+        expect(setCustomBackendOrder).toBeLessThan(reconnectOrder);
+    });
+});

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -111,11 +111,14 @@ export const setCustomBackendThunk = createThunk<
     unknown,
     NetworkSymbol,
     { state: SetCustomBackendThunkState }
->(`${BLOCKCHAIN_MODULE_PREFIX}/setCustomBackendThunk`, (symbol, { getState }) => {
+>(`${BLOCKCHAIN_MODULE_PREFIX}/setCustomBackendThunk`, async (symbol, { dispatch, getState }) => {
     const blockchain = selectBlockchainState(getState());
     const backends = [getBackendFromSettings(symbol, blockchain[symbol].backends)];
+    const result = await setBackendsToConnect(backends);
 
-    return setBackendsToConnect(backends);
+    await dispatch(reconnectBlockchainThunk({ symbol }));
+
+    return result;
 });
 
 export type InitBlockchainThunkState = AccountsRootState &

--- a/suite-native/module-settings/src/hooks/useNetworkBackendForm.ts
+++ b/suite-native/module-settings/src/hooks/useNetworkBackendForm.ts
@@ -16,7 +16,6 @@ import {
 import {
     type BlockchainRootState,
     blockchainActions,
-    reconnectBlockchainThunk,
     selectNetworkBlockchainInfo,
 } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
@@ -119,7 +118,6 @@ export const useNetworkBackendForm = ({ symbol, backendOptions }: Network) => {
                 urls: serverType !== 'default' ? [serverAddress] : [],
             }),
         );
-        dispatch(reconnectBlockchainThunk({ symbol }));
         analytics.report({
             type: events.settingsChangeCoinBackendEvent.name,
             payload: { symbol, type: serverType },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes a custom-backend recovery failure that occurs after a failed backend instance has been removed. Saving a reachable replacement endpoint updated the backend configuration, but `reconnectAllBackends()` had no remaining instance to reconnect, leaving Suite in `connected: false` until another blockchain request was made.

The shared `setCustomBackendThunk` now:

1. Awaits `blockchainSetCustomBackend`.
2. Dispatches and awaits the existing `reconnectBlockchainThunk`.
3. Returns the original backend-setting result.

This uses the established inexpensive reconnect operation that emits `BLOCKCHAIN.CONNECT` or `BLOCKCHAIN.ERROR` and creates a backend instance when one does not exist.

The Native backend form previously dispatched its own reconnect immediately after the backend-setting action. That request could race with asynchronous configuration and became redundant after centralizing the ordered reconnect in the shared thunk, so it has been removed.

A co-located wallet-core regression test verifies the backend payload, the reconnect request, and their invocation order.

## Notes for QA

Primary regression scenario on Desktop:

1. Enable Bitcoin and select a custom Electrum backend.
2. Save `127.0.0.1:9:t` and wait for the connection failure.
3. Replace it with a reachable Electrum endpoint.
4. Confirm the settings.
5. Open Connection Info without clicking another reconnect action or loading an account.
6. Verify Suite reports the reachable backend as connected.

Please also verify:

- Switching between default and custom backends still reconnects normally.
- An unreachable replacement continues to emit and display the connection error.
- Native backend changes reconnect once after the new backend configuration is applied.

Validation performed:

- Focused wallet-core regression test: 1 passed.
- Existing Suite blockchain action tests: 46 passed.
- ESLint and Prettier passed for all changed files.
- Linux Desktop production AppImage built and passed an invalid-to-valid backend recovery smoke test.

## Related Issue

Resolve #30844

## Screenshots:

Not included. This changes connection sequencing and state recovery; it does not introduce a visual change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch core blockchain discovery thunks and a network-backend form hook, so the main risk is around custom backend configuration, backend connection state, and account discovery. A small set of backend-focused E2E tests provides high confidence without running the entire suite. The native hook and the updated unit test file have no direct E2E coverage.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-native/module-settings/src/hooks/useNetworkBackendForm.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly exercises enabling coins, configuring custom Blockbook backend URLs, validating discovery errors/success, and observing backend connection state — all of which rely on the blockchain thunks that manage backend discovery and connection lifecycle.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Configures custom Blockbook backends for BTC and LTC and asserts that account discovery completes and the dashboard graph loads, making it a strong end-to-end check for blockchain thunk changes that affect backend-driven discovery.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — Covers enabling/disabling networks and setting a custom Blockbook backend for ETH with the backend indicator, sharing the network/backend configuration path affected by the blockchain thunk changes.
- `suite/e2e/tests/settings/electrum.test.ts` — Validates discovery over a custom Electrum backend for regtest, which exercises the same backend-selection and discovery infrastructure touched by the blockchain thunks.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts`
- `suite-native/module-settings/src/hooks/useNetworkBackendForm.ts`

_Updated: 2026-08-28T08:46:16.161Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/custom-backend-reconnect-reopen/web/](https://dev.suite.sldev.cz/suite-web/fix/custom-backend-reconnect-reopen/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/custom-backend-reconnect-reopen&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/custom-backend-reconnect-reopen&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/custom-backend-reconnect-reopen&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T08:48:33.163Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-28T08:47:33.292Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->