### PR TITLE
Extend Cardano fake pending tx deadline to 15 minutes

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsThunks.test.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.test.ts
@@ -12,30 +12,32 @@ const account = {
     networkType: 'cardano',
 } as unknown as Account;
 
+const BLOCK_HEIGHT = 100;
+
 const initStore = () =>
     configureMockStore({
         preloadedState: {
             wallet: {
-                blockchain: { ada: { blockHeight: 100 } },
+                blockchain: { ada: { blockHeight: BLOCK_HEIGHT } },
             },
         },
     });
 
+const dispatchFakePendingTx = async (store: ReturnType<typeof initStore>) => {
+    await store.dispatch(
+        addFakePendingCardanoTxThunk({
+            precomposedTransaction: { totalSpent: '2170000', fee: '170000' },
+            txid: 'test-txid',
+            account,
+        }),
+    );
+
+    return store.getActions().find(transactionsActions.addTransaction.match);
+};
+
 describe('addFakePendingCardanoTxThunk', () => {
     it('stores the pending tx with the fee excluded from the amount, matching the confirmed tx from blockfrost', async () => {
-        const store = initStore();
-
-        await store.dispatch(
-            addFakePendingCardanoTxThunk({
-                precomposedTransaction: { totalSpent: '2170000', fee: '170000' },
-                txid: 'test-txid',
-                account,
-            }),
-        );
-
-        const addTransactionAction = store
-            .getActions()
-            .find(transactionsActions.addTransaction.match);
+        const addTransactionAction = await dispatchFakePendingTx(initStore());
 
         expect(addTransactionAction?.payload.transactions).toEqual([
             expect.objectContaining({
@@ -45,8 +47,19 @@ describe('addFakePendingCardanoTxThunk', () => {
                 fee: '170000',
                 totalSpent: '2170000',
                 blockHash: undefined,
-                deadline: 110,
+                deadline: 145,
             }),
         ]);
+    });
+
+    it('keeps the pending tx alive for 15 minutes worth of Cardano blocks, as Blockfrost only reports the tx once it is confirmed and indexed', async () => {
+        const addTransactionAction = await dispatchFakePendingTx(initStore());
+
+        const [transaction] = addTransactionAction?.payload.transactions ?? [];
+        const cardanoBlockTimeSeconds = 20;
+
+        expect(transaction?.deadline).toBe(
+            BLOCK_HEIGHT + Math.ceil((15 * 60) / cardanoBlockTimeSeconds),
+        );
     });
 });

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -61,6 +61,11 @@ import { ethereumGetCurrentNonceThunk } from '../send/sendFormEthereumThunks';
 import { type SendRootState } from '../send/sendFormReducer';
 import { selectSendSignedTx } from '../send/sendFormSelectors';
 
+// How long a locally added fake pending tx is kept in the UI.
+const FAKE_TX_TTL_SECONDS = 15 * 60;
+// Cardano's average block interval, not reported by @trezor/connect.
+const CARDANO_BLOCK_TIME_SECONDS = 20;
+
 /**
  * Replace existing transaction in the reducer (RBF)
  * There might be multiple occurrences of the same transaction assigned to multiple accounts in the storage:
@@ -419,7 +424,6 @@ export const addFakePendingEvmTxThunk = createThunk<
         const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);
         const rawFeeInfo = selectRawNetworkFeeInfo(getState(), account.symbol);
 
-        const FAKE_TX_TTL_SECONDS = 15 * 60; // keep fake tx for 15 minutes
         const deadline = FAKE_TX_TTL_SECONDS / rawFeeInfo!.blockTime;
 
         const sig = getEvmTransactionTextSignature(precomposedForm.transactionData);
@@ -485,7 +489,7 @@ export const addFakePendingCardanoTxThunk = createThunk<
                 totalInput: '0',
                 totalOutput: '0',
             },
-            deadline: blockHeight + 10,
+            deadline: blockHeight + Math.ceil(FAKE_TX_TTL_SECONDS / CARDANO_BLOCK_TIME_SECONDS),
         };
         dispatch(transactionsActions.addTransaction({ transactions: [fakeTx], account }));
     },
@@ -511,7 +515,6 @@ export const addFakePendingTronTxThunk = createThunk<
     ({ txid, account, amount, fee, type, target, tronSpecific }, { dispatch, getState }) => {
         if (account.networkType !== 'tron') return;
 
-        const FAKE_TX_TTL_SECONDS = 15 * 60;
         const blockTime = selectRawNetworkFeeInfo(getState(), account.symbol)?.blockTime ?? 0;
         const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol) ?? 0;
         const deadline = blockHeight + Math.ceil(FAKE_TX_TTL_SECONDS / blockTime);


### PR DESCRIPTION
## Description

Evicting the fake pending Cardano tx after a hardcoded 10 blocks made slower txs vanish from history. It now uses the same 15-minute TTL as the EVM and Tron thunks.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30034