### PR TITLE
Prevent mobile e2e open handles hanging runs

### DIFF
--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -397,6 +397,9 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
 
         return null;
     }
+    terminate() {
+        this.client.terminate();
+    }
 
     // legacy api, should be removed probably
     dispose() {

--- a/packages/websocket-client/src/client.test.ts
+++ b/packages/websocket-client/src/client.test.ts
@@ -1,4 +1,4 @@
-import { type ServerOptions, type WebSocket, WebSocketServer } from 'ws';
+import WS, { type ServerOptions, type WebSocket, WebSocketServer } from 'ws';
 
 import { WebsocketClient } from './client';
 
@@ -61,6 +61,34 @@ const createServer = async () => {
 
     return { server, url: `ws://localhost:${port}` };
 };
+
+/** Captures the `ws` instance created by the client, which is otherwise private. */
+const spyOnSocket = (cli: WebsocketClient<any>) => {
+    let socket: WebSocket | undefined;
+    // @ts-expect-error initWebsocket is protected
+    jest.spyOn(cli, 'initWebsocket').mockImplementation(options => {
+        // @ts-expect-error initWebsocket is protected
+        socket = WebsocketClient.prototype.initWebsocket.call(cli, options);
+
+        return socket;
+    });
+
+    return () => socket;
+};
+
+/**
+ * `terminate()` only moves the socket to `CLOSING`, `CLOSED` is reached on the next tick.
+ * The listener has to be attached after `terminate()`, which strips the previous ones.
+ */
+const waitForSocketClose = (socket?: WebSocket) =>
+    new Promise<void>(resolve => {
+        if (socket?.readyState === WS.CLOSED) {
+            resolve();
+
+            return;
+        }
+        socket?.once('close', () => resolve());
+    });
 
 describe('WebsocketClient', () => {
     let server: Server;
@@ -151,6 +179,42 @@ describe('WebsocketClient', () => {
         await cli.connect();
         cli.dispose();
         expect(disconnectedSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('client.terminate() destroys an open socket', async () => {
+        const cli = new Client({ url: server.getUrl() });
+        const socket = spyOnSocket(cli);
+        await cli.connect();
+
+        cli.terminate();
+
+        expect(cli.isConnected()).toEqual(false);
+        await waitForSocketClose(socket());
+        expect(socket()?.readyState).toEqual(WS.CLOSED);
+        expect(() => cli.terminate()).not.toThrow();
+    });
+
+    it('client.terminate() destroys a socket that never opened', async () => {
+        const cli = new Client({ url: server.getUrl() });
+        const socket = spyOnSocket(cli);
+        // NOTE: intentionally not awaited, the socket is still CONNECTING
+        const abandoned = cli.connect();
+        expect(socket()?.readyState).toEqual(WS.CONNECTING);
+
+        // `disconnect()` would be a no-op here and leak the underlying handle
+        cli.terminate();
+
+        await expect(abandoned).rejects.toThrow('websocket_terminated');
+        await waitForSocketClose(socket());
+        expect(socket()?.readyState).toEqual(WS.CLOSED);
+
+        // the abandoned attempt must not be handed out by the next `connect()`
+        await cli.connect();
+        expect(cli.isConnected()).toEqual(true);
+        const resp = await cli.sendMessage({ method: 'init' });
+        expect(resp.success).toEqual(true);
+
+        cli.terminate();
     });
 
     it('throws connection error', async () => {

--- a/packages/websocket-client/src/client.test.ts
+++ b/packages/websocket-client/src/client.test.ts
@@ -181,6 +181,19 @@ describe('WebsocketClient', () => {
         expect(disconnectedSpy).toHaveBeenCalledTimes(0);
     });
 
+    it('client.dispose() rejects a pending connection attempt', async () => {
+        const cli = new Client({ url: server.getUrl() });
+        // NOTE: intentionally not awaited, the socket is still CONNECTING
+        const abandoned = cli.connect();
+
+        cli.dispose();
+
+        await expect(abandoned).rejects.toThrow('websocket_disposed');
+
+        // `dispose` leaves the socket itself behind, release it so the run can exit
+        cli.terminate();
+    });
+
     it('client.terminate() destroys an open socket', async () => {
         const cli = new Client({ url: server.getUrl() });
         const socket = spyOnSocket(cli);

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -311,6 +311,10 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
 
     dispose() {
         this.removeAllListeners();
+        // `onClose` below strips the handlers that would settle an attempt still in flight,
+        // so it has to be dropped here as well - otherwise `connectPromise` would keep being
+        // handed out until the connection timeout fires.
+        this.clearConnectionAttempt(new WebsocketError('websocket_disposed'));
         this.disconnect();
         this.onClose();
     }

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws';
 
-import { TypedEmitter, createDeferred, createDeferredManager } from '@trezor/utils';
+import { type Deferred, TypedEmitter, createDeferred, createDeferredManager } from '@trezor/utils';
 
 type WebsocketOptions = {
     url: string;
@@ -43,6 +43,8 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
     private ws?: WebSocket;
     private pingTimeout?: ReturnType<typeof setTimeout>;
     private connectPromise?: Promise<void>;
+    private connectDeferred?: Deferred;
+    private connectionTimeout?: ReturnType<typeof setTimeout>;
 
     protected createWebsocket?(): WebSocket;
     protected ping() {
@@ -195,6 +197,7 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
         // create deferred promise
         const dfd = createDeferred();
         this.connectPromise = dfd.promise;
+        this.connectDeferred = dfd;
 
         const ws = this.createWebsocket ? this.createWebsocket() : this.initWebsocket(this.options);
 
@@ -212,6 +215,7 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
             this.options.connectionTimeout || this.options.timeout || DEFAULT_TIMEOUT,
         );
         (connectionTimeout as any).unref?.();
+        this.connectionTimeout = connectionTimeout;
 
         ws.once('error', error => {
             clearTimeout(connectionTimeout);
@@ -228,7 +232,10 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
 
         // wait for onopen event
         return dfd.promise.finally(() => {
-            this.connectPromise = undefined;
+            // a newer attempt may already be in flight if this one was dropped by `terminate`
+            if (this.connectDeferred === dfd) {
+                this.clearConnectionAttempt();
+            }
         });
     }
 
@@ -259,6 +266,33 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
         }
 
         return Promise.resolve();
+    }
+
+    // Rejecting the deferred is what unblocks callers already awaiting the attempt.
+    private clearConnectionAttempt(error?: WebsocketError) {
+        const dfd = this.connectDeferred;
+
+        clearTimeout(this.connectionTimeout);
+        this.connectionTimeout = undefined;
+        this.connectDeferred = undefined;
+        this.connectPromise = undefined;
+
+        if (error) {
+            dfd?.reject(error);
+        }
+    }
+
+    /**
+     * Unlike `disconnect`, which is a no-op unless the socket is `OPEN`, this also releases
+     * sockets stuck in `CONNECTING`/`CLOSING`, whose handle would keep the event loop alive.
+     * The client stays usable, the next `connect()` starts from scratch.
+     */
+    terminate() {
+        const { ws } = this;
+        this.clearConnectionAttempt(new WebsocketError('websocket_terminated'));
+        this.onClose();
+        ws?.terminate();
+        this.ws = undefined;
     }
 
     isConnected() {

--- a/packages/websocket-client/src/ws.browser.ts
+++ b/packages/websocket-client/src/ws.browser.ts
@@ -50,6 +50,11 @@ class WSWrapper extends EventEmitter {
         }
     }
 
+    // Counterpart of `ws.terminate()` in Node.js, closes the socket in any `readyState`.
+    terminate() {
+        this._ws.close();
+    }
+
     send(message: any) {
         if (this.readyState !== WSWrapper.OPEN) {
             throw new WebsocketError(`Connection is not open. state: ${this.readyState}`);

--- a/packages/websocket-client/src/ws.native.ts
+++ b/packages/websocket-client/src/ws.native.ts
@@ -56,6 +56,11 @@ class WSWrapper extends EventEmitter {
         }
     }
 
+    // Counterpart of `ws.terminate()` in Node.js, closes the socket in any `readyState`.
+    terminate() {
+        this._ws.close();
+    }
+
     send(message: any) {
         if (this.readyState !== WSWrapper.OPEN) {
             throw new WebsocketError(`Connection is not open. state: ${this.readyState}`);

--- a/suite-native/app/e2e/jest.perTestFile.teardown.ts
+++ b/suite-native/app/e2e/jest.perTestFile.teardown.ts
@@ -1,38 +1,52 @@
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-const TEARDOWN_TIMEOUT = 30_000;
+const TERMINATE_APP_TIMEOUT = 15_000;
+const TREZOR_USER_ENV_TIMEOUT = 15_000;
+
+/**
+ * Rejections are swallowed on purpose - a request abandoned here gets rejected later by
+ * `TrezorUserEnvLink.terminate()` and an unhandled rejection would kill the Jest process.
+ */
+const withTimeout = async (label: string, promise: Promise<unknown>, timeoutMs: number) => {
+    const guarded = promise.catch(error => {
+        console.error(`Error during Detox teardown: ${label} failed.`, error);
+    });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>(resolve => {
+        timer = setTimeout(() => {
+            console.error(`Error during Detox teardown: ${label} timed out after ${timeoutMs} ms.`);
+            resolve();
+        }, timeoutMs);
+        timer.unref?.();
+    });
+
+    await Promise.race([guarded, timeout]);
+    clearTimeout(timer);
+};
 
 // We want to stop trezor at two places:
 // 1) afterAll - to cover normal test run teardowns
 // 2) beforeEach - to cover cases where previous tests hang and afterAll is not called
-const stopTrezorUserEnv = async () => {
-    if (device.getPlatform() === 'android') {
-        await TrezorUserEnvLink.stopEmu();
-        await TrezorUserEnvLink.stopBridge();
-        await TrezorUserEnvLink.disconnect();
-    }
-};
-
-const teardownPromises = async () => {
+const teardown = async () => {
     try {
-        await device.terminateApp();
-        await stopTrezorUserEnv();
-    } catch (error) {
-        console.error('Error during Detox global teardown:', error);
+        await withTimeout('device.terminateApp()', device.terminateApp(), TERMINATE_APP_TIMEOUT);
+
+        if (device.getPlatform() === 'android') {
+            await withTimeout('stopEmu()', TrezorUserEnvLink.stopEmu(), TREZOR_USER_ENV_TIMEOUT);
+            await withTimeout(
+                'stopBridge()',
+                TrezorUserEnvLink.stopBridge(),
+                TREZOR_USER_ENV_TIMEOUT,
+            );
+        }
+    } finally {
+        // Has to run even when the steps above time out. Otherwise the trezor-user-env websocket
+        // stays open and its TCP handle keeps Jest from exiting after the last test file.
+        TrezorUserEnvLink.terminate();
     }
 };
 
-afterAll(async () => {
-    // We don't want timed out global teardown to fail test run.
-    let timer: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise<void>(resolve => {
-        timer = setTimeout(resolve, TEARDOWN_TIMEOUT);
-        timer.unref?.();
-    });
-    await Promise.race([teardownPromises(), timeoutPromise]);
-});
+afterAll(teardown);
 
-beforeEach(async () => {
-    await device.terminateApp();
-    await stopTrezorUserEnv();
-});
+beforeEach(teardown);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=matejkriz/fix-mobile-e2e-open-handles&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=matejkriz/fix-mobile-e2e-open-handles&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/fix-mobile-e2e-open-handles&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T15:08:17.286Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T15:07:54.542Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/matejkriz/fix-mobile-e2e-open-handles/web/](https://dev.suite.sldev.cz/suite-web/matejkriz/fix-mobile-e2e-open-handles/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are low-level websocket/client and trezor-user-env-link infrastructure that E2E tests rely on for device, bridge, and regtest communication, but none are statically referenced by the candidate tests. I therefore inferred coverage by selecting tests that exercise bridge lifecycle, bridge sessions, device power/reconnect cycles, and regtest RPC. No Suite-native or browser-specific websocket implementations are covered by the available suite/e2e tests.

<details><summary><b>Changed files (6)</b></summary>

- `packages/trezor-user-env-link/src/api.ts`
- `packages/websocket-client/src/client.test.ts`
- `packages/websocket-client/src/client.ts`
- `packages/websocket-client/src/ws.browser.ts`
- `packages/websocket-client/src/ws.native.ts`
- `suite-native/app/e2e/jest.perTestFile.teardown.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Directly exercises bridge daemon spawning and lifecycle, which relies on trezor-user-env-link and websocket-client to start, monitor, and stop the bridge process. A regression here would be immediately visible and breaks a core E2E infrastructure path.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Validates bundled bridge process startup/shutdown and external bridge restart scenarios; these operations flow through the changed websocket-client/trezor-user-env-link code and are the most direct E2E coverage available.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Inferred coverage: exercises device power-off/power-on, passphrase wallet creation, and address verification, all of which depend on trezor-user-env-link device control via websocket.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Inferred coverage: intentionally stops and restarts the bridge to simulate disconnect/reconnect during a recovery dry run, stressing websocket reconnection and trezor-user-env-link bridge control.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Inferred coverage: manipulates Bridge sessions across browser tabs and reclaims stolen sessions, directly exercising bridge transport/session enumeration that is backed by the changed websocket layer.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Inferred coverage: uses trezor-user-env-link regtest RPC helpers (sendToAddressAndMineBlock, mineBlocks) to fund wallets and mine blocks, covering a different surface of the trezor-user-env-link API affected by the websocket changes.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/websocket-client/src/client.test.ts`
- `packages/websocket-client/src/ws.browser.ts`
- `packages/websocket-client/src/ws.native.ts`
- `suite-native/app/e2e/jest.perTestFile.teardown.ts`

_Updated: 2026-08-28T15:06:27.184Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->