### PR TITLE
fix(suite-native): revert showExternalIcon from the Link component

### DIFF
--- a/suite-native/link/package.json
+++ b/suite-native/link/package.json
@@ -14,8 +14,6 @@
         "@suite-common/analytics": "workspace:*",
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-native/analytics": "workspace:*",
-        "@suite-native/atoms": "workspace:*",
-        "@suite-native/icons": "workspace:*",
         "@suite-native/toasts": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",

--- a/suite-native/link/src/components/Link.tsx
+++ b/suite-native/link/src/components/Link.tsx
@@ -1,16 +1,13 @@
-import { type GestureResponderEvent, Pressable, type TextProps } from 'react-native';
+import { type GestureResponderEvent, type TextProps } from 'react-native';
 import Animated, {
     interpolateColor,
     useAnimatedStyle,
-    useDerivedValue,
     useSharedValue,
     withTiming,
 } from 'react-native-reanimated';
 
 import type { RequireAtLeastOne } from 'type-fest';
 
-import { HStack } from '@suite-native/atoms';
-import { type CSSColor, Icon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import type { Color, TypographyStyle } from '@trezor/theme';
 
@@ -22,7 +19,6 @@ type LinkProps = RequireAtLeastOne<
         href?: string;
         onPress?: () => void;
         isUnderlined?: boolean;
-        showExternalIcon?: boolean;
         textColor?: Color;
         textPressedColor?: Color;
         textVariant?: TypographyStyle;
@@ -51,11 +47,12 @@ const ANIMATION_DURATION = 100;
 const IS_NOT_PRESSED_VALUE = 0;
 const IS_PRESSED_VALUE = 1;
 
+const noop = () => {};
+
 export const Link = ({
     href,
     label,
     isUnderlined = false,
-    showExternalIcon = false,
     textColor = 'contentBrand',
     textPressedColor = 'contentBrandPressed',
     textVariant = 'body-md',
@@ -67,16 +64,13 @@ export const Link = ({
     const openLink = useOpenLink();
     const isPressed = useSharedValue(IS_NOT_PRESSED_VALUE);
 
-    const animatedColor = useDerivedValue<CSSColor>(
-        () =>
-            interpolateColor(
-                isPressed.value,
-                [IS_NOT_PRESSED_VALUE, IS_PRESSED_VALUE],
-                [utils.colors[textColor], utils.colors[textPressedColor]],
-            ) as CSSColor,
-    );
-
-    const animatedTextColorStyle = useAnimatedStyle(() => ({ color: animatedColor.value }));
+    const animatedTextColorStyle = useAnimatedStyle(() => ({
+        color: interpolateColor(
+            isPressed.value,
+            [IS_NOT_PRESSED_VALUE, IS_PRESSED_VALUE],
+            [utils.colors[textColor], utils.colors[textPressedColor]],
+        ),
+    }));
 
     const handlePressIn = (e: GestureResponderEvent) => {
         // eslint-disable-next-line react-hooks/immutability
@@ -94,23 +88,19 @@ export const Link = ({
     };
 
     return (
-        <Pressable onPressIn={handlePressIn} onPressOut={handlePressOut}>
-            <HStack spacing="sp6" alignItems="center">
-                <Animated.Text
-                    {...textProps}
-                    suppressHighlighting
-                    style={[
-                        applyStyle(textStyle, { isUnderlined, textVariant }),
-                        animatedTextColorStyle,
-                        style,
-                    ]}
-                >
-                    {label}
-                </Animated.Text>
-                {showExternalIcon && (
-                    <Icon.Animated name="arrowLineUpRight" color={animatedColor} size="medium" />
-                )}
-            </HStack>
-        </Pressable>
+        <Animated.Text
+            {...textProps}
+            onPressIn={handlePressIn}
+            onPress={noop} // If the handling is defined in onPress, the very short taps are sometimes ignored
+            onPressOut={handlePressOut}
+            style={[
+                applyStyle(textStyle, { isUnderlined, textVariant }),
+                animatedTextColorStyle,
+                style,
+            ]}
+            suppressHighlighting
+        >
+            {label}
+        </Animated.Text>
     );
 };

--- a/suite-native/link/src/stories/Link.stories.tsx
+++ b/suite-native/link/src/stories/Link.stories.tsx
@@ -20,7 +20,6 @@ export const Link: LinkStory = {
         label: 'This is a link',
         href: 'https://trezor.io',
         isUnderlined: false,
-        showExternalIcon: false,
         textColor: 'contentPrimary',
         textPressedColor: 'contentPrimaryPressed',
         textVariant: 'body-md',
@@ -37,9 +36,6 @@ export const Link: LinkStory = {
             table: { disable: true },
         },
         isUnderlined: {
-            control: { type: 'boolean' },
-        },
-        showExternalIcon: {
             control: { type: 'boolean' },
         },
         textColor: {

--- a/suite-native/link/tsconfig.json
+++ b/suite-native/link/tsconfig.json
@@ -9,8 +9,6 @@
             "path": "../../suite-common/dependency-injection"
         },
         { "path": "../analytics" },
-        { "path": "../atoms" },
-        { "path": "../icons" },
         { "path": "../toasts" },
         {
             "path": "../../packages/styles-native"

--- a/suite-native/module-activity-center/src/components/releaseNotes/ReleaseNotesTabContent.tsx
+++ b/suite-native/module-activity-center/src/components/releaseNotes/ReleaseNotesTabContent.tsx
@@ -1,17 +1,23 @@
 import { View } from 'react-native';
 
-import { Badge, Box, Card, CardDivider, HStack, Text, VStack } from '@suite-native/atoms';
+import {
+    Badge,
+    Box,
+    Card,
+    CardDivider,
+    HStack,
+    Text,
+    TextButton,
+    VStack,
+} from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { Link } from '@suite-native/link';
+import { useOpenLink } from '@suite-native/link';
 import { MarkdownText } from '@suite-native/markdown';
 import { getSuiteVersion } from '@trezor/env-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { GITHUB_REPO_URL } from '@trezor/urls';
 
 import releaseNotesMarkdown from '../../../assets/release-notes.md';
-
-const getMobileReleaseUrl = (version: string) =>
-    `${GITHUB_REPO_URL}/releases#release-v${version}@mobile`;
 
 const headerCardStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.surfaceFillSunken,
@@ -30,9 +36,19 @@ const mainCardStyle = prepareNativeStyle(utils => ({
     paddingBottom: utils.spacings.sp12,
 }));
 
+const buttonStyle = prepareNativeStyle(_ => ({
+    alignSelf: 'flex-start',
+}));
+
 export const ReleaseNotesTabContent = () => {
+    const openLink = useOpenLink();
     const { applyStyle } = useNativeStyles();
+
     const version = getSuiteVersion();
+
+    const openMobileReleaseNotes = () => {
+        openLink(`${GITHUB_REPO_URL}/releases#release-v${version}@mobile`);
+    };
 
     return (
         <Box>
@@ -48,14 +64,16 @@ export const ReleaseNotesTabContent = () => {
                 <VStack spacing="sp12">
                     <MarkdownText markdown={releaseNotesMarkdown} />
                     <CardDivider />
-                    <Link
-                        href={getMobileReleaseUrl(version)}
-                        label={<Translation id="moduleActivityCenter.releaseNotes.viewOnGithub" />}
+                    <TextButton
+                        priority="secondary"
+                        size="small"
                         isUnderlined
-                        showExternalIcon
-                        textVariant="body-sm"
-                        textColor="contentSecondary"
-                    />
+                        iconRight="arrowLineUpRight"
+                        style={applyStyle(buttonStyle)}
+                        onPress={openMobileReleaseNotes}
+                    >
+                        <Translation id="moduleActivityCenter.releaseNotes.viewOnGithub" />
+                    </TextButton>
                 </VStack>
             </Card>
         </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12785,8 +12785,6 @@ __metadata:
     "@suite-common/analytics": "workspace:*"
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-native/analytics": "workspace:*"
-    "@suite-native/atoms": "workspace:*"
-    "@suite-native/icons": "workspace:*"
     "@suite-native/toasts": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"


### PR DESCRIPTION
## Description

- `TextButton` used for the GitHub link in release notes.
- c22fc69732b03179d234c9e36b41da6e0f701b9c reverted to fix the misaligned links.

## Related Issue

Resolve #31670

## Screenshots:

| Trusted reseller | Holographic seal | View on GitHub |
| --- | --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/09486275-c0ab-4403-8bc5-fd8753bcc7a2" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/1e75b204-d2d9-4d9a-b292-017a93436db7" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/91437541-c5e5-46a7-a4af-500653c52602" /> |

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files live under `suite-native`, which is the React Native mobile codebase. The 126 candidate tests are Playwright E2E tests for the web/desktop Trezor Suite app and do not exercise any native/mobile UI components such as the Link component or ReleaseNotesTabContent. Consequently, no test in the provided pool can validate these changes; native/mobile E2E tests (if available) would be required instead. Static coverage mapping returned no results, and the LLM analysis of the candidate tests provides no evidence that any of them touch the changed functionality.

<details><summary><b>Changed files (5)</b></summary>

- `suite-native/link/package.json`
- `suite-native/link/src/components/Link.tsx`
- `suite-native/link/src/stories/Link.stories.tsx`
- `suite-native/link/tsconfig.json`
- `suite-native/module-activity-center/src/components/releaseNotes/ReleaseNotesTabContent.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `suite-native/link/package.json`
- `suite-native/link/src/components/Link.tsx`
- `suite-native/link/src/stories/Link.stories.tsx`
- `suite-native/link/tsconfig.json`
- `suite-native/module-activity-center/src/components/releaseNotes/ReleaseNotesTabContent.tsx`

_Updated: 2026-08-28T13:11:18.483Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/release-notes-github-button/web/](https://dev.suite.sldev.cz/suite-web/fix/native/release-notes-github-button/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/release-notes-github-button&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/release-notes-github-button&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/release-notes-github-button&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T13:14:45.973Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T13:14:23.075Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->