### PR TITLE
chore(eslint): enforce named dependency contracts

### DIFF
--- a/eslint-local-rules/enforce-di-factory-contracts/rule.test.ts
+++ b/eslint-local-rules/enforce-di-factory-contracts/rule.test.ts
@@ -1,0 +1,145 @@
+import { enforceDiFactoryContractsRule } from './rule';
+import { namedContractsFilename, namedContractsRuleTester } from '../named-contracts/testUtils';
+
+namedContractsRuleTester.run('enforce-di-factory-contracts', enforceDiFactoryContractsRule, {
+    valid: [
+        {
+            filename: namedContractsFilename,
+            code: `
+                type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
+
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
+
+                function createSave(deps: SaveDeps): Save {
+                    return () => deps.logger.log();
+                }
+            `,
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type NativeAppDeps = { logger: { log: () => void } };
+                type NativeServices = { save: () => void };
+
+                const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices => ({
+                    save: () => deps.logger.log(),
+                });
+            `,
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                const createMockDeps = <T>(deps: T): T => deps;
+            `,
+        },
+    ],
+    invalid: [
+        {
+            filename: namedContractsFilename,
+            code: `
+                type SaveDeps = { logger: { log: () => void } };
+                type Save = () => void;
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+            output: `
+                type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
+
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeSeparated',
+                    data: { previousName: 'SaveDeps', nextName: 'Save' },
+                },
+                {
+                    messageId: 'contractMustBeSeparated',
+                    data: { previousName: 'Save', nextName: 'createSave' },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type Save = () => void;
+
+                type SaveDeps = { logger: { log: () => void } };
+
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+            output: `
+                type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
+
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'dependencyFactoryContractOrder',
+                    data: {
+                        depsName: 'SaveDeps',
+                        serviceName: 'Save',
+                        factoryName: 'createSave',
+                    },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type CreateSaveDeps = { logger: { log: () => void } };
+                type Save = () => void;
+
+                const createSave = (deps: CreateSaveDeps): Save => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeNamed',
+                    data: { contractName: 'SaveDeps', consumerName: 'createSave' },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type SaveDeps = { logger: { log: () => void } };
+
+                const createSave = (deps: SaveDeps) => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'dependencyFactoryReturnType',
+                    data: { factoryName: 'createSave' },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
+
+                const createSave = ({ logger }: SaveDeps): Save => () => logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'dependencyFactoryParameter',
+                    data: { factoryName: 'createSave', contractName: 'SaveDeps' },
+                },
+            ],
+        },
+    ],
+} as Parameters<typeof namedContractsRuleTester.run>[2]);

--- a/eslint-local-rules/enforce-di-factory-contracts/rule.ts
+++ b/eslint-local-rules/enforce-di-factory-contracts/rule.ts
@@ -1,0 +1,181 @@
+import type { Rule } from 'eslint';
+import ts from 'typescript';
+
+import {
+    createNamedContractRuleListener,
+    getTypeReferenceName,
+    getVariableFunction,
+} from '../named-contracts/utils';
+
+/** Enforces local, predictably named dependency contracts for DI service factories. */
+export const enforceDiFactoryContractsRule: Rule.RuleModule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Enforces explicit, named dependency and return contracts for dependency-injected service factories.',
+            category: 'Best Practices',
+            recommended: false,
+        },
+        fixable: 'code',
+        messages: {
+            contractMustBeNamed:
+                "Use the named '{{contractName}}' contract instead of an inline or differently named type.",
+            contractMustBeSeparated:
+                "Leave an empty line between '{{previousName}}' and '{{nextName}}'.",
+            dependencyFactoryContractOrder:
+                "Declare '{{depsName}}' before '{{serviceName}}' for '{{factoryName}}'.",
+            dependencyFactoryParameter:
+                "Pass '{{contractName}}' as a single 'deps' parameter to dependency-injected factory '{{factoryName}}'.",
+            dependencyFactoryReturnType:
+                "Give dependency-injected factory '{{factoryName}}' an explicit named service return type.",
+        },
+        schema: [],
+    },
+    create: context =>
+        createNamedContractRuleListener(
+            context,
+            ({
+                createAdjacentDeclarationSwapFix,
+                localTypeAliases,
+                report,
+                statements,
+                validateContractBlockSpacing,
+            }) => {
+                const validateDependencyFactory = (
+                    factoryName: string,
+                    factoryFunction: ts.FunctionLikeDeclaration,
+                    statementIndex: number,
+                ) => {
+                    // Composition roots and dependency-object builders wire services together;
+                    // they are not factories for the service named after `create`.
+                    if (factoryName.endsWith('CompositionRoot') || factoryName.endsWith('Deps')) {
+                        return;
+                    }
+
+                    const depsParameter = factoryFunction.parameters[0];
+
+                    if (depsParameter === undefined) {
+                        return;
+                    }
+
+                    const serviceName = factoryName.slice('create'.length);
+                    const expectedDepsName = `${serviceName}Deps`;
+                    const actualDepsName = getTypeReferenceName(depsParameter.type);
+                    const isNamedDepsParameter =
+                        ts.isIdentifier(depsParameter.name) && depsParameter.name.text === 'deps';
+
+                    if (!isNamedDepsParameter && !actualDepsName?.endsWith('Deps')) {
+                        return;
+                    }
+
+                    if (!isNamedDepsParameter) {
+                        report(depsParameter.name, 'dependencyFactoryParameter', {
+                            factoryName,
+                            contractName: expectedDepsName,
+                        });
+                    }
+
+                    if (actualDepsName !== expectedDepsName) {
+                        report(depsParameter.type ?? depsParameter, 'contractMustBeNamed', {
+                            consumerName: factoryName,
+                            contractName: expectedDepsName,
+                        });
+                    }
+
+                    const returnTypeName = getTypeReferenceName(factoryFunction.type);
+
+                    if (returnTypeName === undefined) {
+                        report(factoryFunction, 'dependencyFactoryReturnType', { factoryName });
+                    }
+
+                    const depsDeclaration = localTypeAliases.get(expectedDepsName);
+
+                    if (depsDeclaration === undefined) {
+                        return;
+                    }
+
+                    const depsStatementIndex = statements.indexOf(depsDeclaration);
+                    const serviceDeclaration =
+                        returnTypeName === undefined
+                            ? undefined
+                            : localTypeAliases.get(returnTypeName);
+                    const serviceStatementIndex =
+                        serviceDeclaration === undefined
+                            ? undefined
+                            : statements.indexOf(serviceDeclaration);
+                    const firstContractIndex = Math.min(
+                        depsStatementIndex,
+                        serviceStatementIndex ?? depsStatementIndex,
+                    );
+                    const isInAdjacentTypeBlock = statements
+                        .slice(firstContractIndex, statementIndex)
+                        .every(
+                            statement =>
+                                ts.isTypeAliasDeclaration(statement) ||
+                                ts.isInterfaceDeclaration(statement),
+                        );
+
+                    if (!isInAdjacentTypeBlock) {
+                        return;
+                    }
+
+                    if (
+                        serviceDeclaration !== undefined &&
+                        serviceStatementIndex !== undefined &&
+                        depsStatementIndex > serviceStatementIndex
+                    ) {
+                        report(
+                            depsDeclaration,
+                            'dependencyFactoryContractOrder',
+                            {
+                                factoryName,
+                                depsName: expectedDepsName,
+                                serviceName: serviceDeclaration.name.text,
+                            },
+                            createAdjacentDeclarationSwapFix(serviceDeclaration, depsDeclaration),
+                        );
+                    }
+
+                    validateContractBlockSpacing(firstContractIndex, statementIndex, factoryName);
+                };
+
+                statements.forEach((statement, statementIndex) => {
+                    if (ts.isFunctionDeclaration(statement)) {
+                        if (statement.name?.text.startsWith('create')) {
+                            validateDependencyFactory(
+                                statement.name.text,
+                                statement,
+                                statementIndex,
+                            );
+                        }
+
+                        return;
+                    }
+
+                    if (!ts.isVariableStatement(statement)) {
+                        return;
+                    }
+
+                    for (const declaration of statement.declarationList.declarations) {
+                        if (
+                            !ts.isIdentifier(declaration.name) ||
+                            !declaration.name.text.startsWith('create')
+                        ) {
+                            continue;
+                        }
+
+                        const factoryFunction = getVariableFunction(declaration);
+
+                        if (factoryFunction !== undefined) {
+                            validateDependencyFactory(
+                                declaration.name.text,
+                                factoryFunction,
+                                statementIndex,
+                            );
+                        }
+                    }
+                });
+            },
+        ),
+};

--- a/eslint-local-rules/enforce-di-factory-contracts/rule.ts
+++ b/eslint-local-rules/enforce-di-factory-contracts/rule.ts
@@ -1,11 +1,8 @@
 import type { Rule } from 'eslint';
 import ts from 'typescript';
 
-import {
-    createNamedContractRuleListener,
-    getTypeReferenceName,
-    getVariableFunction,
-} from '../named-contracts/utils';
+import { createNamedContractRuleListener } from '../named-contracts/utils';
+import { getTypeReferenceName, getVariableFunction } from '../utils';
 
 /** Enforces local, predictably named dependency contracts for DI service factories. */
 export const enforceDiFactoryContractsRule: Rule.RuleModule = {

--- a/eslint-local-rules/enforce-named-contracts/rule.test.ts
+++ b/eslint-local-rules/enforce-named-contracts/rule.test.ts
@@ -1,0 +1,323 @@
+import { RuleTester } from 'eslint';
+import path from 'node:path';
+import { parser } from 'typescript-eslint';
+
+import { enforceNamedContractsRule } from './rule';
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parser,
+        parserOptions: {
+            ecmaVersion: 2020,
+            projectService: {
+                allowDefaultProject: ['named-contracts.ts'],
+            },
+            sourceType: 'module',
+            tsconfigRootDir: path.join(__dirname, '../..'),
+        },
+    },
+});
+
+const filename = path.join(__dirname, '../..', 'named-contracts.ts');
+
+ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
+    valid: [
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
+                const dependencyFreeThunk = createThunk<void, void, void>('test', () => undefined);
+            `,
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkState = { value: string };
+                type SaveThunkDeps = { save: () => void };
+
+                const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkState = { value: string };
+                type SaveThunkDeps = { save: () => void };
+                type SaveThunkDispatch = (action: unknown) => void;
+
+                const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkState = { value: string };
+
+                const saveThunks = createThunk<void, void, { state: SaveThunkState }>(
+                    'save',
+                    () => undefined,
+                );
+            `,
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkState = { value: string };
+
+                const saveThunkInner = createThunk<void, void, { state: SaveThunkState }>(
+                    'save',
+                    () => undefined,
+                );
+            `,
+        },
+        {
+            filename,
+            code: `
+                type SaveThunkState = { value: string };
+                type SaveThunkDeps = { save: () => void };
+
+                const save = () => (
+                    dispatch: unknown,
+                    getState: () => SaveThunkState,
+                    extra: SaveThunkDeps,
+                ) => {
+                    void dispatch;
+                    void getState;
+                    void extra;
+                };
+            `,
+        },
+        {
+            filename,
+            code: `
+                type SaveThunkState = { value: string };
+                type SaveThunkDeps = { save: () => void };
+
+                function save() {
+                    return (
+                        dispatch: unknown,
+                        getState: () => SaveThunkState,
+                        extra: SaveThunkDeps,
+                    ) => {
+                        void dispatch;
+                        void getState;
+                        void extra;
+                    };
+                }
+            `,
+        },
+        {
+            filename,
+            code: `
+                type Save = () => void;
+                type SaveDeps = { logger: { log: () => void } };
+
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+        },
+        {
+            filename,
+            code: `
+                type Save = () => void;
+                type SaveDeps = { logger: { log: () => void } };
+
+                function createSave(deps: SaveDeps): Save {
+                    return () => deps.logger.log();
+                }
+            `,
+        },
+        {
+            filename,
+            code: `
+                type NativeAppDeps = { logger: { log: () => void } };
+                type NativeServices = { save: () => void };
+
+                const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices => ({
+                    save: () => deps.logger.log(),
+                });
+            `,
+        },
+        {
+            filename,
+            code: `
+                const createMockDeps = <T>(deps: T): T => deps;
+            `,
+        },
+    ],
+    invalid: [
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config = void>(name: string, callback: unknown) => unknown;
+                const saveThunk = createThunk<void, void>('save', () => undefined);
+            `,
+            errors: [{ messageId: 'missingThunkConfig', data: { thunkName: 'saveThunk' } }],
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                const saveThunk = createThunk<void, void, {}>('save', () => undefined);
+            `,
+            errors: [{ messageId: 'emptyThunkConfig', data: { thunkName: 'saveThunk' } }],
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type State = { value: string };
+                type Deps = { save: () => void };
+
+                const saveThunk = createThunk<void, void, { state: State; extra: Deps }>(
+                    'save',
+                    () => undefined,
+                );
+            `,
+            errors: [
+                { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkState' } },
+                { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkDeps' } },
+            ],
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkState = { value: string };
+                const unrelated = true;
+
+                const saveThunk = createThunk<void, void, { state: SaveThunkState }>(
+                    'save',
+                    () => unrelated,
+                );
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeAdjacent',
+                    data: { contractName: 'SaveThunkState', consumerName: 'saveThunk' },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkDeps = { save: () => void };
+
+                const saveThunk = createThunk<void, void, { state: void; extra: SaveThunkDeps }>(
+                    'save',
+                    () => undefined,
+                );
+            `,
+            errors: [
+                {
+                    messageId: 'voidContractProperty',
+                    data: { propertyName: 'state', thunkName: 'saveThunk' },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                type State = { value: string };
+                type Deps = { save: () => void };
+
+                const save = () => (
+                    dispatch: unknown,
+                    getState: () => State,
+                    extra: Deps,
+                ) => {
+                    void dispatch;
+                    void getState;
+                    void extra;
+                };
+            `,
+            errors: [
+                { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkState' } },
+                { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkDeps' } },
+            ],
+        },
+        {
+            filename,
+            code: `
+                const save = () => (dispatch, getState, extra) => {
+                    void dispatch;
+                    void getState;
+                    void extra;
+                };
+            `,
+            errors: [
+                { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkState' } },
+                { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkDeps' } },
+            ],
+        },
+        {
+            filename,
+            code: `
+                const save = () => (_, getState, extra) => {
+                    void getState;
+                    void extra;
+                };
+            `,
+            errors: [
+                { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkState' } },
+                { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkDeps' } },
+            ],
+        },
+        {
+            filename,
+            code: `
+                type CreateSaveDeps = { logger: { log: () => void } };
+                type Save = () => void;
+
+                const createSave = (deps: CreateSaveDeps): Save => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeNamed',
+                    data: { contractName: 'SaveDeps', consumerName: 'createSave' },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                type SaveDeps = { logger: { log: () => void } };
+                const createSave = (deps: SaveDeps) => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'dependencyFactoryReturnType',
+                    data: { factoryName: 'createSave' },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                type Save = () => void;
+                type SaveDeps = { logger: { log: () => void } };
+
+                const createSave = ({ logger }: SaveDeps): Save => () => logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'dependencyFactoryParameter',
+                    data: { factoryName: 'createSave', contractName: 'SaveDeps' },
+                },
+            ],
+        },
+    ],
+} as Parameters<typeof ruleTester.run>[2]);

--- a/eslint-local-rules/enforce-named-contracts/rule.test.ts
+++ b/eslint-local-rules/enforce-named-contracts/rule.test.ts
@@ -35,6 +35,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
+
                 type SaveThunkDeps = { save: () => void };
 
                 const saveThunk = createThunk<
@@ -49,7 +50,9 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
+
                 type SaveThunkDeps = { save: () => void };
+
                 type SaveThunkDispatch = (action: unknown) => void;
 
                 const saveThunk = createThunk<
@@ -87,6 +90,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             filename,
             code: `
                 type SaveThunkState = { value: string };
+
                 type SaveThunkDeps = { save: () => void };
 
                 const save = () => (
@@ -104,6 +108,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             filename,
             code: `
                 type SaveThunkState = { value: string };
+
                 type SaveThunkDeps = { save: () => void };
 
                 function save() {
@@ -122,8 +127,9 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
         {
             filename,
             code: `
-                type Save = () => void;
                 type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
 
                 const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
             `,
@@ -131,8 +137,9 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
         {
             filename,
             code: `
-                type Save = () => void;
                 type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
 
                 function createSave(deps: SaveDeps): Save {
                     return () => deps.logger.log();
@@ -158,6 +165,111 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
         },
     ],
     invalid: [
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkState = { value: string };
+                type SaveThunkDeps = { save: () => void };
+                const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
+            output: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkState = { value: string };
+
+                type SaveThunkDeps = { save: () => void };
+
+                const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeSeparated',
+                    data: { previousName: 'SaveThunkState', nextName: 'SaveThunkDeps' },
+                },
+                {
+                    messageId: 'contractMustBeSeparated',
+                    data: { previousName: 'SaveThunkDeps', nextName: 'saveThunk' },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkDeps = { save: () => void };
+
+                type SaveThunkState = { value: string };
+
+                const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
+            errors: [
+                {
+                    messageId: 'contractOrder',
+                    data: {
+                        stateName: 'SaveThunkState',
+                        depsName: 'SaveThunkDeps',
+                        consumerName: 'saveThunk',
+                    },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                type SaveDeps = { logger: { log: () => void } };
+                type Save = () => void;
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+            output: `
+                type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
+
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeSeparated',
+                    data: { previousName: 'SaveDeps', nextName: 'Save' },
+                },
+                {
+                    messageId: 'contractMustBeSeparated',
+                    data: { previousName: 'Save', nextName: 'createSave' },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                type Save = () => void;
+
+                type SaveDeps = { logger: { log: () => void } };
+
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'dependencyFactoryContractOrder',
+                    data: {
+                        depsName: 'SaveDeps',
+                        serviceName: 'Save',
+                        factoryName: 'createSave',
+                    },
+                },
+            ],
+        },
         {
             filename,
             code: `
@@ -295,6 +407,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             filename,
             code: `
                 type SaveDeps = { logger: { log: () => void } };
+
                 const createSave = (deps: SaveDeps) => () => deps.logger.log();
             `,
             errors: [
@@ -307,8 +420,9 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
         {
             filename,
             code: `
-                type Save = () => void;
                 type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
 
                 const createSave = ({ logger }: SaveDeps): Save => () => logger.log();
             `,

--- a/eslint-local-rules/enforce-named-contracts/rule.test.ts
+++ b/eslint-local-rules/enforce-named-contracts/rule.test.ts
@@ -214,6 +214,18 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
                     { state: SaveThunkState; extra: SaveThunkDeps }
                 >('save', () => undefined);
             `,
+            output: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                type SaveThunkState = { value: string };
+
+                type SaveThunkDeps = { save: () => void };
+
+                const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
             errors: [
                 {
                     messageId: 'contractOrder',
@@ -259,6 +271,13 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
 
                 const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
             `,
+            output: `
+                type SaveDeps = { logger: { log: () => void } };
+
+                type Save = () => void;
+
+                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
+            `,
             errors: [
                 {
                     messageId: 'dependencyFactoryContractOrder',
@@ -266,6 +285,70 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
                         depsName: 'SaveDeps',
                         serviceName: 'Save',
                         factoryName: 'createSave',
+                    },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                export type SaveThunkDeps = { save: () => void };
+
+                export type SaveThunkState = { value: string };
+
+                export const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
+            output: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                export type SaveThunkState = { value: string };
+
+                export type SaveThunkDeps = { save: () => void };
+
+                export const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
+            errors: [
+                {
+                    messageId: 'contractOrder',
+                    data: {
+                        stateName: 'SaveThunkState',
+                        depsName: 'SaveThunkDeps',
+                        consumerName: 'saveThunk',
+                    },
+                },
+            ],
+        },
+        {
+            filename,
+            code: `
+                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+                // Saving requires access to this service.
+                type SaveThunkDeps = { save: () => void };
+
+                type SaveThunkState = { value: string };
+
+                const saveThunk = createThunk<
+                    void,
+                    void,
+                    { state: SaveThunkState; extra: SaveThunkDeps }
+                >('save', () => undefined);
+            `,
+            output: null,
+            errors: [
+                {
+                    messageId: 'contractOrder',
+                    data: {
+                        stateName: 'SaveThunkState',
+                        depsName: 'SaveThunkDeps',
+                        consumerName: 'saveThunk',
                     },
                 },
             ],

--- a/eslint-local-rules/enforce-named-contracts/rule.ts
+++ b/eslint-local-rules/enforce-named-contracts/rule.ts
@@ -1,0 +1,502 @@
+import type { Rule } from 'eslint';
+import ts from 'typescript';
+
+type TypeAwareParserServices = {
+    esTreeNodeToTSNodeMap?: ReadonlyMap<Rule.Node, ts.Node>;
+    program?: ts.Program;
+    tsNodeToESTreeNodeMap?: ReadonlyMap<ts.Node, Rule.Node>;
+};
+
+type RequiredContract = {
+    expectedName: string;
+    node: ts.TypeNode;
+};
+
+type MessageId =
+    | 'contractMustBeAdjacent'
+    | 'contractMustBeNamed'
+    | 'dependencyFactoryParameter'
+    | 'dependencyFactoryReturnType'
+    | 'emptyThunkConfig'
+    | 'missingThunkConfig'
+    | 'thunkConfigMustBeInline'
+    | 'voidContractProperty';
+
+const thunkCreators = new Set(['createSingleInstanceThunk', 'createThunk']);
+
+const capitalize = (name: string) => `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+
+const getThunkContractBaseName = (name: string) => {
+    const capitalizedName = capitalize(name);
+
+    if (capitalizedName.endsWith('Thunks')) {
+        return capitalizedName.slice(0, -1);
+    }
+
+    if (capitalizedName.endsWith('ThunkInner')) {
+        return capitalizedName.slice(0, -'Inner'.length);
+    }
+
+    return capitalizedName.endsWith('Thunk') ? capitalizedName : `${capitalizedName}Thunk`;
+};
+
+const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+    if (
+        ts.isParenthesizedExpression(expression) ||
+        ts.isAsExpression(expression) ||
+        ts.isTypeAssertionExpression(expression) ||
+        ts.isNonNullExpression(expression)
+    ) {
+        return unwrapExpression(expression.expression);
+    }
+
+    return expression;
+};
+
+const getFunctionExpression = (expression: ts.Expression) => {
+    const unwrappedExpression = unwrapExpression(expression);
+
+    return ts.isArrowFunction(unwrappedExpression) || ts.isFunctionExpression(unwrappedExpression)
+        ? unwrappedExpression
+        : undefined;
+};
+
+const getReturnedFunction = (functionNode: ts.FunctionLikeDeclaration) => {
+    if (functionNode.body === undefined) {
+        return undefined;
+    }
+
+    if (!ts.isBlock(functionNode.body)) {
+        return getFunctionExpression(functionNode.body);
+    }
+
+    const returnStatements = functionNode.body.statements.filter(ts.isReturnStatement);
+    const [returnStatement] = returnStatements;
+
+    if (returnStatements.length !== 1 || returnStatement?.expression === undefined) {
+        return undefined;
+    }
+
+    return getFunctionExpression(returnStatement.expression);
+};
+
+const getInnermostReturnedFunction = (functionNode: ts.FunctionLikeDeclaration) => {
+    let currentFunction = functionNode;
+    let returnedFunction = getReturnedFunction(currentFunction);
+
+    while (returnedFunction !== undefined) {
+        currentFunction = returnedFunction;
+        returnedFunction = getReturnedFunction(currentFunction);
+    }
+
+    return currentFunction;
+};
+
+const getTypeReferenceName = (node: ts.TypeNode | undefined) =>
+    node !== undefined && ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)
+        ? node.typeName.text
+        : undefined;
+
+const getPropertyName = (node: ts.TypeElement) => {
+    if (!ts.isPropertySignature(node) || node.name === undefined) {
+        return undefined;
+    }
+
+    return ts.isIdentifier(node.name) || ts.isStringLiteralLike(node.name)
+        ? node.name.text
+        : undefined;
+};
+
+const isVoidType = (node: ts.TypeNode | undefined) =>
+    node !== undefined && node.kind === ts.SyntaxKind.VoidKeyword;
+
+const isEmptyContractType = (node: ts.TypeNode | undefined) => {
+    if (node?.kind === ts.SyntaxKind.UnknownKeyword || isVoidType(node)) {
+        return true;
+    }
+
+    if (node === undefined || !ts.isTypeReferenceNode(node) || !ts.isIdentifier(node.typeName)) {
+        return false;
+    }
+
+    return (
+        node.typeName.text === 'Record' &&
+        node.typeArguments?.[0]?.kind === ts.SyntaxKind.NeverKeyword
+    );
+};
+
+const getVariableFunction = (declaration: ts.VariableDeclaration) =>
+    declaration.initializer === undefined
+        ? undefined
+        : getFunctionExpression(declaration.initializer);
+
+const getThunkImplementationFromFunction = (outerFunction: ts.FunctionLikeDeclaration) => {
+    const implementation = getInnermostReturnedFunction(outerFunction);
+    const rawParameterNames = implementation.parameters.map(parameter =>
+        ts.isIdentifier(parameter.name) ? parameter.name.text : '',
+    );
+    const parameterNames = rawParameterNames.map(name => name.replace(/^_/, ''));
+
+    return (parameterNames[0] === 'dispatch' || rawParameterNames[0] === '_') &&
+        (parameterNames[1] === 'getState' || parameterNames[2] === 'extra')
+        ? implementation
+        : undefined;
+};
+
+const getThunkImplementation = (declaration: ts.VariableDeclaration) => {
+    const outerFunction = getVariableFunction(declaration);
+
+    return outerFunction === undefined
+        ? undefined
+        : getThunkImplementationFromFunction(outerFunction);
+};
+
+const getGetStateReturnType = (parameter: ts.ParameterDeclaration | undefined) => {
+    if (parameter?.type === undefined) {
+        return undefined;
+    }
+
+    return ts.isFunctionTypeNode(parameter.type) ? parameter.type.type : parameter.type;
+};
+
+/**
+ * Enforces local, predictably named state and dependency contracts for thunks and DI factories.
+ */
+export const enforceNamedContractsRule: Rule.RuleModule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Enforces explicit, named State and Deps contracts for thunks and dependency-injected service factories.',
+            category: 'Best Practices',
+            recommended: false,
+        },
+        messages: {
+            contractMustBeAdjacent:
+                "Declare '{{contractName}}' in the contiguous type block directly above '{{consumerName}}'.",
+            contractMustBeNamed:
+                "Use the named '{{contractName}}' contract instead of an inline or differently named type.",
+            dependencyFactoryParameter:
+                "Pass '{{contractName}}' as a single 'deps' parameter to dependency-injected factory '{{factoryName}}'.",
+            dependencyFactoryReturnType:
+                "Give dependency-injected factory '{{factoryName}}' an explicit named service return type.",
+            emptyThunkConfig: "Use explicit 'void' for dependency-free thunk '{{thunkName}}'.",
+            missingThunkConfig:
+                "Give thunk '{{thunkName}}' an explicit third generic: 'void' or a named State/Deps config.",
+            thunkConfigMustBeInline:
+                "Inline the RTK config for '{{thunkName}}' so its named State and Deps contracts stay visible.",
+            voidContractProperty:
+                "Omit '{{propertyName}}: void' from '{{thunkName}}'; use 'void' only as the complete dependency-free config.",
+        },
+        schema: [],
+    },
+    create(context) {
+        const parserServices = context.sourceCode.parserServices as TypeAwareParserServices;
+
+        if (
+            parserServices.program === undefined ||
+            parserServices.esTreeNodeToTSNodeMap === undefined ||
+            parserServices.tsNodeToESTreeNodeMap === undefined
+        ) {
+            return {};
+        }
+
+        return {
+            'Program:exit': programNode => {
+                const sourceFile = parserServices.esTreeNodeToTSNodeMap?.get(
+                    programNode as Rule.Node,
+                );
+
+                if (sourceFile === undefined || !ts.isSourceFile(sourceFile)) {
+                    return;
+                }
+
+                const { statements } = sourceFile;
+                const localTypeAliases = new Map(
+                    statements
+                        .filter(ts.isTypeAliasDeclaration)
+                        .map(declaration => [declaration.name.text, declaration] as const),
+                );
+
+                const report = (
+                    node: ts.Node,
+                    messageId: MessageId,
+                    data: Record<string, string>,
+                ) => {
+                    const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(node);
+
+                    if (reportNode !== undefined) {
+                        context.report({ node: reportNode, messageId, data });
+                    }
+                };
+
+                const validateNamedContract = (
+                    node: ts.TypeNode | undefined,
+                    expectedName: string,
+                    consumerName: string,
+                    requiredContracts: RequiredContract[],
+                ) => {
+                    if (node === undefined || getTypeReferenceName(node) !== expectedName) {
+                        report(node ?? sourceFile, 'contractMustBeNamed', {
+                            consumerName,
+                            contractName: expectedName,
+                        });
+
+                        return;
+                    }
+
+                    requiredContracts.push({ expectedName, node });
+                };
+
+                const validateAdjacentContracts = (
+                    statementIndex: number,
+                    consumerName: string,
+                    requiredContracts: readonly RequiredContract[],
+                ) => {
+                    if (requiredContracts.length === 0) {
+                        return;
+                    }
+
+                    const adjacentTypeNames: string[] = [];
+
+                    for (let index = statementIndex - 1; index >= 0; index -= 1) {
+                        const statement = statements[index];
+
+                        if (statement === undefined) {
+                            break;
+                        }
+
+                        if (
+                            !ts.isTypeAliasDeclaration(statement) &&
+                            !ts.isInterfaceDeclaration(statement)
+                        ) {
+                            break;
+                        }
+
+                        adjacentTypeNames.push(statement.name.text);
+                    }
+
+                    for (const contract of requiredContracts) {
+                        if (
+                            adjacentTypeNames.includes(contract.expectedName) &&
+                            localTypeAliases.has(contract.expectedName)
+                        ) {
+                            continue;
+                        }
+
+                        report(contract.node, 'contractMustBeAdjacent', {
+                            consumerName,
+                            contractName: contract.expectedName,
+                        });
+                    }
+                };
+
+                const validateRtkThunk = (
+                    thunkName: string,
+                    callExpression: ts.CallExpression,
+                    statementIndex: number,
+                ) => {
+                    const configType = callExpression.typeArguments?.[2];
+
+                    if (configType === undefined) {
+                        report(callExpression, 'missingThunkConfig', { thunkName });
+
+                        return;
+                    }
+
+                    if (isVoidType(configType)) {
+                        return;
+                    }
+
+                    if (!ts.isTypeLiteralNode(configType)) {
+                        report(configType, 'thunkConfigMustBeInline', { thunkName });
+
+                        return;
+                    }
+
+                    const contractBaseName = getThunkContractBaseName(thunkName);
+                    const requiredContracts: RequiredContract[] = [];
+                    let hasNonContractConfig = false;
+                    let hasStateOrDeps = false;
+
+                    for (const member of configType.members) {
+                        const propertyName = getPropertyName(member);
+
+                        if (propertyName !== 'state' && propertyName !== 'extra') {
+                            hasNonContractConfig = true;
+                            continue;
+                        }
+
+                        if (!ts.isPropertySignature(member) || member.type === undefined) {
+                            continue;
+                        }
+
+                        hasStateOrDeps = true;
+
+                        if (isVoidType(member.type)) {
+                            report(member.type, 'voidContractProperty', {
+                                propertyName,
+                                thunkName,
+                            });
+                            continue;
+                        }
+
+                        const suffix = propertyName === 'state' ? 'State' : 'Deps';
+                        validateNamedContract(
+                            member.type,
+                            `${contractBaseName}${suffix}`,
+                            thunkName,
+                            requiredContracts,
+                        );
+                    }
+
+                    if (!hasStateOrDeps && !hasNonContractConfig) {
+                        report(configType, 'emptyThunkConfig', { thunkName });
+                    }
+
+                    validateAdjacentContracts(statementIndex, thunkName, requiredContracts);
+                };
+
+                const validateVanillaThunk = (
+                    thunkName: string,
+                    implementation: ts.FunctionLikeDeclaration,
+                    statementIndex: number,
+                ) => {
+                    const contractBaseName = getThunkContractBaseName(thunkName);
+                    const requiredContracts: RequiredContract[] = [];
+                    const getStateType = getGetStateReturnType(implementation.parameters[1]);
+                    const extraType = implementation.parameters[2]?.type;
+
+                    if (
+                        implementation.parameters[1] !== undefined &&
+                        !isEmptyContractType(getStateType)
+                    ) {
+                        validateNamedContract(
+                            getStateType,
+                            `${contractBaseName}State`,
+                            thunkName,
+                            requiredContracts,
+                        );
+                    }
+
+                    if (
+                        implementation.parameters[2] !== undefined &&
+                        !isEmptyContractType(extraType)
+                    ) {
+                        validateNamedContract(
+                            extraType,
+                            `${contractBaseName}Deps`,
+                            thunkName,
+                            requiredContracts,
+                        );
+                    }
+
+                    validateAdjacentContracts(statementIndex, thunkName, requiredContracts);
+                };
+
+                const validateDependencyFactory = (
+                    factoryName: string,
+                    factoryFunction: ts.FunctionLikeDeclaration,
+                ) => {
+                    // Composition roots and dependency-object builders wire services together;
+                    // they are not factories for the service named after `create`.
+                    if (factoryName.endsWith('CompositionRoot') || factoryName.endsWith('Deps')) {
+                        return;
+                    }
+
+                    const depsParameter = factoryFunction.parameters[0];
+
+                    if (depsParameter === undefined) {
+                        return;
+                    }
+
+                    const serviceName = factoryName.slice('create'.length);
+                    const expectedDepsName = `${serviceName}Deps`;
+                    const actualDepsName = getTypeReferenceName(depsParameter.type);
+                    const isNamedDepsParameter =
+                        ts.isIdentifier(depsParameter.name) && depsParameter.name.text === 'deps';
+
+                    if (!isNamedDepsParameter && !actualDepsName?.endsWith('Deps')) {
+                        return;
+                    }
+
+                    if (!isNamedDepsParameter) {
+                        report(depsParameter.name, 'dependencyFactoryParameter', {
+                            factoryName,
+                            contractName: expectedDepsName,
+                        });
+                    }
+
+                    if (actualDepsName !== expectedDepsName) {
+                        report(depsParameter.type ?? depsParameter, 'contractMustBeNamed', {
+                            consumerName: factoryName,
+                            contractName: expectedDepsName,
+                        });
+                    }
+
+                    if (getTypeReferenceName(factoryFunction.type) === undefined) {
+                        report(factoryFunction, 'dependencyFactoryReturnType', { factoryName });
+                    }
+                };
+
+                statements.forEach((statement, statementIndex) => {
+                    if (ts.isFunctionDeclaration(statement)) {
+                        if (statement.name !== undefined) {
+                            const declarationName = statement.name.text;
+                            const vanillaThunk = getThunkImplementationFromFunction(statement);
+
+                            if (vanillaThunk !== undefined) {
+                                validateVanillaThunk(declarationName, vanillaThunk, statementIndex);
+                            }
+
+                            if (declarationName.startsWith('create')) {
+                                validateDependencyFactory(declarationName, statement);
+                            }
+                        }
+
+                        return;
+                    }
+
+                    if (!ts.isVariableStatement(statement)) {
+                        return;
+                    }
+
+                    for (const declaration of statement.declarationList.declarations) {
+                        if (
+                            !ts.isIdentifier(declaration.name) ||
+                            declaration.initializer === undefined
+                        ) {
+                            continue;
+                        }
+
+                        const declarationName = declaration.name.text;
+                        const unwrappedInitializer = unwrapExpression(declaration.initializer);
+
+                        if (
+                            ts.isCallExpression(unwrappedInitializer) &&
+                            ts.isIdentifier(unwrappedInitializer.expression) &&
+                            thunkCreators.has(unwrappedInitializer.expression.text)
+                        ) {
+                            validateRtkThunk(declarationName, unwrappedInitializer, statementIndex);
+                            continue;
+                        }
+
+                        const vanillaThunk = getThunkImplementation(declaration);
+
+                        if (vanillaThunk !== undefined) {
+                            validateVanillaThunk(declarationName, vanillaThunk, statementIndex);
+                        }
+
+                        if (declarationName.startsWith('create')) {
+                            const factoryFunction = getVariableFunction(declaration);
+
+                            if (factoryFunction !== undefined) {
+                                validateDependencyFactory(declarationName, factoryFunction);
+                            }
+                        }
+                    }
+                });
+            },
+        };
+    },
+};

--- a/eslint-local-rules/enforce-named-contracts/rule.ts
+++ b/eslint-local-rules/enforce-named-contracts/rule.ts
@@ -174,7 +174,7 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
             category: 'Best Practices',
             recommended: false,
         },
-        fixable: 'whitespace',
+        fixable: 'code',
         messages: {
             contractMustBeAdjacent:
                 "Declare '{{contractName}}' in the contiguous type block directly above '{{consumerName}}'.",
@@ -231,12 +231,62 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                     node: ts.Node,
                     messageId: MessageId,
                     data: Record<string, string>,
+                    fix?: Rule.ReportFixer,
                 ) => {
                     const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(node);
 
                     if (reportNode !== undefined) {
-                        context.report({ node: reportNode, messageId, data });
+                        context.report({ node: reportNode, messageId, data, fix });
                     }
+                };
+
+                const createAdjacentDeclarationSwapFix = (
+                    firstDeclaration: ts.Statement,
+                    secondDeclaration: ts.Statement,
+                ): Rule.ReportFixer | undefined => {
+                    const firstStatementIndex = statements.indexOf(firstDeclaration);
+                    const secondStatementIndex = statements.indexOf(secondDeclaration);
+
+                    if (secondStatementIndex !== firstStatementIndex + 1) {
+                        return undefined;
+                    }
+
+                    const previousStatement = statements[firstStatementIndex - 1];
+                    const nextStatement = statements[secondStatementIndex + 1];
+                    const firstStart = firstDeclaration.getStart(sourceFile);
+                    const secondStart = secondDeclaration.getStart(sourceFile);
+                    const leadingTrivia = sourceFile.text.slice(
+                        previousStatement?.end ?? 0,
+                        firstStart,
+                    );
+                    const betweenDeclarations = sourceFile.text.slice(
+                        firstDeclaration.end,
+                        secondStart,
+                    );
+                    const trailingTrivia = sourceFile.text.slice(
+                        secondDeclaration.end,
+                        nextStatement?.getStart(sourceFile) ?? sourceFile.end,
+                    );
+                    const containsComment = (text: string) => /\/\/|\/\*/u.test(text);
+
+                    // A comment in the surrounding whitespace may describe one declaration.
+                    // Moving code without knowing which declaration owns it could change its meaning.
+                    if (
+                        containsComment(leadingTrivia) ||
+                        containsComment(betweenDeclarations) ||
+                        containsComment(trailingTrivia)
+                    ) {
+                        return undefined;
+                    }
+
+                    const firstText = sourceFile.text.slice(firstStart, firstDeclaration.end);
+                    const secondText = sourceFile.text.slice(secondStart, secondDeclaration.end);
+
+                    return fixer =>
+                        fixer.replaceTextRange(
+                            [firstStart, secondDeclaration.end],
+                            `${secondText}${betweenDeclarations}${firstText}`,
+                        );
                 };
 
                 const validateContractBlockSpacing = (
@@ -384,11 +434,16 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                         depsDeclaration !== undefined &&
                         statements.indexOf(stateDeclaration) > statements.indexOf(depsDeclaration)
                     ) {
-                        report(depsDeclaration, 'contractOrder', {
-                            consumerName,
-                            stateName: stateDeclaration.name.text,
-                            depsName: depsDeclaration.name.text,
-                        });
+                        report(
+                            depsDeclaration,
+                            'contractOrder',
+                            {
+                                consumerName,
+                                stateName: stateDeclaration.name.text,
+                                depsName: depsDeclaration.name.text,
+                            },
+                            createAdjacentDeclarationSwapFix(depsDeclaration, stateDeclaration),
+                        );
                     }
 
                     const firstContractIndex = Math.min(
@@ -578,11 +633,19 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                                 serviceStatementIndex !== undefined &&
                                 depsStatementIndex > serviceStatementIndex
                             ) {
-                                report(depsDeclaration, 'dependencyFactoryContractOrder', {
-                                    factoryName,
-                                    depsName: expectedDepsName,
-                                    serviceName: serviceDeclaration.name.text,
-                                });
+                                report(
+                                    depsDeclaration,
+                                    'dependencyFactoryContractOrder',
+                                    {
+                                        factoryName,
+                                        depsName: expectedDepsName,
+                                        serviceName: serviceDeclaration.name.text,
+                                    },
+                                    createAdjacentDeclarationSwapFix(
+                                        serviceDeclaration,
+                                        depsDeclaration,
+                                    ),
+                                );
                             }
 
                             validateContractBlockSpacing(

--- a/eslint-local-rules/enforce-named-contracts/rule.ts
+++ b/eslint-local-rules/enforce-named-contracts/rule.ts
@@ -14,7 +14,10 @@ type RequiredContract = {
 
 type MessageId =
     | 'contractMustBeAdjacent'
+    | 'contractMustBeSeparated'
+    | 'contractOrder'
     | 'contractMustBeNamed'
+    | 'dependencyFactoryContractOrder'
     | 'dependencyFactoryParameter'
     | 'dependencyFactoryReturnType'
     | 'emptyThunkConfig'
@@ -171,13 +174,19 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
             category: 'Best Practices',
             recommended: false,
         },
+        fixable: 'whitespace',
         messages: {
             contractMustBeAdjacent:
                 "Declare '{{contractName}}' in the contiguous type block directly above '{{consumerName}}'.",
+            contractMustBeSeparated:
+                "Leave an empty line between '{{previousName}}' and '{{nextName}}'.",
+            contractOrder: "Declare '{{stateName}}' before '{{depsName}}' for '{{consumerName}}'.",
             contractMustBeNamed:
                 "Use the named '{{contractName}}' contract instead of an inline or differently named type.",
             dependencyFactoryParameter:
                 "Pass '{{contractName}}' as a single 'deps' parameter to dependency-injected factory '{{factoryName}}'.",
+            dependencyFactoryContractOrder:
+                "Declare '{{depsName}}' before '{{serviceName}}' for '{{factoryName}}'.",
             dependencyFactoryReturnType:
                 "Give dependency-injected factory '{{factoryName}}' an explicit named service return type.",
             emptyThunkConfig: "Use explicit 'void' for dependency-free thunk '{{thunkName}}'.",
@@ -227,6 +236,64 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
 
                     if (reportNode !== undefined) {
                         context.report({ node: reportNode, messageId, data });
+                    }
+                };
+
+                const validateContractBlockSpacing = (
+                    firstStatementIndex: number,
+                    consumerStatementIndex: number,
+                    consumerName: string,
+                ) => {
+                    const contractBlock = statements.slice(
+                        firstStatementIndex,
+                        consumerStatementIndex + 1,
+                    );
+
+                    for (let index = 1; index < contractBlock.length; index += 1) {
+                        const previousStatement = contractBlock[index - 1];
+                        const nextStatement = contractBlock[index];
+
+                        if (previousStatement === undefined || nextStatement === undefined) {
+                            continue;
+                        }
+
+                        const textBetweenStatements = sourceFile.text.slice(
+                            previousStatement.end,
+                            nextStatement.getStart(sourceFile),
+                        );
+
+                        if (/\r?\n[\t ]*\r?\n/u.test(textBetweenStatements)) {
+                            continue;
+                        }
+
+                        const previousName =
+                            (ts.isTypeAliasDeclaration(previousStatement) ||
+                                ts.isInterfaceDeclaration(previousStatement)) &&
+                            previousStatement.name.text;
+                        const nextName =
+                            (ts.isTypeAliasDeclaration(nextStatement) ||
+                                ts.isInterfaceDeclaration(nextStatement)) &&
+                            nextStatement.name.text;
+                        const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(nextStatement);
+
+                        if (reportNode !== undefined) {
+                            context.report({
+                                node: reportNode,
+                                messageId: 'contractMustBeSeparated',
+                                data: {
+                                    previousName: previousName || 'the previous declaration',
+                                    nextName: nextName || consumerName,
+                                },
+                                fix: fixer => {
+                                    const { line } = sourceFile.getLineAndCharacterOfPosition(
+                                        nextStatement.getStart(sourceFile),
+                                    );
+                                    const start = sourceFile.getPositionOfLineAndCharacter(line, 0);
+
+                                    return fixer.insertTextBeforeRange([start, start], '\n');
+                                },
+                            });
+                        }
                     }
                 };
 
@@ -289,6 +356,46 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                             contractName: contract.expectedName,
                         });
                     }
+
+                    const contractDeclarations = requiredContracts.flatMap(contract => {
+                        const declaration = localTypeAliases.get(contract.expectedName);
+
+                        return declaration === undefined ? [] : [declaration];
+                    });
+
+                    if (
+                        contractDeclarations.length !== requiredContracts.length ||
+                        contractDeclarations.some(
+                            declaration => !adjacentTypeNames.includes(declaration.name.text),
+                        )
+                    ) {
+                        return;
+                    }
+
+                    const stateDeclaration = contractDeclarations.find(declaration =>
+                        declaration.name.text.endsWith('State'),
+                    );
+                    const depsDeclaration = contractDeclarations.find(declaration =>
+                        declaration.name.text.endsWith('Deps'),
+                    );
+
+                    if (
+                        stateDeclaration !== undefined &&
+                        depsDeclaration !== undefined &&
+                        statements.indexOf(stateDeclaration) > statements.indexOf(depsDeclaration)
+                    ) {
+                        report(depsDeclaration, 'contractOrder', {
+                            consumerName,
+                            stateName: stateDeclaration.name.text,
+                            depsName: depsDeclaration.name.text,
+                        });
+                    }
+
+                    const firstContractIndex = Math.min(
+                        ...contractDeclarations.map(declaration => statements.indexOf(declaration)),
+                    );
+
+                    validateContractBlockSpacing(firstContractIndex, statementIndex, consumerName);
                 };
 
                 const validateRtkThunk = (
@@ -397,6 +504,7 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                 const validateDependencyFactory = (
                     factoryName: string,
                     factoryFunction: ts.FunctionLikeDeclaration,
+                    statementIndex: number,
                 ) => {
                     // Composition roots and dependency-object builders wire services together;
                     // they are not factories for the service named after `create`.
@@ -434,8 +542,55 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                         });
                     }
 
-                    if (getTypeReferenceName(factoryFunction.type) === undefined) {
+                    const returnTypeName = getTypeReferenceName(factoryFunction.type);
+
+                    if (returnTypeName === undefined) {
                         report(factoryFunction, 'dependencyFactoryReturnType', { factoryName });
+                    }
+
+                    const depsDeclaration = localTypeAliases.get(expectedDepsName);
+
+                    if (depsDeclaration !== undefined) {
+                        const depsStatementIndex = statements.indexOf(depsDeclaration);
+                        const serviceDeclaration =
+                            returnTypeName === undefined
+                                ? undefined
+                                : localTypeAliases.get(returnTypeName);
+                        const serviceStatementIndex =
+                            serviceDeclaration === undefined
+                                ? undefined
+                                : statements.indexOf(serviceDeclaration);
+                        const firstContractIndex = Math.min(
+                            depsStatementIndex,
+                            serviceStatementIndex ?? depsStatementIndex,
+                        );
+                        const isInAdjacentTypeBlock = statements
+                            .slice(firstContractIndex, statementIndex)
+                            .every(
+                                statement =>
+                                    ts.isTypeAliasDeclaration(statement) ||
+                                    ts.isInterfaceDeclaration(statement),
+                            );
+
+                        if (isInAdjacentTypeBlock) {
+                            if (
+                                serviceDeclaration !== undefined &&
+                                serviceStatementIndex !== undefined &&
+                                depsStatementIndex > serviceStatementIndex
+                            ) {
+                                report(depsDeclaration, 'dependencyFactoryContractOrder', {
+                                    factoryName,
+                                    depsName: expectedDepsName,
+                                    serviceName: serviceDeclaration.name.text,
+                                });
+                            }
+
+                            validateContractBlockSpacing(
+                                firstContractIndex,
+                                statementIndex,
+                                factoryName,
+                            );
+                        }
                     }
                 };
 
@@ -450,7 +605,11 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                             }
 
                             if (declarationName.startsWith('create')) {
-                                validateDependencyFactory(declarationName, statement);
+                                validateDependencyFactory(
+                                    declarationName,
+                                    statement,
+                                    statementIndex,
+                                );
                             }
                         }
 
@@ -491,7 +650,11 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                             const factoryFunction = getVariableFunction(declaration);
 
                             if (factoryFunction !== undefined) {
-                                validateDependencyFactory(declarationName, factoryFunction);
+                                validateDependencyFactory(
+                                    declarationName,
+                                    factoryFunction,
+                                    statementIndex,
+                                );
                             }
                         }
                     }

--- a/eslint-local-rules/enforce-thunk-contracts/rule.test.ts
+++ b/eslint-local-rules/enforce-thunk-contracts/rule.test.ts
@@ -1,29 +1,10 @@
-import { RuleTester } from 'eslint';
-import path from 'node:path';
-import { parser } from 'typescript-eslint';
+import { enforceThunkContractsRule } from './rule';
+import { namedContractsFilename, namedContractsRuleTester } from '../named-contracts/testUtils';
 
-import { enforceNamedContractsRule } from './rule';
-
-const ruleTester = new RuleTester({
-    languageOptions: {
-        parser,
-        parserOptions: {
-            ecmaVersion: 2020,
-            projectService: {
-                allowDefaultProject: ['named-contracts.ts'],
-            },
-            sourceType: 'module',
-            tsconfigRootDir: path.join(__dirname, '../..'),
-        },
-    },
-});
-
-const filename = path.join(__dirname, '../..', 'named-contracts.ts');
-
-ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
+namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRule, {
     valid: [
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
 
@@ -31,7 +12,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             `,
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
@@ -46,7 +27,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             `,
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
@@ -63,7 +44,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             `,
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
@@ -75,7 +56,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             `,
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
@@ -87,7 +68,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             `,
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 type SaveThunkState = { value: string };
 
@@ -105,7 +86,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             `,
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 type SaveThunkState = { value: string };
 
@@ -124,49 +105,10 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
                 }
             `,
         },
-        {
-            filename,
-            code: `
-                type SaveDeps = { logger: { log: () => void } };
-
-                type Save = () => void;
-
-                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
-            `,
-        },
-        {
-            filename,
-            code: `
-                type SaveDeps = { logger: { log: () => void } };
-
-                type Save = () => void;
-
-                function createSave(deps: SaveDeps): Save {
-                    return () => deps.logger.log();
-                }
-            `,
-        },
-        {
-            filename,
-            code: `
-                type NativeAppDeps = { logger: { log: () => void } };
-                type NativeServices = { save: () => void };
-
-                const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices => ({
-                    save: () => deps.logger.log(),
-                });
-            `,
-        },
-        {
-            filename,
-            code: `
-                const createMockDeps = <T>(deps: T): T => deps;
-            `,
-        },
     ],
     invalid: [
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
@@ -201,7 +143,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkDeps = { save: () => void };
@@ -238,59 +180,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
-            code: `
-                type SaveDeps = { logger: { log: () => void } };
-                type Save = () => void;
-                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
-            `,
-            output: `
-                type SaveDeps = { logger: { log: () => void } };
-
-                type Save = () => void;
-
-                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
-            `,
-            errors: [
-                {
-                    messageId: 'contractMustBeSeparated',
-                    data: { previousName: 'SaveDeps', nextName: 'Save' },
-                },
-                {
-                    messageId: 'contractMustBeSeparated',
-                    data: { previousName: 'Save', nextName: 'createSave' },
-                },
-            ],
-        },
-        {
-            filename,
-            code: `
-                type Save = () => void;
-
-                type SaveDeps = { logger: { log: () => void } };
-
-                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
-            `,
-            output: `
-                type SaveDeps = { logger: { log: () => void } };
-
-                type Save = () => void;
-
-                const createSave = (deps: SaveDeps): Save => () => deps.logger.log();
-            `,
-            errors: [
-                {
-                    messageId: 'dependencyFactoryContractOrder',
-                    data: {
-                        depsName: 'SaveDeps',
-                        serviceName: 'Save',
-                        factoryName: 'createSave',
-                    },
-                },
-            ],
-        },
-        {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 export type SaveThunkDeps = { save: () => void };
@@ -327,7 +217,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 // Saving requires access to this service.
@@ -354,7 +244,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config = void>(name: string, callback: unknown) => unknown;
                 const saveThunk = createThunk<void, void>('save', () => undefined);
@@ -362,7 +252,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             errors: [{ messageId: 'missingThunkConfig', data: { thunkName: 'saveThunk' } }],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 const saveThunk = createThunk<void, void, {}>('save', () => undefined);
@@ -370,7 +260,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             errors: [{ messageId: 'emptyThunkConfig', data: { thunkName: 'saveThunk' } }],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type State = { value: string };
@@ -387,7 +277,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
@@ -406,7 +296,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkDeps = { save: () => void };
@@ -424,7 +314,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 type State = { value: string };
                 type Deps = { save: () => void };
@@ -445,7 +335,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 const save = () => (dispatch, getState, extra) => {
                     void dispatch;
@@ -459,7 +349,7 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
             ],
         },
         {
-            filename,
+            filename: namedContractsFilename,
             code: `
                 const save = () => (_, getState, extra) => {
                     void getState;
@@ -471,50 +361,5 @@ ruleTester.run('enforce-named-contracts', enforceNamedContractsRule, {
                 { messageId: 'contractMustBeNamed', data: { contractName: 'SaveThunkDeps' } },
             ],
         },
-        {
-            filename,
-            code: `
-                type CreateSaveDeps = { logger: { log: () => void } };
-                type Save = () => void;
-
-                const createSave = (deps: CreateSaveDeps): Save => () => deps.logger.log();
-            `,
-            errors: [
-                {
-                    messageId: 'contractMustBeNamed',
-                    data: { contractName: 'SaveDeps', consumerName: 'createSave' },
-                },
-            ],
-        },
-        {
-            filename,
-            code: `
-                type SaveDeps = { logger: { log: () => void } };
-
-                const createSave = (deps: SaveDeps) => () => deps.logger.log();
-            `,
-            errors: [
-                {
-                    messageId: 'dependencyFactoryReturnType',
-                    data: { factoryName: 'createSave' },
-                },
-            ],
-        },
-        {
-            filename,
-            code: `
-                type SaveDeps = { logger: { log: () => void } };
-
-                type Save = () => void;
-
-                const createSave = ({ logger }: SaveDeps): Save => () => logger.log();
-            `,
-            errors: [
-                {
-                    messageId: 'dependencyFactoryParameter',
-                    data: { factoryName: 'createSave', contractName: 'SaveDeps' },
-                },
-            ],
-        },
     ],
-} as Parameters<typeof ruleTester.run>[2]);
+} as Parameters<typeof namedContractsRuleTester.run>[2]);

--- a/eslint-local-rules/enforce-thunk-contracts/rule.ts
+++ b/eslint-local-rules/enforce-thunk-contracts/rule.ts
@@ -1,13 +1,13 @@
 import type { Rule } from 'eslint';
 import ts from 'typescript';
 
+import { createNamedContractRuleListener } from '../named-contracts/utils';
 import {
-    createNamedContractRuleListener,
     getFunctionExpression,
     getTypeReferenceName,
     getVariableFunction,
     unwrapExpression,
-} from '../named-contracts/utils';
+} from '../utils';
 
 type RequiredContract = {
     expectedName: string;

--- a/eslint-local-rules/enforce-thunk-contracts/rule.ts
+++ b/eslint-local-rules/enforce-thunk-contracts/rule.ts
@@ -1,29 +1,18 @@
 import type { Rule } from 'eslint';
 import ts from 'typescript';
 
-type TypeAwareParserServices = {
-    esTreeNodeToTSNodeMap?: ReadonlyMap<Rule.Node, ts.Node>;
-    program?: ts.Program;
-    tsNodeToESTreeNodeMap?: ReadonlyMap<ts.Node, Rule.Node>;
-};
+import {
+    createNamedContractRuleListener,
+    getFunctionExpression,
+    getTypeReferenceName,
+    getVariableFunction,
+    unwrapExpression,
+} from '../named-contracts/utils';
 
 type RequiredContract = {
     expectedName: string;
     node: ts.TypeNode;
 };
-
-type MessageId =
-    | 'contractMustBeAdjacent'
-    | 'contractMustBeSeparated'
-    | 'contractOrder'
-    | 'contractMustBeNamed'
-    | 'dependencyFactoryContractOrder'
-    | 'dependencyFactoryParameter'
-    | 'dependencyFactoryReturnType'
-    | 'emptyThunkConfig'
-    | 'missingThunkConfig'
-    | 'thunkConfigMustBeInline'
-    | 'voidContractProperty';
 
 const thunkCreators = new Set(['createSingleInstanceThunk', 'createThunk']);
 
@@ -41,27 +30,6 @@ const getThunkContractBaseName = (name: string) => {
     }
 
     return capitalizedName.endsWith('Thunk') ? capitalizedName : `${capitalizedName}Thunk`;
-};
-
-const unwrapExpression = (expression: ts.Expression): ts.Expression => {
-    if (
-        ts.isParenthesizedExpression(expression) ||
-        ts.isAsExpression(expression) ||
-        ts.isTypeAssertionExpression(expression) ||
-        ts.isNonNullExpression(expression)
-    ) {
-        return unwrapExpression(expression.expression);
-    }
-
-    return expression;
-};
-
-const getFunctionExpression = (expression: ts.Expression) => {
-    const unwrappedExpression = unwrapExpression(expression);
-
-    return ts.isArrowFunction(unwrappedExpression) || ts.isFunctionExpression(unwrappedExpression)
-        ? unwrappedExpression
-        : undefined;
 };
 
 const getReturnedFunction = (functionNode: ts.FunctionLikeDeclaration) => {
@@ -95,11 +63,6 @@ const getInnermostReturnedFunction = (functionNode: ts.FunctionLikeDeclaration) 
     return currentFunction;
 };
 
-const getTypeReferenceName = (node: ts.TypeNode | undefined) =>
-    node !== undefined && ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)
-        ? node.typeName.text
-        : undefined;
-
 const getPropertyName = (node: ts.TypeElement) => {
     if (!ts.isPropertySignature(node) || node.name === undefined) {
         return undefined;
@@ -127,11 +90,6 @@ const isEmptyContractType = (node: ts.TypeNode | undefined) => {
         node.typeArguments?.[0]?.kind === ts.SyntaxKind.NeverKeyword
     );
 };
-
-const getVariableFunction = (declaration: ts.VariableDeclaration) =>
-    declaration.initializer === undefined
-        ? undefined
-        : getFunctionExpression(declaration.initializer);
 
 const getThunkImplementationFromFunction = (outerFunction: ts.FunctionLikeDeclaration) => {
     const implementation = getInnermostReturnedFunction(outerFunction);
@@ -162,15 +120,12 @@ const getGetStateReturnType = (parameter: ts.ParameterDeclaration | undefined) =
     return ts.isFunctionTypeNode(parameter.type) ? parameter.type.type : parameter.type;
 };
 
-/**
- * Enforces local, predictably named state and dependency contracts for thunks and DI factories.
- */
-export const enforceNamedContractsRule: Rule.RuleModule = {
+/** Enforces local, predictably named state and dependency contracts for thunks. */
+export const enforceThunkContractsRule: Rule.RuleModule = {
     meta: {
         type: 'problem',
         docs: {
-            description:
-                'Enforces explicit, named State and Deps contracts for thunks and dependency-injected service factories.',
+            description: 'Enforces explicit, named State and Deps contracts for thunks.',
             category: 'Best Practices',
             recommended: false,
         },
@@ -183,12 +138,6 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
             contractOrder: "Declare '{{stateName}}' before '{{depsName}}' for '{{consumerName}}'.",
             contractMustBeNamed:
                 "Use the named '{{contractName}}' contract instead of an inline or differently named type.",
-            dependencyFactoryParameter:
-                "Pass '{{contractName}}' as a single 'deps' parameter to dependency-injected factory '{{factoryName}}'.",
-            dependencyFactoryContractOrder:
-                "Declare '{{depsName}}' before '{{serviceName}}' for '{{factoryName}}'.",
-            dependencyFactoryReturnType:
-                "Give dependency-injected factory '{{factoryName}}' an explicit named service return type.",
             emptyThunkConfig: "Use explicit 'void' for dependency-free thunk '{{thunkName}}'.",
             missingThunkConfig:
                 "Give thunk '{{thunkName}}' an explicit third generic: 'void' or a named State/Deps config.",
@@ -199,154 +148,17 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
         },
         schema: [],
     },
-    create(context) {
-        const parserServices = context.sourceCode.parserServices as TypeAwareParserServices;
-
-        if (
-            parserServices.program === undefined ||
-            parserServices.esTreeNodeToTSNodeMap === undefined ||
-            parserServices.tsNodeToESTreeNodeMap === undefined
-        ) {
-            return {};
-        }
-
-        return {
-            'Program:exit': programNode => {
-                const sourceFile = parserServices.esTreeNodeToTSNodeMap?.get(
-                    programNode as Rule.Node,
-                );
-
-                if (sourceFile === undefined || !ts.isSourceFile(sourceFile)) {
-                    return;
-                }
-
-                const { statements } = sourceFile;
-                const localTypeAliases = new Map(
-                    statements
-                        .filter(ts.isTypeAliasDeclaration)
-                        .map(declaration => [declaration.name.text, declaration] as const),
-                );
-
-                const report = (
-                    node: ts.Node,
-                    messageId: MessageId,
-                    data: Record<string, string>,
-                    fix?: Rule.ReportFixer,
-                ) => {
-                    const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(node);
-
-                    if (reportNode !== undefined) {
-                        context.report({ node: reportNode, messageId, data, fix });
-                    }
-                };
-
-                const createAdjacentDeclarationSwapFix = (
-                    firstDeclaration: ts.Statement,
-                    secondDeclaration: ts.Statement,
-                ): Rule.ReportFixer | undefined => {
-                    const firstStatementIndex = statements.indexOf(firstDeclaration);
-                    const secondStatementIndex = statements.indexOf(secondDeclaration);
-
-                    if (secondStatementIndex !== firstStatementIndex + 1) {
-                        return undefined;
-                    }
-
-                    const previousStatement = statements[firstStatementIndex - 1];
-                    const nextStatement = statements[secondStatementIndex + 1];
-                    const firstStart = firstDeclaration.getStart(sourceFile);
-                    const secondStart = secondDeclaration.getStart(sourceFile);
-                    const leadingTrivia = sourceFile.text.slice(
-                        previousStatement?.end ?? 0,
-                        firstStart,
-                    );
-                    const betweenDeclarations = sourceFile.text.slice(
-                        firstDeclaration.end,
-                        secondStart,
-                    );
-                    const trailingTrivia = sourceFile.text.slice(
-                        secondDeclaration.end,
-                        nextStatement?.getStart(sourceFile) ?? sourceFile.end,
-                    );
-                    const containsComment = (text: string) => /\/\/|\/\*/u.test(text);
-
-                    // A comment in the surrounding whitespace may describe one declaration.
-                    // Moving code without knowing which declaration owns it could change its meaning.
-                    if (
-                        containsComment(leadingTrivia) ||
-                        containsComment(betweenDeclarations) ||
-                        containsComment(trailingTrivia)
-                    ) {
-                        return undefined;
-                    }
-
-                    const firstText = sourceFile.text.slice(firstStart, firstDeclaration.end);
-                    const secondText = sourceFile.text.slice(secondStart, secondDeclaration.end);
-
-                    return fixer =>
-                        fixer.replaceTextRange(
-                            [firstStart, secondDeclaration.end],
-                            `${secondText}${betweenDeclarations}${firstText}`,
-                        );
-                };
-
-                const validateContractBlockSpacing = (
-                    firstStatementIndex: number,
-                    consumerStatementIndex: number,
-                    consumerName: string,
-                ) => {
-                    const contractBlock = statements.slice(
-                        firstStatementIndex,
-                        consumerStatementIndex + 1,
-                    );
-
-                    for (let index = 1; index < contractBlock.length; index += 1) {
-                        const previousStatement = contractBlock[index - 1];
-                        const nextStatement = contractBlock[index];
-
-                        if (previousStatement === undefined || nextStatement === undefined) {
-                            continue;
-                        }
-
-                        const textBetweenStatements = sourceFile.text.slice(
-                            previousStatement.end,
-                            nextStatement.getStart(sourceFile),
-                        );
-
-                        if (/\r?\n[\t ]*\r?\n/u.test(textBetweenStatements)) {
-                            continue;
-                        }
-
-                        const previousName =
-                            (ts.isTypeAliasDeclaration(previousStatement) ||
-                                ts.isInterfaceDeclaration(previousStatement)) &&
-                            previousStatement.name.text;
-                        const nextName =
-                            (ts.isTypeAliasDeclaration(nextStatement) ||
-                                ts.isInterfaceDeclaration(nextStatement)) &&
-                            nextStatement.name.text;
-                        const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(nextStatement);
-
-                        if (reportNode !== undefined) {
-                            context.report({
-                                node: reportNode,
-                                messageId: 'contractMustBeSeparated',
-                                data: {
-                                    previousName: previousName || 'the previous declaration',
-                                    nextName: nextName || consumerName,
-                                },
-                                fix: fixer => {
-                                    const { line } = sourceFile.getLineAndCharacterOfPosition(
-                                        nextStatement.getStart(sourceFile),
-                                    );
-                                    const start = sourceFile.getPositionOfLineAndCharacter(line, 0);
-
-                                    return fixer.insertTextBeforeRange([start, start], '\n');
-                                },
-                            });
-                        }
-                    }
-                };
-
+    create: context =>
+        createNamedContractRuleListener(
+            context,
+            ({
+                createAdjacentDeclarationSwapFix,
+                localTypeAliases,
+                report,
+                sourceFile,
+                statements,
+                validateContractBlockSpacing,
+            }) => {
                 const validateNamedContract = (
                     node: ts.TypeNode | undefined,
                     expectedName: string,
@@ -556,121 +368,15 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                     validateAdjacentContracts(statementIndex, thunkName, requiredContracts);
                 };
 
-                const validateDependencyFactory = (
-                    factoryName: string,
-                    factoryFunction: ts.FunctionLikeDeclaration,
-                    statementIndex: number,
-                ) => {
-                    // Composition roots and dependency-object builders wire services together;
-                    // they are not factories for the service named after `create`.
-                    if (factoryName.endsWith('CompositionRoot') || factoryName.endsWith('Deps')) {
-                        return;
-                    }
-
-                    const depsParameter = factoryFunction.parameters[0];
-
-                    if (depsParameter === undefined) {
-                        return;
-                    }
-
-                    const serviceName = factoryName.slice('create'.length);
-                    const expectedDepsName = `${serviceName}Deps`;
-                    const actualDepsName = getTypeReferenceName(depsParameter.type);
-                    const isNamedDepsParameter =
-                        ts.isIdentifier(depsParameter.name) && depsParameter.name.text === 'deps';
-
-                    if (!isNamedDepsParameter && !actualDepsName?.endsWith('Deps')) {
-                        return;
-                    }
-
-                    if (!isNamedDepsParameter) {
-                        report(depsParameter.name, 'dependencyFactoryParameter', {
-                            factoryName,
-                            contractName: expectedDepsName,
-                        });
-                    }
-
-                    if (actualDepsName !== expectedDepsName) {
-                        report(depsParameter.type ?? depsParameter, 'contractMustBeNamed', {
-                            consumerName: factoryName,
-                            contractName: expectedDepsName,
-                        });
-                    }
-
-                    const returnTypeName = getTypeReferenceName(factoryFunction.type);
-
-                    if (returnTypeName === undefined) {
-                        report(factoryFunction, 'dependencyFactoryReturnType', { factoryName });
-                    }
-
-                    const depsDeclaration = localTypeAliases.get(expectedDepsName);
-
-                    if (depsDeclaration !== undefined) {
-                        const depsStatementIndex = statements.indexOf(depsDeclaration);
-                        const serviceDeclaration =
-                            returnTypeName === undefined
-                                ? undefined
-                                : localTypeAliases.get(returnTypeName);
-                        const serviceStatementIndex =
-                            serviceDeclaration === undefined
-                                ? undefined
-                                : statements.indexOf(serviceDeclaration);
-                        const firstContractIndex = Math.min(
-                            depsStatementIndex,
-                            serviceStatementIndex ?? depsStatementIndex,
-                        );
-                        const isInAdjacentTypeBlock = statements
-                            .slice(firstContractIndex, statementIndex)
-                            .every(
-                                statement =>
-                                    ts.isTypeAliasDeclaration(statement) ||
-                                    ts.isInterfaceDeclaration(statement),
-                            );
-
-                        if (isInAdjacentTypeBlock) {
-                            if (
-                                serviceDeclaration !== undefined &&
-                                serviceStatementIndex !== undefined &&
-                                depsStatementIndex > serviceStatementIndex
-                            ) {
-                                report(
-                                    depsDeclaration,
-                                    'dependencyFactoryContractOrder',
-                                    {
-                                        factoryName,
-                                        depsName: expectedDepsName,
-                                        serviceName: serviceDeclaration.name.text,
-                                    },
-                                    createAdjacentDeclarationSwapFix(
-                                        serviceDeclaration,
-                                        depsDeclaration,
-                                    ),
-                                );
-                            }
-
-                            validateContractBlockSpacing(
-                                firstContractIndex,
-                                statementIndex,
-                                factoryName,
-                            );
-                        }
-                    }
-                };
-
                 statements.forEach((statement, statementIndex) => {
                     if (ts.isFunctionDeclaration(statement)) {
                         if (statement.name !== undefined) {
-                            const declarationName = statement.name.text;
                             const vanillaThunk = getThunkImplementationFromFunction(statement);
 
                             if (vanillaThunk !== undefined) {
-                                validateVanillaThunk(declarationName, vanillaThunk, statementIndex);
-                            }
-
-                            if (declarationName.startsWith('create')) {
-                                validateDependencyFactory(
-                                    declarationName,
-                                    statement,
+                                validateVanillaThunk(
+                                    statement.name.text,
+                                    vanillaThunk,
                                     statementIndex,
                                 );
                             }
@@ -708,21 +414,8 @@ export const enforceNamedContractsRule: Rule.RuleModule = {
                         if (vanillaThunk !== undefined) {
                             validateVanillaThunk(declarationName, vanillaThunk, statementIndex);
                         }
-
-                        if (declarationName.startsWith('create')) {
-                            const factoryFunction = getVariableFunction(declaration);
-
-                            if (factoryFunction !== undefined) {
-                                validateDependencyFactory(
-                                    declarationName,
-                                    factoryFunction,
-                                    statementIndex,
-                                );
-                            }
-                        }
                     }
                 });
             },
-        };
-    },
+        ),
 };

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -6,8 +6,8 @@ require('ts-node').register({
 });
 
 const { analyticsEventNameRule } = require('./analytics-event-name/rule');
-const { enforceDiFactoryContractsRule } = require('./enforce-di-factory-contracts/rule');
-const { enforceThunkContractsRule } = require('./enforce-thunk-contracts/rule');
+const { enforceDiFactoryContractsRule } = require('./named-contracts/di/rule');
+const { enforceThunkContractsRule } = require('./named-contracts/thunks/rule');
 const { noOverrideDsComponentRule } = require('./no-override-ds-component/rule');
 const { noPackageDeepImportsRule } = require('./no-package-deep-imports/rule');
 const { noSuiteImportsInSuiteCommonRule } = require('./no-suite-imports-in-suite-common/rule');

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -6,7 +6,8 @@ require('ts-node').register({
 });
 
 const { analyticsEventNameRule } = require('./analytics-event-name/rule');
-const { enforceNamedContractsRule } = require('./enforce-named-contracts/rule');
+const { enforceDiFactoryContractsRule } = require('./enforce-di-factory-contracts/rule');
+const { enforceThunkContractsRule } = require('./enforce-thunk-contracts/rule');
 const { noOverrideDsComponentRule } = require('./no-override-ds-component/rule');
 const { noPackageDeepImportsRule } = require('./no-package-deep-imports/rule');
 const { noSuiteImportsInSuiteCommonRule } = require('./no-suite-imports-in-suite-common/rule');
@@ -14,7 +15,8 @@ const { noUnusedIntersectionMembersRule } = require('./no-unused-intersection-me
 
 module.exports = {
     'analytics-event-name': analyticsEventNameRule,
-    'enforce-named-contracts': enforceNamedContractsRule,
+    'enforce-di-factory-contracts': enforceDiFactoryContractsRule,
+    'enforce-thunk-contracts': enforceThunkContractsRule,
     'no-override-ds-component': noOverrideDsComponentRule,
     'no-package-deep-imports': noPackageDeepImportsRule,
     'no-suite-imports-in-suite-common': noSuiteImportsInSuiteCommonRule,

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -6,6 +6,7 @@ require('ts-node').register({
 });
 
 const { analyticsEventNameRule } = require('./analytics-event-name/rule');
+const { enforceNamedContractsRule } = require('./enforce-named-contracts/rule');
 const { noOverrideDsComponentRule } = require('./no-override-ds-component/rule');
 const { noPackageDeepImportsRule } = require('./no-package-deep-imports/rule');
 const { noSuiteImportsInSuiteCommonRule } = require('./no-suite-imports-in-suite-common/rule');
@@ -13,6 +14,7 @@ const { noUnusedIntersectionMembersRule } = require('./no-unused-intersection-me
 
 module.exports = {
     'analytics-event-name': analyticsEventNameRule,
+    'enforce-named-contracts': enforceNamedContractsRule,
     'no-override-ds-component': noOverrideDsComponentRule,
     'no-package-deep-imports': noPackageDeepImportsRule,
     'no-suite-imports-in-suite-common': noSuiteImportsInSuiteCommonRule,

--- a/eslint-local-rules/named-contracts/di/rule.test.ts
+++ b/eslint-local-rules/named-contracts/di/rule.test.ts
@@ -1,5 +1,5 @@
 import { enforceDiFactoryContractsRule } from './rule';
-import { namedContractsFilename, namedContractsRuleTester } from '../named-contracts/testUtils';
+import { namedContractsFilename, namedContractsRuleTester } from '../testUtils';
 
 namedContractsRuleTester.run('enforce-di-factory-contracts', enforceDiFactoryContractsRule, {
     valid: [

--- a/eslint-local-rules/named-contracts/di/rule.test.ts
+++ b/eslint-local-rules/named-contracts/di/rule.test.ts
@@ -28,6 +28,33 @@ namedContractsRuleTester.run('enforce-di-factory-contracts', enforceDiFactoryCon
         {
             filename: namedContractsFilename,
             code: `
+                type CreateSaveFactoryDeps = { logger: { log: () => void } };
+
+                type SaveFactory = () => () => void;
+
+                type SaveFactoryDep = { saveFactory: SaveFactory };
+
+                const createSaveFactory = (deps: CreateSaveFactoryDeps): SaveFactory =>
+                    () => () => deps.logger.log();
+            `,
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type MMKVStorageDeps = { getEncryptionKey: () => string };
+
+                type MMKVStorage = { get: () => string };
+
+                type MMKVStorageDep = { mmkvStorage: MMKVStorage };
+
+                const createMMKVStorage = (deps: MMKVStorageDeps): MMKVStorage => ({
+                    get: deps.getEncryptionKey,
+                });
+            `,
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
                 type NativeAppDeps = { logger: { log: () => void } };
                 type NativeServices = { save: () => void };
 
@@ -40,6 +67,18 @@ namedContractsRuleTester.run('enforce-di-factory-contracts', enforceDiFactoryCon
             filename: namedContractsFilename,
             code: `
                 const createMockDeps = <T>(deps: T): T => deps;
+            `,
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type ConcreteSaveDeps = { logger: { log: () => void } };
+
+                type AbstractSave = () => void;
+
+                // eslint-disable-next-line rule-to-test/enforce-di-factory-contracts -- Concrete implementation of the abstract AbstractSave contract.
+                const createConcreteSave = (deps: ConcreteSaveDeps): AbstractSave =>
+                    () => deps.logger.log();
             `,
         },
     ],
@@ -66,6 +105,62 @@ namedContractsRuleTester.run('enforce-di-factory-contracts', enforceDiFactoryCon
                 {
                     messageId: 'contractMustBeSeparated',
                     data: { previousName: 'Save', nextName: 'createSave' },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type CreateSaveFactoryDeps = { logger: { log: () => void } };
+
+                type SaveFactory = () => () => void;
+
+                type CreateSaveDep = { createSave: SaveFactory };
+
+                const createSaveFactory = (deps: CreateSaveFactoryDeps): SaveFactory =>
+                    () => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeNamed',
+                    data: {
+                        contractName: 'SaveFactoryDep',
+                        consumerName: 'SaveFactory',
+                    },
+                },
+                {
+                    messageId: 'serviceDependencyProperty',
+                    data: {
+                        serviceName: 'SaveFactory',
+                        propertyName: 'saveFactory',
+                    },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type SaveFactoryDeps = { logger: { log: () => void } };
+
+                type CreateSave = () => () => void;
+
+                const createSaveFactory = (deps: SaveFactoryDeps): CreateSave =>
+                    () => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeNamed',
+                    data: {
+                        contractName: 'SaveFactory',
+                        consumerName: 'createSaveFactory',
+                    },
+                },
+                {
+                    messageId: 'contractMustBeNamed',
+                    data: {
+                        contractName: 'CreateSaveFactoryDeps',
+                        consumerName: 'createSaveFactory',
+                    },
                 },
             ],
         },
@@ -138,6 +233,28 @@ namedContractsRuleTester.run('enforce-di-factory-contracts', enforceDiFactoryCon
                 {
                     messageId: 'dependencyFactoryParameter',
                     data: { factoryName: 'createSave', contractName: 'SaveDeps' },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type WrongDeps = { logger: { log: () => void } };
+
+                type AbstractSave = () => void;
+
+                // eslint-disable-next-line rule-to-test/enforce-di-factory-contracts -- Concrete implementation of the abstract AbstractSave contract.
+                const createConcreteSave = (
+                    deps: WrongDeps,
+                ): AbstractSave => () => deps.logger.log();
+            `,
+            errors: [
+                {
+                    messageId: 'contractMustBeNamed',
+                    data: {
+                        contractName: 'ConcreteSaveDeps',
+                        consumerName: 'createConcreteSave',
+                    },
                 },
             ],
         },

--- a/eslint-local-rules/named-contracts/di/rule.ts
+++ b/eslint-local-rules/named-contracts/di/rule.ts
@@ -1,8 +1,8 @@
 import type { Rule } from 'eslint';
 import ts from 'typescript';
 
-import { createNamedContractRuleListener } from '../named-contracts/utils';
-import { getTypeReferenceName, getVariableFunction } from '../utils';
+import { getTypeReferenceName, getVariableFunction } from '../../utils';
+import { createNamedContractRuleListener } from '../utils';
 
 /** Enforces local, predictably named dependency contracts for DI service factories. */
 export const enforceDiFactoryContractsRule: Rule.RuleModule = {

--- a/eslint-local-rules/named-contracts/di/rule.ts
+++ b/eslint-local-rules/named-contracts/di/rule.ts
@@ -1,8 +1,18 @@
 import type { Rule } from 'eslint';
 import ts from 'typescript';
 
-import { getTypeReferenceName, getVariableFunction } from '../../utils';
+import { getTypeReferenceName, getVariableFunction, toLowerCamelCase } from '../../utils';
 import { createNamedContractRuleListener } from '../utils';
+
+const getServiceDependencyMembers = (
+    declaration: ts.TypeAliasDeclaration | ts.InterfaceDeclaration,
+) => {
+    if (ts.isInterfaceDeclaration(declaration)) {
+        return declaration.members;
+    }
+
+    return ts.isTypeLiteralNode(declaration.type) ? declaration.type.members : [];
+};
 
 /** Enforces local, predictably named dependency contracts for DI service factories. */
 export const enforceDiFactoryContractsRule: Rule.RuleModule = {
@@ -26,6 +36,8 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
                 "Pass '{{contractName}}' as a single 'deps' parameter to dependency-injected factory '{{factoryName}}'.",
             dependencyFactoryReturnType:
                 "Give dependency-injected factory '{{factoryName}}' an explicit named service return type.",
+            serviceDependencyProperty:
+                "Expose the '{{serviceName}}' service as '{{propertyName}}' in its dependency contract.",
         },
         schema: [],
     },
@@ -41,6 +53,7 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
             }) => {
                 const validateDependencyFactory = (
                     factoryName: string,
+                    factoryNameNode: ts.Node,
                     factoryFunction: ts.FunctionLikeDeclaration,
                     statementIndex: number,
                 ) => {
@@ -57,7 +70,13 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
                     }
 
                     const serviceName = factoryName.slice('create'.length);
-                    const expectedDepsName = `${serviceName}Deps`;
+                    // `createSave` creates the `Save` service, so it uses `SaveDeps`.
+                    // `createSaveFactory` creates the `SaveFactory` service. Its own creator
+                    // therefore uses `CreateSaveFactoryDeps`, which keeps the two factory
+                    // layers distinguishable.
+                    const expectedDepsName = factoryName.endsWith('Factory')
+                        ? `${factoryName.charAt(0).toUpperCase()}${factoryName.slice(1)}Deps`
+                        : `${serviceName}Deps`;
                     const actualDepsName = getTypeReferenceName(depsParameter.type);
                     const isNamedDepsParameter =
                         ts.isIdentifier(depsParameter.name) && depsParameter.name.text === 'deps';
@@ -84,7 +103,53 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
 
                     if (returnTypeName === undefined) {
                         report(factoryFunction, 'dependencyFactoryReturnType', { factoryName });
+                    } else if (returnTypeName !== serviceName) {
+                        report(factoryNameNode, 'contractMustBeNamed', {
+                            consumerName: factoryName,
+                            contractName: serviceName,
+                        });
                     }
+
+                    const expectedServiceDepName = `${serviceName}Dep`;
+                    const expectedServicePropertyName = toLowerCamelCase(serviceName);
+
+                    // A service does not always need a `Dep` wrapper. When it has one, keep the
+                    // service name everywhere: `SaveFactory` becomes
+                    // `{ saveFactory: SaveFactory }` inside `SaveFactoryDep`.
+                    statements.forEach(statement => {
+                        if (
+                            (!ts.isTypeAliasDeclaration(statement) &&
+                                !ts.isInterfaceDeclaration(statement)) ||
+                            !statement.name.text.endsWith('Dep')
+                        ) {
+                            return;
+                        }
+
+                        const serviceProperties = getServiceDependencyMembers(statement).filter(
+                            member =>
+                                ts.isPropertySignature(member) &&
+                                getTypeReferenceName(member.type) === serviceName,
+                        );
+
+                        serviceProperties.forEach(property => {
+                            if (statement.name.text !== expectedServiceDepName) {
+                                report(statement.name, 'contractMustBeNamed', {
+                                    consumerName: serviceName,
+                                    contractName: expectedServiceDepName,
+                                });
+                            }
+
+                            if (
+                                !ts.isIdentifier(property.name) ||
+                                property.name.text !== expectedServicePropertyName
+                            ) {
+                                report(property.name, 'serviceDependencyProperty', {
+                                    serviceName,
+                                    propertyName: expectedServicePropertyName,
+                                });
+                            }
+                        });
+                    });
 
                     const depsDeclaration = localTypeAliases.get(expectedDepsName);
 
@@ -142,6 +207,7 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
                         if (statement.name?.text.startsWith('create')) {
                             validateDependencyFactory(
                                 statement.name.text,
+                                statement.name,
                                 statement,
                                 statementIndex,
                             );
@@ -167,6 +233,7 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
                         if (factoryFunction !== undefined) {
                             validateDependencyFactory(
                                 declaration.name.text,
+                                declaration.name,
                                 factoryFunction,
                                 statementIndex,
                             );

--- a/eslint-local-rules/named-contracts/testUtils.ts
+++ b/eslint-local-rules/named-contracts/testUtils.ts
@@ -1,0 +1,19 @@
+import { RuleTester } from 'eslint';
+import path from 'node:path';
+import { parser } from 'typescript-eslint';
+
+export const namedContractsRuleTester = new RuleTester({
+    languageOptions: {
+        parser,
+        parserOptions: {
+            ecmaVersion: 2020,
+            projectService: {
+                allowDefaultProject: ['named-contracts.ts'],
+            },
+            sourceType: 'module',
+            tsconfigRootDir: path.join(__dirname, '../..'),
+        },
+    },
+});
+
+export const namedContractsFilename = path.join(__dirname, '../..', 'named-contracts.ts');

--- a/eslint-local-rules/named-contracts/thunks/rule.test.ts
+++ b/eslint-local-rules/named-contracts/thunks/rule.test.ts
@@ -1,5 +1,5 @@
 import { enforceThunkContractsRule } from './rule';
-import { namedContractsFilename, namedContractsRuleTester } from '../named-contracts/testUtils';
+import { namedContractsFilename, namedContractsRuleTester } from '../testUtils';
 
 namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRule, {
     valid: [

--- a/eslint-local-rules/named-contracts/thunks/rule.test.ts
+++ b/eslint-local-rules/named-contracts/thunks/rule.test.ts
@@ -15,6 +15,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 type SaveThunkState = { value: string };
 
                 type SaveThunkDeps = { save: () => void };
@@ -30,6 +31,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 type SaveThunkState = { value: string };
 
                 type SaveThunkDeps = { save: () => void };
@@ -47,6 +49,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 type SaveThunkState = { value: string };
 
                 const saveThunks = createThunk<void, void, { state: SaveThunkState }>(
@@ -59,6 +62,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 type SaveThunkState = { value: string };
 
                 const saveThunkInner = createThunk<void, void, { state: SaveThunkState }>(
@@ -110,6 +114,50 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
         {
             filename: namedContractsFilename,
             code: `
+                type GetState = () => { value: string };
+
+                type SaveThunkState = ReturnType<GetState>;
+
+                const save = () => (
+                    dispatch: unknown,
+                    getState: () => SaveThunkState,
+                ) => {
+                    void dispatch;
+                    void getState;
+                };
+            `,
+            errors: [
+                {
+                    messageId: 'stateContractMustBeExplicit',
+                    data: { contractName: 'SaveThunkState' },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
+                type AppState = { value: string };
+
+                type SaveThunkState = AppState;
+
+                const save = () => (
+                    dispatch: unknown,
+                    getState: () => SaveThunkState,
+                ) => {
+                    void dispatch;
+                    void getState;
+                };
+            `,
+            errors: [
+                {
+                    messageId: 'stateContractMustBeExplicit',
+                    data: { contractName: 'SaveThunkState' },
+                },
+            ],
+        },
+        {
+            filename: namedContractsFilename,
+            code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
                 type SaveThunkState = { value: string };
                 type SaveThunkDeps = { save: () => void };
@@ -121,6 +169,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             `,
             output: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 type SaveThunkState = { value: string };
 
                 type SaveThunkDeps = { save: () => void };
@@ -132,6 +181,13 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
                 >('save', () => undefined);
             `,
             errors: [
+                {
+                    messageId: 'contractMustBeSeparated',
+                    data: {
+                        previousName: 'the previous declaration',
+                        nextName: 'SaveThunkState',
+                    },
+                },
                 {
                     messageId: 'contractMustBeSeparated',
                     data: { previousName: 'SaveThunkState', nextName: 'SaveThunkDeps' },
@@ -146,6 +202,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 type SaveThunkDeps = { save: () => void };
 
                 type SaveThunkState = { value: string };
@@ -158,6 +215,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             `,
             output: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 type SaveThunkState = { value: string };
 
                 type SaveThunkDeps = { save: () => void };
@@ -183,6 +241,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 export type SaveThunkDeps = { save: () => void };
 
                 export type SaveThunkState = { value: string };
@@ -195,6 +254,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             `,
             output: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 export type SaveThunkState = { value: string };
 
                 export type SaveThunkDeps = { save: () => void };
@@ -220,6 +280,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 // Saving requires access to this service.
                 type SaveThunkDeps = { save: () => void };
 
@@ -299,6 +360,7 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
             filename: namedContractsFilename,
             code: `
                 declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
+
                 type SaveThunkDeps = { save: () => void };
 
                 const saveThunk = createThunk<void, void, { state: void; extra: SaveThunkDeps }>(

--- a/eslint-local-rules/named-contracts/thunks/rule.ts
+++ b/eslint-local-rules/named-contracts/thunks/rule.ts
@@ -1,13 +1,13 @@
 import type { Rule } from 'eslint';
 import ts from 'typescript';
 
-import { createNamedContractRuleListener } from '../named-contracts/utils';
 import {
     getFunctionExpression,
     getTypeReferenceName,
     getVariableFunction,
     unwrapExpression,
-} from '../utils';
+} from '../../utils';
+import { createNamedContractRuleListener } from '../utils';
 
 type RequiredContract = {
     expectedName: string;

--- a/eslint-local-rules/named-contracts/thunks/rule.ts
+++ b/eslint-local-rules/named-contracts/thunks/rule.ts
@@ -141,6 +141,8 @@ export const enforceThunkContractsRule: Rule.RuleModule = {
             emptyThunkConfig: "Use explicit 'void' for dependency-free thunk '{{thunkName}}'.",
             missingThunkConfig:
                 "Give thunk '{{thunkName}}' an explicit third generic: 'void' or a named State/Deps config.",
+            stateContractMustBeExplicit:
+                "Define '{{contractName}}' from the minimal RootState types the thunk reads; do not derive it from GetState or an app-wide state type.",
             thunkConfigMustBeInline:
                 "Inline the RTK config for '{{thunkName}}' so its named State and Deps contracts stay visible.",
             voidContractProperty:
@@ -172,6 +174,25 @@ export const enforceThunkContractsRule: Rule.RuleModule = {
                         });
 
                         return;
+                    }
+
+                    const declaration = localTypeAliases.get(expectedName);
+                    const declaredStateTypeName =
+                        declaration !== undefined && ts.isTypeAliasDeclaration(declaration)
+                            ? getTypeReferenceName(declaration.type)
+                            : undefined;
+
+                    if (
+                        expectedName.endsWith('State') &&
+                        declaration !== undefined &&
+                        ts.isTypeAliasDeclaration(declaration) &&
+                        (declaredStateTypeName === 'AppState' ||
+                            declaredStateTypeName === 'GetState' ||
+                            declaredStateTypeName === 'ReturnType')
+                    ) {
+                        report(declaration.type, 'stateContractMustBeExplicit', {
+                            contractName: expectedName,
+                        });
                     }
 
                     requiredContracts.push({ expectedName, node });

--- a/eslint-local-rules/named-contracts/utils.ts
+++ b/eslint-local-rules/named-contracts/utils.ts
@@ -1,11 +1,11 @@
 import type { Rule } from 'eslint';
 import ts from 'typescript';
 
-type TypeAwareParserServices = {
-    esTreeNodeToTSNodeMap?: ReadonlyMap<Rule.Node, ts.Node>;
-    program?: ts.Program;
-    tsNodeToESTreeNodeMap?: ReadonlyMap<ts.Node, Rule.Node>;
-};
+import {
+    type TypeScriptNodeReporter,
+    createTypeScriptNodeReporter,
+    getTypeScriptParserServices,
+} from '../utils';
 
 export type NamedContractRuleContext = {
     createAdjacentDeclarationSwapFix: (
@@ -13,12 +13,7 @@ export type NamedContractRuleContext = {
         secondDeclaration: ts.Statement,
     ) => Rule.ReportFixer | undefined;
     localTypeAliases: Map<string, ts.TypeAliasDeclaration>;
-    report: (
-        node: ts.Node,
-        messageId: string,
-        data: Record<string, string>,
-        fix?: Rule.ReportFixer,
-    ) => void;
+    report: TypeScriptNodeReporter;
     sourceFile: ts.SourceFile;
     statements: ts.NodeArray<ts.Statement>;
     validateContractBlockSpacing: (
@@ -28,54 +23,19 @@ export type NamedContractRuleContext = {
     ) => void;
 };
 
-export const unwrapExpression = (expression: ts.Expression): ts.Expression => {
-    if (
-        ts.isParenthesizedExpression(expression) ||
-        ts.isAsExpression(expression) ||
-        ts.isTypeAssertionExpression(expression) ||
-        ts.isNonNullExpression(expression)
-    ) {
-        return unwrapExpression(expression.expression);
-    }
-
-    return expression;
-};
-
-export const getFunctionExpression = (expression: ts.Expression) => {
-    const unwrappedExpression = unwrapExpression(expression);
-
-    return ts.isArrowFunction(unwrappedExpression) || ts.isFunctionExpression(unwrappedExpression)
-        ? unwrappedExpression
-        : undefined;
-};
-
-export const getVariableFunction = (declaration: ts.VariableDeclaration) =>
-    declaration.initializer === undefined
-        ? undefined
-        : getFunctionExpression(declaration.initializer);
-
-export const getTypeReferenceName = (node: ts.TypeNode | undefined) =>
-    node !== undefined && ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)
-        ? node.typeName.text
-        : undefined;
-
 export const createNamedContractRuleListener = (
     context: Rule.RuleContext,
     validate: (contractContext: NamedContractRuleContext) => void,
 ): Rule.RuleListener => {
-    const parserServices = context.sourceCode.parserServices as TypeAwareParserServices;
+    const parserServices = getTypeScriptParserServices(context);
 
-    if (
-        parserServices.program === undefined ||
-        parserServices.esTreeNodeToTSNodeMap === undefined ||
-        parserServices.tsNodeToESTreeNodeMap === undefined
-    ) {
+    if (parserServices === undefined) {
         return {};
     }
 
     return {
         'Program:exit': programNode => {
-            const sourceFile = parserServices.esTreeNodeToTSNodeMap?.get(programNode as Rule.Node);
+            const sourceFile = parserServices.getTypeScriptNode(programNode as Rule.Node);
 
             if (sourceFile === undefined || !ts.isSourceFile(sourceFile)) {
                 return;
@@ -88,13 +48,7 @@ export const createNamedContractRuleListener = (
                     .map(declaration => [declaration.name.text, declaration] as const),
             );
 
-            const report: NamedContractRuleContext['report'] = (node, messageId, data, fix) => {
-                const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(node);
-
-                if (reportNode !== undefined) {
-                    context.report({ node: reportNode, messageId, data, fix });
-                }
-            };
+            const report = createTypeScriptNodeReporter(context, parserServices);
 
             const createAdjacentDeclarationSwapFix: NamedContractRuleContext['createAdjacentDeclarationSwapFix'] =
                 (firstDeclaration, secondDeclaration) => {
@@ -175,26 +129,22 @@ export const createNamedContractRuleListener = (
                             (ts.isTypeAliasDeclaration(nextStatement) ||
                                 ts.isInterfaceDeclaration(nextStatement)) &&
                             nextStatement.name.text;
-                        const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(nextStatement);
+                        report(
+                            nextStatement,
+                            'contractMustBeSeparated',
+                            {
+                                previousName: previousName || 'the previous declaration',
+                                nextName: nextName || consumerName,
+                            },
+                            fixer => {
+                                const { line } = sourceFile.getLineAndCharacterOfPosition(
+                                    nextStatement.getStart(sourceFile),
+                                );
+                                const start = sourceFile.getPositionOfLineAndCharacter(line, 0);
 
-                        if (reportNode !== undefined) {
-                            context.report({
-                                node: reportNode,
-                                messageId: 'contractMustBeSeparated',
-                                data: {
-                                    previousName: previousName || 'the previous declaration',
-                                    nextName: nextName || consumerName,
-                                },
-                                fix: fixer => {
-                                    const { line } = sourceFile.getLineAndCharacterOfPosition(
-                                        nextStatement.getStart(sourceFile),
-                                    );
-                                    const start = sourceFile.getPositionOfLineAndCharacter(line, 0);
-
-                                    return fixer.insertTextBeforeRange([start, start], '\n');
-                                },
-                            });
-                        }
+                                return fixer.insertTextBeforeRange([start, start], '\n');
+                            },
+                        );
                     }
                 };
 

--- a/eslint-local-rules/named-contracts/utils.ts
+++ b/eslint-local-rules/named-contracts/utils.ts
@@ -99,8 +99,11 @@ export const createNamedContractRuleListener = (
 
             const validateContractBlockSpacing: NamedContractRuleContext['validateContractBlockSpacing'] =
                 (firstStatementIndex, consumerStatementIndex, consumerName) => {
+                    // Include the declaration immediately before the contracts so the block is
+                    // separated on both sides, not only between its own declarations and consumer.
+                    const spacingBlockStartIndex = Math.max(firstStatementIndex - 1, 0);
                     const contractBlock = statements.slice(
-                        firstStatementIndex,
+                        spacingBlockStartIndex,
                         consumerStatementIndex + 1,
                     );
 
@@ -137,12 +140,18 @@ export const createNamedContractRuleListener = (
                                 nextName: nextName || consumerName,
                             },
                             fixer => {
-                                const { line } = sourceFile.getLineAndCharacterOfPosition(
-                                    nextStatement.getStart(sourceFile),
-                                );
-                                const start = sourceFile.getPositionOfLineAndCharacter(line, 0);
+                                const firstNewline = textBetweenStatements.match(/\r?\n/u);
+                                const start =
+                                    firstNewline?.index === undefined
+                                        ? nextStatement.getStart(sourceFile)
+                                        : previousStatement.end +
+                                          firstNewline.index +
+                                          firstNewline[0].length;
 
-                                return fixer.insertTextBeforeRange([start, start], '\n');
+                                return fixer.insertTextBeforeRange(
+                                    [start, start],
+                                    firstNewline?.[0] ?? '\n\n',
+                                );
                             },
                         );
                     }

--- a/eslint-local-rules/named-contracts/utils.ts
+++ b/eslint-local-rules/named-contracts/utils.ts
@@ -1,0 +1,211 @@
+import type { Rule } from 'eslint';
+import ts from 'typescript';
+
+type TypeAwareParserServices = {
+    esTreeNodeToTSNodeMap?: ReadonlyMap<Rule.Node, ts.Node>;
+    program?: ts.Program;
+    tsNodeToESTreeNodeMap?: ReadonlyMap<ts.Node, Rule.Node>;
+};
+
+export type NamedContractRuleContext = {
+    createAdjacentDeclarationSwapFix: (
+        firstDeclaration: ts.Statement,
+        secondDeclaration: ts.Statement,
+    ) => Rule.ReportFixer | undefined;
+    localTypeAliases: Map<string, ts.TypeAliasDeclaration>;
+    report: (
+        node: ts.Node,
+        messageId: string,
+        data: Record<string, string>,
+        fix?: Rule.ReportFixer,
+    ) => void;
+    sourceFile: ts.SourceFile;
+    statements: ts.NodeArray<ts.Statement>;
+    validateContractBlockSpacing: (
+        firstStatementIndex: number,
+        consumerStatementIndex: number,
+        consumerName: string,
+    ) => void;
+};
+
+export const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+    if (
+        ts.isParenthesizedExpression(expression) ||
+        ts.isAsExpression(expression) ||
+        ts.isTypeAssertionExpression(expression) ||
+        ts.isNonNullExpression(expression)
+    ) {
+        return unwrapExpression(expression.expression);
+    }
+
+    return expression;
+};
+
+export const getFunctionExpression = (expression: ts.Expression) => {
+    const unwrappedExpression = unwrapExpression(expression);
+
+    return ts.isArrowFunction(unwrappedExpression) || ts.isFunctionExpression(unwrappedExpression)
+        ? unwrappedExpression
+        : undefined;
+};
+
+export const getVariableFunction = (declaration: ts.VariableDeclaration) =>
+    declaration.initializer === undefined
+        ? undefined
+        : getFunctionExpression(declaration.initializer);
+
+export const getTypeReferenceName = (node: ts.TypeNode | undefined) =>
+    node !== undefined && ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)
+        ? node.typeName.text
+        : undefined;
+
+export const createNamedContractRuleListener = (
+    context: Rule.RuleContext,
+    validate: (contractContext: NamedContractRuleContext) => void,
+): Rule.RuleListener => {
+    const parserServices = context.sourceCode.parserServices as TypeAwareParserServices;
+
+    if (
+        parserServices.program === undefined ||
+        parserServices.esTreeNodeToTSNodeMap === undefined ||
+        parserServices.tsNodeToESTreeNodeMap === undefined
+    ) {
+        return {};
+    }
+
+    return {
+        'Program:exit': programNode => {
+            const sourceFile = parserServices.esTreeNodeToTSNodeMap?.get(programNode as Rule.Node);
+
+            if (sourceFile === undefined || !ts.isSourceFile(sourceFile)) {
+                return;
+            }
+
+            const { statements } = sourceFile;
+            const localTypeAliases = new Map(
+                statements
+                    .filter(ts.isTypeAliasDeclaration)
+                    .map(declaration => [declaration.name.text, declaration] as const),
+            );
+
+            const report: NamedContractRuleContext['report'] = (node, messageId, data, fix) => {
+                const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(node);
+
+                if (reportNode !== undefined) {
+                    context.report({ node: reportNode, messageId, data, fix });
+                }
+            };
+
+            const createAdjacentDeclarationSwapFix: NamedContractRuleContext['createAdjacentDeclarationSwapFix'] =
+                (firstDeclaration, secondDeclaration) => {
+                    const firstStatementIndex = statements.indexOf(firstDeclaration);
+                    const secondStatementIndex = statements.indexOf(secondDeclaration);
+
+                    if (secondStatementIndex !== firstStatementIndex + 1) {
+                        return undefined;
+                    }
+
+                    const previousStatement = statements[firstStatementIndex - 1];
+                    const nextStatement = statements[secondStatementIndex + 1];
+                    const firstStart = firstDeclaration.getStart(sourceFile);
+                    const secondStart = secondDeclaration.getStart(sourceFile);
+                    const leadingTrivia = sourceFile.text.slice(
+                        previousStatement?.end ?? 0,
+                        firstStart,
+                    );
+                    const betweenDeclarations = sourceFile.text.slice(
+                        firstDeclaration.end,
+                        secondStart,
+                    );
+                    const trailingTrivia = sourceFile.text.slice(
+                        secondDeclaration.end,
+                        nextStatement?.getStart(sourceFile) ?? sourceFile.end,
+                    );
+                    const containsComment = (text: string) => /\/\/|\/\*/u.test(text);
+
+                    // A comment in the surrounding whitespace may describe one declaration.
+                    // Moving code without knowing which declaration owns it could change its meaning.
+                    if (
+                        containsComment(leadingTrivia) ||
+                        containsComment(betweenDeclarations) ||
+                        containsComment(trailingTrivia)
+                    ) {
+                        return undefined;
+                    }
+
+                    const firstText = sourceFile.text.slice(firstStart, firstDeclaration.end);
+                    const secondText = sourceFile.text.slice(secondStart, secondDeclaration.end);
+
+                    return fixer =>
+                        fixer.replaceTextRange(
+                            [firstStart, secondDeclaration.end],
+                            `${secondText}${betweenDeclarations}${firstText}`,
+                        );
+                };
+
+            const validateContractBlockSpacing: NamedContractRuleContext['validateContractBlockSpacing'] =
+                (firstStatementIndex, consumerStatementIndex, consumerName) => {
+                    const contractBlock = statements.slice(
+                        firstStatementIndex,
+                        consumerStatementIndex + 1,
+                    );
+
+                    for (let index = 1; index < contractBlock.length; index += 1) {
+                        const previousStatement = contractBlock[index - 1];
+                        const nextStatement = contractBlock[index];
+
+                        if (previousStatement === undefined || nextStatement === undefined) {
+                            continue;
+                        }
+
+                        const textBetweenStatements = sourceFile.text.slice(
+                            previousStatement.end,
+                            nextStatement.getStart(sourceFile),
+                        );
+
+                        if (/\r?\n[\t ]*\r?\n/u.test(textBetweenStatements)) {
+                            continue;
+                        }
+
+                        const previousName =
+                            (ts.isTypeAliasDeclaration(previousStatement) ||
+                                ts.isInterfaceDeclaration(previousStatement)) &&
+                            previousStatement.name.text;
+                        const nextName =
+                            (ts.isTypeAliasDeclaration(nextStatement) ||
+                                ts.isInterfaceDeclaration(nextStatement)) &&
+                            nextStatement.name.text;
+                        const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(nextStatement);
+
+                        if (reportNode !== undefined) {
+                            context.report({
+                                node: reportNode,
+                                messageId: 'contractMustBeSeparated',
+                                data: {
+                                    previousName: previousName || 'the previous declaration',
+                                    nextName: nextName || consumerName,
+                                },
+                                fix: fixer => {
+                                    const { line } = sourceFile.getLineAndCharacterOfPosition(
+                                        nextStatement.getStart(sourceFile),
+                                    );
+                                    const start = sourceFile.getPositionOfLineAndCharacter(line, 0);
+
+                                    return fixer.insertTextBeforeRange([start, start], '\n');
+                                },
+                            });
+                        }
+                    }
+                };
+
+            validate({
+                createAdjacentDeclarationSwapFix,
+                localTypeAliases,
+                report,
+                sourceFile,
+                statements,
+                validateContractBlockSpacing,
+            });
+        },
+    };
+};

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -1,15 +1,11 @@
 import type { Rule } from 'eslint';
 import ts from 'typescript';
 
+import { createTypeScriptNodeReporter, getTypeScriptParserServices } from '../utils';
+
 // This rule proves that a member is removable instead of trying to reconstruct complete data flow.
 // It records concrete requirements, marks ambiguous escapes as opaque, and reports only when every
 // requirement remains satisfied without the member. See `README.md` for the full design.
-
-type TypeAwareParserServices = {
-    esTreeNodeToTSNodeMap?: ReadonlyMap<Rule.Node, ts.Node>;
-    program?: ts.Program;
-    tsNodeToESTreeNodeMap?: ReadonlyMap<ts.Node, Rule.Node>;
-};
 
 type IntersectionMember = {
     name: string;
@@ -716,23 +712,18 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
         schema: [],
     },
     create(context) {
-        const parserServices = context.sourceCode.parserServices as TypeAwareParserServices;
+        const parserServices = getTypeScriptParserServices(context);
 
-        if (
-            parserServices.program === undefined ||
-            parserServices.esTreeNodeToTSNodeMap === undefined ||
-            parserServices.tsNodeToESTreeNodeMap === undefined
-        ) {
+        if (parserServices === undefined) {
             return {};
         }
 
         const checker = parserServices.program.getTypeChecker();
+        const report = createTypeScriptNodeReporter(context, parserServices);
 
         return {
             'Program:exit': programNode => {
-                const sourceFile = parserServices.esTreeNodeToTSNodeMap?.get(
-                    programNode as Rule.Node,
-                );
+                const sourceFile = parserServices.getTypeScriptNode(programNode as Rule.Node);
 
                 if (sourceFile === undefined || !ts.isSourceFile(sourceFile)) {
                     return;
@@ -849,19 +840,9 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
 
                         if (isMemberUsed) return;
 
-                        const reportNode = parserServices.tsNodeToESTreeNodeMap?.get(member.node);
-
-                        if (reportNode === undefined) {
-                            return;
-                        }
-
-                        context.report({
-                            node: reportNode,
-                            messageId: 'unusedIntersectionMember',
-                            data: {
-                                memberName: member.name,
-                                typeName: contract.name,
-                            },
+                        report(member.node, 'unusedIntersectionMember', {
+                            memberName: member.name,
+                            typeName: contract.name,
                         });
                     });
                 }

--- a/eslint-local-rules/utils.ts
+++ b/eslint-local-rules/utils.ts
@@ -81,6 +81,16 @@ export const getTypeReferenceName = (node: ts.TypeNode | undefined) =>
         ? node.typeName.text
         : undefined;
 
+export const toLowerCamelCase = (value: string) => {
+    const leadingInitialism = value.match(/^[A-Z]+(?=[A-Z][a-z]|$)/u)?.[0];
+
+    if (leadingInitialism !== undefined) {
+        return `${leadingInitialism.toLowerCase()}${value.slice(leadingInitialism.length)}`;
+    }
+
+    return `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
+};
+
 export const getNodeSourcePath = (node: Rule.Node): string | null => {
     if (
         'source' in node &&

--- a/eslint-local-rules/utils.ts
+++ b/eslint-local-rules/utils.ts
@@ -1,4 +1,85 @@
 import type { Rule } from 'eslint';
+import ts from 'typescript';
+
+type TypeAwareParserServices = {
+    esTreeNodeToTSNodeMap?: ReadonlyMap<Rule.Node, ts.Node>;
+    program?: ts.Program;
+    tsNodeToESTreeNodeMap?: ReadonlyMap<ts.Node, Rule.Node>;
+};
+
+export type TypeScriptParserServices = {
+    getESTreeNode: (node: ts.Node) => Rule.Node | undefined;
+    getTypeScriptNode: (node: Rule.Node) => ts.Node | undefined;
+    program: ts.Program;
+};
+
+export type TypeScriptNodeReporter = (
+    node: ts.Node,
+    messageId: string,
+    data: Record<string, string>,
+    fix?: Rule.ReportFixer,
+) => void;
+
+export const getTypeScriptParserServices = (
+    context: Rule.RuleContext,
+): TypeScriptParserServices | undefined => {
+    const parserServices = context.sourceCode.parserServices as TypeAwareParserServices;
+
+    if (
+        parserServices.program === undefined ||
+        parserServices.esTreeNodeToTSNodeMap === undefined ||
+        parserServices.tsNodeToESTreeNodeMap === undefined
+    ) {
+        return undefined;
+    }
+
+    return {
+        getESTreeNode: node => parserServices.tsNodeToESTreeNodeMap?.get(node),
+        getTypeScriptNode: node => parserServices.esTreeNodeToTSNodeMap?.get(node),
+        program: parserServices.program,
+    };
+};
+
+export const createTypeScriptNodeReporter =
+    (context: Rule.RuleContext, parserServices: TypeScriptParserServices): TypeScriptNodeReporter =>
+    (node, messageId, data, fix) => {
+        const reportNode = parserServices.getESTreeNode(node);
+
+        if (reportNode !== undefined) {
+            context.report({ node: reportNode, messageId, data, fix });
+        }
+    };
+
+export const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+    if (
+        ts.isParenthesizedExpression(expression) ||
+        ts.isAsExpression(expression) ||
+        ts.isTypeAssertionExpression(expression) ||
+        ts.isNonNullExpression(expression)
+    ) {
+        return unwrapExpression(expression.expression);
+    }
+
+    return expression;
+};
+
+export const getFunctionExpression = (expression: ts.Expression) => {
+    const unwrappedExpression = unwrapExpression(expression);
+
+    return ts.isArrowFunction(unwrappedExpression) || ts.isFunctionExpression(unwrappedExpression)
+        ? unwrappedExpression
+        : undefined;
+};
+
+export const getVariableFunction = (declaration: ts.VariableDeclaration) =>
+    declaration.initializer === undefined
+        ? undefined
+        : getFunctionExpression(declaration.initializer);
+
+export const getTypeReferenceName = (node: ts.TypeNode | undefined) =>
+    node !== undefined && ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)
+        ? node.typeName.text
+        : undefined;
 
 export const getNodeSourcePath = (node: Rule.Node): string | null => {
     if (

--- a/packages/connect-explorer/src/actions/methodActions.ts
+++ b/packages/connect-explorer/src/actions/methodActions.ts
@@ -5,7 +5,9 @@ import TrezorConnectMobile from '@trezor/connect-mobile';
 import TrezorConnect from '@trezor/connect-web';
 import { getDeepValue } from '@trezor/schema-utils/src/utils';
 
-import type { Dispatch, Field, GetState } from '../types';
+import { type MethodRootState } from '../reducers/methodReducer';
+import { type ConnectRootState } from '../reducers/trezorConnectReducer';
+import type { Dispatch, Field } from '../types';
 import {
     ADD_BATCH,
     FIELD_CHANGE,
@@ -63,7 +65,9 @@ export const onSetManualMode = (manualMode: boolean) => ({
     manualMode,
 });
 
-export const onSubmit = () => async (dispatch: Dispatch, getState: GetState) => {
+type OnSubmitThunkState = ConnectRootState & MethodRootState;
+
+export const onSubmit = () => async (dispatch: Dispatch, getState: () => OnSubmitThunkState) => {
     const { method, connect } = getState();
     if (!method?.name) throw new Error('method name not specified');
     dispatch({ type: SET_METHOD_PROCESSING, payload: true });
@@ -88,44 +92,49 @@ export const onSubmit = () => async (dispatch: Dispatch, getState: GetState) => 
     dispatch(onResponse(response));
 };
 
-export const onCodeChange = (value: string) => (dispatch: Dispatch, getState: GetState) => {
-    try {
-        const { fields } = getState().method;
-        const parsed = JSON5.parse(value);
-        const processField = (field: Field<unknown>) => {
-            const valuePath = [...(field.path || []), ...field.name.split('.')].filter(f => !!f);
-            const value = getDeepValue(parsed, valuePath);
+type OnCodeChangeThunkState = MethodRootState;
 
-            if (field.type === 'array') {
-                // ensure the array has the correct number of items
-                if (value) {
-                    for (let i = field.items.length; i < value.length; i++) {
-                        const { batch } = field;
-                        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-                        const firstBatch: (typeof batch)[number] = batch[0];
-                        dispatch(onBatchAdd(field, firstBatch.fields));
+export const onCodeChange =
+    (value: string) => (dispatch: Dispatch, getState: () => OnCodeChangeThunkState) => {
+        try {
+            const { fields } = getState().method;
+            const parsed = JSON5.parse(value);
+            const processField = (field: Field<unknown>) => {
+                const valuePath = [...(field.path || []), ...field.name.split('.')].filter(
+                    f => !!f,
+                );
+                const value = getDeepValue(parsed, valuePath);
+
+                if (field.type === 'array') {
+                    // ensure the array has the correct number of items
+                    if (value) {
+                        for (let i = field.items.length; i < value.length; i++) {
+                            const { batch } = field;
+                            // @ts-expect-error: indexing with noUncheckedIndexedAccess
+                            const firstBatch: (typeof batch)[number] = batch[0];
+                            dispatch(onBatchAdd(field, firstBatch.fields));
+                        }
+                        for (let i = field.items.length; i > value.length; i--) {
+                            dispatch(onBatchRemove(field, field.items[i - 1]));
+                        }
                     }
-                    for (let i = field.items.length; i > value.length; i--) {
-                        dispatch(onBatchRemove(field, field.items[i - 1]));
-                    }
+
+                    field.items.forEach(batch => {
+                        batch.forEach(processField);
+                    });
+                } else if (field.type === 'union') {
+                    field.options.forEach(batch => {
+                        batch.forEach(processField);
+                    });
+                } else {
+                    dispatch(onFieldChange(field, value));
                 }
-
-                field.items.forEach(batch => {
-                    batch.forEach(processField);
-                });
-            } else if (field.type === 'union') {
-                field.options.forEach(batch => {
-                    batch.forEach(processField);
-                });
-            } else {
-                dispatch(onFieldChange(field, value));
-            }
-        };
-        fields.forEach(processField);
-    } catch (error) {
-        console.error('Invalid JSON', error);
-    }
-};
+            };
+            fields.forEach(processField);
+        } catch (error) {
+            console.error('Invalid JSON', error);
+        }
+    };
 
 export const onCancelCall = () => () => {
     TrezorConnect.cancel();

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -1,7 +1,8 @@
 import TrezorConnectMobile from '@trezor/connect-mobile';
 import TrezorConnect from '@trezor/connect-web';
 
-import type { Dispatch, GetState } from '../types';
+import { type ConnectRootState } from '../reducers/trezorConnectReducer';
+import type { Dispatch } from '../types';
 import {
     type ConnectOptions,
     ON_CHANGE_CONNECT_OPTIONS,
@@ -80,7 +81,9 @@ export const init =
 export const initWithOptions = (options: ConnectOptions) => (dispatch: Dispatch) =>
     dispatch(init(options));
 
-export const onSubmitInit = () => (dispatch: Dispatch, getState: GetState) => {
+type OnSubmitInitThunkState = ConnectRootState;
+
+export const onSubmitInit = () => (dispatch: Dispatch, getState: () => OnSubmitInitThunkState) => {
     const { connect } = getState();
 
     return dispatch(initWithOptions(connect.options ?? {}));

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -23,6 +23,10 @@ import { isFieldBasic } from '../types/common';
 
 type Action = MethodAction | TrezorConnectAction;
 
+export type MethodRootState = {
+    method: MethodState;
+};
+
 // Recursively find a field in the schema (inner function)
 const findFieldsNested = (
     schema: Field<any>[],

--- a/packages/connect-explorer/src/reducers/trezorConnectReducer.ts
+++ b/packages/connect-explorer/src/reducers/trezorConnectReducer.ts
@@ -10,6 +10,10 @@ export type ConnectState = {
     initError?: string;
 };
 
+export type ConnectRootState = {
+    connect: ConnectState;
+};
+
 const initialState: ConnectState = {
     options: undefined,
     isInitializing: false,

--- a/packages/connect-explorer/src/types/index.ts
+++ b/packages/connect-explorer/src/types/index.ts
@@ -9,7 +9,6 @@ export * from './actions';
 export type Action = MethodAction | TrezorConnectAction;
 
 export type AppState = AppState$;
-export type GetState = () => AppState$;
 
 export interface Dispatch extends ThunkDispatch<AppState$, any, Action> {
     <A>(action: A): A extends (...args: any) => infer R ? R : A;

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -92,16 +92,11 @@ export const localRulesConfig = [
         },
     },
     {
-        files: [
-            'networks/**/src/**/*.{ts,tsx}',
-            'packages/**/src/**/*.{ts,tsx}',
-            'suite/**/src/**/*.{ts,tsx}',
-            'suite-common/**/src/**/*.{ts,tsx}',
-            'suite-native/**/src/**/*.{ts,tsx}',
-        ],
+        files: ['**/src/**/*.{ts,tsx}'],
         ignores: ['**/__fixtures__/**', '**/*.test.{ts,tsx}', '**/*.type-test.ts'],
         rules: {
-            'local-rules/enforce-named-contracts': 'error',
+            'local-rules/enforce-di-factory-contracts': 'error',
+            'local-rules/enforce-thunk-contracts': 'error',
         },
     },
     ...(areExpensiveChecksEnabled

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -105,6 +105,19 @@ export const localRulesConfig = [
                       'local-rules/no-unused-intersection-members': 'error',
                   },
               },
+              {
+                  files: [
+                      'networks/**/src/**/*.{ts,tsx}',
+                      'packages/**/src/**/*.{ts,tsx}',
+                      'suite/**/src/**/*.{ts,tsx}',
+                      'suite-common/**/src/**/*.{ts,tsx}',
+                      'suite-native/**/src/**/*.{ts,tsx}',
+                  ],
+                  ignores: ['**/__fixtures__/**', '**/*.test.{ts,tsx}', '**/*.type-test.ts'],
+                  rules: {
+                      'local-rules/enforce-named-contracts': 'error',
+                  },
+              },
           ]
         : []),
 ];

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -91,6 +91,19 @@ export const localRulesConfig = [
             'local-rules/no-suite-imports-in-suite-common': 'error',
         },
     },
+    {
+        files: [
+            'networks/**/src/**/*.{ts,tsx}',
+            'packages/**/src/**/*.{ts,tsx}',
+            'suite/**/src/**/*.{ts,tsx}',
+            'suite-common/**/src/**/*.{ts,tsx}',
+            'suite-native/**/src/**/*.{ts,tsx}',
+        ],
+        ignores: ['**/__fixtures__/**', '**/*.test.{ts,tsx}', '**/*.type-test.ts'],
+        rules: {
+            'local-rules/enforce-named-contracts': 'error',
+        },
+    },
     ...(areExpensiveChecksEnabled
         ? [
               {
@@ -103,19 +116,6 @@ export const localRulesConfig = [
                   ],
                   rules: {
                       'local-rules/no-unused-intersection-members': 'error',
-                  },
-              },
-              {
-                  files: [
-                      'networks/**/src/**/*.{ts,tsx}',
-                      'packages/**/src/**/*.{ts,tsx}',
-                      'suite/**/src/**/*.{ts,tsx}',
-                      'suite-common/**/src/**/*.{ts,tsx}',
-                      'suite-native/**/src/**/*.{ts,tsx}',
-                  ],
-                  ignores: ['**/__fixtures__/**', '**/*.test.{ts,tsx}', '**/*.type-test.ts'],
-                  rules: {
-                      'local-rules/enforce-named-contracts': 'error',
                   },
               },
           ]

--- a/packages/requirements/src/execCliCommand.ts
+++ b/packages/requirements/src/execCliCommand.ts
@@ -18,14 +18,14 @@ export type ExecCliCommandParams = {
     readonly options?: ExecOptions;
 };
 
+export type ExecCliCommandDeps = {
+    readonly console: Pick<Console, 'log'>;
+};
+
 export type ExecCliCommand = (params: ExecCliCommandParams) => Promise<ExecResult>;
 
 export type ExecCliCommandDep = {
     readonly execCliCommand: ExecCliCommand;
-};
-
-export type ExecCliCommandDeps = {
-    readonly console: Pick<Console, 'log'>;
 };
 
 export const createExecCliCommand =

--- a/packages/requirements/src/getAffectedWorkspaces.ts
+++ b/packages/requirements/src/getAffectedWorkspaces.ts
@@ -20,9 +20,9 @@ type GetAffectedWorkspacesResult = {
     readonly workspaces: ReadonlyArray<WorkspaceInfo>;
 };
 
-export type GetAffectedWorkspaces = (cwd: string) => Promise<GetAffectedWorkspacesResult>;
-
 export type GetAffectedWorkspacesDeps = ExecCliCommandDep & { requirementsWorkspaceName: string };
+
+export type GetAffectedWorkspaces = (cwd: string) => Promise<GetAffectedWorkspacesResult>;
 
 export const createGetAffectedWorkspaces =
     (deps: GetAffectedWorkspacesDeps): GetAffectedWorkspaces =>

--- a/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothEraseBondsThunk.ts
@@ -36,6 +36,7 @@ export const forgetBluetoothDeviceThunk = createThunk<void, ForgetBluetoothDevic
 );
 
 type UnpairCurrentBondThunkParams = Record<never, never>;
+
 type UnpairCurrentBondThunkState = DeviceRootState;
 
 /**

--- a/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
+++ b/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
@@ -14,7 +14,7 @@ export const exportMetadataToBip329File = createThunk<
         account: Account;
         defaultAccountLabel: string;
     },
-    { state: void; extra: ExportMetadataToBip329FileThunkDeps }
+    { extra: ExportMetadataToBip329FileThunkDeps }
 >(
     METADATA.EXPORT_METADATA_TO_BIP329_FILE,
     ({ account, defaultAccountLabel }, { dispatch, extra: { services } }) => {

--- a/packages/suite/src/actions/labels/moveLabelsForRbfThunk.ts
+++ b/packages/suite/src/actions/labels/moveLabelsForRbfThunk.ts
@@ -31,7 +31,9 @@ export type MoveLabelsForRbfThunkState = DeviceRootState &
     MessageSystemRootState &
     MoveLabelsForRbfOldMetadataThunkState &
     WithSuiteSyncState;
+
 export type MoveLabelsForRbfThunkDeps = WithServices<MigrateSuiteSyncLabelsForRbfTransactionDep>;
+
 type MoveLabelsForRbfThunkDispatch = ThunkDispatch<
     MoveLabelsForRbfThunkState,
     MoveLabelsForRbfThunkDeps,

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -97,12 +97,13 @@ const goToPreviousStep =
 
 const resetOnboarding = createAction(ONBOARDING.RESET_ONBOARDING);
 
-type GoToSuiteState = DeviceRootState &
+type GoToSuiteThunkState = DeviceRootState &
     GotoThunkState &
     OnboardingRootState &
     StartDiscoveryThunkState &
     WalletSettingsRootState;
-type GoToSuiteDeps = WithServices<DesktopAnalyticsDep & SuiteRouterHistoryDep> &
+
+type GoToSuiteThunkDeps = WithServices<DesktopAnalyticsDep & SuiteRouterHistoryDep> &
     StartDiscoveryThunkDeps;
 
 export type GoToSuiteOptions = {
@@ -112,9 +113,9 @@ export type GoToSuiteOptions = {
 const goToSuite =
     ({ skipDeviceSetupCompletedEvent }: GoToSuiteOptions = {}) =>
     (
-        dispatch: ThunkDispatch<GoToSuiteState, GoToSuiteDeps, UnknownAction>,
-        getState: () => GoToSuiteState,
-        extra: GoToSuiteDeps,
+        dispatch: ThunkDispatch<GoToSuiteThunkState, GoToSuiteThunkDeps, UnknownAction>,
+        getState: () => GoToSuiteThunkState,
+        extra: GoToSuiteThunkDeps,
     ) => {
         const device = selectSelectedDevice(getState());
         const onboardingAnalytics = selectOnboardingAnalytics(getState());
@@ -186,6 +187,7 @@ type GoToNextStepThunkState = DeviceRootState &
     StartDiscoveryThunkState &
     SuiteSettingsRootState &
     WalletSettingsRootState;
+
 type GoToNextStepThunkDeps = {
     services: DesktopAnalyticsDep & SuiteRouterHistoryDep;
 } & StartDiscoveryThunkDeps;
@@ -229,6 +231,7 @@ type BeginOnboardingTutorialThunkState = DeviceRootState &
     StartDiscoveryThunkState &
     SuiteSettingsRootState &
     WalletSettingsRootState;
+
 type BeginOnboardingTutorialThunkDeps = {
     services: DesktopAnalyticsDep & SuiteRouterHistoryDep;
 } & StartDiscoveryThunkDeps;
@@ -268,14 +271,15 @@ const resolveNextAfterSkipped =
         return resolvedNextStep?.id;
     };
 
-type RecoveryRerunState = DeviceRootState & GotoThunkState & { recovery: RecoveryState };
-type RecoveryRerunDeps = { services: DesktopAnalyticsDep & SuiteRouterHistoryDep };
+type RecoveryRerunThunkState = DeviceRootState & GotoThunkState & { recovery: RecoveryState };
+
+type RecoveryRerunThunkDeps = { services: DesktopAnalyticsDep & SuiteRouterHistoryDep };
 
 const recoveryRerun =
     () =>
     async (
-        dispatch: ThunkDispatch<RecoveryRerunState, RecoveryRerunDeps, UnknownAction>,
-        getState: () => RecoveryRerunState,
+        dispatch: ThunkDispatch<RecoveryRerunThunkState, RecoveryRerunThunkDeps, UnknownAction>,
+        getState: () => RecoveryRerunThunkState,
     ) => {
         const result = await dispatch(recoveryRerunThunk());
 

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -113,6 +113,7 @@ export const changeWipeCode =
     };
 
 type ResetDeviceThunkState = DeviceRootState & SuiteSettingsRootState & MessageSystemRootState;
+
 type ResetDeviceThunkDeps = { services: ReportSecurityCheckDep };
 
 export const resetDevice =

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -67,8 +67,9 @@ export const disableAnalyticsThunk =
         dispatch(analyticsActions.disableAnalytics());
     };
 
-type InitAnalyticsThunkState = AnalyticsRootState;
-type InitAnalyticsThunkDeps = WithServices<DesktopAnalyticsDep>;
+type InitThunkState = AnalyticsRootState;
+
+type InitThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 /**
  * Init analytics, should be always run on application start (see suiteMiddleware). It:
@@ -79,9 +80,9 @@ type InitAnalyticsThunkDeps = WithServices<DesktopAnalyticsDep>;
 export const init =
     () =>
     (
-        dispatch: ThunkDispatch<InitAnalyticsThunkState, InitAnalyticsThunkDeps, UnknownAction>,
-        getState: () => InitAnalyticsThunkState,
-        extra: InitAnalyticsThunkDeps,
+        dispatch: ThunkDispatch<InitThunkState, InitThunkDeps, UnknownAction>,
+        getState: () => InitThunkState,
+        extra: InitThunkDeps,
     ) => {
         const sessionId = getTrackingRandomId();
         // if instanceId does not exist yet (was not loaded from storage), create a new one

--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -11,6 +11,7 @@ import * as storageActions from 'src/actions/suite/storageActions';
 const AUTO_EJECT_PREFIX = '@suite/autoEject';
 
 type SetAutoEjectEnabledThunkProps = { shouldEnable: boolean };
+
 type SetAutoEjectEnabledThunkState = GotoThunkState & SetDeviceAutoEjectThunkState;
 
 type SetAutoEjectEnabledThunkDeps = GotoThunkDeps;

--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -12,6 +12,7 @@ const AUTO_EJECT_PREFIX = '@suite/autoEject';
 
 type SetAutoEjectEnabledThunkProps = { shouldEnable: boolean };
 type SetAutoEjectEnabledThunkState = GotoThunkState & SetDeviceAutoEjectThunkState;
+
 type SetAutoEjectEnabledThunkDeps = GotoThunkDeps;
 
 export const setAutoEjectEnabledThunk = createThunk<

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -72,6 +72,7 @@ type InitThunkState = ConnectInitThunkState &
     UpdateMissingTxFiatRatesThunkState &
     WalletConnectInitThunkState &
     WalletSettingsRootState;
+
 type InitThunkDeps = ConnectInitThunkDeps &
     GotoThunkDeps &
     InitBlockchainThunkDeps &

--- a/packages/suite/src/actions/suite/protocolActions.test.ts
+++ b/packages/suite/src/actions/suite/protocolActions.test.ts
@@ -8,7 +8,7 @@ import * as protocolConstants from './constants/protocolConstants';
 import * as protocolActions from './protocolActions';
 import {
     type HandleProtocolRequestDispatchDeps,
-    type HandleProtocolRequestState,
+    type HandleProtocolRequestThunkState,
 } from './protocolActions';
 
 jest.mock('@suite-common/walletconnect', () => ({
@@ -19,7 +19,7 @@ const findNetworkSymbolForProtocol: FindNetworkSymbolForProtocol = protocol =>
     protocol === 'bitcoin' ? asNetworkSymbol('btc') : null;
 
 const createHandleProtocolRequestDeps = () => {
-    const getState = (): HandleProtocolRequestState => {
+    const getState = (): HandleProtocolRequestThunkState => {
         throw new Error('This thunk must not read state in this test.');
     };
     const extra: HandleProtocolRequestDispatchDeps = {

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -41,24 +41,25 @@ export const fillSendForm = createAction<boolean>(PROTOCOL.FILL_SEND_FORM);
 
 export const resetProtocol = createAction(PROTOCOL.RESET);
 
-export type HandleProtocolRequestDeps = WithServices<
+export type HandleProtocolRequestThunkState = GotoThunkState & WalletConnectInitThunkState;
+
+export type HandleProtocolRequestThunkDeps = WithServices<
     DesktopAnalyticsDep & FindNetworkSymbolForProtocolDep & SuiteRouterHistoryDep
 >;
 
-export type HandleProtocolRequestState = GotoThunkState & WalletConnectInitThunkState;
-export type HandleProtocolRequestDispatchDeps = HandleProtocolRequestDeps &
+export type HandleProtocolRequestDispatchDeps = HandleProtocolRequestThunkDeps &
     WalletConnectInitThunkDeps;
 
 export const handleProtocolRequest =
     (uri: string) =>
     (
         dispatch: ThunkDispatch<
-            HandleProtocolRequestState,
+            HandleProtocolRequestThunkState,
             HandleProtocolRequestDispatchDeps,
             UnknownAction
         >,
-        _getState: () => HandleProtocolRequestState,
-        extra: HandleProtocolRequestDeps,
+        _getState: () => HandleProtocolRequestThunkState,
+        extra: HandleProtocolRequestThunkDeps,
     ) => {
         dispatch(handleCoinProtocolUri(uri, saveCoinProtocol));
 

--- a/packages/suite/src/actions/suite/suiteForgetDeviceThunk.ts
+++ b/packages/suite/src/actions/suite/suiteForgetDeviceThunk.ts
@@ -19,6 +19,7 @@ export type ForgetDeviceThunkParams = {
 };
 
 type SuiteForgetDeviceThunkState = ForgetDeviceThunkState;
+
 type SuiteForgetDeviceThunkDeps = ForgetDeviceThunkDeps;
 
 export const suiteForgetDeviceThunk = createThunk<

--- a/packages/suite/src/actions/suite/suiteThunks.ts
+++ b/packages/suite/src/actions/suite/suiteThunks.ts
@@ -6,6 +6,7 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 import { removeDatabase } from './storageActions';
 
 type ResetSuiteAppThunkState = GotoThunkState;
+
 type ResetSuiteAppThunkDeps = GotoThunkDeps & {
     services: ReloadAppDep;
 };

--- a/packages/suite/src/actions/wallet/addWalletThunk.ts
+++ b/packages/suite/src/actions/wallet/addWalletThunk.ts
@@ -3,6 +3,7 @@ import { DEVICE_MODULE_PREFIX } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 
 type RedirectAfterWalletSelectedThunkState = GotoThunkState;
+
 type RedirectAfterWalletSelectedThunkDeps = GotoThunkDeps;
 
 export const redirectAfterWalletSelectedThunk = createThunk<
@@ -40,6 +41,7 @@ export const redirectAfterWalletSelectedThunk = createThunk<
 );
 
 type OpenSwitchDeviceDialogThunkState = GotoThunkState;
+
 type OpenSwitchDeviceDialogThunkDeps = GotoThunkDeps;
 
 export const openSwitchDeviceDialog = createThunk<

--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -31,16 +31,18 @@ type ExportTransactionsThunkParams = {
     type: ExportFileType;
     searchQuery: string;
 };
+
+const selectMetadataState = (state: MetadataRootState) => state.metadata;
+
 type ExportTransactionsThunkState = FiatRatesRootState &
     SelectAccountLabelsForSearchState &
     TokenDefinitionsRootState &
     TransactionsRootState &
     WalletSettingsRootState;
+
 type ExportTransactionsThunkDeps = WithServices<{
     saveAs: (data: Blob, fileName: string) => void;
 }>;
-
-const selectMetadataState = (state: MetadataRootState) => state.metadata;
 
 export const exportTransactionsThunk = createThunk<
     void,

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -39,9 +39,6 @@ import {
 const DAY_IN_SECONDS = 3600 * 24;
 
 type GraphRootState = { wallet: { graph: GraphState } };
-type FetchAccountGraphDataThunkState = BlockchainRootState &
-    GraphRootState &
-    WalletSettingsRootState;
 
 const selectAccountGraphData = (state: GraphRootState, account: Account) =>
     state.wallet.graph.data.find(
@@ -58,6 +55,10 @@ export const accountGraphStart = createAction<Omit<GraphData, 'data'>>(ACCOUNT_G
 export const aggregatedGraphStart = createAction(AGGREGATED_GRAPH_START);
 export const aggregatedGraphSuccess = createAction(AGGREGATED_GRAPH_SUCCESS);
 export const setSelectedRange = createAction<GraphRange>(SET_SELECTED_RANGE);
+
+type FetchAccountGraphDataThunkState = BlockchainRootState &
+    GraphRootState &
+    WalletSettingsRootState;
 
 /**
  * Fetch the account history (received, sent amounts, num of txs) for the given `startDate`, `endDate`.

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -198,9 +198,11 @@ const actions = new Set<UnknownAction['type']>([
 /*
  * Called from WalletMiddleware
  */
+type SyncSelectedAccountThunkState = SelectedAccountState;
+
 export const syncSelectedAccount =
     (action: UnknownAction) =>
-    (dispatch: Dispatch<UnknownAction>, getState: () => SelectedAccountState) => {
+    (dispatch: Dispatch<UnknownAction>, getState: () => SyncSelectedAccountThunkState) => {
         // ignore not listed actions
         if (!actions.has(action.type)) return;
         const state = getState();

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -57,6 +57,7 @@ import {
 } from '../../labels/moveLabelsForRbfThunk';
 
 type SaveSendFormDraftThunkParams = { formState: FormState };
+
 type SaveSendFormDraftThunkState = SelectedAccountRootState;
 
 export const saveSendFormDraftThunk = createThunk<
@@ -155,6 +156,7 @@ type ApplySendFormMetadataLabelsThunkParams = {
     precomposedTransaction: GeneralPrecomposedTransactionFinal;
     txid: string;
 };
+
 type ApplySendFormMetadataLabelsThunkState = DeviceRootState &
     MessageSystemRootState &
     MetadataRootState &

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -116,6 +116,7 @@ type UpdateRbfLabelsThunkParams = {
 };
 
 type UpdateRbfLabelsThunkState = MoveLabelsForRbfThunkState & ReplaceTransactionThunkState;
+
 type UpdateRbfLabelsThunkDeps = MoveLabelsForRbfThunkDeps;
 
 const updateRbfLabelsThunk = createThunk<
@@ -159,6 +160,7 @@ type ApplySendFormMetadataLabelsThunkState = DeviceRootState &
     MetadataRootState &
     SendRootState &
     WithSuiteSyncState;
+
 type ApplySendFormMetadataLabelsThunkDeps = WithServices<SuiteSyncDep>;
 
 const applySendFormMetadataLabelsThunk = createThunk<
@@ -248,6 +250,7 @@ type SignAndPushSendFormTransactionThunkState = ApplySendFormMetadataLabelsThunk
     PushSendFormTransactionThunkState &
     SignTransactionThunkState &
     UpdateRbfLabelsThunkState;
+
 type SignAndPushSendFormTransactionThunkDeps = ApplySendFormMetadataLabelsThunkDeps &
     CancelSignSendFormTransactionThunkDeps &
     PushSendFormTransactionThunkDeps &

--- a/packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts
@@ -7,9 +7,9 @@ import {
 } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
-type CancelSignYieldTxState = StablecoinYieldRootState;
+type CancelSignYieldTxThunkState = StablecoinYieldRootState;
 
-export const cancelSignYieldTx = createThunk<void, void, { state: CancelSignYieldTxState }>(
+export const cancelSignYieldTx = createThunk<void, void, { state: CancelSignYieldTxThunkState }>(
     `${STABLECOIN_YIELD_PREFIX}/thunk/cancelSignYieldTx`,
     (_params, { dispatch, getState }) => {
         const { serializedTx } = selectStablecoinYieldTxReview(getState());

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -72,6 +72,7 @@ type ClaimMerklRewardsThunkState = DeviceRootState &
     MessageSystemRootState &
     SynchronizeSentTransactionThunkState &
     WalletSettingsRootState;
+
 type ClaimMerklRewardsThunkDeps = SynchronizeSentTransactionThunkDeps & {
     services: DesktopAnalyticsDep;
 };

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -67,6 +67,7 @@ type ClaimMerklRewardsParams = {
     flowKey: string;
     rewards: ClaimMerklReward[];
 };
+
 type ClaimMerklRewardsThunkState = DeviceRootState &
     EthereumGetCurrentNonceThunkState &
     MessageSystemRootState &

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -28,6 +28,7 @@ type SubmitYieldDepositPayload = {
     flowData: YieldFlowResolvedData;
     amount: string;
 };
+
 type SubmitYieldDepositThunkState = ComposeYieldDepositTransactionThunkState &
     SendYieldTransactionState;
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -30,6 +30,7 @@ type SubmitYieldDepositPayload = {
 };
 type SubmitYieldDepositThunkState = ComposeYieldDepositTransactionThunkState &
     SendYieldTransactionState;
+
 type SubmitYieldDepositThunkDeps = SendYieldTransactionDeps & {
     services: DesktopAnalyticsDep;
 };

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -28,6 +28,7 @@ type SubmitYieldWithdrawPayload = {
     amount: string;
     flowType: YieldWithdrawFlowType;
 };
+
 type SubmitYieldWithdrawThunkState = ComposeYieldWithdrawTransactionThunkState &
     SendYieldTransactionState;
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -30,6 +30,7 @@ type SubmitYieldWithdrawPayload = {
 };
 type SubmitYieldWithdrawThunkState = ComposeYieldWithdrawTransactionThunkState &
     SendYieldTransactionState;
+
 type SubmitYieldWithdrawThunkDeps = SendYieldTransactionDeps & {
     services: DesktopAnalyticsDep;
 };

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -341,6 +341,7 @@ const getPoolDelegation = (
 };
 
 type SignTransactionThunkState = DeviceRootState & SelectedAccountRootState & StakeRootState;
+
 type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const signTransaction =

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -124,6 +124,7 @@ type SignTransactionThunkState = DeviceRootState &
     EthereumGetCurrentNonceThunkState &
     SelectedAccountRootState &
     WalletSettingsRootState;
+
 type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const signTransaction =

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -51,6 +51,7 @@ type SignTransactionThunkState = BlockchainRootState &
     DeviceRootState &
     SelectedAccountRootState &
     WalletSettingsRootState;
+
 type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const signTransaction =

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -117,6 +117,7 @@ type PushTransactionThunkState = DeviceRootState &
     StakeRootState &
     SyncAccountsWithBlockchainThunkState &
     WalletSettingsRootState;
+
 type PushTransactionThunkDeps = WithServices<DesktopAnalyticsDep> &
     SyncAccountsWithBlockchainThunkDeps;
 
@@ -282,6 +283,7 @@ type SignTransactionThunkState = DeviceRootState &
     StakeRootState &
     SyncAccountsWithBlockchainThunkState &
     WalletSettingsRootState;
+
 type SignTransactionThunkDeps = PushTransactionThunkDeps;
 
 export const signTransaction =

--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -21,6 +21,7 @@ import { submitRequestForm } from '../tradingCommonActions';
 
 type SelectBuyQuoteThunkParams = { quote: BuyTrade };
 type SelectBuyQuoteThunkState = GotoThunkState & TradingFormAccountRootState;
+
 type SelectBuyQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;
 
 export const selectBuyQuoteThunk = createThunk<

--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -20,6 +20,7 @@ import { createQuoteLink } from 'src/utils/wallet/trading/buyUtils';
 import { submitRequestForm } from '../tradingCommonActions';
 
 type SelectBuyQuoteThunkParams = { quote: BuyTrade };
+
 type SelectBuyQuoteThunkState = GotoThunkState & TradingFormAccountRootState;
 
 type SelectBuyQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;

--- a/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
@@ -19,6 +19,7 @@ type SelectExchangeQuoteThunkProps = {
     fractionButton?: number;
 };
 type SelectExchangeQuoteThunkState = GotoThunkState & TradingRootState;
+
 type SelectExchangeQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;
 
 export const selectExchangeQuoteThunk = createThunk<

--- a/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
@@ -18,6 +18,7 @@ type SelectExchangeQuoteThunkProps = {
     rateType?: string;
     fractionButton?: number;
 };
+
 type SelectExchangeQuoteThunkState = GotoThunkState & TradingRootState;
 
 type SelectExchangeQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;

--- a/packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.ts
@@ -15,6 +15,7 @@ import { buildSellReturnUrl } from 'src/utils/wallet/trading/buildSellReturnUrl'
 import { submitRequestForm } from '../tradingCommonActions';
 
 type RequestSellTradeThunkParams = { quote: SellFiatTrade };
+
 export type RequestSellTradeThunkState = TradingFormAccountRootState;
 
 export const requestSellTradeThunk = createThunk<

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
@@ -15,6 +15,7 @@ import {
 import { type RequestSellTradeThunkState, requestSellTradeThunk } from './requestSellTradeThunk';
 
 type SelectSellQuoteThunkParams = { quote: SellFiatTrade; fractionButton?: number };
+
 type SelectSellQuoteThunkState = GotoThunkState & RequestSellTradeThunkState;
 
 type SelectSellQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
@@ -16,6 +16,7 @@ import { type RequestSellTradeThunkState, requestSellTradeThunk } from './reques
 
 type SelectSellQuoteThunkParams = { quote: SellFiatTrade; fractionButton?: number };
 type SelectSellQuoteThunkState = GotoThunkState & RequestSellTradeThunkState;
+
 type SelectSellQuoteThunkDeps = GotoThunkDeps & WithServices<DesktopAnalyticsDep>;
 
 export const selectSellQuoteThunk = createThunk<

--- a/packages/suite/src/actions/wallet/tron-stake/cancelSignTronFreezeTx.ts
+++ b/packages/suite/src/actions/wallet/tron-stake/cancelSignTronFreezeTx.ts
@@ -7,12 +7,12 @@ import {
 } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
-type CancelSignTronFreezeTxState = TronStakeRootState;
+type CancelSignTronFreezeTxThunkState = TronStakeRootState;
 
 export const cancelSignTronFreezeTx = createThunk<
     void,
     void,
-    { state: CancelSignTronFreezeTxState }
+    { state: CancelSignTronFreezeTxThunkState }
 >(`${TRON_STAKE_PREFIX}/thunk/cancelSignTronFreezeTx`, (_params, { dispatch, getState }) => {
     const { serializedTx } = selectTronStakeTxReview(getState());
 

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -34,6 +34,7 @@ type UnwrapNativeTokenPayload = {
 
 type SubmitUnwrapNativeTokenThunkState = ComposeYieldUnwrapTransactionThunkState &
     SendYieldTransactionState;
+
 type SubmitUnwrapNativeTokenThunkDeps = SendYieldTransactionDeps & {
     services: AnalyticsDep;
 };

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -37,6 +37,7 @@ type WrapNativeTokenPayload = {
 
 type SubmitWrapNativeTokenThunkState = ComposeYieldWrapTransactionThunkState &
     SendYieldTransactionState;
+
 type SubmitWrapNativeTokenThunkDeps = SendYieldTransactionDeps & {
     services: AnalyticsDep;
 };

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -11,6 +11,7 @@ import {
     updateLastAnonymityReportTimestamp,
 } from '@suite/coinjoin';
 import {
+    type RouterRootState,
     anchorChange,
     routerLocationChange,
     selectRouteName,
@@ -69,6 +70,7 @@ export type PrepareAnalyticsMiddlewareDeps = WithServices<DesktopAnalyticsDep>;
 
 type AnalyticsMiddlewareState = CoinjoinRootState &
     GetSuiteReadyPayloadState &
+    RouterRootState &
     TokenDefinitionsRootState & {
         suite: Pick<SuiteRootState['suite'], 'lifecycle'>;
     };

--- a/packages/suite/src/support/createConnectInitHooks.ts
+++ b/packages/suite/src/support/createConnectInitHooks.ts
@@ -13,28 +13,25 @@ type ConnectInitHooksDeps = {
     getState: () => any;
 };
 
-export const createConnectInitHooks = ({
-    dispatch,
-    getState,
-}: ConnectInitHooksDeps): ConnectInitHooks => ({
+export const createConnectInitHooks = (deps: ConnectInitHooksDeps): ConnectInitHooks => ({
     deviceEvent: {
         [DEVICE.CONNECT]: device => {
-            dispatch(markDeviceAsRecentlyConnectedThunk(device));
-            dispatch(bluetoothOnDeviceConnectedThunk(device));
+            deps.dispatch(markDeviceAsRecentlyConnectedThunk(device));
+            deps.dispatch(bluetoothOnDeviceConnectedThunk(device));
         },
         [DEVICE.CONNECT_UNACQUIRED]: device => {
-            dispatch(markDeviceAsRecentlyConnectedThunk(device));
+            deps.dispatch(markDeviceAsRecentlyConnectedThunk(device));
         },
     },
     uiEvent: {
         [UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
-            dispatch(openModal({ type: UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED }));
-            dispatch(preserveModal());
+            deps.dispatch(openModal({ type: UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED }));
+            deps.dispatch(preserveModal());
         },
         [UI_REQUEST.REQUEST_WORD]: () => {
-            if (selectRecoveryStatus(getState()) === 'waiting-for-confirmation') {
+            if (selectRecoveryStatus(deps.getState()) === 'waiting-for-confirmation') {
                 // Since the device asked for a first word, we can safely assume we've received confirmation from the user
-                dispatch(recoveryActions.setStatus('in-progress'));
+                deps.dispatch(recoveryActions.setStatus('in-progress'));
             }
         },
     },

--- a/suite-common/bip329/src/createBip329.ts
+++ b/suite-common/bip329/src/createBip329.ts
@@ -11,12 +11,12 @@ export type GetIsSuiteSyncEnabledDep = {
     getIsSuiteSyncEnabled: GetIsSuiteSyncEnabled;
 };
 
-export type CreateBip329Deps = GetIsSuiteSyncEnabledDep &
+export type Bip329Deps = GetIsSuiteSyncEnabledDep &
     LegacyToBip329Dep &
     ExportSuiteSyncToBip329Dep &
     ImportBip329ToSuiteSyncDep;
 
-export const createBip329 = (deps: CreateBip329Deps): Bip329 => ({
+export const createBip329 = (deps: Bip329Deps): Bip329 => ({
     export: params => {
         if (deps.getIsSuiteSyncEnabled()) {
             return deps.exportSuiteSyncToBip329(params);

--- a/suite-common/bip329/src/createBip329CompositionRoot.ts
+++ b/suite-common/bip329/src/createBip329CompositionRoot.ts
@@ -1,23 +1,20 @@
 import { type Bip329Dep } from '@suite-common/bip329-types';
 
 import { type GetIsSuiteSyncEnabledDep, createBip329 } from './createBip329';
+import { type LegacyToBip329Deps, createLegacyToBip329 } from './legacy/createLegacyToBip329';
 import {
-    type GetLegacyAccountLabelsDep,
-    createLegacyToBip329,
-} from './legacy/createLegacyToBip329';
-import {
-    type ImportBip329ToSuiteSyncDeps,
+    type Bip329ToSuiteSyncDeps,
     createBip329ToSuiteSync,
 } from './suiteSync/createBip329ToSuiteSync';
 import {
-    type GetAllLabelsForAccountDeps,
+    type SuiteSyncToBip329Deps,
     createSuiteSyncToBip329,
 } from './suiteSync/createSuiteSyncToBip329';
 
 type CreateBip329CompositionRootDeps = GetIsSuiteSyncEnabledDep &
-    GetLegacyAccountLabelsDep &
-    GetAllLabelsForAccountDeps &
-    ImportBip329ToSuiteSyncDeps;
+    LegacyToBip329Deps &
+    SuiteSyncToBip329Deps &
+    Bip329ToSuiteSyncDeps;
 
 export const createBip329CompositionRoot = (deps: CreateBip329CompositionRootDeps): Bip329Dep => {
     const legacyToBip329 = createLegacyToBip329({

--- a/suite-common/bip329/src/legacy/createLegacyToBip329.ts
+++ b/suite-common/bip329/src/legacy/createLegacyToBip329.ts
@@ -6,14 +6,14 @@ import { slip15ToBip329 } from './slip15ToBip329';
 
 export type GetLegacyAccountLabels = (accountKey: AccountKey) => AccountLabels;
 
-export type GetLegacyAccountLabelsDep = {
+export type LegacyToBip329Deps = {
     getLegacyAccountLabels: GetLegacyAccountLabels;
 };
 
 export type LegacyToBip329Dep = { legacyToBip329: ExportBip329 };
 
 export const createLegacyToBip329 =
-    (deps: GetLegacyAccountLabelsDep): ExportBip329 =>
+    (deps: LegacyToBip329Deps): ExportBip329 =>
     ({ account }) => {
         const accountLabels = deps.getLegacyAccountLabels(account.key);
 

--- a/suite-common/bip329/src/legacy/createLegacyToBip329.ts
+++ b/suite-common/bip329/src/legacy/createLegacyToBip329.ts
@@ -12,6 +12,7 @@ export type LegacyToBip329Deps = {
 
 export type LegacyToBip329Dep = { legacyToBip329: ExportBip329 };
 
+// eslint-disable-next-line local-rules/enforce-di-factory-contracts -- Concrete implementation of the abstract ExportBip329 contract.
 export const createLegacyToBip329 =
     (deps: LegacyToBip329Deps): ExportBip329 =>
     ({ account }) => {

--- a/suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.ts
+++ b/suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.ts
@@ -11,6 +11,7 @@ export type ImportBip329ToSuiteSyncDep = {
 
 export type Bip329ToSuiteSyncDeps = UpdateAddressLabelDep & UpdateOutputLabelDep;
 
+// eslint-disable-next-line local-rules/enforce-di-factory-contracts -- Concrete implementation of the abstract ImportBip329 contract.
 export const createBip329ToSuiteSync =
     (deps: Bip329ToSuiteSyncDeps): ImportBip329 =>
     async ({ deviceStaticSessionId, accountDescriptor, bip329Labels }) => {

--- a/suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.ts
+++ b/suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.ts
@@ -9,10 +9,10 @@ export type ImportBip329ToSuiteSyncDep = {
     importBip329ToSuiteSync: ImportBip329;
 };
 
-export type ImportBip329ToSuiteSyncDeps = UpdateAddressLabelDep & UpdateOutputLabelDep;
+export type Bip329ToSuiteSyncDeps = UpdateAddressLabelDep & UpdateOutputLabelDep;
 
 export const createBip329ToSuiteSync =
-    (deps: ImportBip329ToSuiteSyncDeps): ImportBip329 =>
+    (deps: Bip329ToSuiteSyncDeps): ImportBip329 =>
     async ({ deviceStaticSessionId, accountDescriptor, bip329Labels }) => {
         for (const label of bip329Labels) {
             switch (label.type) {

--- a/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.ts
+++ b/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.ts
@@ -28,6 +28,7 @@ export type ExportSuiteSyncToBip329Dep = {
     exportSuiteSyncToBip329: ExportBip329;
 };
 
+// eslint-disable-next-line local-rules/enforce-di-factory-contracts -- Concrete implementation of the abstract ExportBip329 contract.
 export const createSuiteSyncToBip329 =
     (deps: SuiteSyncToBip329Deps): ExportBip329 =>
     ({ account }) => {

--- a/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.ts
+++ b/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.ts
@@ -20,7 +20,7 @@ export type GetAllLabelsForAccountParams = {
 
 export type GetAllLabelsForAccount = (params: GetAllLabelsForAccountParams) => AllLabelsForAccount;
 
-export type GetAllLabelsForAccountDeps = {
+export type SuiteSyncToBip329Deps = {
     getAllLabelsForAccount: GetAllLabelsForAccount;
 };
 
@@ -29,7 +29,7 @@ export type ExportSuiteSyncToBip329Dep = {
 };
 
 export const createSuiteSyncToBip329 =
-    (deps: GetAllLabelsForAccountDeps): ExportBip329 =>
+    (deps: SuiteSyncToBip329Deps): ExportBip329 =>
     ({ account }) => {
         const { walletDescriptor } = parseStaticSessionId(account.deviceState);
 

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -54,6 +54,11 @@ const CONNECT_INIT_MODULE = '@common/connect-init';
 // If you are looking where connectInitSettings is defined, it is defined in packages/suite/src/support/extraDependencies.ts
 // or in suite-native/state/src/extraDependencies.ts depends on which platform this connectInitThunk runs.
 
+export type ConnectInitThunkState = DeviceRootState &
+    FirmwareRootState &
+    MessageSystemRootState &
+    WalletSettingsRootState;
+
 export type ConnectInitThunkDeps = {
     actions: LockDeviceDep;
     services: {
@@ -68,11 +73,6 @@ export type ConnectInitThunkDeps = {
         ThpHostNameDep &
         TransportsDep;
 };
-
-export type ConnectInitThunkState = DeviceRootState &
-    FirmwareRootState &
-    MessageSystemRootState &
-    WalletSettingsRootState;
 
 export type ConnectInitThunkDispatch = ThunkDispatch<
     ConnectInitThunkState,

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -71,6 +71,7 @@ type ConnectPopupCallThunkParams<M extends CallMethodKeys> = {
 };
 
 export type ConnectPopupCallThunkState = DeviceRootState & ConnectPopupStateRootState;
+
 export type ConnectPopupCallThunkDeps = {
     actions: LockDeviceDep;
     services: AnalyticsDep;
@@ -307,6 +308,7 @@ export const connectPopupCallThunk = <M extends CallMethodKeys>(
 > => connectPopupCallThunkInner(params) as any;
 
 type ConnectPopupDeeplinkThunkState = DeviceRootState & ConnectPopupStateRootState;
+
 type ConnectPopupDeeplinkThunkDeps = {
     actions: LockDeviceDep;
     services: AnalyticsDep;
@@ -392,6 +394,7 @@ export const connectPopupDeeplinkThunk = createThunk<
 });
 
 type ConnectPopupVerifyAddressThunkState = DeviceRootState & ConnectPopupStateRootState;
+
 type ConnectPopupVerifyAddressThunkDeps = {
     actions: LockDeviceDep;
 };
@@ -492,6 +495,7 @@ const resolveCandidateValue = (
 type ConnectPopupLoadSelectAccountPageThunkState = DeviceRootState &
     ConnectPopupStateRootState &
     AccountsRootState;
+
 type ConnectPopupLoadSelectAccountPageThunkDeps = {
     actions: LockDeviceDep;
 };
@@ -851,6 +855,7 @@ export const connectPopupLoadSelectAccountPageThunk = createThunk<
 type ConnectPopupSelectManualAccountThunkState = DeviceRootState &
     ConnectPopupStateRootState &
     AccountsRootState;
+
 type ConnectPopupSelectManualAccountThunkDeps = {
     actions: LockDeviceDep;
 };
@@ -884,6 +889,7 @@ export const connectPopupSelectManualAccountThunk = createThunk<
 type ConnectPopupBackToManualAccountsThunkState = DeviceRootState &
     ConnectPopupStateRootState &
     AccountsRootState;
+
 type ConnectPopupBackToManualAccountsThunkDeps = {
     actions: LockDeviceDep;
 };
@@ -914,6 +920,7 @@ export const connectPopupBackToManualAccountsThunk = createThunk<
 // Verifies a single candidate address on the device. Safe to run while the selectAccount call is
 // pending because that method holds no device session (useDevice = false).
 type ConnectPopupVerifySelectAccountThunkState = DeviceRootState & ConnectPopupStateRootState;
+
 type ConnectPopupVerifySelectAccountThunkDeps = {
     actions: LockDeviceDep;
 };

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -27,10 +27,11 @@ export type FirmwareUpdateResult = {
     connectResponse?: Awaited<ReturnType<typeof TrezorConnect.firmwareUpdate>>;
 };
 
+export type FirmwareUpdateThunkState = DeviceRootState & FirmwareRootState;
+
 export type FirmwareUpdateThunkDeps = WithServices<
     GetBinFilesBaseUrlDep & GetLanguageDep & ReportSecurityCheckDep
 >;
-export type FirmwareUpdateThunkState = DeviceRootState & FirmwareRootState;
 
 export const firmwareUpdate = createThunk<
     FirmwareUpdateResult,

--- a/suite-common/message-system/src/messageSystemThunks.ts
+++ b/suite-common/message-system/src/messageSystemThunks.ts
@@ -70,6 +70,7 @@ const shouldFetchConfig = (isLocal: boolean, lastTimestamp: number) => {
 
     return now >= lastTimestamp + interval;
 };
+
 type FetchConfigThunkState = MessageSystemRootState;
 
 export const fetchConfigThunk = createThunk<void, void, { state: FetchConfigThunkState }>(

--- a/suite-common/networks/src/NetworkModuleRepository.ts
+++ b/suite-common/networks/src/NetworkModuleRepository.ts
@@ -3,6 +3,8 @@ import { isArrayMember, typedObjectValues } from '@trezor/utils';
 
 import type { NetworkSymbol, StaticNetworkModulesDep } from './NetworkModules';
 
+export type NetworkModuleRepositoryDeps = StaticNetworkModulesDep;
+
 export type NetworkModuleRepository = {
     get: <T extends NetworkSymbol>(symbol: T) => SuiteCommonNetworkModule<T>;
     getSupportedNetworks: () => readonly NetworkSymbol[];
@@ -12,8 +14,6 @@ export type NetworkModuleRepository = {
 export type NetworkModuleRepositoryDep = {
     networkModuleRepository: NetworkModuleRepository;
 };
-
-export type NetworkModuleRepositoryDeps = StaticNetworkModulesDep;
 
 export const createNetworkModuleRepository = (
     deps: NetworkModuleRepositoryDeps,

--- a/suite-common/suite-rbf-labels-migrations/src/createMigrateSuiteSyncLabelsForRbfTransaction.ts
+++ b/suite-common/suite-rbf-labels-migrations/src/createMigrateSuiteSyncLabelsForRbfTransaction.ts
@@ -14,8 +14,10 @@ import { type StaticSessionId } from '@trezor/connect';
 import { parseStaticSessionId } from '@trezor/device-utils';
 import { typedObjectEntries } from '@trezor/utils';
 
+type SetLabelsForSuiteSyncDeps = UpdateOutputLabelDep;
+
 export const createSetLabelsForSuiteSync =
-    (deps: UpdateOutputLabelDep): SetLabelsForSuiteSync =>
+    (deps: SetLabelsForSuiteSyncDeps): SetLabelsForSuiteSync =>
     ({ newTxId, deviceStaticSessionId, suiteSyncOutputLabelsToBeUpdated }) =>
         Promise.all(
             suiteSyncOutputLabelsToBeUpdated.map(outputLabel =>
@@ -30,8 +32,10 @@ export const createSetLabelsForSuiteSync =
             ),
         );
 
+type DeleteLabelsForSuiteSyncDeps = UpdateOutputLabelDep;
+
 export const createDeleteLabelsForSuiteSync =
-    (deps: UpdateOutputLabelDep): DeleteLabelsForSuiteSync =>
+    (deps: DeleteLabelsForSuiteSyncDeps): DeleteLabelsForSuiteSync =>
     ({ deviceStaticSessionId, transactionOutputsToDelete }) =>
         Promise.all(
             transactionOutputsToDelete.flatMap(deleteOutput =>

--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -11,20 +11,20 @@ import { Schema } from './schema';
 // See: https://www.evolu.dev/docs/faq#how-to-delete-opfs-sqlite-in-browser
 const VERSION = 9;
 
-type EvoluInstanceFactoryDeps = {
+type CreateEvoluInstanceFactoryDeps = {
     run: Run<EvoluPlatformDeps>;
 };
 
-export type CreateEvoluInstance = (params: {
+export type EvoluInstanceFactory = (params: {
     suiteSyncOwner: SuiteSyncOwner;
 }) => Promise<Evolu<typeof Schema>>;
 
-export type CreateEvoluInstanceDep = {
-    createEvoluInstance: CreateEvoluInstance;
+export type EvoluInstanceFactoryDep = {
+    evoluInstanceFactory: EvoluInstanceFactory;
 };
 
 export const createEvoluInstanceFactory =
-    (deps: EvoluInstanceFactoryDeps): CreateEvoluInstance =>
+    (deps: CreateEvoluInstanceFactoryDeps): EvoluInstanceFactory =>
     async ({ suiteSyncOwner }) => {
         const owner = createEvoluAppOwnerFromTrezorData({ data: suiteSyncOwner.ownerSecret });
 

--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -11,7 +11,7 @@ import { Schema } from './schema';
 // See: https://www.evolu.dev/docs/faq#how-to-delete-opfs-sqlite-in-browser
 const VERSION = 9;
 
-type CreateEvoluInstanceFactoryDeps = {
+type EvoluInstanceFactoryDeps = {
     run: Run<EvoluPlatformDeps>;
 };
 
@@ -24,7 +24,7 @@ export type CreateEvoluInstanceDep = {
 };
 
 export const createEvoluInstanceFactory =
-    (deps: CreateEvoluInstanceFactoryDeps): CreateEvoluInstance =>
+    (deps: EvoluInstanceFactoryDeps): CreateEvoluInstance =>
     async ({ suiteSyncOwner }) => {
         const owner = createEvoluAppOwnerFromTrezorData({ data: suiteSyncOwner.ownerSecret });
 

--- a/suite-common/suite-sync-evolu/src/evoluStorage.test.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.test.ts
@@ -29,9 +29,9 @@ const suiteSyncOwner: SuiteSyncOwner = {
 };
 
 const createTestStorage = async (run: Run<EvoluPlatformDeps>) => {
-    const createEvoluInstance = createEvoluInstanceFactory({ run });
+    const evoluInstanceFactory = createEvoluInstanceFactory({ run });
 
-    return await createEvoluStorageFactory({ createEvoluInstance })({ suiteSyncOwner });
+    return await createEvoluStorageFactory({ evoluInstanceFactory })({ suiteSyncOwner });
 };
 
 describe(createEvoluStorageFactory.name, () => {

--- a/suite-common/suite-sync-evolu/src/evoluStorage.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.ts
@@ -2,20 +2,22 @@ import { type Evolu, createOwnerWebSocketTransport } from '@evolu/common';
 
 import { type CreateSuiteStorage, type SuiteSyncStorage } from '@suite-common/suite-sync-storage';
 
-import { type CreateEvoluInstanceDep } from './createEvoluInstance';
+import { type EvoluInstanceFactoryDep } from './createEvoluInstance';
 import { type AccountTableSchema, EvoluAccountTable } from './data/accountTable';
 import { AddressEvoluTable, type AddressTableSchema } from './data/addressTable';
 import { OutputEvoluTable, type OutputTableSchema } from './data/outputTable';
 import { EvoluWalletTable, type WalletTableSchema } from './data/walletTable';
 
-export type EvoluStorageFactoryDeps = CreateEvoluInstanceDep;
+export type CreateEvoluStorageFactoryDeps = EvoluInstanceFactoryDep;
+
+export type EvoluStorageFactory = CreateSuiteStorage;
 
 /**
  * This is intended as Wrapper around Evolu. In case we need to change Evolu for
  * something else, this is the Public API for the rest of the Suite ecosystem.
  */
 export const createEvoluStorageFactory =
-    (deps: EvoluStorageFactoryDeps): CreateSuiteStorage =>
+    (deps: CreateEvoluStorageFactoryDeps): EvoluStorageFactory =>
     async ({ suiteSyncOwner }): Promise<SuiteSyncStorage> => {
         /**
          * Dispose function of the connected owner. When owner is changed
@@ -25,7 +27,7 @@ export const createEvoluStorageFactory =
 
         let unuseOwner = () => {};
 
-        const evolu = await deps.createEvoluInstance({ suiteSyncOwner });
+        const evolu = await deps.evoluInstanceFactory({ suiteSyncOwner });
 
         const disconnectRelay = () => {
             unuseOwner();

--- a/suite-common/suite-sync-evolu/src/evoluStorage.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.ts
@@ -8,14 +8,14 @@ import { AddressEvoluTable, type AddressTableSchema } from './data/addressTable'
 import { OutputEvoluTable, type OutputTableSchema } from './data/outputTable';
 import { EvoluWalletTable, type WalletTableSchema } from './data/walletTable';
 
-export type CreateEvoluStorageFactoryDeps = CreateEvoluInstanceDep;
+export type EvoluStorageFactoryDeps = CreateEvoluInstanceDep;
 
 /**
  * This is intended as Wrapper around Evolu. In case we need to change Evolu for
  * something else, this is the Public API for the rest of the Suite ecosystem.
  */
 export const createEvoluStorageFactory =
-    (deps: CreateEvoluStorageFactoryDeps): CreateSuiteStorage =>
+    (deps: EvoluStorageFactoryDeps): CreateSuiteStorage =>
     async ({ suiteSyncOwner }): Promise<SuiteSyncStorage> => {
         /**
          * Dispose function of the connected owner. When owner is changed

--- a/suite-common/suite-sync-quota-manager/src/challenge/createPrepareChallengeSessionFetch.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/challenge/createPrepareChallengeSessionFetch.test.ts
@@ -1,11 +1,11 @@
 import { ok } from '@trezor/type-utils';
 
 import { createPrepareChallengeSessionFetch } from './createPrepareChallengeSessionFetch';
-import { createPrepareChallengeSessionDepsMock } from './mocks/createPrepareChallengeSessionDepsMock';
+import { createPrepareChallengeSessionFetchDepsMock } from './mocks/createPrepareChallengeSessionFetchDepsMock';
 
 describe(createPrepareChallengeSessionFetch.name, () => {
     it('should prepare challenge unique for each session', async () => {
-        const deps = createPrepareChallengeSessionDepsMock({
+        const deps = createPrepareChallengeSessionFetchDepsMock({
             sessionIds: ['mocked-session-id', 'mocked-session-id-2'],
             quotaManagerFetchResponses: [
                 ok({

--- a/suite-common/suite-sync-quota-manager/src/challenge/createPrepareChallengeSessionFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/challenge/createPrepareChallengeSessionFetch.ts
@@ -22,10 +22,10 @@ export type PrepareChallengeSessionFetchDep = {
     prepareChallengeSessionFetch: PrepareChallengeSessionFetch;
 };
 
-export type PrepareChallengeSessionDeps = QuotaManagerFetchDep & GenerateSessionIdDep;
+export type PrepareChallengeSessionFetchDeps = QuotaManagerFetchDep & GenerateSessionIdDep;
 
 export const createPrepareChallengeSessionFetch =
-    (deps: PrepareChallengeSessionDeps): PrepareChallengeSessionFetch =>
+    (deps: PrepareChallengeSessionFetchDeps): PrepareChallengeSessionFetch =>
     async () => {
         const sessionId = deps.generateSessionId();
 

--- a/suite-common/suite-sync-quota-manager/src/challenge/createPrepareChallengeSessionFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/challenge/createPrepareChallengeSessionFetch.ts
@@ -16,13 +16,13 @@ export type PrepareChallengeSessionResult = Result<
     QuotaManagerFetchCommunicationError
 >;
 
+export type PrepareChallengeSessionFetchDeps = QuotaManagerFetchDep & GenerateSessionIdDep;
+
 export type PrepareChallengeSessionFetch = () => Promise<PrepareChallengeSessionResult>;
 
 export type PrepareChallengeSessionFetchDep = {
     prepareChallengeSessionFetch: PrepareChallengeSessionFetch;
 };
-
-export type PrepareChallengeSessionFetchDeps = QuotaManagerFetchDep & GenerateSessionIdDep;
 
 export const createPrepareChallengeSessionFetch =
     (deps: PrepareChallengeSessionFetchDeps): PrepareChallengeSessionFetch =>

--- a/suite-common/suite-sync-quota-manager/src/challenge/mocks/createPrepareChallengeSessionFetchDepsMock.ts
+++ b/suite-common/suite-sync-quota-manager/src/challenge/mocks/createPrepareChallengeSessionFetchDepsMock.ts
@@ -3,20 +3,20 @@ import { createMockDeps } from '@suite-common/dependency-injection';
 import { createQuotaManagerFetchMock } from '../../mocks/createQuotaManagerFetchMock';
 import { type QuotaManagerFetchResult } from '../../quotaManagerFetch';
 import { createGenerateSessionIdMock } from '../../session/mocks/createGenerateSessionIdMock';
-import { type PrepareChallengeSessionDeps } from '../createPrepareChallengeSessionFetch';
+import { type PrepareChallengeSessionFetchDeps } from '../createPrepareChallengeSessionFetch';
 
-type CreatePrepareChallengeSessionDepsMockParams = {
+type CreatePrepareChallengeSessionFetchDepsMockParams = {
     sessionIds: string[];
     quotaManagerFetchResponses: QuotaManagerFetchResult[];
-    patch?: Partial<PrepareChallengeSessionDeps>;
+    patch?: Partial<PrepareChallengeSessionFetchDeps>;
 };
 
-export const createPrepareChallengeSessionDepsMock = ({
+export const createPrepareChallengeSessionFetchDepsMock = ({
     sessionIds,
     quotaManagerFetchResponses,
     patch = {},
-}: CreatePrepareChallengeSessionDepsMockParams) =>
-    createMockDeps<PrepareChallengeSessionDeps>({
+}: CreatePrepareChallengeSessionFetchDepsMockParams) =>
+    createMockDeps<PrepareChallengeSessionFetchDeps>({
         generateSessionId: createGenerateSessionIdMock(sessionIds),
         quotaManagerFetch: createQuotaManagerFetchMock(quotaManagerFetchResponses),
         ...patch,

--- a/suite-common/suite-sync-quota-manager/src/device/createCheckStorageByPublicKeyFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createCheckStorageByPublicKeyFetch.ts
@@ -34,14 +34,14 @@ export type CheckStorageByPublicKeyDep = {
     checkStorageByPublicKeyFetch: CheckStorageByPublicKeyFetch;
 };
 
-type CheckStorageByPublicKeyFetchDep = QuotaManagerFetchDep;
+type CheckStorageByPublicKeyFetchDeps = QuotaManagerFetchDep;
 
 /**
  * Ask quota manager for storage allowance by public key.
  * Returns also unspent space left.
  */
 export const createCheckStorageByPublicKeyFetch =
-    (deps: CheckStorageByPublicKeyFetchDep): CheckStorageByPublicKeyFetch =>
+    (deps: CheckStorageByPublicKeyFetchDeps): CheckStorageByPublicKeyFetch =>
     async ({ publicKey }) => {
         const result = await deps.quotaManagerFetch({
             path: '/storage/ask',

--- a/suite-common/suite-sync-quota-manager/src/device/createCheckStorageByPublicKeyFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createCheckStorageByPublicKeyFetch.ts
@@ -26,6 +26,8 @@ export type CheckStorageByPublicKeyResult = Result<
     QuotaManagerFetchCommunicationError
 >;
 
+type CheckStorageByPublicKeyFetchDeps = QuotaManagerFetchDep;
+
 export type CheckStorageByPublicKeyFetch = (
     params: CheckStorageByPublicKeyFetchParams,
 ) => Promise<CheckStorageByPublicKeyResult>;
@@ -33,8 +35,6 @@ export type CheckStorageByPublicKeyFetch = (
 export type CheckStorageByPublicKeyDep = {
     checkStorageByPublicKeyFetch: CheckStorageByPublicKeyFetch;
 };
-
-type CheckStorageByPublicKeyFetchDeps = QuotaManagerFetchDep;
 
 /**
  * Ask quota manager for storage allowance by public key.

--- a/suite-common/suite-sync-quota-manager/src/device/createCheckStorageByPublicKeyFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createCheckStorageByPublicKeyFetch.ts
@@ -32,7 +32,7 @@ export type CheckStorageByPublicKeyFetch = (
     params: CheckStorageByPublicKeyFetchParams,
 ) => Promise<CheckStorageByPublicKeyResult>;
 
-export type CheckStorageByPublicKeyDep = {
+export type CheckStorageByPublicKeyFetchDep = {
     checkStorageByPublicKeyFetch: CheckStorageByPublicKeyFetch;
 };
 

--- a/suite-common/suite-sync-quota-manager/src/device/createEnsureDeviceHasQuota.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createEnsureDeviceHasQuota.ts
@@ -13,7 +13,7 @@ import { type Result, err, exhaustive, ok } from '@trezor/type-utils';
 import { type RegisterDeviceDep } from './createRegisterDevice';
 import { QuotaManagerCommunicationFailed } from '../errors';
 import { quotaManagerDeviceFetched } from '../quotaManagerActions';
-import { type CheckStorageByPublicKeyDep } from './createCheckStorageByPublicKeyFetch';
+import { type CheckStorageByPublicKeyFetchDep } from './createCheckStorageByPublicKeyFetch';
 
 export type EnsureDeviceHasQuotaParams = {
     device: TrezorDeviceWithState;
@@ -22,7 +22,7 @@ export type EnsureDeviceHasQuotaParams = {
 
 export type EnsureDeviceHasQuotaDeps = {
     dispatch: Dispatch;
-} & CheckStorageByPublicKeyDep &
+} & CheckStorageByPublicKeyFetchDep &
     RegisterDeviceDep;
 
 export type EnsureDeviceHasQuota = (

--- a/suite-common/suite-sync-quota-manager/src/device/createEnsureDeviceHasQuota.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createEnsureDeviceHasQuota.ts
@@ -20,6 +20,11 @@ export type EnsureDeviceHasQuotaParams = {
     delegatedKey: DelegatedIdentityKey;
 };
 
+export type EnsureDeviceHasQuotaDeps = {
+    dispatch: Dispatch;
+} & CheckStorageByPublicKeyDep &
+    RegisterDeviceDep;
+
 export type EnsureDeviceHasQuota = (
     params: EnsureDeviceHasQuotaParams,
 ) => Promise<
@@ -28,11 +33,6 @@ export type EnsureDeviceHasQuota = (
         QuotaManagerCommunicationFailedErrType | ProofOfDelegatedSignFailedType | DeviceErrorType
     >
 >;
-
-export type EnsureDeviceHasQuotaDeps = {
-    dispatch: Dispatch;
-} & CheckStorageByPublicKeyDep &
-    RegisterDeviceDep;
 
 export type EnsureDeviceHasQuotaDep = {
     ensureDeviceHasQuota: EnsureDeviceHasQuota;

--- a/suite-common/suite-sync-quota-manager/src/device/createRegisterDeviceFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createRegisterDeviceFetch.ts
@@ -30,11 +30,11 @@ export type RegisterDeviceFetchResult = Result<
     QuotaManagerFetchCommunicationError
 >;
 
+export type RegisterDeviceFetchDeps = QuotaManagerFetchDep;
+
 export type RegisterDeviceFetch = (
     params: RegisterDeviceFetchParams,
 ) => Promise<RegisterDeviceFetchResult>;
-
-export type RegisterDeviceFetchDeps = QuotaManagerFetchDep;
 
 export type RegisterDeviceFetchDep = {
     registerDeviceFetch: RegisterDeviceFetch;

--- a/suite-common/suite-sync-quota-manager/src/owner/createAllocateOwnerQuota.ts
+++ b/suite-common/suite-sync-quota-manager/src/owner/createAllocateOwnerQuota.ts
@@ -36,14 +36,14 @@ export type AllocateOwnerQuotaErr =
     | WriteModeRequiredForAllocationErrType
     | QuotaManagerCommunicationFailedErrType;
 
-export type AllocateOwnerQuota = (
-    params: AllocateOwnerQuotaParams,
-) => Promise<Result<void, AllocateOwnerQuotaErr>>;
-
 export type AllocateOwnerQuotaDeps = {
     getLeftDeviceQuota: GetLeftDeviceQuota;
 } & TransferStorageFetchDep &
     PrepareChallengeSessionFetchDep;
+
+export type AllocateOwnerQuota = (
+    params: AllocateOwnerQuotaParams,
+) => Promise<Result<void, AllocateOwnerQuotaErr>>;
 
 export type AllocateOwnerQuotaDep = {
     allocateOwnerQuota: AllocateOwnerQuota;

--- a/suite-common/suite-sync-quota-manager/src/owner/createCheckStorageByOwnerIdFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/owner/createCheckStorageByOwnerIdFetch.ts
@@ -25,6 +25,8 @@ export type CheckStorageByOwnerIdResult = Result<
     QuotaManagerFetchCommunicationError
 >;
 
+type CheckStorageByOwnerIdFetchDeps = QuotaManagerFetchDep;
+
 export type CheckStorageByOwnerIdFetch = (
     params: CheckStorageByOwnerIdParams,
 ) => Promise<CheckStorageByOwnerIdResult>;
@@ -32,8 +34,6 @@ export type CheckStorageByOwnerIdFetch = (
 export type CheckStorageByOwnerIdFetchDep = {
     checkStorageByOwnerIdFetch: CheckStorageByOwnerIdFetch;
 };
-
-type CheckStorageByOwnerIdFetchDeps = QuotaManagerFetchDep;
 
 /**
  * Ask quota manager for storage allowance by owner ID.

--- a/suite-common/suite-sync-quota-manager/src/owner/createEnsureOwnerHasAllocatedQuota.ts
+++ b/suite-common/suite-sync-quota-manager/src/owner/createEnsureOwnerHasAllocatedQuota.ts
@@ -23,6 +23,11 @@ export type EnsureOwnerHasAllocatedQuotaParams = {
     isWriteMode: boolean;
 };
 
+export type EnsureOwnerHasAllocatedQuotaDeps = {
+    dispatch: Dispatch;
+} & CheckStorageByOwnerIdFetchDep &
+    AllocateOwnerQuotaDep;
+
 export type EnsureOwnerHasAllocatedQuota = (
     params: EnsureOwnerHasAllocatedQuotaParams,
 ) => Promise<
@@ -33,11 +38,6 @@ export type EnsureOwnerHasAllocatedQuota = (
         | QuotaManagerCommunicationFailedErrType
     >
 >;
-
-export type EnsureOwnerHasAllocatedQuotaDeps = {
-    dispatch: Dispatch;
-} & CheckStorageByOwnerIdFetchDep &
-    AllocateOwnerQuotaDep;
 
 export type EnsureOwnerHasAllocatedQuotaDep = {
     ensureOwnerHasAllocatedQuota: EnsureOwnerHasAllocatedQuota;

--- a/suite-common/suite-sync-quota-manager/src/owner/createTransferStorageFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/owner/createTransferStorageFetch.ts
@@ -38,13 +38,13 @@ export type TransferStorageResult = Result<
     QuotaManagerFetchCommunicationError
 >;
 
-export type TransferStorageFetch = (
-    params: TransferStorageFetchParams,
-) => Promise<TransferStorageResult>;
-
 export type TransferStorageFetchDeps = {
     dispatch: Dispatch;
 } & QuotaManagerFetchDep;
+
+export type TransferStorageFetch = (
+    params: TransferStorageFetchParams,
+) => Promise<TransferStorageResult>;
 
 export type TransferStorageFetchDep = {
     transferStorageFetch: TransferStorageFetch;

--- a/suite-common/suite-sync-quota-manager/src/owner/createTransferStorageFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/owner/createTransferStorageFetch.ts
@@ -42,7 +42,7 @@ export type TransferStorageFetch = (
     params: TransferStorageFetchParams,
 ) => Promise<TransferStorageResult>;
 
-export type TransferStorageDeps = {
+export type TransferStorageFetchDeps = {
     dispatch: Dispatch;
 } & QuotaManagerFetchDep;
 
@@ -56,7 +56,7 @@ export type TransferStorageFetchDep = {
  * Can be used to increase the quota of the owner by transferring unspent storage from the device.
  */
 export const createTransferStorageFetch =
-    (deps: TransferStorageDeps): TransferStorageFetch =>
+    (deps: TransferStorageFetchDeps): TransferStorageFetch =>
     async ({ params, walletDescriptor, deviceId }) => {
         const result = await deps.quotaManagerFetch({
             path: '/storage/add',

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
@@ -31,6 +31,12 @@ export type QuotaManagerFetchParams = {
     queryParams?: Record<string, string | number | boolean>;
 };
 
+export type FetchDep = {
+    fetch: typeof fetch;
+};
+
+export type QuotaManagerFetchDeps = GetQuotaManagerUrlDep & FetchDep;
+
 export type QuotaManagerFetch = (
     params: QuotaManagerFetchParams,
 ) => Promise<QuotaManagerFetchResult>;
@@ -38,12 +44,6 @@ export type QuotaManagerFetch = (
 export type QuotaManagerFetchDep = {
     quotaManagerFetch: QuotaManagerFetch;
 };
-
-export type FetchDep = {
-    fetch: typeof fetch;
-};
-
-export type QuotaManagerFetchDeps = GetQuotaManagerUrlDep & FetchDep;
 
 export const createQuotaManagerFetch =
     (deps: QuotaManagerFetchDeps): QuotaManagerFetch =>

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.ts
@@ -43,10 +43,10 @@ export type FetchDep = {
     fetch: typeof fetch;
 };
 
-export type CreateQuotaManagerFetchDeps = GetQuotaManagerUrlDep & FetchDep;
+export type QuotaManagerFetchDeps = GetQuotaManagerUrlDep & FetchDep;
 
 export const createQuotaManagerFetch =
-    (deps: CreateQuotaManagerFetchDeps): QuotaManagerFetch =>
+    (deps: QuotaManagerFetchDeps): QuotaManagerFetch =>
     async ({ path, method, body, queryParams }) => {
         const base = deps.getQuotaManagerUrl();
         const normalizedBase = base.endsWith('/') ? base : `${base}/`;

--- a/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts
@@ -13,7 +13,7 @@ import { asWalletDescriptor } from '@trezor/device-utils';
 import { err, ok } from '@trezor/type-utils';
 
 import {
-    type CreateSuiteSyncInternalErrorHandlerDeps,
+    type SuiteSyncInternalErrorHandlerDeps,
     createSuiteSyncInternalErrorHandler,
 } from './createSuiteSyncInternalErrorHandler';
 
@@ -32,7 +32,7 @@ const createDevice = (overrides: Partial<TrezorDevice> = {}): TrezorDevice =>
 
 describe(createSuiteSyncInternalErrorHandler.name, () => {
     it('propagates a device error when no selected device is available', async () => {
-        const deps = createMockDeps<CreateSuiteSyncInternalErrorHandlerDeps>({
+        const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
             allocateOwnerQuota: null,
             ensureDelegatedIdentityKey: null,
             suiteSyncUncontrolledErrorHandler: () => undefined,
@@ -53,7 +53,7 @@ describe(createSuiteSyncInternalErrorHandler.name, () => {
 
     it('retrieves delegated key and allocates additional owner quota for RelayQuotaExceeded', async () => {
         const device = createDevice();
-        const deps = createMockDeps<CreateSuiteSyncInternalErrorHandlerDeps>({
+        const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
             allocateOwnerQuota: () => Promise.resolve(ok()),
             ensureDelegatedIdentityKey: () =>
                 Promise.resolve(ok(asDelegatedIdentityKey('delegated-key'))),
@@ -79,7 +79,7 @@ describe(createSuiteSyncInternalErrorHandler.name, () => {
     it('propagates delegated key retrieval failures', async () => {
         const device = createDevice();
         const deviceError: DeviceErrorType = DeviceError('Delegated key failed');
-        const deps = createMockDeps<CreateSuiteSyncInternalErrorHandlerDeps>({
+        const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
             allocateOwnerQuota: null,
             ensureDelegatedIdentityKey: () => Promise.resolve(err(deviceError)),
             suiteSyncUncontrolledErrorHandler: () => undefined,
@@ -104,7 +104,7 @@ describe(createSuiteSyncInternalErrorHandler.name, () => {
             caused: new Error('quota manager failed'),
         };
 
-        const deps = createMockDeps<CreateSuiteSyncInternalErrorHandlerDeps>({
+        const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
             allocateOwnerQuota: () => Promise.resolve(err(allocationError)),
             ensureDelegatedIdentityKey: () =>
                 Promise.resolve(ok(asDelegatedIdentityKey('delegated-key'))),
@@ -126,7 +126,7 @@ describe(createSuiteSyncInternalErrorHandler.name, () => {
         const device = createDevice();
         const relayError = { type: 'RelayOther', message: 'relay failed' } as const;
 
-        const deps = createMockDeps<CreateSuiteSyncInternalErrorHandlerDeps>({
+        const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
             allocateOwnerQuota: null,
             ensureDelegatedIdentityKey: null,
             suiteSyncUncontrolledErrorHandler: () => undefined,

--- a/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.ts
@@ -10,7 +10,7 @@ import { type SuiteSyncUncontrolledErrorHandlerDep } from './suiteSyncUncontroll
 
 type GetSelectedDevice = () => TrezorDevice | undefined;
 
-export type CreateSuiteSyncInternalErrorHandlerDeps = AllocateOwnerQuotaDep &
+export type SuiteSyncInternalErrorHandlerDeps = AllocateOwnerQuotaDep &
     EnsureDelegatedIdentityKeyDep &
     SuiteSyncUncontrolledErrorHandlerDep &
     // Todo: temporary, see: https://github.com/trezor/trezor-suite/issues/27049
@@ -24,7 +24,7 @@ export type CreateSuiteSyncInternalErrorHandlerDeps = AllocateOwnerQuotaDep &
  *              errors and propagate them upstream.
  */
 export const createSuiteSyncInternalErrorHandler =
-    (deps: CreateSuiteSyncInternalErrorHandlerDeps): SuiteSyncInternalErrorHandler =>
+    (deps: SuiteSyncInternalErrorHandlerDeps): SuiteSyncInternalErrorHandler =>
     async (error: Errors) => {
         const { type } = error;
 

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.test.ts
@@ -3,7 +3,7 @@ import type { Dispatch } from '@reduxjs/toolkit';
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import type { StaticSessionId } from '@trezor/connect';
 
-import { type CreateTurnOffSuiteSyncDeps, createTurnOffSuiteSync } from './createTurnOffSuiteSync';
+import { type TurnOffSuiteSyncDeps, createTurnOffSuiteSync } from './createTurnOffSuiteSync';
 import { clearAll } from './data/suiteSyncDataReducer';
 import { updateSuiteSyncEnabled } from './suiteSyncSlice';
 
@@ -12,7 +12,7 @@ const deviceStaticSessionId2: StaticSessionId = '4@5:6';
 
 describe(createTurnOffSuiteSync.name, () => {
     it('returns early when suite sync is already disabled', async () => {
-        const deps = createMockDeps<CreateTurnOffSuiteSyncDeps>({
+        const deps = createMockDeps<TurnOffSuiteSyncDeps>({
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
             getAllDeviceSessionIds: () => [],
@@ -28,7 +28,7 @@ describe(createTurnOffSuiteSync.name, () => {
     });
 
     it('disables suite sync and turns off sync for all devices', async () => {
-        const deps = createMockDeps<CreateTurnOffSuiteSyncDeps>({
+        const deps = createMockDeps<TurnOffSuiteSyncDeps>({
             getIsSuiteSyncEnabled: () => true,
             dispatch: mock<Dispatch>(() => {}),
             getAllDeviceSessionIds: () => [deviceStaticSessionId1, deviceStaticSessionId2],
@@ -49,7 +49,7 @@ describe(createTurnOffSuiteSync.name, () => {
     });
 
     it('clears data and flushes storage even when no devices exist', async () => {
-        const deps = createMockDeps<CreateTurnOffSuiteSyncDeps>({
+        const deps = createMockDeps<TurnOffSuiteSyncDeps>({
             getIsSuiteSyncEnabled: () => true,
             dispatch: mock<Dispatch>(() => {}),
             getAllDeviceSessionIds: () => [],

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -10,14 +10,14 @@ import {
 import { clearAll } from './data/suiteSyncDataReducer';
 import { updateSuiteSyncEnabled } from './suiteSyncSlice';
 
-export type CreateTurnOffSuiteSyncDeps = {
+export type TurnOffSuiteSyncDeps = {
     getIsSuiteSyncEnabled: () => boolean;
     dispatch: Dispatch;
 } & GetAllDeviceSessionIdsDep &
     TurnOffSuiteSyncForWalletDep;
 
 export const createTurnOffSuiteSync =
-    (deps: CreateTurnOffSuiteSyncDeps): TurnOffSuiteSync =>
+    (deps: TurnOffSuiteSyncDeps): TurnOffSuiteSync =>
     async (params: { ensureSettingsPersisted?: () => Promise<void> } = {}) => {
         const isSuiteSyncEnabled = deps.getIsSuiteSyncEnabled();
 

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.test.ts
@@ -6,7 +6,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { SuiteSyncUnavailableOnDeviceError } from './createEnsureSuiteSyncKeys';
-import { type CreateTurnOnSuiteSyncDeps, createTurnOnSuiteSync } from './createTurnOnSuiteSync';
+import { type TurnOnSuiteSyncDeps, createTurnOnSuiteSync } from './createTurnOnSuiteSync';
 import type { GetDeviceForStaticSessionIdDep } from './getDeviceForStaticSessionId';
 import { setSuiteSyncError, updateSuiteSyncEnabled } from './suiteSyncSlice';
 import { createSuiteSyncStorageMock } from '../mocks/mockCreateSuiteSyncStorage';
@@ -22,7 +22,7 @@ const createConnectedDevice = () =>
 
 describe(createTurnOnSuiteSync.name, () => {
     it('returns ok early when suite sync is already enabled', async () => {
-        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps>({
+        const deps = createMockDeps<TurnOnSuiteSyncDeps>({
             getIsSuiteSyncEnabled: () => true,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ok(createSuiteSyncStorageMock())),
@@ -40,7 +40,7 @@ describe(createTurnOnSuiteSync.name, () => {
     it('enables suite sync and ensures wallet sync when deviceStaticSessionId is provided', async () => {
         const storage = createSuiteSyncStorageMock();
 
-        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps>({
+        const deps = createMockDeps<TurnOnSuiteSyncDeps>({
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ok(storage)),
@@ -59,7 +59,7 @@ describe(createTurnOnSuiteSync.name, () => {
     });
 
     it('enables suite sync without calling ensureWalletSuiteSyncOn when deviceStaticSessionId is undefined', async () => {
-        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps>({
+        const deps = createMockDeps<TurnOnSuiteSyncDeps>({
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ok(createSuiteSyncStorageMock())),
@@ -75,7 +75,7 @@ describe(createTurnOnSuiteSync.name, () => {
     });
 
     it('enables suite sync and dispatches DeviceError when remembered device is disconnected', async () => {
-        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps & GetDeviceForStaticSessionIdDep>({
+        const deps = createMockDeps<TurnOnSuiteSyncDeps & GetDeviceForStaticSessionIdDep>({
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ok(createSuiteSyncStorageMock())),
@@ -103,7 +103,7 @@ describe(createTurnOnSuiteSync.name, () => {
     it('returns ensureWalletSuiteSyncOn error when it fails', async () => {
         const ensureWalletSuiteSyncOnResult = err(SuiteSyncUnavailableOnDeviceError());
 
-        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps>({
+        const deps = createMockDeps<TurnOnSuiteSyncDeps>({
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ensureWalletSuiteSyncOnResult),

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -10,14 +10,14 @@ import { ok } from '@trezor/type-utils';
 import { type GetDeviceForStaticSessionIdDep } from './getDeviceForStaticSessionId';
 import { setSuiteSyncError, updateSuiteSyncEnabled } from './suiteSyncSlice';
 
-export type CreateTurnOnSuiteSyncDeps = {
+export type TurnOnSuiteSyncDeps = {
     getIsSuiteSyncEnabled: () => boolean;
     dispatch: Dispatch;
 } & EnsureWalletSuiteSyncOnDep &
     GetDeviceForStaticSessionIdDep;
 
 export const createTurnOnSuiteSync =
-    (deps: CreateTurnOnSuiteSyncDeps): TurnOnSuiteSync =>
+    (deps: TurnOnSuiteSyncDeps): TurnOnSuiteSync =>
     async ({ deviceStaticSessionId }) => {
         const isSuiteSyncEnabled = deps.getIsSuiteSyncEnabled();
         const isDeviceConnected = deviceStaticSessionId

--- a/suite-common/suite-sync/src/data/createEnsureSubscribedStorage.test.ts
+++ b/suite-common/suite-sync/src/data/createEnsureSubscribedStorage.test.ts
@@ -19,7 +19,7 @@ import { err, ok } from '@trezor/type-utils';
 import { createSuiteSyncStorageMock } from '../../mocks/mockCreateSuiteSyncStorage';
 import { SuiteSyncUnavailableOnDeviceError } from '../createEnsureSuiteSyncKeys';
 import {
-    type CreateEnsureSubscribedStorageDeps,
+    type EnsureSubscribedStorageDeps,
     createEnsureSubscribedStorage,
 } from './createEnsureSubscribedStorage';
 import { createStorageIdFromDeviceStaticSessionId } from '../storage/createStorageIdFromDeviceStaticSessionId';
@@ -82,7 +82,7 @@ describe(createEnsureSubscribedStorage.name, () => {
         const suiteSyncListener = createListenerMock();
         const storageResult = err(SuiteSyncUnavailableOnDeviceError());
 
-        const deps = createMockDeps<CreateEnsureSubscribedStorageDeps>({
+        const deps = createMockDeps<EnsureSubscribedStorageDeps>({
             ensureStorage: () => Promise.resolve(storageResult),
             subscriptionStorage: createSubscriptionStorage(),
             suiteSyncListener,
@@ -115,7 +115,7 @@ describe(createEnsureSubscribedStorage.name, () => {
             unsubscribe: jest.fn(),
         });
 
-        const deps = createMockDeps<CreateEnsureSubscribedStorageDeps>({
+        const deps = createMockDeps<EnsureSubscribedStorageDeps>({
             ensureStorage: () => Promise.resolve(ok(storage)),
             subscriptionStorage,
             suiteSyncListener,
@@ -140,7 +140,7 @@ describe(createEnsureSubscribedStorage.name, () => {
             outputs: { subscribe: () => () => {} },
         });
 
-        const deps = createMockDeps<CreateEnsureSubscribedStorageDeps>({
+        const deps = createMockDeps<EnsureSubscribedStorageDeps>({
             ensureStorage: () => Promise.resolve(ok(storage)),
             subscriptionStorage: createSubscriptionStorage(),
             suiteSyncListener,
@@ -173,7 +173,7 @@ describe(createEnsureSubscribedStorage.name, () => {
 
         const storage = createStorageWithEmitters(storageEmitters);
 
-        const deps = createMockDeps<CreateEnsureSubscribedStorageDeps>({
+        const deps = createMockDeps<EnsureSubscribedStorageDeps>({
             ensureStorage: () => Promise.resolve(ok(storage)),
             subscriptionStorage: createSubscriptionStorage(),
             suiteSyncListener,

--- a/suite-common/suite-sync/src/data/createEnsureSubscribedStorage.ts
+++ b/suite-common/suite-sync/src/data/createEnsureSubscribedStorage.ts
@@ -11,7 +11,7 @@ import { typedObjectValues } from '@trezor/utils';
 import { type EnsureStorageDep } from '../storage/createEnsureStorage';
 import { createStorageIdFromDeviceStaticSessionId } from '../storage/createStorageIdFromDeviceStaticSessionId';
 
-export type CreateEnsureSubscribedStorageDeps = EnsureStorageDep &
+export type EnsureSubscribedStorageDeps = EnsureStorageDep &
     SubscriptionStorageDep &
     SuiteSyncListenerDep;
 
@@ -20,7 +20,7 @@ export type CreateEnsureSubscribedStorageDeps = EnsureStorageDep &
  * - Ensure storage changes are subscribed to Redux-facing listeners exactly once.
  */
 export const createEnsureSubscribedStorage =
-    (deps: CreateEnsureSubscribedStorageDeps): EnsureSubscribedStorage =>
+    (deps: EnsureSubscribedStorageDeps): EnsureSubscribedStorage =>
     async ({ deviceStaticSessionId, isWriteMode }): ReturnType<EnsureSubscribedStorage> => {
         const storageResult = await deps.ensureStorage({
             deviceStaticSessionId,

--- a/suite-common/suite-sync/src/data/createSuiteSyncListener.ts
+++ b/suite-common/suite-sync/src/data/createSuiteSyncListener.ts
@@ -11,11 +11,11 @@ import {
     upsertManyWallets,
 } from './suiteSyncDataReducer';
 
-export type CreateSuiteSyncListenerDeps = {
+export type SuiteSyncListenerDeps = {
     dispatch: Dispatch;
 };
 
-export const createSuiteSyncListener = (deps: CreateSuiteSyncListenerDeps): SuiteSyncListener => ({
+export const createSuiteSyncListener = (deps: SuiteSyncListenerDeps): SuiteSyncListener => ({
     onEntityChange: {
         wallets: (_deviceStaticId, entities) => {
             deps.dispatch(upsertManyWallets(entities));

--- a/suite-common/suite-sync/src/data/labeling/createSuiteSyncWriteLabels.ts
+++ b/suite-common/suite-sync/src/data/labeling/createSuiteSyncWriteLabels.ts
@@ -11,11 +11,11 @@ import { selectSuiteSyncAddressLabel } from '../address/suiteSyncAddressSelector
 import { selectSuiteSyncOutputLabel } from '../output/suiteSyncOutputSelectors';
 import { selectSuiteSyncWalletLabel } from '../wallet/suiteSyncWalletSelectors';
 
-export type SuiteSyncWriteLabels = WriteLabelsDep;
-
 export type SuiteSyncWriteLabelsDeps = {
     getState: () => any;
 } & SuiteSyncAnalyticsDep;
+
+export type SuiteSyncWriteLabels = WriteLabelsDep;
 
 export const createSuiteSyncWriteLabels = (
     deps: SuiteSyncWriteLabelsDeps,

--- a/suite-common/suite-sync/src/data/labeling/createSuiteSyncWriteLabels.ts
+++ b/suite-common/suite-sync/src/data/labeling/createSuiteSyncWriteLabels.ts
@@ -13,12 +13,12 @@ import { selectSuiteSyncWalletLabel } from '../wallet/suiteSyncWalletSelectors';
 
 export type SuiteSyncWriteLabels = WriteLabelsDep;
 
-export type CreateSuiteSyncWriteLabelsDeps = {
+export type SuiteSyncWriteLabelsDeps = {
     getState: () => any;
 } & SuiteSyncAnalyticsDep;
 
 export const createSuiteSyncWriteLabels = (
-    deps: CreateSuiteSyncWriteLabelsDeps,
+    deps: SuiteSyncWriteLabelsDeps,
 ): SuiteSyncWriteLabels => ({
     writeWalletLabel: createWriteWalletLabel({
         analytics: deps.analytics,

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -96,7 +96,7 @@ export {
 export {
     createSuiteSyncWriteLabels,
     type SuiteSyncWriteLabels,
-    type CreateSuiteSyncWriteLabelsDeps,
+    type SuiteSyncWriteLabelsDeps,
 } from './data/labeling/createSuiteSyncWriteLabels';
 export {
     isSuiteSyncSupportedByDevice,

--- a/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.test.ts
+++ b/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.test.ts
@@ -4,7 +4,7 @@ import { asDeviceUniquePath } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import {
-    type CreateEnsureSuiteSyncOwnerDeps,
+    type EnsureSuiteSyncOwnerDeps,
     createEnsureSuiteSyncOwner,
 } from './createEnsureSuiteSyncOwner';
 import { type RetrieveSuiteSyncOwnerParams } from './createRetrieveSuiteSyncOwner';
@@ -25,8 +25,8 @@ const owner = {
 };
 
 const createDeps = (
-    overrides: Partial<CreateEnsureSuiteSyncOwnerDeps> = {},
-): CreateEnsureSuiteSyncOwnerDeps => ({
+    overrides: Partial<EnsureSuiteSyncOwnerDeps> = {},
+): EnsureSuiteSyncOwnerDeps => ({
     loadSuiteSyncOwnerFromState: jest.fn().mockResolvedValue(null),
     retrieveSuiteSyncOwner: jest.fn().mockResolvedValue(ok(owner)),
     saveSuiteSyncOwner: jest.fn(),

--- a/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
@@ -3,10 +3,10 @@ import { ok } from '@trezor/type-utils';
 import { isNotNull } from '@trezor/utils';
 
 import { type LoadSuiteSyncOwnerFromStateDep } from './createLoadSuiteSyncOwnerFromState';
-import { type RetrieveSuiteSyncOwnerKeysDep } from './createRetrieveSuiteSyncOwner';
+import { type RetrieveSuiteSyncOwnerDep } from './createRetrieveSuiteSyncOwner';
 import { type SaveSuiteSyncOwnerDep } from './createSaveSuiteSyncOwner';
 
-export type EnsureSuiteSyncOwnerDeps = RetrieveSuiteSyncOwnerKeysDep &
+export type EnsureSuiteSyncOwnerDeps = RetrieveSuiteSyncOwnerDep &
     LoadSuiteSyncOwnerFromStateDep &
     SaveSuiteSyncOwnerDep;
 

--- a/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
@@ -6,7 +6,7 @@ import { type LoadSuiteSyncOwnerFromStateDep } from './createLoadSuiteSyncOwnerF
 import { type RetrieveSuiteSyncOwnerKeysDep } from './createRetrieveSuiteSyncOwner';
 import { type SaveSuiteSyncOwnerDep } from './createSaveSuiteSyncOwner';
 
-export type CreateEnsureSuiteSyncOwnerDeps = RetrieveSuiteSyncOwnerKeysDep &
+export type EnsureSuiteSyncOwnerDeps = RetrieveSuiteSyncOwnerKeysDep &
     LoadSuiteSyncOwnerFromStateDep &
     SaveSuiteSyncOwnerDep;
 
@@ -16,7 +16,7 @@ export type CreateEnsureSuiteSyncOwnerDeps = RetrieveSuiteSyncOwnerKeysDep &
  * - Retrieve and persist the owner only when it is not cached already.
  */
 export const createEnsureSuiteSyncOwner =
-    (deps: CreateEnsureSuiteSyncOwnerDeps): EnsureSuiteSyncOwner =>
+    (deps: EnsureSuiteSyncOwnerDeps): EnsureSuiteSyncOwner =>
     async ({ device, delegatedKey }) => {
         const currentSuiteSyncOwner = await deps.loadSuiteSyncOwnerFromState({
             deviceStaticId: device.state.staticSessionId,

--- a/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
@@ -25,6 +25,11 @@ export type RetrieveSuiteSyncOwnerParams = {
     delegatedKey: DelegatedIdentityKey;
 };
 
+export type RetrieveSuiteSyncOwnerDeps = {
+    createSuiteSyncOwner: CreateSuiteSyncOwner;
+    trezorConnect: Pick<typeof TrezorConnect, 'evoluGetNode'>;
+};
+
 export type RetrieveSuiteSyncOwner = (
     params: RetrieveSuiteSyncOwnerParams,
 ) => Promise<
@@ -39,11 +44,6 @@ export type RetrieveSuiteSyncOwner = (
 
 export type RetrieveSuiteSyncOwnerKeysDep = {
     retrieveSuiteSyncOwner: RetrieveSuiteSyncOwner;
-};
-
-export type RetrieveSuiteSyncOwnerDeps = {
-    createSuiteSyncOwner: CreateSuiteSyncOwner;
-    trezorConnect: Pick<typeof TrezorConnect, 'evoluGetNode'>;
 };
 
 export const createRetrieveSuiteSyncOwner =

--- a/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
@@ -42,7 +42,7 @@ export type RetrieveSuiteSyncOwner = (
     >
 >;
 
-export type RetrieveSuiteSyncOwnerKeysDep = {
+export type RetrieveSuiteSyncOwnerDep = {
     retrieveSuiteSyncOwner: RetrieveSuiteSyncOwner;
 };
 

--- a/suite-common/suite-sync/src/relay/createUpdateRelayConnectionStatus.ts
+++ b/suite-common/suite-sync/src/relay/createUpdateRelayConnectionStatus.ts
@@ -10,11 +10,11 @@ import {
 } from '../suiteSyncSlice';
 import { type SuiteSyncRelayConnectionEvent } from './relayConnectionStatus';
 
-export type UpdateRelayConnectionStatus = (event: SuiteSyncRelayConnectionEvent) => void;
-
 export type UpdateRelayConnectionStatusDeps = {
     dispatch: Dispatch;
 };
+
+export type UpdateRelayConnectionStatus = (event: SuiteSyncRelayConnectionEvent) => void;
 
 export const createUpdateRelayConnectionStatus =
     (deps: UpdateRelayConnectionStatusDeps): UpdateRelayConnectionStatus =>

--- a/suite-common/suite-sync/src/storage/createEnsureStorage.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureStorage.ts
@@ -41,7 +41,7 @@ export type EnsureStorageParams = {
     isWriteMode: boolean;
 };
 
-export type CreateEnsureStorage = (
+export type EnsureStorage = (
     params: EnsureStorageParams,
 ) => Promise<
     Result<
@@ -56,7 +56,7 @@ export type CreateEnsureStorage = (
 >;
 
 export type EnsureStorageDep = {
-    ensureStorage: CreateEnsureStorage;
+    ensureStorage: EnsureStorage;
 };
 
 /**
@@ -65,8 +65,8 @@ export type EnsureStorageDep = {
  * - Orchestrate prerequisites such as keys and quota before the storage is used.
  */
 export const createEnsureStorage =
-    (deps: EnsureStorageDeps): CreateEnsureStorage =>
-    async ({ deviceStaticSessionId, isWriteMode }): ReturnType<CreateEnsureStorage> => {
+    (deps: EnsureStorageDeps): EnsureStorage =>
+    async ({ deviceStaticSessionId, isWriteMode }): ReturnType<EnsureStorage> => {
         const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
         const { walletDescriptor } = parseStaticSessionId(deviceStaticSessionId);
 

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnUncontrolled.test.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnUncontrolled.test.ts
@@ -4,7 +4,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { SuiteSyncUnavailableOnDeviceError } from '../createEnsureSuiteSyncKeys';
-import { type CreateEnsureWalletSuiteSyncOnUncontrolledDeps } from './createEnsureWalletSuiteSyncOnUncontrolled';
+import { type EnsureWalletSuiteSyncOnUncontrolledDeps } from './createEnsureWalletSuiteSyncOnUncontrolled';
 import { createEnsureWalletSuiteSyncOnUncontrolled } from './createEnsureWalletSuiteSyncOnUncontrolled';
 
 const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
@@ -15,7 +15,7 @@ describe(createEnsureWalletSuiteSyncOnUncontrolled.name, () => {
             id: 'device-id',
             state: { staticSessionId: DEVICE_STATIC_SESSION_ID_123 },
         });
-        const deps = createMockDeps<CreateEnsureWalletSuiteSyncOnUncontrolledDeps>({
+        const deps = createMockDeps<EnsureWalletSuiteSyncOnUncontrolledDeps>({
             ensureWalletSuiteSyncOn: () => Promise.resolve(ok({ data: {} } as any)),
             suiteSyncUncontrolledErrorHandler: () => undefined,
             getDeviceForStaticSessionId: () => device,
@@ -35,7 +35,7 @@ describe(createEnsureWalletSuiteSyncOnUncontrolled.name, () => {
             state: { staticSessionId: DEVICE_STATIC_SESSION_ID_123 },
         });
         const error = { type: 'QuotaManagerCommunicationFailed' as const, caused: 'network' };
-        const deps = createMockDeps<CreateEnsureWalletSuiteSyncOnUncontrolledDeps>({
+        const deps = createMockDeps<EnsureWalletSuiteSyncOnUncontrolledDeps>({
             ensureWalletSuiteSyncOn: () => Promise.resolve(err(error)),
             suiteSyncUncontrolledErrorHandler: () => undefined,
             getDeviceForStaticSessionId: () => device,
@@ -54,7 +54,7 @@ describe(createEnsureWalletSuiteSyncOnUncontrolled.name, () => {
 
     it('does not call async error handler for unsupported device error', async () => {
         const error = SuiteSyncUnavailableOnDeviceError();
-        const deps = createMockDeps<CreateEnsureWalletSuiteSyncOnUncontrolledDeps>({
+        const deps = createMockDeps<EnsureWalletSuiteSyncOnUncontrolledDeps>({
             ensureWalletSuiteSyncOn: () => Promise.resolve(err(error)),
             suiteSyncUncontrolledErrorHandler: () => undefined,
             getDeviceForStaticSessionId: () => mockSuiteDevice({ state: undefined }),

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnUncontrolled.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnUncontrolled.ts
@@ -7,12 +7,12 @@ import {
 import { type GetDeviceForStaticSessionIdDep } from '../getDeviceForStaticSessionId';
 import { type SuiteSyncUncontrolledErrorHandlerDep } from '../suiteSyncUncontrolledErrorHandler';
 
-export type CreateEnsureWalletSuiteSyncOnUncontrolledDeps = EnsureWalletSuiteSyncOnDep &
+export type EnsureWalletSuiteSyncOnUncontrolledDeps = EnsureWalletSuiteSyncOnDep &
     SuiteSyncUncontrolledErrorHandlerDep &
     GetDeviceForStaticSessionIdDep;
 
 export const createEnsureWalletSuiteSyncOnUncontrolled =
-    (deps: CreateEnsureWalletSuiteSyncOnUncontrolledDeps): EnsureWalletSuiteSyncOnUncontrolled =>
+    (deps: EnsureWalletSuiteSyncOnUncontrolledDeps): EnsureWalletSuiteSyncOnUncontrolled =>
     async params => {
         const result = await deps.ensureWalletSuiteSyncOn(params);
 

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.test.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.test.ts
@@ -4,7 +4,7 @@ import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import { type StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
-import type { CreateEnsureWalletSuiteSyncOnWithFwCheckDeps } from './createEnsureWalletSuiteSyncOnWithErrorHandler';
+import type { EnsureWalletSuiteSyncOnWithErrorHandlerDeps } from './createEnsureWalletSuiteSyncOnWithErrorHandler';
 import { createEnsureWalletSuiteSyncOnWithErrorHandler } from './createEnsureWalletSuiteSyncOnWithErrorHandler';
 
 const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
@@ -65,7 +65,7 @@ describe(createEnsureWalletSuiteSyncOnWithErrorHandler.name, () => {
     ])(
         'dispatches correct error for $description and passes result through',
         async ({ innerResult, expectedDispatchedAction }) => {
-            const deps = createMockDeps<CreateEnsureWalletSuiteSyncOnWithFwCheckDeps>({
+            const deps = createMockDeps<EnsureWalletSuiteSyncOnWithErrorHandlerDeps>({
                 dispatch: mock<Dispatch>(() => {}),
                 ensureWalletSuiteSyncOn: () => Promise.resolve(innerResult),
             });
@@ -85,7 +85,7 @@ describe(createEnsureWalletSuiteSyncOnWithErrorHandler.name, () => {
     it('delegates to ensureWalletSuiteSyncOn with correct params', async () => {
         const ensureResult = ok({ data: {} } as any);
 
-        const deps = createMockDeps<CreateEnsureWalletSuiteSyncOnWithFwCheckDeps>({
+        const deps = createMockDeps<EnsureWalletSuiteSyncOnWithErrorHandlerDeps>({
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ensureResult),
         });

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts
@@ -8,7 +8,7 @@ import { exhaustive } from '@trezor/type-utils';
 
 import { resetSuiteSyncError, setSuiteSyncError } from '../suiteSyncSlice';
 
-export type CreateEnsureWalletSuiteSyncOnWithFwCheckDeps = {
+export type EnsureWalletSuiteSyncOnWithErrorHandlerDeps = {
     dispatch: Dispatch;
 } & EnsureWalletSuiteSyncOnDep;
 
@@ -17,7 +17,7 @@ export type CreateEnsureWalletSuiteSyncOnWithFwCheckDeps = {
  * suite sync errors to the Redux store.
  */
 export const createEnsureWalletSuiteSyncOnWithErrorHandler =
-    (deps: CreateEnsureWalletSuiteSyncOnWithFwCheckDeps): EnsureWalletSuiteSyncOn =>
+    (deps: EnsureWalletSuiteSyncOnWithErrorHandlerDeps): EnsureWalletSuiteSyncOn =>
     async params => {
         const result = await deps.ensureWalletSuiteSyncOn(params);
 

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts
@@ -16,6 +16,7 @@ export type EnsureWalletSuiteSyncOnWithErrorHandlerDeps = {
  * Decorator for `ensureWalletSuiteSyncOn` that handles dispatching of all
  * suite sync errors to the Redux store.
  */
+// eslint-disable-next-line local-rules/enforce-di-factory-contracts -- Decorator implementing the abstract EnsureWalletSuiteSyncOn contract.
 export const createEnsureWalletSuiteSyncOnWithErrorHandler =
     (deps: EnsureWalletSuiteSyncOnWithErrorHandlerDeps): EnsureWalletSuiteSyncOn =>
     async params => {

--- a/suite-common/suite-sync/src/storage/createTurnOffSuiteSyncForWallet.test.ts
+++ b/suite-common/suite-sync/src/storage/createTurnOffSuiteSyncForWallet.test.ts
@@ -7,7 +7,7 @@ import { createSubscriptionStorageMock } from '../../mocks/mockCreateSubscriptio
 import { setSuiteSyncOwner } from '../suiteSyncSlice';
 import { createStorageIdFromDeviceStaticSessionId } from './createStorageIdFromDeviceStaticSessionId';
 import {
-    type CreateTurnOffSuiteSyncForWalletDeps,
+    type TurnOffSuiteSyncForWalletDeps,
     createTurnOffSuiteSyncForWallet,
 } from './createTurnOffSuiteSyncForWallet';
 
@@ -15,7 +15,7 @@ const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
 
 describe(createTurnOffSuiteSyncForWallet.name, () => {
     it('disposes wallet storage, deletes repository entry, and clears owner from state', async () => {
-        const deps = createMockDeps<CreateTurnOffSuiteSyncForWalletDeps>({
+        const deps = createMockDeps<TurnOffSuiteSyncForWalletDeps>({
             dispatch: mock<Dispatch>(() => {}),
             subscriptionStorage: createSubscriptionStorageMock(),
             suiteSyncStorageRepository: {

--- a/suite-common/suite-sync/src/storage/createTurnOffSuiteSyncForWallet.ts
+++ b/suite-common/suite-sync/src/storage/createTurnOffSuiteSyncForWallet.ts
@@ -9,11 +9,11 @@ import {
 import { createStorageIdFromDeviceStaticSessionId } from './createStorageIdFromDeviceStaticSessionId';
 import { setSuiteSyncOwner } from '../suiteSyncSlice';
 
-export type CreateTurnOffSuiteSyncForWalletDeps = SuiteSyncStorageRepositoryDep &
+export type TurnOffSuiteSyncForWalletDeps = SuiteSyncStorageRepositoryDep &
     SubscriptionStorageDep & { dispatch: Dispatch };
 
 export const createTurnOffSuiteSyncForWallet =
-    (deps: CreateTurnOffSuiteSyncForWalletDeps): TurnOffSuiteSyncForWallet =>
+    (deps: TurnOffSuiteSyncForWalletDeps): TurnOffSuiteSyncForWallet =>
     async ({ deviceStaticSessionId }) => {
         const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
 

--- a/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
@@ -39,8 +39,9 @@ export const getTokenDefinitionThunk = createThunk<
     },
 );
 
-export type InitTokenDefinitionsThunkDeps = WithServices<GetTokenDefinitionsEnabledNetworksDep>;
 export type InitTokenDefinitionsThunkState = TokenDefinitionsRootState;
+
+export type InitTokenDefinitionsThunkDeps = WithServices<GetTokenDefinitionsEnabledNetworksDep>;
 
 export const initTokenDefinitionsThunk = createThunk<
     unknown[],
@@ -82,8 +83,9 @@ export const initTokenDefinitionsThunk = createThunk<
 
 let tokenDefinitionsTimeout: TimerId | null = null;
 
-type PeriodicCheckTokenDefinitionsThunkDeps = InitTokenDefinitionsThunkDeps;
 type PeriodicCheckTokenDefinitionsThunkState = InitTokenDefinitionsThunkState;
+
+type PeriodicCheckTokenDefinitionsThunkDeps = InitTokenDefinitionsThunkDeps;
 
 export const periodicCheckTokenDefinitionsThunk = createThunk<
     void,

--- a/suite-common/trading/src/thunks/common/clearQuotesAndParamsByTradingTypeThunk.ts
+++ b/suite-common/trading/src/thunks/common/clearQuotesAndParamsByTradingTypeThunk.ts
@@ -14,20 +14,17 @@ export const clearQuotesAndParamsByTradingTypeThunk = createThunk<
     void,
     ClearQuotesAndParamsByTradingTypeThunkProps,
     void
->(
-    `${TRADING_THUNK_PREFIX}/clearQuotesAndParamsByTradingType`,
-    ({ tradingType }: ClearQuotesAndParamsByTradingTypeThunkProps, { dispatch }) => {
-        switch (tradingType) {
-            case 'buy':
-                dispatch(tradingBuyActions.clearQuotesAndParams());
-                break;
+>(`${TRADING_THUNK_PREFIX}/clearQuotesAndParamsByTradingType`, ({ tradingType }, { dispatch }) => {
+    switch (tradingType) {
+        case 'buy':
+            dispatch(tradingBuyActions.clearQuotesAndParams());
+            break;
 
-            case 'sell':
-                dispatch(tradingSellActions.clearQuotesAndParams());
-                break;
+        case 'sell':
+            dispatch(tradingSellActions.clearQuotesAndParams());
+            break;
 
-            default:
-                return exhaustive(tradingType);
-        }
-    },
-);
+        default:
+            return exhaustive(tradingType);
+    }
+});

--- a/suite-common/trading/src/thunks/common/clearQuotesAndParamsByTradingTypeThunk.ts
+++ b/suite-common/trading/src/thunks/common/clearQuotesAndParamsByTradingTypeThunk.ts
@@ -10,7 +10,11 @@ export type ClearQuotesAndParamsByTradingTypeThunkProps = {
     tradingType: TradingTradeBuySellType;
 };
 
-export const clearQuotesAndParamsByTradingTypeThunk = createThunk(
+export const clearQuotesAndParamsByTradingTypeThunk = createThunk<
+    void,
+    ClearQuotesAndParamsByTradingTypeThunkProps,
+    void
+>(
     `${TRADING_THUNK_PREFIX}/clearQuotesAndParamsByTradingType`,
     ({ tradingType }: ClearQuotesAndParamsByTradingTypeThunkProps, { dispatch }) => {
         switch (tradingType) {

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -30,8 +30,8 @@ export interface LoadInitialDataThunkProps {
     forcedApiKey?: string;
 }
 
-type LoadInitialDataThunkState = TradingRootStateWithAccounts;
 export type GetTradingEnvironment = () => TradeServerEnvironment | undefined;
+type LoadInitialDataThunkState = TradingRootStateWithAccounts;
 export type LoadInitialDataThunkDeps = WithServices<{
     getSelectedAccount: () => SelectedAccountStatus;
     getTradingEnvironment: GetTradingEnvironment;

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -31,7 +31,9 @@ export interface LoadInitialDataThunkProps {
 }
 
 export type GetTradingEnvironment = () => TradeServerEnvironment | undefined;
+
 type LoadInitialDataThunkState = TradingRootStateWithAccounts;
+
 export type LoadInitialDataThunkDeps = WithServices<{
     getSelectedAccount: () => SelectedAccountStatus;
     getTradingEnvironment: GetTradingEnvironment;

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -30,14 +30,14 @@ export interface LoadInitialDataThunkProps {
     forcedApiKey?: string;
 }
 
-export type GetTradingEnvironment = () => TradeServerEnvironment | undefined;
-
 type LoadInitialDataThunkState = TradingRootStateWithAccounts;
 
 export type LoadInitialDataThunkDeps = WithServices<{
     getSelectedAccount: () => SelectedAccountStatus;
     getTradingEnvironment: GetTradingEnvironment;
 }>;
+
+export type GetTradingEnvironment = () => TradeServerEnvironment | undefined;
 
 export const loadInitialDataThunk = createThunk<
     void,

--- a/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
+++ b/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
@@ -26,6 +26,7 @@ export interface VerifyAddressThunk {
 type VerifyAddressThunkState = ConfirmAddressOnDeviceThunkState &
     TradingRootState &
     WalletSettingsRootState;
+
 type VerifyAddressThunkDeps = {
     actions: OpenModalDep;
 };

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -76,6 +76,7 @@ export const getQuoteRequestData = ({
 };
 
 type HandleExchangeRequestThunkState = AccountsRootState & TradingRootState;
+
 type HandleExchangeRequestThunkDeps = WithServices<AddressValidatorDep>;
 
 export const handleExchangeRequestThunk = createThunk<

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -145,7 +145,9 @@ export const reportAccountInfoThunk = createThunk<
 
 // Left here for clarity, but shouldn't be called anywhere but in blockchainActions.syncAccounts
 // as we usually want to update all accounts for a single coin at once
-export type FetchAndUpdateAccountThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
+type FetchAndUpdateAccountThunkParams = {
+    accountKey: AccountKey;
+};
 export type FetchAndUpdateAccountThunkState = AccountsRootState &
     BlockchainRootState &
     DeviceRootState &
@@ -153,9 +155,7 @@ export type FetchAndUpdateAccountThunkState = AccountsRootState &
     TokenDefinitionsRootState &
     TransactionsRootState &
     WalletSettingsRootState;
-type FetchAndUpdateAccountThunkParams = {
-    accountKey: AccountKey;
-};
+export type FetchAndUpdateAccountThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 
 export const fetchAndUpdateAccountThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -150,6 +150,7 @@ export const reportAccountInfoThunk = createThunk<
 type FetchAndUpdateAccountThunkParams = {
     accountKey: AccountKey;
 };
+
 export type FetchAndUpdateAccountThunkState = AccountsRootState &
     BlockchainRootState &
     DeviceRootState &

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -102,8 +102,9 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
     return tokens;
 };
 
-export type ReportWalletBalanceThunkDeps = WithServices<AnalyticsDep>;
 export type ReportWalletBalanceThunkState = AccountsRootState;
+
+export type ReportWalletBalanceThunkDeps = WithServices<AnalyticsDep>;
 
 export const reportWalletBalanceThunk = createThunk<
     void,
@@ -116,8 +117,9 @@ export const reportWalletBalanceThunk = createThunk<
     });
 });
 
-export type ReportAccountInfoThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 export type ReportAccountInfoThunkState = AccountsRootState & TokenDefinitionsRootState;
+
+export type ReportAccountInfoThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 
 export const reportAccountInfoThunk = createThunk<
     void,
@@ -155,6 +157,7 @@ export type FetchAndUpdateAccountThunkState = AccountsRootState &
     TokenDefinitionsRootState &
     TransactionsRootState &
     WalletSettingsRootState;
+
 export type FetchAndUpdateAccountThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 
 export const fetchAndUpdateAccountThunk = createThunk<

--- a/suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts
+++ b/suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts
@@ -34,7 +34,7 @@ export interface ComposeAllowanceTransactionThunkParams {
 export const composeAllowanceTransactionThunk = createThunk<
     PrecomposedLevels,
     ComposeAllowanceTransactionThunkParams,
-    { rejectValue: ComposeFeeLevelsError; state: void }
+    { rejectValue: ComposeFeeLevelsError }
 >(
     `${ALLOWANCE_MODULE_PREFIX}/composeAllowanceTransactionThunk`,
     async ({ feeInfo, account, contract, selectedFee, customFee, data }, { rejectWithValue }) => {

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -168,6 +168,7 @@ type SubscribeBlockchainThunkParams = {
     fiatRates?: boolean;
     onConnect?: boolean;
 };
+
 export type SubscribeBlockchainThunkState = AccountsRootState;
 
 // called from WalletMiddleware after ACCOUNT.ADD/UPDATE action

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -162,12 +162,12 @@ export const initBlockchainThunk = createThunk<
 const isAccountSubscribable = (account: Account) =>
     !account.failed && isTrezorConnectBackendType(account.backendType);
 
-export type SubscribeBlockchainThunkState = AccountsRootState;
 type SubscribeBlockchainThunkParams = {
     symbol: NetworkSymbol;
     fiatRates?: boolean;
     onConnect?: boolean;
 };
+export type SubscribeBlockchainThunkState = AccountsRootState;
 
 // called from WalletMiddleware after ACCOUNT.ADD/UPDATE action
 // or after BLOCKCHAIN.CONNECT event (blockchainActions.onConnect)

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -124,6 +124,7 @@ export const setCustomBackendThunk = createThunk<
 export type InitBlockchainThunkState = AccountsRootState &
     BlockchainRootState &
     WalletSettingsRootState;
+
 export type InitBlockchainThunkDeps = WithServices<AnalyticsDep>;
 
 export const initBlockchainThunk = createThunk<
@@ -275,11 +276,12 @@ const tryClearTimeout = (timeout?: TimerId) => {
     if (timeout) clearTimeout(timeout);
 };
 
+export type SyncAccountsWithBlockchainThunkState = BlockchainRootState &
+    FetchAndUpdateAccountThunkState;
+
 export type SyncAccountsWithBlockchainThunkDeps = WithServices<
     AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
 >;
-export type SyncAccountsWithBlockchainThunkState = BlockchainRootState &
-    FetchAndUpdateAccountThunkState;
 
 export const syncAccountsWithBlockchainThunk = createThunk<
     void,
@@ -331,6 +333,7 @@ export const syncAccountsWithBlockchainThunk = createThunk<
 
 type OnBlockchainConnectThunkState = SyncAccountsWithBlockchainThunkState &
     GetOrFetchRawFeeInfoThunkState;
+
 type OnBlockchainConnectThunkDeps = WithServices<
     AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
 >;
@@ -357,6 +360,7 @@ export const onBlockchainConnectThunk = createThunk<
 });
 
 type OnBlockMinedThunkState = SyncAccountsWithBlockchainThunkState;
+
 type OnBlockMinedThunkDeps = WithServices<
     AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
 >;
@@ -392,6 +396,7 @@ export const onBlockMinedThunk = createThunk<
 type OnBlockchainNotificationThunkState = DeviceRootState &
     SyncAccountsWithBlockchainThunkState &
     WalletSettingsRootState;
+
 type OnBlockchainNotificationThunkDeps = WithServices<
     AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
 >;
@@ -469,6 +474,7 @@ export const onBlockchainNotificationThunk = createThunk<
 });
 
 type OnBlockchainDisconnectThunkState = SyncAccountsWithBlockchainThunkState;
+
 type OnBlockchainDisconnectThunkDeps = WithServices<
     AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
 >;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -69,6 +69,7 @@ import {
     type WalletSettingsRootState,
     selectIsDeviceAutoEjectEnabled,
 } from '../settings/walletSettingsReducer';
+
 type HandleDeviceDisconnectThunkState = DeviceRootState;
 
 /**
@@ -107,6 +108,7 @@ type ForgetDisconnectedDevicesThunkParams = {
     device: Device | TrezorDevice;
     forceForget?: boolean;
 };
+
 type ForgetDisconnectedDevicesThunkState = DeviceRootState;
 
 /**
@@ -143,6 +145,7 @@ type ObserveSelectedDeviceResult = {
     isDeviceBecomingAcquired: boolean;
     isDeviceBecomingConnected: boolean;
 };
+
 type ObserveSelectedDeviceThunkState = DeviceRootState;
 
 /**
@@ -205,6 +208,7 @@ type AcquireDeviceThunkParams = {
     requestedDevice?: TrezorDevice | null;
     startDiscovery?: boolean;
 };
+
 type AcquireDeviceThunkState = RunDiscoveryThunkState;
 
 type AcquireDeviceThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
@@ -292,6 +296,7 @@ type ConfirmAddressOnDeviceThunk = {
     chunkify: boolean;
     showOnTrezor?: boolean;
 };
+
 export type ConfirmAddressOnDeviceThunkState = AccountsRootState & DeviceRootState;
 
 export const confirmAddressOnDeviceThunk = createThunk<
@@ -376,6 +381,7 @@ export const deviceConnectThunks = createThunk<
 type SetDeviceAutoEjectThunkParams = {
     shouldEnable: boolean;
 };
+
 export type SetDeviceAutoEjectThunkState = DeviceRootState & WalletSettingsRootState;
 
 export const setDeviceAutoEjectThunk = createThunk<
@@ -505,6 +511,7 @@ export type ForgetDeviceThunkParams = {
     skipDisconnect?: boolean;
     deviceId?: TrezorDevice['id'];
 };
+
 export type ForgetDeviceThunkState = ForgetDevicePersistentDataThunkState;
 
 export type ForgetDeviceThunkDeps = {
@@ -558,6 +565,7 @@ type HandlePostWipeCleanupThunkParams = {
     initialDevice: TrezorDevice;
     deviceInstances: AcquiredDevice[];
 };
+
 type HandlePostWipeCleanupThunkState = ForgetDevicePersistentDataThunkState;
 
 type HandlePostWipeCleanupThunkDeps = {

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -206,6 +206,7 @@ type AcquireDeviceThunkParams = {
     startDiscovery?: boolean;
 };
 type AcquireDeviceThunkState = RunDiscoveryThunkState;
+
 type AcquireDeviceThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
@@ -340,11 +341,11 @@ type DeviceConnectThunksParams = {
     device: Device;
 };
 
+export type DeviceConnectThunkState = FirmwareRootState & RunDiscoveryThunkState;
+
 export type DeviceConnectThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
-
-export type DeviceConnectThunkState = FirmwareRootState & RunDiscoveryThunkState;
 
 export const deviceConnectThunks = createThunk<
     void,
@@ -440,11 +441,12 @@ type ForgetDevicePersistentDataThunkParams = {
  * This includes wallets, `persistentDeviceData`, Bluetooth, THP.
  * But not wallets, see `forgetDevice` (ejecting wallets & forgetting the rest are separate features).
  */
+export type ForgetDevicePersistentDataThunkState = DeviceRootState &
+    WithBluetoothState<BluetoothDeviceCommon>;
+
 export type ForgetDevicePersistentDataThunkDeps = {
     thunks: ForgetBluetoothDeviceDep;
 };
-export type ForgetDevicePersistentDataThunkState = DeviceRootState &
-    WithBluetoothState<BluetoothDeviceCommon>;
 
 export const forgetDevicePersistentDataThunk = createThunk<
     void,
@@ -504,6 +506,7 @@ export type ForgetDeviceThunkParams = {
     deviceId?: TrezorDevice['id'];
 };
 export type ForgetDeviceThunkState = ForgetDevicePersistentDataThunkState;
+
 export type ForgetDeviceThunkDeps = {
     thunks: ForgetBluetoothDeviceDep;
 };
@@ -555,11 +558,12 @@ type HandlePostWipeCleanupThunkParams = {
     initialDevice: TrezorDevice;
     deviceInstances: AcquiredDevice[];
 };
+type HandlePostWipeCleanupThunkState = ForgetDevicePersistentDataThunkState;
+
 type HandlePostWipeCleanupThunkDeps = {
     actions: OpenModalDep;
     thunks: ForgetBluetoothDeviceDep;
 };
-type HandlePostWipeCleanupThunkState = ForgetDevicePersistentDataThunkState;
 
 const handlePostWipeCleanupThunk = createThunk<
     void,
@@ -603,6 +607,7 @@ const handlePostWipeCleanupThunk = createThunk<
 );
 
 type DeviceWipedFromDeviceThunkState = ForgetDevicePersistentDataThunkState;
+
 type DeviceWipedFromDeviceThunkDeps = {
     thunks: ForgetBluetoothDeviceDep;
     actions: OpenModalDep;
@@ -627,6 +632,7 @@ export const deviceWipedFromDeviceThunk = createThunk<
 });
 
 type WipeDeviceThunkState = ForgetDevicePersistentDataThunkState;
+
 type WipeDeviceThunkDeps = {
     thunks: ForgetBluetoothDeviceDep;
     actions: OpenModalDep;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -103,11 +103,11 @@ export const handleDeviceDisconnect = createThunk<
     dispatch(selectDeviceThunk({ device: available[0] }));
 });
 
-type ForgetDisconnectedDevicesThunkState = DeviceRootState;
 type ForgetDisconnectedDevicesThunkParams = {
     device: Device | TrezorDevice;
     forceForget?: boolean;
 };
+type ForgetDisconnectedDevicesThunkState = DeviceRootState;
 
 /**
  * Triggered by `@trezor/connect DEVICE_EVENT` via suiteMiddleware

--- a/suite-common/wallet-core/src/device/entropyCheckThunks.ts
+++ b/suite-common/wallet-core/src/device/entropyCheckThunks.ts
@@ -44,6 +44,7 @@ type ProcessEntropyCheckResultThunkParams = {
     device: AcquiredDevice;
     result: Awaited<ReturnType<typeof TrezorConnect.resetDevice>>;
 };
+
 type ProcessEntropyCheckResultThunkDeps = FailEntropyCheckThunkDeps;
 
 export const processEntropyCheckResultThunk = createThunk<

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -307,10 +307,11 @@ type RunDiscoveryParams = {
     callId?: string;
 };
 
+export type RunDiscoveryThunkState = DiscoveryReportingThunkState;
+
 export type RunDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
-export type RunDiscoveryThunkState = DiscoveryReportingThunkState;
 
 export const runDiscoveryThunk = createThunk<
     void,
@@ -624,6 +625,7 @@ type StartDiscoveryThunkParams = {
     useScopedCallIds?: boolean;
 };
 export type StartDiscoveryThunkState = RunDiscoveryThunkState;
+
 export type StartDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };
@@ -667,6 +669,7 @@ export const startDiscoveryThunk = createThunk<
 );
 
 type RunAdditionalDiscoveryThunkState = RunDiscoveryThunkState;
+
 type RunAdditionalDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 
 export const runAdditionalDiscoveryThunk = createThunk<
@@ -837,6 +840,7 @@ export const submitPassphrase = createThunk<
 );
 
 type StartOrRestartDiscoveryThunkState = RunDiscoveryThunkState;
+
 type StartOrRestartDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
     thunks: FetchAndSaveMetadataDep;
 };

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -794,13 +794,13 @@ export const runAdditionalDiscoveryThunk = createThunk<
     },
 );
 
-type SubmitPassphraseThunkState = DiscoveryRootState;
 type SubmitPassphraseThunkParams = {
     device: TrezorDevice;
     passphrase: string;
     passphraseOnDevice?: boolean;
     requestId?: string;
 };
+type SubmitPassphraseThunkState = DiscoveryRootState;
 
 export const submitPassphrase = createThunk<
     void,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -89,6 +89,7 @@ const deviceStateEqualTo = (first: DeviceState) => {
     return (second?: DeviceState) =>
         firstParsed ? firstParsed === second?.staticSessionId?.split(':')[0] : false;
 };
+
 type ApplyDeviceStatesThunkState = DeviceRootState & WalletSettingsRootState;
 
 export const applyDeviceStatesThunk = createThunk<
@@ -231,6 +232,7 @@ type ApplyDeviceStateErrorThunkProps = {
     code: string | undefined;
     devicePath: DeviceUniquePath;
 };
+
 type ApplyDeviceStateErrorThunkState = DiscoveryRootState;
 
 const applyDeviceStateErrorThunk = createThunk<
@@ -624,6 +626,7 @@ type StartDiscoveryThunkParams = {
     isAddingExistingWallet?: boolean;
     useScopedCallIds?: boolean;
 };
+
 export type StartDiscoveryThunkState = RunDiscoveryThunkState;
 
 export type StartDiscoveryThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
@@ -803,6 +806,7 @@ type SubmitPassphraseThunkParams = {
     passphraseOnDevice?: boolean;
     requestId?: string;
 };
+
 type SubmitPassphraseThunkState = DiscoveryRootState;
 
 export const submitPassphrase = createThunk<

--- a/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
@@ -18,14 +18,14 @@ import {
 import { defaultTrezorUIEventHandlerThunk } from '../uiEvent/defaultTrezorUIEventHandlerThunk';
 import { registerScopedCallId, unregisterScopedCallId } from '../uiEvent/scopedCallIdRegistry';
 
+type RunPassphraseWalletAddingDiscoveryThunkParams = {
+    device: TrezorDevice;
+};
+type RunPassphraseWalletAddingDiscoveryThunkState = RunDiscoveryThunkState;
 type RunPassphraseWalletAddingDiscoveryThunkDeps = WithServices<
     AnalyticsDep & ConnectInitHooksDeps & GetTradedAccountKeysDep
 > & {
     thunks: FetchAndSaveMetadataDep;
-};
-type RunPassphraseWalletAddingDiscoveryThunkState = RunDiscoveryThunkState;
-type RunPassphraseWalletAddingDiscoveryThunkParams = {
-    device: TrezorDevice;
 };
 
 // The "run" step. Exported because for a *new* hidden wallet the run is deferred from

--- a/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
@@ -22,6 +22,7 @@ type RunPassphraseWalletAddingDiscoveryThunkParams = {
     device: TrezorDevice;
 };
 type RunPassphraseWalletAddingDiscoveryThunkState = RunDiscoveryThunkState;
+
 type RunPassphraseWalletAddingDiscoveryThunkDeps = WithServices<
     AnalyticsDep & ConnectInitHooksDeps & GetTradedAccountKeysDep
 > & {
@@ -70,6 +71,7 @@ type StartDiscoveryOfExistingPassphraseWalletThunkPayload = {
     useScopedCallIds?: boolean;
 };
 type StartDiscoveryOfExistingPassphraseWalletThunkState = RunDiscoveryThunkState;
+
 type StartDiscoveryOfExistingPassphraseWalletThunkDeps = WithServices<
     AnalyticsDep & ConnectInitHooksDeps & GetTradedAccountKeysDep
 > & {
@@ -123,6 +125,7 @@ type StartAddWalletDiscoveryThunkParams = {
 };
 type StartAddWalletDiscoveryThunkState = StartDiscoveryOfExistingPassphraseWalletThunkState &
     StartDiscoveryThunkState;
+
 type StartAddWalletDiscoveryThunkDeps = StartDiscoveryOfExistingPassphraseWalletThunkDeps &
     StartDiscoveryThunkDeps;
 

--- a/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
@@ -21,6 +21,7 @@ import { registerScopedCallId, unregisterScopedCallId } from '../uiEvent/scopedC
 type RunPassphraseWalletAddingDiscoveryThunkParams = {
     device: TrezorDevice;
 };
+
 type RunPassphraseWalletAddingDiscoveryThunkState = RunDiscoveryThunkState;
 
 type RunPassphraseWalletAddingDiscoveryThunkDeps = WithServices<
@@ -70,6 +71,7 @@ type StartDiscoveryOfExistingPassphraseWalletThunkPayload = {
     isAddingHiddenWallet?: boolean;
     useScopedCallIds?: boolean;
 };
+
 type StartDiscoveryOfExistingPassphraseWalletThunkState = RunDiscoveryThunkState;
 
 type StartDiscoveryOfExistingPassphraseWalletThunkDeps = WithServices<
@@ -123,6 +125,7 @@ type StartAddWalletDiscoveryThunkParams = {
     isAddingHiddenWallet?: boolean;
     isAddingExistingWallet?: boolean;
 };
+
 type StartAddWalletDiscoveryThunkState = StartDiscoveryOfExistingPassphraseWalletThunkState &
     StartDiscoveryThunkState;
 

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -18,6 +18,7 @@ import { isNative } from '@trezor/env-utils';
 type SelectDeviceThunkParams = {
     device: Device | TrezorDevice | undefined;
 };
+
 type SelectDeviceThunkState = DeviceRootState;
 
 /**

--- a/suite-common/wallet-core/src/explorer/explorerThunks.ts
+++ b/suite-common/wallet-core/src/explorer/explorerThunks.ts
@@ -10,6 +10,7 @@ type SetNetworkExplorerThunkParams = {
     symbol: NetworkSymbol;
     explorer?: Explorer;
 };
+
 type SetNetworkExplorerThunkState = ExplorerState;
 
 type SetNetworkExplorerThunkDeps = WithServices<AnalyticsDep>;

--- a/suite-common/wallet-core/src/explorer/explorerThunks.ts
+++ b/suite-common/wallet-core/src/explorer/explorerThunks.ts
@@ -11,6 +11,7 @@ type SetNetworkExplorerThunkParams = {
     explorer?: Explorer;
 };
 type SetNetworkExplorerThunkState = ExplorerState;
+
 type SetNetworkExplorerThunkDeps = WithServices<AnalyticsDep>;
 
 export const setNetworkExplorerThunk = createThunk<

--- a/suite-common/wallet-core/src/explorer/explorerThunks.ts
+++ b/suite-common/wallet-core/src/explorer/explorerThunks.ts
@@ -6,12 +6,12 @@ import { EXPLORER_MODULE_PREFIX, explorerActions } from './explorerActions';
 import { type ExplorerState } from './explorerReducer';
 import { selectNetworkExplorerType } from './explorerSelectors';
 
-type SetNetworkExplorerThunkDeps = WithServices<AnalyticsDep>;
-type SetNetworkExplorerThunkState = ExplorerState;
 type SetNetworkExplorerThunkParams = {
     symbol: NetworkSymbol;
     explorer?: Explorer;
 };
+type SetNetworkExplorerThunkState = ExplorerState;
+type SetNetworkExplorerThunkDeps = WithServices<AnalyticsDep>;
 
 export const setNetworkExplorerThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -18,6 +18,7 @@ import {
     type WalletSettingsRootState,
     selectEnabledNetworks,
 } from '../settings/walletSettingsReducer';
+
 type PreloadFeeInfoThunkState = WalletSettingsRootState;
 
 // Conditionally subscribe to blockchain backend
@@ -75,6 +76,7 @@ type UpdateFeeInfoThunkProps = {
     networkSymbol: NetworkSymbol;
     artificialDelay?: number;
 };
+
 export type UpdateFeeInfoThunkState = BlockchainRootState & DeviceRootState & FeesRootState;
 
 /**
@@ -126,6 +128,7 @@ export const updateFeeInfoThunk = createThunk<
 interface GetOrFetchRawFeeInfoThunkProps {
     networkSymbol: NetworkSymbol;
 }
+
 export type GetOrFetchRawFeeInfoThunkState = UpdateFeeInfoThunkState;
 
 export const getOrFetchRawFeeInfoThunk = createThunk<

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -123,11 +123,10 @@ export const updateFeeInfoThunk = createThunk<
     },
 );
 
-export type GetOrFetchRawFeeInfoThunkState = UpdateFeeInfoThunkState;
-
 interface GetOrFetchRawFeeInfoThunkProps {
     networkSymbol: NetworkSymbol;
 }
+export type GetOrFetchRawFeeInfoThunkState = UpdateFeeInfoThunkState;
 
 export const getOrFetchRawFeeInfoThunk = createThunk<
     FeeInfo | undefined,

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -385,8 +385,9 @@ type PeriodicFetchFiatRatesThunkPayload = {
     localCurrency: BaseCurrencyCode;
 };
 
-export type PeriodicFetchFiatRatesThunkDeps = WithServices<GetIsWindowVisibleDep>;
 export type PeriodicFetchFiatRatesThunkState = FetchFiatRatesThunkState;
+
+export type PeriodicFetchFiatRatesThunkDeps = WithServices<GetIsWindowVisibleDep>;
 
 export const periodicFetchFiatRatesThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -190,6 +190,7 @@ type UpdateCurrentFiatRatesThunkPayload = {
     forceFetchToken?: boolean;
     skipCache?: boolean;
 };
+
 export type UpdateFiatRatesThunkState = BlockchainRootState & TokenDefinitionsRootState;
 
 export const updateFiatRatesThunk = createThunk<
@@ -285,6 +286,7 @@ type UpdateMissingTxFiatRatesThunkParams = {
     localCurrency: BaseCurrencyCode;
     accountKey?: AccountKey;
 };
+
 export type UpdateMissingTxFiatRatesThunkState = FiatRatesRootState &
     TransactionsRootState &
     UpdateTxsFiatRatesThunkState;

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -281,13 +281,13 @@ export const updateFiatRatesThunk = createThunk<
     },
 );
 
-export type UpdateMissingTxFiatRatesThunkState = FiatRatesRootState &
-    TransactionsRootState &
-    UpdateTxsFiatRatesThunkState;
 type UpdateMissingTxFiatRatesThunkParams = {
     localCurrency: BaseCurrencyCode;
     accountKey?: AccountKey;
 };
+export type UpdateMissingTxFiatRatesThunkState = FiatRatesRootState &
+    TransactionsRootState &
+    UpdateTxsFiatRatesThunkState;
 
 export const updateMissingTxFiatRatesThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -61,6 +61,7 @@ const getSequence = ({ account, formValues }: GetSequenceParams) => {
 
     return undefined; // Must be undefined for final (non-RBF) transaction with no locktime
 };
+
 type ComposeBitcoinTransactionFeeLevelsThunkState = DeviceRootState & WalletSettingsRootState;
 
 export const composeBitcoinTransactionFeeLevelsThunk = createThunk<

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -28,6 +28,7 @@ import {
     type WalletSettingsRootState,
     selectAddressDisplayType,
 } from '../settings/walletSettingsReducer';
+
 type ComposeCardanoTransactionFeeLevelsThunkState = void;
 
 export const composeCardanoTransactionFeeLevelsThunk = createThunk<
@@ -148,6 +149,7 @@ type SignCardanoTransactionThunkArguments = Omit<
 > & {
     precomposedTransaction: PrecomposedTransactionFinalCardano;
 };
+
 type SignCardanoSendFormTransactionThunkState = WalletSettingsRootState;
 
 export const signCardanoSendFormTransactionThunk = createThunk<

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -269,6 +269,7 @@ export const calculate = (
 
     return payloadData;
 };
+
 type ComposeEthereumTransactionFeeLevelsThunkState = DeviceRootState & TransactionsRootState;
 
 export const composeEthereumTransactionFeeLevelsThunk = createThunk<
@@ -540,6 +541,7 @@ interface EthereumGetCurrentNonceThunkParams {
     // See ResolveEthereumNonceParams: temporarily required so no caller can silently fall back to the stale nonce.
     fetchConfirmedNonce?: boolean;
 }
+
 export type EthereumGetCurrentNonceThunkState = TransactionsRootState;
 
 export const ethereumGetCurrentNonceThunk = createThunk<

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -111,6 +111,7 @@ const calculate = (
 
     return payloadData;
 };
+
 type ComposeRippleStellarTransactionFeeLevelsThunkState = void;
 
 export const composeRippleStellarTransactionFeeLevelsThunk = createThunk<

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -167,6 +167,7 @@ function assertIsSolanaAccount(
     if (account.networkType !== 'solana')
         throw new Error(`Invalid network type. ${account.networkType}`);
 }
+
 type ComposeSolanaTransactionFeeLevelsThunkState = BlockchainRootState;
 
 export const composeSolanaTransactionFeeLevelsThunk = createThunk<

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -260,10 +260,11 @@ export const composeSendFormTransactionFeeLevelsThunk = createThunk<
     },
 );
 
+export type CancelSignSendFormTransactionThunkState = SendRootState;
+
 export type CancelSignSendFormTransactionThunkDeps = {
     actions: OnModalCancelDep;
 };
-export type CancelSignSendFormTransactionThunkState = SendRootState;
 
 export const cancelSignSendFormTransactionThunk = createThunk<
     void,
@@ -307,6 +308,7 @@ type SynchronizeSentTransactionThunkParams = {
 export type SynchronizeSentTransactionThunkState = FeesRootState &
     SendRootState &
     SyncAccountsWithBlockchainThunkState;
+
 export type SynchronizeSentTransactionThunkDeps = WithServices<
     AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
 >;
@@ -399,6 +401,7 @@ export const synchronizeSentTransactionThunk = createThunk<
 );
 
 export type PushSendFormTransactionThunkState = SynchronizeSentTransactionThunkState;
+
 export type PushSendFormTransactionThunkDeps = {
     actions: OnModalCancelDep;
     services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
@@ -581,6 +584,7 @@ type PushSendFormRawTransactionThunkParams = {
     isMevProtectionEnabled: boolean;
 };
 type PushSendFormRawTransactionThunkState = DeviceRootState & SyncAccountsWithBlockchainThunkState;
+
 type PushSendFormRawTransactionThunkDeps = WithServices<
     AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep
 >;

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -121,6 +121,7 @@ type ConvertSendFormDraftsBtcAmountUnitsThunkParams = {
     selectedAccountKey?: AccountKey;
     isOnSendPage?: boolean;
 };
+
 type ConvertSendFormDraftsBtcAmountUnitsThunkState = AccountsRootState &
     SendRootState &
     WalletSettingsRootState;
@@ -185,6 +186,7 @@ type CoinSpecificComposeResponse = ActionsFromAsyncThunk<
     | typeof composeSolanaTransactionFeeLevelsThunk
     | typeof composeTronTransactionFeeLevelsThunk
 >;
+
 export type ComposeSendFormTransactionFeeLevelsThunkState = BlockchainRootState &
     DeviceRootState &
     WalletSettingsRootState;
@@ -305,6 +307,7 @@ type SynchronizeSentTransactionThunkParams = {
     // account.misc.nonce (which reads one too high until the backend picks up the real tx).
     ethereumNonce?: string;
 };
+
 export type SynchronizeSentTransactionThunkState = FeesRootState &
     SendRootState &
     SyncAccountsWithBlockchainThunkState;
@@ -583,6 +586,7 @@ type PushSendFormRawTransactionThunkParams = {
     identity?: string;
     isMevProtectionEnabled: boolean;
 };
+
 type PushSendFormRawTransactionThunkState = DeviceRootState & SyncAccountsWithBlockchainThunkState;
 
 type PushSendFormRawTransactionThunkDeps = WithServices<
@@ -656,6 +660,7 @@ type SignTransactionThunkParams = {
     selectedAccount: Account;
     paymentRequests?: PROTO.PaymentRequest[];
 };
+
 export type SignTransactionThunkState = AccountsRootState &
     DeviceRootState &
     TransactionsRootState &

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -117,13 +117,13 @@ import {
     signTronSendFormTransactionThunk,
 } from './tron/sendFormTronThunks';
 
-type ConvertSendFormDraftsBtcAmountUnitsThunkState = AccountsRootState &
-    SendRootState &
-    WalletSettingsRootState;
 type ConvertSendFormDraftsBtcAmountUnitsThunkParams = {
     selectedAccountKey?: AccountKey;
     isOnSendPage?: boolean;
 };
+type ConvertSendFormDraftsBtcAmountUnitsThunkState = AccountsRootState &
+    SendRootState &
+    WalletSettingsRootState;
 
 export const convertSendFormDraftsBtcAmountUnitsThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldApprovalThunks.ts
@@ -183,13 +183,13 @@ export const openYieldRevokeModal = ({
         txType: 'revoke',
     });
 };
-type HandleYieldApproveSuccessTxidThunkState = StablecoinYieldRootState;
 type HandleYieldApproveSuccessTxidThunkParams = YieldSessionPayload & {
     fee?: string;
     isAmountUnlimited?: boolean;
     submittedAt?: number;
     txid: string;
 };
+type HandleYieldApproveSuccessTxidThunkState = StablecoinYieldRootState;
 
 export const handleYieldApproveSuccessTxidThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldApprovalThunks.ts
@@ -189,6 +189,7 @@ type HandleYieldApproveSuccessTxidThunkParams = YieldSessionPayload & {
     submittedAt?: number;
     txid: string;
 };
+
 type HandleYieldApproveSuccessTxidThunkState = StablecoinYieldRootState;
 
 export const handleYieldApproveSuccessTxidThunk = createThunk<

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts
@@ -59,6 +59,7 @@ type ComposeYieldDepositTransactionPayload = {
     flowData: YieldFlowResolvedData;
     amount: string;
 };
+
 export type ComposeYieldDepositTransactionThunkState = ComposeYieldEvmTransactionThunkState;
 
 export const composeYieldDepositTransactionThunk = createThunk<

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWithdrawThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWithdrawThunks.ts
@@ -30,10 +30,10 @@ type ComposeYieldWithdrawTransactionPayload = {
     flowType: YieldWithdrawFlowType;
 };
 
-export type ComposeYieldWithdrawTransactionThunkState = ComposeYieldEvmTransactionThunkState;
-
 export const isYieldWithdrawFeeError = (reason: ComposeYieldWithdrawErrorReason) =>
     reason === 'fee-estimation-failed' || reason === 'missing-fee-level';
+
+export type ComposeYieldWithdrawTransactionThunkState = ComposeYieldEvmTransactionThunkState;
 
 export const composeYieldWithdrawTransactionThunk = createThunk<
     ComposeYieldWithdrawResult,

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
@@ -52,6 +52,7 @@ type ComposeYieldUnwrapTransactionPayload = {
     token: Pick<YieldFlowDisplayToken, 'contractAddress' | 'decimals'>;
     unwrapAmount: string;
 };
+
 export type ComposeYieldWrapTransactionThunkState = ComposeYieldEvmTransactionThunkState;
 
 /**

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
@@ -99,8 +99,6 @@ export const composeYieldWrapTransactionThunk = createThunk<
     },
 );
 
-export type TrackWrappedNativeTokenThunkState = AccountsRootState;
-
 type TrackWrappedNativeTokenPayload = {
     accountKey: AccountKey;
     /**
@@ -111,6 +109,8 @@ type TrackWrappedNativeTokenPayload = {
      */
     mode?: 'fetch-balance' | 'ensure-tracked';
 };
+
+export type TrackWrappedNativeTokenThunkState = AccountsRootState;
 
 /**
  * Makes sure the account tracks the wrapped-native token (e.g. WETH) of its network. Wrapping

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -24,6 +24,7 @@ function stakingDataNeedsRefetch(data: StakeRootState['wallet']['stake']['data']
 
     return shouldRefetch;
 }
+
 export type InitStakeDataThunkState = StakeRootState & WalletSettingsRootState;
 
 export const initStakeDataThunk = createThunk<void, void, { state: InitStakeDataThunkState }>(

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -794,7 +794,7 @@ type FetchTransactionsFromNowUntilTimestampParams = {
     accountKey: AccountKey;
     timestamp: Timestamp | null;
 };
-export type FetchTransactionsFromNowUntilTimestampState = AccountsRootState &
+export type FetchTransactionsFromNowUntilTimestampThunkState = AccountsRootState &
     TransactionsRootState &
     FetchAllTransactionsForAccountThunkState &
     FetchTransactionsPageThunkState;
@@ -802,7 +802,7 @@ export type FetchTransactionsFromNowUntilTimestampState = AccountsRootState &
 export const fetchTransactionsFromNowUntilTimestamp = createSingleInstanceThunk<
     FetchTransactionsFromNowUntilTimestampParams,
     WalletAccountTransaction[],
-    { state: FetchTransactionsFromNowUntilTimestampState }
+    { state: FetchTransactionsFromNowUntilTimestampThunkState }
 >(
     `${TRANSACTIONS_MODULE_PREFIX}/fetchTransactionsForAccount`,
     async ({ accountKey, timestamp }, { dispatch, getState }) => {

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -71,6 +71,7 @@ interface ReplaceTransactionThunkParams {
     precomposedTransaction: PrecomposedTransactionFinalBumpFeeRbf;
     newTxid: string;
 }
+
 export type ReplaceTransactionThunkState = AccountsRootState &
     SendRootState &
     TransactionsRootState;
@@ -148,6 +149,7 @@ interface AddFakePendingTransactionParams {
     precomposedTransaction: PrecomposedTransactionFinal;
     account: Account;
 }
+
 type AddFakePendingTxThunkState = AccountsRootState & BlockchainRootState & SendRootState;
 
 export const addFakePendingTxThunk = createThunk<
@@ -378,6 +380,7 @@ type AddFakePendingEvmTxThunkParams = {
     // correct it yet.
     ethereumNonce?: string;
 };
+
 type AddFakePendingEvmTxThunkState = BlockchainRootState & FeesRootState & TransactionsRootState;
 
 export const addFakePendingEvmTxThunk = createThunk<
@@ -449,6 +452,7 @@ type AddFakePendingCardanoTxThunkParams = {
     account: Account;
     cardanoSpecific?: WalletAccountTransaction['cardanoSpecific'];
 };
+
 type AddFakePendingCardanoTxThunkState = BlockchainRootState;
 
 export const addFakePendingCardanoTxThunk = createThunk<
@@ -500,6 +504,7 @@ interface AddFakePendingTronTxThunkParams {
     target?: { addresses: string[]; amount: string };
     tronSpecific?: WalletAccountTransaction['tronSpecific'];
 }
+
 export type AddFakePendingTronTxThunkState = BlockchainRootState & FeesRootState;
 
 export const addFakePendingTronTxThunk = createThunk<
@@ -566,6 +571,7 @@ type FetchTransactionsPageThunkParams = {
     noLoading?: boolean;
     forceRefetch?: boolean;
 };
+
 type FetchTransactionsPageThunkState = AccountsRootState &
     BlockchainRootState &
     TransactionsRootState;
@@ -654,6 +660,7 @@ export const fetchTransactionsPageThunk = createThunk<
 type FetchUtxoTransactionsForAccountThunkParams = {
     accountKey: AccountKey;
 };
+
 type FetchUtxoTransactionsForAccountThunkState = AccountsRootState & TransactionsRootState;
 
 export const fetchUtxoTransactionsForAccountThunk = createSingleInstanceThunk<
@@ -707,6 +714,7 @@ type FetchAllTransactionsForAccountThunkParams = {
     accountKey: AccountKey;
     noLoading?: boolean;
 };
+
 type FetchAllTransactionsForAccountThunkState = AccountsRootState &
     TransactionsRootState &
     FetchTransactionsPageThunkState;
@@ -794,6 +802,7 @@ type FetchTransactionsFromNowUntilTimestampParams = {
     accountKey: AccountKey;
     timestamp: Timestamp | null;
 };
+
 export type FetchTransactionsFromNowUntilTimestampThunkState = AccountsRootState &
     TransactionsRootState &
     FetchAllTransactionsForAccountThunkState &

--- a/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.ts
+++ b/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.ts
@@ -10,6 +10,7 @@ const MODULE = '@common/wallet-core/uiEvent';
 export type UiEventAction = Without<UiEventMessage | PopupEventMessage, 'event'>;
 
 export type DefaultTrezorUIEventHandlerThunkState = DeviceRootState;
+
 export type DefaultTrezorUIEventHandlerThunkDeps = WithServices<ConnectInitHooksDeps>;
 
 export const defaultTrezorUIEventHandlerThunk = createThunk<

--- a/suite-common/walletconnect/src/adapters/bitcoin.ts
+++ b/suite-common/walletconnect/src/adapters/bitcoin.ts
@@ -38,6 +38,7 @@ const findAccount = (accounts: Account[], firstAddress: string) =>
 export type BitcoinRequestThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
     AccountsRootState &
     WalletConnectStateRootState;
+
 export type BitcoinRequestThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
 const bitcoinRequestThunk = createThunk<

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -47,6 +47,7 @@ export type EthereumRequestThunkState = trezorConnectPopupActions.ConnectPopupCa
     MevProtectionRootState &
     WalletSettingsRootState &
     TransactionsRootState;
+
 export type EthereumRequestThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
 const ethereumRequestThunk = createThunk<

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -30,6 +30,7 @@ const methods = [
 
 type SolanaSignTransactionThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
     AccountsRootState;
+
 type SolanaSignTransactionThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
 const solanaSignTransaction = createThunk<
@@ -111,6 +112,7 @@ const solanaSignTransaction = createThunk<
 );
 
 export type SolanaRequestThunkState = SolanaSignTransactionThunkState & WalletConnectStateRootState;
+
 export type SolanaRequestThunkDeps = SolanaSignTransactionThunkDeps;
 
 const solanaRequestThunk = createThunk<

--- a/suite-common/walletconnect/src/adapters/stellar.ts
+++ b/suite-common/walletconnect/src/adapters/stellar.ts
@@ -60,6 +60,7 @@ const resolveStellarRequestContext = (event: WalletKitTypes.SessionRequest) => {
 
 type StellarSignXDRThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
     AccountsRootState;
+
 type StellarSignXDRThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
 const stellarSignXDR = createThunk<
@@ -133,6 +134,7 @@ const stellarSignXDR = createThunk<
 );
 
 export type StellarRequestThunkState = StellarSignXDRThunkState & WalletConnectStateRootState;
+
 export type StellarRequestThunkDeps = StellarSignXDRThunkDeps;
 
 const stellarRequestThunk = createThunk<

--- a/suite-common/walletconnect/src/adapters/tron.ts
+++ b/suite-common/walletconnect/src/adapters/tron.ts
@@ -108,6 +108,7 @@ const processNamespaces = (
 export type TronRequestThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
     AccountsRootState &
     WalletConnectStateRootState;
+
 export type TronRequestThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
 const tronRequestThunk = createThunk<

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -42,6 +42,7 @@ type SuccessfulAccountsThunkState = AccountsRootState & DeviceRootState & Wallet
 
 type SessionAuthenticateThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
     SuccessfulAccountsThunkState;
+
 type SessionAuthenticateThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
 const sessionAuthenticateThunk = createThunk<
@@ -132,6 +133,7 @@ const sessionAuthenticateThunk = createThunk<
 });
 
 type SessionProposalThunkState = SuccessfulAccountsThunkState;
+
 type SessionProposalThunkDeps = WithServices<AnalyticsDep>;
 
 const sessionProposalThunk = createThunk<
@@ -167,6 +169,7 @@ const sessionProposalThunk = createThunk<
 });
 
 type SessionRequestThunkState = WalletConnectRequestThunkState;
+
 type SessionRequestThunkDeps = WalletConnectRequestThunkDeps;
 
 const sessionRequestThunk = createThunk<
@@ -292,6 +295,7 @@ export const switchSelectedAccountThunk = createThunk<
 );
 
 type SessionProposalApproveThunkState = SuccessfulAccountsThunkState & WalletConnectStateRootState;
+
 type SessionProposalApproveThunkDeps = WithServices<AnalyticsDep>;
 
 export const sessionProposalApproveThunk = createThunk<
@@ -374,6 +378,7 @@ export const sessionProposalApproveThunk = createThunk<
 );
 
 type SessionProposalRejectThunkState = WalletConnectStateRootState;
+
 type SessionProposalRejectThunkDeps = WithServices<AnalyticsDep>;
 
 export const sessionProposalRejectThunk = createThunk<
@@ -404,6 +409,7 @@ export type WalletConnectInitThunkState = SessionAuthenticateThunkState &
     SessionProposalThunkState &
     SessionRequestThunkState &
     SessionProposalRejectThunkState;
+
 export type WalletConnectInitThunkDeps = SessionAuthenticateThunkDeps &
     SessionProposalThunkDeps &
     SessionRequestThunkDeps &
@@ -469,6 +475,7 @@ export const walletConnectInitThunk = createThunk<
 });
 
 type WalletConnectPairThunkState = WalletConnectInitThunkState;
+
 type WalletConnectPairThunkDeps = WalletConnectInitThunkDeps;
 
 export const walletConnectPairThunk = createThunk<

--- a/suite-native/analytics-redux/src/analyticsThunks.ts
+++ b/suite-native/analytics-redux/src/analyticsThunks.ts
@@ -19,36 +19,34 @@ const ACTION_PREFIX = '@suite-native/analytics';
 
 type EnableAnalyticsThunkDeps = WithServices<NativeAnalyticsDep>;
 
-const enableAnalyticsThunk = createThunk<
-    void,
-    void,
-    { state: void; extra: EnableAnalyticsThunkDeps }
->(`${ACTION_PREFIX}/enableAnalyticsThunk`, (_, { dispatch, extra }) => {
-    extra.services.analytics.report({
-        type: events.settingsDataPermissionEvent.name,
-        payload: { analyticsPermission: true },
-    });
-    allowSentryReport(true);
-    dispatch(analyticsActions.enableAnalytics());
-});
+const enableAnalyticsThunk = createThunk<void, void, { extra: EnableAnalyticsThunkDeps }>(
+    `${ACTION_PREFIX}/enableAnalyticsThunk`,
+    (_, { dispatch, extra }) => {
+        extra.services.analytics.report({
+            type: events.settingsDataPermissionEvent.name,
+            payload: { analyticsPermission: true },
+        });
+        allowSentryReport(true);
+        dispatch(analyticsActions.enableAnalytics());
+    },
+);
 
 type DisableAnalyticsThunkDeps = WithServices<NativeAnalyticsDep>;
 
-const disableAnalyticsThunk = createThunk<
-    void,
-    void,
-    { state: void; extra: DisableAnalyticsThunkDeps }
->(`${ACTION_PREFIX}/disableAnalyticsThunk`, (_, { dispatch, extra }) => {
-    extra.services.analytics.report(
-        {
-            type: events.settingsDataPermissionEvent.name,
-            payload: { analyticsPermission: false },
-        },
-        { force: true },
-    );
-    allowSentryReport(false);
-    dispatch(analyticsActions.disableAnalytics());
-});
+const disableAnalyticsThunk = createThunk<void, void, { extra: DisableAnalyticsThunkDeps }>(
+    `${ACTION_PREFIX}/disableAnalyticsThunk`,
+    (_, { dispatch, extra }) => {
+        extra.services.analytics.report(
+            {
+                type: events.settingsDataPermissionEvent.name,
+                payload: { analyticsPermission: false },
+            },
+            { force: true },
+        );
+        allowSentryReport(false);
+        dispatch(analyticsActions.disableAnalytics());
+    },
+);
 
 export type InitAnalyticsThunkState = AnalyticsRootState;
 export type InitAnalyticsThunkDeps = WithServices<NativeAnalyticsDep>;

--- a/suite-native/analytics-redux/src/analyticsThunks.ts
+++ b/suite-native/analytics-redux/src/analyticsThunks.ts
@@ -49,6 +49,7 @@ const disableAnalyticsThunk = createThunk<void, void, { extra: DisableAnalyticsT
 );
 
 export type InitAnalyticsThunkState = AnalyticsRootState;
+
 export type InitAnalyticsThunkDeps = WithServices<NativeAnalyticsDep>;
 
 export const initAnalyticsThunk = createThunk<

--- a/suite-native/app-init/src/appInitThunks.ts
+++ b/suite-native/app-init/src/appInitThunks.ts
@@ -59,6 +59,7 @@ type PostOnboardingInitThunkState = ConnectInitThunkState &
     PeriodicFetchFiatRatesThunkState &
     CreateImportedDeviceThunkState &
     WalletConnectInitThunkState;
+
 type PostOnboardingInitThunkDeps = ConnectInitThunkDeps &
     InitBlockchainThunkDeps &
     InitTokenDefinitionsThunkDeps &
@@ -107,6 +108,7 @@ type ApplicationInitThunkState = SettingsSliceRootState &
     MessageSystemRootState &
     InitAnalyticsThunkState &
     PostOnboardingInitThunkState;
+
 type ApplicationInitThunkDeps = InitAnalyticsThunkDeps & PostOnboardingInitThunkDeps;
 
 export const applicationInit = createThunk<

--- a/suite-native/biometrics/src/biometricsThunks.ts
+++ b/suite-native/biometrics/src/biometricsThunks.ts
@@ -43,7 +43,7 @@ const BIOMETRICS_THUNK_PREFIX = 'biometrics';
 export const authenticateUserThunk = createThunk<
     LocalAuthenticationResult,
     void,
-    { rejectValue: AuthenticateError; state: void }
+    { rejectValue: AuthenticateError }
 >(`${BIOMETRICS_THUNK_PREFIX}/authenticate`, async (_, { rejectWithValue }) => {
     const isBiometricsAvailable = await getIsBiometricsFeatureAvailable();
 

--- a/suite-native/biometrics/src/biometricsThunks.ts
+++ b/suite-native/biometrics/src/biometricsThunks.ts
@@ -61,6 +61,7 @@ export const authenticateUserThunk = createThunk<
 });
 
 type ToggleBiometricsSettingsThunkState = BiometricsSliceRootState;
+
 type ToggleBiometricsSettingsThunkDeps = WithServices<NativeAnalyticsDep>;
 
 export const toggleBiometricsSettingsThunk = createThunk<

--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -41,6 +41,7 @@ const shouldRefetchAccount = ({
 
 type SyncAccountsWithBlockchainThunkParams = { symbol: NetworkSymbol };
 export type SyncAccountsWithBlockchainThunkState = FetchAndUpdateAccountThunkState;
+
 export type SyncAccountsWithBlockchainThunkDeps = FetchAndUpdateAccountThunkDeps;
 
 export const syncAccountsWithBlockchainThunk = createThunk<
@@ -69,6 +70,7 @@ export const syncAccountsWithBlockchainThunk = createThunk<
 });
 
 export type SyncAllAccountsWithBlockchainThunkState = SyncAccountsWithBlockchainThunkState;
+
 export type SyncAllAccountsWithBlockchainThunkDeps = SyncAccountsWithBlockchainThunkDeps;
 
 export const syncAllAccountsWithBlockchainThunk = createThunk<
@@ -91,6 +93,7 @@ export const syncAllAccountsWithBlockchainThunk = createThunk<
 type OnBlockchainConnectThunkParams = { symbol: string };
 export type OnBlockchainConnectThunkState = SubscribeBlockchainThunkState &
     SyncAccountsWithBlockchainThunkState;
+
 export type OnBlockchainConnectThunkDeps = SyncAccountsWithBlockchainThunkDeps;
 
 export const onBlockchainConnectThunk = createThunk<
@@ -111,6 +114,7 @@ export const onBlockchainConnectThunk = createThunk<
 });
 
 export type OnBlockchainNotificationThunkState = FetchAndUpdateAccountThunkState;
+
 export type OnBlockchainNotificationThunkDeps = FetchAndUpdateAccountThunkDeps;
 
 export const onBlockchainNotificationThunk = createThunk<

--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -40,6 +40,7 @@ const shouldRefetchAccount = ({
 };
 
 type SyncAccountsWithBlockchainThunkParams = { symbol: NetworkSymbol };
+
 export type SyncAccountsWithBlockchainThunkState = FetchAndUpdateAccountThunkState;
 
 export type SyncAccountsWithBlockchainThunkDeps = FetchAndUpdateAccountThunkDeps;
@@ -91,6 +92,7 @@ export const syncAllAccountsWithBlockchainThunk = createThunk<
 });
 
 type OnBlockchainConnectThunkParams = { symbol: string };
+
 export type OnBlockchainConnectThunkState = SubscribeBlockchainThunkState &
     SyncAccountsWithBlockchainThunkState;
 

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -46,6 +46,7 @@ const getResetDeviceConfig = (walletBackupType: BackupType): PROTO.ResetDevice =
 };
 
 type CreateAndBackupWalletThunkState = DeviceRootState & MessageSystemRootState;
+
 type CreateAndBackupWalletThunkDeps = WithServices<ReportSecurityCheckDep>;
 
 export const createAndBackupWalletThunk = createThunk<

--- a/suite-native/firmware/src/firmwareThunks.ts
+++ b/suite-native/firmware/src/firmwareThunks.ts
@@ -4,6 +4,7 @@ import { createThunk } from '@suite-common/redux-utils';
 const NATIVE_FIRMWARE_MODULE_PREFIX = 'nativeFirmware';
 
 type SetTemporaryRememberedDeviceThunkPayload = { temporaryRemember: boolean };
+
 type SetTemporaryRememberedDeviceThunkState = DeviceRootState;
 
 export const setTemporaryRememberedDeviceThunk = createThunk<

--- a/suite-native/graph/src/graphThunks.ts
+++ b/suite-native/graph/src/graphThunks.ts
@@ -12,7 +12,7 @@ import {
     getTimeFrameForHistoryHours,
 } from '@suite-common/graph';
 import { createThunk } from '@suite-common/redux-utils';
-import { type FetchTransactionsFromNowUntilTimestampState } from '@suite-common/wallet-core';
+import { type FetchTransactionsFromNowUntilTimestampThunkState } from '@suite-common/wallet-core';
 
 import { accountDetailGraphAtoms } from './accountDetailGraphAtoms';
 import { type GraphInstanceId, isPortfolioGraphInstanceId } from './graphInstances';
@@ -27,8 +27,6 @@ import { checkAndReportGraphError, omitErrorMessageSensitiveData } from './utils
 
 const GRAPH_MODULE_PREFIX = '@suite-native/graph';
 const GRAPH_NOT_AVAILABLE_ERROR_MESSAGE = 'Graph is not available for testnet coins.';
-
-type RefetchGraphThunkState = FetchTransactionsFromNowUntilTimestampState;
 
 // The app doesn't mount any jotai Provider, so all atoms live in the default store
 // and it is safe to write them from outside of React. Do not add a jotai Provider.
@@ -125,6 +123,8 @@ const fetchGraphDataToAtoms = async ({
 
     return { status: RefetchGraphThunkStatus.Fetched };
 };
+
+type RefetchGraphThunkState = FetchTransactionsFromNowUntilTimestampThunkState;
 
 export const refetchGraphThunk = createThunk<
     RefetchGraphThunkResult,

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -45,6 +45,7 @@ const getAccountTypeFromDescriptor = (descriptor: string, symbol: NetworkSymbol)
 };
 
 type ImportAccountThunkState = AccountsRootState & TokenDefinitionsRootState;
+
 type ImportAccountThunkDeps = WithServices<GetTokenDefinitionsEnabledNetworksDep>;
 
 export const importAccountThunk = createThunk<

--- a/suite-native/module-earn/src/wrappedNativeTokenThunks.ts
+++ b/suite-native/module-earn/src/wrappedNativeTokenThunks.ts
@@ -141,6 +141,7 @@ export const signWrappedNativeTokenThunk = createThunk<
 export type PushWrappedNativeTokenThunkState = MevProtectionRootState &
     SynchronizeSentTransactionThunkState &
     WalletSettingsRootState;
+
 export type PushWrappedNativeTokenThunkDeps = SynchronizeSentTransactionThunkDeps;
 
 export const pushWrappedNativeTokenThunk = createThunk<

--- a/suite-native/module-earn/src/yieldClaimThunks.ts
+++ b/suite-native/module-earn/src/yieldClaimThunks.ts
@@ -191,6 +191,7 @@ export type PushYieldClaimReviewThunkState = MevProtectionRootState &
     StablecoinYieldRootState &
     SynchronizeSentTransactionThunkState &
     WalletSettingsRootState;
+
 export type PushYieldClaimReviewThunkDeps = SynchronizeSentTransactionThunkDeps;
 
 export const pushYieldClaimReviewThunk = createThunk<

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -177,6 +177,7 @@ export type PushYieldActionReviewThunkState = MevProtectionRootState &
     StablecoinYieldRootState &
     SynchronizeSentTransactionThunkState &
     WalletSettingsRootState;
+
 export type PushYieldActionReviewThunkDeps = SynchronizeSentTransactionThunkDeps;
 
 export const pushYieldActionReviewThunk = createThunk<

--- a/suite-native/module-receive/src/receiveThunks.ts
+++ b/suite-native/module-receive/src/receiveThunks.ts
@@ -52,6 +52,7 @@ export const setCurrentFreshAddressForFlowEntryThunk = createThunk<
 );
 
 export type AddReceiveAddressThunkState = ReceiveAddressListRootState;
+
 export type AddReceiveAddressThunkDeps = WithServices<NativeAnalyticsDep>;
 
 export const addReceiveAddressThunk = createThunk<

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -112,7 +112,7 @@ type PushTradingTxnThunkParams = {
 export const pushTradingTxnThunk = createThunk<
     Ok<{ txid: string }>,
     PushTradingTxnThunkParams,
-    { rejectValue: SerializedError | string; state: void }
+    { rejectValue: SerializedError | string }
 >(
     `${NATIVE_TRADING_EXCHANGE_THUNK_PREFIX}/pushTransaction`,
     async ({ serializedTx, account }, { rejectWithValue, fulfillWithValue }) => {

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -490,6 +490,7 @@ export type SignAndPushSendFormTransactionThunkState = MevProtectionRootState &
     SignTradingTransactionThunkState &
     PushSendFormTransactionThunkState &
     AddTransactionLabelingThunkState;
+
 export type SignAndPushSendFormTransactionThunkDeps = PushSendFormTransactionThunkDeps &
     AddTransactionLabelingThunkDeps;
 

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -148,6 +148,7 @@ type ComposeTradingTransactionThunkParams = {
     maxPriorityFeePerGas?: string;
     isSlip24Active?: boolean;
 };
+
 export type ComposeTradingTransactionThunkState = TradingRootState &
     ComposeSendFormTransactionFeeLevelsThunkState &
     EnhancePrecomposedTransactionThunkState;
@@ -301,6 +302,7 @@ type ComposeEvmApprovalFeeLevelsThunkParams = {
     };
     approvalTypeOverride?: DexApprovalType;
 };
+
 export type ComposeEvmApprovalFeeLevelsThunkState = TokensRootState & FormDraftRootState;
 
 export const composeEvmApprovalFeeLevelsThunk = createThunk<
@@ -485,6 +487,7 @@ export const signTradingTransactionThunk = createThunk<
 type SignAndPushSendFormTransactionThunkParams = TradingSignAndPushSendFormTransactionProps & {
     waitForPushApprovalPromise: () => Promise<boolean>;
 };
+
 export type SignAndPushSendFormTransactionThunkState = MevProtectionRootState &
     EnhancePrecomposedTransactionThunkState &
     SignTradingTransactionThunkState &

--- a/suite-native/platform-encryption-native/src/nativePlatformEncryption.ts
+++ b/suite-native/platform-encryption-native/src/nativePlatformEncryption.ts
@@ -21,6 +21,7 @@ type NativePlatformEncryptionDeps = EnsureEncryptionKeyDep;
 const deriveKey = (mmkvKey: string): Buffer =>
     crypto.createHash('sha256').update(mmkvKey, 'hex').digest();
 
+// eslint-disable-next-line local-rules/enforce-di-factory-contracts -- Concrete implementation of the abstract PlatformEncryption contract.
 export const createNativePlatformEncryption = (
     deps: NativePlatformEncryptionDeps,
 ): PlatformEncryption => ({

--- a/suite-native/send/src/cancelTransactionThunks.ts
+++ b/suite-native/send/src/cancelTransactionThunks.ts
@@ -47,6 +47,7 @@ type SignAndPushEvmCancelTransactionThunkState = AccountsRootState &
     SignTransactionNativeThunkState &
     PushSendFormTransactionThunkState &
     CleanupSendFormThunkState;
+
 type SignAndPushEvmCancelTransactionThunkDeps = PushSendFormTransactionThunkDeps;
 
 /**

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -209,6 +209,7 @@ export type SendTransactionThunkState = MevProtectionRootState &
     TokensRootState &
     PushSendFormTransactionThunkState &
     AddTransactionLabelingThunkState;
+
 export type SendTransactionThunkDeps = PushSendFormTransactionThunkDeps &
     AddTransactionLabelingThunkDeps &
     WithServices<NativeAnalyticsDep>;

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -128,6 +128,7 @@ type CleanupSendFormThunkParams = {
     tokenContract?: TokenAddress;
     shouldDeleteDraft?: boolean;
 };
+
 export type CleanupSendFormThunkState = DeviceRootState;
 
 export const cleanupSendFormThunk = createThunk<

--- a/suite-native/staking/src/stakeNativeThunks.ts
+++ b/suite-native/staking/src/stakeNativeThunks.ts
@@ -86,6 +86,7 @@ export const signStakeTransactionNativeThunk = createThunk<
 export type PushStakeTransactionNativeThunkState = AccountsRootState &
     MevProtectionRootState &
     PushSendFormTransactionThunkState;
+
 export type PushStakeTransactionNativeThunkDeps = PushSendFormTransactionThunkDeps;
 
 export const pushStakeTransactionNativeThunk = createThunk<

--- a/suite-native/storage/src/mmkvStorage.ts
+++ b/suite-native/storage/src/mmkvStorage.ts
@@ -55,13 +55,15 @@ const tryInitStorage = (encryptionKey: string) => {
     }
 };
 
+type MMKVStorageDeps = EnsureEncryptionKeyDep;
+
 type GetMMKVRaw = {
     getMMKV: () => Promise<MMKV>;
 };
-export type MMKVStorage = Storage & GetMMKVRaw;
-export type MMKVStorageDep = { mmkvStorage: MMKVStorage };
 
-type MMKVStorageDeps = EnsureEncryptionKeyDep;
+export type MMKVStorage = Storage & GetMMKVRaw;
+
+export type MMKVStorageDep = { mmkvStorage: MMKVStorage };
 
 export const createMMKVStorage = (deps: MMKVStorageDeps): MMKVStorage => {
     let mmkv: MMKV | null = null;

--- a/suite-native/storage/src/mmkvStorage.ts
+++ b/suite-native/storage/src/mmkvStorage.ts
@@ -61,9 +61,9 @@ type GetMMKVRaw = {
 export type MMKVStorage = Storage & GetMMKVRaw;
 export type MMKVStorageDep = { mmkvStorage: MMKVStorage };
 
-type CreateMMKVStorageDeps = EnsureEncryptionKeyDep;
+type MMKVStorageDeps = EnsureEncryptionKeyDep;
 
-export const createMMKVStorage = (deps: CreateMMKVStorageDeps): MMKVStorage => {
+export const createMMKVStorage = (deps: MMKVStorageDeps): MMKVStorage => {
     let mmkv: MMKV | null = null;
 
     const ensureMMKV = async () => {

--- a/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
+++ b/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
@@ -42,7 +42,7 @@ export const createSuiteSyncNativeCompositionRoot = (
     return createSuiteSyncCompositionRoot({
         ...deps,
         createSuiteStorage: createEvoluStorageFactory({
-            createEvoluInstance: createEvoluInstanceFactory({ run }),
+            evoluInstanceFactory: createEvoluInstanceFactory({ run }),
         }),
         createSuiteSyncOwner: evoluCreateSuiteSyncOwner,
         getIsTorEnabled: () => false,

--- a/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
+++ b/suite-native/transaction-management/src/addTransactionLabelingThunk.ts
@@ -25,6 +25,7 @@ type AddTransactionLabelingThunkParams = {
 export type AddTransactionLabelingThunkState = WithSuiteSyncAndDeviceState &
     MessageSystemRootState &
     SendRootState;
+
 export type AddTransactionLabelingThunkDeps = WithServices<SuiteSyncDep>;
 
 // Todo: This code below is kinda copy-paste from `applySendFormMetadataLabelsThunk` in Desktop.

--- a/suite/backup/src/backupDeviceThunk.ts
+++ b/suite/backup/src/backupDeviceThunk.ts
@@ -12,9 +12,9 @@ type BackupDeviceThunkParams = {
     skipSuccessToast?: boolean;
 };
 
-export type BackupDeviceThunkDeps = WithServices<DesktopAnalyticsDep>;
-
 export type BackupDeviceThunkState = DeviceRootState;
+
+export type BackupDeviceThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const backupDeviceThunk = createThunk<
     void,

--- a/suite/coinjoin/src/coinjoinAccountActions.ts
+++ b/suite/coinjoin/src/coinjoinAccountActions.ts
@@ -1,13 +1,19 @@
 import { type Dispatch, createAction, isAnyOf } from '@reduxjs/toolkit';
 
-import { selectIsDeviceLocked } from '@suite/locks';
-import { openModal } from '@suite/modal';
-import { goto, selectRouteName } from '@suite/router';
-import { selectDevices, selectSelectedDevice } from '@suite-common/device';
+import { type SelectedAccountRootState } from '@suite/account';
+import { type LocksRootState, selectIsDeviceLocked } from '@suite/locks';
+import { type ModalRootState, openModal } from '@suite/modal';
+import { type RouterRootState, goto, selectRouteName } from '@suite/router';
+import { type TorRootState } from '@suite/tor';
+import { type DeviceRootState, selectDevices, selectSelectedDevice } from '@suite-common/device';
+import { type MessageSystemRootState } from '@suite-common/message-system';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import type { Network, NetworkAccount, NetworkSymbol } from '@suite-common/wallet-config';
 import {
+    type AccountsRootState,
+    type BlockchainRootState,
+    type TransactionsRootState,
     accountsActions,
     selectAccountByKey,
     transactionsActions,
@@ -26,7 +32,8 @@ import { promiseAllSequence } from '@trezor/utils';
 import * as coinjoinClientActions from './coinjoinClientActions';
 import * as COINJOIN from './coinjoinConstants';
 import {
-    type GetState,
+    type CoinjoinRootState,
+    type SuiteOnlineRootState,
     selectCoinjoinAccountByKey,
     selectCoinjoinAccounts,
     selectCoinjoinSessionBlockerByAccountKey,
@@ -197,7 +204,7 @@ const warn = (...params: any[]) => isDevEnv && console.warn(...params);
 
 const getCheckpoints = (
     account: Extract<Account, { backendType: 'coinjoin' }>,
-    getState: GetState,
+    getState: () => CoinjoinRootState,
 ) => selectCoinjoinAccountByKey(getState(), account.key)?.checkpoints;
 
 const getAccountCache = ({ addresses, path }: Extract<Account, { backendType: 'coinjoin' }>) => {
@@ -216,8 +223,10 @@ const getAccountCache = ({ addresses, path }: Extract<Account, { backendType: 'c
     };
 };
 
+type UpdateClientAccountThunkState = AccountsRootState & CoinjoinRootState & ModalRootState;
+
 export const updateClientAccount =
-    (account: Account) => (dispatch: Dispatch, getState: GetState) => {
+    (account: Account) => (dispatch: Dispatch, getState: () => UpdateClientAccountThunkState) => {
         if (!isCoinjoinSupportedSymbol(account.symbol)) return;
         const client = coinjoinClientActions.getCoinjoinClient(account.symbol);
         if (!client) return;
@@ -256,9 +265,11 @@ export const updateClientAccount =
         }
     };
 
+type CoinjoinAccountCheckReorgThunkState = CoinjoinRootState & TransactionsRootState;
+
 const coinjoinAccountCheckReorg =
     (account: Account, checkpoint: ScanAccountProgress['checkpoint']) =>
-    (dispatch: Dispatch, getState: GetState) => {
+    (dispatch: Dispatch, getState: () => CoinjoinAccountCheckReorgThunkState) => {
         const state = getState();
         const previousCheckpoint = selectCoinjoinAccountByKey(state, account.key)?.checkpoints?.[0];
         if (!previousCheckpoint) return;
@@ -288,6 +299,8 @@ const coinjoinAccountAddTransactions =
         }
     };
 
+type UpdatePendingAccountInfoThunkState = CoinjoinRootState & TransactionsRootState;
+
 /**
  Action called from coinjoinMiddleware as reaction to prepending tx creation.
  Prepending tx could be created either as result of successful CoinjoinRound (not broadcasted by suite)
@@ -301,7 +314,8 @@ const coinjoinAccountAddTransactions =
  In case of adding a coinjoin transaction, log anonymity gain.
  */
 export const updatePendingAccountInfo =
-    (accountKey: AccountKey) => async (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) =>
+    async (dispatch: Dispatch, getState: () => UpdatePendingAccountInfoThunkState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
         const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
@@ -347,9 +361,13 @@ export const updatePendingAccountInfo =
         }
     };
 
+type CreatePendingTransactionThunkState = AccountsRootState &
+    BlockchainRootState &
+    CoinjoinRootState;
+
 export const createPendingTransaction =
     (accountKey: AccountKey, payload: BroadcastedTransactionDetails) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: () => CreatePendingTransactionThunkState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
         const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
@@ -371,9 +389,12 @@ export const createPendingTransaction =
         );
     };
 
+type CleanPendingTransactionsThunkState = BlockchainRootState & TransactionsRootState;
+
 /** Remove outdated pending transactions */
 const cleanPendingTransactions =
-    (account: Account, pending: { txid: string }[]) => (dispatch: Dispatch, getState: GetState) => {
+    (account: Account, pending: { txid: string }[]) =>
+    (dispatch: Dispatch, getState: () => CleanPendingTransactionsThunkState) => {
         const {
             wallet: {
                 transactions: { transactions },
@@ -395,9 +416,13 @@ const cleanPendingTransactions =
         }
     };
 
+type FetchAndUpdateAccountThunkState = CoinjoinRootState &
+    SelectedAccountRootState &
+    TransactionsRootState;
+
 export const fetchAndUpdateAccount =
     ({ key: accountKey, symbol }: Account) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: () => FetchAndUpdateAccountThunkState) => {
         const state = getState();
         // do not sync if any account CoinjoinSession is in critical phase
         if (selectIsAnySessionInCriticalPhase(state)) return;
@@ -500,8 +525,11 @@ export const fetchAndUpdateAccount =
         }
     };
 
+type ClearCoinjoinInstancesThunkState = CoinjoinRootState;
+
 export const clearCoinjoinInstances =
-    (symbol: CoinjoinSymbol) => (dispatch: Dispatch, getState: GetState) => {
+    (symbol: CoinjoinSymbol) =>
+    (dispatch: Dispatch, getState: () => ClearCoinjoinInstancesThunkState) => {
         const cjAccount = selectCoinjoinAccounts(getState()).find(a => a.symbol === symbol);
         // clear CoinjoinClientInstance if there are no related accounts left
         if (!cjAccount) {
@@ -514,9 +542,11 @@ const handleError = (error: string) => (dispatch: Dispatch) => {
     dispatch(notificationsActions.addToast({ type: 'error', error }));
 };
 
+type CreateCoinjoinAccountThunkState = DeviceRootState;
+
 export const createCoinjoinAccount =
     (network: Network, account: NetworkAccount) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: () => CreateCoinjoinAccountThunkState) => {
         if (account.accountType !== 'coinjoin') {
             throw new Error('createCoinjoinAccount: invalid account type');
         }
@@ -607,9 +637,11 @@ export const createCoinjoinAccount =
         return dispatch(fetchAndUpdateAccount(coinjoinAccount.payload));
     };
 
+type RescanCoinjoinAccountThunkState = AccountsRootState & CoinjoinRootState;
+
 export const rescanCoinjoinAccount =
     (accountKey: AccountKey, fullRescan = false) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: () => RescanCoinjoinAccountThunkState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
         if (account?.backendType !== 'coinjoin' || account.syncing) return;
@@ -641,9 +673,11 @@ export const rescanCoinjoinAccount =
         return dispatch(fetchAndUpdateAccount(payload));
     };
 
+type AuthorizeCoinjoinThunkState = DeviceRootState;
+
 const authorizeCoinjoin =
     (account: Account, coordinator: string, params: CoinjoinSessionParameters) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: () => AuthorizeCoinjoinThunkState) => {
         const device = selectSelectedDevice(getState());
 
         // authorize coinjoin session on Trezor
@@ -675,10 +709,12 @@ const authorizeCoinjoin =
         );
     };
 
+type StartCoinjoinSessionThunkState = CoinjoinRootState;
+
 // called from coinjoin account UI
 export const startCoinjoinSession =
     (account: Account, params: CoinjoinSessionParameters) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: () => StartCoinjoinSessionThunkState) => {
         if (account.accountType !== 'coinjoin') {
             throw new Error('startCoinjoinSession: invalid account type');
         }
@@ -713,12 +749,18 @@ export const startCoinjoinSession =
         dispatch(coinjoinSessionStarting(account.key, false));
     };
 
+type RestoreCoinjoinSessionThunkState = AccountsRootState &
+    CoinjoinRootState &
+    DeviceRootState &
+    LocksRootState;
+
 // called from coinjoin account UI
 // try to restore current paused CoinjoinSession
 // use same parameters as in startCoinjoinSession but recalculate maxRounds value
 // if Trezor is already preauthorized it will not ask for confirmation
 export const restoreCoinjoinSession =
-    (accountKey: AccountKey) => async (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) =>
+    async (dispatch: Dispatch, getState: () => RestoreCoinjoinSessionThunkState) => {
         // TODO: check if device is connected, passphrase is authorized...
         const isDeviceLocked = selectIsDeviceLocked(getState());
         const device = selectSelectedDevice(getState());
@@ -794,36 +836,51 @@ export const restoreCoinjoinSession =
         dispatch(coinjoinSessionStarting(accountKey, false));
     };
 
-export const pauseAllCoinjoinSessions = () => (dispatch: Dispatch, getState: GetState) => {
-    const state = getState();
-    const coinjoinAccounts = selectCoinjoinAccounts(state);
+type PauseAllCoinjoinSessionsThunkState = CoinjoinRootState;
 
-    coinjoinAccounts.forEach(account => {
-        const hasRunningSession = selectIsAccountWithSessionByAccountKey(state, account.key);
-        if (hasRunningSession) {
-            dispatch(coinjoinClientActions.pauseCoinjoinSession(account.key));
-        }
-    });
-};
+export const pauseAllCoinjoinSessions =
+    () => (dispatch: Dispatch, getState: () => PauseAllCoinjoinSessionsThunkState) => {
+        const state = getState();
+        const coinjoinAccounts = selectCoinjoinAccounts(state);
+
+        coinjoinAccounts.forEach(account => {
+            const hasRunningSession = selectIsAccountWithSessionByAccountKey(state, account.key);
+            if (hasRunningSession) {
+                dispatch(coinjoinClientActions.pauseCoinjoinSession(account.key));
+            }
+        });
+    };
+
+type RestorePausedCoinjoinSessionsThunkState = CoinjoinRootState &
+    DeviceRootState &
+    LocksRootState &
+    MessageSystemRootState &
+    RouterRootState &
+    SelectedAccountRootState &
+    SuiteOnlineRootState &
+    TorRootState;
 
 // check for blocking conditions of interrupted sessions and restore those eligible
-export const restorePausedCoinjoinSessions = () => (dispatch: Dispatch, getState: GetState) => {
-    const state = getState();
-    const coinjoinAccounts = selectCoinjoinAccounts(state);
-    const eligibleAccounts = coinjoinAccounts.filter(({ key, session }) => {
-        const hasSendFormOpen =
-            selectRouteName(state) === 'wallet-send' &&
-            key === state.wallet.selectedAccount.account?.key;
-        const blocker = selectCoinjoinSessionBlockerByAccountKey(state, key);
+export const restorePausedCoinjoinSessions =
+    () => (dispatch: Dispatch, getState: () => RestorePausedCoinjoinSessionsThunkState) => {
+        const state = getState();
+        const coinjoinAccounts = selectCoinjoinAccounts(state);
+        const eligibleAccounts = coinjoinAccounts.filter(({ key, session }) => {
+            const hasSendFormOpen =
+                selectRouteName(state) === 'wallet-send' &&
+                key === state.wallet.selectedAccount.account?.key;
+            const blocker = selectCoinjoinSessionBlockerByAccountKey(state, key);
 
-        return !hasSendFormOpen && !blocker && session?.paused;
-    });
+            return !hasSendFormOpen && !blocker && session?.paused;
+        });
 
-    eligibleAccounts.forEach(account => dispatch(restoreCoinjoinSession(account.key)));
-};
+        eligibleAccounts.forEach(account => dispatch(restoreCoinjoinSession(account.key)));
+    };
+
+type StopCoinjoinAccountThunkState = CoinjoinRootState;
 
 export const stopCoinjoinAccount =
-    (account: Account) => (dispatch: Dispatch, getState: GetState) => {
+    (account: Account) => (dispatch: Dispatch, getState: () => StopCoinjoinAccountThunkState) => {
         const cjAccount = selectCoinjoinAccountByKey(getState(), account.key);
 
         if (cjAccount?.session) {
@@ -838,8 +895,13 @@ export const stopCoinjoinAccount =
         }
     };
 
+type StopCoinjoinSessionByDeviceIdThunkState = AccountsRootState &
+    CoinjoinRootState &
+    DeviceRootState;
+
 export const stopCoinjoinSessionByDeviceId =
-    (deviceID: string) => (dispatch: Dispatch, getState: GetState) => {
+    (deviceID: string) =>
+    (dispatch: Dispatch, getState: () => StopCoinjoinSessionByDeviceIdThunkState) => {
         const state = getState();
 
         const devices = selectDevices(state);
@@ -871,28 +933,34 @@ export const stopCoinjoinSessionByDeviceId =
         });
     };
 
-export const restoreCoinjoinAccounts = () => (dispatch: Dispatch, getState: GetState) => {
-    const { coinjoin } = getState().wallet;
+type RestoreCoinjoinAccountsThunkState = CoinjoinRootState;
 
-    // find all networks to restore
-    const coinjoinSymbols = coinjoin.accounts.reduce<NetworkSymbol[]>((res, account) => {
-        if (!res.includes(account.symbol)) {
-            return res.concat(account.symbol);
-        }
+export const restoreCoinjoinAccounts =
+    () => (dispatch: Dispatch, getState: () => RestoreCoinjoinAccountsThunkState) => {
+        const { coinjoin } = getState().wallet;
 
-        return res;
-    }, []);
+        // find all networks to restore
+        const coinjoinSymbols = coinjoin.accounts.reduce<NetworkSymbol[]>((res, account) => {
+            if (!res.includes(account.symbol)) {
+                return res.concat(account.symbol);
+            }
 
-    // async actions in sequence, initialize CoinjoinCService for each network
-    return promiseAllSequence(
-        coinjoinSymbols.map(
-            symbol => () => dispatch(coinjoinClientActions.initCoinjoinService(symbol)),
-        ),
-    );
-};
+            return res;
+        }, []);
+
+        // async actions in sequence, initialize CoinjoinCService for each network
+        return promiseAllSequence(
+            coinjoinSymbols.map(
+                symbol => () => dispatch(coinjoinClientActions.initCoinjoinService(symbol)),
+            ),
+        );
+    };
+
+type ToggleAutostopCoinjoinThunkState = CoinjoinRootState;
 
 export const toggleAutostopCoinjoin =
-    (accountKey: AccountKey) => (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) =>
+    (dispatch: Dispatch, getState: () => ToggleAutostopCoinjoinThunkState) => {
         const currentAccountState = selectSessionByAccountKey(getState(), accountKey);
 
         if (!currentAccountState) {
@@ -904,28 +972,31 @@ export const toggleAutostopCoinjoin =
         dispatch(coinjoinSessionAutostop(accountKey, newState));
     };
 
-export const logCoinjoinAccounts = () => (_: Dispatch, getState: GetState) => {
-    const {
-        accounts,
-        coinjoin: { accounts: cjAccounts },
-        transactions: { transactions },
-    } = getState().wallet;
-    accounts
-        .filter(({ accountType }) => accountType === 'coinjoin')
-        .forEach(account => {
-            const handle = getAccountProgressHandle(account);
-            const cjAccount = cjAccounts.find(({ key }) => key === account.key);
-            const checkpoints = cjAccount?.checkpoints?.map(cp => cp.blockHeight);
-            const txs = transactions[account.key];
-            log(
-                `CoinjoinAccount remembered: ${handle}, checkpoints: ${checkpoints}, transactions: ${txs?.length}`,
-            );
-        });
-    cjAccounts
-        .filter(({ key }) => !accounts.some(acc => acc.key === key))
-        .forEach(cjAccount => {
-            const handle = getAccountProgressHandle(cjAccount);
-            const checkpoints = cjAccount.checkpoints?.map(cp => cp.blockHeight);
-            warn(`CoinjoinAccount residue: ${handle}, checkpoints: ${checkpoints}`);
-        });
-};
+type LogCoinjoinAccountsThunkState = CoinjoinRootState & TransactionsRootState;
+
+export const logCoinjoinAccounts =
+    () => (_: Dispatch, getState: () => LogCoinjoinAccountsThunkState) => {
+        const {
+            accounts,
+            coinjoin: { accounts: cjAccounts },
+            transactions: { transactions },
+        } = getState().wallet;
+        accounts
+            .filter(({ accountType }) => accountType === 'coinjoin')
+            .forEach(account => {
+                const handle = getAccountProgressHandle(account);
+                const cjAccount = cjAccounts.find(({ key }) => key === account.key);
+                const checkpoints = cjAccount?.checkpoints?.map(cp => cp.blockHeight);
+                const txs = transactions[account.key];
+                log(
+                    `CoinjoinAccount remembered: ${handle}, checkpoints: ${checkpoints}, transactions: ${txs?.length}`,
+                );
+            });
+        cjAccounts
+            .filter(({ key }) => !accounts.some(acc => acc.key === key))
+            .forEach(cjAccount => {
+                const handle = getAccountProgressHandle(cjAccount);
+                const checkpoints = cjAccount.checkpoints?.map(cp => cp.blockHeight);
+                warn(`CoinjoinAccount residue: ${handle}, checkpoints: ${checkpoints}`);
+            });
+    };

--- a/suite/coinjoin/src/coinjoinClientActions.ts
+++ b/suite/coinjoin/src/coinjoinClientActions.ts
@@ -1,12 +1,21 @@
 import { type Dispatch, createAction } from '@reduxjs/toolkit';
 
-import { selectIsDeviceLocked } from '@suite/locks';
-import { closeModal, openModal } from '@suite/modal';
-import { selectDevices } from '@suite-common/device';
-import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
+import { type LocksRootState, selectIsDeviceLocked } from '@suite/locks';
+import { type ModalRootState, closeModal, openModal } from '@suite/modal';
+import { type DeviceRootState, selectDevices } from '@suite-common/device';
+import {
+    Feature,
+    type MessageSystemRootState,
+    selectIsFeatureDisabled,
+} from '@suite-common/message-system';
 import { getDeviceInstances } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectAccountByKey, selectAddressDisplayType } from '@suite-common/wallet-core';
+import {
+    type AccountsRootState,
+    type WalletSettingsRootState,
+    selectAccountByKey,
+    selectAddressDisplayType,
+} from '@suite-common/wallet-core';
 import { type Account, type AccountKey, AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getUtxoOutpoint } from '@suite-common/wallet-utils';
 import {
@@ -26,7 +35,7 @@ import { arrayDistinct, arrayToDictionary, promiseAllSequence } from '@trezor/ut
 
 import * as COINJOIN from './coinjoinConstants';
 import {
-    type GetState,
+    type CoinjoinRootState,
     selectCoinjoinAccounts,
     selectRoundsDurationInHours,
     selectRoundsLeftByAccountKey,
@@ -157,8 +166,11 @@ export type CoinjoinClientAction = ReturnType<
 export const getCoinjoinClient = (symbol: CoinjoinSymbol) =>
     CoinjoinService.getInstance(symbol)?.client;
 
+type UnregisterByAccountKeyThunkState = AccountsRootState;
+
 export const unregisterByAccountKey =
-    (accountKey: string) => (_dispatch: Dispatch, getState: GetState) => {
+    (accountKey: string) =>
+    (_dispatch: Dispatch, getState: () => UnregisterByAccountKeyThunkState) => {
         const { accounts } = getState().wallet;
         const realAccount = accounts.find(a => a.key === accountKey);
 
@@ -177,6 +189,8 @@ export const endCoinjoinSession = (accountKey: string) => (dispatch: Dispatch) =
     dispatch(unregisterByAccountKey(accountKey));
 };
 
+type SetBusyScreenThunkState = AccountsRootState & DeviceRootState;
+
 /**
  * Show "do not disconnect" screen on Trezor.
  * Multiple possible setups:
@@ -185,7 +199,8 @@ export const endCoinjoinSession = (accountKey: string) => (dispatch: Dispatch) =
  * - N accounts on X devices (like two physical device)
  */
 export const setBusyScreen =
-    (accountKeys: string[], expiry?: number) => (_dispatch: Dispatch, getState: GetState) => {
+    (accountKeys: string[], expiry?: number) =>
+    (_dispatch: Dispatch, getState: () => SetBusyScreenThunkState) => {
         const {
             wallet: { accounts },
         } = getState();
@@ -228,11 +243,14 @@ export const setBusyScreen =
         );
     };
 
-export const hasCriticalPhaseModal = () => (_: Dispatch, getState: GetState) => {
-    const { modal } = getState();
+type HasCriticalPhaseModalThunkState = ModalRootState;
 
-    return 'payload' in modal && modal.payload.type === 'critical-coinjoin-phase';
-};
+export const hasCriticalPhaseModal =
+    () => (_: Dispatch, getState: () => HasCriticalPhaseModalThunkState) => {
+        const { modal } = getState();
+
+        return 'payload' in modal && modal.payload.type === 'critical-coinjoin-phase';
+    };
 
 export const closeCriticalPhaseModal = () => (dispatch: Dispatch) => {
     if (dispatch(hasCriticalPhaseModal())) {
@@ -240,9 +258,12 @@ export const closeCriticalPhaseModal = () => (dispatch: Dispatch) => {
     }
 };
 
+type PauseCoinjoinSessionThunkState = AccountsRootState;
+
 // called from coinjoin account UI or exceptions like device disconnection, forget wallet/account etc.
 export const pauseCoinjoinSession =
-    (accountKey: AccountKey) => (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) =>
+    (dispatch: Dispatch, getState: () => PauseCoinjoinSessionThunkState) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || !isCoinjoinSupportedSymbol(account.symbol)) {
@@ -258,9 +279,12 @@ export const pauseCoinjoinSession =
         dispatch(coinjoinSessionPause(accountKey));
     };
 
+type StopCoinjoinSessionThunkState = AccountsRootState & CoinjoinRootState & DeviceRootState;
+
 // called from coinjoin account UI or exceptions like device disconnection, forget wallet/account etc.
 export const stopCoinjoinSession =
-    (accountKey: AccountKey) => async (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) =>
+    async (dispatch: Dispatch, getState: () => StopCoinjoinSessionThunkState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
 
@@ -317,9 +341,11 @@ export const stopCoinjoinSession =
         dispatch(coinjoinAccountUnregister(accountKey));
     };
 
+type OnCoinjoinRoundChangedThunkState = AccountsRootState & CoinjoinRootState;
+
 export const onCoinjoinRoundChanged =
     ({ round }: CoinjoinRoundEvent) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: () => OnCoinjoinRoundChangedThunkState) => {
         const state = getState();
         const coinjoinAccounts = selectCoinjoinAccounts(state);
         const roundsDurationInHours = selectRoundsDurationInHours(state);
@@ -408,9 +434,14 @@ export const onCoinjoinRoundChanged =
 const coinjoinResponseError = (utxos: CoinjoinRequestEvent['inputs'], error: string) =>
     utxos.map(u => ({ outpoint: u.outpoint, error }));
 
+type GetOwnershipProofThunkState = AccountsRootState &
+    CoinjoinRootState &
+    DeviceRootState &
+    LocksRootState;
+
 const getOwnershipProof =
     (request: Extract<CoinjoinRequestEvent, { type: 'ownership' }>) =>
-    async (_dispatch: Dispatch, getState: GetState) => {
+    async (_dispatch: Dispatch, getState: () => GetOwnershipProofThunkState) => {
         const state = getState();
         const {
             wallet: { coinjoin, accounts },
@@ -528,9 +559,14 @@ export const clientEmitException =
         });
     };
 
+type SignCoinjoinTxThunkState = AccountsRootState &
+    CoinjoinRootState &
+    DeviceRootState &
+    WalletSettingsRootState;
+
 const signCoinjoinTx =
     (request: Extract<CoinjoinRequestEvent, { type: 'signature' }>) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: () => SignCoinjoinTxThunkState) => {
         const {
             wallet: { coinjoin, accounts },
         } = getState();
@@ -686,8 +722,11 @@ export const onCoinjoinClientRequest = (data: CoinjoinRequestEvent[]) => (dispat
         }),
     );
 
+type InitCoinjoinServiceThunkState = AccountsRootState & CoinjoinRootState & MessageSystemRootState;
+
 export const initCoinjoinService =
-    (symbol: Account['symbol']) => async (dispatch: Dispatch, getState: GetState) => {
+    (symbol: Account['symbol']) =>
+    async (dispatch: Dispatch, getState: () => InitCoinjoinServiceThunkState) => {
         const state = getState();
         const { clients, debug, accounts } = state.wallet.coinjoin;
 

--- a/suite/coinjoin/src/coinjoinMiddleware.ts
+++ b/suite/coinjoin/src/coinjoinMiddleware.ts
@@ -1,19 +1,28 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 import type { Dispatch, MiddlewareAPI, UnknownAction } from 'redux';
 
-import { lockDevice, selectIsDeviceOrUiLocked } from '@suite/locks';
-import { routerLocationChange, selectRouteName, selectSettingsBackRoute } from '@suite/router';
+import { type SelectedAccountRootState } from '@suite/account';
+import { type LocksRootState, lockDevice, selectIsDeviceOrUiLocked } from '@suite/locks';
+import { type ModalRootState } from '@suite/modal';
+import {
+    type RouterRootState,
+    routerLocationChange,
+    selectRouteName,
+    selectSettingsBackRoute,
+} from '@suite/router';
 import { onSuiteInit, onSuiteReady, updateOnlineStatus } from '@suite/suite-lifecycle';
-import { selectIsTorEnabled, torActions } from '@suite/tor';
-import { deviceActions } from '@suite-common/device';
+import { type TorRootState, selectIsTorEnabled, torActions } from '@suite/tor';
+import { type DeviceRootState, deviceActions } from '@suite-common/device';
 import {
     Feature,
+    type MessageSystemRootState,
     messageSystemActions,
     selectFeatureConfig,
     selectIsFeatureDisabled,
 } from '@suite-common/message-system';
 import { addToast } from '@suite-common/toast-notifications';
 import {
+    type AccountsRootState,
     accountsActions,
     blockchainActions,
     discoveryActions,
@@ -29,6 +38,7 @@ import * as coinjoinAccountActions from './coinjoinAccountActions';
 import * as coinjoinClientActions from './coinjoinClientActions';
 import {
     type CoinjoinRootState,
+    type SuiteOnlineRootState,
     selectCoinjoinAccountByKey,
     selectCoinjoinSessionBlockerByAccountKey,
     selectIsAccountWithSessionInCriticalPhaseByAccountKey,
@@ -37,8 +47,19 @@ import {
 import { CoinjoinService } from './coinjoinService';
 import { isCoinjoinSupportedSymbol } from './coinjoinUtils';
 
+type CoinjoinMiddlewareState = AccountsRootState &
+    CoinjoinRootState &
+    DeviceRootState &
+    LocksRootState &
+    MessageSystemRootState &
+    ModalRootState &
+    RouterRootState &
+    SelectedAccountRootState &
+    SuiteOnlineRootState &
+    TorRootState;
+
 export const coinjoinMiddleware =
-    (api: MiddlewareAPI<Dispatch, CoinjoinRootState>) =>
+    (api: MiddlewareAPI<Dispatch, CoinjoinMiddlewareState>) =>
     (next: Dispatch) =>
     (action: UnknownAction): UnknownAction => {
         // cancel discovery for each CoinjoinBackend

--- a/suite/coinjoin/src/coinjoinSelectors.ts
+++ b/suite/coinjoin/src/coinjoinSelectors.ts
@@ -1,7 +1,5 @@
 import { type SelectedAccountRootState, selectSelectedAccount } from '@suite/account';
 import { type LocksRootState, selectIsDeviceOrUiLocked } from '@suite/locks';
-import { type ModalRootState } from '@suite/modal';
-import { type RouterRootState } from '@suite/router';
 import { type TorRootState, selectIsTorEnabled } from '@suite/tor';
 import { type DeviceRootState, selectDeviceStatus } from '@suite-common/device';
 import {
@@ -11,13 +9,7 @@ import {
     selectIsFeatureDisabled,
 } from '@suite-common/message-system';
 import { createWeakMapSelector } from '@suite-common/redux-utils';
-import {
-    type AccountsRootState,
-    type BlockchainRootState,
-    type TransactionsRootState,
-    type WalletSettingsRootState,
-    selectAccountByKey,
-} from '@suite-common/wallet-core';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { getInputSize, getOutputSize } from '@trezor/coinjoin';
 import { BigNumber } from '@trezor/utils';
@@ -46,23 +38,14 @@ export type CoinjoinRootState = {
     wallet: {
         coinjoin: CoinjoinState;
     };
-    // slim slice of the suite reducer; declared locally to avoid a dependency on the suite app
+};
+
+// Slim suite slice declared locally to avoid a dependency on the desktop app's whole state.
+export type SuiteOnlineRootState = {
     suite: {
         online: boolean;
     };
-} & AccountsRootState &
-    BlockchainRootState &
-    TransactionsRootState &
-    WalletSettingsRootState &
-    SelectedAccountRootState &
-    DeviceRootState &
-    RouterRootState &
-    ModalRootState &
-    TorRootState &
-    MessageSystemRootState &
-    LocksRootState;
-
-export type GetState = () => CoinjoinRootState;
+};
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<CoinjoinRootState>();
 
@@ -117,7 +100,9 @@ export const selectTargetAnonymityByAccountKey = (
     return coinjoinAccount.setup?.targetAnonymity ?? DEFAULT_TARGET_ANONYMITY;
 };
 
-export const selectCurrentCoinjoinBalanceBreakdown = (state: CoinjoinRootState) => {
+export const selectCurrentCoinjoinBalanceBreakdown = (
+    state: CoinjoinRootState & SelectedAccountRootState,
+) => {
     const selectedAccount = selectSelectedAccount(state);
     const targetAnonymity = selectedAccount
         ? selectTargetAnonymityByAccountKey(state, selectedAccount.key)
@@ -157,7 +142,7 @@ export const selectRegisteredUtxosByAccountKey = createMemoizedSelector(
 );
 
 export const selectSessionProgressByAccountKey = (
-    state: CoinjoinRootState,
+    state: AccountsRootState & CoinjoinRootState,
     accountKey: AccountKey | null,
 ) => {
     const relatedAccount = selectAccountByKey(state, accountKey);
@@ -178,7 +163,9 @@ export const selectSessionProgressByAccountKey = (
     return progress;
 };
 
-export const selectCurrentCoinjoinSession = (state: CoinjoinRootState) => {
+export const selectCurrentCoinjoinSession = (
+    state: CoinjoinRootState & SelectedAccountRootState,
+) => {
     const selectedAccount = selectSelectedAccount(state);
     const coinjoinAccounts = selectCoinjoinAccounts(state);
 
@@ -191,7 +178,9 @@ export const selectCurrentCoinjoinSession = (state: CoinjoinRootState) => {
     return session;
 };
 
-export const selectCurrentTargetAnonymity = (state: CoinjoinRootState) => {
+export const selectCurrentTargetAnonymity = (
+    state: CoinjoinRootState & SelectedAccountRootState,
+) => {
     const selectedAccount = selectSelectedAccount(state);
     const targetAnonymity = selectedAccount
         ? selectTargetAnonymityByAccountKey(state, selectedAccount.key)
@@ -257,7 +246,7 @@ export const selectMinAllowedInputWithFee = (state: CoinjoinRootState, accountKe
 };
 
 export const selectIsNothingToAnonymizeByAccountKey = (
-    state: CoinjoinRootState,
+    state: AccountsRootState & CoinjoinRootState,
     accountKey: AccountKey,
 ) => {
     const minAllowedInputWithFee = selectMinAllowedInputWithFee(state, accountKey);
@@ -275,7 +264,7 @@ export const selectIsNothingToAnonymizeByAccountKey = (
 };
 
 export const selectWeightedAnonymityByAccountKey = (
-    state: CoinjoinRootState,
+    state: AccountsRootState & CoinjoinRootState,
     accountKey: AccountKey,
 ) => {
     const account = selectAccountByKey(state, accountKey);
@@ -298,7 +287,7 @@ export const selectWeightedAnonymityByAccountKey = (
 };
 
 export const selectRoundsNeededByAccountKey = (
-    state: CoinjoinRootState,
+    state: AccountsRootState & CoinjoinRootState,
     accountKey: AccountKey,
 ) => {
     const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
@@ -359,7 +348,7 @@ export const selectRoundsLeftByAccountKey = (state: CoinjoinRootState, accountKe
     return maxRounds - signedRounds.length;
 };
 
-export const selectHasAnonymitySetError = (state: CoinjoinRootState) => {
+export const selectHasAnonymitySetError = (state: SelectedAccountRootState) => {
     const selectedAccount = selectSelectedAccount(state);
 
     if (!selectedAccount) {
@@ -376,7 +365,13 @@ export const selectHasAnonymitySetError = (state: CoinjoinRootState) => {
 };
 
 export const selectCoinjoinSessionBlockerByAccountKey = (
-    state: CoinjoinRootState & DeviceRootState & LocksRootState,
+    state: CoinjoinRootState &
+        DeviceRootState &
+        LocksRootState &
+        MessageSystemRootState &
+        SelectedAccountRootState &
+        SuiteOnlineRootState &
+        TorRootState,
     accountKey: AccountKey | null,
 ) => {
     if (accountKey === null) {
@@ -416,7 +411,15 @@ export const selectCoinjoinSessionBlockerByAccountKey = (
     }
 };
 
-export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState & DeviceRootState) => {
+export const selectCurrentCoinjoinWheelStates = (
+    state: CoinjoinRootState &
+        DeviceRootState &
+        LocksRootState &
+        MessageSystemRootState &
+        SelectedAccountRootState &
+        SuiteOnlineRootState &
+        TorRootState,
+) => {
     const { notAnonymized } = selectCurrentCoinjoinBalanceBreakdown(state);
     const { key, balance } = selectSelectedAccount(state) || {};
     const coinjoinAccount = selectCoinjoinAccountByKey(state, key || null);
@@ -471,7 +474,7 @@ export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState & Devi
 
 // return tuple of arguments used by startCoinjoinSession action
 export const selectStartCoinjoinSessionArguments = (
-    state: CoinjoinRootState,
+    state: CoinjoinRootState & SelectedAccountRootState,
     accountKey: AccountKey,
 ) => {
     const selectedAccount = selectSelectedAccount(state);
@@ -503,7 +506,9 @@ export const selectStartCoinjoinSessionArguments = (
     ] as const;
 };
 
-export const selectCurrentSessionDeadlineInfo = (state: CoinjoinRootState) => {
+export const selectCurrentSessionDeadlineInfo = (
+    state: CoinjoinRootState & SelectedAccountRootState,
+) => {
     const session = selectCurrentCoinjoinSession(state);
 
     const { roundPhase, roundPhaseDeadline, sessionDeadline } = session || {};
@@ -516,7 +521,7 @@ export const selectCurrentSessionDeadlineInfo = (state: CoinjoinRootState) => {
 };
 
 // Return true if it's not explicitly set to false in the message-system config.
-export const selectIsPublic = (state: CoinjoinRootState) =>
+export const selectIsPublic = (state: MessageSystemRootState) =>
     selectFeatureConfig(state, Feature.coinjoin)?.isPublic !== false;
 
 export const selectIsSessionAutostopped = (state: CoinjoinRootState, accountKey: AccountKey) => {

--- a/suite/desktop-update/src/desktopUpdateActionsThunks.ts
+++ b/suite/desktop-update/src/desktopUpdateActionsThunks.ts
@@ -12,12 +12,12 @@ import {
     desktopUpdateActions,
 } from './desktopUpdateReducer';
 
-type GetState = () => DesktopUpdateRootState;
-
+type AvailableThunkState = DesktopUpdateRootState;
 type AvailableThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const availableThunk =
-    (info: UpdateInfo) => (dispatch: Dispatch, getState: GetState, extra: AvailableThunkDeps) => {
+    (info: UpdateInfo) =>
+    (dispatch: Dispatch, getState: () => AvailableThunkState, extra: AvailableThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { allowPrerelease } = getState().desktopUpdate;
 
@@ -42,10 +42,11 @@ export const notAvailableThunk = (info: UpdateInfo) => (dispatch: Dispatch) => {
     dispatch(desktopUpdateActions.notAvailable(info));
 };
 
+type DownloadThunkState = DesktopUpdateRootState;
 type DownloadThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const downloadThunk =
-    () => (dispatch: Dispatch, getState: GetState, extra: DownloadThunkDeps) => {
+    () => (dispatch: Dispatch, getState: () => DownloadThunkState, extra: DownloadThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { latest, allowPrerelease } = getState().desktopUpdate;
 
@@ -62,10 +63,12 @@ export const downloadThunk =
         dispatch(desktopUpdateActions.download());
     };
 
+type ReadyThunkState = DesktopUpdateRootState;
 type ReadyThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const readyThunk =
-    (info: UpdateInfo) => (dispatch: Dispatch, getState: GetState, extra: ReadyThunkDeps) => {
+    (info: UpdateInfo) =>
+    (dispatch: Dispatch, getState: () => ReadyThunkState, extra: ReadyThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { latest, allowPrerelease } = getState().desktopUpdate;
 
@@ -84,11 +87,12 @@ export const readyThunk =
         dispatch(desktopUpdateActions.ready(info));
     };
 
+type InstallUpdateThunkState = DesktopUpdateRootState;
 type InstallUpdateThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const installUpdateThunk =
     ({ installNow }: { installNow: boolean }) =>
-    (_: Dispatch, getState: GetState, extra: InstallUpdateThunkDeps) => {
+    (_: Dispatch, getState: () => InstallUpdateThunkState, extra: InstallUpdateThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { desktopUpdate } = getState();
 
@@ -116,26 +120,28 @@ export const installUpdateThunk =
         }
     };
 
+type ErrorThunkState = DesktopUpdateRootState;
 type ErrorThunkDeps = WithServices<DesktopAnalyticsDep>;
 
-export const errorThunk = () => (dispatch: Dispatch, getState: GetState, extra: ErrorThunkDeps) => {
-    // eslint-disable-next-line no-restricted-syntax
-    const { state, latest, allowPrerelease } = getState().desktopUpdate;
+export const errorThunk =
+    () => (dispatch: Dispatch, getState: () => ErrorThunkState, extra: ErrorThunkDeps) => {
+        // eslint-disable-next-line no-restricted-syntax
+        const { state, latest, allowPrerelease } = getState().desktopUpdate;
 
-    // Ignore displaying errors while checking
-    if (state !== UpdateState.Checking) {
-        dispatch(notificationsActions.addToast({ type: 'auto-updater-error', state }));
+        // Ignore displaying errors while checking
+        if (state !== UpdateState.Checking) {
+            dispatch(notificationsActions.addToast({ type: 'auto-updater-error', state }));
 
-        const payload = getAppUpdatePayload({
-            status: AppUpdateEventStatus.Error,
-            earlyAccessProgram: allowPrerelease,
-            updateInfo: latest,
-        });
-        extra.services.analytics.report({
-            type: events.appUpdateEvent.name,
-            payload,
-        });
-    }
+            const payload = getAppUpdatePayload({
+                status: AppUpdateEventStatus.Error,
+                earlyAccessProgram: allowPrerelease,
+                updateInfo: latest,
+            });
+            extra.services.analytics.report({
+                type: events.appUpdateEvent.name,
+                payload,
+            });
+        }
 
-    dispatch(desktopUpdateActions.notAvailable());
-};
+        dispatch(desktopUpdateActions.notAvailable());
+    };

--- a/suite/desktop-update/src/desktopUpdateActionsThunks.ts
+++ b/suite/desktop-update/src/desktopUpdateActionsThunks.ts
@@ -13,6 +13,7 @@ import {
 } from './desktopUpdateReducer';
 
 type AvailableThunkState = DesktopUpdateRootState;
+
 type AvailableThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const availableThunk =
@@ -43,6 +44,7 @@ export const notAvailableThunk = (info: UpdateInfo) => (dispatch: Dispatch) => {
 };
 
 type DownloadThunkState = DesktopUpdateRootState;
+
 type DownloadThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const downloadThunk =
@@ -64,6 +66,7 @@ export const downloadThunk =
     };
 
 type ReadyThunkState = DesktopUpdateRootState;
+
 type ReadyThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const readyThunk =
@@ -88,6 +91,7 @@ export const readyThunk =
     };
 
 type InstallUpdateThunkState = DesktopUpdateRootState;
+
 type InstallUpdateThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const installUpdateThunk =
@@ -121,6 +125,7 @@ export const installUpdateThunk =
     };
 
 type ErrorThunkState = DesktopUpdateRootState;
+
 type ErrorThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const errorThunk =

--- a/suite/labeling/src/processLegacyMetadataIntoSuiteSyncThunk.ts
+++ b/suite/labeling/src/processLegacyMetadataIntoSuiteSyncThunk.ts
@@ -27,7 +27,7 @@ type ProcessLegacyMetadataIntoSuiteSyncThunkDeps = WithServices<SuiteSyncDep>;
 export const processLegacyMetadataIntoSuiteSyncThunk = createThunk<
     Result<void, EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError>,
     ProcessMetadataMessageThunkParams,
-    { state: void; extra: ProcessLegacyMetadataIntoSuiteSyncThunkDeps }
+    { extra: ProcessLegacyMetadataIntoSuiteSyncThunkDeps }
 >(
     '@suite/labeling/processMetadataMessageThunk',
     async ({ payload, deviceStaticSessionId, value }, { dispatch, extra: { services } }) => {

--- a/suite/metadata-migration/src/createMigrateLabelsIfAvailable.test.ts
+++ b/suite/metadata-migration/src/createMigrateLabelsIfAvailable.test.ts
@@ -13,7 +13,7 @@ import { type Result, err, ok } from '@trezor/type-utils';
 import { createDeferred } from '@trezor/utils';
 
 import {
-    type CreateMigrateLabelsIfAvailableDeps,
+    type MigrateLabelsIfAvailableDeps,
     createMigrateLabelsIfAvailable,
 } from './createMigrateLabelsIfAvailable';
 import { type MigrationCounts, type MigrationError } from './legacyLabelsMigration';
@@ -42,7 +42,7 @@ describe(createMigrateLabelsIfAvailable.name, () => {
     it('dispatches migration flag and success toast after successful migration with changes', async () => {
         const device = createDevice();
         const dispatch: Dispatch = jest.fn();
-        const deps = createMockDeps<CreateMigrateLabelsIfAvailableDeps>({
+        const deps = createMockDeps<MigrateLabelsIfAvailableDeps>({
             dispatch,
             migrateLegacyLabelsToSuiteSync: () => Promise.resolve(ok({ changed: 2, skipped: 1 })),
             getIsMetadataEnabled: () => true,
@@ -80,7 +80,7 @@ describe(createMigrateLabelsIfAvailable.name, () => {
 
     it('skips migration when wallet has already been migrated', async () => {
         const dispatch: Dispatch = jest.fn();
-        const deps = createMockDeps<CreateMigrateLabelsIfAvailableDeps>({
+        const deps = createMockDeps<MigrateLabelsIfAvailableDeps>({
             dispatch,
             migrateLegacyLabelsToSuiteSync: () => Promise.resolve(ok({ changed: 2, skipped: 1 })),
             getIsMetadataEnabled: () => true,
@@ -104,7 +104,7 @@ describe(createMigrateLabelsIfAvailable.name, () => {
         const device = createDevice();
         const migration = createDeferred<Result<MigrationCounts, MigrationError>>();
         const dispatch: Dispatch = jest.fn();
-        const deps = createMockDeps<CreateMigrateLabelsIfAvailableDeps>({
+        const deps = createMockDeps<MigrateLabelsIfAvailableDeps>({
             dispatch,
             migrateLegacyLabelsToSuiteSync: () => migration.promise,
             getIsMetadataEnabled: () => true,
@@ -147,7 +147,7 @@ describe(createMigrateLabelsIfAvailable.name, () => {
         const secondDevice = createDevice(secondDeviceStaticSessionId);
         const secondMigration = createDeferred<Result<MigrationCounts, MigrationError>>();
 
-        const deps = createMockDeps<CreateMigrateLabelsIfAvailableDeps>({
+        const deps = createMockDeps<MigrateLabelsIfAvailableDeps>({
             dispatch,
             migrateLegacyLabelsToSuiteSync: selectedDevice => {
                 if (selectedDevice === firstDevice) {
@@ -204,7 +204,7 @@ describe(createMigrateLabelsIfAvailable.name, () => {
 
     it('marks wallet as migrated without showing toast when nothing changed', async () => {
         const dispatch: Dispatch = jest.fn();
-        const deps = createMockDeps<CreateMigrateLabelsIfAvailableDeps>({
+        const deps = createMockDeps<MigrateLabelsIfAvailableDeps>({
             dispatch,
             migrateLegacyLabelsToSuiteSync: () => Promise.resolve(ok({ changed: 0, skipped: 3 })),
             getIsMetadataEnabled: () => true,
@@ -230,7 +230,7 @@ describe(createMigrateLabelsIfAvailable.name, () => {
         const cause = createSuiteSyncUpdateError(new Error('migration failed'));
 
         const dispatch: Dispatch = jest.fn();
-        const deps = createMockDeps<CreateMigrateLabelsIfAvailableDeps>({
+        const deps = createMockDeps<MigrateLabelsIfAvailableDeps>({
             dispatch,
             migrateLegacyLabelsToSuiteSync: () =>
                 Promise.resolve(

--- a/suite/metadata-migration/src/createMigrateLabelsIfAvailable.ts
+++ b/suite/metadata-migration/src/createMigrateLabelsIfAvailable.ts
@@ -12,7 +12,7 @@ import { type WalletDescriptor, parseStaticSessionId } from '@trezor/device-util
 
 import type { MigrateLegacyLabelsToSuiteSync } from './migrateLegacyLabelsToSuiteSync';
 
-export type CreateMigrateLabelsIfAvailableDeps = {
+export type MigrateLabelsIfAvailableDeps = {
     dispatch: Dispatch;
     migrateLegacyLabelsToSuiteSync: MigrateLegacyLabelsToSuiteSync;
     getIsMetadataEnabled: () => boolean;
@@ -24,7 +24,7 @@ export type CreateMigrateLabelsIfAvailableDeps = {
 };
 
 export const createMigrateLabelsIfAvailable = (
-    deps: CreateMigrateLabelsIfAvailableDeps,
+    deps: MigrateLabelsIfAvailableDeps,
 ): OnStorageEnsured => {
     const isMigratingByWalletDescriptor = new Map<WalletDescriptor, true>();
 

--- a/suite/metadata-migration/src/createMigrateLabelsIfAvailable.ts
+++ b/suite/metadata-migration/src/createMigrateLabelsIfAvailable.ts
@@ -23,6 +23,7 @@ export type MigrateLabelsIfAvailableDeps = {
     ) => TrezorDevice | undefined;
 };
 
+// eslint-disable-next-line local-rules/enforce-di-factory-contracts -- Concrete implementation of the abstract OnStorageEnsured contract.
 export const createMigrateLabelsIfAvailable = (
     deps: MigrateLabelsIfAvailableDeps,
 ): OnStorageEnsured => {

--- a/suite/metadata-migration/src/migrateLegacyLabelsToSuiteSync.ts
+++ b/suite/metadata-migration/src/migrateLegacyLabelsToSuiteSync.ts
@@ -20,11 +20,6 @@ import type {
 } from './legacyLabelsMigration';
 import { createAccountLabelsParams } from './migrationUtils';
 
-export type MigrateLegacyLabelsToSuiteSync = (
-    selectedDevice: TrezorDeviceWithState,
-    storage: SuiteSyncStorage,
-) => Promise<Result<MigrationCounts, MigrationError>>;
-
 export type MigrateLegacyLabelsToSuiteSyncDeps = {
     getAccountsByDeviceState: GetAccountsByDeviceState;
     getLegacyAccountLabels: GetLegacyAccountLabels;
@@ -33,6 +28,11 @@ export type MigrateLegacyLabelsToSuiteSyncDeps = {
     MigrateAccountLabelsDep &
     MigrateAddressLabelsDep &
     MigrateOutputLabelsDep;
+
+export type MigrateLegacyLabelsToSuiteSync = (
+    selectedDevice: TrezorDeviceWithState,
+    storage: SuiteSyncStorage,
+) => Promise<Result<MigrationCounts, MigrationError>>;
 
 export const createMigrateLegacyLabelsToSuiteSync =
     (deps: MigrateLegacyLabelsToSuiteSyncDeps): MigrateLegacyLabelsToSuiteSync =>

--- a/suite/metadata/src/metadataDataThunks.ts
+++ b/suite/metadata/src/metadataDataThunks.ts
@@ -20,27 +20,32 @@ import * as METADATA_LABELING from './metadataLabelingConstants';
 import { type MetadataRootState, selectSelectedProviderForLabels } from './metadataReducer';
 import * as metadataUtils from './metadataUtils';
 
+type DisposeMetadataThunkState = MetadataRootState;
+
 /**
  * dispose metadata from all labelable objects.
  */
-export const disposeMetadata = () => (dispatch: Dispatch, getState: () => MetadataRootState) => {
-    const provider = selectSelectedProviderForLabels(getState());
+export const disposeMetadata =
+    () => (dispatch: Dispatch, getState: () => DisposeMetadataThunkState) => {
+        const provider = selectSelectedProviderForLabels(getState());
 
-    if (!provider) {
-        return;
-    }
+        if (!provider) {
+            return;
+        }
 
-    dispatch({
-        type: METADATA.SET_DATA,
-        payload: {
-            provider,
-            data: undefined,
-        },
-    });
-};
+        dispatch({
+            type: METADATA.SET_DATA,
+            payload: {
+                provider,
+                data: undefined,
+            },
+        });
+    };
+
+type DisposeMetadataKeysThunkState = MetadataRootState;
 
 export const disposeMetadataKeys =
-    () => (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    () => (dispatch: Dispatch, getState: () => DisposeMetadataKeysThunkState) => {
         const devices = selectDevices(getState());
         const accounts = selectAccounts(getState());
 

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -35,8 +35,11 @@ import {
 } from './metadataReducer';
 import * as metadataUtils from './metadataUtils';
 
+type GetLabelableEntitiesThunkState = MetadataRootState;
+
 const getLabelableEntities =
-    (deviceState: StaticSessionId) => (_dispatch: Dispatch, getState: () => MetadataRootState) =>
+    (deviceState: StaticSessionId) =>
+    (_dispatch: Dispatch, getState: () => GetLabelableEntitiesThunkState) =>
         selectLabelableEntities(getState(), deviceState);
 
 type LabelableEntity = ReturnType<ReturnType<typeof getLabelableEntities>>[number];
@@ -103,9 +106,11 @@ const fetchMetadata =
         };
     };
 
+type SetAccountMetadataKeyThunkState = MetadataRootState;
+
 export const setAccountMetadataKey =
     (account: Account, encryptionVersion = METADATA_LABELING.ENCRYPTION_VERSION) =>
-    (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    (dispatch: Dispatch, getState: () => SetAccountMetadataKeyThunkState) => {
         const device = selectDeviceByStaticSessionId(getState(), account.deviceState);
         const deviceMetaKey = device?.metadata[encryptionVersion]?.key;
 
@@ -138,12 +143,14 @@ export const setAccountMetadataKey =
         return account;
     };
 
+type SyncMetadataKeysThunkState = MetadataRootState;
+
 /**
  * Fill any record in reducer that may have metadata with metadata keys (not values).
  */
 const syncMetadataKeys =
     (device: TrezorDevice, encryptionVersion = METADATA_LABELING.ENCRYPTION_VERSION) =>
-    (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    (dispatch: Dispatch, getState: () => SyncMetadataKeysThunkState) => {
         if (!device.metadata[METADATA_LABELING.ENCRYPTION_VERSION]) {
             return;
         }
@@ -161,9 +168,11 @@ const syncMetadataKeys =
         // keys sooner when enabling labeling on device;
     };
 
+type FetchAndSaveMetadataThunkState = MetadataRootState;
+
 export const fetchAndSaveMetadata =
     (deviceStateArg?: StaticSessionId) =>
-    async (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    async (dispatch: Dispatch, getState: () => FetchAndSaveMetadataThunkState) => {
         const provider = selectSelectedProviderForLabels(getState());
         if (!provider) return;
 
@@ -267,8 +276,10 @@ export const fetchAndSaveMetadata =
         }
     };
 
+type FetchAndSaveMetadataForAllDevicesThunkState = MetadataRootState;
+
 export const fetchAndSaveMetadataForAllDevices =
-    () => (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    () => (dispatch: Dispatch, getState: () => FetchAndSaveMetadataForAllDevicesThunkState) => {
         const metadata = selectMetadata(getState());
         if (!metadata.enabled) {
             return;
@@ -284,9 +295,11 @@ export const fetchAndSaveMetadataForAllDevices =
         });
     };
 
+type AddDeviceMetadataThunkState = MetadataRootState;
+
 export const addDeviceMetadata =
     (payload: Extract<MetadataAddPayload, { type: 'walletLabel' }>) =>
-    (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    (dispatch: Dispatch, getState: () => AddDeviceMetadataThunkState) => {
         const devices = selectDevices(getState());
         const device = devices.find(d => d.state?.staticSessionId === payload.entityKey);
         const provider = selectSelectedProviderForLabels(getState());
@@ -346,6 +359,8 @@ export const addDeviceMetadata =
         });
     };
 
+type AddAccountMetadataThunkState = MetadataRootState;
+
 /**
  * @param payload - metadata payload
  * @param save - should metadata be saved into persistent storage? this is useful when you are updating multiple records
@@ -353,7 +368,7 @@ export const addDeviceMetadata =
  */
 export const addAccountMetadata =
     (payload: Exclude<MetadataAddPayload, { type: 'walletLabel' }>) =>
-    (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    (dispatch: Dispatch, getState: () => AddAccountMetadataThunkState) => {
         const account = getState().wallet.accounts.find(a => a.key === payload.entityKey);
         const provider = selectSelectedProviderForLabels(getState());
 
@@ -463,12 +478,14 @@ export const addAccountMetadata =
         });
     };
 
+type SetDeviceMetadataKeyThunkState = MetadataRootState;
+
 /**
  * Generate device master-key
  * */
 export const setDeviceMetadataKey =
     (device: TrezorDevice, encryptionVersion = METADATA_LABELING.ENCRYPTION_VERSION) =>
-    async (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    async (dispatch: Dispatch, getState: () => SetDeviceMetadataKeyThunkState) => {
         if (!device.state?.staticSessionId || !device.connected) return;
 
         const result = await TrezorConnect.cipherKeyValue({
@@ -511,9 +528,11 @@ export const setDeviceMetadataKey =
         return { success: false };
     };
 
+type AddMetadataThunkState = MetadataRootState;
+
 export const addMetadata =
     (payload: MetadataAddPayload) =>
-    async (dispatch: Dispatch, getState: () => MetadataRootState): Promise<boolean> => {
+    async (dispatch: Dispatch, getState: () => AddMetadataThunkState): Promise<boolean> => {
         const result = await dispatch(
             payload.type === 'walletLabel'
                 ? addDeviceMetadata(payload)
@@ -560,6 +579,10 @@ export const addMetadata =
 
 export type InitMetadataDeps = WithServices<DesktopAnalyticsDep>;
 
+type InitThunkState = MetadataRootState;
+
+type InitThunkDeps = InitMetadataDeps;
+
 /**
  * init - prepare everything needed to load + decrypt and upload + decrypt metadata. Note that this method
  * consists of number of steps of which not all have to necessarily happen. For example
@@ -571,7 +594,7 @@ export type InitMetadataDeps = WithServices<DesktopAnalyticsDep>;
  */
 export const init =
     (force: boolean, deviceStateArg?: StaticSessionId) =>
-    async (dispatch: Dispatch, getState: () => MetadataRootState, extra: InitMetadataDeps) => {
+    async (dispatch: Dispatch, getState: () => InitThunkState, extra: InitThunkDeps) => {
         let device = deviceStateArg
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
             : selectSelectedDevice(getState());

--- a/suite/metadata/src/metadataPasswordsActions.ts
+++ b/suite/metadata/src/metadataPasswordsActions.ts
@@ -19,9 +19,11 @@ import { type MetadataRootState, selectSelectedProviderForPasswords } from './me
 import * as metadataUtils from './metadataUtils';
 import { type FetchIntervalTrackingId } from './metadataUtils';
 
+type FetchPasswordsThunkState = MetadataRootState;
+
 const fetchPasswords =
     (keys: LabelableEntityKeys) =>
-    async (dispatch: Dispatch, _getState: () => MetadataRootState) => {
+    async (dispatch: Dispatch, _getState: () => FetchPasswordsThunkState) => {
         const provider = dispatch(
             metadataProviderActions.getProviderInstance({
                 clientId: METADATA_PROVIDER.DROPBOX_PASSWORDS_CLIENT_ID,
@@ -79,7 +81,9 @@ const fetchPasswords =
         );
     };
 
-export const init = () => async (dispatch: Dispatch, getState: () => MetadataRootState) => {
+type InitThunkState = MetadataRootState;
+
+export const init = () => async (dispatch: Dispatch, getState: () => InitThunkState) => {
     let device = selectSelectedDevice(getState());
 
     if (!device?.state?.staticSessionId) {
@@ -194,9 +198,11 @@ export const init = () => async (dispatch: Dispatch, getState: () => MetadataRoo
     }
 };
 
+type AddPasswordMetadataThunkState = MetadataRootState;
+
 export const addPasswordMetadata =
     (nextId: number, payload: PasswordEntry, fileName: string, aesKey: string) =>
-    (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    (dispatch: Dispatch, getState: () => AddPasswordMetadataThunkState) => {
         if (!payload.note) {
             return Promise.resolve({ success: false, error: 'required field (note) missing' });
         }
@@ -240,9 +246,11 @@ export const addPasswordMetadata =
         });
     };
 
+type RemovePasswordMetadataThunkState = MetadataRootState;
+
 export const removePasswordMetadata =
     (index: number, fileName: string, aesKey: string) =>
-    (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    (dispatch: Dispatch, getState: () => RemovePasswordMetadataThunkState) => {
         const provider = selectSelectedProviderForPasswords(getState());
         const providerInstance = dispatch(
             metadataProviderActions.getProviderInstance({

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -65,12 +65,14 @@ const createProviderInstance = (
 
 type GetProviderInstanceParams = { clientId: string; dataType: DataType };
 
+type GetProviderInstanceThunkState = MetadataRootState;
+
 /**
  * Return already existing instance of AbstractProvider or recreate it from token;
  */
 export const getProviderInstance =
     ({ clientId, dataType = 'labels' }: GetProviderInstanceParams) =>
-    (_dispatch: Dispatch, getState: () => MetadataRootState) => {
+    (_dispatch: Dispatch, getState: () => GetProviderInstanceThunkState) => {
         const state = getState();
         const { providers } = state.metadata;
 
@@ -103,12 +105,16 @@ type DisconnectProviderParams = {
 
 type DisconnectProviderDeps = WithServices<DesktopAnalyticsDep>;
 
+type DisconnectProviderThunkState = MetadataRootState;
+
+type DisconnectProviderThunkDeps = DisconnectProviderDeps;
+
 export const disconnectProvider =
     ({ clientId, dataType, removeMetadata = true }: DisconnectProviderParams) =>
     async (
         dispatch: Dispatch,
-        _getState: () => MetadataRootState,
-        extra: DisconnectProviderDeps,
+        _getState: () => DisconnectProviderThunkState,
+        extra: DisconnectProviderThunkDeps,
     ) => {
         typedObjectKeys(fetchIntervals).forEach((id: FetchIntervalTrackingId) => {
             const [trackedDataType, trackedClientId] = id.split('-');
@@ -243,9 +249,17 @@ type ConnectProviderParams = {
 
 export type ConnectProviderDeps = WithServices<DesktopAnalyticsDep>;
 
+type ConnectProviderThunkState = MetadataRootState;
+
+type ConnectProviderThunkDeps = ConnectProviderDeps;
+
 export const connectProvider =
     ({ type, dataType = 'labels', clientId }: ConnectProviderParams) =>
-    async (dispatch: Dispatch, getState: () => MetadataRootState, extra: ConnectProviderDeps) => {
+    async (
+        dispatch: Dispatch,
+        getState: () => ConnectProviderThunkState,
+        extra: ConnectProviderThunkDeps,
+    ) => {
         const providerInstance = createProviderInstance(
             type,
             {},
@@ -293,8 +307,10 @@ export const connectProvider =
         return true;
     };
 
+type ExportMetadataToLocalFileThunkState = MetadataRootState;
+
 export const exportMetadataToLocalFile =
-    () => async (dispatch: Dispatch, getState: () => MetadataRootState) => {
+    () => async (dispatch: Dispatch, getState: () => ExportMetadataToLocalFileThunkState) => {
         const provider = selectSelectedProviderForLabels(getState());
         if (!provider) return;
         const providerInstance = dispatch(

--- a/suite/modal/src/modalActions.ts
+++ b/suite/modal/src/modalActions.ts
@@ -34,7 +34,7 @@ export const removePreserveModal = createAction(MODAL_REMOVE_PRESERVE);
  */
 export const preserveModalOnTxTimeout = createAction(MODAL_PRESERVE_ON_TX_TIMEOUT);
 
-type OnReceiveConfirmationState = {
+type OnReceiveConfirmationThunkState = {
     modal: {
         context: string;
         requestId?: string;
@@ -42,7 +42,8 @@ type OnReceiveConfirmationState = {
 };
 
 export const onReceiveConfirmation =
-    (confirmation: boolean) => (dispatch: Dispatch, getState: () => OnReceiveConfirmationState) => {
+    (confirmation: boolean) =>
+    (dispatch: Dispatch, getState: () => OnReceiveConfirmationThunkState) => {
         const requestId = selectModalConfirmationRequestId(getState());
         TrezorConnect.uiResponse({
             type: UI_RESPONSE.RECEIVE_CONFIRMATION,

--- a/suite/platform-encryption-electron/src/electronPlatformEncryption.ts
+++ b/suite/platform-encryption-electron/src/electronPlatformEncryption.ts
@@ -11,6 +11,7 @@ export type ElectronPlatformEncryptionDeps = {
     desktopApi: DesktopApi;
 };
 
+// eslint-disable-next-line local-rules/enforce-di-factory-contracts -- Concrete implementation of the abstract PlatformEncryption contract.
 export const createElectronPlatformEncryption = (
     deps: ElectronPlatformEncryptionDeps,
 ): PlatformEncryption => ({

--- a/suite/receive/src/address/revealNextAddressThunk.ts
+++ b/suite/receive/src/address/revealNextAddressThunk.ts
@@ -22,7 +22,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 
-type RevealNextAddressState = AccountsRootState &
+type RevealNextAddressThunkState = AccountsRootState &
     TransactionsRootState &
     ReceiveRootState &
     SelectLabeledUnusedAddressesState;
@@ -33,7 +33,7 @@ export const revealNextAddressThunk =
     ({ accountKey }: { accountKey: AccountKey }) =>
     (
         dispatch: Dispatch,
-        getState: () => RevealNextAddressState,
+        getState: () => RevealNextAddressThunkState,
         extra: RevealNextAddressThunkDeps,
     ) => {
         const account = selectAccountByKey(getState(), accountKey);

--- a/suite/receive/src/verification/showAddressThunk.ts
+++ b/suite/receive/src/verification/showAddressThunk.ts
@@ -20,11 +20,12 @@ import {
 } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
-type ShowAddressThunkDeps = WithServices<DesktopAnalyticsDep>;
 type ShowAddressThunkState = DeviceRootState &
     WalletSettingsRootState &
     SelectedAccountRootState &
     ReceiveRootState;
+
+type ShowAddressThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const showAddressThunk =
     ({ path }: { path: string }) =>

--- a/suite/receive/src/verification/showAddressThunk.ts
+++ b/suite/receive/src/verification/showAddressThunk.ts
@@ -21,15 +21,16 @@ import {
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 type ShowAddressThunkDeps = WithServices<DesktopAnalyticsDep>;
+type ShowAddressThunkState = DeviceRootState &
+    WalletSettingsRootState &
+    SelectedAccountRootState &
+    ReceiveRootState;
 
 export const showAddressThunk =
     ({ path }: { path: string }) =>
     async (
         dispatch: Dispatch,
-        getState: () => DeviceRootState &
-            WalletSettingsRootState &
-            SelectedAccountRootState &
-            ReceiveRootState,
+        getState: () => ShowAddressThunkState,
         extra: ShowAddressThunkDeps,
     ) => {
         const device = selectSelectedDevice(getState());

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -23,8 +23,9 @@ const recoveryInputTypeToInputMethod: Record<RecoveryInputType, PROTO.RecoveryDe
     advanced: PROTO.RecoveryDeviceInputMethod.Matrix,
 };
 
-type CheckSeedThunkDeps = WithServices<DesktopAnalyticsDep>;
 type CheckSeedThunkState = DeviceRootState & { recovery: RecoveryState };
+
+type CheckSeedThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const checkSeedThunk = createThunk<
     void,
@@ -123,8 +124,9 @@ export const recoverDeviceThunk = createThunk<void, void, { state: RecoverDevice
     },
 );
 
-type RecoveryRerunThunkDeps = WithServices<DesktopAnalyticsDep>;
 type RecoveryRerunThunkState = DeviceRootState & { recovery: RecoveryState };
+
+type RecoveryRerunThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 // Recovery mode is persistent on T2T1. This means that device stays in recovery mode even after reconnecting.
 // In such case, we need to call again the call that brought device into recovery mode (either proper recovery

--- a/suite/router/src/createSuiteRouterHistory.ts
+++ b/suite/router/src/createSuiteRouterHistory.ts
@@ -1,21 +1,19 @@
 import { ensureRouterPath, getPrefixedURL, stripPrefixedURL } from './router';
 import { type SuiteRouterHistory, type SuiteRouterHistoryDeps } from './suiteRouterHistory';
 
-export const createSuiteRouterHistory = ({
-    history,
-}: SuiteRouterHistoryDeps): SuiteRouterHistory => ({
+export const createSuiteRouterHistory = (deps: SuiteRouterHistoryDeps): SuiteRouterHistory => ({
     getLocation: () => {
-        const { location } = history;
+        const { location } = deps.history;
 
         return ensureRouterPath({ ...location, pathname: stripPrefixedURL(location.pathname) });
     },
     navigate: (to, state) =>
-        history.push(
+        deps.history.push(
             { ...to, pathname: to.pathname ? getPrefixedURL(to.pathname) : undefined },
             state,
         ),
     listen: listener =>
-        history.listen(({ location, action }) =>
+        deps.history.listen(({ location, action }) =>
             listener({ location: ensureRouterPath(location), action }),
         ),
 });

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -31,6 +31,7 @@ import { type SuiteRouterHistoryDep } from './suiteRouterHistory';
 type OnLocationChangeThunkParams = RouterPathOptional & {
     anchor?: AnchorType;
 };
+
 type OnLocationChangeThunkState = LocksRootState & ModalRootState & RouterRootState;
 
 export const onLocationChange = createThunk<
@@ -175,6 +176,7 @@ export const closeModalApp = createThunk<
 type InitialRedirectionThunkParams = {
     isInitialRun?: boolean;
 };
+
 type InitialRedirectionThunkState = GotoThunkState;
 
 type InitialRedirectionThunkDeps = GotoThunkDeps;

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -28,10 +28,10 @@ import { type SuiteRouterHistoryDep } from './suiteRouterHistory';
  * Handle changes of history.location and history.location.hash
  * Called from ./support/RouterHandler
  */
-type OnLocationChangeThunkState = LocksRootState & ModalRootState & RouterRootState;
 type OnLocationChangeThunkParams = RouterPathOptional & {
     anchor?: AnchorType;
 };
+type OnLocationChangeThunkState = LocksRootState & ModalRootState & RouterRootState;
 
 export const onLocationChange = createThunk<
     ReturnType<typeof routerLocationChange> | null | undefined,

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -57,6 +57,7 @@ export const onLocationChange = createThunk<
  * Called from `@suite-middlewares/suiteMiddleware`
  */
 type RouterInitThunkState = LocksRootState & ModalRootState & RouterRootState;
+
 type RouterInitThunkDeps = WithServices<SuiteRouterHistoryDep>;
 
 export const routerInit = createThunk<
@@ -79,6 +80,7 @@ type GotoPayload = {
 };
 
 export type GotoThunkState = LocksRootState & ModalRootState & RouterRootState;
+
 export type GotoThunkDeps = WithServices<SuiteRouterHistoryDep>;
 
 export const goto = createThunk<void, GotoPayload, { state: GotoThunkState; extra: GotoThunkDeps }>(
@@ -138,6 +140,7 @@ export const goto = createThunk<void, GotoPayload, { state: GotoThunkState; extr
  * Reverse operation (again without touching history) needs to be done in back action.
  */
 type CloseModalAppThunkState = GotoThunkState;
+
 type CloseModalAppThunkDeps = GotoThunkDeps;
 
 export const closeModalApp = createThunk<
@@ -173,6 +176,7 @@ type InitialRedirectionThunkParams = {
     isInitialRun?: boolean;
 };
 type InitialRedirectionThunkState = GotoThunkState;
+
 type InitialRedirectionThunkDeps = GotoThunkDeps;
 
 export const initialRedirection = createThunk<

--- a/suite/sign-verify/src/signVerifyActions.ts
+++ b/suite/sign-verify/src/signVerifyActions.ts
@@ -220,6 +220,7 @@ export const showAddress =
             .catch(onError(dispatch, 'verify-address-error'));
 
 type SignThunkState = SignVerifyRootState;
+
 type SignThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const sign =
@@ -282,6 +283,7 @@ export const sign =
     };
 
 type VerifyThunkState = SignVerifyRootState;
+
 type VerifyThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const verify =

--- a/suite/sign-verify/src/signVerifyActions.ts
+++ b/suite/sign-verify/src/signVerifyActions.ts
@@ -25,8 +25,6 @@ export type SignVerifyRootState = DeviceRootState & WalletSettingsRootState;
 
 type GetState = () => SignVerifyRootState;
 
-type SignVerifyThunkDeps = WithServices<DesktopAnalyticsDep>;
-
 const CANCEL_ERROR_CODES: ErrorCode[] = ['Method_Cancel', 'Failure_ActionCancelled'];
 
 const getFailureAttributes = ({ code }: SerializedError) => ({
@@ -211,12 +209,18 @@ const onError =
         return false as const;
     };
 
+type ShowAddressThunkState = SignVerifyRootState;
+
 export const showAddress =
-    (account: Account, address: string, path: string) => (dispatch: Dispatch, getState: GetState) =>
+    (account: Account, address: string, path: string) =>
+    (dispatch: Dispatch, getState: () => ShowAddressThunkState) =>
         getStateParams(account, getState)
             .then(showAddressByNetwork(dispatch, address, path))
             .then(throwWhenFailed)
             .catch(onError(dispatch, 'verify-address-error'));
+
+type SignThunkState = SignVerifyRootState;
+type SignThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const sign =
     (
@@ -227,7 +231,7 @@ export const sign =
         isElectrum = false,
         isCose = false,
     ) =>
-    async (dispatch: Dispatch, getState: GetState, extra: SignVerifyThunkDeps) => {
+    async (dispatch: Dispatch, getState: () => SignThunkState, extra: SignThunkDeps) => {
         const { analytics } = extra.services;
         const signatureFormat = isElectrum ? 'electrum' : 'trezor';
 
@@ -277,9 +281,12 @@ export const sign =
         }
     };
 
+type VerifyThunkState = SignVerifyRootState;
+type VerifyThunkDeps = WithServices<DesktopAnalyticsDep>;
+
 export const verify =
     (account: Account, address: string, message: string, signature: string, hex = false) =>
-    async (dispatch: Dispatch, getState: GetState, extra: SignVerifyThunkDeps) => {
+    async (dispatch: Dispatch, getState: () => VerifyThunkState, extra: VerifyThunkDeps) => {
         const { analytics } = extra.services;
 
         try {

--- a/suite/sign-verify/src/signVerifyActions.ts
+++ b/suite/sign-verify/src/signVerifyActions.ts
@@ -23,8 +23,6 @@ import * as SIGN_VERIFY from './signVerifyConstants';
 
 export type SignVerifyRootState = DeviceRootState & WalletSettingsRootState;
 
-type GetState = () => SignVerifyRootState;
-
 const CANCEL_ERROR_CODES: ErrorCode[] = ['Method_Cancel', 'Failure_ActionCancelled'];
 
 const getFailureAttributes = ({ code }: SerializedError) => ({
@@ -50,7 +48,10 @@ const throwWhenFailed = <T>(response: Result<T, SerializedError>) =>
         ? Promise.resolve(response.payload)
         : Promise.reject(new Error(response.error.message));
 
-const getStateParams = (account: Account, getState: GetState): Promise<StateParams> => {
+const getStateParams = (
+    account: Account,
+    getState: () => SignVerifyRootState,
+): Promise<StateParams> => {
     const device = selectSelectedDevice(getState());
     const addressDisplayType = selectAddressDisplayType(getState());
 

--- a/suite/suite-sync/src/evolu/createEvoluConsole.ts
+++ b/suite/suite-sync/src/evolu/createEvoluConsole.ts
@@ -24,6 +24,8 @@ export type EvoluConsoleDeps = {
     updateRelayConnectionStatus: UpdateRelayConnectionStatus;
 };
 
+type EvoluConsole = Console;
+
 const isEvoluWebSocketEventName = (value: unknown): value is EvoluWebSocketEventName =>
     typeof value === 'string' && isArrayMember(value, evoluWebSocketEventNames);
 
@@ -33,7 +35,7 @@ const getErrorMessage = (value: unknown): string | undefined => {
     return JSON.stringify(value);
 };
 
-export const createEvoluConsole = (deps: EvoluConsoleDeps): Console => {
+export const createEvoluConsole = (deps: EvoluConsoleDeps): EvoluConsole => {
     const evoluConsoleStoreOutput = createConsoleStoreOutput();
     const console = createConsole({
         level: 'debug',

--- a/suite/suite-sync/src/evolu/createEvoluDeps.ts
+++ b/suite/suite-sync/src/evolu/createEvoluDeps.ts
@@ -35,7 +35,7 @@ export const createEvoluDeps = (deps: EvoluDepsFactoryDeps): EvoluDeps => {
     });
     const run = createRun(evoluDeps);
     const createSuiteStorage = createEvoluStorageFactory({
-        createEvoluInstance: createEvoluInstanceFactory({ run }),
+        evoluInstanceFactory: createEvoluInstanceFactory({ run }),
     });
     const subscribeError: SubscribeSuiteSyncInternalErrorHandler =
         suiteSyncInternalErrorHandler => {

--- a/suite/suite-sync/src/evolu/createOnSharedWorkerUnsupported.ts
+++ b/suite/suite-sync/src/evolu/createOnSharedWorkerUnsupported.ts
@@ -2,12 +2,15 @@ import { type Dispatch } from '@reduxjs/toolkit';
 
 import { notificationsActions } from '@suite-common/toast-notifications';
 
-type CreateOnSharedWorkerUnsupportedDeps = {
+type OnSharedWorkerUnsupported = () => void;
+
+type OnSharedWorkerUnsupportedDeps = {
     dispatch: Dispatch;
 };
 
 export const createOnSharedWorkerUnsupported =
-    (deps: CreateOnSharedWorkerUnsupportedDeps) => () => {
+    (deps: OnSharedWorkerUnsupportedDeps): OnSharedWorkerUnsupported =>
+    () => {
         console.error('Suite Sync shared worker is unsupported in this tab.');
 
         deps.dispatch(

--- a/suite/suite-sync/src/evolu/createOnSharedWorkerUnsupported.ts
+++ b/suite/suite-sync/src/evolu/createOnSharedWorkerUnsupported.ts
@@ -2,11 +2,11 @@ import { type Dispatch } from '@reduxjs/toolkit';
 
 import { notificationsActions } from '@suite-common/toast-notifications';
 
-type OnSharedWorkerUnsupported = () => void;
-
 type OnSharedWorkerUnsupportedDeps = {
     dispatch: Dispatch;
 };
+
+type OnSharedWorkerUnsupported = () => void;
 
 export const createOnSharedWorkerUnsupported =
     (deps: OnSharedWorkerUnsupportedDeps): OnSharedWorkerUnsupported =>

--- a/suite/suite-sync/src/turnOnDesktopSuiteSync.ts
+++ b/suite/suite-sync/src/turnOnDesktopSuiteSync.ts
@@ -1,14 +1,14 @@
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type TurnOnSuiteSync, type TurnOnSuiteSyncDep } from '@suite-common/suite-sync-types';
 
-type CreateTurnOnDesktopSuiteSyncDeps = TurnOnSuiteSyncDep & DesktopAnalyticsDep;
+type TurnOnDesktopSuiteSyncDeps = TurnOnSuiteSyncDep & DesktopAnalyticsDep;
 
 /**
  * This is decorator to add a Desktop specific functionality to the "Suite Sync: Turn On"
  * operation.
  */
 export const createTurnOnDesktopSuiteSync =
-    (deps: CreateTurnOnDesktopSuiteSyncDeps): TurnOnSuiteSync =>
+    (deps: TurnOnDesktopSuiteSyncDeps): TurnOnSuiteSync =>
     params => {
         deps.analytics.report({
             type: events.settingsGeneralLabelingProviderEvent.name,

--- a/suite/suite-sync/src/turnOnDesktopSuiteSync.ts
+++ b/suite/suite-sync/src/turnOnDesktopSuiteSync.ts
@@ -3,12 +3,14 @@ import { type TurnOnSuiteSync, type TurnOnSuiteSyncDep } from '@suite-common/sui
 
 type TurnOnDesktopSuiteSyncDeps = TurnOnSuiteSyncDep & DesktopAnalyticsDep;
 
+type TurnOnDesktopSuiteSync = TurnOnSuiteSync;
+
 /**
  * This is decorator to add a Desktop specific functionality to the "Suite Sync: Turn On"
  * operation.
  */
 export const createTurnOnDesktopSuiteSync =
-    (deps: TurnOnDesktopSuiteSyncDeps): TurnOnSuiteSync =>
+    (deps: TurnOnDesktopSuiteSyncDeps): TurnOnDesktopSuiteSync =>
     params => {
         deps.analytics.report({
             type: events.settingsGeneralLabelingProviderEvent.name,

--- a/suite/tor-desktop/src/bootstrap/setTorBootstrapSlowThunk.ts
+++ b/suite/tor-desktop/src/bootstrap/setTorBootstrapSlowThunk.ts
@@ -4,8 +4,10 @@ import { type TorRootState, selectTorBootstrap, torActions } from '@suite/tor';
 import { type TorBootstrap } from '@suite/tor-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
+type SetTorBootstrapSlowThunkState = TorRootState;
+
 export const setTorBootstrapSlowThunk =
-    (isSlow: boolean) => (dispatch: Dispatch, getState: () => TorRootState) => {
+    (isSlow: boolean) => (dispatch: Dispatch, getState: () => SetTorBootstrapSlowThunkState) => {
         const previousTorBootstrap = selectTorBootstrap(getState());
 
         if (!previousTorBootstrap) {

--- a/suite/tor-desktop/src/bootstrap/setTorBootstrapThunk.ts
+++ b/suite/tor-desktop/src/bootstrap/setTorBootstrapThunk.ts
@@ -3,8 +3,11 @@ import type { Dispatch } from '@reduxjs/toolkit';
 import { type TorRootState, selectTorBootstrap, torActions } from '@suite/tor';
 import { type TorBootstrap } from '@suite/tor-types';
 
+type SetTorBootstrapThunkState = TorRootState;
+
 export const setTorBootstrapThunk =
-    (torBootstrap: TorBootstrap) => (dispatch: Dispatch, getState: () => TorRootState) => {
+    (torBootstrap: TorBootstrap) =>
+    (dispatch: Dispatch, getState: () => SetTorBootstrapThunkState) => {
         const previousTorBootstrap = selectTorBootstrap(getState());
 
         const payload: TorBootstrap = {

--- a/suite/tor-desktop/src/toggleTorThunk.ts
+++ b/suite/tor-desktop/src/toggleTorThunk.ts
@@ -11,17 +11,21 @@ import { type BlockchainRootState, selectBlockchainState } from '@suite-common/w
 import { getCustomBackends } from '@suite-common/wallet-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
-type ToggleTorRootState = TorRootState & ModalRootState & RouterRootState & BlockchainRootState;
-type ToggleTorDeps = WithServices<DesktopAnalyticsDep>;
+type ToggleTorThunkState = TorRootState & ModalRootState & RouterRootState & BlockchainRootState;
+type ToggleTorThunkDeps = WithServices<DesktopAnalyticsDep>;
 
-export type ToggleTorDispatch = ThunkDispatch<ToggleTorRootState, ToggleTorDeps, UnknownAction>;
+export type ToggleTorDispatch = ThunkDispatch<
+    ToggleTorThunkState,
+    ToggleTorThunkDeps,
+    UnknownAction
+>;
 
 export const toggleTor =
     (shouldEnable: boolean) =>
     async (
         dispatch: ToggleTorDispatch,
-        getState: () => ToggleTorRootState,
-        extra: ToggleTorDeps,
+        getState: () => ToggleTorThunkState,
+        extra: ToggleTorThunkDeps,
     ) => {
         const modal = selectModalType(getState());
         const torBootstrap = selectTorBootstrap(getState());

--- a/suite/tor-desktop/src/toggleTorThunk.ts
+++ b/suite/tor-desktop/src/toggleTorThunk.ts
@@ -12,6 +12,7 @@ import { getCustomBackends } from '@suite-common/wallet-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 type ToggleTorThunkState = TorRootState & ModalRootState & RouterRootState & BlockchainRootState;
+
 type ToggleTorThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export type ToggleTorDispatch = ThunkDispatch<

--- a/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
@@ -4,7 +4,7 @@ import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import {
     type CoinProtocol,
-    type HandleCoinProtocolUriDeps,
+    type HandleCoinProtocolUriThunkDeps,
     handleCoinProtocolUri,
 } from './handleCoinProtocolUri';
 
@@ -23,7 +23,7 @@ const setup = () => {
         payload: coinProtocol,
     }));
 
-    const extra: HandleCoinProtocolUriDeps = {
+    const extra: HandleCoinProtocolUriThunkDeps = {
         services: {
             analytics: mockDesktopAnalytics(report),
             findNetworkSymbolForProtocol,

--- a/suite/transfer-uri/src/handleCoinProtocolUri.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.ts
@@ -19,7 +19,7 @@ export type CoinProtocol = {
 
 type SaveCoinProtocol = (coinProtocol: CoinProtocol) => UnknownAction;
 
-export type HandleCoinProtocolUriDeps = WithServices<
+export type HandleCoinProtocolUriThunkDeps = WithServices<
     FindNetworkSymbolForProtocolDep & DesktopAnalyticsDep
 >;
 
@@ -32,7 +32,7 @@ export type HandleCoinProtocolUriDeps = WithServices<
  */
 export const handleCoinProtocolUri =
     (uri: string, saveCoinProtocol: SaveCoinProtocol) =>
-    (dispatch: Dispatch, _getState: unknown, extra: HandleCoinProtocolUriDeps) => {
+    (dispatch: Dispatch, _getState: unknown, extra: HandleCoinProtocolUriThunkDeps) => {
         // Report any URI carrying a recognizable scheme (incl. unknown-protocol deeplinks).
         const reportScheme = (scheme: string, amountPresent: boolean) =>
             extra.services.analytics.report({


### PR DESCRIPTION
## Description

Enforce explicit, predictably named state and dependency contracts for RTK and vanilla thunks, plus the project’s dependency-injected service factory shape. Require consistently separated `State → Deps → thunk` and `Deps → service type → factory` blocks, and migrate existing affected definitions.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/enforce-dependency-contracts/web/](https://dev.suite.sldev.cz/suite-web/chore/enforce-dependency-contracts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/enforce-dependency-contracts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/enforce-dependency-contracts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/enforce-dependency-contracts&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T09:47:47.410Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T09:48:09.149Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->