### PR TITLE
test(wallet-core): cover phishing filtering of transaction notifications

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts
@@ -1,3 +1,12 @@
+import { type DeviceRootState } from '@suite-common/device';
+import {
+    type NotificationsRootState,
+    type TransactionNotification,
+} from '@suite-common/toast-notifications';
+import {
+    DUST_PHISHING_THRESHOLD,
+    type TokenDefinitionsRootState,
+} from '@suite-common/token-definitions';
 import {
     type Account,
     type AccountKey,
@@ -9,10 +18,13 @@ import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { type TransactionsRootState } from './transactionsReducerTypes';
 import {
     selectEvmPrivatePendingHint,
+    selectHasUnseenNonPhishingTransactionNotifications,
+    selectNonPhishingTransactionNotifications,
     selectTransactionsWithMissingRates,
 } from './transactionsSelectors';
 import { type AccountsRootState } from '../accounts/accountsReducer';
 import { type FiatRatesRootState } from '../fiat-rates/fiatRatesTypes';
+import { type PhishingRootState } from '../phishing/phishingReducerTypes';
 
 const ACCOUNT_KEY = 'descriptor-eth-device' as AccountKey;
 const LOCAL_CURRENCY = 'usd' as BaseCurrencyCode;
@@ -113,5 +125,107 @@ describe('selectEvmPrivatePendingHint', () => {
     it('returns undefined when the account has no transactions', () => {
         const state = getHintState([pendingSentTx(7)]);
         expect(selectEvmPrivatePendingHint(state, 'missing-account' as AccountKey)).toBeUndefined();
+    });
+});
+
+describe('selectNonPhishingTransactionNotifications', () => {
+    const PHISHING_ACCOUNT_KEY = 'phishing-eth-account' as AccountKey;
+    const DEVICE_STATE = 'phishing-device-session';
+    const DESCRIPTOR = '0x37567E60ab231b7D7f26B5b34FDD719098E4Ee1b';
+
+    const ETH_USD_RATE = 2000;
+
+    // 5e11 wei is 0.001 USD at the rate above, a fifth of the dust threshold. 1e16 wei is 20 USD.
+    const DUST_AMOUNT_IN_WEI = '500000000000';
+    const MEANINGFUL_AMOUNT_IN_WEI = '10000000000000000';
+
+    const phishingEthAccount = {
+        key: PHISHING_ACCOUNT_KEY,
+        symbol: 'eth',
+        descriptor: DESCRIPTOR,
+        deviceState: DEVICE_STATE,
+    } as unknown as Account;
+
+    const receivedTransaction = (amount: string): WalletAccountTransaction =>
+        ({
+            txid: 'received-tx',
+            symbol: 'eth',
+            type: 'recv',
+            amount,
+            blockTime: HOUR_ALIGNED_TIMESTAMP,
+            tokens: [],
+            internalTransfers: [],
+        }) as unknown as WalletAccountTransaction;
+
+    const receivedNotification: TransactionNotification = {
+        context: 'event',
+        type: 'tx-received',
+        id: 1,
+        seen: false,
+        descriptor: DESCRIPTOR,
+        symbol: 'eth',
+        txid: 'received-tx',
+        formattedAmount: '0.0000005 ETH',
+    } as TransactionNotification;
+
+    type PhishingState = NotificationsRootState &
+        TokenDefinitionsRootState &
+        TransactionsRootState &
+        AccountsRootState &
+        FiatRatesRootState &
+        PhishingRootState &
+        DeviceRootState;
+
+    const getPhishingState = ({
+        amount,
+        isDustPhishingEnabled = true,
+    }: {
+        amount: string;
+        isDustPhishingEnabled?: boolean;
+    }): PhishingState =>
+        ({
+            notifications: [receivedNotification],
+            device: { selectedDevice: { state: { staticSessionId: DEVICE_STATE } } },
+            // ETH declares the coin-definitions feature, so an entry is required here or
+            // phishing detection bails out early.
+            tokenDefinitions: { eth: {} },
+            wallet: {
+                accounts: [phishingEthAccount],
+                transactions: {
+                    transactions: { [PHISHING_ACCOUNT_KEY]: [receivedTransaction(amount)] },
+                    phishing: {},
+                },
+                fiat: { historic: { 'eth-usd': { [HOUR_ALIGNED_TIMESTAMP]: ETH_USD_RATE } } },
+                phishing: {
+                    dustPhishing: {
+                        isEnabled: isDustPhishingEnabled,
+                        dustThreshold: DUST_PHISHING_THRESHOLD,
+                    },
+                },
+            },
+        }) as unknown as PhishingState;
+
+    it('omits a notification whose transaction moves a dust-sized amount', () => {
+        const state = getPhishingState({ amount: DUST_AMOUNT_IN_WEI });
+
+        expect(selectNonPhishingTransactionNotifications(state)).toEqual([]);
+        expect(selectHasUnseenNonPhishingTransactionNotifications(state)).toBe(false);
+    });
+
+    it('keeps a notification whose transaction moves a meaningful amount', () => {
+        const state = getPhishingState({ amount: MEANINGFUL_AMOUNT_IN_WEI });
+
+        expect(selectNonPhishingTransactionNotifications(state)).toEqual([receivedNotification]);
+        expect(selectHasUnseenNonPhishingTransactionNotifications(state)).toBe(true);
+    });
+
+    it('keeps a dust notification when the user turned dust phishing detection off', () => {
+        const state = getPhishingState({
+            amount: DUST_AMOUNT_IN_WEI,
+            isDustPhishingEnabled: false,
+        });
+
+        expect(selectNonPhishingTransactionNotifications(state)).toEqual([receivedNotification]);
+        expect(selectHasUnseenNonPhishingTransactionNotifications(state)).toBe(true);
     });
 });


### PR DESCRIPTION
## Description

Adds unit coverage for `selectNonPhishingTransactionNotifications` and
`selectHasUnseenNonPhishingTransactionNotifications`, which had none.

The phishing detectors are already covered by fixtures in `@suite-common/token-definitions`. What
was missing is the step after them: that a transaction they flag really does drop out of the
notification list, so a scam transaction never shows up in Activity and never lights up the unseen
indicator.

Three cases — a dust-sized ETH receive is filtered out, a meaningful amount comes through, and so
does the dust one once the user turns dust phishing detection off. The last two are deliberate
controls: the selector needs an account, a transaction, a token-definitions entry and a fiat rate
all lined up at once, and any one of those wrong would empty the list in all three cases.

Test-only change, no production code touched.

## Notes for QA

Nothing to test manually. Verified with a mutation check: neutering `isDustValuePhishing` fails
exactly the dust case and leaves the other two green.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to a unit test file for transaction selectors, so the primary E2E risk is regressions in transaction display, filtering, and state grouping. Run the focused wallet transaction tests rather than broad coverage; no static mapping existed, so these recommendations are inferred from the selector functionality the changed file exercises.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises transaction display, time-range filtering, latest-transaction lookup, and address search in the wallet UI — all consumer paths of transaction selectors. A regression in transactionSelectors would most visibly surface here.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Tests pending versus confirmed transaction grouping, status labels, and transaction detail modals, which rely on selector-derived transaction state. A selector change could alter how pending/confirmed transactions are categorized or displayed.
- `suite/e2e/tests/wallet/pagination.test.ts` — Covers paginated transaction list rendering and navigation on a Bitcoin account. If transaction selectors affect list ordering, slicing, or address formatting, this test would catch the regression.

</details>

_Updated: 2026-08-28T13:22:20.964Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/phishing-notification-selectors/web/](https://dev.suite.sldev.cz/suite-web/test/phishing-notification-selectors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/phishing-notification-selectors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/phishing-notification-selectors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/phishing-notification-selectors&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T13:25:06.217Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-28T13:24:41.421Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->