### PR TITLE
fix(suite-native): stop yield claim fee from refreshing on unrelated store updates

### DIFF
--- a/suite-common/wallet-core/src/fees/feesReducer.test.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.test.ts
@@ -1,0 +1,78 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type FeeInfo, type FeesState } from '@suite-common/wallet-types';
+
+import { selectConvertedNetworkFeeInfo } from './feesReducer';
+import { type FeesRootState } from './feesSelectors';
+
+const ethSymbol = asNetworkSymbol('eth');
+const btcSymbol = asNetworkSymbol('btc');
+
+const ethFeeInfo: FeeInfo = {
+    blockHeight: 200,
+    blockTime: 12,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 1,
+    levels: [{ label: 'normal', feePerUnit: '3000000000', blocks: 2 }],
+};
+
+const btcFeeInfo: FeeInfo = {
+    blockHeight: 800000,
+    blockTime: 10,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 0,
+    levels: [{ label: 'normal', feePerUnit: '10', blocks: 3 }],
+};
+
+const buildState = (fees: FeesState): FeesRootState => ({ wallet: { fees } });
+
+describe('selectConvertedNetworkFeeInfo', () => {
+    it('returns null when the network has no fee entry', () => {
+        const state = buildState({ [btcSymbol]: { status: 'loaded', data: btcFeeInfo } });
+
+        expect(selectConvertedNetworkFeeInfo(state, ethSymbol)).toBeNull();
+        expect(selectConvertedNetworkFeeInfo(state, undefined)).toBeNull();
+    });
+
+    it('returns converted fee info when the network entry exists without data yet', () => {
+        const state = buildState({ [ethSymbol]: { status: 'loading' } });
+
+        expect(selectConvertedNetworkFeeInfo(state, ethSymbol)).not.toBeNull();
+    });
+
+    it('keeps the returned reference stable when another network fees change', () => {
+        const ethEntry = { status: 'loaded', data: ethFeeInfo } as const;
+        const stateBefore = buildState({ [ethSymbol]: ethEntry });
+        const stateAfter = buildState({
+            [ethSymbol]: ethEntry,
+            [btcSymbol]: { status: 'loaded', data: btcFeeInfo },
+        });
+
+        expect(selectConvertedNetworkFeeInfo(stateAfter, ethSymbol)).toBe(
+            selectConvertedNetworkFeeInfo(stateBefore, ethSymbol),
+        );
+    });
+
+    it('keeps the returned reference stable when only the network status changes', () => {
+        const stateBefore = buildState({ [ethSymbol]: { status: 'loaded', data: ethFeeInfo } });
+        const stateAfter = buildState({ [ethSymbol]: { status: 'loading', data: ethFeeInfo } });
+
+        expect(selectConvertedNetworkFeeInfo(stateAfter, ethSymbol)).toBe(
+            selectConvertedNetworkFeeInfo(stateBefore, ethSymbol),
+        );
+    });
+
+    it('returns new converted fee info when the network fee data change', () => {
+        const stateBefore = buildState({ [ethSymbol]: { status: 'loaded', data: ethFeeInfo } });
+        const stateAfter = buildState({
+            [ethSymbol]: { status: 'loaded', data: { ...ethFeeInfo, blockHeight: 201 } },
+        });
+
+        const feeInfoBefore = selectConvertedNetworkFeeInfo(stateBefore, ethSymbol);
+        const feeInfoAfter = selectConvertedNetworkFeeInfo(stateAfter, ethSymbol);
+
+        expect(feeInfoAfter).not.toBe(feeInfoBefore);
+        expect(feeInfoAfter?.blockHeight).toBe(201);
+    });
+});

--- a/suite-common/wallet-core/src/fees/feesReducer.ts
+++ b/suite-common/wallet-core/src/fees/feesReducer.ts
@@ -13,7 +13,7 @@ import { getConvertedOrDefaultFeeInfo, isEip1559 } from '@suite-common/wallet-ut
 import { type FeeLevel } from '@trezor/connect';
 
 import { feesActions } from './feesActions';
-import { type FeesRootState, selectFees } from './feesSelectors';
+import { type FeesRootState, selectFees, selectRawNetworkFeeInfo } from './feesSelectors';
 import { updateFeeInfoThunk } from './feesThunks';
 
 export { type FeesRootState, selectFees, selectRawNetworkFeeInfo } from './feesSelectors';
@@ -46,19 +46,27 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<FeesRootState>();
 
 /**
  * Returns feeInfo per network, cleaned up, and for Ethereum also converted from wei to Gwei.
+ *
+ * Inputs are limited to the given network's fee data (plus entry existence) so the returned
+ * reference stays stable across unrelated fees updates — other networks' fees and status-only
+ * changes (e.g. `loading`) of the same network.
  */
 export const selectConvertedNetworkFeeInfo = createMemoizedSelector(
-    [selectFees, (_state: FeesRootState, symbol?: NetworkSymbol) => symbol],
-    (fees, symbol): FeeInfo | null => {
-        if (!symbol || !fees[symbol]) return null;
+    [
+        selectRawNetworkFeeInfo,
+        (state: FeesRootState, symbol?: NetworkSymbol) =>
+            symbol !== undefined && selectFees(state)[symbol] !== undefined,
+        (_state: FeesRootState, symbol?: NetworkSymbol) => symbol,
+    ],
+    (rawFeeInfo, hasFeeEntry, symbol): FeeInfo | null => {
+        if (!symbol || !hasFeeEntry) return null;
 
         const networkType = getNetworkType(symbol);
-        const feeInfo = getConvertedOrDefaultFeeInfo({
-            networkType,
-            feeInfo: fees[symbol].data,
-        });
 
-        return feeInfo;
+        return getConvertedOrDefaultFeeInfo({
+            networkType,
+            feeInfo: rawFeeInfo,
+        });
     },
 );
 

--- a/suite-native/module-earn/src/hooks/useYieldClaimFees.test.ts
+++ b/suite-native/module-earn/src/hooks/useYieldClaimFees.test.ts
@@ -1,0 +1,190 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { buildClaimCalldata } from '@suite-common/earn-stablecoin';
+import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { estimateYieldFeeLevel, formDraftReducer } from '@suite-common/wallet-core';
+import { type FeesState, type PrecomposedLevels } from '@suite-common/wallet-types';
+import {
+    act,
+    createLightStore,
+    createStaticReducer,
+    renderHookWithStoreProvider,
+} from '@suite-native/test-utils-store';
+import { prepareSendFormReducer } from '@suite-native/transaction-management';
+
+import { useYieldClaimFees } from './useYieldClaimFees';
+import { type StablecoinYieldAccountRewards } from '../utils/stablecoinYieldClaimSummaryUtils';
+import { buildYieldClaimFeeLevels, getYieldClaimFee } from '../utils/yieldClaimFeeUtils';
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    estimateYieldFeeLevel: jest.fn(),
+    ethereumGetCurrentNonceThunk: jest.fn(() => () => ({
+        unwrap: () => Promise.resolve({ nonce: '5' }),
+    })),
+}));
+
+jest.mock('@suite-common/earn-stablecoin', () => ({
+    ...jest.requireActual('@suite-common/earn-stablecoin'),
+    buildClaimCalldata: jest.fn(),
+    buildUnsignedClaimTransaction: jest.fn(() => ({ type: 'unsigned-claim-transaction' })),
+}));
+
+jest.mock('../utils/yieldClaimFeeUtils', () => ({
+    buildYieldClaimFeeLevels: jest.fn(),
+    getYieldClaimFee: jest.fn(),
+}));
+
+const estimateYieldFeeLevelMock = jest.mocked(estimateYieldFeeLevel);
+const buildClaimCalldataMock = jest.mocked(buildClaimCalldata);
+const buildYieldClaimFeeLevelsMock = jest.mocked(buildYieldClaimFeeLevels);
+const getYieldClaimFeeMock = jest.mocked(getYieldClaimFee);
+
+const FEE_LEVELS = {
+    normal: { type: 'final', fee: '21000000', feeLimit: '21000' },
+} as unknown as PrecomposedLevels;
+
+const FEES_STATE = {
+    eth: {
+        status: 'loaded',
+        data: {
+            blockHeight: 100,
+            blockTime: 12,
+            minFee: 1,
+            maxFee: 100,
+            minPriorityFee: 1,
+            levels: [{ label: 'normal', feePerUnit: '10', blocks: 1 }],
+        },
+    },
+} as unknown as FeesState;
+
+const ACCOUNT = {
+    key: 'account-key',
+    symbol: 'eth',
+    networkType: 'ethereum',
+    descriptor: '0xSenderAddress',
+    deviceState: 'device-state',
+    availableBalance: '1000000000000000000',
+} as unknown as StablecoinYieldAccountRewards['account'];
+
+const createAccountRewards = (amount = '100') =>
+    ({
+        account: ACCOUNT,
+        rewards: [{ amount, proofs: [], token: { address: '0xToken', symbol: 'TKN' } }],
+        totalFiatClaimableAmount: '1',
+    }) as unknown as StablecoinYieldAccountRewards;
+
+type HookProps = {
+    accountRewards: StablecoinYieldAccountRewards | null;
+    isEnabled: boolean;
+};
+
+const createTestStore = () =>
+    createLightStore({
+        reducer: {
+            // Static slices required by the test store provider (formatters config).
+            discreetMode: createStaticReducer({ isActive: false }),
+            locale: createStaticReducer({ systemLocaleCode: 'en', appLocaleCode: 'system' }),
+            wallet: combineReducers({
+                settings: createStaticReducer({
+                    localCurrency: 'usd',
+                    bitcoinAmountUnit: 0,
+                    addressDisplayType: 'chunked',
+                }),
+                fees: createStaticReducer(FEES_STATE),
+                formDrafts: formDraftReducer,
+                send: prepareSendFormReducer(extraDependenciesCommonMock),
+            }),
+        },
+    });
+
+const renderYieldClaimFees = (initialProps: HookProps) =>
+    renderHookWithStoreProvider((props: HookProps) => useYieldClaimFees(props), {
+        store: createTestStore(),
+        initialProps,
+    });
+
+/** Fires the fee preparation debounce (300 ms) and lets the pending promises settle. */
+const settleDebounce = () => act(() => jest.advanceTimersByTimeAsync(300));
+
+describe('useYieldClaimFees', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        estimateYieldFeeLevelMock.mockResolvedValue({
+            success: true,
+            payload: { feeLimit: '21000' },
+        } as unknown as Awaited<ReturnType<typeof estimateYieldFeeLevel>>);
+        buildClaimCalldataMock.mockImplementation(
+            ({ rewards }) =>
+                `0xcalldata-${rewards.map(reward => reward.amount).join('-')}` as ReturnType<
+                    typeof buildClaimCalldata
+                >,
+        );
+        buildYieldClaimFeeLevelsMock.mockReturnValue(FEE_LEVELS);
+        getYieldClaimFeeMock.mockReturnValue({
+            gasLimit: '21000',
+            maxFeePerGas: '10',
+            maxPriorityFeePerGas: '1',
+        } as ReturnType<typeof getYieldClaimFee>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.useRealTimers();
+    });
+
+    it('prepares the claim fee', async () => {
+        const { result } = renderYieldClaimFees({
+            accountRewards: createAccountRewards(),
+            isEnabled: true,
+        });
+
+        expect(result.current.isPreparingClaimFee).toBe(true);
+
+        await settleDebounce();
+
+        expect(estimateYieldFeeLevelMock).toHaveBeenCalledTimes(1);
+        expect(result.current.isPreparingClaimFee).toBe(false);
+        expect(result.current.preparedAction).not.toBeNull();
+    });
+
+    it('does not re-prepare when rewards only get a new identity with unchanged values', async () => {
+        const { result, rerender } = renderYieldClaimFees({
+            accountRewards: createAccountRewards(),
+            isEnabled: true,
+        });
+
+        await settleDebounce();
+
+        const { preparedAction } = result.current;
+
+        // A new deep-equal object, as produced by e.g. an unrelated fiat rates update.
+        rerender({ accountRewards: createAccountRewards(), isEnabled: true });
+
+        expect(result.current.isPreparingClaimFee).toBe(false);
+        expect(result.current.preparedAction).toBe(preparedAction);
+
+        await settleDebounce();
+
+        expect(estimateYieldFeeLevelMock).toHaveBeenCalledTimes(1);
+        expect(result.current.preparedAction).toBe(preparedAction);
+    });
+
+    it('re-prepares when the claim rewards actually change', async () => {
+        const { result, rerender } = renderYieldClaimFees({
+            accountRewards: createAccountRewards(),
+            isEnabled: true,
+        });
+
+        await settleDebounce();
+
+        rerender({ accountRewards: createAccountRewards('200'), isEnabled: true });
+
+        expect(result.current.isPreparingClaimFee).toBe(true);
+
+        await settleDebounce();
+
+        expect(estimateYieldFeeLevelMock).toHaveBeenCalledTimes(2);
+        expect(result.current.preparedAction).not.toBeNull();
+    });
+});

--- a/suite-native/module-earn/src/hooks/yield/useYieldClaimFees.test.ts
+++ b/suite-native/module-earn/src/hooks/yield/useYieldClaimFees.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { buildClaimCalldata } from '@suite-common/earn-stablecoin';
-import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
 import { estimateYieldFeeLevel, formDraftReducer } from '@suite-common/wallet-core';
 import { type FeesState, type PrecomposedLevels } from '@suite-common/wallet-types';
 import {
@@ -13,8 +13,8 @@ import {
 import { prepareSendFormReducer } from '@suite-native/transaction-management';
 
 import { useYieldClaimFees } from './useYieldClaimFees';
-import { type StablecoinYieldAccountRewards } from '../utils/stablecoinYieldClaimSummaryUtils';
-import { buildYieldClaimFeeLevels, getYieldClaimFee } from '../utils/yieldClaimFeeUtils';
+import { type StablecoinYieldAccountRewards } from '../../utils/yield/stablecoinYieldClaimSummaryUtils';
+import { buildYieldClaimFeeLevels, getYieldClaimFee } from '../../utils/yield/yieldClaimFeeUtils';
 
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
@@ -30,7 +30,7 @@ jest.mock('@suite-common/earn-stablecoin', () => ({
     buildUnsignedClaimTransaction: jest.fn(() => ({ type: 'unsigned-claim-transaction' })),
 }));
 
-jest.mock('../utils/yieldClaimFeeUtils', () => ({
+jest.mock('../../utils/yield/yieldClaimFeeUtils', () => ({
     buildYieldClaimFeeLevels: jest.fn(),
     getYieldClaimFee: jest.fn(),
 }));
@@ -93,7 +93,10 @@ const createTestStore = () =>
                 }),
                 fees: createStaticReducer(FEES_STATE),
                 formDrafts: formDraftReducer,
-                send: prepareSendFormReducer(extraDependenciesCommonMock),
+                send: prepareSendFormReducer({
+                    actionTypes: { storageLoad: mockActionType('storageLoad') },
+                    reducers: { storageLoadFormDrafts: mockReducer() },
+                }),
             }),
         },
     });
@@ -134,7 +137,7 @@ describe('useYieldClaimFees', () => {
     });
 
     it('prepares the claim fee', async () => {
-        const { result } = renderYieldClaimFees({
+        const { result } = await renderYieldClaimFees({
             accountRewards: createAccountRewards(),
             isEnabled: true,
         });
@@ -149,7 +152,7 @@ describe('useYieldClaimFees', () => {
     });
 
     it('does not re-prepare when rewards only get a new identity with unchanged values', async () => {
-        const { result, rerender } = renderYieldClaimFees({
+        const { result, rerender } = await renderYieldClaimFees({
             accountRewards: createAccountRewards(),
             isEnabled: true,
         });
@@ -159,7 +162,7 @@ describe('useYieldClaimFees', () => {
         const { preparedAction } = result.current;
 
         // A new deep-equal object, as produced by e.g. an unrelated fiat rates update.
-        rerender({ accountRewards: createAccountRewards(), isEnabled: true });
+        await rerender({ accountRewards: createAccountRewards(), isEnabled: true });
 
         expect(result.current.isPreparingClaimFee).toBe(false);
         expect(result.current.preparedAction).toBe(preparedAction);
@@ -171,14 +174,14 @@ describe('useYieldClaimFees', () => {
     });
 
     it('re-prepares when the claim rewards actually change', async () => {
-        const { result, rerender } = renderYieldClaimFees({
+        const { result, rerender } = await renderYieldClaimFees({
             accountRewards: createAccountRewards(),
             isEnabled: true,
         });
 
         await settleDebounce();
 
-        rerender({ accountRewards: createAccountRewards('200'), isEnabled: true });
+        await rerender({ accountRewards: createAccountRewards('200'), isEnabled: true });
 
         expect(result.current.isPreparingClaimFee).toBe(true);
 

--- a/suite-native/module-earn/src/hooks/yield/useYieldClaimFees.ts
+++ b/suite-native/module-earn/src/hooks/yield/useYieldClaimFees.ts
@@ -30,7 +30,7 @@ import {
     selectFeeLevels,
     transactionManagementActions,
 } from '@suite-native/transaction-management';
-import { useDebounce } from '@trezor/react-utils';
+import { useDebounce, useFreshRef } from '@trezor/react-utils';
 
 import { useYieldFeeEstimationError } from './useYieldFeeEstimationError';
 import {
@@ -105,13 +105,13 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
     const feeInfo = useSelector((state: FeesRootState) =>
         selectConvertedNetworkFeeInfo(state, account?.symbol),
     );
+    const feeInfoRef = useFreshRef(feeInfo);
     const formDraft = useSelector((state: FormDraftRootState) =>
         claimFormDraftKey
             ? (selectDeepCopyOfFormDraft(state, claimFormDraftKey) as FormState | undefined)
             : undefined,
     );
-    const formDraftRef = useRef(formDraft);
-    formDraftRef.current = formDraft;
+    const formDraftRef = useFreshRef(formDraft);
     const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
     const selectedFee = formDraft?.selectedFee ?? 'normal';
     const selectedFeeLevel = feeLevels[selectedFee];
@@ -172,7 +172,9 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
             }: PrepareClaimFeeParams,
             requestId: number,
         ) => {
-            if (!feeInfo || !claimFormDraftKey) {
+            const currentFeeInfo = feeInfoRef.current;
+
+            if (!currentFeeInfo || !claimFormDraftKey) {
                 clearClaimFeeState();
 
                 return;
@@ -213,7 +215,7 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
                 });
                 const claimFeeLevels = buildYieldClaimFeeLevels({
                     availableBalance: claimAccount.availableBalance,
-                    feeInfo,
+                    feeInfo: currentFeeInfo,
                     formDraft: claimFormDraft,
                     gasLimit: feeLevel.payload.feeLimit,
                 });
@@ -242,8 +244,25 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
                 }
             }
         },
-        [claimFormDraftKey, clearClaimFeeState, dispatch, feeInfo, setHasFeeEstimationError],
+        [
+            claimFormDraftKey,
+            clearClaimFeeState,
+            dispatch,
+            feeInfoRef,
+            formDraftRef,
+            setHasFeeEstimationError,
+        ],
     );
+
+    const prepareClaimFeeParamsRef = useFreshRef(prepareClaimFeeParams);
+
+    // Value-stable keys of the fee preparation inputs. `prepareClaimFeeParams` gets a new identity
+    // whenever `accountRewards` does (e.g. on any fiat rates update), so keying the effect on the
+    // params object would keep re-running the fee preparation without its actual inputs changing.
+    const claimCalldata = prepareClaimFeeParams?.claimCalldata ?? null;
+    const claimContractAddress = prepareClaimFeeParams?.contractAddress ?? null;
+    const claimChainId = prepareClaimFeeParams?.chainId ?? null;
+    const feeInfoBlockHeight = feeInfo?.blockHeight ?? null;
 
     useEffect(() => {
         const requestId = requestIdRef.current + 1;
@@ -251,7 +270,9 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
 
         setHasFeeEstimationError(false);
 
-        if (!prepareClaimFeeParams) {
+        const params = prepareClaimFeeParamsRef.current;
+
+        if (!params) {
             clearClaimFeeState();
 
             return;
@@ -259,13 +280,17 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
 
         setBaseContext(null);
         setIsPreparingClaimFee(true);
-        void debounce(() => void prepareClaimFee(prepareClaimFeeParams, requestId));
+        void debounce(() => void prepareClaimFee(params, requestId));
     }, [
+        claimCalldata,
+        claimChainId,
+        claimContractAddress,
         clearClaimFeeState,
         debounce,
         feeEstimationRetryKey,
+        feeInfoBlockHeight,
         prepareClaimFee,
-        prepareClaimFeeParams,
+        prepareClaimFeeParamsRef,
         setHasFeeEstimationError,
     ]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The claim form kept re-preparing the fee (and toggling the Continue button) because the fee preparation effect in `useYieldClaimFees` was keyed on object identities that get recreated by unrelated store updates — mainly fiat rate refreshes propagating through `accountRewards`.

- `useYieldClaimFees`: the prepare effect is now keyed on value-stable primitives (claim calldata, contract address, chain id, fee info block height); volatile objects are read via refs at execution time. Fee preparation now re-runs only when its actual inputs change
- `selectConvertedNetworkFeeInfo`: derives from the given network's fee data instead of the whole fees state, so its reference stays stable across other networks' updates and status-only changes

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31733

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only suite-web/suite-desktop source change is the fees reducer in suite-common/wallet-core, which is a broad shared dependency. The mobile yield hook changes are suite-native only and not covered by these Playwright E2E tests. I recommend a small, targeted set of tests that directly configure and assert custom fees in send and trading flows, where fee reducer regressions would be user-visible. No broad coverage is needed.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/wallet-core/src/fees/feesReducer.test.ts`
- `suite-common/wallet-core/src/fees/feesReducer.ts`
- `suite-native/module-earn/src/hooks/yield/useYieldClaimFees.test.ts`
- `suite-native/module-earn/src/hooks/yield/useYieldClaimFees.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/sell-inputs.test.ts` — Directly exercises custom Bitcoin fee rate switching, Max amount calculation (balance minus fee), and fee validation in the sell form. A regression in fee reducer state would be immediately visible in the displayed fee and Max amount behavior.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Validates custom Bitcoin fee rate input (10 sat/vB), fee rate display in the confirmation modal, and fee rate shown on the device emulator's Fee Info screen. This directly relies on fee reducer state for custom fee selection.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Exercises custom EIP-1559 fee parameters (gas limit, max fee per gas, max priority fee per gas), their display in the device prompt, and Fee Info screen values. Changes to fee reducer state would break these assertions.
- `suite/e2e/tests/wallet/send-base.test.ts` — Covers setting custom Ethereum-style fees on Base network and verifying gas limit, max fee per gas, and max priority fee per gas in the device prompt. The fee reducer is central to storing and computing these values.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly tests custom gas fee input and the resulting fee breakdown displayed on the device confirmation screen. This is one of the primary user flows that reads from fee reducer state.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Uses custom gas fees in the sell flow and verifies fee-related fields on the device prompt. While important, it shares the same fee infrastructure already covered by swap-fees-ethereum and send-eth.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Exercises Send Max calculation which subtracts transaction fee and network reserve from balance. Fee state changes could affect the computed max amount and total sent display.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/fees/feesReducer.test.ts`
- `suite-native/module-earn/src/hooks/yield/useYieldClaimFees.test.ts`
- `suite-native/module-earn/src/hooks/yield/useYieldClaimFees.ts`

_Updated: 2026-09-02T17:41:44.852Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/converted-fee-info-selector-stability/web/](https://dev.suite.sldev.cz/suite-web/fix/converted-fee-info-selector-stability/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/converted-fee-info-selector-stability&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/converted-fee-info-selector-stability&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/converted-fee-info-selector-stability&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T17:44:57.968Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T17:44:46.445Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->