### PR TITLE
test(suite-native): stub looping videos in E2E builds

### DIFF
--- a/suite-native/device/src/components/TrezorAnimation.e2e.tsx
+++ b/suite-native/device/src/components/TrezorAnimation.e2e.tsx
@@ -1,0 +1,21 @@
+import { View } from 'react-native';
+
+import type { VideoPlayer } from 'expo-video/src/VideoPlayer.types';
+
+import { useNativeStyles } from '@trezor/styles-native';
+
+import { animationStyle } from './TrezorAnimation.styles';
+
+type TrezorAnimationProps = {
+    player: VideoPlayer;
+};
+
+// The source is a looping 2000x2666 H.264 video and the Android emulator decodes
+// it in its own host process. That decoding is a known source of emulator
+// instability and of CPU starvation on CI runners, so E2E builds only reserve the
+// layout space instead of playing anything.
+export const TrezorAnimation = (_props: TrezorAnimationProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return <View style={applyStyle(animationStyle)} />;
+};

--- a/suite-native/device/src/components/TrezorAnimation.styles.ts
+++ b/suite-native/device/src/components/TrezorAnimation.styles.ts
@@ -1,0 +1,12 @@
+import { prepareNativeStyle } from '@trezor/styles-native';
+
+const ANIMATION_WIDTH = 2000;
+const ANIMATION_HEIGHT = 2667;
+
+export const animationStyle = prepareNativeStyle(({ borders }) => ({
+    flexShrink: 1,
+    alignSelf: 'center',
+    width: '100%',
+    aspectRatio: ANIMATION_WIDTH / ANIMATION_HEIGHT,
+    borderRadius: borders.radii.r16,
+}));

--- a/suite-native/device/src/components/TrezorAnimation.tsx
+++ b/suite-native/device/src/components/TrezorAnimation.tsx
@@ -4,18 +4,9 @@ import { useFocusEffect } from '@react-navigation/native';
 import { VideoView } from 'expo-video';
 import type { VideoPlayer } from 'expo-video/src/VideoPlayer.types';
 
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { useNativeStyles } from '@trezor/styles-native';
 
-const ANIMATION_WIDTH = 2000;
-const ANIMATION_HEIGHT = 2667;
-
-const animationStyle = prepareNativeStyle(({ borders }) => ({
-    flexShrink: 1,
-    alignSelf: 'center',
-    width: '100%',
-    aspectRatio: ANIMATION_WIDTH / ANIMATION_HEIGHT,
-    borderRadius: borders.radii.r16,
-}));
+import { animationStyle } from './TrezorAnimation.styles';
 
 type TrezorAnimationProps = {
     player: VideoPlayer;

--- a/suite-native/module-authorize-device/src/components/connect/BluetoothPairingAnimation.e2e.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/BluetoothPairingAnimation.e2e.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import { useNativeStyles } from '@trezor/styles-native';
+
+import { animationStyle } from './BluetoothPairingAnimation.styles';
+
+// Looping H.264 playback is decoded by the Android emulator host process, which
+// destabilizes it on CI runners, so E2E builds only reserve the layout space.
+export const BluetoothPairingAnimation = () => {
+    const { applyStyle } = useNativeStyles();
+
+    return <View style={applyStyle(animationStyle)} />;
+};

--- a/suite-native/module-authorize-device/src/components/connect/BluetoothPairingAnimation.styles.ts
+++ b/suite-native/module-authorize-device/src/components/connect/BluetoothPairingAnimation.styles.ts
@@ -1,0 +1,6 @@
+import { prepareNativeStyle } from '@trezor/styles-native';
+
+export const animationStyle = prepareNativeStyle(({ borders }) => ({
+    aspectRatio: 1,
+    borderRadius: borders.radii.r16,
+}));

--- a/suite-native/module-authorize-device/src/components/connect/BluetoothPairingAnimation.tsx
+++ b/suite-native/module-authorize-device/src/components/connect/BluetoothPairingAnimation.tsx
@@ -3,18 +3,15 @@ import React from 'react';
 import { VideoView, useVideoPlayer } from 'expo-video';
 
 import { useActiveColorScheme } from '@suite-native/theme';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { useNativeStyles } from '@trezor/styles-native';
 import { type ThemeColorVariant } from '@trezor/theme';
+
+import { animationStyle } from './BluetoothPairingAnimation.styles';
 
 const bluetoothPairingAnimations = {
     standard: require('../../assets/bluetooth-pairing-standard.mp4'),
     dark: require('../../assets/bluetooth-pairing-dark.mp4'),
 } as const satisfies Record<ThemeColorVariant, string>;
-
-const animationStyle = prepareNativeStyle(({ borders }) => ({
-    aspectRatio: 1,
-    borderRadius: borders.radii.r16,
-}));
 
 export const BluetoothPairingAnimation = () => {
     const bluetoothPairingAnimation = bluetoothPairingAnimations[useActiveColorScheme()];

--- a/suite-native/video-assets/src/components/Video.e2e.tsx
+++ b/suite-native/video-assets/src/components/Video.e2e.tsx
@@ -1,0 +1,19 @@
+import { View } from 'react-native';
+
+import { useNativeStyles } from '@trezor/styles-native';
+
+import { type VideoName } from '../videos';
+import { videoContainer } from './Video.styles';
+
+type VideoProps = {
+    name: VideoName;
+    aspectRatio?: number;
+};
+
+// Looping H.264 playback is decoded by the Android emulator host process, which
+// destabilizes it on CI runners, so E2E builds only reserve the layout space.
+export const Video = ({ aspectRatio = 1 }: VideoProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return <View style={applyStyle(videoContainer, { aspectRatio })} />;
+};

--- a/suite-native/video-assets/src/components/Video.styles.ts
+++ b/suite-native/video-assets/src/components/Video.styles.ts
@@ -1,0 +1,21 @@
+import { prepareNativeStyle } from '@trezor/styles-native';
+
+type VideoStyleProps = {
+    aspectRatio: number;
+};
+
+export const videoContainer = prepareNativeStyle((utils, { aspectRatio }: VideoStyleProps) => ({
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: utils.borders.radii.r20,
+    aspectRatio,
+}));
+
+export const videoStyle = prepareNativeStyle<VideoStyleProps>((_, { aspectRatio }) => ({
+    flex: 1,
+    aspectRatio,
+}));
+
+export const activityIndicatorStyle = prepareNativeStyle(_ => ({
+    position: 'absolute',
+}));

--- a/suite-native/video-assets/src/components/Video.tsx
+++ b/suite-native/video-assets/src/components/Video.tsx
@@ -4,34 +4,15 @@ import Animated, { FadeIn } from 'react-native-reanimated';
 import { useEvent } from 'expo';
 import { VideoView, useVideoPlayer } from 'expo-video';
 
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { useNativeStyles } from '@trezor/styles-native';
 
 import { type VideoName, videos } from '../videos';
+import { activityIndicatorStyle, videoContainer, videoStyle } from './Video.styles';
 
 type VideoProps = {
     name: VideoName;
     aspectRatio?: number;
 };
-
-type VideoStyleProps = {
-    aspectRatio: number;
-};
-
-const videoContainer = prepareNativeStyle((utils, { aspectRatio }: VideoStyleProps) => ({
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: utils.borders.radii.r20,
-    aspectRatio,
-}));
-
-const videoStyle = prepareNativeStyle<VideoStyleProps>((_, { aspectRatio }) => ({
-    flex: 1,
-    aspectRatio,
-}));
-
-const activityIndicatorStyle = prepareNativeStyle(_ => ({
-    position: 'absolute',
-}));
 
 export const Video = ({ name, aspectRatio = 1 }: VideoProps) => {
     const { applyStyle, utils } = useNativeStyles();


### PR DESCRIPTION
## Description

The connect / turn-on device and Bluetooth pairing animations are looping H.264 videos — the device ones 2000x2666 @ 30 fps. The Android emulator decodes them in **its own host process**, so every test sitting on the "connect your Trezor" screen pays for continuous video decoding with CPU the emulated device does not have. Host-side media decoding is also a long-standing source of emulator instability.

No test looks at these animations, so E2E builds now render a same-sized placeholder instead.

## Notes for QA

- **Only E2E (Detox) builds are affected.** The overrides are picked up exclusively via `RN_SRC_EXT`, so debug and production builds are untouched — the animations must still play normally in the app. Worth a quick check that the connect-device, turn-on-device and Bluetooth pairing animations still animate in a regular build.
- In E2E runs the animations are replaced by empty space of the same size, so layout and scroll behaviour are unchanged. No test asserts on video content, so no test should change behaviour — expect the same or better pass rate, and slightly faster runs on the device-connect screens.
- Applies to iOS E2E builds too, since that workflow sets `RN_SRC_EXT` as well.


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/e2e-stub-video-animations&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->