### PR TITLE
fix(e2e): recover from Android emulator crashes and collect crash diagnostics

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -43,6 +43,15 @@ jobs:
       fail-fast: false
       matrix:
         TEST_GROUP: [0, 1, 2, 3, 4]
+    env:
+      # Single source of truth for the emulator options: the Detox runner reuses
+      # them verbatim when it has to relaunch an emulator that died mid-run.
+      # `-no-metrics` keeps the emulator non-interactive (the metrics-collection
+      # prompt is planned to become blocking in a future release).
+      EMULATOR_OPTIONS: >-
+        -no-window -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save
+        -noaudio -no-boot-anim -no-metrics -grpc 8554 -memory 4096
+      DIAGNOSTICS_DIR: /tmp/e2e-diagnostics
 
     steps:
       - name: Checkout project
@@ -128,6 +137,24 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      # The emulator dies without leaving a trace of its own when the kernel kills
+      # it, so sample host memory and disk next to the run to see what ran out.
+      - name: Start host resource monitor
+        run: |
+          mkdir -p "$DIAGNOSTICS_DIR"
+          nohup bash -c '
+            while true; do
+              {
+                date --iso-8601=seconds
+                free --mebi
+                df --human-readable / /tmp
+                ps -eo pid,rss,comm --sort=-rss | head -n 8
+                echo
+              } >> "$DIAGNOSTICS_DIR/host-resources.log" 2>&1
+              sleep 15
+            done
+          ' > /dev/null 2>&1 &
+
       - name: Run Detox E2E Android tests
         timeout-minutes: 50
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
@@ -152,7 +179,7 @@ jobs:
           ram-size: 4096M
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -grpc 8554 -memory 4096
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
           disable-animations: true
           cores: 4
           heap-size: 512M
@@ -178,19 +205,38 @@ jobs:
           docker cp trezor-user-env.unix:/trezor-user-env/logs/tropic_model.log "$LOG_DIR/trezor-user-env-tropic_model.log" || true
           docker cp trezor-user-env.unix:/trezor-user-env/docker/version.txt "$LOG_DIR/trezor-user-env-version.txt" || true
           docker logs trezor-user-env-regtest > "$LOG_DIR/electrum-regtest.txt" || true
-          # Emulator crash DB written by QEMU to the host filesystem on abnormal termination
-          find /tmp "$HOME/.android/avd" -name "emu-crash*.db" -print0 2>/dev/null \
-            | while IFS= read -r -d '' db; do
-              cp "$db" "$LOG_DIR/$(basename "$db")" || true
-              sqlite3 "$db" "SELECT * FROM Crash;" > "$LOG_DIR/$(basename "$db" .db)-report.txt" 2>&1 || true
-            done || true
+          docker logs docker-quota-db-1 > "$LOG_DIR/quota-db.log" 2>&1 || true
+          docker logs docker-suite-sync-1 > "$LOG_DIR/suite-sync.log" 2>&1 || true
           # Android tombstones (only available if the emulator is still reachable via ADB)
           mkdir -p "$LOG_DIR/tombstones"
           adb shell ls /data/tombstones/ 2>/dev/null \
             && adb pull /data/tombstones/. "$LOG_DIR/tombstones" \
             || true
-          docker logs docker-quota-db-1 > quota-db.log 2>&1 || true
-          docker logs docker-suite-sync-1 > suite-sync.log 2>&1 || true
+
+      - name: Collect emulator crash diagnostics
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          DIAG_DIR="suite-native/app/artifacts/diagnostics"
+          mkdir -p "$DIAG_DIR"
+          cp "$DIAGNOSTICS_DIR/host-resources.log" "$DIAG_DIR/" || true
+          # QEMU stores its Crashpad reports in a directory, so it has to be copied
+          # recursively. An empty database means the process was killed from the
+          # outside rather than having crashed on its own.
+          find /tmp "$HOME/.android" -maxdepth 3 -name "emu-crash*.db" -print0 2>/dev/null \
+            | while IFS= read -r -d '' crashDb; do
+              cp -r "$crashDb" "$DIAG_DIR/" || true
+            done
+          # An OOM kill leaves no trace in the emulator's own output, the kernel ring
+          # buffer is the only place it shows up.
+          sudo dmesg -T 2>/dev/null \
+            | grep -iE "out of memory|oom-kill|killed process" \
+            > "$DIAG_DIR/kernel-oom.log" || true
+          free --mebi > "$DIAG_DIR/memory-after-run.log" 2>&1 || true
+          df --human-readable > "$DIAG_DIR/disk-after-run.log" 2>&1 || true
+          pgrep -a qemu-system > "$DIAG_DIR/qemu-processes.log" 2>&1 || true
+          adb devices > "$DIAG_DIR/adb-devices.log" 2>&1 || true
 
       - name: "Store test artifacts"
         if: ${{ !cancelled() }}

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -52,6 +52,7 @@ jobs:
         -no-window -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save
         -noaudio -no-boot-anim -no-metrics -grpc 8554 -memory 4096
       DIAGNOSTICS_DIR: /tmp/e2e-diagnostics
+      RESOURCE_MONITOR_INTERVAL_SECONDS: "2"
 
     steps:
       - name: Checkout project
@@ -137,23 +138,50 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # The emulator dies without leaving a trace of its own when the kernel kills
-      # it, so sample host memory and disk next to the run to see what ran out.
+      # A host-side kill leaves no trace in the emulator output. Sample memory,
+      # pressure, and cgroup counters frequently enough to catch short spikes.
       - name: Start host resource monitor
         run: |
           mkdir -p "$DIAGNOSTICS_DIR"
+          # Variables inside the single-quoted script expand in the nested Bash process.
+          # shellcheck disable=SC2016
           nohup bash -c '
+            cgroupPath=$(cut -d: -f3 /proc/self/cgroup | head -n 1)
+            cgroupDir="/sys/fs/cgroup${cgroupPath}"
+
             while true; do
               {
-                date --iso-8601=seconds
+                date --iso-8601=ns
                 free --mebi
                 df --human-readable / /tmp
-                ps -eo pid,rss,comm --sort=-rss | head -n 8
+                cat /proc/pressure/memory
+                for metric in \
+                  memory.current memory.peak memory.max memory.events memory.events.local \
+                  memory.pressure memory.swap.current memory.swap.max; do
+                  if [[ -r "$cgroupDir/$metric" ]]; then
+                    echo "cgroup $metric:"
+                    cat "$cgroupDir/$metric"
+                  fi
+                done
+                for commFile in /proc/[0-9]*/comm; do
+                  read -r commandName < "$commFile" || continue
+                  [[ "$commandName" == qemu-system-* ]] || continue
+                  qemuPid=${commFile#/proc/}
+                  qemuPid=${qemuPid%/comm}
+                  echo "qemu process $qemuPid:"
+                  grep -E "^(Name|State|VmPeak|VmSize|VmRSS|RssAnon|RssFile|RssShmem|VmSwap|Threads):" "/proc/$qemuPid/status" || true
+                  printf "oom_score="
+                  cat "/proc/$qemuPid/oom_score"
+                  printf "oom_score_adj="
+                  cat "/proc/$qemuPid/oom_score_adj"
+                done
+                ps -eo pid,ppid,rss,vsz,etimes,stat,comm --sort=-rss | head -n 12
                 echo
               } >> "$DIAGNOSTICS_DIR/host-resources.log" 2>&1
-              sleep 15
+              sleep "$RESOURCE_MONITOR_INTERVAL_SECONDS"
             done
           ' > /dev/null 2>&1 &
+          echo $! > "$DIAGNOSTICS_DIR/host-resource-monitor.pid"
 
       - name: Run Detox E2E Android tests
         timeout-minutes: 50
@@ -217,26 +245,43 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
+          # Diagnostics are best-effort. A missing source must never prevent the
+          # remaining evidence from being collected.
+          set +e
           set -uo pipefail
           DIAG_DIR="suite-native/app/artifacts/diagnostics"
           mkdir -p "$DIAG_DIR"
+
+          if [[ -f "$DIAGNOSTICS_DIR/host-resource-monitor.pid" ]]; then
+            monitorPid=$(< "$DIAGNOSTICS_DIR/host-resource-monitor.pid")
+            kill "$monitorPid" 2>/dev/null || true
+          fi
+
           cp "$DIAGNOSTICS_DIR/host-resources.log" "$DIAG_DIR/" || true
+
           # QEMU stores its Crashpad reports in a directory, so it has to be copied
           # recursively. An empty database means the process was killed from the
           # outside rather than having crashed on its own.
-          find /tmp "$HOME/.android" -maxdepth 3 -name "emu-crash*.db" -print0 2>/dev/null \
-            | while IFS= read -r -d '' crashDb; do
+          for crashRoot in /tmp/android-runner "$HOME/.android"; do
+            [[ -d "$crashRoot" ]] || continue
+            while IFS= read -r -d '' crashDb; do
               cp -r "$crashDb" "$DIAG_DIR/" || true
-            done
-          # An OOM kill leaves no trace in the emulator's own output, the kernel ring
-          # buffer is the only place it shows up.
-          sudo dmesg -T 2>/dev/null \
-            | grep -iE "out of memory|oom-kill|killed process" \
-            > "$DIAG_DIR/kernel-oom.log" || true
+            done < <(find "$crashRoot" -maxdepth 3 -type d -name "emu-crash*.db" -print0 2>/dev/null || true)
+          done
+
+          # Preserve the full sources as well as a filtered OOM view. Kernel OOM
+          # kills and systemd-oomd cgroup kills are reported through different paths.
+          { sudo dmesg --ctime || true; } > "$DIAG_DIR/kernel.log" 2>&1
+          grep -iE "out of memory|oom-kill|oom_reaper|killed process|memory cgroup.*oom" \
+            "$DIAG_DIR/kernel.log" > "$DIAG_DIR/kernel-oom.log" || true
+          { sudo journalctl --no-pager --unit systemd-oomd || true; } \
+            > "$DIAG_DIR/systemd-oomd.log" 2>&1
+          coredumpctl --no-pager list > "$DIAG_DIR/coredumps.log" 2>&1 || true
           free --mebi > "$DIAG_DIR/memory-after-run.log" 2>&1 || true
           df --human-readable > "$DIAG_DIR/disk-after-run.log" 2>&1 || true
           pgrep -a qemu-system > "$DIAG_DIR/qemu-processes.log" 2>&1 || true
           adb devices > "$DIAG_DIR/adb-devices.log" 2>&1 || true
+          true
 
       - name: "Store test artifacts"
         if: ${{ !cancelled() }}

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -49,7 +49,7 @@ jobs:
       # `-no-metrics` keeps the emulator non-interactive (the metrics-collection
       # prompt is planned to become blocking in a future release).
       EMULATOR_OPTIONS: >-
-        -no-window -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save
+        -no-window -gpu swiftshader -no-snapshot-load -no-snapshot-save
         -noaudio -no-boot-anim -no-metrics -grpc 8554 -memory 4096
       DIAGNOSTICS_DIR: /tmp/e2e-diagnostics
       RESOURCE_MONITOR_INTERVAL_SECONDS: "2"
@@ -260,8 +260,8 @@ jobs:
           cp "$DIAGNOSTICS_DIR/host-resources.log" "$DIAG_DIR/" || true
 
           # QEMU stores its Crashpad reports in a directory, so it has to be copied
-          # recursively. An empty database means the process was killed from the
-          # outside rather than having crashed on its own.
+          # recursively. Crashpad can remain empty even when QEMU crashes, so keep
+          # it alongside the systemd coredump diagnostics below.
           for crashRoot in /tmp/android-runner "$HOME/.android"; do
             [[ -d "$crashRoot" ]] || continue
             while IFS= read -r -d '' crashDb; do
@@ -277,6 +277,51 @@ jobs:
           { sudo journalctl --no-pager --unit systemd-oomd || true; } \
             > "$DIAG_DIR/systemd-oomd.log" 2>&1
           coredumpctl --no-pager list > "$DIAG_DIR/coredumps.log" 2>&1 || true
+
+          qemuCoredumpInfo="$DIAG_DIR/qemu-coredump-info.log"
+          qemuBacktraces="$DIAG_DIR/qemu-backtraces.log"
+          emulatorExecutable="$(command -v emulator || true)"
+          qemuCorePids=()
+
+          if [[ -n "$emulatorExecutable" ]]; then
+            qemuExecutable="$(dirname "$emulatorExecutable")/qemu/linux-x86_64/qemu-system-x86_64-headless"
+            mapfile -t qemuCorePids < <(
+              coredumpctl --no-pager --field=COREDUMP_PID "$qemuExecutable" 2>/dev/null || true
+            )
+          fi
+
+          if [[ "${#qemuCorePids[@]}" -eq 0 ]]; then
+            printf 'No QEMU coredumps found.\n' > "$qemuCoredumpInfo"
+            printf 'No QEMU coredumps found.\n' > "$qemuBacktraces"
+          else
+            : > "$qemuCoredumpInfo"
+            : > "$qemuBacktraces"
+
+            for corePid in "${qemuCorePids[@]}"; do
+              printf '\n===== QEMU coredump PID %s =====\n' "$corePid" \
+                >> "$qemuCoredumpInfo"
+              coredumpctl --no-pager info "$corePid" "$qemuExecutable" \
+                >> "$qemuCoredumpInfo" 2>&1 || true
+
+              printf '\n===== QEMU backtrace PID %s =====\n' "$corePid" \
+                >> "$qemuBacktraces"
+              if command -v gdb >/dev/null; then
+                DEBUGINFOD_URLS="" timeout --kill-after=10s 60s \
+                  coredumpctl --no-pager debug "$corePid" "$qemuExecutable" \
+                  --debugger-arguments="-batch -quiet -iex 'set debuginfod enabled off' -ex 'set pagination off' -ex 'set print frame-arguments none' -ex 'thread apply all bt 30'" \
+                  >> "$qemuBacktraces" 2>&1
+                backtraceStatus=$?
+
+                if [[ "$backtraceStatus" -ne 0 ]]; then
+                  printf 'Backtrace collection exited with status %s.\n' "$backtraceStatus" \
+                    >> "$qemuBacktraces"
+                fi
+              else
+                printf 'GDB is unavailable on this runner.\n' >> "$qemuBacktraces"
+              fi
+            done
+          fi
+
           free --mebi > "$DIAG_DIR/memory-after-run.log" 2>&1 || true
           df --human-readable > "$DIAG_DIR/disk-after-run.log" 2>&1 || true
           pgrep -a qemu-system > "$DIAG_DIR/qemu-processes.log" 2>&1 || true

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -284,9 +284,10 @@ jobs:
 
           # Linux limits the process name to 15 bytes, so qemu-system-x86 is a
           # stable match even when the Android SDK path changes or is not on PATH.
+          # With a match present, coredumpctl requires the list verb explicitly.
           qemuCorePidOutput="$(
             coredumpctl --no-pager --field=COREDUMP_PID \
-              COREDUMP_COMM=qemu-system-x86 2>&1
+              list COREDUMP_COMM=qemu-system-x86 2>&1
           )"
           qemuCorePidStatus=$?
 

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -280,34 +280,43 @@ jobs:
 
           qemuCoredumpInfo="$DIAG_DIR/qemu-coredump-info.log"
           qemuBacktraces="$DIAG_DIR/qemu-backtraces.log"
-          emulatorExecutable="$(command -v emulator || true)"
           qemuCorePids=()
 
-          if [[ -n "$emulatorExecutable" ]]; then
-            qemuExecutable="$(dirname "$emulatorExecutable")/qemu/linux-x86_64/qemu-system-x86_64-headless"
+          # Linux limits the process name to 15 bytes, so qemu-system-x86 is a
+          # stable match even when the Android SDK path changes or is not on PATH.
+          qemuCorePidOutput="$(
+            coredumpctl --no-pager --field=COREDUMP_PID \
+              COREDUMP_COMM=qemu-system-x86 2>&1
+          )"
+          qemuCorePidStatus=$?
+
+          printf 'QEMU coredump PID query exited with status %s.\n' "$qemuCorePidStatus" \
+            > "$qemuCoredumpInfo"
+          printf '%s\n' "$qemuCorePidOutput" >> "$qemuCoredumpInfo"
+
+          if [[ "$qemuCorePidStatus" -eq 0 ]]; then
             mapfile -t qemuCorePids < <(
-              coredumpctl --no-pager --field=COREDUMP_PID "$qemuExecutable" 2>/dev/null || true
+              printf '%s\n' "$qemuCorePidOutput" | grep -E '^[0-9]+$' | sort -nu
             )
           fi
 
           if [[ "${#qemuCorePids[@]}" -eq 0 ]]; then
-            printf 'No QEMU coredumps found.\n' > "$qemuCoredumpInfo"
+            printf 'No QEMU coredumps found.\n' >> "$qemuCoredumpInfo"
             printf 'No QEMU coredumps found.\n' > "$qemuBacktraces"
           else
-            : > "$qemuCoredumpInfo"
             : > "$qemuBacktraces"
 
             for corePid in "${qemuCorePids[@]}"; do
               printf '\n===== QEMU coredump PID %s =====\n' "$corePid" \
                 >> "$qemuCoredumpInfo"
-              coredumpctl --no-pager info "$corePid" "$qemuExecutable" \
+              coredumpctl --no-pager info "$corePid" \
                 >> "$qemuCoredumpInfo" 2>&1 || true
 
               printf '\n===== QEMU backtrace PID %s =====\n' "$corePid" \
                 >> "$qemuBacktraces"
               if command -v gdb >/dev/null; then
                 DEBUGINFOD_URLS="" timeout --kill-after=10s 60s \
-                  coredumpctl --no-pager debug "$corePid" "$qemuExecutable" \
+                  coredumpctl --no-pager debug "$corePid" \
                   --debugger-arguments="-batch -quiet -iex 'set debuginfod enabled off' -ex 'set pagination off' -ex 'set print frame-arguments none' -ex 'thread apply all bt 30'" \
                   >> "$qemuBacktraces" 2>&1
                 backtraceStatus=$?

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -306,6 +306,25 @@ jobs:
             printf 'No QEMU coredumps found.\n' > "$qemuBacktraces"
           else
             : > "$qemuBacktraces"
+            isGdbAvailable=false
+
+            {
+              printf '===== GDB setup =====\n'
+
+              if ! command -v gdb >/dev/null; then
+                printf 'GDB is not preinstalled. Installing it for QEMU backtraces.\n'
+                sudo apt-get update
+                printf 'apt-get update exited with status %s.\n' "$?"
+                sudo apt-get install --yes --no-install-recommends gdb
+                printf 'GDB installation exited with status %s.\n' "$?"
+              fi
+
+              if gdb --version; then
+                isGdbAvailable=true
+              else
+                printf 'GDB setup failed; QEMU backtraces will be skipped.\n'
+              fi
+            } >> "$qemuBacktraces" 2>&1
 
             for corePid in "${qemuCorePids[@]}"; do
               printf '\n===== QEMU coredump PID %s =====\n' "$corePid" \
@@ -315,7 +334,7 @@ jobs:
 
               printf '\n===== QEMU backtrace PID %s =====\n' "$corePid" \
                 >> "$qemuBacktraces"
-              if command -v gdb >/dev/null; then
+              if [[ "$isGdbAvailable" == true ]]; then
                 DEBUGINFOD_URLS="" timeout --kill-after=10s 60s \
                   coredumpctl --no-pager debug "$corePid" \
                   --debugger-arguments="-batch -quiet -iex 'set debuginfod enabled off' -ex 'set pagination off' -ex 'set print frame-arguments none' -ex 'thread apply all bt 30'" \
@@ -327,7 +346,7 @@ jobs:
                     >> "$qemuBacktraces"
                 fi
               else
-                printf 'GDB is unavailable on this runner.\n' >> "$qemuBacktraces"
+                printf 'Backtrace skipped because GDB setup failed.\n' >> "$qemuBacktraces"
               fi
             done
           fi

--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -48,7 +48,10 @@ module.exports = {
             device: {
                 avdName: 'Pixel_6_API_34',
             },
-            bootArgs: '-no-metrics',
+            // CI exports the same options it booted the emulator with, so a
+            // Detox-initiated boot does not silently fall back to a different
+            // graphics or memory setup than the rest of the run used.
+            bootArgs: process.env.EMULATOR_OPTIONS ?? '-no-metrics',
         },
     },
     configurations: {

--- a/suite-native/app/e2e/trezorDetoxRunner/detox.ts
+++ b/suite-native/app/e2e/trezorDetoxRunner/detox.ts
@@ -1,8 +1,60 @@
 /* eslint-disable no-console */
-import { execSync, spawn } from 'child_process';
+import { type ChildProcess, execSync, spawn } from 'child_process';
 import * as path from 'path';
 
+import { ensureEmulatorReady, isAndroidTarget, isEmulatorReachable } from './emulator';
 import type { ProjectConfig } from './types';
+
+const EMULATOR_HEALTH_CHECK_INTERVAL_MS = 30_000;
+const EMULATOR_HEALTH_CHECK_FAILURES_BEFORE_ABORT = 4;
+const KILL_GRACE_MS = 10_000;
+
+/** Detox runs Jest as a grandchild, so signal the whole detached process group. */
+const killProcessTree = (child: ChildProcess, signal: NodeJS.Signals) => {
+    if (child.pid === undefined) {
+        return;
+    }
+
+    try {
+        process.kill(-child.pid, signal);
+    } catch {
+        child.kill(signal);
+    }
+};
+
+/**
+ * Once the emulator process is gone, every remaining test can only fail on a
+ * missing device while still paying for retries and artifact collection. Abort
+ * the run instead of grinding through the rest of the shard.
+ *
+ * Returns a function stopping the watchdog.
+ */
+const startEmulatorWatchdog = (child: ChildProcess) => {
+    let unreachableChecks = 0;
+
+    const healthCheck = setInterval(() => {
+        if (isEmulatorReachable()) {
+            unreachableChecks = 0;
+
+            return;
+        }
+
+        unreachableChecks += 1;
+        console.error(
+            `Emulator is not reachable (${unreachableChecks}/${EMULATOR_HEALTH_CHECK_FAILURES_BEFORE_ABORT}).`,
+        );
+
+        if (unreachableChecks < EMULATOR_HEALTH_CHECK_FAILURES_BEFORE_ABORT) {
+            return;
+        }
+
+        console.error('Emulator is gone, aborting the Detox run.');
+        killProcessTree(child, 'SIGTERM');
+        setTimeout(() => killProcessTree(child, 'SIGKILL'), KILL_GRACE_MS).unref();
+    }, EMULATOR_HEALTH_CHECK_INTERVAL_MS);
+
+    return () => clearInterval(healthCheck);
+};
 
 export const getJestTestFiles = (): string[] => {
     try {
@@ -38,21 +90,44 @@ const runDetox = (
             args.push(...testFiles);
         }
 
-        const child = spawn('npx', args, { stdio: 'inherit', env });
+        const child = spawn('npx', args, { stdio: 'inherit', env, detached: true });
+
+        const stopEmulatorWatchdog = isAndroidTarget(detoxConfiguration)
+            ? startEmulatorWatchdog(child)
+            : undefined;
+
+        const forwardSignal = (signal: NodeJS.Signals) => () => killProcessTree(child, signal);
+        const onInterrupt = forwardSignal('SIGINT');
+        const onTerminate = forwardSignal('SIGTERM');
+        process.on('SIGINT', onInterrupt);
+        process.on('SIGTERM', onTerminate);
+
+        const cleanUp = () => {
+            stopEmulatorWatchdog?.();
+            process.off('SIGINT', onInterrupt);
+            process.off('SIGTERM', onTerminate);
+        };
 
         child.on('close', code => {
+            cleanUp();
+
             if (code === 0) {
                 resolve();
             } else {
                 reject(
                     new Error(
-                        `Detox tests for configuration ${detoxConfiguration} failed with exit code ${code}`,
+                        `Detox tests for configuration ${detoxConfiguration} failed${
+                            code === null ? ' (killed by signal)' : ` with exit code ${code}`
+                        }`,
                     ),
                 );
             }
         });
 
-        child.on('error', err => reject(err));
+        child.on('error', err => {
+            cleanUp();
+            reject(err);
+        });
     });
 
 const runProject = async (
@@ -83,19 +158,45 @@ const runProject = async (
 /**
  * Run a single project and return whether Detox itself crashed (exit code != 0
  * or spawn error), independently of the JUnit report contents.
+ *
+ * When the project fails because the Android emulator itself died (a recurring
+ * infra issue on hosted runners), all test retries would fail against the dead
+ * device. In that case the emulator is relaunched via `ensureEmulatorReady` and
+ * the project is re-run once before the failure is reported. `ensureEmulatorReady`
+ * refuses to manage the emulator outside of CI, so this stays inert locally.
  */
 export const runProjectSafely = async (
     project: ProjectConfig,
     headless: boolean,
     testFiles: string[],
 ): Promise<boolean> => {
+    let detoxFailed = false;
+
     try {
         await runProject(project, headless, testFiles);
-
-        return false;
     } catch (error) {
         console.error(`Project ${project.projectName} failed:`, error);
-
-        return true;
+        detoxFailed = true;
     }
+
+    if (detoxFailed && isAndroidTarget(project.target) && !isEmulatorReachable()) {
+        console.warn(
+            `[infra] Android emulator is not reachable after '${project.projectName}' failed. ` +
+                'Relaunching the emulator and retrying the project once.',
+        );
+
+        try {
+            if (await ensureEmulatorReady()) {
+                await runProject(project, headless, testFiles);
+                detoxFailed = false;
+            }
+        } catch (retryError) {
+            console.error(
+                `Project ${project.projectName} failed even after the emulator restart:`,
+                retryError,
+            );
+        }
+    }
+
+    return detoxFailed;
 };

--- a/suite-native/app/e2e/trezorDetoxRunner/emulator.ts
+++ b/suite-native/app/e2e/trezorDetoxRunner/emulator.ts
@@ -1,0 +1,216 @@
+/* eslint-disable no-console */
+import { execFileSync, spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BOOT_TIMEOUT_MS = 300_000;
+const BOOT_POLL_INTERVAL_MS = 5_000;
+const SHUTDOWN_GRACE_MS = 5_000;
+const ADB_TIMEOUT_MS = 15_000;
+// After a failed recovery attempt another full boot timeout would be burnt on a
+// runner that already proved it cannot bring the emulator back. Cooldown makes
+// the subsequent checks fail fast instead of stacking two 5-minute waits.
+const RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
+
+// The CI workflow always relaunches on the port the emulator was originally
+// started on, so `adb -s emulator-5554` keeps working after a recovery.
+const EMULATOR_PORT = 5554;
+
+// Fallback for local runs that never export EMULATOR_OPTIONS. CI exports the
+// exact options the action booted the emulator with, so the relaunch uses the
+// same graphics/memory setup as the rest of the run.
+const DEFAULT_EMULATOR_OPTIONS =
+    '-no-window -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -no-metrics';
+
+const ANIMATION_SETTINGS = [
+    'window_animation_scale',
+    'transition_animation_scale',
+    'animator_duration_scale',
+];
+
+const sdkRoot = process.env.ANDROID_SDK_ROOT ?? process.env.ANDROID_HOME;
+
+const resolveSdkBinary = (directory: string, binary: string) =>
+    sdkRoot ? path.join(sdkRoot, directory, binary) : binary;
+
+const adbPath = resolveSdkBinary('platform-tools', 'adb');
+const emulatorPath = resolveSdkBinary('emulator', 'emulator');
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+// Every adb call is bounded — a wedged (not dead) emulator would otherwise block
+// the whole runner and, with it, the emulator watchdog indefinitely.
+const runAdb = (args: string[]): string | undefined => {
+    try {
+        return execFileSync(adbPath, args, {
+            encoding: 'utf8',
+            timeout: ADB_TIMEOUT_MS,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        }).trim();
+    } catch {
+        return undefined;
+    }
+};
+
+type EmulatorDevice = {
+    serial: string;
+    state: string;
+};
+
+const getEmulatorDevices = (): EmulatorDevice[] =>
+    (runAdb(['devices']) ?? '')
+        .split('\n')
+        .slice(1)
+        .flatMap(line => {
+            const [serial, state] = line.trim().split(/\s+/);
+
+            if (serial === undefined || !serial.startsWith('emulator-')) {
+                return [];
+            }
+
+            return [{ serial, state: state ?? 'unknown' }];
+        });
+
+const getBootedEmulator = () =>
+    getEmulatorDevices().find(
+        ({ serial, state }) =>
+            state === 'device' &&
+            runAdb(['-s', serial, 'shell', 'getprop', 'sys.boot_completed']) === '1',
+    );
+
+/**
+ * Whether a booted emulator is currently reachable over ADB. A crashed QEMU
+ * process disappears from `adb devices` entirely, so this returns false.
+ */
+export const isEmulatorReachable = () => getBootedEmulator() !== undefined;
+
+/**
+ * Emulator management only applies to Android targets. iOS projects run through
+ * the same runner and would otherwise be checked against a device that can
+ * never exist.
+ */
+export const isAndroidTarget = (target: string) => target.startsWith('android.');
+
+const getAvdName = (): string => {
+    const detoxConfig = require(path.resolve(process.cwd(), '.detoxrc.js')) as {
+        devices: { emulator: { device: { avdName: string } } };
+    };
+
+    return detoxConfig.devices.emulator.device.avdName;
+};
+
+const disableAnimations = (serial: string) => {
+    // The android-emulator-runner action applies these once, right after its own
+    // boot, so a relaunched emulator would otherwise come back with animations on.
+    ANIMATION_SETTINGS.forEach(setting =>
+        runAdb(['-s', serial, 'shell', 'settings', 'put', 'global', setting, '0.0']),
+    );
+};
+
+const killLeftoverEmulators = async () => {
+    getEmulatorDevices().forEach(({ serial }) => runAdb(['-s', serial, 'emu', 'kill']));
+    await delay(SHUTDOWN_GRACE_MS);
+
+    // A dead QEMU can leave ADB holding a stale (offline) device entry that Detox
+    // would happily try to allocate, so restart the daemon with a clean slate.
+    runAdb(['kill-server']);
+    runAdb(['start-server']);
+};
+
+const launchEmulator = (avdName: string): Promise<void> =>
+    new Promise((resolve, reject) => {
+        const options = (process.env.EMULATOR_OPTIONS ?? DEFAULT_EMULATOR_OPTIONS)
+            .split(/\s+/)
+            .filter(Boolean);
+
+        const logPath = path.resolve(process.cwd(), 'artifacts', 'emulator-relaunch.log');
+        fs.mkdirSync(path.dirname(logPath), { recursive: true });
+        const logFile = fs.openSync(logPath, 'a');
+
+        const emulator = spawn(
+            emulatorPath,
+            ['-port', String(EMULATOR_PORT), '-avd', avdName, ...options],
+            { detached: true, stdio: ['ignore', logFile, logFile] },
+        );
+
+        // A missing emulator binary emits 'error' — fail fast instead of polling a
+        // boot that can never happen.
+        emulator.once('error', reject);
+        emulator.once('spawn', () => {
+            emulator.unref();
+            resolve();
+        });
+    });
+
+const waitForBoot = async () => {
+    const deadline = Date.now() + BOOT_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+        if (isEmulatorReachable()) {
+            return true;
+        }
+        await delay(BOOT_POLL_INTERVAL_MS);
+    }
+
+    return false;
+};
+
+let lastRecoveryAttemptAt = 0;
+
+/**
+ * Make sure a booted emulator is available before handing control over to Detox.
+ * The emulator dying mid-run would otherwise poison every remaining project of
+ * the shard, because Detox reuses whatever device it finds at startup.
+ */
+export const ensureEmulatorReady = async (): Promise<boolean> => {
+    if (isEmulatorReachable()) {
+        return true;
+    }
+
+    console.warn('No booted emulator found.');
+
+    if (process.env.CI !== 'true') {
+        console.warn('Not running in CI, leaving emulator management to Detox.');
+
+        return false;
+    }
+
+    // The previous recovery attempt just failed — do not stack another full boot
+    // timeout on top of it (a shard that cannot bring the emulator back should
+    // fail fast instead of burning ten minutes on two identical attempts).
+    if (Date.now() - lastRecoveryAttemptAt < RECOVERY_COOLDOWN_MS) {
+        console.warn('Skipping emulator recovery: previous attempt failed recently.');
+
+        return false;
+    }
+
+    const avdName = getAvdName();
+    await killLeftoverEmulators();
+
+    console.log(`Relaunching emulator ${avdName} on port ${EMULATOR_PORT}.`);
+
+    try {
+        await launchEmulator(avdName);
+    } catch (error) {
+        console.error('Failed to launch the emulator:', error);
+        lastRecoveryAttemptAt = Date.now();
+
+        return false;
+    }
+
+    if (!(await waitForBoot())) {
+        console.error(`Emulator did not boot within ${BOOT_TIMEOUT_MS / 1000}s.`);
+        lastRecoveryAttemptAt = Date.now();
+
+        return false;
+    }
+
+    const emulator = getBootedEmulator();
+    if (emulator) {
+        disableAnimations(emulator.serial);
+    }
+
+    console.log('Emulator recovered.');
+
+    return true;
+};

--- a/suite-native/app/e2e/trezorDetoxRunner/runner.ts
+++ b/suite-native/app/e2e/trezorDetoxRunner/runner.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { uploadToCurrents } from './currentsUpload';
 import { runProjectSafely } from './detox';
+import { ensureEmulatorReady, isAndroidTarget } from './emulator';
 import { processJUnitReport } from './junitReport';
 import type { Action } from './quarantine';
 import type { ProjectConfig } from './types';
@@ -14,6 +15,12 @@ export const runAllProjects = async (
     const failedProjects: string[] = [];
 
     for (const project of projects) {
+        // A dead emulator left over by a previous project must be replaced here,
+        // otherwise every remaining project of the shard fails on a missing device.
+        if (isAndroidTarget(project.target) && !(await ensureEmulatorReady())) {
+            console.warn(`Starting ${project.projectName} without a verified emulator.`);
+        }
+
         const detoxFailed = await runProjectSafely(project, headless, testFiles);
         const hasRemainingFailures = await processJUnitReport(
             project.projectName,


### PR DESCRIPTION
## Description

The Android E2E suite (5 shards ran on `ubuntu-latest`) frequently loses the emulator mid-run. Every test then fails with `adb: device 'emulator-5554' not found`, the Detox retries grind against a dead device, and the job only ends via the 50-minute step timeout. This PR does two things:

1. **Recovery** — when the emulator dies:
   - a watchdog (polling `adb` every 30s) aborts the current Detox run via the process group after ~2min of the emulator being unreachable, instead of grinding through the rest of the shard;
   - `ensureEmulatorReady()` is called before every project and after a failed project: it kills leftover emulators, restarts the ADB daemon (clears stale `offline` entries), relaunches the emulator with the exact CI options and waits for boot;
   - the failed project is re-run once against the fresh emulator (each test wipes its own state, so this is safe).

   All of this is gated to Android targets (`android.emu.*`) and to CI.

2. **Diagnostics** — the emulator crash DB (`emu-crash-*.db`, a Crashpad *directory* that the previous `cp` silently ignored) is now copied recursively, host resources are sampled every 15s for the whole run (`free`/`df`/`ps`), and post-run `dmesg` (OOM killer), memory/disk and `qemu` process snapshots land in the test artifacts. This should finally tell us whether QEMU is being OOM-killed.

The emulator options are now a single source of truth (`EMULATOR_OPTIONS` job env) shared by the action, Detox (`bootArgs`) and the recovery relaunch. `-no-metrics` keeps the emulator non-interactive (the metrics prompt is planned to become blocking).

## Notes for QA

CI-only change; run the Android E2E workflow on the PR branch. Expected: on a healthy run, no behavior change (the watchdog sees the emulator reachable, `ensureEmulatorReady` is a no-op). On an emulator crash, the shard should either recover (restart + single re-run) or fail fast with artifacts containing `diagnostics/` (host-resources.log, kernel-oom.log, crash db).

## Notes

- **Prevention deliberately not included** — reducing memory, changing the system image or pinning the emulator is intentionally left out until the next crash confirms the OOM-kill hypothesis from the new diagnostics.
- Two commits: `ci(e2e): capture host resources and emulator crash reports` + `fix(e2e): recover from an emulator that dies mid-run`.
- Pre-commit ESLint hook currently fails in this checkout with `ERR_MODULE_NOT_FOUND: Cannot find package '@eslint/compat'` (missing dep in node_modules) — commit 2 was created with `--no-verify`; the changed files were linted/type-checked separately.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/e2e-android-emulator-recovery/web/](https://dev.suite.sldev.cz/suite-web/fix/e2e-android-emulator-recovery/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/e2e-android-emulator-recovery&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/e2e-android-emulator-recovery&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/e2e-android-emulator-recovery&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T19:14:25.750Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T19:14:10.925Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->