### PR TITLE
test(e2e): observe the live trading responses via a fixture

### DIFF
--- a/suite/e2e/fixtures/trading/index.ts
+++ b/suite/e2e/fixtures/trading/index.ts
@@ -87,7 +87,9 @@ export const tradeGeneralResponses: Partial<
     [tradeEndpoint.sellList]: sellList,
 };
 
-export const getCompanyNameFromList = (name: string, type: 'buyList' | 'sellList' | 'swapList') => {
+type ProviderList = 'buyList' | 'sellList' | 'swapList';
+
+const findProviderInList = (name: string, type: ProviderList) => {
     const listMap = {
         buyList: buyList.providers,
         sellList: sellList.providers,
@@ -103,8 +105,14 @@ export const getCompanyNameFromList = (name: string, type: 'buyList' | 'sellList
         );
     }
 
-    return provider.companyName;
+    return provider;
 };
+
+export const getCompanyNameFromList = (name: string, type: ProviderList) =>
+    findProviderInList(name, type).companyName;
+
+export const getSupportUrlFromList = (name: string, type: ProviderList) =>
+    findProviderInList(name, type).supportUrl;
 
 export {
     info,

--- a/suite/e2e/fixtures/trading/index.ts
+++ b/suite/e2e/fixtures/trading/index.ts
@@ -61,6 +61,7 @@ export const tradeEndpoint = {
     sellList: `${tradeApiUrl}/api/v3/sell/list`,
     sellQuotes: `${tradeApiUrl}/api/v3/sell/fiat/quotes`,
     sellTrade: `${tradeApiUrl}/api/v3/sell/fiat/trade`,
+    sellConfirm: `${tradeApiUrl}/api/v3/sell/fiat/confirm`,
     sellWatch: `${tradeApiUrl}/api/v3/sell/fiat/watch/*`,
 } as const;
 

--- a/suite/e2e/fixtures/trading/statusFlow.ts
+++ b/suite/e2e/fixtures/trading/statusFlow.ts
@@ -7,7 +7,6 @@ export type TradeStatusPhase = {
     translationValues?: (provider: string) => Record<string, string | number>;
 };
 
-// Only CONVERTING renders the provider name, hence the lone translationValues.
 export const swapStatusFlow: readonly TradeStatusPhase[] = [
     { status: 'CONFIRMING', translationKey: 'TR_EXCHANGE_DETAIL_SENDING_TRANSACTION' },
     {
@@ -16,4 +15,13 @@ export const swapStatusFlow: readonly TradeStatusPhase[] = [
         translationValues: provider => ({ providerName: provider, type: 'swap' }),
     },
     { status: 'SUCCESS', translationKey: 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE' },
+];
+
+export const sellStatusFlow: readonly TradeStatusPhase[] = [
+    { status: 'PENDING', translationKey: 'TR_SELL_DETAIL_SENDING_TRANSACTION' },
+    {
+        status: 'SUCCESS',
+        translationKey: 'TR_TRADING_DETAIL_PROCESSING',
+        translationValues: provider => ({ providerName: provider, type: 'sell' }),
+    },
 ];

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -10,6 +10,7 @@ import { BlockbookMock } from './mocks/blockBookMock';
 import { MetadataMock } from './mocks/metadataMock';
 import { SolanaStakingMock } from './mocks/solanaStakingMock';
 import { TradingMockNew } from './mocks/trading/tradingMockNew';
+import { TradingResponses, observeTradingResponses } from './mocks/trading/tradingResponses';
 import { TradingMock } from './mocks/tradingMock';
 import { YieldMock } from './mocks/yieldMock';
 import { AnalyticsSection } from './pageObjects/analyticsSection';
@@ -61,6 +62,7 @@ type Fixtures = {
     solanaStakingMock: SolanaStakingMock;
     tradingMock: TradingMock;
     tradingMockNew: TradingMockNew;
+    tradingResponses: TradingResponses;
     connectPermissionsModal: ConnectPermissionsModal;
     connectSelectAccountModal: ConnectSelectAccountModal;
     stakingSection: StakingSection;
@@ -110,8 +112,8 @@ const test = suiteBaseTest.extend<Fixtures>({
     recoveryModal: async ({ page }, use) => {
         await use(new RecoveryModal(page));
     },
-    tradingPage: async ({ page, devicePrompt }, use) => {
-        await use(new TradingPage(page, devicePrompt));
+    tradingPage: async ({ page, devicePrompt, target }, use) => {
+        await use(new TradingPage(page, devicePrompt, target));
     },
     feeSection: async ({ page }, use) => {
         await use(new FeeSection(page));
@@ -160,6 +162,9 @@ const test = suiteBaseTest.extend<Fixtures>({
         const tradingMockNew = new TradingMockNew(page);
         await use(tradingMockNew);
         await tradingMockNew.stop();
+    },
+    tradingResponses: async ({ page }, use) => {
+        await use(observeTradingResponses(page));
     },
     connectSelectAccountModal: async ({ page }, use) => {
         await use(new ConnectSelectAccountModal(page));

--- a/suite/e2e/support/mocks/trading/tradingMockNew.ts
+++ b/suite/e2e/support/mocks/trading/tradingMockNew.ts
@@ -1,5 +1,5 @@
 import { Page } from '@playwright/test';
-import type { CryptoId, ExchangeTrade } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { getSimulatedReceiveAmount } from '@suite-common/trading';
 import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
@@ -8,15 +8,6 @@ import { TradingChainBackend, createTradingChainBackend } from './tradingChainBa
 import { tradeEndpoint } from '../../../fixtures/trading';
 import { step } from '../../common';
 
-// TODO: loose for DEX (no sendAddress, optional fields); revisit in the sell migration PR.
-export type CapturedLiveTrade = ExchangeTrade & {
-    sendAddress: string;
-    exchange: string;
-    sendStringAmount: string;
-    receive: CryptoId;
-    receiveStringAmount: string;
-};
-
 type TxSimulationResult = NonNullable<Parameters<typeof getSimulatedReceiveAmount>[0]>;
 type TxSimulationScan = Omit<TxSimulationResult['payload'], 'needsDisclaimer'>;
 
@@ -24,16 +15,20 @@ type TradeFlow = 'buy' | 'sell' | 'swap';
 type TradeEndpoints = {
     readonly trade: string;
     readonly watch: string;
+    readonly confirm?: string;
 };
 
 const TRADE_ENDPOINTS: Record<TradeFlow, TradeEndpoints> = {
     buy: { trade: tradeEndpoint.buyTrade, watch: tradeEndpoint.buyWatch },
-    sell: { trade: tradeEndpoint.sellTrade, watch: tradeEndpoint.sellWatch },
+    sell: {
+        trade: tradeEndpoint.sellTrade,
+        watch: tradeEndpoint.sellWatch,
+        confirm: tradeEndpoint.sellConfirm,
+    },
     swap: { trade: tradeEndpoint.swapTrade, watch: tradeEndpoint.swapWatch },
 };
 
 const WATCH_POLL_PERIOD = '00:30';
-const TRADE_RESPONSE_TIMEOUT = 90_000;
 const WATCH_POLL_TIMEOUT = 35_000;
 const ADVANCE_ATTEMPTS = 5;
 
@@ -61,8 +56,11 @@ const assertPassphraseEnv = () => {
 export class TradingMockNew {
     private flow?: TradeFlow;
     private backend?: TradingChainBackend;
-    private capturedTrade: CapturedLiveTrade | null = null;
     private capturedTxSimulation: TxSimulationResult | null = null;
+    private rewriteRedirect = false;
+    private mockStatusPage = false;
+    private status?: string;
+    private watchFields: Record<string, string> = {};
 
     constructor(private page: Page) {
         assertPassphraseEnv();
@@ -107,19 +105,15 @@ export class TradingMockNew {
     }
 
     @step()
-    async rewriteTradeRedirect() {
+    async rewriteProviderRedirect() {
         if (this.tradeFlow === 'swap') {
-            throw new Error('rewriteTradeRedirect is buy/sell only; swap has no provider redirect');
+            throw new Error(
+                'rewriteProviderRedirect is buy/sell only; swap has no provider redirect',
+            );
         }
 
-        await this.page.route(this.endpoints.trade, async route => {
-            const response = await route.fetch();
-            const body = await response.json();
-            const { returnUrl } = route.request().postDataJSON();
-            body.trade.partnerData = returnUrl;
-            body.tradeForm.form.formAction = returnUrl;
-            await route.fulfill({ response, json: body });
-        });
+        this.rewriteRedirect = true;
+        await this.routeTrade();
     }
 
     @step()
@@ -128,12 +122,8 @@ export class TradingMockNew {
             throw new Error('mockProviderStatusPage is swap only');
         }
 
-        await this.page.route(this.endpoints.trade, async route => {
-            const response = await route.fetch();
-            const body = await response.json();
-            body.statusUrl = `${MOCK_PROVIDER_STATUS_ORIGIN}/${body.orderId}`;
-            await route.fulfill({ response, json: body });
-        });
+        this.mockStatusPage = true;
+        await this.routeTrade();
 
         await this.page.context().route(`${MOCK_PROVIDER_STATUS_ORIGIN}/*`, async route => {
             const orderId = route.request().url().split('/').pop() ?? '';
@@ -145,46 +135,21 @@ export class TradingMockNew {
         });
     }
 
-    async waitForLiveTrade() {
-        const response = await this.page.waitForResponse(this.endpoints.trade, {
-            timeout: TRADE_RESPONSE_TIMEOUT,
-        });
-        const trade = (await response.json()) as ExchangeTrade;
-        // A DEX trade sends to the provider's router contract (`dexTx`), so it has no sendAddress.
-        const hasDepositAddress = trade.isDex || trade.sendAddress;
-        if (
-            !trade.exchange ||
-            !trade.sendStringAmount ||
-            !trade.receive ||
-            !trade.receiveStringAmount ||
-            !hasDepositAddress
-        ) {
+    // Amount the last captured simulation credits, derived the same way the confirm step derives
+    // the amount it renders. A re-quote refetches the scan, so read this at assertion time.
+    simulatedReceiveAmount(receive: CryptoId): string {
+        if (!this.capturedTxSimulation) {
             throw new Error(
-                'Live trade response is missing exchange, sendStringAmount, receive, receiveStringAmount or sendAddress',
+                'No tx simulation captured - is captureTxSimulation() set up in beforeEach?',
             );
         }
 
-        this.capturedTrade = trade as CapturedLiveTrade;
-    }
-
-    get liveTrade(): CapturedLiveTrade {
-        if (!this.capturedTrade) {
-            throw new Error('Live trade response was not captured yet');
-        }
-
-        return this.capturedTrade;
-    }
-
-    // Amount the last captured simulation credits, derived the same way the confirm step derives
-    // the amount it renders. A re-quote refetches the scan, so read this at assertion time.
-    get simulatedReceiveAmount(): string {
-        const amount = getSimulatedReceiveAmount(
-            this.capturedTxSimulation ?? undefined,
-            this.liveTrade.receive,
-        );
+        const amount = getSimulatedReceiveAmount(this.capturedTxSimulation, receive);
 
         if (!amount) {
-            throw new Error('No captured simulation credits the receive asset of the trade');
+            throw new Error(
+                'The captured simulation does not credit the receive asset of the trade',
+            );
         }
 
         return amount;
@@ -208,13 +173,21 @@ export class TradingMockNew {
     }
 
     @step()
+    async setWatchFields(fields: Record<string, string>) {
+        this.watchFields = fields;
+        await this.routeStatus();
+    }
+
+    @step()
     async setStatus(status: string) {
-        await this.routeWatch(status);
+        this.status = status;
+        await this.routeStatus();
     }
 
     @step()
     async advanceStatus(status: string) {
-        await this.routeWatch(status);
+        this.status = status;
+        await this.routeStatus();
 
         for (let attempt = 0; attempt < ADVANCE_ATTEMPTS; attempt++) {
             const watchResponsePromise = this.page
@@ -235,9 +208,40 @@ export class TradingMockNew {
         await this.backend?.stop();
     }
 
-    private async routeWatch(status: string) {
+    private async routeTrade() {
+        await this.page.route(this.endpoints.trade, async route => {
+            const response = await route.fetch();
+            const body = await response.json();
+
+            if (this.rewriteRedirect) {
+                const { returnUrl } = route.request().postDataJSON();
+                body.trade.partnerData = returnUrl;
+                body.tradeForm.form.formAction = returnUrl;
+            }
+
+            if (this.mockStatusPage) {
+                body.statusUrl = `${MOCK_PROVIDER_STATUS_ORIGIN}/${body.orderId}`;
+            }
+
+            await route.fulfill({ response, json: body });
+        });
+    }
+
+    private async routeStatus() {
         await this.page.route(this.endpoints.watch, async route => {
-            await route.fulfill({ json: { status, sendAddress: this.liveTrade.sendAddress } });
+            await route.fulfill({ json: { status: this.status, ...this.watchFields } });
+        });
+
+        const { confirm } = this.endpoints;
+        if (!confirm) {
+            return; // buy and swap flows have no confirm endpoint
+        }
+
+        // Live Invity rejects a confirm carrying an address it never issued and a txid that is not
+        // on chain, so the posted trade is echoed back with the status the test is driving.
+        await this.page.route(confirm, async route => {
+            const trade = route.request().postDataJSON();
+            await route.fulfill({ json: { ...trade, status: this.status } });
         });
     }
 }

--- a/suite/e2e/support/mocks/trading/tradingResponses.ts
+++ b/suite/e2e/support/mocks/trading/tradingResponses.ts
@@ -1,0 +1,157 @@
+import { Page } from '@playwright/test';
+import type {
+    BuyListResponse,
+    BuyProviderInfo,
+    BuyTrade,
+    ExchangeListResponse,
+    ExchangeProviderInfo,
+    ExchangeTrade,
+    SellFiatTrade,
+    SellListResponse,
+    SellProviderInfo,
+} from 'invity-api';
+
+import { tradeEndpoint } from '../../../fixtures/trading';
+
+// A trade is created mid-test on demand; the list loads with the page.
+const TRADE_TIMEOUT = 90_000;
+const LIST_TIMEOUT = 30_000;
+
+// Live responses of the trading API, one group per flow, read off the wire rather than from
+// checked-in fixtures - live values differ between runs, and a stale provider list fails hard on
+// whichever provider happens to win an offer. Only observes - it never routes, so it cannot
+// collide with the routes the trading mock installs. Armed when the fixture is created, so no
+// test has to arm anything before the click that triggers the request.
+type FlowResponses<TTrade, TList, TProvider> = {
+    /** The live trade of this flow. Resolves once the endpoint has answered; re-readable. */
+    trade(): Promise<Required<TTrade>>;
+    /** The full `list` response - providers plus, for buy/sell, the geo-detected extras. */
+    list(): Promise<TList>;
+    /** One provider's entry in the live list, found by its internal name. */
+    provider(exchange: string): Promise<TProvider>;
+    /** The display name of one provider in the live list. */
+    companyName(exchange: string): Promise<string>;
+};
+
+export type TradingResponses = {
+    buy: FlowResponses<BuyTrade, BuyListResponse, BuyProviderInfo>;
+    sell: FlowResponses<SellFiatTrade, SellListResponse, SellProviderInfo>;
+    swap: FlowResponses<ExchangeTrade, ExchangeListResponse, ExchangeProviderInfo>;
+};
+
+type ObservedResponse<T> = { get(): Promise<T> };
+
+const observeJsonResponse = <T>(page: Page, endpoint: string, timeout: number) => {
+    let resolveArrival!: (body: T) => void;
+    let rejectArrival!: (error: Error) => void;
+    const arrived = new Promise<T>((resolve, reject) => {
+        resolveArrival = resolve;
+        rejectArrival = reject;
+    });
+
+    // get() surfaces the rejection; without this it would also raise an unhandled rejection.
+    arrived.catch(() => {});
+
+    page.on('response', async response => {
+        if (response.url() !== endpoint) return;
+
+        try {
+            const body = await response.text();
+
+            if (!response.ok()) {
+                throw new Error(`${response.status()} - ${body}`);
+            }
+
+            resolveArrival(JSON.parse(body) as T);
+        } catch (error) {
+            rejectArrival(new Error(`Live response from ${endpoint} failed: ${error}`));
+        }
+    });
+
+    const get = async () => {
+        let timer: ReturnType<typeof setTimeout>;
+        const timedOut = new Promise<never>((_, reject) => {
+            timer = setTimeout(
+                () => reject(new Error(`No response from ${endpoint} within ${timeout}ms`)),
+                timeout,
+            );
+        });
+
+        try {
+            return await Promise.race([arrived, timedOut]);
+        } finally {
+            clearTimeout(timer!);
+        }
+    };
+
+    return { get };
+};
+
+const createFlowResponses = <
+    TTrade,
+    TList,
+    TProvider extends { name: string; companyName: string },
+>(
+    page: Page,
+    endpoints: { trade: string; list: string },
+    unwrapTrade: (body: unknown) => Required<TTrade>,
+    selectProviders: (list: TList) => TProvider[],
+): FlowResponses<TTrade, TList, TProvider> => {
+    const tradeResponse: ObservedResponse<unknown> = observeJsonResponse(
+        page,
+        endpoints.trade,
+        TRADE_TIMEOUT,
+    );
+    const listResponse: ObservedResponse<TList> = observeJsonResponse(
+        page,
+        endpoints.list,
+        LIST_TIMEOUT,
+    );
+
+    const provider = async (exchange: string) => {
+        const providers = selectProviders(await listResponse.get());
+        const found = providers.find(item => item.name === exchange);
+
+        if (!found) {
+            throw new Error(
+                `Provider "${exchange}" is not in the live list from ${endpoints.list}. Available: ${providers
+                    .map(item => item.name)
+                    .join(', ')}`,
+            );
+        }
+
+        return found;
+    };
+
+    return {
+        trade: async () => unwrapTrade(await tradeResponse.get()),
+        list: () => listResponse.get(),
+        provider,
+        companyName: async exchange => (await provider(exchange)).companyName,
+    };
+};
+
+// Buy and sell wrap both the trade and the providers in an envelope, swap returns them bare.
+const unwrapBareTrade = <T>(body: unknown) => body as Required<T>;
+const unwrapTradeEnvelope = <T>(body: unknown) => (body as { trade: Required<T> }).trade;
+
+export const observeTradingResponses = (page: Page): TradingResponses => ({
+    buy: createFlowResponses(
+        page,
+        { trade: tradeEndpoint.buyTrade, list: tradeEndpoint.buyList },
+        unwrapTradeEnvelope<BuyTrade>,
+        (list: BuyListResponse) => list.providers,
+    ),
+    sell: createFlowResponses(
+        page,
+        { trade: tradeEndpoint.sellTrade, list: tradeEndpoint.sellList },
+        unwrapTradeEnvelope<SellFiatTrade>,
+        (list: SellListResponse) => list.providers,
+    ),
+    swap: createFlowResponses(
+        page,
+        { trade: tradeEndpoint.swapTrade, list: tradeEndpoint.swapList },
+        unwrapBareTrade<ExchangeTrade>,
+        (list: ExchangeListResponse) => list,
+    ),
+});

--- a/suite/e2e/support/pageObjects/toastSection.ts
+++ b/suite/e2e/support/pageObjects/toastSection.ts
@@ -3,11 +3,13 @@ import { type Locator, type Page } from '@playwright/test';
 export class ToastSection {
     readonly approved: Locator;
     readonly approvedAmount: Locator;
+    readonly txSent: Locator;
     readonly yieldDeposit: Locator;
 
     constructor(private readonly page: Page) {
         this.approved = this.page.getByTestId('@toast/tx-approved');
         this.approvedAmount = this.page.getByTestId('@toast/tx-approved/amount');
+        this.txSent = this.page.getByTestId('@toast/tx-sent');
         this.yieldDeposit = this.page.getByTestId('@toast/tx-yield-deposit');
     }
 }

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -15,8 +15,9 @@ import { TradingQuotesSection } from './quotesSection';
 import { TradingReceiveAccount } from './receiveAccount';
 import { TransactionDetailSidebar } from './transactionDetailSidebar';
 import { tradeEndpoint } from '../../../fixtures/trading';
-import { step } from '../../common';
+import { isDesktopProject, isWebProject, step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
+import { type PlaywrightTarget } from '../../testExtends/suiteTestOptions';
 import { BuyAsset, SellAsset } from '../../types';
 
 export class TradingPage {
@@ -69,6 +70,7 @@ export class TradingPage {
     constructor(
         private page: Page,
         devicePrompt: DevicePrompt,
+        private target: PlaywrightTarget,
     ) {
         this.fees = new FeeSection(page);
         this.assetPicker = new TradingAssetPicker(page);
@@ -391,10 +393,14 @@ export class TradingPage {
 
     @step()
     async waitForRedirectCompletion() {
-        const tradeHeading = this.page.getByRole('heading', { name: 'Trade' });
+        if (isDesktopProject(this.target)) {
+            await expect(this.confirmation.confirmAndSendButton).toBeVisible({ timeout: 30_000 });
+        } else if (isWebProject(this.target)) {
+            const tradeHeading = this.page.getByRole('heading', { name: 'Trade' });
 
-        await expect(tradeHeading).toBeHidden();
-        await expect(tradeHeading).toBeVisible({ timeout: 30_000 });
+            await expect(tradeHeading).toBeHidden();
+            await expect(tradeHeading).toBeVisible({ timeout: 30_000 });
+        }
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -237,6 +237,10 @@ export class TradingPage {
         fiatCurrencyCode?: BaseCurrencyCode;
         country?: TradingCountryCode;
     }) {
+        // The form resets to its defaults once sellInfo lands, roughly 2s after it becomes interactive
+        await this.page.expectReduxObjectNotToBeEmpty('wallet.trading.sell.sellInfo', {
+            timeout: 30_000,
+        });
         await this.inputs.selectCountryOfResidence(country);
         await this.inputs.selectFiatCurrency(fiatCurrencyCode);
         const isFiatRateLoadingFlag = `wallet.fiat.current.${networkSymbolOrTokenId}-${fiatCurrencyCode}.isLoading`;
@@ -398,7 +402,7 @@ export class TradingPage {
         } else if (isWebProject(this.target)) {
             const tradeHeading = this.page.getByRole('heading', { name: 'Trade' });
 
-            await expect(tradeHeading).toBeHidden();
+            await expect(tradeHeading).toBeHidden({ timeout: 30_000 });
             await expect(tradeHeading).toBeVisible({ timeout: 30_000 });
         }
     }

--- a/suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts
+++ b/suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts
@@ -3,7 +3,6 @@ import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { getCompanyNameFromList } from '../../fixtures/trading';
 import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
 import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
@@ -39,6 +38,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
         device,
         devicePrompt,
         tradingMockNew,
+        tradingResponses,
     }) => {
         await test.step('Fill in a Swap form', async () => {
             await tradingPage.fillSwapForm({
@@ -62,30 +62,27 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         let receiveAmount: string;
         let providerName: string;
-        let liveTradePromise: ReturnType<typeof tradingMockNew.waitForLiveTrade>;
 
         await test.step('Confirm the Swap trade', async () => {
             receiveAmount = await tradingPage.quotes.getBestOfferAmount();
             await tradingPage.fees.waitToBeCalculated();
-            liveTradePromise = tradingMockNew.waitForLiveTrade();
             await tradingPage.swapBestOfferButton.click();
         });
 
         await test.step('Open modal and verify recipient on prompt and device', async () => {
+            const { exchange, sendAddress } = await tradingResponses.swap.trade();
+            providerName = await tradingResponses.swap.companyName(exchange);
+
             await tradingPage.confirmation.openConfirmAndSendModal();
-            await liveTradePromise;
-            providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
             await expect(devicePrompt.header.accountLabel).toHaveText(sendAccountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
-                formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
+                formatAddressWithNewlines(sendAddress),
             );
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: 'Send' },
-                    body: [
-                        transformAddress(tradingMockNew.liveTrade.sendAddress, 'fourTetragrams'),
-                    ],
+                    body: [transformAddress(sendAddress, 'fourTetragrams')],
                     actions: { right_button: 'Continue' },
                 },
                 T3T1: {
@@ -145,11 +142,13 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
 
+            const { sendStringAmount } = await tradingResponses.swap.trade();
+
             await tradingPage.verifySwapToast({
                 sendAccount: sendAccountLabel,
                 receiveAccount: receiveAccountLabel,
                 // The toast echoes the provider's formatting of the amount, not the one we typed.
-                sendAmount: tradingMockNew.liveTrade.sendStringAmount,
+                sendAmount: sendStringAmount,
                 receiveAmount,
             });
         });

--- a/suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts
@@ -1,13 +1,11 @@
 import { getCryptoId } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 
-import { getCompanyNameFromList } from '../../fixtures/trading';
 import { countDecimalPlaces } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 
 const approvalAmount = '10';
 const accountLabel = 'Ethereum #2';
-const dexProvider = getCompanyNameFromList('lifi', 'swapList');
 const providerName = 'LiFI Diamond';
 const positiveEthereumAmountPattern = /^(?!0+(?:\.0+)?\s*ETH$)\d+(?:\.\d+)?\s*ETH$/;
 
@@ -40,7 +38,10 @@ test.describe('Trading - DEX swap approval (LI.FI)', { tag: ['@T3T1', '@T3W1'] }
         device,
         tradingMockNew,
         toastSection,
+        tradingResponses,
     }) => {
+        const dexProvider = await tradingResponses.swap.companyName('lifi');
+
         await test.step('Select USDC to ETH LI.FI DEX offer', async () => {
             await tradingPage.fillSwapForm({
                 amount: approvalAmount,

--- a/suite/e2e/tests/trading/swap-dex-lifi.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi.test.ts
@@ -2,7 +2,6 @@ import { getCryptoId } from '@suite-common/trading';
 import { fromGwei, localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { getCompanyNameFromList } from '../../fixtures/trading';
 import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
 import { expect, test } from '../../support/fixtures';
 
@@ -11,7 +10,6 @@ const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
 const accountLabel = 'Ethereum #1';
 const usdcCryptoId = getCryptoId('eth', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
 const usdcDecimals = 6;
-const dexProvider = getCompanyNameFromList('lifi', 'swapList');
 
 // A DEX swap broadcasts the swap itself, so there is no CONFIRMING deposit phase.
 const dexStatusFlow = swapStatusFlow.filter(phase => phase.status !== 'CONFIRMING');
@@ -58,7 +56,10 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
         tradingPage,
         devicePrompt,
         tradingMockNew,
+        tradingResponses,
     }) => {
+        const dexProvider = await tradingResponses.swap.companyName('lifi');
+
         await test.step('Fill in the Swap form (ETH -> USDC)', async () => {
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
@@ -88,9 +89,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             feeRate = `${maxFeePerGasRounded} Gwei`;
             priorityFeeRate = `${maxPriorityFeePerGasRounded} Gwei`;
 
-            const liveTradePromise = tradingMockNew.waitForLiveTrade();
             await tradingPage.swapBestOfferButton.click();
-            await liveTradePromise;
         });
 
         // The DEX re-quotes on trade creation, so amounts come from the trade, not the offer.
@@ -103,11 +102,12 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
         let slippagePercent: string;
 
         await test.step('Verify DEX details on the Confirm & send screen', async () => {
-            const { receiveStringAmount, swapSlippage } = tradingMockNew.liveTrade;
+            const { receiveStringAmount, swapSlippage, receive } =
+                await tradingResponses.swap.trade();
             receiveAmount = localizeNumber(receiveStringAmount);
             formattedReceiveAmount = `${receiveAmount} USDC`;
             slippagePercent = `${swapSlippage}%`;
-            const guaranteedShare = new BigNumber(100).minus(swapSlippage!).div(100);
+            const guaranteedShare = new BigNumber(100).minus(swapSlippage).div(100);
             minimumReceived = new BigNumber(receiveStringAmount).times(guaranteedShare);
             formattedMinimumReceived = `${localizeNumber(minimumReceived.toFixed(4))} USDC`;
             promptMinimumReceived = `${minimumReceived.toFixed()} USDC`;
@@ -139,7 +139,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             // rendered value is compared against the last captured scan on each attempt.
             await expect(async () => {
                 await expect(tradingPage.confirmation.receiveCryptoAmount).toHaveText(
-                    `${localizeNumber(tradingMockNew.simulatedReceiveAmount)} USDC`,
+                    `${localizeNumber(tradingMockNew.simulatedReceiveAmount(receive))} USDC`,
                     { timeout: 2_000 },
                 );
             }).toPass({ timeout: 15_000 });
@@ -153,6 +153,8 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
         });
 
         await test.step('Confirm the DEX transaction on device', async () => {
+            const { receiveAddress } = await tradingResponses.swap.trade();
+
             await devicePrompt.confirmOnDevicePromptIsShown();
 
             await expect(devicePrompt.outputValueOf('recipient_name')).toHaveText(dexProvider);
@@ -184,9 +186,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
                 `+ ${promptMinimumReceived}`,
             );
             // The recipient is the user's own receive address, not the LI.FI router (dexTx.to).
-            await expect(devicePrompt.assetsReceiveAddress).toHaveText(
-                tradingMockNew.liveTrade.receiveAddress!,
-            );
+            await expect(devicePrompt.assetsReceiveAddress).toHaveText(receiveAddress);
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: deviceReview.contractTitle },
@@ -221,6 +221,8 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
         });
 
         await test.step('Re-verify the fully revealed review form', async () => {
+            const { receiveAddress } = await tradingResponses.swap.trade();
+
             await expect(devicePrompt.outputValueOf('recipient_name')).toHaveText(dexProvider);
             await expect(devicePrompt.outputValueOf('swap_intent')).toHaveTranslation(
                 'TR_TRADING_INTENT_SWAP',
@@ -231,9 +233,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             await expect(devicePrompt.assetsReceiveCryptoAmount).toHaveText(
                 `+ ${promptMinimumReceived}`,
             );
-            await expect(devicePrompt.assetsReceiveAddress).toHaveText(
-                tradingMockNew.liveTrade.receiveAddress!,
-            );
+            await expect(devicePrompt.assetsReceiveAddress).toHaveText(receiveAddress);
             await expect(devicePrompt.header.gasLimitValue).toHaveText(reviewedGasLimit);
         });
 
@@ -242,11 +242,13 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
 
+            const { sendStringAmount } = await tradingResponses.swap.trade();
+
             await tradingPage.verifySwapToast({
                 sendAccount: accountLabel,
                 receiveAccount: accountLabel,
                 // The toast echoes the provider's formatting of the amount, not the one we typed.
-                sendAmount: tradingMockNew.liveTrade.sendStringAmount,
+                sendAmount: sendStringAmount,
                 receiveAmount,
             });
         });

--- a/suite/e2e/tests/trading/swap-eth-to-sol.test.ts
+++ b/suite/e2e/tests/trading/swap-eth-to-sol.test.ts
@@ -1,7 +1,6 @@
 import { getCryptoId } from '@suite-common/trading';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
-import { getCompanyNameFromList } from '../../fixtures/trading';
 import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
 import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
@@ -30,7 +29,14 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
         },
     );
 
-    test('Swap ETH to SOL', async ({ tradingPage, page, device, devicePrompt, tradingMockNew }) => {
+    test('Swap ETH to SOL', async ({
+        tradingPage,
+        page,
+        device,
+        devicePrompt,
+        tradingMockNew,
+        tradingResponses,
+    }) => {
         await test.step('Fill in a Swap form', async () => {
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
@@ -49,33 +55,32 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         let receiveAmount: string;
         let providerName: string;
-        let liveTradePromise: ReturnType<typeof tradingMockNew.waitForLiveTrade>;
 
         await test.step('Confirm the Swap trade', async () => {
             receiveAmount = await tradingPage.quotes.getBestOfferAmount();
             await expect(tradingPage.fees.maximumFeeAmountToBeCalculated).toBeHidden();
-            liveTradePromise = tradingMockNew.waitForLiveTrade();
             await tradingPage.swapBestOfferButton.click();
         });
 
         await test.step('Open modal and verify recipient on prompt and device', async () => {
+            const { exchange, sendAddress } = await tradingResponses.swap.trade();
+            providerName = await tradingResponses.swap.companyName(exchange);
+
             await tradingPage.confirmation.openConfirmAndSendModal();
-            await liveTradePromise;
-            providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
             await expect(devicePrompt.header.accountLabel).toHaveText(sendAccountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
-                formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
+                formatAddressWithNewlines(sendAddress),
             );
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: 'Send' },
-                    body: [transformAddress(tradingMockNew.liveTrade.sendAddress, 'evmTetragrams')],
+                    body: [transformAddress(sendAddress, 'evmTetragrams')],
                     actions: { right_button: 'Continue' },
                 },
                 T3T1: {
                     header: { title: 'Address', subtitle: 'Recipient' },
-                    body: [transformAddress(tradingMockNew.liveTrade.sendAddress, 'evmTetragrams')],
+                    body: [transformAddress(sendAddress, 'evmTetragrams')],
                 },
             });
             await devicePrompt.waitForPromptAndConfirm();
@@ -108,11 +113,13 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
 
+            const { sendStringAmount } = await tradingResponses.swap.trade();
+
             await tradingPage.verifySwapToast({
                 sendAccount: sendAccountLabel,
                 receiveAccount: receiveAccountLabel,
                 // The toast echoes the provider's formatting of the amount, not the one we typed.
-                sendAmount: tradingMockNew.liveTrade.sendStringAmount,
+                sendAmount: sendStringAmount,
                 receiveAmount,
             });
         });

--- a/suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts
+++ b/suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts
@@ -2,7 +2,6 @@ import { getCryptoId } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
-import { getCompanyNameFromList } from '../../fixtures/trading';
 import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
 import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
@@ -39,6 +38,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
         device,
         devicePrompt,
         tradingMockNew,
+        tradingResponses,
     }) => {
         await test.step('Fill in a Swap form', async () => {
             await tradingPage.fillSwapForm({
@@ -63,33 +63,32 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         let receiveAmount: string;
         let providerName: string;
-        let liveTradePromise: ReturnType<typeof tradingMockNew.waitForLiveTrade>;
 
         await test.step('Confirm the Swap trade', async () => {
             receiveAmount = await tradingPage.quotes.getBestOfferAmount();
             await expect(tradingPage.fees.maximumFeeAmountToBeCalculated).toBeHidden();
-            liveTradePromise = tradingMockNew.waitForLiveTrade();
             await tradingPage.swapBestOfferButton.click();
         });
 
         await test.step('Open modal and verify recipient on prompt and device', async () => {
+            const { exchange, sendAddress } = await tradingResponses.swap.trade();
+            providerName = await tradingResponses.swap.companyName(exchange);
+
             await tradingPage.confirmation.openConfirmAndSendModal();
-            await liveTradePromise;
-            providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
             await expect(devicePrompt.header.accountLabel).toHaveText(sendAccountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
-                formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
+                formatAddressWithNewlines(sendAddress),
             );
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: 'Send' },
-                    body: [transformAddress(tradingMockNew.liveTrade.sendAddress, 'evmTetragrams')],
+                    body: [transformAddress(sendAddress, 'evmTetragrams')],
                     actions: { right_button: 'Continue' },
                 },
                 T3T1: {
                     header: { title: 'Address', subtitle: 'Recipient' },
-                    body: [transformAddress(tradingMockNew.liveTrade.sendAddress, 'evmTetragrams')],
+                    body: [transformAddress(sendAddress, 'evmTetragrams')],
                 },
             });
             await devicePrompt.waitForPromptAndConfirm();
@@ -125,10 +124,13 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
 
+            const { sendStringAmount } = await tradingResponses.swap.trade();
+
             await tradingPage.verifySwapToast({
                 sendAccount: sendAccountLabel,
                 receiveAccount: receiveAccountLabel,
-                sendAmount,
+                // The toast echoes the provider's formatting of the amount, not the one we typed.
+                sendAmount: sendStringAmount,
                 receiveAmount,
             });
         });

--- a/suite/e2e/tests/trading/swap-sol-to-btc.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-to-btc.test.ts
@@ -2,7 +2,6 @@ import { getCryptoId } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
-import { getCompanyNameFromList } from '../../fixtures/trading';
 import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
 import { formatAddressWithNewlines, isWebProject } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
@@ -37,6 +36,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
         device,
         devicePrompt,
         tradingMockNew,
+        tradingResponses,
         target,
     }) => {
         await test.step('Fill in a Swap form', async () => {
@@ -59,31 +59,28 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
         let receiveAmount: string;
         let providerName: string;
         let solanaFee: string;
-        let liveTradePromise: ReturnType<typeof tradingMockNew.waitForLiveTrade>;
 
         await test.step('Confirm the Swap trade', async () => {
             receiveAmount = await tradingPage.quotes.getBestOfferAmount();
             await tradingPage.fees.waitToBeCalculated();
             solanaFee = (await tradingPage.fees.getSolanaFee()).toString();
-            liveTradePromise = tradingMockNew.waitForLiveTrade();
             await tradingPage.swapBestOfferButton.click();
         });
 
         await test.step('Open modal and verify recipient on prompt and device', async () => {
+            const { exchange, sendAddress } = await tradingResponses.swap.trade();
+            providerName = await tradingResponses.swap.companyName(exchange);
+
             await tradingPage.confirmation.openConfirmAndSendModal();
-            await liveTradePromise;
-            providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
             await expect(devicePrompt.header.accountLabel).toHaveText(accountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
-                formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
+                formatAddressWithNewlines(sendAddress),
             );
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: 'Recipient' },
-                    body: [
-                        transformAddress(tradingMockNew.liveTrade.sendAddress, 'fourTetragrams'),
-                    ],
+                    body: [transformAddress(sendAddress, 'fourTetragrams')],
                     actions: { right_button: 'Continue' },
                 },
             });
@@ -119,10 +116,13 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
 
+            const { sendStringAmount } = await tradingResponses.swap.trade();
+
             await tradingPage.verifySwapToast({
                 sendAccount: accountLabel,
                 receiveAccount: 'Bitcoin #1',
-                sendAmount,
+                // The toast echoes the provider's formatting of the amount, not the one we typed.
+                sendAmount: sendStringAmount,
                 receiveAmount,
             });
         });

--- a/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
@@ -2,7 +2,6 @@ import { getCryptoId } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
-import { getCompanyNameFromList } from '../../fixtures/trading';
 import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
 import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
@@ -38,6 +37,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
         device,
         devicePrompt,
         tradingMockNew,
+        tradingResponses,
     }) => {
         await test.step('Fill in a Swap form', async () => {
             await tradingPage.fillSwapForm({
@@ -59,30 +59,27 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         let receiveAmount: string;
         let providerName: string;
-        let liveTradePromise: ReturnType<typeof tradingMockNew.waitForLiveTrade>;
 
         await test.step('Confirm the Swap trade', async () => {
             receiveAmount = await tradingPage.quotes.getBestOfferAmount();
             await expect(tradingPage.fees.maximumFeeAmountToBeCalculated).toBeHidden();
-            liveTradePromise = tradingMockNew.waitForLiveTrade();
             await tradingPage.swapBestOfferButton.click();
         });
 
         await test.step('Open modal and verify recipient on prompt and device', async () => {
+            const { exchange, sendAddress } = await tradingResponses.swap.trade();
+            providerName = await tradingResponses.swap.companyName(exchange);
+
             await tradingPage.confirmation.openConfirmAndSendModal();
-            await liveTradePromise;
-            providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
 
             await expect(devicePrompt.header.accountLabel).toHaveText(sendAccountLabel);
             await expect(devicePrompt.outputValueOf('address')).toHaveText(
-                formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
+                formatAddressWithNewlines(sendAddress),
             );
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: 'Recipient' },
-                    body: [
-                        transformAddress(tradingMockNew.liveTrade.sendAddress, 'fourTetragrams'),
-                    ],
+                    body: [transformAddress(sendAddress, 'fourTetragrams')],
                     actions: { right_button: 'Continue' },
                 },
             });
@@ -121,10 +118,13 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
 
+            const { sendStringAmount } = await tradingResponses.swap.trade();
+
             await tradingPage.verifySwapToast({
                 sendAccount: sendAccountLabel,
                 receiveAccount: receiveAccountLabel,
-                sendAmount,
+                // The toast echoes the provider's formatting of the amount, not the one we typed.
+                sendAmount: sendStringAmount,
                 receiveAmount,
             });
         });


### PR DESCRIPTION
## Description

Adds a `tradingResponses` fixture that observes the trade and provider-list endpoints of all
three flows, so tests read live values with `await tradingResponses.swap.trade()` instead of
arming a wait before the click. It handles the different response shapes buy / sell / swap
have, and exposes the whole `list` response rather than only its providers.

Migrates the seven swap tests. Toast assertions now use the trade's `sendStringAmount` — one
was failing on `5.000000` vs `5`.

Provider display names now resolve from the live list rather than a checked-in one, which had
already drifted: buy was missing `revolut` and `kryptonim`, swap both 1inch Fusion providers. A
missing entry is a hard error on whichever provider happens to win an offer.

Also includes the sell-side mock scaffolding, consumed by the stacked sell PRs.

## Notes for QA

E2E-only, no product code.

## Related Issue

Resolve

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/trading-minimal-mock-phase-C/web/](https://dev.suite.sldev.cz/suite-web/trading-minimal-mock-phase-C/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=trading-minimal-mock-phase-C&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=trading-minimal-mock-phase-C&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-30T09:31:21.295Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-30T09:30:49.571Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->