### PR TITLE
test(e2e): migrate the BTC sell test to the minimalistic mock

### DIFF
--- a/suite/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/sell-bitcoin.test.ts
@@ -87,7 +87,7 @@ test.describe('Trading - Sell BTC', { tag: ['@T3W1', '@T3T1'] }, () => {
                 `${localizeNumber(cryptoStringAmount)} BTC`,
             );
             await expect(tradingPage.confirmation.fiatAmount).toHaveText(
-                `€${localizeNumber(fiatStringAmount, 'en-US', 0, 2)}`,
+                `€${localizeNumber(fiatStringAmount, 'en-US', 2, 2)}`,
             );
         });
 

--- a/suite/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/sell-bitcoin.test.ts
@@ -1,97 +1,184 @@
-import { capitalizeFirstLetter } from '@trezor/utils';
+import { localizeNumber } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
 
-import {
-    getCompanyNameFromList,
-    sellQuotesBTC,
-    sellTradeBTC,
-    sellWatchBTC,
-    tradeApiRequest,
-    tradeEndpoint,
-} from '../../fixtures/trading';
+import { sellStatusFlow } from '../../fixtures/trading/statusFlow';
 import { formatAddressWithNewlines } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
+import { transformAddress } from '../../support/testExtends/customMatchers';
 
-// Expected values based on our mocked responses
-const fiatAmount = sellQuotesBTC[0]?.fiatStringAmount ?? '';
-const cryptoAmount = sellQuotesBTC[0]?.cryptoStringAmount ?? '';
-const provider = getCompanyNameFromList(sellQuotesBTC[0]?.exchange ?? '', 'sellList');
-const providerAddress = sellWatchBTC.destinationAddress;
-const providerPaymentId = sellWatchBTC.destinationPaymentExtraId;
-const formattedCryptoAmount = `${cryptoAmount} BTC`;
-const formattedFiatAmount = `€${fiatAmount}`;
-const { paymentMethodName } = sellTradeBTC.trade;
-const formattedAddress = formatAddressWithNewlines(sellWatchBTC.destinationAddress);
+const sendAmount = '0.0015';
+const formattedSendAmount = `${localizeNumber(sendAmount)} BTC`;
+const accountLabel = 'Bitcoin #1';
 
-test.describe('Trading - Sell BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+// Live Invity never hands out a deposit address for a payment its provider page never initiated,
+// so the test supplies one. It is an address of this same wallet: the broadcast is already blocked
+// by the backend, and a self-owned address means even a regression there could not move funds out.
+const depositAddress = 'bc1qftjj5a3s8emtxhexlgpne5d7zp26qsjfxhhgfu';
+const depositPaymentExtraId = '6d666a5f-b99c-4482-b8bc-2df04fc11b7b';
+
+test.describe('Trading - Sell BTC', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
 
-    test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage, settingsPage }) => {
-        await test.step('Mocking responses', async () => {
-            await page.route(tradeEndpoint.sellQuotes, async route => {
-                await route.fulfill({ json: sellQuotesBTC });
+    test.beforeEach(
+        async ({
+            onboardingPage,
+            dashboardPage,
+            settingsPage,
+            walletPage,
+            tradingPage,
+            tradingMockNew,
+        }) => {
+            tradingMockNew.setTradeFlow('sell');
+            await tradingMockNew.rewriteProviderRedirect();
+            await tradingMockNew.setWatchFields({
+                destinationAddress: depositAddress,
+                destinationPaymentExtraId: depositPaymentExtraId,
             });
-            await tradingMock.routeTrade(tradeEndpoint.sellTrade, sellTradeBTC);
-            await page.route(tradeEndpoint.sellWatch, async route => {
-                await route.fulfill({ json: sellWatchBTC });
-            });
+            await tradingMockNew.setStatus('SEND_CRYPTO');
+            const btcBackend = await tradingMockNew.startBackend('btc');
+
             await onboardingPage.completeOnboarding();
-            await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+            await settingsPage.changeNetworks({
+                enableNetworks: [{ symbol: 'btc', backend: btcBackend }],
+            });
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-        });
-    });
-
-    test('Sell Bitcoin for best offer', async ({ page, tradingPage, walletPage, devicePrompt }) => {
-        await test.step('Open sell form', async () => {
-            await walletPage.openTrading();
+            await walletPage.openTrading({ symbol: 'btc' });
             await tradingPage.sellTabButton.click();
-        });
+        },
+    );
 
+    test('Sell Bitcoin for best offer', async ({
+        tradingPage,
+        page,
+        device,
+        devicePrompt,
+        tradingMockNew,
+        toastSection,
+        tradingResponses,
+    }) => {
         await test.step('Fill in a sell request', async () => {
-            await tradingPage.fillSellForm({ cryptoAmount });
-            await expect(tradingPage.quotes.bestOfferAmount).toHaveText(fiatAmount);
-            await expect(tradingPage.quotes.provider).toHaveText(capitalizeFirstLetter(provider));
+            await tradingPage.fillSellForm({ cryptoAmount: sendAmount });
             await tradingPage.fees.expectBitcoinFeeCalculated();
         });
 
-        await test.step('Confirm button shows provider name and KYC warning is visible', async () => {
-            await expect(tradingPage.sellBestOfferButton).toHaveTranslation('TR_TRADING_SELL_VIA', {
-                values: { providerName: provider },
-            });
-            await expect(tradingPage.sellBestOfferButton.locator('svg')).toBeVisible();
-            await expect(tradingPage.kycWarning).toBeVisible();
-        });
+        let providerName: string;
 
-        await test.step('Confirm sell', async () => {
-            const tradeRequestPromise = page.waitForRequest(tradeEndpoint.sellTrade);
+        await test.step('Confirm the sell trade and return from the provider', async () => {
             await tradingPage.sellBestOfferButton.click();
-            await expect.soft(tradeRequestPromise).toHavePayload(tradeApiRequest.sellTradePayload, {
-                omit: ['returnUrl', 'trade.orderId', 'trade.paymentId', 'trade.refundAddress'],
-            });
+            await tradingPage.waitForRedirectCompletion();
         });
-
-        await tradingPage.waitForRedirectCompletion();
 
         await test.step('Verify all confirmation values', async () => {
-            await expect(tradingPage.confirmation.fiatAmount).toHaveText(formattedFiatAmount);
-            await expect(tradingPage.confirmation.cryptoAmount).toHaveText(formattedCryptoAmount);
-            await expect(tradingPage.confirmation.provider).toHaveText(provider);
-            await expect(tradingPage.confirmation.paymentMethod).toHaveText(paymentMethodName);
-            await expect(tradingPage.confirmation.address).toHaveText(providerAddress);
-            await expect(tradingPage.confirmation.account).toHaveText('Bitcoin #1');
-            await expect(tradingPage.confirmation.paymentId).toHaveText(providerPaymentId);
-        });
+            const { exchange, cryptoStringAmount, fiatStringAmount } =
+                await tradingResponses.sell.trade();
+            providerName = await tradingResponses.sell.companyName(exchange);
 
-        await test.step('Initiate send', async () => {
-            await tradingPage.confirmation.initiateSendConfirmation();
-            await expect(devicePrompt.header.accountLabel).toHaveText('Bitcoin #1');
-            await expect(devicePrompt.outputValueOf('address')).toHaveText(formattedAddress);
-            await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
-                formattedCryptoAmount,
+            await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+            await expect(tradingPage.confirmation.paymentMethod).toHaveTranslation(
+                'TR_PAYMENT_METHOD_CREDITCARD',
             );
-            await expect(devicePrompt.cryptoAmountOf('fee')).toHaveTextGreaterThan(0);
+            await expect(tradingPage.confirmation.account).toContainText(accountLabel);
+            await expect(tradingPage.confirmation.address).toHaveText(depositAddress);
+            await expect(tradingPage.confirmation.paymentId).toHaveText(depositPaymentExtraId);
+            // Providers pad differently ("0.00150000"), so both amounts are normalised the way
+            // the panel formats them rather than compared to the raw strings.
+            await expect(tradingPage.confirmation.cryptoAmount).toHaveText(
+                `${localizeNumber(cryptoStringAmount)} BTC`,
+            );
+            await expect(tradingPage.confirmation.fiatAmount).toHaveText(
+                `€${localizeNumber(fiatStringAmount, 'en-US', 0, 2)}`,
+            );
         });
 
-        // Rest of the flow is not implemented as we don't know how to mock the send request and actually not send the crypto
+        await test.step('Verify recipient on prompt and device', async () => {
+            await tradingPage.confirmation.openConfirmAndSendModal();
+
+            await expect(devicePrompt.header.accountLabel).toHaveText(accountLabel);
+            await expect(devicePrompt.outputValueOf('address')).toHaveText(
+                formatAddressWithNewlines(depositAddress),
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [transformAddress(depositAddress, 'fourTetragrams')],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Address', subtitle: 'Recipient #1' },
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Verify amount on prompt and device', async () => {
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
+                formattedSendAmount,
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [['Amount'], [formattedSendAmount]],
+                    actions: { right_button: 'Confirm' },
+                },
+                T3T1: {
+                    header: { title: 'Amount', subtitle: 'Recipient #1' },
+                    body: [[formattedSendAmount]],
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Verify total and fee on prompt and device', async () => {
+            // The BTC fee is live; derive the total from it and crosscheck modal against device.
+            await expect(devicePrompt.cryptoAmountOf('fee')).toHaveText(/\d/);
+            const reviewFee = await devicePrompt.cryptoAmountOf('fee').innerText();
+            const totalAmount = new BigNumber(reviewFee).plus(sendAmount).toString();
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
+                `${totalAmount} BTC`,
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        ['Total amount'],
+                        [`${totalAmount} BTC`],
+                        ['incl. Transaction fee'],
+                        [`${reviewFee} BTC`],
+                    ],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+            await expect(devicePrompt.sendButton).toBeEnabled();
+        });
+
+        await test.step('Send crypto to provider (broadcast blocked by mock)', async () => {
+            await page.clock.install();
+            await devicePrompt.sendButton.click();
+
+            await expect(tradingPage.transactionDetailHeader).toHaveTranslation(
+                'TR_SELL_HEADER_TITLE',
+            );
+            // Unlike the swap toast, this one carries the composed amount rather than the
+            // provider's own formatting of it, so it matches the amount the test typed.
+            await expect(toastSection.txSent).toContainTranslation('TOAST_TX_SENT', {
+                values: { amount: formattedSendAmount, account: accountLabel },
+            });
+        });
+
+        for (const phase of sellStatusFlow) {
+            await test.step(`Wait for status change to ${phase.status}`, async () => {
+                await tradingMockNew.advanceStatus(phase.status);
+                const values = phase.translationValues?.(providerName);
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    phase.translationKey,
+                    { values },
+                );
+            });
+        }
     });
 });


### PR DESCRIPTION
## Description

Stacked on #31865. Moves `sell-bitcoin` onto `TradingMockNew` — trade, quotes
and provider stay live, only the broadcast and watch status are controlled.

## Notes for QA

E2E-only, no product code.

## Related Issue

Resolve <!-- link the issue here -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/trading-minimal-mock-phase-C-sell/web/](https://dev.suite.sldev.cz/suite-web/trading-minimal-mock-phase-C-sell/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=trading-minimal-mock-phase-C-sell&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=trading-minimal-mock-phase-C-sell&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T11:08:25.556Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T11:09:20.955Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->