### PR TITLE
chore(connect): redact also WordAck and PinMatrixAck

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -18,6 +18,8 @@ import type { TypedCallProvider } from '../types/typed-call-provider';
 
 const blacklist: Record<string, string[] | true> = {
     PassphraseAck: ['passphrase'],
+    PinMatrixAck: ['pin'],
+    WordAck: ['word'],
     CipheredKeyValue: ['value'],
     GetPublicKey: ['address_n'],
     PublicKey: ['node', 'xpub'],


### PR DESCRIPTION
## Description

Redact `WordAck` and `PinMatrixAck` from debug logs, especially `WordAck` as it contains the BIP39 seed words.
Of course this is not a big problem, beacuse:
- you have to explicitely turn on Debug settings, and also Connect logs in Settings > Debug
- the debug logs never make it to `.log` file, only terminal stdout
- this affects only T1B1 wallet recovery with Standard (24 words)
- and just a reminder of the security model of T1B1 Standard recovery: the words are shuffled, with order unknown on host-side. Even a compromised unordered 24-tuple of seed words has a 79 bits of entropy.

The `PinMatrixAck` is even less of an issue, because the T1B1 PIN matrix or Advanced T1B1 Recovery only give you a random number of 1–6, but still, let's redact it to be consistent. 

## Notes for QA

- turn on Debug settings
- turn on Settings > Debug > TrezorConnect logs
- restart Suite, now start it **via a terminal**
- connect an uninitialized T1B1
- start 24-word wallet on T1B1: with classic recovery method
- enter any few words
- the terminal stdout should have words redacted

## Logs

Before
```
DeviceCommands Received WordRequest { type: 'WordRequestType_Plain' }
Core handleMessage ui-receive_word
DeviceCommands Sending WordAck { word: 'all' }


DeviceCommands Received WordRequest { type: 'WordRequestType_Matrix9' }
Core handleMessage ui-receive_word
DeviceCommands Sending WordAck { word: '7' }


DeviceCommands Received PinMatrixRequest { type: 'PinMatrixRequestType_NewFirst' }
DeviceCommands Sending PinMatrixAck { pin: '1' }
```

After
```
DeviceCommands Received WordRequest { type: 'WordRequestType_Plain' }
Core handleMessage ui-receive_word
DeviceCommands Sending WordAck { word: '(redacted...)' }


DeviceCommands Received WordRequest { type: 'WordRequestType_Matrix9' }
Core handleMessage ui-receive_word
DeviceCommands Sending WordAck { word: '(redacted...)' }


DeviceCommands Received PinMatrixRequest { type: 'PinMatrixRequestType_NewFirst' }
DeviceCommands Sending PinMatrixAck { pin: '(redacted...)' }
```

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** DeviceCurrentSession.ts is a broad dependency referenced by 139 tests, so the strategy focuses narrowly on tests that exercise the device session lifecycle itself: multi-session steal/reclaim, reconnect persistence, no-session behavior, and session interruption/recovery. These targeted tests provide high confidence that changes to session acquisition, persistence, and cleanup do not break core device communication flows.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/src/device/DeviceCurrentSession.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Directly exercises Bridge session enumerate/acquire/release logic, including session stealing, reclaiming, and multi-tab takeover. A regression in DeviceCurrentSession would most likely surface here first.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests passphrase wallet session caching across device disconnect/reconnect and verifies that address confirmation reuses the cached session after re-authorization. This directly relies on correct session persistence.
- `suite/e2e/tests/wallet/without-device.test.ts` — Validates behavior when no device session is available: disconnected status, connection modal during send, and disconnected device banner. This covers the no-session edge of DeviceCurrentSession.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Simulates device disconnection mid-backup and verifies proper error handling after reconnect. This exercises session interruption and recovery during a sensitive device operation.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Verifies that an in-progress recovery session persists across page reload and device reconnect. This tests session state resilience and reinitialization logic.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Covers switching between multiple hidden (passphrase-protected) wallets and address verification, which relies on correct per-wallet session management and caching.
- `suite/e2e/tests/settings/forget-device.test.ts` — Tests forgetting devices across connected/disconnected states and Bluetooth history, exercising session cleanup and device state transitions.

</details>

_Updated: 2026-09-07T06:28:47.395Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/redact-wordack-and-pinack/web/](https://dev.suite.sldev.cz/suite-web/chore/redact-wordack-and-pinack/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/redact-wordack-and-pinack&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/redact-wordack-and-pinack&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/redact-wordack-and-pinack&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T06:30:25.915Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T06:30:05.011Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->