### PR TITLE
[PoC] Stellar SEP-41 (type-C) contract token balances via Soroban RPC

### DIFF
--- a/networks/stellar/network-stellar/src/constants/index.ts
+++ b/networks/stellar/network-stellar/src/constants/index.ts
@@ -6,6 +6,8 @@ export {
     toStellarNetworkSymbol,
 } from './networkSymbol';
 export type { StellarNetworkSymbol } from './networkSymbol';
+export { STELLAR_SOROBAN_RPC_URL, STELLAR_CONTRACT_TOKENS } from './soroban';
+export type { StellarContractToken } from './soroban';
 
 export const STELLAR_DECIMALS = 7;
 

--- a/networks/stellar/network-stellar/src/constants/soroban.ts
+++ b/networks/stellar/network-stellar/src/constants/soroban.ts
@@ -1,0 +1,51 @@
+/**
+ * Soroban (contract / type-C token) configuration.
+ *
+ * ⚠️ PROOF-OF-CONCEPT: `STELLAR_SOROBAN_RPC_URL` points at a public, keyless
+ * Stellar RPC (standard `stellar-rpc` JSON-RPC, no SLA, rate-limited) as a
+ * stopgap. Before production, replace it with a Trezor-hosted proxy (cf.
+ * `sol.trezor.io`) so the endpoint stays within Trezor's trust boundary, and
+ * source the token allow-list from the hosted definitions pipeline instead of
+ * this file. Swapping the URL is the only change needed — the interface is
+ * identical across any conformant `stellar-rpc`.
+ */
+export const STELLAR_SOROBAN_RPC_URL = 'https://mainnet.sorobanrpc.com';
+
+export interface StellarContractToken {
+    contract: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+}
+
+/**
+ * Curated allow-list of Soroban contract (SEP-41 / type-C) tokens to look up.
+ *
+ * There is no on-chain registry of an account's contract-token holdings, so
+ * discovery is an explicit allow-list rather than auto-discovery. Every entry
+ * has been verified as a native contract token (its address is NOT the Stellar
+ * Asset Contract of any classic asset).
+ */
+export const STELLAR_CONTRACT_TOKENS: StellarContractToken[] = [
+    {
+        // Centrifuge deRWA — Janus Henderson Short-Term US Treasury (LayerZero OFT)
+        contract: 'CBI7UCH5KGSVQRO5H4SUCZUTZABCITZLRHQQZTWL2TK4RZ72TAR6IHRV',
+        name: 'deJTRSY',
+        symbol: 'deJTRSY',
+        decimals: 18,
+    },
+    {
+        // Centrifuge deRWA — AAA CLO strategy (LayerZero OFT)
+        contract: 'CC64WBDGS6QQP22QTTIACYIXT3WF7BBQEYOQPLTP7GTKYY7PZ74QYGSL',
+        name: 'deJAAA',
+        symbol: 'deJAAA',
+        decimals: 18,
+    },
+    {
+        // Blend BLND:USDC 80/20 Comet backstop LP token
+        contract: 'CAS3FL6TLZKDGGSISDBWGGPXT3NRR4DYTZD7YOD3HMYO6LTJUVGRVEAM',
+        name: 'Blend BLND:USDC Backstop LP',
+        symbol: 'CPAL',
+        decimals: 7,
+    },
+];

--- a/networks/stellar/network-stellar/src/runtime/exports.ts
+++ b/networks/stellar/network-stellar/src/runtime/exports.ts
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './assets';
+export * from './soroban';
 export * from './transactions';

--- a/networks/stellar/network-stellar/src/runtime/soroban.ts
+++ b/networks/stellar/network-stellar/src/runtime/soroban.ts
@@ -1,0 +1,220 @@
+import {
+    Account,
+    Address,
+    BASE_FEE,
+    Contract,
+    Networks,
+    StrKey,
+    TransactionBuilder,
+    rpc,
+    scValToNative,
+    type xdr,
+} from '@stellar/stellar-sdk';
+
+/**
+ * Soroban (Stellar) JSON-RPC helpers for reading SEP-41 contract-token balances.
+ *
+ * Contract tokens (`C…` addresses) live in Soroban contract storage and are
+ * invisible to Horizon. Their balances are read from a Stellar RPC node over
+ * JSON-RPC via a read-only `simulateTransaction` of the token's SEP-41
+ * `balance(addr)` function: no signing, no fees, no ledger change — and it works
+ * for any SEP-41-compliant token regardless of its storage layout.
+ */
+
+// A read-only simulation still needs a syntactically valid ed25519 (`G…`) source
+// account, but its existence and sequence are irrelevant. Derive a deterministic
+// all-zero placeholder rather than depend on a real funded account.
+const SIMULATION_SOURCE_ACCOUNT = StrKey.encodeEd25519PublicKey(Buffer.alloc(32));
+
+// Upper bound for reading the whole contract-token allow-list from the RPC.
+const SEP41_READ_TIMEOUT_MS = 10_000;
+
+export type SorobanServer = rpc.Server;
+
+export const getSorobanServer = (url: string): SorobanServer =>
+    new rpc.Server(url, { allowHttp: url.startsWith('http://') });
+
+const simulateContractRead = async (
+    server: SorobanServer,
+    contractId: string,
+    method: string,
+    args: xdr.ScVal[],
+    networkPassphrase: string,
+): Promise<unknown> => {
+    const source = new Account(SIMULATION_SOURCE_ACCOUNT, '0');
+    const transaction = new TransactionBuilder(source, {
+        fee: BASE_FEE,
+        networkPassphrase,
+    })
+        .addOperation(new Contract(contractId).call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+    const simulation = await server.simulateTransaction(transaction);
+
+    if (rpc.Api.isSimulationError(simulation)) {
+        // Contract is not a SEP-41 token, or the function panicked.
+        return undefined;
+    }
+
+    const retval = simulation.result?.retval;
+
+    return retval ? scValToNative(retval) : undefined;
+};
+
+/**
+ * Reads a single SEP-41 `balance(holder)` from a contract token.
+ * Returns the balance as a base-unit string, or `undefined` when it cannot be
+ * read (not a token / no balance entry / RPC failure).
+ */
+export const getContractTokenBalance = async (
+    server: SorobanServer,
+    contractId: string,
+    holder: string,
+    networkPassphrase: string = Networks.PUBLIC,
+): Promise<string | undefined> => {
+    const balance = await simulateContractRead(
+        server,
+        contractId,
+        'balance',
+        [Address.fromString(holder).toScVal()],
+        networkPassphrase,
+    );
+
+    // SEP-41 `balance` returns an i128 -> scValToNative yields a bigint.
+    return balance == null ? undefined : (balance as bigint).toString();
+};
+
+/** SEP-41 descriptive metadata, read from the token contract itself. */
+export interface Sep41Metadata {
+    decimals?: number;
+    symbol?: string;
+    name?: string;
+}
+
+/**
+ * Reads a token's SEP-41 metadata (`decimals`/`symbol`/`name`) from the contract.
+ * Makes tokens self-describing, so callers need only supply contract addresses.
+ */
+export const getContractTokenMetadata = async (
+    server: SorobanServer,
+    contractId: string,
+    networkPassphrase: string = Networks.PUBLIC,
+): Promise<Sep41Metadata> => {
+    const [decimals, symbol, name] = await Promise.all([
+        simulateContractRead(server, contractId, 'decimals', [], networkPassphrase),
+        simulateContractRead(server, contractId, 'symbol', [], networkPassphrase),
+        simulateContractRead(server, contractId, 'name', [], networkPassphrase),
+    ]);
+
+    // `decimals` is a u32 -> number; be tolerant of a bigint too.
+    const isNumeric = typeof decimals === 'number' || typeof decimals === 'bigint';
+
+    return {
+        decimals: isNumeric ? Number(decimals) : undefined,
+        symbol: typeof symbol === 'string' ? symbol : undefined,
+        name: typeof name === 'string' ? name : undefined,
+    };
+};
+
+/** A fully-described SEP-41 token holding for an account. */
+export interface Sep41Token extends Sep41Metadata {
+    contract: string;
+    balance: string;
+}
+
+/**
+ * Reads a contract's full SEP-41 data (balance + metadata) for `holder`.
+ * Returns `undefined` when the contract does not behave like a SEP-41 token
+ * (neither a balance nor `decimals` could be read).
+ */
+export const getSep41Token = async (
+    server: SorobanServer,
+    contractId: string,
+    holder: string,
+    networkPassphrase: string = Networks.PUBLIC,
+): Promise<Sep41Token | undefined> => {
+    const [balance, metadata] = await Promise.all([
+        getContractTokenBalance(server, contractId, holder, networkPassphrase),
+        getContractTokenMetadata(server, contractId, networkPassphrase),
+    ]);
+
+    if (balance == null && metadata.decimals == null) {
+        return undefined;
+    }
+
+    return { contract: contractId, balance: balance ?? '0', ...metadata };
+};
+
+/**
+ * Reads full SEP-41 token data for a fixed allow-list of contracts held by
+ * `holder`. Self-describing (metadata comes from each contract). There is no
+ * on-chain registry of contract-token holdings, so discovery is an explicit
+ * allow-list rather than auto-discovery. Failed reads are dropped.
+ */
+export const readSep41Tokens = async (
+    rpcUrl: string,
+    holder: string,
+    contractIds: string[],
+    networkPassphrase: string = Networks.PUBLIC,
+): Promise<Sep41Token[]> => {
+    const server = getSorobanServer(rpcUrl);
+
+    const read = Promise.all(
+        contractIds.map(contract =>
+            getSep41Token(server, contract, holder, networkPassphrase).catch(() => undefined),
+        ),
+    );
+
+    // A slow or unreachable RPC must never stall account loading, so cap the read
+    // and fall back to no contract tokens if it does not finish in time.
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<(Sep41Token | undefined)[]>(resolve => {
+        timeoutId = setTimeout(() => resolve([]), SEP41_READ_TIMEOUT_MS);
+    });
+
+    try {
+        const tokens = await Promise.race([read, timeout]);
+
+        return tokens.filter((token): token is Sep41Token => token != null);
+    } finally {
+        clearTimeout(timeoutId);
+    }
+};
+
+/**
+ * Reads SEP-41 balances for a fixed list of contract tokens held by `holder`.
+ * Discovery is an explicit allow-list — there is no on-chain registry of an
+ * account's contract-token holdings. Missing/failed reads resolve to `'0'`.
+ */
+export const getContractTokenBalances = (
+    server: SorobanServer,
+    holder: string,
+    contractIds: string[],
+    networkPassphrase: string = Networks.PUBLIC,
+): Promise<{ contract: string; balance: string }[]> =>
+    Promise.all(
+        contractIds.map(async contract => {
+            try {
+                const balance = await getContractTokenBalance(
+                    server,
+                    contract,
+                    holder,
+                    networkPassphrase,
+                );
+
+                return { contract, balance: balance ?? '0' };
+            } catch {
+                return { contract, balance: '0' };
+            }
+        }),
+    );
+
+/** Convenience: create a server and read a fixed token list in one call. */
+export const readStellarContractTokenBalances = (
+    rpcUrl: string,
+    holder: string,
+    contractIds: string[],
+    networkPassphrase: string = Networks.PUBLIC,
+): Promise<{ contract: string; balance: string }[]> =>
+    getContractTokenBalances(getSorobanServer(rpcUrl), holder, contractIds, networkPassphrase);

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -26,7 +26,8 @@ export type TokenStandard =
     | 'SPL'
     | 'SPL-2022'
     | 'BLOCKFROST'
-    | 'STELLAR-CLASSIC';
+    | 'STELLAR-CLASSIC'
+    | 'STELLAR-CONTRACT';
 
 export type FiatRatesBySymbol = {
     [K in BaseCurrencyCode]?: number | undefined;

--- a/packages/blockchain-link/src/workers/stellar/handlers/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/stellar/handlers/getAccountInfo.ts
@@ -1,14 +1,22 @@
-import type { AccountInfo, MessageTypes } from '@trezor/blockchain-link-types';
+import type { AccountInfo, MessageTypes, TokenInfo } from '@trezor/blockchain-link-types';
 import { CustomError, RESPONSES } from '@trezor/blockchain-link-types';
 import * as utils from '@trezor/blockchain-link-utils/src/stellar';
-import { STELLAR_DECIMALS, toStroops } from '@trezor/network-stellar/constants';
+import {
+    STELLAR_CONTRACT_TOKENS,
+    STELLAR_DECIMALS,
+    STELLAR_SOROBAN_RPC_URL,
+    toStroops,
+} from '@trezor/network-stellar/constants';
 import stellar from '@trezor/network-stellar/runtime';
 import { BigNumber } from '@trezor/utils';
 
 import { RESERVE } from '../reserve';
 import type { Request } from '../types';
 
-export const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => {
+export const getAccountInfo = async (
+    request: Request<MessageTypes.GetAccountInfo>,
+    isTestnet: boolean,
+) => {
     const { payload } = request;
 
     // initial state (basic)
@@ -32,7 +40,7 @@ export const getAccountInfo = async (request: Request<MessageTypes.GetAccountInf
     };
 
     const api = await request.connect();
-    const { identifyTransaction, isNotFoundError } = await stellar();
+    const { identifyTransaction, isNotFoundError, readSep41Tokens } = await stellar();
     let info;
     try {
         info = await api.accounts().accountId(payload.descriptor).call();
@@ -94,6 +102,49 @@ export const getAccountInfo = async (request: Request<MessageTypes.GetAccountInf
                 decimals: STELLAR_DECIMALS,
             };
         });
+
+    // Soroban contract (type-C / SEP-41) tokens.
+    // Horizon cannot see these, so they are read from a Stellar RPC node.
+    // Tokens are self-describing: balance + metadata (decimals/symbol/name) are
+    // read from each contract's SEP-41 interface. Discovery is a curated
+    // allow-list (no on-chain registry of contract-token holdings exists).
+    // Enabled on mainnet only (the PoC RPC endpoint is mainnet).
+    if (!isTestnet && STELLAR_CONTRACT_TOKENS.length > 0) {
+        try {
+            const sep41Tokens = await readSep41Tokens(
+                STELLAR_SOROBAN_RPC_URL,
+                payload.descriptor,
+                STELLAR_CONTRACT_TOKENS.map(token => token.contract),
+            );
+            const fallbackByContract = new Map(
+                STELLAR_CONTRACT_TOKENS.map(token => [token.contract, token]),
+            );
+
+            const contractTokens: TokenInfo[] = sep41Tokens
+                // Contract tokens have no trustline opt-in, so only surface the ones the
+                // account actually holds (non-zero) rather than the whole allow-list.
+                .filter(token => token.balance !== '0')
+                .map(token => {
+                    // Prefer on-chain SEP-41 metadata; fall back to the curated entry.
+                    const fallback = fallbackByContract.get(token.contract);
+
+                    return {
+                        standard: 'STELLAR-CONTRACT',
+                        contract: token.contract,
+                        balance: token.balance,
+                        name: token.name ?? fallback?.name,
+                        symbol: (token.symbol ?? fallback?.symbol ?? '').toUpperCase(),
+                        decimals: token.decimals ?? fallback?.decimals ?? STELLAR_DECIMALS,
+                    };
+                });
+
+            account.tokens = [...(account.tokens ?? []), ...contractTokens];
+        } catch (error) {
+            // Contract-token enrichment must never break classic account loading.
+            console.warn('Stellar: failed to read Soroban SEP-41 tokens', error);
+        }
+    }
+
     account.empty = false;
 
     if (payload.details !== 'txs') {

--- a/packages/blockchain-link/src/workers/stellar/stellarWorker.ts
+++ b/packages/blockchain-link/src/workers/stellar/stellarWorker.ts
@@ -21,7 +21,7 @@ const onRequest = (request: Request<MessageTypes.Message>, isTestnet: boolean) =
         case MESSAGES.GET_INFO:
             return getInfo(request, isTestnet);
         case MESSAGES.GET_ACCOUNT_INFO:
-            return getAccountInfo(request);
+            return getAccountInfo(request, isTestnet);
         case MESSAGES.ESTIMATE_FEE:
             return estimateFee(request);
         case MESSAGES.PUSH_TRANSACTION:


### PR DESCRIPTION
> **⚠️ Proof of concept — not for merge as-is.** Read/display only, mainnet-only, hardcoded token allow-list, public keyless RPC. See _Caveats_ below.

## Description

Adds a first, **read-only** capability for **Soroban contract (SEP-41 / "type-C") tokens** in Suite — the token class that lives in contract storage and is **invisible to Horizon** (e.g. Centrifuge deJTRSY/deJAAA, Blend `CPAL`). Suite previously showed **nothing** for these.

When a **mainnet** Stellar account loads, the worker now also reads a curated allow-list of contract tokens from a **Stellar RPC node** and merges them into `account.tokens` alongside classic (trustline) tokens.

**How it works**
- New Soroban JSON-RPC client (`network-stellar/runtime/soroban.ts`) reads each token's full **SEP-41 interface** via read-only `simulateTransaction`: `balance(holder)` + on-chain `decimals()` / `symbol()` / `name()`. Tokens are **self-describing** — the allow-list only supplies contract addresses.
- New token standard `STELLAR-CONTRACT` (`blockchain-link-types`).
- Worker (`blockchain-link/workers/stellar`) merges results into `account.tokens` after the classic tokens; wrapped in try/catch so an RPC failure never breaks classic account loading. Mainnet only.

**Discovery:** there is no on-chain registry of an account's contract-token holdings, so discovery is an explicit **curated allow-list** (no auto-discovery), currently a hardcoded constant.

**Only JSON-RPC method used:** `simulateTransaction` (relevant for proxy whitelisting).

## Notes for QA

- Web/desktop/native, **mainnet** Stellar account only (testnet is intentionally skipped).
- On the account **Tokens** tab, the curated contract tokens should appear next to classic tokens with correct balance + symbol/decimals read live from the contract (e.g. `CPAL` "Comet Pool Token", 7 decimals).
- If the RPC endpoint is down/rate-limited, classic tokens and the rest of the account must still load normally (contract-token read is best-effort).
- No sending/receiving or history changes for contract tokens in this PR.

## Caveats (why it's a PoC)

- **Curated allow-list is hardcoded** in `constants/soroban.ts` — production should source it from the hosted definitions pipeline (`data.trezor.io/.../stellar…json`), like classic token metadata.
- **RPC endpoint is a public, keyless stopgap** (`https://mainnet.sorobanrpc.com`, no SLA, rate-limited). Production must route through a Trezor-hosted proxy (cf. `sol.trezor.io`); the interface is identical, so it's a URL-only change. Proxy whitelist: `simulateTransaction`.
- **No secrets in this PR** (the earlier QuickNode key was removed).
- **Read/display only.** No transaction **history** for contract tokens (would need `getEvents`). **Sending** is out of scope and **firmware-blocked** (device `invokeHostFunction` unsupported).
- **Not yet type-checked/tested in-repo** — verified against the live RPC only; needs `yarn type-check` + unit tests.
- **Complementary to** `feat/stellar-sac-history` (SAC/classic transfer history + manual-add via Horizon). That PR does not read native contract-token balances; this one does. Intended to be combined later.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/stellar-support-check/web/](https://dev.suite.sldev.cz/suite-web/stellar-support-check/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=stellar-support-check&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=stellar-support-check&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T11:52:17.949Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T11:52:48.288Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on Stellar/Soroban blockchain-link infrastructure. The only E2E test that directly touches Stellar user flows is the swap-token-to-disabled-network test, which enables XLM and discovers a Stellar account. Run that test as high priority. Soroban-specific runtime and constant files have no inferred E2E coverage; deeper Stellar send/receive/discovery flows also lack E2E tests, so consider unit/integration coverage for those.

<details><summary><b>Changed files (7)</b></summary>

- `networks/stellar/network-stellar/src/constants/index.ts`
- `networks/stellar/network-stellar/src/constants/soroban.ts`
- `networks/stellar/network-stellar/src/runtime/exports.ts`
- `networks/stellar/network-stellar/src/runtime/soroban.ts`
- `packages/blockchain-link-types/src/common.ts`
- `packages/blockchain-link/src/workers/stellar/handlers/getAccountInfo.ts`
- `packages/blockchain-link/src/workers/stellar/stellarWorker.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This is the only identified E2E test that exercises the Stellar (XLM) network path: it enables the disabled Stellar network, triggers Stellar account discovery, and selects a Stellar receive account. Changes to Stellar workers, network-stellar constants/runtime, and blockchain-link types could break account discovery or network enablement for XLM, which this test would catch.

</details>

⚠️ **Changes with no test coverage (3)**
- `networks/stellar/network-stellar/src/constants/soroban.ts`
- `networks/stellar/network-stellar/src/runtime/exports.ts`
- `networks/stellar/network-stellar/src/runtime/soroban.ts`

_Updated: 2026-09-03T11:50:24.568Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->