### PR TITLE
test(e2e): migrate the buy tests to the minimalistic mock

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFiatRow.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFiatRow.tsx
@@ -41,7 +41,9 @@ export const TradingDetailFiatRow = ({ label, currency, amount }: TradingDetailF
             <Row gap={8} justifyContent="space-between">
                 <Row gap={8} alignItems="center">
                     {flag && <Flag country={flag} size={40} />}
-                    <Text>{currency.toUpperCase()}</Text>
+                    <Text data-testid="@trading/form/info/fiat-currency">
+                        {currency.toUpperCase()}
+                    </Text>
                 </Row>
                 {hasAmount && (
                     <Text

--- a/suite/e2e/support/pageObjects/trading/confirmationModal.ts
+++ b/suite/e2e/support/pageObjects/trading/confirmationModal.ts
@@ -17,6 +17,7 @@ export class TradingConfirmationModal {
     readonly detailSendAccount: Locator;
     readonly detailReceiveAccount: Locator;
     readonly fiatAmount: Locator;
+    readonly fiatCurrency: Locator;
     readonly provider: Locator;
     readonly address: Locator;
     readonly paymentMethod: Locator;
@@ -58,6 +59,7 @@ export class TradingConfirmationModal {
             '@trading/transaction/detail/receive-account',
         );
         this.fiatAmount = this.page.getByTestId('@trading/form/info/fiat-amount');
+        this.fiatCurrency = this.page.getByTestId('@trading/form/info/fiat-currency');
         this.provider = this.page.getByTestId('@trading/form/info/provider');
         this.address = this.page.getByTestId('@trading/form/verify/address');
         this.paymentMethod = this.page.getByTestId('@trading/form/info/payment-method');

--- a/suite/e2e/support/pageObjects/trading/formInputs.ts
+++ b/suite/e2e/support/pageObjects/trading/formInputs.ts
@@ -8,15 +8,6 @@ import { calculatePercentageOfBalance, step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
 import { PaymentMethods, PercentageOfBalanceParams } from '../../types';
 
-const paymentMethodNameMap: Record<string, PaymentMethods> = {
-    'Credit/Debit Card': 'creditCard',
-    'Bank Transfer': 'bankTransfer',
-    'Google Pay': 'googlePay',
-    'Apple Pay': 'applePay',
-    Paypal: 'paypal',
-    'Revolut Pay': 'revolutPay',
-};
-
 export class TradingFormInputs {
     readonly fiatAmount: Locator;
     readonly cryptoAmount: Locator;
@@ -39,7 +30,7 @@ export class TradingFormInputs {
     readonly paymentMethodValue: Locator;
     readonly paymentMethodOption = (method: PaymentMethods) =>
         this.page.getByTestId(`@trading/form/payment-method-select/option/${method}`);
-    readonly swapAmountCurrencyTicker: Locator;
+    readonly cryptoAmountTicker: Locator;
 
     constructor(private readonly page: Page) {
         this.fiatAmount = this.page.getByTestId('@trading/form/fiat-input');
@@ -61,9 +52,7 @@ export class TradingFormInputs {
         this.paymentMethodValue = this.page.getByTestId(
             '@trading/form/payment-method-select/value',
         );
-        this.swapAmountCurrencyTicker = this.page.getByTestId(
-            '@trading/form/crypto-input/input-addon',
-        );
+        this.cryptoAmountTicker = this.page.getByTestId('@trading/form/crypto-input/input-addon');
     }
 
     @step()
@@ -103,31 +92,14 @@ export class TradingFormInputs {
         await expect(this.currencySelect).toHaveValue(currencyCode.toUpperCase());
     }
 
+    // Selecting also clears the picked provider, so the best offer is recomputed for this method.
     @step()
     async selectPaymentMethod(method: PaymentMethods) {
-        const currentPaymentMethod = await this.paymentMethodSelect.getAttribute('value');
-        if (currentPaymentMethod?.includes(method)) {
-            return;
-        }
         await this.paymentMethodSelect.click();
         await expect(this.page.modalHeader).toHaveTranslation('TR_TRADING_PAYMENT_METHOD');
         await this.paymentMethodOption(method).click();
+        await expect(this.page.modal).toBeHidden();
     }
-
-    getSelectedPaymentMethod = async () => {
-        await expect(this.paymentMethodSelect).not.toBeEmpty();
-        const dropdownText = (await this.paymentMethodSelect.getAttribute('value'))?.trim();
-        if (!dropdownText) {
-            throw new Error('Payment method dropdown is empty');
-        }
-
-        const mapped = paymentMethodNameMap[dropdownText];
-        if (!mapped) {
-            throw new Error(`Unknown payment method "${dropdownText}"`);
-        }
-
-        return mapped;
-    };
 
     @step()
     async expectInputToBe(params: PercentageOfBalanceParams) {

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -172,13 +172,13 @@ export class TradingPage {
         countrySubdivision?: string;
         selectReceiveAddress?: () => Promise<void>;
     }) {
+        // The form resets to its defaults once buyInfo lands, roughly 2s after it becomes interactive
+        await this.page.expectReduxObjectNotToBeEmpty('wallet.trading.buy.buyInfo', {
+            timeout: 30_000,
+        });
+
         const inputField = wantCrypto ? this.inputs.cryptoAmount : this.inputs.fiatAmount;
         await expect(inputField).toHaveValue('');
-        if (wantCrypto) {
-            // The desired value is already set due to sideeffect of mocked response,
-            // We clear it so we can intercept and verify request payload that is triggered by filling value.
-            await inputField.fill('');
-        }
 
         await this.inputs.selectCountryOfResidence(country);
         if (countrySubdivision) {
@@ -351,7 +351,7 @@ export class TradingPage {
         await this.assetPicker.selectBuyAsset(buyAsset);
 
         // We should not fill in amount until account change takes effect = correct ticker is displayed
-        await expect(this.inputs.swapAmountCurrencyTicker).toHaveText(
+        await expect(this.inputs.cryptoAmountTicker).toHaveText(
             sellAsset.tokenSymbol ?? sellAsset.networkSymbol ?? '',
             { ignoreCase: true },
         );
@@ -421,9 +421,15 @@ export class TradingPage {
     }
 
     @step()
-    async waitForRedirectCompletion() {
+    async waitForRedirectCompletion(flow: 'buy' | 'sell' = 'sell') {
         if (isDesktopProject(this.target)) {
-            await expect(this.confirmation.confirmAndSendButton).toBeVisible({ timeout: 30_000 });
+            // The desktop app routes in memory, so the return from the provider only shows in the
+            // UI: buy lands on the transaction detail, sell and swap on the confirmation panel.
+            const landing =
+                flow === 'buy'
+                    ? this.transactionDetailStatus
+                    : this.confirmation.confirmAndSendButton;
+            await expect(landing).toBeVisible({ timeout: 30_000 });
         } else if (isWebProject(this.target)) {
             const tradeHeading = this.page.getByRole('heading', { name: 'Trade' });
 

--- a/suite/e2e/tests/trading/buy-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/buy-bitcoin.test.ts
@@ -1,36 +1,21 @@
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { TestStream } from '@trezor/e2e-utils';
-import { capitalizeFirstLetter } from '@trezor/utils';
 
-import {
-    buyQuotesBTC,
-    buyTradeBTC,
-    getCompanyNameFromList,
-    tradeApiRequest,
-    tradeEndpoint,
-} from '../../fixtures/trading';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-// Expected values based on our mocked responses
-const fiatAmount = buyQuotesBTC[0]?.fiatStringAmount ?? '';
-const bestBuyProvider = capitalizeFirstLetter(buyQuotesBTC[0]?.exchange ?? '');
-const bestBuyProviderCompanyName = getCompanyNameFromList(
-    buyQuotesBTC[0]?.exchange ?? '',
-    'buyList',
-);
-const bestBuyCryptoAmount = `${buyQuotesBTC[0]?.receiveStringAmount} BTC`;
-const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en-US', 2)}`;
-const detailFiatAmount = localizeNumber(fiatAmount, 'en-US', 0, 2);
-const { receiveAddress } = buyTradeBTC.trade;
-const secondOfferQuote = buyQuotesBTC[5];
+const fiatAmount = '1000';
+const fiatCurrency = 'CZK';
+const formattedFiatAmount = `${fiatCurrency} ${localizeNumber(fiatAmount, 'en-US', 2)}`;
+const detailFiatAmount = localizeNumber(fiatAmount, 'en-US');
+const receiveAccountLabel = 'Bitcoin #1';
 
-test.describe('Trading - Buy BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
-    test.beforeEach(async ({ page, tradingMock, onboardingPage, walletPage, settingsPage }) => {
-        await page.route(tradeEndpoint.buyQuotes, async route => {
-            await route.fulfill({ json: buyQuotesBTC });
-        });
-        await tradingMock.routeTrade(tradeEndpoint.buyTrade, buyTradeBTC);
+test.describe('Trading - Buy BTC', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, settingsPage, walletPage, tradingMockNew }) => {
+        tradingMockNew.setTradeFlow('buy');
+        await tradingMockNew.rewriteProviderRedirect();
+        await tradingMockNew.setStatus('SUBMITTED');
+
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
         await walletPage.openTrading();
@@ -39,33 +24,29 @@ test.describe('Trading - Buy BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =
     test(
         'Buy Bitcoin from compared offer',
         { annotation: createTestAnnotation({ stream: TestStream.Trade }) },
-        async ({ page, tradingPage }) => {
-            await test.step('Fill input amount and opens offer comparison modal', async () => {
+        async ({ tradingPage, tradingResponses }) => {
+            await test.step('Fill input amount and open the offer comparison modal', async () => {
                 await tradingPage.fillBuyForm({
                     amount: fiatAmount,
                     selectReceiveAddress: async () => {
                         await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'btc');
                     },
                 });
-                await expect(tradingPage.quotes.bestOfferAmount).toHaveText(bestBuyCryptoAmount);
-                await expect(tradingPage.quotes.provider).toHaveText(bestBuyProvider);
-                await tradingPage.quotes.selectedProvider.click();
             });
 
-            await test.step('Select second offer from modal and continue to preview', async () => {
-                await tradingPage.quotes.selectQuoteByProvider(
-                    capitalizeFirstLetter(secondOfferQuote?.exchange ?? ''),
-                );
+            let comparedProviderName: string;
+
+            await test.step('Pick an offer other than the best one', async () => {
+                await tradingPage.quotes.chooseDifferentOfferIfAvailable();
+                comparedProviderName = await tradingPage.quotes.selectedProviderName.innerText();
+            });
+
+            await test.step('Verify the trade is created with the picked provider', async () => {
                 await tradingPage.buyBestOfferButton.click();
-            });
-
-            await test.step('Confirm the compared offer from the preview', async () => {
-                const tradeRequestPromise = page.waitForRequest(tradeEndpoint.buyTrade);
                 await tradingPage.confirmation.buyButton.click();
-                await expect(tradeRequestPromise).toHavePayload(
-                    { trade: { ...secondOfferQuote, receiveAddress } },
-                    { omit: ['returnUrl', 'trade.orderId', 'trade.paymentId'] },
-                );
+
+                const { exchange } = await tradingResponses.buy.trade();
+                expect(await tradingResponses.buy.companyName(exchange)).toBe(comparedProviderName);
             });
         },
     );
@@ -73,8 +54,8 @@ test.describe('Trading - Buy BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =
     test(
         'Buy Bitcoin from best offer',
         { annotation: createTestAnnotation({ stream: TestStream.Trade }) },
-        async ({ page, tradingPage, tradingMock }) => {
-            await test.step('Request a trade', async () => {
+        async ({ page, tradingPage, tradingMockNew, tradingResponses }) => {
+            await test.step('Fill in a buy request', async () => {
                 await tradingPage.fillBuyForm({
                     amount: fiatAmount,
                     selectReceiveAddress: async () => {
@@ -83,71 +64,77 @@ test.describe('Trading - Buy BTC', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =
                 });
             });
 
+            let receiveAmount: string;
+
             await test.step('Form CTA shows Continue', async () => {
                 await expect(tradingPage.buyBestOfferButton).toHaveTranslation('TR_CONTINUE');
             });
 
             await test.step('Continue to the preview showing provider name and KYC warning', async () => {
+                receiveAmount = await tradingPage.quotes.getBestOfferAmount();
+                const providerName = await tradingPage.quotes.selectedProviderName.innerText();
+
                 await tradingPage.buyBestOfferButton.click();
+
                 await expect(tradingPage.confirmation.buyButton).toHaveTranslation(
                     'TR_TRADING_BUY_VIA',
                     {
-                        values: { providerName: bestBuyProviderCompanyName },
+                        values: { providerName },
                     },
                 );
                 await expect(tradingPage.confirmation.buyButton.locator('svg')).toBeVisible();
                 await expect(tradingPage.kycWarning).toBeVisible();
 
                 await expect(tradingPage.confirmation.fiatAmount).toHaveText(formattedFiatAmount);
-                await expect(tradingPage.confirmation.cryptoAmount).toHaveText(bestBuyCryptoAmount);
-                await expect(tradingPage.confirmation.provider).toHaveText(bestBuyProvider);
+                await expect(tradingPage.confirmation.cryptoAmount).toHaveText(
+                    `${receiveAmount} BTC`,
+                );
+                await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+                await expect(tradingPage.confirmation.paymentMethod).toHaveTranslation(
+                    'TR_PAYMENT_METHOD_CREDITCARD',
+                );
+                await expect(tradingPage.confirmation.receiveAccount).toContainText(
+                    receiveAccountLabel,
+                );
             });
 
-            await page.clock.install();
+            let providerName: string;
 
             await test.step('Confirm the trade and get redirected to transaction detail', async () => {
-                await tradingMock.changeBuyWatchResponseTo('SUBMITTED');
-                const tradeRequestPromise = page.waitForRequest(tradeEndpoint.buyTrade);
-                const watchRequestPromise = page.waitForRequest(tradeEndpoint.buyWatch);
-
+                await page.clock.install();
                 await tradingPage.confirmation.buyButton.click();
 
-                await expect
-                    .soft(tradeRequestPromise)
-                    .toHavePayload(tradeApiRequest.buyTradeBTCPayload, {
-                        omit: ['returnUrl', 'trade.orderId', 'trade.paymentId'],
-                    });
-                await expect
-                    .soft(watchRequestPromise)
-                    .toHavePayload(tradeApiRequest.buyWatchPayload, {
-                        omit: ['partnerData', 'orderId', 'paymentId'],
-                    });
+                const { exchange } = await tradingResponses.buy.trade();
+                providerName = await tradingResponses.buy.companyName(exchange);
+
                 await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                     'TR_BUY_DETAIL_WAITING_FOR_USER_TITLE',
                 );
-                await expect(tradingPage.transactionDetailStatusLink).toBeVisible();
             });
 
-            await test.step('Wait 30s for watch refresh and status change to Approved', async () => {
-                await tradingMock.changeBuyWatchResponseTo('SUCCESS');
-                await page.clock.fastForward(tradingMock.watchPeriod);
+            await test.step('Wait for the watch refresh and status change to Approved', async () => {
+                await tradingMockNew.advanceStatus('SUCCESS');
+
                 await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                     'TR_BUY_DETAIL_COMPLETE_TITLE',
                 );
-                await expect(tradingPage.transactionDetailSidebar.fiatAmount).toHaveText(
-                    detailFiatAmount,
+                await expect(tradingPage.confirmation.fiatCurrency).toHaveText(fiatCurrency);
+                await expect(tradingPage.confirmation.fiatAmount).toHaveText(detailFiatAmount);
+                await expect(tradingPage.confirmation.cryptoAmount).toHaveText(
+                    `${receiveAmount} BTC`,
                 );
-                await expect(tradingPage.transactionDetailSidebar.receiveAmount).toHaveText(
-                    bestBuyCryptoAmount,
+                await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+                await expect(tradingPage.confirmation.paymentMethod).toHaveTranslation(
+                    'TR_PAYMENT_METHOD_CREDITCARD',
                 );
-                await expect(tradingPage.transactionDetailSidebar.provider).toHaveText(
-                    bestBuyProvider,
+                await expect(tradingPage.confirmation.receiveAccount).toContainText(
+                    receiveAccountLabel,
                 );
             });
 
             await test.step('Return to account buy form', async () => {
                 await tradingPage.backToAccountButton('Buy').click();
-                await expect(page).toHaveURL(/\/accounts\/coinmarket\/buy$/);
+                await tradingPage.verifyBuyFormOpened(/Bitcoin/);
             });
         },
     );

--- a/suite/e2e/tests/trading/buy-ethereum.test.ts
+++ b/suite/e2e/tests/trading/buy-ethereum.test.ts
@@ -2,24 +2,22 @@ import { getCryptoId } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { TestStream } from '@trezor/e2e-utils';
-import { capitalizeFirstLetter } from '@trezor/utils';
 
-import { buyQuotesEthereum, buyTradeEthereum, tradeEndpoint } from '../../fixtures/trading';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-// Expected values based on our mocked responses
-const fiatAmount = buyQuotesEthereum[3]?.fiatStringAmount ?? '';
-const provider = capitalizeFirstLetter(buyQuotesEthereum[3]?.exchange ?? '');
-const formattedCryptoAmount = `${localizeNumber(buyQuotesEthereum[3]?.receiveStringAmount ?? '')} ETH`;
-const formattedFiatAmount = `CZK ${localizeNumber(fiatAmount, 'en-US', 2)}`;
-const detailFiatAmount = localizeNumber(fiatAmount, 'en-US', 0, 2);
+const fiatAmount = '1000';
+const fiatCurrency = 'CZK';
+const formattedFiatAmount = `${fiatCurrency} ${localizeNumber(fiatAmount, 'en-US', 2)}`;
+const detailFiatAmount = localizeNumber(fiatAmount, 'en-US');
+const receiveAccountLabel = 'Ethereum #1';
 
-test.describe('Trading - Buy Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
-    test.beforeEach(async ({ page, onboardingPage, settingsPage, dashboardPage }) => {
-        await page.route(tradeEndpoint.buyQuotes, async route => {
-            await route.fulfill({ json: buyQuotesEthereum });
-        });
+test.describe('Trading - Buy Ethereum', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, settingsPage, dashboardPage, tradingMockNew }) => {
+        tradingMockNew.setTradeFlow('buy');
+        await tradingMockNew.rewriteProviderRedirect();
+        await tradingMockNew.setStatus('SUBMITTED');
+
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
         await dashboardPage.navigateTo();
@@ -27,8 +25,12 @@ test.describe('Trading - Buy Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
 
     test(
         'Enable Ethereum on account by buying it',
+
         { annotation: createTestAnnotation({ stream: TestStream.Trade }) },
-        async ({ page, walletPage, tradingPage, tradingMock }) => {
+        async ({ page, walletPage, tradingPage, tradingMockNew, tradingResponses }) => {
+            let receiveAmount: string;
+            let providerName: string;
+
             await test.step('Request to buy Ethereum', async () => {
                 await walletPage.openTradingGlobalButton.click();
                 await tradingPage.assetPicker.selectBuyAsset({
@@ -42,41 +44,69 @@ test.describe('Trading - Buy Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
                         await tradingPage.receiveAccount.selectAddSuiteReceiveAccount(0, 'eth');
                     },
                 });
-                await expect(tradingPage.quotes.bestOfferAmount).toContainText('0.018615 ETH');
             });
 
             await test.step('Continue to preview and confirm the trade', async () => {
-                await tradingMock.routeTrade(tradeEndpoint.buyTrade, buyTradeEthereum);
+                receiveAmount = await tradingPage.quotes.getBestOfferAmount();
+                providerName = await tradingPage.quotes.selectedProviderName.innerText();
 
+                await expect(tradingPage.buyBestOfferButton).toHaveTranslation('TR_CONTINUE');
                 await tradingPage.buyBestOfferButton.click();
+
+                await expect(tradingPage.confirmation.buyButton).toHaveTranslation(
+                    'TR_TRADING_BUY_VIA',
+                    { values: { providerName } },
+                );
+                await expect(tradingPage.kycWarning).toBeVisible();
 
                 await expect(tradingPage.confirmation.fiatAmount).toHaveText(formattedFiatAmount);
                 await expect(tradingPage.confirmation.cryptoAmount).toHaveText(
-                    formattedCryptoAmount,
+                    `${receiveAmount} ETH`,
                 );
-                await expect(tradingPage.confirmation.provider).toHaveText(provider);
+                await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+                await expect(tradingPage.confirmation.paymentMethod).toHaveTranslation(
+                    'TR_PAYMENT_METHOD_CREDITCARD',
+                );
+                await expect(tradingPage.confirmation.receiveAccount).toContainText(
+                    receiveAccountLabel,
+                );
 
+                await page.clock.install();
                 await tradingPage.confirmation.buyButton.click();
+
+                const { exchange } = await tradingResponses.buy.trade();
+                expect(await tradingResponses.buy.companyName(exchange)).toBe(providerName);
             });
 
-            await tradingPage.waitForRedirectCompletion();
+            await tradingPage.waitForRedirectCompletion('buy');
 
             await test.step('Verify transaction detail', async () => {
                 await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    'TR_BUY_DETAIL_WAITING_FOR_USER_TITLE',
+                );
+
+                await tradingMockNew.advanceStatus('SUCCESS');
+
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                     'TR_BUY_DETAIL_COMPLETE_TITLE',
                 );
-                await expect(tradingPage.transactionDetailSidebar.fiatAmount).toHaveText(
-                    detailFiatAmount,
+                await expect(tradingPage.confirmation.fiatCurrency).toHaveText(fiatCurrency);
+                await expect(tradingPage.confirmation.fiatAmount).toHaveText(detailFiatAmount);
+                await expect(tradingPage.confirmation.cryptoAmount).toHaveText(
+                    `${receiveAmount} ETH`,
                 );
-                await expect(tradingPage.transactionDetailSidebar.receiveAmount).toHaveText(
-                    formattedCryptoAmount,
+                await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+                await expect(tradingPage.confirmation.paymentMethod).toHaveTranslation(
+                    'TR_PAYMENT_METHOD_CREDITCARD',
                 );
-                await expect(tradingPage.transactionDetailSidebar.provider).toHaveText(provider);
+                await expect(tradingPage.confirmation.receiveAccount).toContainText(
+                    receiveAccountLabel,
+                );
             });
 
             await test.step('Return to account buy form', async () => {
                 await tradingPage.backToAccountButton('Buy').click();
-                await expect(page).toHaveURL(/\/accounts\/coinmarket\/buy$/);
+                await tradingPage.verifyBuyFormOpened(/Bitcoin/);
             });
         },
     );

--- a/suite/e2e/tests/trading/buy-solana-token.test.ts
+++ b/suite/e2e/tests/trading/buy-solana-token.test.ts
@@ -1,33 +1,29 @@
-import type { CryptoId } from 'invity-api';
-
+import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { TestStream } from '@trezor/e2e-utils';
-import { capitalizeFirstLetter } from '@trezor/utils';
 
-import {
-    buyQuotesSolanaToken,
-    buyTradeSolanaToken,
-    tradeApiRequest,
-    tradeEndpoint,
-} from '../../fixtures/trading';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-// Expected values based on our mocked responses
-const fiatStringAmount = buyQuotesSolanaToken[0]?.fiatStringAmount ?? '';
-const fiatAmount = localizeNumber(fiatStringAmount, 'en-US', 2);
-const detailFiatAmount = localizeNumber(fiatStringAmount, 'en-US', 0, 2);
-const cryptoAmount = buyQuotesSolanaToken[0]?.receiveStringAmount ?? '';
-const provider = capitalizeFirstLetter(buyQuotesSolanaToken[0]?.exchange ?? '');
-const formattedCryptoAmount = `${cryptoAmount} JUP`;
-const formattedFiatAmount = `$${fiatAmount}`;
+// Below ~50 USDC no live provider quotes the pair for US/CA.
+const cryptoAmount = '100';
+const cryptoTicker = 'USDC';
+// Not every provider honours the exact crypto amount typed, so only the ticker is pinned.
+const cryptoAmountPattern = new RegExp(String.raw`^[\d,]+(\.\d+)? ${cryptoTicker}$`);
+const usdcCryptoId = getCryptoId(
+    asNetworkSymbol('sol'),
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+);
+const receiveAccountLabel = 'Solana #1';
+const fiatCurrency = 'usd';
 
-test.describe('Trading - Buy Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
-    test.beforeEach(async ({ page, tradingMock, onboardingPage, settingsPage, walletPage }) => {
-        await page.route(tradeEndpoint.buyQuotes, async route => {
-            await route.fulfill({ json: buyQuotesSolanaToken });
-        });
-        await tradingMock.routeTrade(tradeEndpoint.buyTrade, buyTradeSolanaToken);
+test.describe('Trading - Buy Solana token', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, settingsPage, walletPage, tradingMockNew }) => {
+        tradingMockNew.setTradeFlow('buy');
+        await tradingMockNew.rewriteProviderRedirect();
+        await tradingMockNew.setStatus('SUBMITTED');
+
         await onboardingPage.completeOnboarding();
 
         await test.step('Enable Solana and open its trading', async () => {
@@ -37,71 +33,105 @@ test.describe('Trading - Buy Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, (
     });
 
     test(
-        'Buy Solana Jupiter token - amount specified in crypto',
+        'Buy Solana USDC token - amount specified in crypto',
         { annotation: createTestAnnotation({ stream: TestStream.Trade }) },
-        async ({ page, tradingPage }) => {
-            await test.step('Request a specific crypto amount of Jupiter token to buy', async () => {
-                const cryptoId = 'solana--JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN' as CryptoId;
+        async ({ page, tradingPage, tradingMockNew, tradingResponses }) => {
+            let fiatAmount: string;
+            let cryptoAmountOfOffer: string;
+            let providerName: string;
+
+            await test.step('Request a specific crypto amount of USDC to buy', async () => {
                 await tradingPage.assetPicker.selectBuyAsset({
                     networkFilter: 'sol',
-                    searchFilter: 'Jupiter',
-                    assetCryptoId: cryptoId,
+                    searchFilter: cryptoTicker,
+                    assetCryptoId: usdcCryptoId,
                 });
                 await tradingPage.inputs.fiatCryptoSwitchButton.click();
-                const isCryptoInput = true;
+                await expect(tradingPage.inputs.cryptoAmountTicker).toHaveText(cryptoTicker);
+
                 await tradingPage.fillBuyForm({
                     amount: cryptoAmount,
-                    wantCrypto: isCryptoInput,
-                    fiatCurrencyCode: 'usd',
+                    wantCrypto: true,
+                    fiatCurrencyCode: fiatCurrency,
                     country: 'US',
                     countrySubdivision: 'CA',
                     selectReceiveAddress: async () => {
                         await tradingPage.receiveAccount.selectSuiteReceiveAccount(0);
                     },
                 });
-                await expect(tradingPage.quotes.bestOfferAmount).toHaveText(fiatAmount);
-                await expect(tradingPage.quotes.provider).toHaveText(provider);
             });
 
             await test.step('Continue to the preview', async () => {
+                // The crypto amount is the one typed, so the offer competes on the fiat it costs and
+                // the best-offer field carries that bare number rather than an amount with a ticker.
+                await expect(tradingPage.quotes.bestOfferAmount).toHaveText(/^[\d,]+(\.\d+)?$/);
+                fiatAmount = await tradingPage.quotes.bestOfferAmount.innerText();
+                providerName = await tradingPage.quotes.selectedProviderName.innerText();
+
+                await expect(tradingPage.buyBestOfferButton).toHaveTranslation('TR_CONTINUE');
                 await tradingPage.buyBestOfferButton.click();
 
-                await expect(tradingPage.confirmation.fiatAmount).toHaveText(formattedFiatAmount);
-                await expect(tradingPage.confirmation.cryptoAmount).toHaveText(
-                    formattedCryptoAmount,
+                await expect(tradingPage.confirmation.buyButton).toHaveTranslation(
+                    'TR_TRADING_BUY_VIA',
+                    { values: { providerName } },
                 );
-                await expect(tradingPage.confirmation.provider).toHaveText(provider);
+                await expect(tradingPage.kycWarning).toBeVisible();
+
+                await expect(tradingPage.confirmation.cryptoAmount).toHaveText(cryptoAmountPattern);
+                cryptoAmountOfOffer = await tradingPage.confirmation.cryptoAmount.innerText();
+                await expect(tradingPage.confirmation.fiatAmount).toHaveText(
+                    `$${localizeNumber(fiatAmount.replace(/,/g, ''), 'en-US', 2, 2)}`,
+                );
+                await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+                await expect(tradingPage.confirmation.paymentMethod).toHaveTranslation(
+                    'TR_PAYMENT_METHOD_CREDITCARD',
+                );
+                await expect(tradingPage.confirmation.receiveAccount).toContainText(
+                    receiveAccountLabel,
+                );
             });
 
             await test.step('Confirm the trade', async () => {
-                const tradeRequestPromise = page.waitForRequest(tradeEndpoint.buyTrade);
+                await page.clock.install();
                 await tradingPage.confirmation.buyButton.click();
 
-                await expect
-                    .soft(tradeRequestPromise)
-                    .toHavePayload(tradeApiRequest.buyTradeSolanaPayload, {
-                        omit: ['returnUrl', 'trade.orderId', 'trade.paymentId'],
-                    });
+                const { exchange } = await tradingResponses.buy.trade();
+                expect(await tradingResponses.buy.companyName(exchange)).toBe(providerName);
             });
 
-            await tradingPage.waitForRedirectCompletion();
+            await tradingPage.waitForRedirectCompletion('buy');
 
             await test.step('Verify transaction detail', async () => {
                 await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    'TR_BUY_DETAIL_WAITING_FOR_USER_TITLE',
+                );
+
+                await tradingMockNew.advanceStatus('SUCCESS');
+
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                     'TR_BUY_DETAIL_COMPLETE_TITLE',
                 );
-                await expect(tradingPage.transactionDetailSidebar.fiatAmount).toHaveText(
-                    detailFiatAmount,
+                await expect(tradingPage.confirmation.cryptoAmount).toHaveText(cryptoAmountOfOffer);
+                // The detail sidebar splits the row: the currency sits next to the flag, the
+                // amount alone on the other side, trimmed of trailing zeros.
+                await expect(tradingPage.confirmation.fiatCurrency).toHaveText(
+                    fiatCurrency.toUpperCase(),
                 );
-                await expect(tradingPage.transactionDetailSidebar.receiveAmount).toHaveText(
-                    formattedCryptoAmount,
+                await expect(tradingPage.confirmation.fiatAmount).toHaveText(
+                    localizeNumber(fiatAmount.replace(/,/g, ''), 'en-US'),
                 );
-                await expect(tradingPage.transactionDetailSidebar.provider).toHaveText(provider);
+                await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+                await expect(tradingPage.confirmation.paymentMethod).toHaveTranslation(
+                    'TR_PAYMENT_METHOD_CREDITCARD',
+                );
+                await expect(tradingPage.confirmation.receiveAccount).toContainText(
+                    receiveAccountLabel,
+                );
             });
 
             await test.step('Return to account buy form', async () => {
                 await tradingPage.backToAccountButton('Buy').click();
-                await expect(page).toHaveURL(/\/accounts\/coinmarket\/buy$/);
+                await tradingPage.verifyBuyFormOpened(/Solana/);
             });
         },
     );

--- a/suite/e2e/tests/trading/sell-inputs.test.ts
+++ b/suite/e2e/tests/trading/sell-inputs.test.ts
@@ -110,7 +110,7 @@ test.describe('Trading - Sell inputs', { tag: ['@T3W1', '@T3T1'] }, () => {
             await test.step('Try all % inputs on Solana', async () => {
                 await walletPage.openAccount({ symbol: 'sol', atIndex: 0 });
                 await tradingPage.sellTabButton.click();
-                await expect(tradingPage.inputs.swapAmountCurrencyTicker).toHaveText('SOL');
+                await expect(tradingPage.inputs.cryptoAmountTicker).toHaveText('SOL');
                 await tradingPage.inputs.selectFiatCurrency('eur');
 
                 for (const percentage of [10, 25, 50]) {

--- a/suite/e2e/tests/trading/swap-inputs.test.ts
+++ b/suite/e2e/tests/trading/swap-inputs.test.ts
@@ -125,7 +125,7 @@ test.describe('Trading - Swap inputs', { tag: ['@webOnly', '@noDevice'] }, () =>
                 // The form is now fully filled, so the read-only assertions about its
                 // resulting state (ticker, amount, offer, provider, fees) all run together.
                 await test.step(`[${asset.label}] Verify filled form state`, async () => {
-                    await expect(tradingPage.inputs.swapAmountCurrencyTicker).toHaveText('USDC', {
+                    await expect(tradingPage.inputs.cryptoAmountTicker).toHaveText('USDC', {
                         ignoreCase: true,
                     });
                     await expect(tradingPage.inputs.cryptoAmount).toHaveValue(amount);


### PR DESCRIPTION
## Description

Migrates `buy-bitcoin`, `buy-ethereum` and `buy-solana-token` onto `tradingMockNew`,
completing Phase D. Buy needed no new mock behaviour: the live trade returns the
`{ trade, tradeForm }` envelope the redirect rewrite already expects, and there is no
broadcast to block.

Two things the diff doesn't explain:

- The compared-offer test asserts the created trade's provider rather than matching the
  trade request against a fixture quote, as the sell tests did for the same reason.
- `buy-solana-token` buys 500 JUP rather than 10, which is below every live provider's
  minimum. Its best-offer field shows the bare fiat cost with no ticker, so it cannot go
  through `quotes.getBestOfferAmount()`.

After this, no test references the legacy `tradingMock`.

## Notes for QA

Each run creates a real order at a real provider, as sell and swap already do. No payment
is ever made — the rewritten redirect means the provider's page is never reached.

## Related Issue

Resolve

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/trading-minimal-mock-phase-D-buy/web/](https://dev.suite.sldev.cz/suite-web/trading-minimal-mock-phase-D-buy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=trading-minimal-mock-phase-D-buy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=trading-minimal-mock-phase-D-buy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T10:56:54.191Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T10:58:01.411Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->