### PR TITLE
fix(connect): don't report device re-provisioning as incorrect passphrase

### DIFF
--- a/packages/connect/src/device/workflow/validateState.test.ts
+++ b/packages/connect/src/device/workflow/validateState.test.ts
@@ -1,0 +1,159 @@
+import { createStaticSessionId } from '@trezor/device-utils';
+
+import { isUnexpectedState, validateState } from './validateState';
+
+jest.mock('../thp', () => ({
+    createThpSession: jest.fn(() => Promise.resolve()),
+}));
+
+// A standard (empty-passphrase) wallet and a passphrase wallet derive different first Testnet
+// addresses (44'/1'/0'/0/0), i.e. different `walletDescriptor`s.
+const STANDARD_DESCRIPTOR = 'mzPxTvm6F1n4ZeTBrCQU3iXrPF6yyyc4d10fab';
+const PASSPHRASE_DESCRIPTOR = 'n2eMqTT929pb1RDNuqEnxdaLau1rxy3efi';
+
+const DEVICE_ID = 'c4d10fab';
+// A device reset (wipe + recovery) mints a fresh hardware `device_id`.
+const RESET_DEVICE_ID = 'a1b2c3d4';
+
+const state = (walletDescriptor: string, deviceId: string, instance: number) =>
+    createStaticSessionId({ walletDescriptor, deviceId, instance });
+
+describe(isUnexpectedState.name, () => {
+    it('is not unexpected when only the deviceId changes (same wallet, re-provisioned device)', () => {
+        // The reported bug: a standard wallet after wipe + recovery of the same seed keeps an
+        // identical walletDescriptor but gets a new device_id. It must NOT be reported as
+        // "Passphrase is incorrect".
+        const expected = state(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
+        const current = state(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 0);
+
+        expect(isUnexpectedState(expected, current)).toBe(false);
+    });
+
+    it('is unexpected when the walletDescriptor differs (wrong passphrase / different seed)', () => {
+        // A saved passphrase wallet on a passphrase-disabled reset device: the device now derives
+        // the empty-passphrase descriptor, which differs. This is the genuine passphrase mismatch
+        // and must still throw Device_InvalidState.
+        const expected = state(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1);
+        const current = state(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 1);
+
+        expect(isUnexpectedState(expected, current)).toBe(true);
+    });
+
+    it('detects a differing walletDescriptor even when the deviceId matches', () => {
+        const expected = state(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1);
+        const current = state(STANDARD_DESCRIPTOR, DEVICE_ID, 1);
+
+        expect(isUnexpectedState(expected, current)).toBe(true);
+    });
+
+    it('ignores the instance number', () => {
+        const expected = state(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
+        const current = state(STANDARD_DESCRIPTOR, DEVICE_ID, 3);
+
+        expect(isUnexpectedState(expected, current)).toBe(false);
+    });
+
+    it('is not unexpected when either state is missing', () => {
+        const current = state(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
+
+        expect(isUnexpectedState(undefined, current)).toBe(false);
+        expect(isUnexpectedState(current, undefined)).toBe(false);
+        expect(isUnexpectedState(undefined, undefined)).toBe(false);
+    });
+});
+
+type FakeState = { staticSessionId?: string; sessionId?: string; deriveCardano?: boolean };
+
+// Minimal stateful device driving the two `validateState` branches. `setState` merges like the
+// real Device, so `getState()` reflects what `getDeviceState` would later return.
+const createFakeDevice = ({
+    protocolName,
+    deviceId,
+    instance,
+    address,
+    savedState,
+}: {
+    protocolName: 'v1' | 'v2';
+    deviceId: string;
+    instance: number;
+    address: string;
+    savedState?: FakeState;
+}) => {
+    let currentState: FakeState | undefined = savedState ? { ...savedState } : undefined;
+    const setState = jest.fn((partial: FakeState) => {
+        currentState = { ...(currentState ?? {}), ...partial };
+    });
+
+    const device = {
+        features: { unlocked: true, device_id: deviceId, session_id: undefined },
+        protocol: { name: protocolName },
+        getState: () => currentState,
+        setState,
+        getInstance: () => instance,
+        getCurrentSession: () => ({
+            typedCall: () => Promise.resolve({ message: { address } }),
+        }),
+        getThpState: () => ({
+            setSessionId: jest.fn(),
+            createNewSessionId: () => Buffer.alloc(2),
+        }),
+        getCommands: () => ({ preauthorize: jest.fn() }),
+        emitDeviceChanged: jest.fn(),
+        toMessageObject: () => ({}),
+    };
+
+    return { device, getState: () => currentState };
+};
+
+const runValidateState = (device: ReturnType<typeof createFakeDevice>['device']) =>
+    validateState({
+        device,
+        method: { useCardanoDerivation: false },
+        signal: {},
+        sendCoreMessage: jest.fn(),
+    } as any);
+
+describe(validateState.name, () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it.each([['v1'], ['v2']] as const)(
+        '%s: adopts the new device_id after re-provisioning instead of keeping a stale staticSessionId',
+        async protocolName => {
+            // Same seed + empty passphrase after wipe/recovery => identical walletDescriptor, new
+            // device_id. Both branches must refresh the saved state so getDeviceState never leaks
+            // the stale device_id (which would later miss in getDeviceByStaticState).
+            const fake = createFakeDevice({
+                protocolName,
+                deviceId: RESET_DEVICE_ID,
+                instance: 0,
+                address: STANDARD_DESCRIPTOR,
+                savedState: { staticSessionId: state(STANDARD_DESCRIPTOR, DEVICE_ID, 0) },
+            });
+
+            await expect(runValidateState(fake.device)).resolves.toBeUndefined();
+
+            expect(fake.getState()?.staticSessionId).toBe(
+                state(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 0),
+            );
+        },
+    );
+
+    it.each([['v1'], ['v2']] as const)(
+        '%s: still throws Device_InvalidState when the walletDescriptor differs (real passphrase mismatch)',
+        async protocolName => {
+            // Saved passphrase wallet, but the reset device has passphrase disabled and now derives
+            // the empty-passphrase wallet => different walletDescriptor => genuine mismatch.
+            const fake = createFakeDevice({
+                protocolName,
+                deviceId: RESET_DEVICE_ID,
+                instance: 1,
+                address: STANDARD_DESCRIPTOR,
+                savedState: { staticSessionId: state(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1) },
+            });
+
+            await expect(runValidateState(fake.device)).rejects.toMatchObject({
+                code: 'Device_InvalidState',
+            });
+        },
+    );
+});

--- a/packages/connect/src/device/workflow/validateState.test.ts
+++ b/packages/connect/src/device/workflow/validateState.test.ts
@@ -1,21 +1,31 @@
+import type { DeviceState } from '@trezor/connect-common';
 import { createStaticSessionId } from '@trezor/device-utils';
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
+import type { IDevice } from '../../types/idevice';
+import type { TypedCallProvider } from '../../types/typed-call-provider';
+import type { WorkflowContext } from '../../types/workflow';
+import { createThpSession } from '../thp';
 import { isUnexpectedState, validateState } from './validateState';
 
 jest.mock('../thp', () => ({
     createThpSession: jest.fn(() => Promise.resolve()),
 }));
 
+const createThpSessionMock = jest.mocked(createThpSession);
+
 // A standard (empty-passphrase) wallet and a passphrase wallet derive different first Testnet
 // addresses (44'/1'/0'/0/0), i.e. different `walletDescriptor`s.
-const STANDARD_DESCRIPTOR = 'mzPxTvm6F1n4ZeTBrCQU3iXrPF6yyyc4d10fab';
+const STANDARD_DESCRIPTOR = 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q';
 const PASSPHRASE_DESCRIPTOR = 'n2eMqTT929pb1RDNuqEnxdaLau1rxy3efi';
 
 const DEVICE_ID = 'c4d10fab';
 // A device reset (wipe + recovery) mints a fresh hardware `device_id`.
 const RESET_DEVICE_ID = 'a1b2c3d4';
 
-const state = (walletDescriptor: string, deviceId: string, instance: number) =>
+const LIVE_THP_SESSION_ID = '0102';
+
+const createState = (walletDescriptor: string, deviceId: string, instance: number) =>
     createStaticSessionId({ walletDescriptor, deviceId, instance });
 
 describe(isUnexpectedState.name, () => {
@@ -23,8 +33,8 @@ describe(isUnexpectedState.name, () => {
         // The reported bug: a standard wallet after wipe + recovery of the same seed keeps an
         // identical walletDescriptor but gets a new device_id. It must NOT be reported as
         // "Passphrase is incorrect".
-        const expected = state(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
-        const current = state(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 0);
+        const expected = createState(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
+        const current = createState(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 0);
 
         expect(isUnexpectedState(expected, current)).toBe(false);
     });
@@ -33,28 +43,28 @@ describe(isUnexpectedState.name, () => {
         // A saved passphrase wallet on a passphrase-disabled reset device: the device now derives
         // the empty-passphrase descriptor, which differs. This is the genuine passphrase mismatch
         // and must still throw Device_InvalidState.
-        const expected = state(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1);
-        const current = state(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 1);
+        const expected = createState(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1);
+        const current = createState(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 1);
 
         expect(isUnexpectedState(expected, current)).toBe(true);
     });
 
     it('detects a differing walletDescriptor even when the deviceId matches', () => {
-        const expected = state(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1);
-        const current = state(STANDARD_DESCRIPTOR, DEVICE_ID, 1);
+        const expected = createState(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1);
+        const current = createState(STANDARD_DESCRIPTOR, DEVICE_ID, 1);
 
         expect(isUnexpectedState(expected, current)).toBe(true);
     });
 
     it('ignores the instance number', () => {
-        const expected = state(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
-        const current = state(STANDARD_DESCRIPTOR, DEVICE_ID, 3);
+        const expected = createState(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
+        const current = createState(STANDARD_DESCRIPTOR, DEVICE_ID, 3);
 
         expect(isUnexpectedState(expected, current)).toBe(false);
     });
 
     it('is not unexpected when either state is missing', () => {
-        const current = state(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
+        const current = createState(STANDARD_DESCRIPTOR, DEVICE_ID, 0);
 
         expect(isUnexpectedState(undefined, current)).toBe(false);
         expect(isUnexpectedState(current, undefined)).toBe(false);
@@ -62,98 +72,165 @@ describe(isUnexpectedState.name, () => {
     });
 });
 
-type FakeState = { staticSessionId?: string; sessionId?: string; deriveCardano?: boolean };
+// Exactly the surface `validateState` reads from a device; the rest of `IDevice` is not needed.
+type MockDevice = Pick<
+    IDevice,
+    'getState' | 'setState' | 'getInstance' | 'emitDeviceChanged' | 'toMessageObject'
+> & {
+    features: Pick<PROTO.Features, 'unlocked' | 'device_id' | 'session_id'>;
+    protocol: Pick<IDevice['protocol'], 'name'>;
+    getCurrentSession: () => Pick<TypedCallProvider, 'typedCall'>;
+    getThpState: () => Pick<
+        NonNullable<ReturnType<IDevice['getThpState']>>,
+        'setSessionId' | 'createNewSessionId'
+    >;
+    getCommands: () => Pick<ReturnType<IDevice['getCommands']>, 'preauthorize'>;
+};
+
+type CreateMockDeviceParams = {
+    protocolName: 'v1' | 'v2';
+    deviceId: string;
+    instance: number;
+    // The first Testnet address the device derives, i.e. the wallet it currently holds.
+    address: string;
+    savedState?: DeviceState;
+};
 
 // Minimal stateful device driving the two `validateState` branches. `setState` merges like the
 // real Device, so `getState()` reflects what `getDeviceState` would later return.
-const createFakeDevice = ({
+const createMockDevice = ({
     protocolName,
     deviceId,
     instance,
     address,
     savedState,
-}: {
-    protocolName: 'v1' | 'v2';
-    deviceId: string;
-    instance: number;
-    address: string;
-    savedState?: FakeState;
-}) => {
-    let currentState: FakeState | undefined = savedState ? { ...savedState } : undefined;
-    const setState = jest.fn((partial: FakeState) => {
-        currentState = { ...(currentState ?? {}), ...partial };
-    });
+}: CreateMockDeviceParams) => {
+    let currentState: DeviceState | undefined = savedState ? { ...savedState } : undefined;
 
-    const device = {
+    const thpState: ReturnType<MockDevice['getThpState']> = {
+        setSessionId: jest.fn(),
+        createNewSessionId: jest.fn(() => Buffer.alloc(2)),
+    };
+
+    const device: MockDevice = {
         features: { unlocked: true, device_id: deviceId, session_id: undefined },
         protocol: { name: protocolName },
         getState: () => currentState,
-        setState,
+        setState: state => {
+            currentState = { ...currentState, ...state };
+        },
         getInstance: () => instance,
         getCurrentSession: () => ({
-            typedCall: () => Promise.resolve({ message: { address } }),
+            typedCall: jest.fn().mockResolvedValue({ message: { address } }),
         }),
-        getThpState: () => ({
-            setSessionId: jest.fn(),
-            createNewSessionId: () => Buffer.alloc(2),
-        }),
+        getThpState: () => thpState,
         getCommands: () => ({ preauthorize: jest.fn() }),
         emitDeviceChanged: jest.fn(),
-        toMessageObject: () => ({}),
+        toMessageObject: jest.fn(),
     };
 
-    return { device, getState: () => currentState };
+    return { device, thpState, getState: () => currentState };
 };
 
-const runValidateState = (device: ReturnType<typeof createFakeDevice>['device']) =>
+const runValidateState = (device: MockDevice) =>
     validateState({
-        device,
+        // Only the members above are exercised; the boundary cast keeps the mock honest about that.
+        device: device as unknown as IDevice,
         method: { useCardanoDerivation: false },
-        signal: {},
+        signal: new AbortController().signal,
         sendCoreMessage: jest.fn(),
-    } as any);
+    } satisfies WorkflowContext);
 
 describe(validateState.name, () => {
     afterEach(() => jest.clearAllMocks());
 
-    it.each([['v1'], ['v2']] as const)(
+    it.each(['v1', 'v2'] as const)(
         '%s: adopts the new device_id after re-provisioning instead of keeping a stale staticSessionId',
         async protocolName => {
             // Same seed + empty passphrase after wipe/recovery => identical walletDescriptor, new
-            // device_id. Both branches must refresh the saved state so getDeviceState never leaks
-            // the stale device_id (which would later miss in getDeviceByStaticState).
-            const fake = createFakeDevice({
+            // device_id. Both branches must refresh the saved state so `getDeviceState` reports
+            // the current device_id.
+            const mock = createMockDevice({
                 protocolName,
                 deviceId: RESET_DEVICE_ID,
                 instance: 0,
                 address: STANDARD_DESCRIPTOR,
-                savedState: { staticSessionId: state(STANDARD_DESCRIPTOR, DEVICE_ID, 0) },
+                savedState: { staticSessionId: createState(STANDARD_DESCRIPTOR, DEVICE_ID, 0) },
             });
 
-            await expect(runValidateState(fake.device)).resolves.toBeUndefined();
+            await expect(runValidateState(mock.device)).resolves.toBeUndefined();
 
-            expect(fake.getState()?.staticSessionId).toBe(
-                state(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 0),
+            expect(mock.getState()?.staticSessionId).toBe(
+                createState(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 0),
             );
         },
     );
 
-    it.each([['v1'], ['v2']] as const)(
+    it.each(['v1', 'v2'] as const)(
         '%s: still throws Device_InvalidState when the walletDescriptor differs (real passphrase mismatch)',
         async protocolName => {
             // Saved passphrase wallet, but the reset device has passphrase disabled and now derives
             // the empty-passphrase wallet => different walletDescriptor => genuine mismatch.
-            const fake = createFakeDevice({
+            const mock = createMockDevice({
                 protocolName,
                 deviceId: RESET_DEVICE_ID,
                 instance: 1,
                 address: STANDARD_DESCRIPTOR,
-                savedState: { staticSessionId: state(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1) },
+                savedState: { staticSessionId: createState(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1) },
             });
 
-            await expect(runValidateState(fake.device)).rejects.toMatchObject({
+            await expect(runValidateState(mock.device)).rejects.toMatchObject({
                 code: 'Device_InvalidState',
             });
         },
     );
+
+    it('v2: keeps the live THP session and adopts the new device_id when only the deviceId changed', async () => {
+        // A remembered THP wallet carries its sessionId. The session still derives the same wallet,
+        // so it must be reused instead of being discarded and re-created (which would re-prompt the
+        // passphrase on every call).
+        const mock = createMockDevice({
+            protocolName: 'v2',
+            deviceId: RESET_DEVICE_ID,
+            instance: 0,
+            address: STANDARD_DESCRIPTOR,
+            savedState: {
+                staticSessionId: createState(STANDARD_DESCRIPTOR, DEVICE_ID, 0),
+                sessionId: LIVE_THP_SESSION_ID,
+            },
+        });
+
+        await expect(runValidateState(mock.device)).resolves.toBeUndefined();
+
+        expect(mock.thpState.setSessionId).toHaveBeenCalledTimes(1);
+        expect(mock.thpState.setSessionId).toHaveBeenCalledWith(
+            Buffer.from(LIVE_THP_SESSION_ID, 'hex'),
+        );
+        expect(createThpSessionMock).not.toHaveBeenCalled();
+        expect(mock.getState()).toEqual({
+            staticSessionId: createState(STANDARD_DESCRIPTOR, RESET_DEVICE_ID, 0),
+            sessionId: LIVE_THP_SESSION_ID,
+        });
+    });
+
+    it('v2: discards the live THP session and still throws when the walletDescriptor differs', async () => {
+        const mock = createMockDevice({
+            protocolName: 'v2',
+            deviceId: RESET_DEVICE_ID,
+            instance: 1,
+            address: STANDARD_DESCRIPTOR,
+            savedState: {
+                staticSessionId: createState(PASSPHRASE_DESCRIPTOR, DEVICE_ID, 1),
+                sessionId: LIVE_THP_SESSION_ID,
+            },
+        });
+
+        await expect(runValidateState(mock.device)).rejects.toMatchObject({
+            code: 'Device_InvalidState',
+        });
+
+        // The unexpected session is reset and a fresh one is created before the final check throws.
+        expect(mock.thpState.setSessionId).toHaveBeenLastCalledWith(Buffer.alloc(1));
+        expect(createThpSessionMock).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -33,17 +33,25 @@ const preauthorizeState = ({ device, method }: WorkflowContext) => {
     }
 };
 
-// Treat two states as "unexpected" if they describe different (walletDescriptor, deviceId)
-// pairs. Instance is intentionally ignored — the same wallet can be referenced through
-// different host-side instance numbers across reconnects.
-const isUnexpectedState = (expected?: StaticSessionId, current?: StaticSessionId) => {
+// A state is "unexpected" only when it describes a DIFFERENT wallet, i.e. a different
+// `walletDescriptor`. The descriptor is the first Testnet address (44'/1'/0'/0/0), a pure
+// function of (seed, passphrase), so a mismatch is exactly what the "Passphrase is incorrect"
+// (Device_InvalidState) guard exists to catch: a passphrase/seed that derives a wallet the host
+// did not expect.
+//
+// `deviceId` and `instance` are intentionally NOT compared:
+//   - A differing `deviceId` with the same `walletDescriptor` is the same wallet on a
+//     re-provisioned device — wiping and recovering the same seed mints a fresh hardware
+//     `device_id`. Reporting that as "Passphrase is incorrect" (as an earlier revision did) is
+//     wrong: the passphrase is fine, only the device identity changed. Physical-device selection
+//     is enforced upstream in `DeviceList.getDeviceByStaticState`, not here.
+//   - `instance` is a host-side number that can differ across reconnects for the same wallet.
+export const isUnexpectedState = (expected?: StaticSessionId, current?: StaticSessionId) => {
     if (!expected || !current) return false;
-    const parsedExpected = parseStaticSessionId(expected);
-    const parsedCurrent = parseStaticSessionId(current);
 
     return (
-        parsedExpected.walletDescriptor !== parsedCurrent.walletDescriptor ||
-        parsedExpected.deviceId !== parsedCurrent.deviceId
+        parseStaticSessionId(expected).walletDescriptor !==
+        parseStaticSessionId(current).walletDescriptor
     );
 };
 
@@ -172,7 +180,12 @@ const validateThpDeviceState = async (context: WorkflowContext) => {
         throw ERRORS.TypedError('Device_InvalidState');
     }
 
-    if (!expectedState) {
+    // Mirror the non-THP `validate` above: refresh the saved state whenever it changed, not only
+    // when it was absent. Reaching here means the wallet matches (a differing `walletDescriptor`
+    // would have thrown), so a difference is a benign `deviceId` change from a re-provisioned
+    // device — adopt it, otherwise `getState()`/`getDeviceState` would keep leaking the stale
+    // `device_id` and later state-only calls would miss in `getDeviceByStaticState`.
+    if (!expectedState || expectedState !== uniqueState) {
         device.setState({ staticSessionId: uniqueState });
     }
 };

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -33,19 +33,16 @@ const preauthorizeState = ({ device, method }: WorkflowContext) => {
     }
 };
 
-// A state is "unexpected" only when it describes a DIFFERENT wallet, i.e. a different
-// `walletDescriptor`. The descriptor is the first Testnet address (44'/1'/0'/0/0), a pure
-// function of (seed, passphrase), so a mismatch is exactly what the "Passphrase is incorrect"
-// (Device_InvalidState) guard exists to catch: a passphrase/seed that derives a wallet the host
-// did not expect.
-//
-// `deviceId` and `instance` are intentionally NOT compared:
-//   - A differing `deviceId` with the same `walletDescriptor` is the same wallet on a
-//     re-provisioned device — wiping and recovering the same seed mints a fresh hardware
-//     `device_id`. Reporting that as "Passphrase is incorrect" (as an earlier revision did) is
-//     wrong: the passphrase is fine, only the device identity changed. Physical-device selection
-//     is enforced upstream in `DeviceList.getDeviceByStaticState`, not here.
-//   - `instance` is a host-side number that can differ across reconnects for the same wallet.
+/**
+ * Two states are "unexpected" when they describe different wallets, i.e. their `walletDescriptor`
+ * (the first Testnet address, a pure function of seed and passphrase) differs. That is the only
+ * thing the "Passphrase is incorrect" (Device_InvalidState) guard exists to catch.
+ *
+ * `deviceId` is not compared: wiping and recovering the same seed mints a fresh hardware
+ * `device_id`, and a host that kept the previous state would otherwise get a passphrase error for
+ * a wallet that did not change. `instance` is not compared either: it is a host-side number that
+ * can differ across reconnects for the same wallet.
+ */
 export const isUnexpectedState = (expected?: StaticSessionId, current?: StaticSessionId) => {
     if (!expected || !current) return false;
 
@@ -180,11 +177,10 @@ const validateThpDeviceState = async (context: WorkflowContext) => {
         throw ERRORS.TypedError('Device_InvalidState');
     }
 
-    // Mirror the non-THP `validate` above: refresh the saved state whenever it changed, not only
-    // when it was absent. Reaching here means the wallet matches (a differing `walletDescriptor`
-    // would have thrown), so a difference is a benign `deviceId` change from a re-provisioned
-    // device — adopt it, otherwise `getState()`/`getDeviceState` would keep leaking the stale
-    // `device_id` and later state-only calls would miss in `getDeviceByStaticState`.
+    // Mirror the non-THP `validate` above and adopt the freshly derived id whenever it differs. The
+    // wallet matches at this point (a differing `walletDescriptor` would have thrown), so the
+    // difference is a new `deviceId` of a re-provisioned device or a caller-supplied `instance`.
+    // Adopting it keeps `getState()`/`getDeviceState` reporting the current `device_id`.
     if (!expectedState || expectedState !== uniqueState) {
         device.setState({ staticSessionId: uniqueState });
     }

--- a/suite-common/device/src/__fixtures__/deviceReducer.ts
+++ b/suite-common/device/src/__fixtures__/deviceReducer.ts
@@ -1,5 +1,6 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { DEVICE } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
 
@@ -9,6 +10,16 @@ import { type DeviceReducerState, deviceReducerInitialState } from '../deviceRed
 // Default devices
 const CONNECT_DEVICE = mockConnectDevice();
 const SUITE_DEVICE = mockSuiteDevice();
+
+// Narrows the mock for payloads that accept acquired devices only.
+const mockAcquiredDevice = (...args: Parameters<typeof mockSuiteDevice>) => {
+    const device = mockSuiteDevice(...args);
+    if (!isDeviceAcquired(device)) {
+        throw new Error('Mocked device is expected to be acquired.');
+    }
+
+    return device;
+};
 
 type Fixture<TAction> = {
     description: string;
@@ -672,6 +683,114 @@ const changed: Fixture<ReturnType<typeof deviceActions.deviceChanged>>[] = [
             ),
         ],
     },
+    {
+        description: `Sync sessionId and deriveCardano from connect for the same wallet`,
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [
+                mockSuiteDevice({
+                    path: '1',
+                    connected: true,
+                    state: {
+                        staticSessionId: '1stTestnet@device_id:0',
+                        sessionId: 'stale-session',
+                    },
+                }),
+            ],
+        },
+        actions: [
+            {
+                type: DEVICE.CHANGED,
+                payload: mockConnectDevice({
+                    path: '1',
+                    state: {
+                        staticSessionId: '1stTestnet@device_id:0',
+                        sessionId: 'fresh-session',
+                        deriveCardano: true,
+                    },
+                }),
+            },
+        ],
+        result: [
+            {
+                state: {
+                    staticSessionId: '1stTestnet@device_id:0',
+                    sessionId: 'fresh-session',
+                    deriveCardano: true,
+                },
+            },
+        ],
+    },
+    {
+        description: `Keep the wallet key but sync sessionId when the same wallet is reported with a new device_id (device wiped and recovered with the same seed)`,
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [
+                mockSuiteDevice({
+                    path: '1',
+                    connected: true,
+                    state: {
+                        staticSessionId: '1stTestnet@device_id:0',
+                        sessionId: 'stale-session',
+                    },
+                }),
+            ],
+        },
+        actions: [
+            {
+                type: DEVICE.CHANGED,
+                payload: mockConnectDevice(
+                    {
+                        path: '1',
+                        state: {
+                            staticSessionId: '1stTestnet@new-device-id:0',
+                            sessionId: 'fresh-session',
+                        },
+                    },
+                    { device_id: 'new-device-id' },
+                ),
+            },
+        ],
+        result: [
+            {
+                id: 'new-device-id',
+                state: { staticSessionId: '1stTestnet@device_id:0', sessionId: 'fresh-session' },
+            },
+        ],
+    },
+    {
+        description: `Do not sync sessionId from a different wallet`,
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [
+                mockSuiteDevice({
+                    path: '1',
+                    connected: true,
+                    state: {
+                        staticSessionId: '1stTestnet@device_id:0',
+                        sessionId: 'stale-session',
+                    },
+                }),
+            ],
+        },
+        actions: [
+            {
+                type: DEVICE.CHANGED,
+                payload: mockConnectDevice({
+                    path: '1',
+                    state: {
+                        staticSessionId: 'otherWallet@device_id:0',
+                        sessionId: 'other-session',
+                    },
+                }),
+            },
+        ],
+        result: [
+            {
+                state: { staticSessionId: '1stTestnet@device_id:0', sessionId: 'stale-session' },
+            },
+        ],
+    },
 ];
 
 const selectDevice: Array<
@@ -1112,6 +1231,73 @@ const remember: Fixture<ReturnType<typeof deviceActions.setRememberDevice>>[] = 
     },
 ];
 
+const setDeviceState: Fixture<ReturnType<typeof deviceActions.setDeviceState>>[] = [
+    {
+        description: `Authorize a connected device without state`,
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [mockSuiteDevice({ path: '1', connected: true })],
+        },
+        actions: [
+            {
+                type: deviceActions.setDeviceState.type,
+                payload: {
+                    device: mockAcquiredDevice({ path: '1', connected: true }),
+                    state: { staticSessionId: '1stTestnet@device_id:0', sessionId: 'session' },
+                    useEmptyPassphrase: true,
+                },
+            },
+        ],
+        result: [
+            {
+                state: { staticSessionId: '1stTestnet@device_id:0', sessionId: 'session' },
+                useEmptyPassphrase: true,
+            },
+        ],
+    },
+    {
+        description: `Keep the wallet key when the same wallet is re-authorized with a new device_id (device wiped and recovered with the same seed)`,
+        initialState: {
+            ...deviceReducerInitialState,
+            devices: [
+                mockSuiteDevice(
+                    {
+                        path: '1',
+                        connected: true,
+                        state: {
+                            staticSessionId: '1stTestnet@device_id:0',
+                            sessionId: 'stale-session',
+                        },
+                    },
+                    { device_id: 'new-device-id' },
+                ),
+            ],
+        },
+        actions: [
+            {
+                type: deviceActions.setDeviceState.type,
+                payload: {
+                    device: mockAcquiredDevice(
+                        { path: '1', connected: true },
+                        { device_id: 'new-device-id' },
+                    ),
+                    state: {
+                        staticSessionId: '1stTestnet@new-device-id:0',
+                        sessionId: 'fresh-session',
+                    },
+                    useEmptyPassphrase: true,
+                },
+            },
+        ],
+        result: [
+            {
+                id: 'new-device-id',
+                state: { staticSessionId: '1stTestnet@device_id:0', sessionId: 'fresh-session' },
+            },
+        ],
+    },
+];
+
 export default {
     connect,
     disconnect,
@@ -1119,4 +1305,5 @@ export default {
     selectDevice,
     forget,
     remember,
+    setDeviceState,
 };

--- a/suite-common/device/src/deviceReducer.test.ts
+++ b/suite-common/device/src/deviceReducer.test.ts
@@ -128,3 +128,20 @@ describe('SUITE.REMEMBER_DEVICE', () => {
         });
     });
 });
+
+describe('setDeviceState', () => {
+    fixtures.setDeviceState.forEach(f => {
+        it(f.description, () => {
+            let state: State = f.initialState;
+            f.actions.forEach(a => {
+                state = deviceReducer(state, a);
+            });
+            expect(state.devices.length).toEqual(f.result.length);
+            state.devices.forEach((device, i) => {
+                const expected = f.result[i];
+                if (!expected) throw new Error(`Missing result at index ${i}`);
+                expect(device).toMatchObject(expected);
+            });
+        });
+    });
+});

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -16,7 +16,11 @@ import * as deviceUtils from '@suite-common/suite-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { type Device, type DeviceState, type Features, type KnownDevice } from '@trezor/connect';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
-import { getFirmwareVersionArray } from '@trezor/device-utils';
+import {
+    getFirmwareVersionArray,
+    isStaticSessionId,
+    parseStaticSessionId,
+} from '@trezor/device-utils';
 import { type Err } from '@trezor/type-utils';
 
 import { type DeviceStateActionPayload, deviceActions } from './deviceActions';
@@ -67,6 +71,15 @@ const isUnlocked = (features: Features): boolean =>
         : // Older FW (<2.3.2) which doesn't have `unlocked` feature also doesn't have auto-lock and is always unlocked.
           true;
 
+// Two states describe the same wallet when their `walletDescriptor` matches. The `deviceId` may
+// differ for the same wallet: wiping and recovering the same seed mints a new hardware `device_id`
+// while the seed, and therefore the wallet, is unchanged.
+const describesSameWallet = (current: DeviceState, upcoming: DeviceState): boolean =>
+    isStaticSessionId(current.staticSessionId) &&
+    isStaticSessionId(upcoming.staticSessionId) &&
+    parseStaticSessionId(current.staticSessionId).walletDescriptor ===
+        parseStaticSessionId(upcoming.staticSessionId).walletDescriptor;
+
 /**
  * Local utility: get state in DeviceState format from AcquiredDevice in backwards compatible way
  * @param upcoming
@@ -78,14 +91,12 @@ const mergeDeviceState = (
 ): DeviceState | undefined => {
     const currentState = device.state;
 
-    // Device state is set explicitly via addAuthorizedDevice/setDeviceState. For the same session we only
+    // Device state is set explicitly via addAuthorizedDevice/setDeviceState. For the same wallet we only
     // sync the volatile sessionId and deriveCardano from connect, so the cardano-derived session is not
-    // recreated (re-prompting the passphrase) on every cardano call.
-    if (
-        !currentState ||
-        !upcoming.state ||
-        currentState.staticSessionId !== upcoming.state.staticSessionId
-    ) {
+    // recreated (re-prompting the passphrase) on every cardano call. The staticSessionId itself is never
+    // adopted here: the wallet stays keyed by the id it was authorized with, even when connect reports
+    // a new deviceId after the device was wiped and recovered with the same seed.
+    if (!currentState || !upcoming.state || !describesSameWallet(currentState, upcoming.state)) {
         return currentState;
     }
 
@@ -370,7 +381,14 @@ const setDeviceState = (
     const targetDevice = affectedDevice[0];
     if (!targetDevice) return;
 
-    targetDevice.state = state;
+    // Re-authorizing an already authorized wallet must not re-key it: accounts are keyed by the
+    // staticSessionId the wallet was authorized with, and connect reports a new deviceId for the
+    // same wallet after the device was wiped and recovered with the same seed.
+    const currentState = targetDevice.state;
+    targetDevice.state =
+        currentState && describesSameWallet(currentState, state)
+            ? { ...state, staticSessionId: currentState.staticSessionId }
+            : state;
     targetDevice.useEmptyPassphrase = useEmptyPassphrase;
     targetDevice.walletNumber = deviceUtils.getNewWalletNumber(draft.devices, device);
     delete targetDevice.discovered;


### PR DESCRIPTION
### Description

Fixes #31883.

`validateState` raised `Device_InvalidState` ("Passphrase is incorrect") whenever the connected device's static session state differed from the host's saved state on either `walletDescriptor` **or** `deviceId`. A factory reset + recovery of the same seed mints a fresh hardware `device_id`, so a standard (empty-passphrase) wallet — whose `walletDescriptor` is unchanged — spuriously failed address verification with "Passphrase is incorrect", even though no passphrase is involved.

### Repro

1. Use a device with passphrase protection enabled, save it in Suite.
2. Wipe the device outside Suite, **without** enabling passphrase protection.
3. Recover the same seed.
4. Open a standard (no-passphrase) wallet and click *Verify* on a receive address → "Passphrase is incorrect".

### Root cause

`walletDescriptor` (the first Testnet address at `44'/1'/0'/0/0`) is a pure function of `(seed, passphrase)` and fully identifies the wallet. `deviceId` only identifies the physical device; connect resolves the device in core `selectDevice` (by the state's `deviceId` while it still matches, then by `path`, then the only attached device), so it does not belong in the wallet-identity guard. Because `isUnexpectedState` also compared `deviceId`, a re-provisioned device (same seed, new `device_id`) tripped the passphrase guard even though the wallet is unchanged. This is long-standing behaviour, not a recent regression: the comparison has included `device_id` since the original whole-string compare of `descriptor@device_id:instance` in trezor/connect.

How Suite ends up with such a state: when the device is wiped while attached to a running Suite, the next call refreshes its features and `deviceReducer.changeDevice` matches the connected entry by `path`, adopts the new `id`, but keeps the saved `state` (`mergeDeviceState` ignores a different `staticSessionId`). The entry then carries `id = NEW` with `state = descriptor@OLD:0`, and every state-carrying call failed. Suite cleans up only after its own wipe flow or a THP `WIPE` push notification.

### Fix

- `isUnexpectedState` now compares only `walletDescriptor`, so the guard fires exactly when the derived wallet differs. A saved passphrase wallet on a passphrase-disabled reset device still (correctly) throws; the same wallet on a re-provisioned device does not.
- The THP branch now adopts the re-provisioned `staticSessionId` the same way the non-THP branch already does. It previously refreshed the saved state only when none existed (`!expectedState`), which was fine while any `deviceId` change threw; now that a benign `deviceId` change no longer throws, it would otherwise keep a stale `descriptor@oldDeviceId` and report it through `getDeviceState` / `DEVICE.CHANGED`; callers that omit `state` on later calls would then miss in `getDeviceByStaticState`.

### Suite follow-up (`fix(device)`)

Connect now reports the wallet back under the new `device_id`, so Suite must not treat that as a different wallet. In `@suite-common/device`:

- `mergeDeviceState` syncs the volatile `sessionId` / `deriveCardano` from `DEVICE.CHANGED` whenever the `walletDescriptor` matches, not only on an identical `staticSessionId` string. Otherwise the stale `sessionId` was re-sent on every call and hidden wallets re-prompted the passphrase each time.
- `setDeviceState` keeps the `staticSessionId` an already authorized wallet was keyed with. Accounts, metadata and discovery are keyed by it, so adopting the new `device_id` (as `runAdditionalDiscoveryThunk` does after enabling a coin) would detach the wallet from its accounts.

The wallet stays keyed by the id it was authorized with; the `deviceId` part of that key is historical.

### Behavioral note

Two distinct physical devices holding the same seed + empty passphrase now validate as the same wallet (identical addresses) instead of erroring — a deliberate consequence of keying on wallet identity rather than device identity.

### Testing

Adds `validateState.test.ts`: unit coverage of `isUnexpectedState`, plus behavioral coverage of both branches (v1 + THP) for state refresh on re-provisioning and the still-throws passphrase-mismatch case, including the THP branch with a live `sessionId`. `deviceReducer` fixtures cover the Suite-side change (`DEVICE.CHANGED` sync and `setDeviceState` keeping the wallet key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch core device state validation and the suite-common device reducer, which underpin onboarding, device sessions, discovery, and passphrase handling. Most of the 139 static hits are transitive, so I recommend a focused set of high-priority tests that directly manipulate or observe device state (sessions, onboarding auth, discovery/passphrase, forget/disconnect) plus a small medium tier covering reload/offline and entropy failure paths.

<details><summary><b>Changed files (5)</b></summary>

- `packages/connect/src/device/workflow/validateState.test.ts`
- `packages/connect/src/device/workflow/validateState.ts`
- `suite-common/device/src/__fixtures__/deviceReducer.ts`
- `suite-common/device/src/deviceReducer.test.ts`
- `suite-common/device/src/deviceReducer.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises the device switcher, ejecting a wallet, adding a standard wallet, and completing discovery. These flows directly update and read the device reducer state and depend on device-state validation to know when the device is ready.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Runs device authenticity checks and toggles firmware hash/revision checks during onboarding. validateState and the device reducer control how device features and security checks are interpreted and surfaced.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Asserts firmware readiness detection during onboarding, a flow where validateState evaluates the connected device's firmware/features state and the reducer stores the result.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Covers device disconnect/reconnect and passphrase wallet caching after reconnection. This directly depends on the reducer's device connection/session state and passphrase cache handling.
- `suite/e2e/tests/settings/forget-device.test.ts` — Forgets TS5/TS7 devices and navigates disconnected/unplug states. It manipulates the device reducer's wallet/device list and relies on correct device-state transitions.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Steals and reclaims Bridge sessions, checking Use Here/Connected status in the UI. This is a direct end-to-end exercise of device session state managed by the reducer and validateState.
- `suite/e2e/tests/wallet/without-device.test.ts` — Verifies disconnected-device banner and the connection modal when no device is present. It tests how the reducer renders the disconnected state and how validateState blocks flows without a device.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Simulates a device disconnect during backup and asserts error banners/toasts. The backup failure path must correctly transition the device reducer state and surface device disconnection.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Dispatches simulated entropy-check failures and asserts the device-compromised modal or error toast. It uses device actions/reducer paths that are part of the changed modules.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Creates a wallet offline and checks the disconnection banner plus discovery failure. Offline state handling flows through the device reducer and readiness validation.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Performs recovery dry runs and recovers from bridge stop/start and page reload. These scenarios reinitialize device state and depend on the reducer to resume correctly.
- `suite/e2e/tests/suite/initial-run.test.ts` — Reloads during onboarding and asserts analytics/onboarding state and final connected-device status. It exercises persistence of the device reducer's initial-run and connection state.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates many coins, reloads mid-discovery, and asserts device status stays connected and discovery completes. Discovery is tightly coupled to device state and reducer-managed discovery status.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect/src/device/workflow/validateState.test.ts`
- `suite-common/device/src/__fixtures__/deviceReducer.ts`
- `suite-common/device/src/deviceReducer.test.ts`

_Updated: 2026-09-06T06:08:17.034Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-passphrase-incorrect-on-standard-wallet/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-passphrase-incorrect-on-standard-wallet/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-passphrase-incorrect-on-standard-wallet&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-passphrase-incorrect-on-standard-wallet&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-passphrase-incorrect-on-standard-wallet&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-06T06:10:15.438Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-06T06:09:35.877Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->