### PR TITLE
feat(e2e): add yield redeem test

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -133,7 +133,13 @@ export const YieldAmountCard = ({
     ) : undefined;
 
     const unitSwitch = unitToggle ? (
-        <TextButton type="button" size="small" onClick={unitToggle.onClick} isUnderlined>
+        <TextButton
+            type="button"
+            size="small"
+            data-testid="@yield/form/unit-toggle-button"
+            onClick={unitToggle.onClick}
+            isUnderlined
+        >
             <Translation
                 id="TR_EARN_YIELD_ENTER_AMOUNT_IN_TOKEN"
                 values={{ tokenSymbol: unitToggle.otherTokenSymbol }}
@@ -218,6 +224,7 @@ export const YieldAmountCard = ({
                                     size="small"
                                     intent="neutral"
                                     priority="secondary"
+                                    data-testid="@yield/form/max-button"
                                     onClick={() => summary.onMaxClick?.()}
                                 >
                                     <Translation id="TR_FRACTION_BUTTONS_MAX" />

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -197,6 +197,7 @@ export const YieldWithdrawForm = () => {
             return (
                 <Banner
                     intent="info"
+                    data-testid="@yield/form/max-withdraw-info"
                     description={
                         <Translation
                             id="TR_EARN_YIELD_MAX_WITHDRAW_INFO"

--- a/suite/e2e/support/mocks/eth-endpoints.ts
+++ b/suite/e2e/support/mocks/eth-endpoints.ts
@@ -89,8 +89,9 @@ export const fixtures = [
         method: 'estimateFee',
         default: true,
         response: ({ params }: any) => {
-            // ERC-4626 vault calls: deposit === 0x6e553f65, withdraw === 0xb460af94
-            const vaultCallSelectors = ['0x6e553f65', '0xb460af94'];
+            // ERC-4626 vault calls: deposit === 0x6e553f65, withdraw === 0xb460af94,
+            // redeem === 0xba087652
+            const vaultCallSelectors = ['0x6e553f65', '0xb460af94', '0xba087652'];
             if (vaultCallSelectors.some(selector => params?.specific?.data?.startsWith(selector))) {
                 return {
                     data: [

--- a/suite/e2e/support/mocks/yieldMock.ts
+++ b/suite/e2e/support/mocks/yieldMock.ts
@@ -172,6 +172,24 @@ const BLOCKAID_WITHDRAW_RESPONSE = createBlockaidBenignResponse({
     },
 });
 
+// Redemption of 3 trSHUSDCp shares pays out 3 × pricePerShare = 3.016822 USDC.
+const BLOCKAID_REDEEM_RESPONSE = createBlockaidBenignResponse({
+    sent: {
+        asset: USDC_VAULT_SHARE_ASSET,
+        rawValue: '0x29a2241af62c0000',
+        value: '3.0',
+        usdPrice: '3.015781224726041',
+        summary: 'Sending 3 trSHUSDCp',
+    },
+    received: {
+        asset: USDC_ASSET,
+        rawValue: '0x2e0876',
+        value: '3.016822',
+        usdPrice: '3.015781224726041',
+        summary: 'Receiving 3.016822 USDC',
+    },
+});
+
 const YIELD_VAULTS_RESPONSE = {
     items: [
         {
@@ -349,6 +367,13 @@ export class YieldMock {
     async mockUsdcWithdraw() {
         await this.page.route(BLOCKAID_API_PATTERN, route =>
             route.fulfill({ json: BLOCKAID_WITHDRAW_RESPONSE }),
+        );
+    }
+
+    @step()
+    async mockUsdcRedeem() {
+        await this.page.route(BLOCKAID_API_PATTERN, route =>
+            route.fulfill({ json: BLOCKAID_REDEEM_RESPONSE }),
         );
     }
 

--- a/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
@@ -15,8 +15,11 @@ export class YieldFlowSection {
     // Deposit step
     readonly depositButton: Locator;
     readonly depositedToast: Locator;
-    // Withdraw step
     readonly withdrawButton: Locator;
+    readonly redeemButton: Locator;
+    readonly unitToggleButton: Locator;
+    readonly maxButton: Locator;
+    readonly maxWithdrawInfoBanner: Locator;
     readonly withdrawnToast: Locator;
     // Flow-complete screen
     readonly flowCompleteHeading: Locator;
@@ -39,6 +42,10 @@ export class YieldFlowSection {
         this.depositButton = this.page.getByTestId('@yield/form/deposit-button');
         this.depositedToast = this.page.getByTestId('@toast/tx-yield-deposit');
         this.withdrawButton = this.page.getByTestId('@yield/form/withdraw-button');
+        this.redeemButton = this.page.getByTestId('@yield/form/redeem-button');
+        this.unitToggleButton = this.page.getByTestId('@yield/form/unit-toggle-button');
+        this.maxButton = this.page.getByTestId('@yield/form/max-button');
+        this.maxWithdrawInfoBanner = this.page.getByTestId('@yield/form/max-withdraw-info');
         this.withdrawnToast = this.page.getByTestId('@toast/tx-yield-withdraw');
         this.flowCompleteHeading = this.page.getByTestId('@yield/flow-complete/heading');
         this.flowCompleteStatus = this.page.getByTestId('@yield/flow-complete/status');

--- a/suite/e2e/tests/yield/redeem.test.ts
+++ b/suite/e2e/tests/yield/redeem.test.ts
@@ -1,0 +1,171 @@
+import ETH_BASE_TX from '../../fixtures/staking/eth-base-tx.json';
+import ETH_STAKE_CONFIRMED_TX from '../../fixtures/staking/eth-stake-confirmed-tx.json';
+import { expect, test } from '../../support/fixtures';
+import { ETH_MOCKED_ACCOUNT } from '../../support/mocks/eth-endpoints';
+import { YIELD_USDC_VAULT_SHARE_TOKEN, YIELD_VAULTS } from '../../support/mocks/yieldMock';
+
+const { usdcPrime } = YIELD_VAULTS;
+const YIELD_USDC_VAULT_DISPLAY_NAME = ['Trezor Steakhouse', '\n', 'USDC Prime Vault'];
+const REDEEM_SHARES_AMOUNT = '3';
+// REDEEM_SHARES_AMOUNT × pricePerShare (1.005607422297114)
+const REDEEM_PAYOUT_AMOUNT = '3.016822';
+// YIELD_USDC_VAULT_SHARE_TOKEN.balance (18 decimals) converted to units
+const REDEEM_MAX_SHARES_AMOUNT = '9.944238455556494216';
+const REDEEM_MAX_FEE = '0.00010840280031 ETH';
+const NEW_BLOCK = {
+    height: 22881954,
+    hash: '0xa07d0d92b6bb9a5f388d47a10b824b4b09e0b3aeb08d0f61c0e30a25f6c8455f',
+};
+
+const buildEthAccountTokens = ({
+    usdcBalance,
+    shareBalance,
+}: {
+    usdcBalance: string;
+    shareBalance: string;
+}) => [
+    ...ETH_MOCKED_ACCOUNT.tokens.map(token =>
+        token.symbol === 'USDC' ? { ...token, balance: usdcBalance } : token,
+    ),
+    { ...YIELD_USDC_VAULT_SHARE_TOKEN, balance: shareBalance },
+];
+
+test.describe('stablecoin yield redeem', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({
+        deviceSetup: {
+            mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
+        },
+    });
+
+    test.beforeEach(async ({ onboardingPage, settingsPage, blockbookMock, yieldMock }) => {
+        await onboardingPage.completeOnboarding();
+        await blockbookMock.start('eth');
+        blockbookMock.updateAccountState({
+            txs: 3,
+            nonce: '2',
+            transactions: [ETH_STAKE_CONFIRMED_TX, ETH_BASE_TX],
+            tokens: buildEthAccountTokens({
+                usdcBalance: '990000000',
+                shareBalance: YIELD_USDC_VAULT_SHARE_TOKEN.balance,
+            }),
+        });
+        await yieldMock.start();
+        await settingsPage.changeNetworks({
+            enableNetworks: [
+                { symbol: 'eth', backend: { type: 'blockbook', url: blockbookMock.url } },
+            ],
+        });
+    });
+
+    test('User can redeem yield vault shares using the max button', async ({
+        yieldSection,
+        yieldFlowSection,
+        txSimulationModal,
+        devicePrompt,
+        device,
+        blockbookMock,
+        yieldMock,
+    }) => {
+        await test.step('Open the withdraw form', async () => {
+            await yieldSection.earnMenuButton.click();
+            await yieldSection.withdrawButton(usdcPrime.id).click();
+        });
+
+        await test.step('Max switches the amount input into trSHUSDCp shares', async () => {
+            await expect(yieldFlowSection.amountUnit).toHaveText('USDC');
+            await yieldFlowSection.maxButton.click();
+
+            await expect(yieldFlowSection.amountUnit).toHaveText('trSHUSDCp');
+            await expect(yieldFlowSection.amountInput).toHaveValue(REDEEM_MAX_SHARES_AMOUNT);
+            await expect(yieldFlowSection.redeemButton).toBeVisible();
+            await expect(yieldFlowSection.withdrawButton).toBeHidden();
+            await expect(yieldFlowSection.maxWithdrawInfoBanner).toHaveTranslation(
+                'TR_EARN_YIELD_MAX_WITHDRAW_INFO',
+                { values: { receiptTokenSymbol: 'trSHUSDCp' } },
+            );
+        });
+
+        await test.step(`Redeem ${REDEEM_SHARES_AMOUNT} trSHUSDCp shares`, async () => {
+            await yieldMock.mockUsdcRedeem();
+            await yieldFlowSection.amountInput.fill(REDEEM_SHARES_AMOUNT);
+            await yieldFlowSection.redeemButton.click();
+
+            await expect(txSimulationModal.sentAsset(0)).toHaveText(
+                `Sending ${REDEEM_SHARES_AMOUNT} trSHUSDCp`,
+            );
+            await expect(txSimulationModal.receivedAsset(0)).toHaveText(
+                `Receiving ${REDEEM_PAYOUT_AMOUNT} USDC`,
+            );
+            await txSimulationModal.confirmButton.click();
+
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Redeem' },
+                    body: [['Review details to', '\n', 'redeem from vault.']],
+                    actions: { right_button: 'Confirm' },
+                },
+            });
+            await devicePrompt.waitForPromptAndClick();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Redeem' },
+                    body: [YIELD_USDC_VAULT_DISPLAY_NAME],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    body: [['Redeem from'], YIELD_USDC_VAULT_DISPLAY_NAME],
+                },
+            });
+            await device.pressYes();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Redeem' },
+                    body: [
+                        ['Redeem amount'],
+                        [`${REDEEM_SHARES_AMOUNT} trSHUSDCp`],
+                        ['Chain'],
+                        ['Ethereum'],
+                    ],
+                    actions: { right_button: 'Continue' },
+                },
+            });
+            await device.pressYes();
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(REDEEM_MAX_FEE);
+            await devicePrompt.waitForFinalPromptAndConfirm();
+
+            blockbookMock.updateAccountState({
+                txs: 4,
+                nonce: '3',
+                tokens: buildEthAccountTokens({
+                    usdcBalance: '993016822',
+                    shareBalance: '6944238455556494216',
+                }),
+            });
+            await devicePrompt.sendButton.click();
+
+            await expect(yieldFlowSection.withdrawnToast).toBeVisible();
+            await expect(yieldFlowSection.flowCompleteHeading).toHaveTranslation(
+                'TR_EARN_YIELD_WITHDRAW_COMPLETE',
+            );
+            await expect(yieldFlowSection.flowCompleteTransferInputAmount).toHaveText(
+                `${REDEEM_SHARES_AMOUNT} trSHUSDCp`,
+            );
+            await expect(yieldFlowSection.flowCompleteTransferOutputAmount).toHaveText(
+                `${REDEEM_PAYOUT_AMOUNT} USDC`,
+            );
+
+            await blockbookMock.sendNewBlockNotification(NEW_BLOCK);
+        });
+
+        await test.step('Dashboard shows the reduced position', async () => {
+            await yieldFlowSection.backToOverviewButton.click();
+
+            await expect(yieldSection.depositedAmount(usdcPrime.id)).toHaveTranslation(
+                'TR_EARN_YIELD_DASHBOARD_DEPOSITED',
+                { values: { amount: '6.983177', displaySymbol: 'USDC' } },
+            );
+            await expect(yieldSection.withdrawButton(usdcPrime.id)).toBeVisible();
+        });
+    });
+});


### PR DESCRIPTION
## Description
Adds an e2e test for the DeFi yield vault redeem flow, covering the max button switching the withdraw form into vault-share units, the transaction simulation and on-device confirmation screens, and the resulting balances on the flow-complete screen and dashboard. 

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-yield-redeem/web/](https://dev.suite.sldev.cz/suite-web/test-yield-redeem/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-yield-redeem&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-yield-redeem&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T15:20:41.903Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T15:20:55.596Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->