### PR TITLE
test(suite): fix live swap tests

### DIFF
--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -1,4 +1,5 @@
 import { Locator, Page } from '@playwright/test';
+import type { ExchangeTrade } from 'invity-api';
 
 import { messages } from '@suite/intl';
 import type { TradingCountryCode } from '@suite-common/trading';
@@ -18,6 +19,8 @@ import { tradeEndpoint } from '../../../fixtures/trading';
 import { step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
 import { BuyAsset, SellAsset } from '../../types';
+
+const LIVE_TRADE_RESPONSE_TIMEOUT = 90_000;
 
 export class TradingPage {
     readonly fees: FeeSection;
@@ -356,7 +359,7 @@ export class TradingPage {
      * @param params.sendAccount - The account label the swap is sent from (e.g., 'Solana #1')
      * @param params.receiveAccount - The account label the swap is received to (e.g., 'Bitcoin #1')
      * @param params.sendAmount - The expected send amount (e.g., '0.001')
-     * @param params.receiveAmount - The expected receive amount (localized, e.g., '0.00002')
+     * @param params.receiveAmount - The expected receive amount exactly as the provider returned it (e.g., '0.07357510')
      */
     @step()
     async verifySwapToast({
@@ -378,6 +381,22 @@ export class TradingPage {
         });
         await expect(this.swapToastSendAmount).toHaveText(sendAmount);
         await expect(this.swapToastReceiveAmount).toHaveText(receiveAmount);
+    }
+
+    // temporary workaround which should be replaced with soon to be merged fixture tradingResponses
+    @step()
+    async waitForLiveTradeAmounts() {
+        const response = await this.page.waitForResponse(tradeEndpoint.swapTrade, {
+            timeout: LIVE_TRADE_RESPONSE_TIMEOUT,
+        });
+        const { sendStringAmount, receiveStringAmount } = (await response.json()) as ExchangeTrade;
+        if (!sendStringAmount || !receiveStringAmount) {
+            throw new Error(
+                'Live trade response is missing sendStringAmount or receiveStringAmount',
+            );
+        }
+
+        return { sendStringAmount, receiveStringAmount };
     }
 
     @step()

--- a/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
@@ -103,6 +103,7 @@ test.describe(
                     sellAsset: {
                         networkSymbol: 'sol',
                         tokenSymbol: sendTokenSymbol,
+                        accountIndex: 1,
                     },
                     buyAsset: {
                         searchFilter: receiveAssetName,
@@ -114,12 +115,11 @@ test.describe(
                 });
             });
 
-            let receiveAmount: string;
+            let liveTradeAmounts: ReturnType<typeof tradingPage.waitForLiveTradeAmounts>;
 
             await test.step('Confirm the Swap trade', async () => {
                 await expect(tradingPage.quotes.bestOfferAmount).toContainText(receiveCoinSymbol);
-                const [amount] = (await tradingPage.quotes.bestOfferAmount.innerText()).split(' ');
-                receiveAmount = localizeNumber(amount ?? '');
+                liveTradeAmounts = tradingPage.waitForLiveTradeAmounts();
                 await tradingPage.waitForSolanaFeesAndClickSwapBestOffer();
             });
 
@@ -136,13 +136,14 @@ test.describe(
             });
 
             await test.step('Send crypto to provider', async () => {
+                const { receiveStringAmount } = await liveTradeAmounts;
                 await devicePrompt.sendButton.click();
 
                 await tradingPage.verifySwapToast({
                     sendAccount: accountLabel,
                     receiveAccount: accountLabel,
                     sendAmount,
-                    receiveAmount,
+                    receiveAmount: receiveStringAmount,
                 });
 
                 await expect(tradingPage.transactionDetailStatus).toHaveTranslation(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes one test. 
- Live swap test needed specified on which index account the send token is. Plus the toast that we verify pulls data directly from quote where decimal length can differ from what suite shows in form. So we started using for this verificaiton the string from quote

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-tests-8-31/web/](https://dev.suite.sldev.cz/suite-web/fix-tests-8-31/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-tests-8-31&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-tests-8-31&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T09:50:40.342Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T09:50:33.136Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->