### PR TITLE
feat(e2e): add sidebar custom-backend icon, explicit revert

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/CustomBackend.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/CustomBackend.tsx
@@ -21,6 +21,7 @@ export const CustomBackend = () => {
             <QuickActionButton
                 tooltip={{ content: <NavBackends customBackends={enabledBackends} /> }}
                 onClick={handleClick}
+                data-testid="@quickActions/customBackend"
                 icon={DatabaseIcon}
                 subIconIntent="brand"
                 subIcon={CheckIcon}

--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -34,6 +34,7 @@ export class DashboardPage {
     readonly addNewHiddenWalletButton: Locator;
     readonly addExistingHiddenWalletButton: Locator;
     readonly hideBalanceButton: Locator;
+    readonly customBackendButton: Locator;
     readonly portfolioFiatAmount: Locator;
     readonly deviceStatus: Locator;
     readonly deviceStatusOnSwitchDevice: Locator;
@@ -89,6 +90,7 @@ export class DashboardPage {
             '@switch-device/add-existing-hidden-wallet-button',
         );
         this.hideBalanceButton = this.page.getByTestId('@quickActions/hideBalances');
+        this.customBackendButton = this.page.getByTestId('@quickActions/customBackend');
         this.portfolioFiatAmount = this.page.getByTestId('@dashboard/portfolio/fiat-amount');
         this.deviceStatus = this.page.locator("[data-testid-alt='@deviceStatus']");
         this.deviceStatusOnSwitchDevice = this.page

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 
-import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol, ServerType } from '@suite-common/wallet-config';
 
 import { step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
@@ -19,7 +19,7 @@ export class CoinsTab {
     readonly networkSymbolAdvanceSettingsButton = (symbol: NetworkSymbol) =>
         this.page.getByTestId(`@settings/wallet/network/${symbol}/advance`);
     readonly coinBackendSelector: Locator;
-    readonly coinBackendSelectorOption = (backend: BackendType) =>
+    readonly coinBackendSelectorOption = (backend: ServerType) =>
         this.page.getByTestId(`@settings/advance/select-type/option/${backend}`);
     readonly coinAddressInput: Locator;
     readonly coinAdvanceSettingSaveButton: Locator;
@@ -65,6 +65,11 @@ export class CoinsTab {
     }
 
     @step()
+    async expectNoCustomBackendIndicator(symbol: NetworkSymbol) {
+        await expect(this.networkBackendStatus(symbol)).toBeHidden();
+    }
+
+    @step()
     async enableNetwork(symbol: NetworkSymbol) {
         const networkSwitch = this.networkSwitch(symbol);
         if (!(await this.isNetworkEnabled(symbol))) {
@@ -83,10 +88,17 @@ export class CoinsTab {
     }
 
     @step()
-    async changeBackend(backend: BackendType, backendUrl: string) {
+    async changeBackend(backend: ServerType, backendUrl: string) {
         await this.coinBackendSelector.click();
         await this.coinBackendSelectorOption(backend).click();
         await this.coinAddressInput.fill(backendUrl);
+        await this.coinAdvanceSettingSaveButton.click();
+    }
+
+    @step()
+    async revertToDefaultBackend() {
+        await this.coinBackendSelector.click();
+        await this.coinBackendSelectorOption('default').click();
         await this.coinAdvanceSettingSaveButton.click();
     }
 }

--- a/suite/e2e/tests/settings/coins-custom-backend.test.ts
+++ b/suite/e2e/tests/settings/coins-custom-backend.test.ts
@@ -1,4 +1,4 @@
-import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol, ServerType } from '@suite-common/wallet-config';
 import { BlockbookProxyMock, TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';
@@ -8,7 +8,7 @@ const BTC_BACKEND_WS_URL = 'wss://btc1.trezor.io/websocket';
 
 type Coin = {
     coin: NetworkSymbol;
-    backendType: BackendType;
+    backendType: ServerType;
     customBackendUrlRight: string;
     customBackendUrlWrong: string;
 };
@@ -128,14 +128,14 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1'] }, () => {
         {
             annotation: createTestAnnotation({
                 testCase:
-                    'Verifies that a custom Bitcoin blockbook backend can be configured while the network is still disabled, that no communication reaches the backend until the network is enabled, and that discovery then talks to that backend.',
+                    'Verifies that a custom Bitcoin blockbook backend can be configured while the network is still disabled, that no communication reaches the backend until the network is enabled, that the sidebar custom-backend icon appears, and that reverting to the default backend reconnects away from the custom server.',
                 category: TestCategory.Settings,
                 priority: TestPriority.Medium,
                 stream: TestStream.Foundation,
             }),
         },
-        async ({ page, settingsPage, walletPage }) => {
-            const backendType: BackendType = 'blockbook';
+        async ({ page, dashboardPage, settingsPage, walletPage }) => {
+            const backendType: ServerType = 'blockbook';
             const backendProxy = new BlockbookProxyMock(BTC_BACKEND_WS_URL);
             await backendProxy.start();
 
@@ -151,6 +151,7 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1'] }, () => {
                     await settingsPage.coinsTab.changeBackend(backendType, backendProxy.url);
                     await settingsPage.coinsTab.expectCustomBackendIndicator('btc');
                     await settingsPage.coinsTab.expectNetworkDisabled('btc');
+                    await expect(dashboardPage.customBackendButton).toBeHidden();
                     expect(
                         backendProxy.connectedClients,
                         'Expected no connection to the backend while the network is disabled',
@@ -173,6 +174,24 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1'] }, () => {
                 });
 
                 await test.step('Open BTC account & verify it is loaded successfully', async () => {
+                    await walletPage.openAccount({ symbol: 'btc' });
+                    await expect(walletPage.emptyAccount).toContainTranslation(
+                        'TR_ACCOUNT_IS_EMPTY_TITLE',
+                    );
+                    await expect(dashboardPage.customBackendButton).toBeVisible();
+                });
+
+                await test.step('Revert to the default backend and reconnect', async () => {
+                    await settingsPage.navigateTo('coins');
+                    await settingsPage.coinsTab.openNetworkAdvanceSettings('btc');
+                    await settingsPage.coinsTab.revertToDefaultBackend();
+                    await settingsPage.coinsTab.expectNoCustomBackendIndicator('btc');
+                    await expect(dashboardPage.customBackendButton).toBeHidden();
+                    await expect
+                        .poll(() => backendProxy.connectedClients, {
+                            message: 'Expected Suite to disconnect from the custom backend',
+                        })
+                        .toBe(0);
                     await walletPage.openAccount({ symbol: 'btc' });
                     await expect(walletPage.emptyAccount).toContainTranslation(
                         'TR_ACCOUNT_IS_EMPTY_TITLE',


### PR DESCRIPTION
## Description
Extend the existing custom-backend e2e to cover the sidebar icon and reverting to the default backend (proxy disconnect + account still loads).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/custom-backend-e2e/web/](https://dev.suite.sldev.cz/suite-web/custom-backend-e2e/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=custom-backend-e2e&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=custom-backend-e2e&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T09:31:05.170Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T09:30:56.553Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->