### PR TITLE
fix(suite): do not show insufficient funds when yield tx is pending

### DIFF
--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -97,16 +97,20 @@ export const YieldDepositForm = () => {
     });
     const hasAllowanceError = allowanceStatus === 'error';
 
+    const shouldCheckWrapAmount = !isAmountInvalidDecimals && !!wrapPendingTransaction;
+    const shouldCheckApproveAmount = !isAmountInvalidDecimals && !!approvalPendingTransaction;
+    const shouldCheckDepositAmount = !isAmountInvalidDecimals && !!depositPendingTransaction;
+
     // Wrapping into the gas reserve is allowed — Max keeps it aside only while the balance covers
     // it — so recommend keeping it rather than blocking. `isAmountTooHigh` only fires above the
     // full balance, and `shouldRecommendWrapReserve` already excludes that over-balance case.
     const showWrapReserveRecommendation =
         flow.currentStep === 'wrap' &&
-        !isAmountInvalidDecimals &&
+        shouldCheckWrapAmount &&
         shouldRecommendWrapReserve(liveAmount, account.formattedBalance);
 
     const renderWrapWarning = () => {
-        if (!isAmountInvalidDecimals && isAmountTooHigh) {
+        if (shouldCheckWrapAmount && isAmountTooHigh) {
             return <YieldActionStepWarning isInsufficientFunds />;
         }
 
@@ -374,10 +378,8 @@ export const YieldDepositForm = () => {
                                         approvalAction={approvalAction}
                                         canRevokeAllowance={canRevokeAllowance}
                                         warning={
-                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                                <YieldActionStepWarning
-                                                    isApproveOverBalance={isAmountTooHigh}
-                                                />
+                                            shouldCheckApproveAmount && isAmountTooHigh ? (
+                                                <YieldActionStepWarning isApproveOverBalance />
                                             ) : undefined
                                         }
                                         isDisabled={
@@ -427,7 +429,7 @@ export const YieldDepositForm = () => {
                                             />
                                         }
                                         warning={
-                                            !isAmountInvalidDecimals ? (
+                                            shouldCheckDepositAmount ? (
                                                 <YieldActionStepWarning
                                                     isInsufficientFunds={isAmountTooHigh}
                                                     isApprovalInsufficient={isApprovalInsufficient}

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -95,6 +95,8 @@ export const UnwrapNativeToken = ({
     const isAmountTooHigh = amount.gt(tokenBalance);
     const isAmountValid = amount.gt(0) && !isAmountTooHigh && methods.formState.isValid;
 
+    const shouldCheckUnwrapAmount = !!broadcast;
+
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
 
     const baseCurrency = useSelector(selectBaseCurrency);
@@ -234,7 +236,7 @@ export const UnwrapNativeToken = ({
                         isSubmitting={unwrapMutation.isPending}
                         isSubmitDisabled={!isAmountValid || isDisabled}
                         warning={
-                            isAmountTooHigh ? (
+                            shouldCheckUnwrapAmount && isAmountTooHigh ? (
                                 <YieldActionStepWarning isInsufficientFunds />
                             ) : undefined
                         }

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -86,6 +86,9 @@ export const YieldWithdrawForm = () => {
         isWrappedNativeVault: flow.isWrappedNativeVault,
     });
 
+    const shouldCheckWithdrawAmount = !isAmountInvalidDecimals && !!withdrawPendingTransaction;
+    const shouldCheckUnwrapAmount = !isAmountInvalidDecimals && !!unwrapPendingTransaction;
+
     const handleOnWithdraw = () => {
         const apyBreakdown = getApyBreakdown(vault.rewardRate?.components);
         analytics.report({
@@ -153,7 +156,7 @@ export const YieldWithdrawForm = () => {
     // Fire once per form mount when the user first hits the insufficient-funds banner
     // (no actionable button on this banner, so impression is the only signal available).
     const hasFiredInsufficientFundsRef = useRef(false);
-    const showsInsufficientFunds = !isAmountInvalidDecimals && isAmountTooHigh;
+    const showsInsufficientFunds = shouldCheckWithdrawAmount && isAmountTooHigh;
 
     useEffect(() => {
         if (!showsInsufficientFunds || hasFiredInsufficientFundsRef.current) {
@@ -186,8 +189,8 @@ export const YieldWithdrawForm = () => {
     };
 
     const getWithdrawWarning = () => {
-        if (!isAmountInvalidDecimals && isAmountTooHigh) {
-            return <YieldActionStepWarning isInsufficientFunds={isAmountTooHigh} />;
+        if (shouldCheckWithdrawAmount && isAmountTooHigh) {
+            return <YieldActionStepWarning isInsufficientFunds />;
         }
 
         if (isMaxWithdrawInfoVisible) {
@@ -312,7 +315,7 @@ export const YieldWithdrawForm = () => {
                                             isAmountInvalidDecimals
                                         }
                                         warning={
-                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                            shouldCheckUnwrapAmount && isAmountTooHigh ? (
                                                 <YieldActionStepWarning isInsufficientFunds />
                                             ) : undefined
                                         }

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -99,6 +99,8 @@ export const WrapNativeToken = ({ account, token, onFlowCompleteChange }: WrapNa
     const isReserveRecommended = shouldRecommendWrapReserve(amountInput, account.formattedBalance);
     const isAmountValid = amount.gt(0) && !isAmountTooHigh && methods.formState.isValid;
 
+    const shouldCheckWrapAmount = !!broadcast;
+
     useEffect(() => {
         if (pendingTxStatus !== 'failed') {
             return;
@@ -161,6 +163,10 @@ export const WrapNativeToken = ({ account, token, onFlowCompleteChange }: WrapNa
     };
 
     const renderWrapWarning = () => {
+        if (!shouldCheckWrapAmount) {
+            return null;
+        }
+
         if (isAmountTooHigh) {
             return <YieldActionStepWarning isInsufficientFunds />;
         }


### PR DESCRIPTION
## Description

When wrapping/unwrapping/depositing/withdrawing max amount, do not show `Insufficient funds` banner while the yield transaction is pending.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31880

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to yield/earn form components. Static coverage mappings for YieldDepositForm.tsx and YieldWithdrawForm.tsx are extremely broad (136 tests each), indicating transitive imports rather than direct coverage. Only the yield/withdrawal test directly exercises the changed withdrawal flow. No tests were identified for the deposit, wrap, or unwrap forms, so those changes are effectively uncovered.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/yield/withdrawal.test.ts` — This test directly exercises the yield withdrawal flow, including entering a withdrawal amount, reviewing the summary, and confirming the transaction — functionality implemented in YieldWithdrawForm.tsx.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`

_Updated: 2026-08-31T09:04:45.112Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/pending-tx-insufficient-funds/web/](https://dev.suite.sldev.cz/suite-web/fix/pending-tx-insufficient-funds/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/pending-tx-insufficient-funds&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/pending-tx-insufficient-funds&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T09:05:22.553Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T09:05:12.429Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->