### PR TITLE
feat(components): add medium form control size

### DIFF
--- a/packages/components/src/components/form/types.ts
+++ b/packages/components/src/components/form/types.ts
@@ -1,4 +1,4 @@
 import { type UISize } from '../../config/types';
 
-export const inputSizes = ['small', 'large'] as const;
+export const inputSizes = ['small', 'medium', 'large'] as const;
 export type InputSize = Extract<UISize, (typeof inputSizes)[number]>;

--- a/packages/components/src/components/form/utils.ts
+++ b/packages/components/src/components/form/utils.ts
@@ -7,6 +7,7 @@ import { commonFocusStyles } from '../../utils/utils';
 
 const heightMap: Record<InputSize, number> = {
     small: 36,
+    medium: 44,
     large: 56,
 };
 
@@ -14,6 +15,7 @@ export const mapSizeToHeight = (size: InputSize): number => heightMap[size];
 
 const paddingTopMap: Record<InputSize, SpacingValue> = {
     small: 16,
+    medium: 16,
     large: 20,
 };
 
@@ -21,6 +23,7 @@ export const mapSizeToPaddingTop = (size: InputSize): SpacingValue => paddingTop
 
 const typographyStyleMap: Record<InputSize, TypographyStyle> = {
     small: 'body-sm',
+    medium: 'body-sm',
     large: 'body-md',
 };
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerSearchHeader/AssetPickerSearchHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerSearchHeader/AssetPickerSearchHeader.tsx
@@ -4,7 +4,6 @@ import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { isNetworkIconSymbol } from '@suite-common/icons';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
-    Box,
     Button,
     type DropdownMenuItemProps,
     Icon,
@@ -20,7 +19,6 @@ import { NetworkIcon, TokenIcon } from '@trezor/product-components';
 import { zIndices } from '@trezor/theme';
 
 const DATA_TESTID_BASE = '@asset-picker/search';
-const SEARCH_HEIGHT = 44;
 
 const NetworkLabel = ({ symbol, name }: { symbol: NetworkSymbol; name: string }) => (
     <Row gap={8}>
@@ -80,43 +78,33 @@ export const AssetPickerSearchHeader = memo(function AssetPickerSearchHeaderInne
     );
 
     return (
-        <Row gap={12} alignItems="center" padding={{ horizontal: 16 }}>
-            <Box
-                flex="1"
-                minWidth={0}
-                height={SEARCH_HEIGHT}
-                borderRadius={12}
-                backgroundColor="surfaceFillRaised"
-                padding={{ horizontal: 16 }}
-            >
-                <Row height="100%" gap={16}>
+        <Row gap={12} padding={{ horizontal: 16 }}>
+            <Input
+                leftContent={
                     <Icon
                         as={MagnifyingGlassIcon}
                         intent="neutral"
                         priority="secondary"
                         size={16}
                     />
-                    <Input
-                        isClean
-                        size="small"
-                        data-testid={`${DATA_TESTID_BASE}/input`}
-                        placeholder={translationString(placeholder)}
-                        value={search}
-                        onChange={event => setSearch(event.target.value)}
-                        onClear={() => setSearch('')}
-                        width="100%"
-                        // eslint-disable-next-line jsx-a11y/no-autofocus
-                        autoFocus={autoFocus}
-                        onBlur={() => {
-                            const trimmedSearch = search.trim();
+                }
+                size="medium"
+                data-testid={`${DATA_TESTID_BASE}/input`}
+                placeholder={translationString(placeholder)}
+                value={search}
+                onChange={event => setSearch(event.target.value)}
+                onClear={() => setSearch('')}
+                width="100%"
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus={autoFocus}
+                onBlur={() => {
+                    const trimmedSearch = search.trim();
 
-                            if (trimmedSearch !== search) {
-                                setSearch(trimmedSearch);
-                            }
-                        }}
-                    />
-                </Row>
-            </Box>
+                    if (trimmedSearch !== search) {
+                        setSearch(trimmedSearch);
+                    }
+                }}
+            />
 
             <Popover
                 ref={popoverRef}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useState } from 'react';
 import { type TranslationKey } from '@suite/intl';
 import { type TradingAssetOption } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Column } from '@trezor/components';
 
 import { AssetRowAsset, AssetsModal } from 'src/components/suite/asset-picker/components';
 import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
@@ -57,23 +58,25 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
 
     return (
         <AssetsModal onClose={closeModal} heading={{ id: heading }} width={480}>
-            <AssetPickerSearchHeader
-                placeholder="TR_ASSET_PICKER_SEARCH_PLACEHOLDER"
-                search={search}
-                setSearch={setSearch}
-                networkFilter={networkSymbol}
-                setNetworkFilter={setNetworkSymbol}
-                networks={networks}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus
-            />
+            <Column gap={8}>
+                <AssetPickerSearchHeader
+                    placeholder="TR_ASSET_PICKER_SEARCH_PLACEHOLDER"
+                    search={search}
+                    setSearch={setSearch}
+                    networkFilter={networkSymbol}
+                    setNetworkFilter={setNetworkSymbol}
+                    networks={networks}
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
+                />
 
-            <AssetListWrapper
-                renderItem={renderItem}
-                listItems={listItems}
-                getItemHeight={getItemHeight}
-                resetScrollTrigger={`${networkSymbol}${throttledSearch}${listItems.length}`}
-            />
+                <AssetListWrapper
+                    renderItem={renderItem}
+                    listItems={listItems}
+                    getItemHeight={getItemHeight}
+                    resetScrollTrigger={`${networkSymbol}${throttledSearch}${listItems.length}`}
+                />
+            </Column>
         </AssetsModal>
     );
 });

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useState } from 'react';
 
 import { type TranslationKey } from '@suite/intl';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Column } from '@trezor/components';
 
 import {
     AssetGroupLabel,
@@ -144,23 +145,25 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
 
     return (
         <AssetsModal onClose={closeModal} heading={{ id: heading }} width={MODAL_WIDTH}>
-            <AssetPickerSearchHeader
-                placeholder="TR_ASSET_PICKER_SEARCH_PLACEHOLDER"
-                search={search}
-                setSearch={setSearch}
-                networkFilter={networkFilter}
-                setNetworkFilter={setNetworkFilter}
-                networks={networks}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus
-            />
+            <Column gap={16}>
+                <AssetPickerSearchHeader
+                    placeholder="TR_ASSET_PICKER_SEARCH_PLACEHOLDER"
+                    search={search}
+                    setSearch={setSearch}
+                    networkFilter={networkFilter}
+                    setNetworkFilter={setNetworkFilter}
+                    networks={networks}
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
+                />
 
-            <AssetListWrapper
-                listItems={listItems}
-                renderItem={renderItem}
-                getItemHeight={getAssetPickerItemHeight}
-                resetScrollTrigger={`${networkFilter}${search}${listItems.length}`}
-            />
+                <AssetListWrapper
+                    listItems={listItems}
+                    renderItem={renderItem}
+                    getItemHeight={getAssetPickerItemHeight}
+                    resetScrollTrigger={`${networkFilter}${search}${listItems.length}`}
+                />
+            </Column>
         </AssetsModal>
     );
 });


### PR DESCRIPTION
## Description

- Add the medium size option to shared Input and Select form controls with a 44 px height.
- Replace the custom trading asset-picker search shell with the shared medium Input.
- Adjust spacing between the search header and asset lists in the buy and sell pickers.

## Notes for QA

- Verify the medium Input and Select variants in the components Storybook.
- Verify search input appearance, typing, clearing, and network filtering in both You buy and You sell asset pickers.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31837

## Screenshots:

See the linked issue for the current and desired designs.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31837-medium-input-size/web/](https://dev.suite.sldev.cz/suite-web/fix/31837-medium-input-size/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31837-medium-input-size&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31837-medium-input-size&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T09:33:22.199Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T09:33:13.588Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the trading asset picker UI (search header and buy/sell modals) plus supporting form utilities/types. Highest regression risk is to asset search, network filtering, and asset selection in buy/sell/swap trading flows. The recommended strategy is to run the targeted asset picker tests first, then a smaller set of broader trading regressions that exercise the picker end-to-end in navigation and live-swap contexts.

<details><summary><b>Changed files (5)</b></summary>

- `packages/components/src/components/form/types.ts`
- `packages/components/src/components/form/utils.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerSearchHeader/AssetPickerSearchHeader.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test explicitly exercises the buy-side asset picker with search and network filtering to select Ethereum. The changed AssetPickerSearchHeader and buy AssetPickerModal are the exact components under test, so a regression in asset search/selection would be caught here.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — The test selects a specific Solana token (JUP) through the asset picker using network and search filters. It directly relies on the AssetPickerSearchHeader and buy AssetPickerModal behavior, making it a precise regression detector for the changed picker UI.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test repeatedly selects sell and buy assets in the swap form via the asset picker, including switching between tokens on different networks. Both the sell and buy AssetPickerModal variants and the search header are exercised.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — The live swap flow fills the swap form and selects sell/buy assets including a cross-chain token (SOL to USDC on Base). It runs the asset picker end-to-end with real backends, providing broader coverage of the changed picker components in a realistic path.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates into buy/sell/swap forms from dashboard assets, account trade sections, global header, tokens, and sidebar. Although it focuses on routing, many entry points pre-select or interact with the trading asset picker context, so picker regressions could break these transitions.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — The sell form uses the sell AssetPickerModal infrastructure and exercises amount input validation, currency switching, and fee handling. Changes to the shared form utilities or sell-side picker could affect input behavior here.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test selects a token on a disabled network (XLM) during a swap and enables the network from the picker/selector. It exercises the asset picker in an edge case involving network enablement, which could be affected by changes to the picker modal logic.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/components/src/components/form/types.ts`

_Updated: 2026-08-31T09:34:46.148Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->