### PR TITLE
[CI clone] Unblock Cardano delegation for first-time stakers (#31748)

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -1,0 +1,93 @@
+import { type AdaPools } from '@suite-common/earn-staking-api';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
+import TrezorConnect, { PROTO } from '@trezor/connect';
+
+import { prepareTxPlan } from './stakeFormCardanoActions';
+
+jest.mock('@trezor/connect', () => {
+    const actual = jest.requireActual('@trezor/connect');
+
+    return {
+        ...actual,
+        __esModule: true,
+        default: {
+            ...actual.default,
+            cardanoComposeTransaction: jest.fn(),
+        },
+    };
+});
+
+const cardanoComposeTransactionMock = TrezorConnect.cardanoComposeTransaction as jest.Mock;
+
+const CHANGE_ADDRESS = {
+    address: 'addr1change',
+    path: "m/1852'/1815'/0'/1/0",
+    transfers: 0,
+    balance: '0',
+    sent: '0',
+    received: '0',
+};
+
+const cardanoPools: AdaPools['pools'] = [];
+
+const mockNeverStakedAccount = (): Account =>
+    mockWalletAccount(
+        {
+            symbol: asNetworkSymbol('ada'),
+            addresses: { change: [CHANGE_ADDRESS], used: [], unused: [] },
+            utxo: [],
+        },
+        {
+            ...networkSpecificDefaultCardano,
+            misc: {
+                staking: { address: '', isActive: false, rewards: '', poolId: null, drep: null },
+            },
+        },
+    );
+
+const mockComposeSuccess = () => {
+    cardanoComposeTransactionMock.mockResolvedValue({
+        success: true,
+        payload: [{ type: 'final', fee: '174301', deposit: '2000000' }],
+    });
+};
+
+describe('prepareTxPlan', () => {
+    beforeEach(() => {
+        cardanoComposeTransactionMock.mockReset();
+    });
+
+    it('composes a delegation for an account that has no staking address and no rewards yet', async () => {
+        mockComposeSuccess();
+
+        const result = await prepareTxPlan({
+            account: mockNeverStakedAccount(),
+            action: 'delegate',
+            cardanoPools,
+        });
+
+        expect(result?.txPlan).toEqual({ type: 'final', fee: '174301', deposit: '2000000' });
+        expect(cardanoComposeTransactionMock).toHaveBeenCalledTimes(1);
+        expect(cardanoComposeTransactionMock.mock.calls[0][0].certificates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: PROTO.CardanoCertificateType.STAKE_REGISTRATION }),
+                expect.objectContaining({ type: PROTO.CardanoCertificateType.STAKE_DELEGATION }),
+            ]),
+        );
+    });
+
+    it('does not compose a withdrawal when there is nothing to withdraw', async () => {
+        mockComposeSuccess();
+
+        const result = await prepareTxPlan({
+            account: mockNeverStakedAccount(),
+            action: 'withdrawal',
+            cardanoPools,
+        });
+
+        expect(result).toBeNull();
+        expect(cardanoComposeTransactionMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -100,12 +100,19 @@ const calculateTransaction = (
     );
 };
 
-export const prepareTxPlan = async (
-    account: Account,
-    action: CardanoAction,
-    cardanoPools: AdaPools['pools'],
-    votingDelegation?: VotingDelegationOption,
-) => {
+type PrepareTxPlanParams = {
+    account: Account;
+    action: CardanoAction;
+    cardanoPools: AdaPools['pools'];
+    votingDelegation?: VotingDelegationOption;
+};
+
+export const prepareTxPlan = async ({
+    account,
+    action,
+    cardanoPools,
+    votingDelegation,
+}: PrepareTxPlanParams) => {
     if (account?.networkType !== 'cardano') return;
 
     const changeAddress = getUnusedChangeAddress(account);
@@ -206,19 +213,19 @@ const getTransactionData = (
     const { account } = selectedAccount;
 
     if (stakeType === 'stake') {
-        return prepareTxPlan(account, 'delegate', cardanoPools, votingDelegation);
+        return prepareTxPlan({ account, action: 'delegate', cardanoPools, votingDelegation });
     }
 
     if (stakeType === 'unstake') {
-        return prepareTxPlan(account, 'deregister', cardanoPools, votingDelegation);
+        return prepareTxPlan({ account, action: 'deregister', cardanoPools, votingDelegation });
     }
 
     if (stakeType === 'claim') {
-        return prepareTxPlan(account, 'withdrawal', cardanoPools, votingDelegation);
+        return prepareTxPlan({ account, action: 'withdrawal', cardanoPools, votingDelegation });
     }
 
     if (stakeType === 'change-delegate') {
-        return prepareTxPlan(account, 'voteDelegate', cardanoPools, votingDelegation);
+        return prepareTxPlan({ account, action: 'voteDelegate', cardanoPools, votingDelegation });
     }
 };
 

--- a/packages/suite/src/hooks/earn/useCardanoStaking.test.tsx
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.test.tsx
@@ -1,0 +1,115 @@
+import { act } from '@testing-library/react';
+
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { stakeInitialState } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
+import TrezorConnect from '@trezor/connect';
+
+import { useCardanoStaking } from './useCardanoStaking';
+
+jest.mock('@trezor/connect', () => {
+    const actual = jest.requireActual('@trezor/connect');
+
+    return {
+        ...actual,
+        __esModule: true,
+        default: {
+            ...actual.default,
+            cardanoComposeTransaction: jest.fn(),
+        },
+    };
+});
+
+const cardanoComposeTransactionMock = TrezorConnect.cardanoComposeTransaction as jest.Mock;
+
+const CHANGE_ADDRESS = {
+    address: 'addr1change',
+    path: "m/1852'/1815'/0'/1/0",
+    transfers: 0,
+    balance: '0',
+    sent: '0',
+    received: '0',
+};
+
+const mockNeverStakedAccount = (): Account =>
+    mockWalletAccount(
+        {
+            symbol: asNetworkSymbol('ada'),
+            availableBalance: '10000000',
+            addresses: { change: [CHANGE_ADDRESS], used: [], unused: [] },
+            utxo: [],
+        },
+        {
+            ...networkSpecificDefaultCardano,
+            misc: {
+                staking: { address: '', isActive: false, rewards: '', poolId: null, drep: null },
+            },
+        },
+    );
+
+const renderCardanoStaking = (account: Account) => {
+    const store = configureMockStore({
+        extra: undefined,
+        preloadedState: {
+            wallet: {
+                selectedAccount: { account },
+                stake: stakeInitialState,
+                transactions: { transactions: {} },
+            },
+        },
+    });
+
+    return renderHookWithStoreProvider(() => useCardanoStaking(), { store });
+};
+
+describe('useCardanoStaking', () => {
+    beforeEach(() => {
+        cardanoComposeTransactionMock.mockReset();
+    });
+
+    it('makes delegation available to an account that has never staked', async () => {
+        cardanoComposeTransactionMock.mockResolvedValue({
+            success: true,
+            payload: [{ type: 'final', fee: '174301', deposit: '2000000' }],
+        });
+
+        const { result } = renderCardanoStaking(mockNeverStakedAccount());
+
+        expect(result.current.delegatingAvailable.status).toBe(false);
+
+        await act(() => result.current.calculateFeeAndDeposit('delegate'));
+
+        expect(result.current.delegatingAvailable.status).toBe(true);
+        expect(result.current.isStakingDisabled).toBe(false);
+        expect(result.current.fee).toBe('174301');
+        expect(result.current.deposit).toBe('2000000');
+    });
+
+    it('keeps staking unavailable when the composed delegation is not final', async () => {
+        cardanoComposeTransactionMock.mockResolvedValue({
+            success: true,
+            payload: [{ type: 'nonfinal', fee: '174301', deposit: '2000000' }],
+        });
+
+        const { result } = renderCardanoStaking(mockNeverStakedAccount());
+
+        await act(() => result.current.calculateFeeAndDeposit('delegate'));
+
+        expect(result.current.delegatingAvailable).toEqual({
+            status: false,
+            reason: 'TX_NOT_FINAL',
+        });
+        expect(result.current.isStakingDisabled).toBe(true);
+    });
+
+    it('does not make withdrawing available when there is nothing to withdraw', async () => {
+        const { result } = renderCardanoStaking(mockNeverStakedAccount());
+
+        await act(() => result.current.calculateFeeAndDeposit('withdrawal'));
+
+        expect(result.current.withdrawingAvailable.status).toBe(false);
+        expect(cardanoComposeTransactionMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -1,22 +1,17 @@
 import { useCallback, useState } from 'react';
 
-import { hasPendingStakeTypeTransaction, selectCardanoPoolsInfo } from '@suite-common/wallet-core';
+import {
+    hasPendingStakeTypeTransaction,
+    selectCardanoPoolsInfo,
+    selectVotingDelegationOption,
+} from '@suite-common/wallet-core';
 import {
     type ActionAvailability,
     type CardanoAction,
     type CardanoStaking,
 } from '@suite-common/wallet-types';
-import {
-    getAddressParameters,
-    getCardanoAccountPoolId,
-    getDelegationCertificates,
-    getStakingPath,
-    getUnusedChangeAddress,
-    isTestnet,
-    selectBestCardanoPool,
-} from '@suite-common/wallet-utils';
-import trezorConnect, { type CardanoCertificate } from '@trezor/connect';
 
+import { prepareTxPlan } from 'src/actions/wallet/stake/stakeFormCardanoActions';
 import { useSelector } from 'src/hooks/suite';
 
 export const useCardanoStaking = (): CardanoStaking => {
@@ -25,6 +20,7 @@ export const useCardanoStaking = (): CardanoStaking => {
     const isCardano = account?.networkType === 'cardano';
 
     const cardanoPools = useSelector(selectCardanoPoolsInfo);
+    const votingDelegation = useSelector(selectVotingDelegationOption);
     const hasPendingTx = useSelector(state =>
         account ? hasPendingStakeTypeTransaction(state, account.key) : false,
     );
@@ -43,88 +39,26 @@ export const useCardanoStaking = (): CardanoStaking => {
         status: false,
     });
 
-    const {
-        rewards: rewardsAmount,
-        address: stakeAddress,
-        isActive: isStakingActive,
-    } = isCardano ? account.misc.staking : {};
+    const { rewards: rewardsAmount, isActive: isStakingActive } = isCardano
+        ? account.misc.staking
+        : {};
 
     const isStakingDisabled =
         (account?.availableBalance === '0' || !delegatingAvailable.status || hasPendingTx) &&
         !loading;
 
-    const prepareTxPlan = useCallback(
+    const calculateFeeAndDeposit = useCallback(
         async (action: CardanoAction) => {
             if (!account) return;
 
-            const changeAddress = getUnusedChangeAddress(account);
-            const stakingPath = getStakingPath(account);
-
-            if (
-                !changeAddress ||
-                !account.utxo ||
-                !account.addresses ||
-                !rewardsAmount ||
-                !stakeAddress
-            )
-                return null;
-
-            const addressParameters = getAddressParameters(account, changeAddress.path);
-
-            const selectedPool = selectBestCardanoPool(
-                cardanoPools,
-                getCardanoAccountPoolId(account),
-            );
-
-            let certificates: CardanoCertificate[] = [];
-
-            if (action === 'delegate') {
-                if (!selectedPool) {
-                    return null;
-                }
-
-                certificates = getDelegationCertificates(
-                    stakingPath,
-                    selectedPool.hex,
-                    !isStakingActive,
-                );
-            }
-
-            const withdrawals =
-                action === 'withdrawal'
-                    ? [
-                          {
-                              amount: rewardsAmount,
-                              path: stakingPath,
-                              stakeAddress,
-                          },
-                      ]
-                    : [];
-
-            const response = await trezorConnect.cardanoComposeTransaction({
-                account: {
-                    descriptor: account.descriptor,
-                    utxo: account.utxo,
-                },
-                certificates,
-                withdrawals,
-                changeAddress,
-                addressParameters,
-                testnet: isTestnet(account.symbol),
-            });
-
-            if (!response.success) throw new Error(response.error.message);
-
-            return { txPlan: response.payload[0], certificates, withdrawals };
-        },
-        [account, isStakingActive, rewardsAmount, stakeAddress, cardanoPools],
-    );
-
-    const calculateFeeAndDeposit = useCallback(
-        async (action: CardanoAction) => {
             setLoading(true);
             try {
-                const composeRes = await prepareTxPlan(action);
+                const composeRes = await prepareTxPlan({
+                    account,
+                    action,
+                    cardanoPools,
+                    votingDelegation,
+                });
                 if (composeRes?.txPlan) {
                     if (composeRes.txPlan.type === 'error') {
                         throw new Error(composeRes.txPlan.error);
@@ -157,7 +91,7 @@ export const useCardanoStaking = (): CardanoStaking => {
 
             setLoading(false);
         },
-        [prepareTxPlan],
+        [account, cardanoPools, votingDelegation],
     );
 
     // TODO: improve this hook for non-cardano accounts


### PR DESCRIPTION
## Description

**CI clone of #31748** — opened only so the pipeline can run. The original PR comes from a fork (`everstake/trezor-suite`) whose workflows are not authorized to execute here.

- Original PR: https://github.com/trezor/trezor-suite/pull/31748
- Original author: @yasiuram (commit authorship is preserved — this branch is the exact same commit, `33d952bcbb`)
- Resolves issue: https://github.com/trezor/trezor-suite/issues/30030

Review discussion belongs on #31748.

## What the change does

`useCardanoStaking` composed its own tx plan and bailed out when the account had no staking address or rewards, permanently disabling the Stake button for first-time stakers. It now reuses the shared `prepareTxPlan`, which applies that guard only to withdrawals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly focused on Cardano staking logic (Redux actions and a React hook). The static coverage mapping lists 136 tests per file, which strongly suggests these files are pulled in through broad shared imports rather than being directly exercised by most tests. The highest-confidence E2E coverage comes from the dedicated ADA staking tests (stake, unstake, claim), with the ADA staking analytics navigation test providing additional reachability coverage. No other tests in the mapping have specific Cardano staking behavior that would be affected.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts`
- `packages/suite/src/hooks/earn/useCardanoStaking.test.tsx`
- `packages/suite/src/hooks/earn/useCardanoStaking.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test directly exercises the Cardano staking rewards claim flow end-to-end, including reward calculations, transaction signing, and balance updates. Changes to stakeFormCardanoActions or useCardanoStaking could affect the claim transaction composition or staking state displayed in the UI.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test covers the full Cardano staking deposit flow, including stake key registration, delegation, fee display, and confirmation. The changed Cardano staking actions and hook are directly in the code path that builds and submits the staking transaction.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test validates Cardano unstaking and deposit reclamation, which relies on the same staking actions and hook infrastructure as staking. A regression in transaction composition or staking account state would be visible here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to ADA staking entry points from the account menu and dashboard assets. While it primarily asserts analytics events, it verifies that ADA staking routes remain reachable and functional after changes to Cardano staking code.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/hooks/earn/useCardanoStaking.test.tsx`

_Updated: 2026-08-31T11:03:09.175Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-delegate-availability-gate/web/](https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-delegate-availability-gate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci-clone/cardano-delegate-availability-gate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci-clone/cardano-delegate-availability-gate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:05:44.308Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:05:48.531Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->