### PR TITLE
[CI clone] Keep the account's current Cardano vote delegation (#31845)

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -6,6 +6,7 @@ import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/
 import TrezorConnect, { PROTO } from '@trezor/connect';
 
 import { prepareTxPlan } from './stakeFormCardanoActions';
+import { VotingDelegationOption } from '@suite-common/wallet-core';
 
 jest.mock('@trezor/connect', () => {
     const actual = jest.requireActual('@trezor/connect');
@@ -142,6 +143,67 @@ describe('prepareTxPlan', () => {
 
         expect(result).toBeNull();
         expect(cardanoComposeTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('composes no vote delegation certificate when the current delegation is kept, so a predefined DRep survives a pool migration', async () => {
+        const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
+
+        const certificateTypes = getCertificateTypes(
+            await migratePool(account, { type: 'current' }),
+        );
+
+        expect(certificateTypes).not.toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
+        expect(certificateTypes).toContain(PROTO.CardanoCertificateType.STAKE_DELEGATION);
+    });
+
+    it('composes a vote delegation certificate for the Everstake option', async () => {
+        const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
+
+        const certificateTypes = getCertificateTypes(
+            await migratePool(account, { type: 'everstake' }),
+        );
+
+        expect(certificateTypes).toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
+    });
+
+    it('composes a vote delegation certificate for an unregistered account, which has no live delegation to keep', async () => {
+        const account = createCardanoAccount({
+            drepId: PREDEFINED_DREP_ID,
+            isStakingActive: false,
+        });
+
+        const certificateTypes = getCertificateTypes(
+            await migratePool(account, { type: 'current' }),
+        );
+
+        expect(certificateTypes).toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
+    });
+
+    it('builds nothing for a vote delegation that keeps the current delegation, leaving nothing to sign', async () => {
+        const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
+
+        const txData = await prepareTxPlan({
+            account,
+            action: 'voteDelegate',
+            cardanoPools: [],
+            votingDelegation: { type: 'current' },
+        });
+
+        expect(txData).toBeNull();
+        expect(TrezorConnect.cardanoComposeTransaction).not.toHaveBeenCalled();
+    });
+});
+
+describe('prepareTxPlan', () => {
+    beforeEach(() => {
+        jest.mocked(TrezorConnect.cardanoComposeTransaction).mockResolvedValue({
+            success: true,
+            payload: [{ type: 'final' }],
+        } as unknown as Awaited<ReturnType<typeof TrezorConnect.cardanoComposeTransaction>>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 
     it('composes no vote delegation certificate when the current delegation is kept, so a predefined DRep survives a pool migration', async () => {

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -1,5 +1,6 @@
 import { type AdaPools } from '@suite-common/earn-staking-api';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
+import type { VotingDelegationOption } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
 import TrezorConnect, { PROTO } from '@trezor/connect';
@@ -18,6 +19,45 @@ jest.mock('@trezor/connect', () => {
         },
     };
 });
+
+const PREDEFINED_DREP_ID = 'drep_always_abstain';
+const NON_EVERSTAKE_POOL_ID = 'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy';
+
+const createCardanoAccount = ({
+    drepId,
+    isStakingActive = true,
+}: {
+    drepId: string | null;
+    isStakingActive?: boolean;
+}): Account =>
+    ({
+        key: 'ada-account-key',
+        index: 0,
+        symbol: 'ada',
+        networkType: 'cardano',
+        descriptor: 'ada-descriptor',
+        utxo: [],
+        addresses: {
+            change: [{ address: 'addr-change', path: "m/1852'/1815'/0'/1/0", transfers: 0 }],
+            used: [],
+            unused: [],
+        },
+        misc: {
+            staking: {
+                address: 'stake-address',
+                rewards: '0',
+                isActive: isStakingActive,
+                poolId: NON_EVERSTAKE_POOL_ID,
+                drep: drepId === null ? null : { drep_id: drepId },
+            },
+        },
+    }) as unknown as Account;
+
+const migratePool = (account: Account, votingDelegation: VotingDelegationOption) =>
+    prepareTxPlan({ account, action: 'delegate', cardanoPools: [], votingDelegation });
+
+const getCertificateTypes = (txData: Awaited<ReturnType<typeof prepareTxPlan>>) =>
+    txData?.certificates.map(certificate => certificate.type);
 
 const cardanoComposeTransactionMock = TrezorConnect.cardanoComposeTransaction as jest.Mock;
 
@@ -57,6 +97,15 @@ const mockComposeSuccess = () => {
 describe('prepareTxPlan', () => {
     beforeEach(() => {
         cardanoComposeTransactionMock.mockReset();
+
+        jest.mocked(TrezorConnect.cardanoComposeTransaction).mockResolvedValue({
+            success: true,
+            payload: [{ type: 'final' }],
+        } as unknown as Awaited<ReturnType<typeof TrezorConnect.cardanoComposeTransaction>>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 
     it('composes a delegation for an account that has no staking address and no rewards yet', async () => {
@@ -72,8 +121,12 @@ describe('prepareTxPlan', () => {
         expect(cardanoComposeTransactionMock).toHaveBeenCalledTimes(1);
         expect(cardanoComposeTransactionMock.mock.calls[0][0].certificates).toEqual(
             expect.arrayContaining([
-                expect.objectContaining({ type: PROTO.CardanoCertificateType.STAKE_REGISTRATION }),
-                expect.objectContaining({ type: PROTO.CardanoCertificateType.STAKE_DELEGATION }),
+                expect.objectContaining({
+                    type: PROTO.CardanoCertificateType.STAKE_REGISTRATION,
+                }),
+                expect.objectContaining({
+                    type: PROTO.CardanoCertificateType.STAKE_DELEGATION,
+                }),
             ]),
         );
     });
@@ -89,5 +142,53 @@ describe('prepareTxPlan', () => {
 
         expect(result).toBeNull();
         expect(cardanoComposeTransactionMock).not.toHaveBeenCalled();
+    });
+
+    it('composes no vote delegation certificate when the current delegation is kept, so a predefined DRep survives a pool migration', async () => {
+        const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
+
+        const certificateTypes = getCertificateTypes(
+            await migratePool(account, { type: 'current' }),
+        );
+
+        expect(certificateTypes).not.toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
+        expect(certificateTypes).toContain(PROTO.CardanoCertificateType.STAKE_DELEGATION);
+    });
+
+    it('composes a vote delegation certificate for the Everstake option', async () => {
+        const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
+
+        const certificateTypes = getCertificateTypes(
+            await migratePool(account, { type: 'everstake' }),
+        );
+
+        expect(certificateTypes).toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
+    });
+
+    it('composes a vote delegation certificate for an unregistered account, which has no live delegation to keep', async () => {
+        const account = createCardanoAccount({
+            drepId: PREDEFINED_DREP_ID,
+            isStakingActive: false,
+        });
+
+        const certificateTypes = getCertificateTypes(
+            await migratePool(account, { type: 'current' }),
+        );
+
+        expect(certificateTypes).toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
+    });
+
+    it('builds nothing for a vote delegation that keeps the current delegation, leaving nothing to sign', async () => {
+        const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
+
+        const txData = await prepareTxPlan({
+            account,
+            action: 'voteDelegate',
+            cardanoPools: [],
+            votingDelegation: { type: 'current' },
+        });
+
+        expect(txData).toBeNull();
+        expect(TrezorConnect.cardanoComposeTransaction).not.toHaveBeenCalled();
     });
 });

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -49,6 +49,7 @@ import {
     getStakingPath,
     getUnusedChangeAddress,
     getVotingCertificates,
+    hasCardanoLiveVoteDelegation,
     isCardanoStakedWithEverstake,
     isTestnet,
     networkAmountToSmallestUnit,
@@ -148,7 +149,10 @@ export const prepareTxPlan = async ({
         );
     }
 
-    if (action === 'delegate' || action === 'voteDelegate') {
+    const isKeepingCurrentVote =
+        votingDelegation?.type === 'current' && hasCardanoLiveVoteDelegation(account);
+
+    if ((action === 'delegate' || action === 'voteDelegate') && !isKeepingCurrentVote) {
         const isVotingToAnotherDrep =
             votingDelegation?.type === 'another_drep' &&
             validateCardanoDrep(votingDelegation.drepId);
@@ -180,6 +184,10 @@ export const prepareTxPlan = async ({
                   },
               ]
             : [];
+
+    if (certificates.length === 0 && withdrawals.length === 0) {
+        return null;
+    }
 
     const response = await TrezorConnect.cardanoComposeTransaction({
         account: {

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx
@@ -1,0 +1,75 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
+import { DEFAULT_VOTING_OPTION, stakeActions, stakeInitialState } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { VotingDelegations } from './VotingDelegations';
+import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
+
+const CUSTOM_DREP_ID = 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs';
+const PREDEFINED_DREP_ID = 'drep_always_abstain';
+
+const createCardanoAccount = (drepId: string | null): Account =>
+    ({
+        key: 'ada-account-key',
+        index: 0,
+        symbol: asNetworkSymbol('ada'),
+        networkType: 'cardano',
+        misc: {
+            staking: { isActive: true, drep: drepId === null ? null : { drep_id: drepId } },
+        },
+    }) as unknown as Account;
+
+const renderVotingDelegations = (account: Account) => {
+    const store = configureMockStore({
+        extra: undefined,
+        preloadedState: {
+            ...mockInitialAppState,
+            wallet: { ...mockInitialAppState.wallet, stake: stakeInitialState },
+        },
+        serializableCheck: { ignoredActions: [] },
+    });
+
+    renderWithProviders(store, {}, <VotingDelegations account={account} />);
+
+    return store;
+};
+
+describe('VotingDelegations', () => {
+    it('keeps a custom DRep the account already votes for instead of resetting it to Everstake', () => {
+        const store = renderVotingDelegations(createCardanoAccount(CUSTOM_DREP_ID));
+
+        expect(store.getActions()).toContainEqual(
+            stakeActions.setVotingDelegationOption({ type: 'current' }),
+        );
+    });
+
+    it('keeps the Everstake DRep without re-delegating to it', () => {
+        const store = renderVotingDelegations(createCardanoAccount(CARDANO_EVERSTAKE_DREP.bech32));
+
+        expect(store.getActions()).toContainEqual(
+            stakeActions.setVotingDelegationOption({ type: 'current' }),
+        );
+    });
+
+    it('keeps a predefined DRep, which no vote delegation certificate can express', () => {
+        const store = renderVotingDelegations(createCardanoAccount(PREDEFINED_DREP_ID));
+
+        expect(store.getActions()).toContainEqual(
+            stakeActions.setVotingDelegationOption({ type: 'current' }),
+        );
+    });
+
+    it('offers Everstake to an account with no vote delegation', () => {
+        const store = renderVotingDelegations(createCardanoAccount(null));
+
+        expect(store.getActions()).toContainEqual(
+            stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION),
+        );
+    });
+});

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
-
 import { Translation } from '@suite/intl';
 import { selectVotingDelegationOption } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Card, CollapsibleBox, Row, Text } from '@trezor/components';
 import { CaretDownIcon } from '@trezor/icons';
 
+import { useSeededCardanoVotingDelegation } from 'src/hooks/earn/useCardanoAccountVotingDelegation';
 import { useSelector } from 'src/hooks/suite';
 
-import { VotingDelegationsOptions } from './VotingDelegationsOptions';
+import { VOTING_OPTION_LABELS, VotingDelegationsOptions } from './VotingDelegationsOptions';
 
 type VotingDelegationsProps = {
     account: Account;
@@ -17,7 +16,11 @@ type VotingDelegationsProps = {
 export const VotingDelegations = ({ account }: VotingDelegationsProps) => {
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
-    if (account.networkType !== 'cardano' || !selectedVotingDelegation) return null;
+    const accountVotingDelegation = useSeededCardanoVotingDelegation(account);
+
+    const isCardanoAccount = account.networkType === 'cardano';
+
+    if (!isCardanoAccount) return null;
 
     return (
         <Card>
@@ -32,20 +35,17 @@ export const VotingDelegations = ({ account }: VotingDelegationsProps) => {
                 toggleIcon={CaretDownIcon}
                 toggleLabel={
                     <Text intent="neutral" typographyStyle="body-sm-strong">
-                        <Translation
-                            id={
-                                selectedVotingDelegation.type === 'another_drep'
-                                    ? 'TR_STAKING_DELEGATE_TO_ANOTHER_DREP'
-                                    : 'TR_STAKING_DELEGATE_TO_EVERSTAKE'
-                            }
-                        />
+                        <Translation id={VOTING_OPTION_LABELS[selectedVotingDelegation.type]} />
                     </Text>
                 }
                 fillType="none"
                 paddingType="none"
                 hasDivider={false}
             >
-                <VotingDelegationsOptions networkType={account.networkType} resetOnMount />
+                <VotingDelegationsOptions
+                    networkType={account.networkType}
+                    hasKeepCurrentOption={!!accountVotingDelegation}
+                />
             </CollapsibleBox>
         </Card>
     );

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { type NetworkType } from '@suite-common/wallet-config';
 import {
-    DEFAULT_VOTING_OPTION,
     type VotingDelegationOption,
     selectVotingDelegationOption,
     stakeActions,
@@ -13,40 +12,31 @@ import { Column, Input, Radio, Text } from '@trezor/components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-const VOTING_OPTIONS: {
-    key: VotingDelegationOption['type'];
-    translationId: TranslationKey;
-}[] = [
-    { key: 'everstake', translationId: 'TR_STAKING_DELEGATE_TO_EVERSTAKE' },
-    { key: 'another_drep', translationId: 'TR_STAKING_DELEGATE_TO_ANOTHER_DREP' },
-];
+export const VOTING_OPTION_LABELS = {
+    everstake: 'TR_STAKING_DELEGATE_TO_EVERSTAKE',
+    another_drep: 'TR_STAKING_DELEGATE_TO_ANOTHER_DREP',
+    current: 'TR_STAKING_KEEP_CURRENT_DELEGATION',
+} as const satisfies Record<VotingDelegationOption['type'], TranslationKey>;
+
+const VOTING_OPTION_KEYS = ['everstake', 'another_drep'] as const;
+
+const VOTING_OPTION_KEYS_WITH_CURRENT = ['current', ...VOTING_OPTION_KEYS] as const;
 
 export interface VotingDelegationsOptionsProps {
     networkType: NetworkType;
-    initialValue?: VotingDelegationOption;
     hasTitle?: boolean;
-    resetOnMount?: boolean;
+    hasKeepCurrentOption?: boolean;
 }
 
 export const VotingDelegationsOptions = ({
     networkType,
-    initialValue = DEFAULT_VOTING_OPTION,
     hasTitle = false,
-    resetOnMount = true,
+    hasKeepCurrentOption = false,
 }: VotingDelegationsOptionsProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
     const [hasError, setHasError] = useState<boolean>(false);
-
-    // reset voting delegation option on modal open
-    useEffect(() => {
-        if (!resetOnMount) {
-            return;
-        }
-
-        dispatch(stakeActions.setVotingDelegationOption(initialValue));
-    }, [dispatch, initialValue, resetOnMount]);
 
     if (networkType !== 'cardano') return null;
 
@@ -63,6 +53,10 @@ export const VotingDelegationsOptions = ({
                     stakeActions.setVotingDelegationOption({ type: 'another_drep', drepId: '' }),
                 );
                 break;
+
+            case 'current':
+                dispatch(stakeActions.setVotingDelegationOption({ type: 'current' }));
+                break;
         }
     };
 
@@ -73,6 +67,8 @@ export const VotingDelegationsOptions = ({
         dispatch(stakeActions.setVotingDelegationOption({ type: 'another_drep', drepId: value }));
     };
 
+    const optionKeys = hasKeepCurrentOption ? VOTING_OPTION_KEYS_WITH_CURRENT : VOTING_OPTION_KEYS;
+
     return (
         <Column gap={8}>
             {hasTitle && (
@@ -81,14 +77,13 @@ export const VotingDelegationsOptions = ({
                 </Text>
             )}
             <Column gap={16} padding={8}>
-                {VOTING_OPTIONS.map(({ key, translationId }) => (
+                {optionKeys.map(key => (
                     <React.Fragment key={key}>
                         <Radio
-                            key={key}
                             isChecked={selectedVotingDelegation.type === key}
                             onChange={() => handleOptionSelect(key)}
                         >
-                            <Translation id={translationId} />
+                            <Translation id={VOTING_OPTION_LABELS[key]} />
                         </Radio>
                         {selectedVotingDelegation.type === 'another_drep' &&
                             key === 'another_drep' && (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/CurrentDelegate.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/CurrentDelegate.tsx
@@ -1,6 +1,7 @@
 import { Translation } from '@suite/intl';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
 import { type Account } from '@suite-common/wallet-types';
+import { getCardanoAccountDrepId } from '@suite-common/wallet-utils';
 import { Column, Paragraph, Text } from '@trezor/components';
 
 type CurrentDelegateProps = {
@@ -9,7 +10,7 @@ type CurrentDelegateProps = {
 export const CurrentDelegate = ({ account }: CurrentDelegateProps) => {
     if (account.networkType !== 'cardano') return null;
 
-    const currentDelegateDrepId = account.misc?.staking?.drep?.drep_id;
+    const currentDelegateDrepId = getCardanoAccountDrepId(account);
 
     const getStakeProviderLabel = () => {
         if (CARDANO_EVERSTAKE_DREP.bech32 === currentDelegateDrepId) return 'Everstake';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -7,16 +7,16 @@ import { useServices } from '@suite-common/dependency-injection';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
 import {
     DEFAULT_VOTING_OPTION,
-    type VotingDelegationOption,
     selectVotingDelegationOption,
     stakeActions,
 } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { validateCardanoDrep } from '@suite-common/wallet-utils';
+import { getCardanoAccountDrepId, validateCardanoDrep } from '@suite-common/wallet-utils';
 import { Card, Column, Modal, Tooltip } from '@trezor/components';
 
 import { VotingDelegationsOptions } from 'src/components/earn';
 import { Fees } from 'src/components/wallet/Fees/Fees';
+import { useSeededCardanoVotingDelegation } from 'src/hooks/earn/useCardanoAccountVotingDelegation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import {
@@ -48,19 +48,10 @@ export const StakeChangeDelegateModalLoaded = ({
     const { changeFeeLevel, feeInfo, composedLevels, methods, handleSubmit, signTx } =
         changeDelegateContextValues;
 
-    const currentDrepId =
-        account.networkType === 'cardano' ? account?.misc?.staking.drep?.drep_id : undefined;
+    const currentDrepId = getCardanoAccountDrepId(account);
     const isEverstake = currentDrepId === CARDANO_EVERSTAKE_DREP.bech32;
 
-    const drepIdOptionValue: undefined | VotingDelegationOption = useMemo(() => {
-        if (!currentDrepId) return;
-
-        if (isEverstake) {
-            return { type: 'everstake' };
-        }
-
-        return { type: 'another_drep', drepId: currentDrepId };
-    }, [currentDrepId, isEverstake]);
+    const drepIdOptionValue = useSeededCardanoVotingDelegation(account);
 
     const handleCancel = () => {
         dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
@@ -94,6 +85,9 @@ export const StakeChangeDelegateModalLoaded = ({
 
     const { isDisabled: isSelectionInvalid, errorType } = useMemo(() => {
         switch (selectedVotingDelegation.type) {
+            case 'current':
+                return { isDisabled: true, errorType: 'current_delegate' as const };
+
             case 'everstake': {
                 if (isEverstake) {
                     return { isDisabled: true, errorType: 'current_delegate' as const };
@@ -152,9 +146,8 @@ export const StakeChangeDelegateModalLoaded = ({
                             <CurrentDelegate account={account} />
                             <VotingDelegationsOptions
                                 networkType={account.networkType}
-                                initialValue={drepIdOptionValue}
                                 hasTitle
-                                resetOnMount
+                                hasKeepCurrentOption={!!drepIdOptionValue}
                             />
 
                             <Fees

--- a/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts
+++ b/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts
@@ -1,0 +1,147 @@
+import { renderHook } from '@testing-library/react';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
+import { stakeActions, stakeInitialState } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+
+import { renderHookWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import {
+    useCardanoAccountVotingDelegation,
+    useSeededCardanoVotingDelegation,
+} from './useCardanoAccountVotingDelegation';
+import { mockInitialAppState } from '../../../mocks/mockInitialAppState';
+
+const CUSTOM_DREP_ID = 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs';
+const PREDEFINED_DREP_ID = 'drep_always_abstain';
+
+const createCardanoAccount = (
+    drepId: string | null,
+    isStakingActive = true,
+    key = 'ada-account-key',
+): Account =>
+    ({
+        key,
+        index: 0,
+        symbol: asNetworkSymbol('ada'),
+        networkType: 'cardano',
+        misc: {
+            staking: {
+                isActive: isStakingActive,
+                drep: drepId === null ? null : { drep_id: drepId },
+            },
+        },
+    }) as unknown as Account;
+
+describe('useCardanoAccountVotingDelegation', () => {
+    it('returns undefined for an account with no vote delegation, so the options keep their own default', () => {
+        const { result } = renderHook(() =>
+            useCardanoAccountVotingDelegation(createCardanoAccount(null)),
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('keeps a custom DRep without re-delegating to it', () => {
+        const { result } = renderHook(() =>
+            useCardanoAccountVotingDelegation(createCardanoAccount(CUSTOM_DREP_ID)),
+        );
+
+        expect(result.current).toEqual({ type: 'current' });
+    });
+
+    it('keeps the Everstake DRep without re-delegating to it', () => {
+        const { result } = renderHook(() =>
+            useCardanoAccountVotingDelegation(createCardanoAccount(CARDANO_EVERSTAKE_DREP.bech32)),
+        );
+
+        expect(result.current).toEqual({ type: 'current' });
+    });
+
+    it('keeps a predefined DRep, which no vote delegation certificate can express', () => {
+        const { result } = renderHook(() =>
+            useCardanoAccountVotingDelegation(createCardanoAccount(PREDEFINED_DREP_ID)),
+        );
+
+        expect(result.current).toEqual({ type: 'current' });
+    });
+
+    it('returns undefined for an unregistered account, whose reported delegation is stale', () => {
+        const { result } = renderHook(() =>
+            useCardanoAccountVotingDelegation(createCardanoAccount(CUSTOM_DREP_ID, false)),
+        );
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined for a non-cardano account', () => {
+        const ethereumAccount = {
+            networkType: 'ethereum',
+            misc: { nonce: '0' },
+        } as unknown as Account;
+
+        const { result } = renderHook(() => useCardanoAccountVotingDelegation(ethereumAccount));
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('keeps the same reference across re-renders, so the options effect does not re-run', () => {
+        const { result, rerender } = renderHook(() =>
+            useCardanoAccountVotingDelegation(createCardanoAccount(CUSTOM_DREP_ID)),
+        );
+        const firstResult = result.current;
+
+        rerender();
+
+        expect(result.current).toBe(firstResult);
+    });
+});
+
+describe('useSeededCardanoVotingDelegation', () => {
+    const renderSeededHook = (account: Account) => {
+        const store = configureMockStore({
+            extra: undefined,
+            preloadedState: {
+                ...mockInitialAppState,
+                wallet: { ...mockInitialAppState.wallet, stake: stakeInitialState },
+            },
+            serializableCheck: { ignoredActions: [] },
+        });
+
+        const { rerender } = renderHookWithProviders(
+            store,
+            {},
+            ({ account: renderedAccount }: { account: Account }) =>
+                useSeededCardanoVotingDelegation(renderedAccount),
+            { initialProps: { account } },
+        );
+
+        return { store, rerender };
+    };
+
+    it('seeds the selection with the delegation the account already has', () => {
+        const { store } = renderSeededHook(createCardanoAccount(CUSTOM_DREP_ID));
+
+        expect(store.getActions()).toEqual([
+            stakeActions.setVotingDelegationOption({ type: 'current' }),
+        ]);
+    });
+
+    it('seeds an account only once, so a later backend update cannot overwrite a user selection', () => {
+        const { store, rerender } = renderSeededHook(createCardanoAccount(null));
+
+        rerender({ account: createCardanoAccount(CUSTOM_DREP_ID) });
+
+        expect(store.getActions()).toHaveLength(1);
+    });
+
+    it('seeds again for a different account', () => {
+        const { store, rerender } = renderSeededHook(createCardanoAccount(null));
+
+        rerender({ account: createCardanoAccount(CUSTOM_DREP_ID, true, 'other-ada-account-key') });
+
+        expect(store.getActions()).toHaveLength(2);
+    });
+});

--- a/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.ts
+++ b/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+import {
+    DEFAULT_VOTING_OPTION,
+    type VotingDelegationOption,
+    stakeActions,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { hasCardanoLiveVoteDelegation } from '@suite-common/wallet-utils';
+
+import { useDispatch } from 'src/hooks/suite';
+
+export const useCardanoAccountVotingDelegation = (
+    account: Account,
+): VotingDelegationOption | undefined => {
+    const hasLiveVoteDelegation = hasCardanoLiveVoteDelegation(account);
+
+    return useMemo(
+        () => (hasLiveVoteDelegation ? { type: 'current' } : undefined),
+        [hasLiveVoteDelegation],
+    );
+};
+
+export const useSeededCardanoVotingDelegation = (
+    account: Account,
+): VotingDelegationOption | undefined => {
+    const dispatch = useDispatch();
+    const accountVotingDelegation = useCardanoAccountVotingDelegation(account);
+    const isCardanoAccount = account.networkType === 'cardano';
+    // Seeds an initial value only: later backend updates must not overwrite the user's selection.
+    const seededAccountKey = useRef<string | undefined>(undefined);
+
+    useEffect(() => {
+        if (!isCardanoAccount || seededAccountKey.current === account.key) return;
+
+        seededAccountKey.current = account.key;
+
+        dispatch(
+            stakeActions.setVotingDelegationOption(
+                accountVotingDelegation ?? DEFAULT_VOTING_OPTION,
+            ),
+        );
+    }, [dispatch, isCardanoAccount, account.key, accountVotingDelegation]);
+
+    return accountVotingDelegation;
+};

--- a/suite-common/wallet-core/src/stake/stakeActions.ts
+++ b/suite-common/wallet-core/src/stake/stakeActions.ts
@@ -16,7 +16,7 @@ type RequestPushTransactionPayload = {
 };
 
 export type VotingDelegationOption =
-    { type: 'everstake' } | { type: 'another_drep'; drepId: string };
+    { type: 'everstake' } | { type: 'another_drep'; drepId: string } | { type: 'current' };
 
 const setVotingDelegationOption = createAction(
     `${STAKE_MODULE_PREFIX}/setVotingDelegationOption`,

--- a/suite-common/wallet-utils/src/__fixtures__/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/cardanoStakingUtils.ts
@@ -2,6 +2,7 @@ import { bech32 } from '@scure/base';
 
 import { type AdaPools } from '@suite-common/earn-staking-api';
 import {
+    CARDANO_EVERSTAKE_DREP,
     CARDANO_EVERSTAKE_STAKING_POOL,
     EVERSTAKE_POOLS,
     FIVE_BINARIES_POOLS,
@@ -200,6 +201,34 @@ export const isCardanoStakedWithFiveBinaries = [
     {
         description: 'account without delegation',
         account: cardanoAccount(undefined),
+        result: false,
+    },
+];
+
+const cardanoAccountWithDrep = (drep: { drep_id: string } | null, isActive = true) => ({
+    networkType: 'cardano',
+    misc: { staking: { poolId: everstakePool, drep, isActive } },
+});
+
+export const hasCardanoLiveVoteDelegation = [
+    {
+        description: 'registered account voting for a DRep',
+        account: cardanoAccountWithDrep({ drep_id: CARDANO_EVERSTAKE_DREP.bech32 }),
+        result: true,
+    },
+    {
+        description: 'registered account with no vote delegation',
+        account: cardanoAccountWithDrep(null),
+        result: false,
+    },
+    {
+        description: 'unregistered account, whose reported DRep is stale',
+        account: cardanoAccountWithDrep({ drep_id: CARDANO_EVERSTAKE_DREP.bech32 }, false),
+        result: false,
+    },
+    {
+        description: 'non-cardano account',
+        account: { networkType: 'ethereum' },
         result: false,
     },
 ];

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.test.ts
@@ -4,6 +4,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import * as fixtures from './__fixtures__/cardanoStakingUtils';
 import {
+    hasCardanoLiveVoteDelegation,
     isCardanoStakedOutsideEverstake,
     isCardanoStakedWithEverstake,
     isCardanoStakedWithFiveBinaries,
@@ -50,6 +51,12 @@ describe('cardano staking utils', () => {
     fixtures.isCardanoStakedWithFiveBinaries.forEach(f => {
         it(`isCardanoStakedWithFiveBinaries: ${f.description}`, () => {
             expect(isCardanoStakedWithFiveBinaries(f.account as Account)).toBe(f.result);
+        });
+    });
+
+    fixtures.hasCardanoLiveVoteDelegation.forEach(f => {
+        it(`hasCardanoLiveVoteDelegation: ${f.description}`, () => {
+            expect(hasCardanoLiveVoteDelegation(f.account as Account)).toBe(f.result);
         });
     });
 });

--- a/suite-common/wallet-utils/src/cardanoStakingUtils.ts
+++ b/suite-common/wallet-utils/src/cardanoStakingUtils.ts
@@ -54,6 +54,17 @@ export const getCardanoAccountPoolId = (account?: Account) => {
     return poolId || null;
 };
 
+export const getCardanoAccountDrepId = (account?: Account) => {
+    if (account?.networkType !== 'cardano') return null;
+
+    const drepId = account.misc?.staking?.drep?.drep_id;
+
+    return drepId || null;
+};
+
+export const hasCardanoLiveVoteDelegation = (account?: Account) =>
+    !!isCardanoStakingActive(account ?? null) && !!getCardanoAccountDrepId(account);
+
 export const isCardanoStakedWithEverstake = (
     account: Account,
     cardanoStakingPools?: AdaPools['pools'],

--- a/suite/analytics/src/events/stakingUpdateProviderEvent.ts
+++ b/suite/analytics/src/events/stakingUpdateProviderEvent.ts
@@ -58,9 +58,13 @@ export const stakingUpdateProviderEvent: EventDef<Attributes, EventType.StakingU
                     version: '26.7.0',
                     notes: 'for Tron, carries the Super Representative address of a Suite-offered representative, or `custom` for a user-entered one',
                 },
+                {
+                    version: '26.9.0',
+                    notes: 'added `current` for Cardano, reported when the delegation already registered on-chain is kept',
+                },
             ],
             description:
-                'Voting delegation provider: `everstake` for Everstake provider, `another_drep` for other delegation providers; for Tron, the Super Representative address or `custom`',
+                'Voting delegation provider: `everstake` for Everstake provider, `another_drep` for other delegation providers, `current` to keep the delegation the account is already registered with (Cardano only, covers the predefined DReps that have no bech32 form); for Tron, the Super Representative address or `custom`',
         },
     },
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10775,6 +10775,10 @@ export const messages = defineMessages({
         id: 'TR_STAKING_DELEGATE_TO_ANOTHER_DREP',
         defaultMessage: 'Delegate to another DRep',
     },
+    TR_STAKING_KEEP_CURRENT_DELEGATION: {
+        id: 'TR_STAKING_KEEP_CURRENT_DELEGATION',
+        defaultMessage: 'Keep your current delegation',
+    },
     TR_STAKING_DELEGATION_INFO_TEXT: {
         id: 'TR_STAKING_DELEGATION_INFO_TEXT',
         defaultMessage:


### PR DESCRIPTION
## Description

**CI clone of #31845** — opened only so the pipeline can run. The original PR comes from a fork (`everstake/trezor-suite`) whose workflows are not authorized to execute here.

- Original PR: https://github.com/trezor/trezor-suite/pull/31845
- Original author: @myasiura-stack (commit authorship is preserved — this branch is the exact same three commits, `77172baed7`, `133913e272`, `438e22e304`)
- Resolves issue: https://github.com/trezor/trezor-suite/issues/30035

Review discussion belongs on #31845.

## What the change does

Delegating or migrating a Cardano account to Everstake silently re-delegated the account's voting rights: the voting options ignored the account's on-chain DRep and reset to "Delegate to Everstake" on every mount. The options now seed from the live DRep and preselect a new "Keep your current delegation" option, and `prepareTxPlan` omits the `VOTE_DELEGATION` certificate when that option is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on Cardano staking, especially voting delegation and stake delegate management. The highest regression risk lies in the ADA initial stake flow, which confirms vote delegation on the device. Running the ADA stake test is essential; the ADA unstake and claim tests provide sensible regression coverage for shared Cardano staking infrastructure without broadening scope unnecessarily.

<details><summary><b>Changed files (15)</b></summary>

- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/CurrentDelegate.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx`
- `packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts`
- `packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.ts`
- `suite-common/wallet-core/src/stake/stakeActions.ts`
- `suite-common/wallet-utils/src/__fixtures__/cardanoStakingUtils.ts`
- `suite-common/wallet-utils/src/cardanoStakingUtils.test.ts`
- `suite-common/wallet-utils/src/cardanoStakingUtils.ts`
- `suite/analytics/src/events/stakingUpdateProviderEvent.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test directly exercises the Cardano staking flow and asserts device prompts for vote delegation and stake delegation, which are the exact areas modified by the changed VotingDelegations components, stakeFormCardanoActions, useCardanoAccountVotingDelegation hook, and cardanoStakingUtils.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test operates on the Cardano staking account state and shares the same staking infrastructure (stakeActions, cardanoStakingUtils) and translation keys; it is a good regression check even though it does not directly exercise voting delegation.
- `suite/e2e/tests/staking/ada/claim.test.ts` — This test interacts with staked Cardano account data and reward handling, relying on Cardano staking utilities and messages that were changed; it helps catch regressions in shared Cardano staking state rendering.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx`
- `packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts`
- `suite-common/wallet-utils/src/__fixtures__/cardanoStakingUtils.ts`
- `suite-common/wallet-utils/src/cardanoStakingUtils.test.ts`
- `suite/analytics/src/events/stakingUpdateProviderEvent.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-08-31T12:56:32.873Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-keep-current-vote-delegation/web/](https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-keep-current-vote-delegation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci-clone/cardano-keep-current-vote-delegation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci-clone/cardano-keep-current-vote-delegation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci-clone/cardano-keep-current-vote-delegation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T12:57:21.411Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T12:57:45.676Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->