### PR TITLE
[CI clone] Scope Cardano voting delegation to its account and reset after signing (#31787)

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -1,0 +1,128 @@
+import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
+import { type AccountVotingDelegation } from '@suite-common/wallet-core';
+import { type Account, type CardanoAction, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
+import { type CardanoCertificate, PROTO } from '@trezor/connect';
+
+import { prepareTxPlan } from './stakeFormCardanoActions';
+
+type CardanoComposeParams = { certificates: CardanoCertificate[] };
+
+const mockCardanoComposeTransaction = jest.fn((_params: CardanoComposeParams) =>
+    Promise.resolve({ success: true, payload: [{ type: 'final' }] }),
+);
+
+jest.mock('@trezor/connect', () => ({
+    ...jest.requireActual('@trezor/connect'),
+    __esModule: true,
+    default: {
+        cardanoComposeTransaction: (params: CardanoComposeParams) =>
+            mockCardanoComposeTransaction(params),
+    },
+}));
+
+// A valid CIP-105 dRep id that is not Everstake's, so the certificate says which one was honored.
+const ANOTHER_DREP = {
+    bech32: 'drep14w46h2at4w46h2at4w46h2at4w46h2at4w46h2at4w46kxzm6ac',
+    hex: 'abababababababababababababababababababababababababababab',
+};
+
+const EVERSTAKE_VOTE_DELEGATION = {
+    keyHash: CARDANO_EVERSTAKE_DREP.hex,
+    scriptHash: undefined,
+    type: PROTO.CardanoDRepType.KEY_HASH,
+};
+
+const createCardanoAccount = (descriptor: string): Account =>
+    mockWalletAccount(
+        {
+            symbol: 'ada',
+            descriptor: asAccountDescriptor(descriptor),
+            utxo: [],
+            addresses: {
+                change: [
+                    {
+                        address: 'addr1_change',
+                        path: "m/1852'/1815'/0'/1/0",
+                        transfers: 0,
+                        balance: '0',
+                        sent: '0',
+                        received: '0',
+                    },
+                ],
+                used: [],
+                unused: [],
+            },
+        },
+        // mockWalletAccount still maps 'ada' to the bitcoin defaults.
+        networkSpecificDefaultCardano,
+    );
+
+const account = createCardanoAccount('adaAccountA');
+const otherAccount = createCardanoAccount('adaAccountB');
+
+const getSignedDrep = async (action: CardanoAction, votingDelegation?: AccountVotingDelegation) => {
+    await prepareTxPlan(account, action, [], votingDelegation);
+
+    const params = mockCardanoComposeTransaction.mock.calls.at(-1)?.[0];
+
+    return params?.certificates?.find(
+        certificate => certificate.type === PROTO.CardanoCertificateType.VOTE_DELEGATION,
+    )?.dRep;
+};
+
+describe('prepareTxPlan voting delegation', () => {
+    beforeEach(() => {
+        mockCardanoComposeTransaction.mockClear();
+    });
+
+    it.each(['delegate', 'voteDelegate'] as const)(
+        'honors a dRep confirmed for the composed account (%s)',
+        async action => {
+            const dRep = await getSignedDrep(action, {
+                accountKey: account.key,
+                option: { type: 'another_drep', drepId: ANOTHER_DREP.bech32 },
+            });
+
+            expect(dRep).toEqual({
+                keyHash: ANOTHER_DREP.hex,
+                scriptHash: undefined,
+                type: PROTO.CardanoDRepType.KEY_HASH,
+            });
+        },
+    );
+
+    it.each(['delegate', 'voteDelegate'] as const)(
+        'falls back to Everstake when the dRep was confirmed for another account (%s)',
+        async action => {
+            const dRep = await getSignedDrep(action, {
+                accountKey: otherAccount.key,
+                option: { type: 'another_drep', drepId: ANOTHER_DREP.bech32 },
+            });
+
+            expect(dRep).toEqual(EVERSTAKE_VOTE_DELEGATION);
+        },
+    );
+
+    it('falls back to Everstake when no dRep was confirmed', async () => {
+        expect(await getSignedDrep('voteDelegate')).toEqual(EVERSTAKE_VOTE_DELEGATION);
+    });
+
+    it('falls back to Everstake when the confirmed dRep id is not a valid bech32 dRep', async () => {
+        const dRep = await getSignedDrep('voteDelegate', {
+            accountKey: account.key,
+            option: { type: 'another_drep', drepId: 'drep1invalid' },
+        });
+
+        expect(dRep).toEqual(EVERSTAKE_VOTE_DELEGATION);
+    });
+
+    it('delegates to Everstake when the Everstake option is confirmed', async () => {
+        const dRep = await getSignedDrep('voteDelegate', {
+            accountKey: account.key,
+            option: { type: 'everstake' },
+        });
+
+        expect(dRep).toEqual(EVERSTAKE_VOTE_DELEGATION);
+    });
+});

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -23,8 +23,8 @@ import {
     MIN_CARDANO_FOR_WITHDRAWALS,
 } from '@suite-common/wallet-constants';
 import {
-    type StakeRootState,
     type AccountVotingDelegation,
+    type StakeRootState,
     selectCardanoPoolsInfo,
 } from '@suite-common/wallet-core';
 import {

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -24,7 +24,7 @@ import {
 } from '@suite-common/wallet-constants';
 import {
     type StakeRootState,
-    type VotingDelegationOption,
+    type AccountVotingDelegation,
     selectCardanoPoolsInfo,
 } from '@suite-common/wallet-core';
 import {
@@ -104,7 +104,7 @@ export const prepareTxPlan = async (
     account: Account,
     action: CardanoAction,
     cardanoPools: AdaPools['pools'],
-    votingDelegation?: VotingDelegationOption,
+    votingDelegation?: AccountVotingDelegation,
 ) => {
     if (account?.networkType !== 'cardano') return;
 
@@ -142,12 +142,14 @@ export const prepareTxPlan = async (
     }
 
     if (action === 'delegate' || action === 'voteDelegate') {
+        const confirmedOption =
+            votingDelegation?.accountKey === account.key ? votingDelegation.option : undefined;
+
         const isVotingToAnotherDrep =
-            votingDelegation?.type === 'another_drep' &&
-            validateCardanoDrep(votingDelegation.drepId);
+            confirmedOption?.type === 'another_drep' && validateCardanoDrep(confirmedOption.drepId);
 
         const drepBech32 = isVotingToAnotherDrep
-            ? votingDelegation.drepId
+            ? confirmedOption.drepId
             : CARDANO_EVERSTAKE_DREP.bech32;
 
         const dRep = parseDrepBech32(drepBech32);
@@ -195,7 +197,7 @@ const getTransactionData = (
     formValues: StakeFormState,
     selectedAccount: SelectedAccountStatus,
     cardanoPools: AdaPools['pools'],
-    votingDelegation?: VotingDelegationOption,
+    votingDelegation?: AccountVotingDelegation,
 ) => {
     const { stakeType } = formValues;
 

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -245,6 +245,9 @@ const pushTransaction =
                     type: events.stakingConfirmEvent.name,
                     payload: { action: stakeType, networkSymbol: account.symbol },
                 });
+
+                // The confirmed delegation is now on-chain; don't let it pre-fill the next flow.
+                dispatch(stakeActions.clearVotingDelegation());
             }
 
             // notification from the backend may be delayed.

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/StakingEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/StakingEarnProviderConsentModal.tsx
@@ -57,7 +57,7 @@ export const StakingEarnProviderConsentModal = ({
             }
             onConfirm={proceedToEarnFlow}
             onCancel={onCancelClick}
-            networkType={account.networkType}
+            account={account}
         >
             <VotingDelegations account={account} />
         </EarnProviderConsentModalLayout>

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/UpdateEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/UpdateEarnProviderConsentModal.tsx
@@ -58,7 +58,7 @@ export const UpdateEarnProviderConsentModal = ({
             }
             onConfirm={proceedToEarnFlow}
             onCancel={onCancelClick}
-            networkType={account.networkType}
+            account={account}
         >
             <VotingDelegations account={account} />
         </EarnProviderConsentModalLayout>

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
@@ -126,7 +126,7 @@ export const YieldEarnProviderConsentModal = ({
             }
             onConfirm={handleOnConfirm}
             onCancel={handleOnCancel}
-            networkType={account.networkType}
+            account={account}
         >
             <VotingDelegations account={account} />
         </EarnProviderConsentModalLayout>

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
@@ -1,8 +1,8 @@
 import { type ReactNode, useMemo, useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { type NetworkType } from '@suite-common/wallet-config';
 import { selectVotingDelegationOption } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
 import { validateCardanoDrep } from '@suite-common/wallet-utils';
 import { Card, Checkbox, Column, Modal } from '@trezor/components';
 
@@ -15,7 +15,7 @@ interface EarnProviderConsentModalLayoutProps {
     consentText: ReactNode;
     onConfirm: () => void;
     onCancel: () => void;
-    networkType: NetworkType;
+    account: Account;
     children?: ReactNode;
 }
 
@@ -26,12 +26,14 @@ export const EarnProviderConsentModalLayout = ({
     consentText,
     onConfirm,
     onCancel,
-    networkType,
+    account,
     children,
 }: EarnProviderConsentModalLayoutProps) => {
     const [hasAgreed, setHasAgreed] = useState(false);
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
-    const isCardanoNetworkType = networkType === 'cardano';
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
+    const isCardanoNetworkType = account.networkType === 'cardano';
 
     const isDrepValid = useMemo(() => {
         if (!isCardanoNetworkType || selectedVotingDelegation.type !== 'another_drep') {

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
@@ -8,11 +8,7 @@ import {
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    DEFAULT_VOTING_OPTION,
-    selectVotingDelegationOption,
-    stakeActions,
-} from '@suite-common/wallet-core';
+import { selectVotingDelegationOption, stakeActions } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -39,7 +35,9 @@ export const useEarnProviderConsentActions = ({
 }: UseEarnProviderConsentActionsProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
 
     const report = (action: EarnModalAction) => {
         if (flow === EarnFlow.Yield) return;
@@ -94,7 +92,7 @@ export const useEarnProviderConsentActions = ({
     const onCancelClick = () => {
         onCancel();
 
-        dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
+        dispatch(stakeActions.clearVotingDelegation());
         report('cancel');
     };
 

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
@@ -19,7 +19,7 @@ type StakeRegistrationDepositCardProps = {
 export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepositCardProps) => {
     const { symbol, key } = account;
 
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
+    const selectedVotingDelegation = useSelector(state => selectVotingDelegationOption(state, key));
 
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, key ?? ''));
     const isUpdateProviderFlow = isStakingActive && account.networkType === 'cardano';

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx
@@ -15,9 +15,11 @@ type VotingDelegationsProps = {
 };
 
 export const VotingDelegations = ({ account }: VotingDelegationsProps) => {
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
 
-    if (account.networkType !== 'cardano' || !selectedVotingDelegation) return null;
+    if (account.networkType !== 'cardano') return null;
 
     return (
         <Card>
@@ -45,7 +47,7 @@ export const VotingDelegations = ({ account }: VotingDelegationsProps) => {
                 paddingType="none"
                 hasDivider={false}
             >
-                <VotingDelegationsOptions networkType={account.networkType} resetOnMount />
+                <VotingDelegationsOptions account={account} resetOnMount />
             </CollapsibleBox>
         </Card>
     );

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx
@@ -47,7 +47,7 @@ export const VotingDelegations = ({ account }: VotingDelegationsProps) => {
                 paddingType="none"
                 hasDivider={false}
             >
-                <VotingDelegationsOptions account={account} resetOnMount />
+                <VotingDelegationsOptions account={account} resetOnMount={false} />
             </CollapsibleBox>
         </Card>
     );

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import {
@@ -40,7 +40,11 @@ export const VotingDelegationsOptions = ({
     const selectedVotingDelegation = useSelector(state =>
         selectVotingDelegationOption(state, accountKey),
     );
-    const [hasError, setHasError] = useState<boolean>(false);
+
+    const hasError =
+        selectedVotingDelegation.type === 'another_drep' &&
+        selectedVotingDelegation.drepId !== '' &&
+        !validateCardanoDrep(selectedVotingDelegation.drepId);
 
     // reset voting delegation option on modal open
     useEffect(() => {
@@ -57,8 +61,6 @@ export const VotingDelegationsOptions = ({
         dispatch(stakeActions.setVotingDelegationOption({ accountKey, option }));
 
     const handleOptionSelect = (type: VotingDelegationOption['type']) => {
-        setHasError(false);
-
         switch (type) {
             case 'everstake':
                 setOption({ type: 'everstake' });
@@ -71,9 +73,6 @@ export const VotingDelegationsOptions = ({
     };
 
     const handleDrepIdChange = (value: string) => {
-        const isDrepValid = validateCardanoDrep(value);
-        setHasError(!isDrepValid);
-
         setOption({ type: 'another_drep', drepId: value });
     };
 

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
-import { type NetworkType } from '@suite-common/wallet-config';
 import {
     DEFAULT_VOTING_OPTION,
     type VotingDelegationOption,
     selectVotingDelegationOption,
     stakeActions,
 } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
 import { validateCardanoDrep } from '@suite-common/wallet-utils';
 import { Column, Input, Radio, Text } from '@trezor/components';
 
@@ -22,21 +22,24 @@ const VOTING_OPTIONS: {
 ];
 
 export interface VotingDelegationsOptionsProps {
-    networkType: NetworkType;
+    account: Account;
     initialValue?: VotingDelegationOption;
     hasTitle?: boolean;
     resetOnMount?: boolean;
 }
 
 export const VotingDelegationsOptions = ({
-    networkType,
+    account,
     initialValue = DEFAULT_VOTING_OPTION,
     hasTitle = false,
     resetOnMount = true,
 }: VotingDelegationsOptionsProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
+    const accountKey = account.key;
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, accountKey),
+    );
     const [hasError, setHasError] = useState<boolean>(false);
 
     // reset voting delegation option on modal open
@@ -45,23 +48,24 @@ export const VotingDelegationsOptions = ({
             return;
         }
 
-        dispatch(stakeActions.setVotingDelegationOption(initialValue));
-    }, [dispatch, initialValue, resetOnMount]);
+        dispatch(stakeActions.setVotingDelegationOption({ accountKey, option: initialValue }));
+    }, [dispatch, accountKey, initialValue, resetOnMount]);
 
-    if (networkType !== 'cardano') return null;
+    if (account.networkType !== 'cardano') return null;
+
+    const setOption = (option: VotingDelegationOption) =>
+        dispatch(stakeActions.setVotingDelegationOption({ accountKey, option }));
 
     const handleOptionSelect = (type: VotingDelegationOption['type']) => {
         setHasError(false);
 
         switch (type) {
             case 'everstake':
-                dispatch(stakeActions.setVotingDelegationOption({ type: 'everstake' }));
+                setOption({ type: 'everstake' });
                 break;
 
             case 'another_drep':
-                dispatch(
-                    stakeActions.setVotingDelegationOption({ type: 'another_drep', drepId: '' }),
-                );
+                setOption({ type: 'another_drep', drepId: '' });
                 break;
         }
     };
@@ -70,7 +74,7 @@ export const VotingDelegationsOptions = ({
         const isDrepValid = validateCardanoDrep(value);
         setHasError(!isDrepValid);
 
-        dispatch(stakeActions.setVotingDelegationOption({ type: 'another_drep', drepId: value }));
+        setOption({ type: 'another_drep', drepId: value });
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -6,7 +6,6 @@ import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
 import {
-    DEFAULT_VOTING_OPTION,
     type VotingDelegationOption,
     selectVotingDelegationOption,
     stakeActions,
@@ -37,9 +36,11 @@ export const StakeChangeDelegateModalLoaded = ({
 }: StakeChangeDelegateModalProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
-
     const { account } = selectedAccount;
+
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
 
     const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
@@ -63,7 +64,7 @@ export const StakeChangeDelegateModalLoaded = ({
     }, [currentDrepId, isEverstake]);
 
     const handleCancel = () => {
-        dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
+        dispatch(stakeActions.clearVotingDelegation());
 
         onCancel?.();
 
@@ -151,7 +152,7 @@ export const StakeChangeDelegateModalLoaded = ({
                         <Column gap={20} hasDivider>
                             <CurrentDelegate account={account} />
                             <VotingDelegationsOptions
-                                networkType={account.networkType}
+                                account={account}
                                 initialValue={drepIdOptionValue}
                                 hasTitle
                                 resetOnMount

--- a/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
+++ b/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
@@ -38,7 +38,9 @@ export const useChangeDelegateForm = ({
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
 
     const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account.networkType,

--- a/suite-common/wallet-core/src/stake/stakeActions.ts
+++ b/suite-common/wallet-core/src/stake/stakeActions.ts
@@ -1,7 +1,11 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type PrecomposedTransactionFinal, type StakeFormState } from '@suite-common/wallet-types';
+import {
+    type AccountKey,
+    type PrecomposedTransactionFinal,
+    type StakeFormState,
+} from '@suite-common/wallet-types';
 
 export const STAKE_MODULE_PREFIX = '@common/wallet-core/stake';
 
@@ -18,12 +22,19 @@ type RequestPushTransactionPayload = {
 export type VotingDelegationOption =
     { type: 'everstake' } | { type: 'another_drep'; drepId: string };
 
+export type AccountVotingDelegation = {
+    accountKey: AccountKey;
+    option: VotingDelegationOption;
+};
+
 const setVotingDelegationOption = createAction(
     `${STAKE_MODULE_PREFIX}/setVotingDelegationOption`,
-    (payload: VotingDelegationOption) => ({
+    (payload: AccountVotingDelegation) => ({
         payload,
     }),
 );
+
+const clearVotingDelegation = createAction(`${STAKE_MODULE_PREFIX}/clearVotingDelegation`);
 
 const requestSignTransaction = createAction(
     `${STAKE_MODULE_PREFIX}/requestSignTransaction`,
@@ -52,6 +63,7 @@ export const stakeActions = {
     requestSignTransaction,
     requestPushTransaction,
     setVotingDelegationOption,
+    clearVotingDelegation,
     setResolvedEthereumNonce,
     dispose,
 };

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -8,7 +8,7 @@ import type { StakeState } from './stakeReducerTypes';
 export const stakeInitialState: StakeState = {
     precomposedTx: undefined,
     serializedTx: undefined,
-    votingDelegation: { type: 'everstake' },
+    votingDelegation: undefined,
     data: stakeDataInitialState,
 };
 
@@ -45,6 +45,9 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
         })
         .addCase(stakeActions.setVotingDelegationOption, (state, action) => {
             state.votingDelegation = action.payload;
+        })
+        .addCase(stakeActions.clearVotingDelegation, state => {
+            delete state.votingDelegation;
         })
         .addCase(stakeActions.dispose, state => {
             delete state.precomposedTx;

--- a/suite-common/wallet-core/src/stake/stakeReducerTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducerTypes.ts
@@ -1,6 +1,6 @@
 import type { PrecomposedTransactionFinal, StakeFormState } from '@suite-common/wallet-types';
 
-import type { VotingDelegationOption } from './stakeActions';
+import type { AccountVotingDelegation } from './stakeActions';
 import type { StakeDataState } from './stakeDataSlice';
 import type { SerializedTx } from '../send/sendFormTypes';
 
@@ -9,7 +9,7 @@ export interface StakeState {
     precomposedForm?: StakeFormState;
     serializedTx?: SerializedTx; // payload for TrezorConnect.pushTransaction
     resolvedEthereumNonce?: string; // EVM nonce resolved at signing time, shown in the review modal
-    votingDelegation: VotingDelegationOption;
+    votingDelegation?: AccountVotingDelegation;
     data: StakeDataState;
 }
 

--- a/suite-common/wallet-core/src/stake/stakeSelectors.test.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.test.ts
@@ -1,7 +1,15 @@
+import { type AccountKey } from '@suite-common/wallet-types';
+
+import { type AccountVotingDelegation } from './stakeActions';
+import { DEFAULT_VOTING_OPTION } from './stakeConstants';
 import { type StakeDataState, stakeDataInitialState } from './stakeDataSlice';
 import { stakeInitialState } from './stakeReducer';
 import type { StakeRootState } from './stakeReducerTypes';
-import { selectCardanoPoolsInfo, selectEthNextRewardPayout } from './stakeSelectors';
+import {
+    selectCardanoPoolsInfo,
+    selectEthNextRewardPayout,
+    selectVotingDelegationOption,
+} from './stakeSelectors';
 
 const buildStakeState = (data: Partial<StakeDataState['data']>): StakeRootState => ({
     wallet: {
@@ -63,5 +71,36 @@ describe('selectCardanoPoolsInfo', () => {
         const state = createState(pools);
 
         expect(selectCardanoPoolsInfo(state)).toBe(pools);
+    });
+});
+
+describe('selectVotingDelegationOption', () => {
+    const accountKey = 'descriptor-a-ada-session' as AccountKey;
+    const otherAccountKey = 'descriptor-b-ada-session' as AccountKey;
+    const anotherDrep: AccountVotingDelegation['option'] = {
+        type: 'another_drep',
+        drepId: 'drep1abc',
+    };
+
+    const createState = (votingDelegation?: AccountVotingDelegation): StakeRootState => ({
+        wallet: { stake: { ...stakeInitialState, votingDelegation } },
+    });
+
+    it('falls back to Everstake when no option was confirmed', () => {
+        expect(selectVotingDelegationOption(createState(), accountKey)).toEqual(
+            DEFAULT_VOTING_OPTION,
+        );
+    });
+
+    it('returns the option confirmed for the queried account', () => {
+        const state = createState({ accountKey, option: anotherDrep });
+
+        expect(selectVotingDelegationOption(state, accountKey)).toEqual(anotherDrep);
+    });
+
+    it('falls back to Everstake when the option belongs to another account', () => {
+        const state = createState({ accountKey: otherAccountKey, option: anotherDrep });
+
+        expect(selectVotingDelegationOption(state, accountKey)).toEqual(DEFAULT_VOTING_OPTION);
     });
 });

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -1,6 +1,6 @@
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import {
     getCardanoAccountPoolId,
     secondsToDays,
@@ -8,6 +8,7 @@ import {
 } from '@suite-common/wallet-utils';
 
 import type { VotingDelegationOption } from './stakeActions';
+import { DEFAULT_VOTING_OPTION } from './stakeConstants';
 import type { StakeRootState } from './stakeReducerTypes';
 
 export const selectStake = (state: StakeRootState) => state.wallet.stake;
@@ -75,8 +76,16 @@ export const selectPoolStatsApy = (
     }
 };
 
-export const selectVotingDelegationOption = (state: StakeRootState): VotingDelegationOption =>
-    selectStake(state).votingDelegation;
+export const selectVotingDelegationOption = (
+    state: StakeRootState,
+    accountKey: AccountKey,
+): VotingDelegationOption => {
+    const { votingDelegation } = selectStake(state);
+
+    return votingDelegation?.accountKey === accountKey
+        ? votingDelegation.option
+        : DEFAULT_VOTING_OPTION;
+};
 
 export const selectStakePrecomposedForm = (state: StakeRootState) =>
     selectStake(state).precomposedForm;


### PR DESCRIPTION
## Description

**CI clone of #31787** — opened only so the pipeline can run. The original PR comes from a fork (`everstake/trezor-suite`) whose workflows are not authorized to execute here.

- Original PR: https://github.com/trezor/trezor-suite/pull/31787
- Original author: @myasiura-stack (commit authorship is preserved — this branch is the exact same commit as the original PR head, `3c9b932f82`)
- Resolves issue: https://github.com/trezor/trezor-suite/issues/30036

The five original commits are @myasiura-stack's; the final one, `refactor(suite): derive voting delegations options error from state`, is mine, added on top after review.

Review discussion belongs on #31787.

## What the change does

`stake.votingDelegation` was a single, account-agnostic slice field, so a dRep picked for one account stayed selected after switching accounts and after the delegation had already been signed — the only thing preventing stale cross-account leakage was that both consuming modals happened to mount `VotingDelegationsOptions` with `resetOnMount`.

The selected dRep is now stored together with the account key it was confirmed for. Both `selectVotingDelegationOption` and `prepareTxPlan` honor it only for that account and otherwise fall back to the Everstake default, so the compose and sign paths are guarded independently of which components happened to mount. It is cleared once the staking transaction is pushed, and it is no longer reset when the voting section collapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-account-scoped-voting-delegation/web/](https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-account-scoped-voting-delegation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on staking infrastructure—Cardano staking actions, delegation UI, provider-consent modals, and the wallet-core stake Redux slice. The highest risk is to Cardano staking flows and the provider-consent step in first-time ETH/SOL staking. Running the ADA stake/claim/unstake tests plus ETH and SOL initial-stake tests provides direct coverage of the changed code. A handful of related staking and yield tests add regression confidence for shared state and consent infrastructure without expanding into unrelated suites.

<details><summary><b>Changed files (18)</b></summary>

- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts`
- `packages/suite/src/actions/wallet/stakeActions.ts`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/StakingEarnProviderConsentModal.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/UpdateEarnProviderConsentModal.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts`
- `packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx`
- `packages/suite/src/hooks/wallet/useChangeDelegateForm.ts`
- `suite-common/wallet-core/src/stake/stakeActions.ts`
- `suite-common/wallet-core/src/stake/stakeReducer.ts`
- `suite-common/wallet-core/src/stake/stakeReducerTypes.ts`
- `suite-common/wallet-core/src/stake/stakeSelectors.test.ts`
- `suite-common/wallet-core/src/stake/stakeSelectors.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Directly exercises the Cardano staking end-to-end flow, including stake key registration, stake delegation, vote delegation, and the registration deposit card UI. Changes to stakeFormCardanoActions, VotingDelegations, StakeRegistrationDepositCard, StakeChangeDelegateModal/useChangeDelegateForm, and wallet-core stake state all feed into this path.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Directly covers Cardano reward claiming, which is driven by stakeFormCardanoActions and wallet-core stake state. A regression here would be immediately visible to ADA stakers.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Directly covers Cardano unstaking and deposit reclamation, which relies on stakeFormCardanoActions and the wallet-core stake slice changed in this PR.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Exercises the first-time Ethereum staking flow, including the Everstake provider consent step that uses the StakingEarnProviderConsentModal and useEarnProviderConsentActions changed in this PR, plus the wallet-core stake state.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Exercises the first-time Solana staking flow, including the Everstake provider consent modal and actions changed in this PR, plus the shared wallet-core stake state.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Additional Ethereum staking scenario that shares the provider consent and wallet-core stake infrastructure updated in this PR; good regression coverage beyond the initial-stake path.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Ethereum unstaking flow relies on the wallet-core stake state and stake actions that were changed; validates that unstake/claim transitions still work correctly.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Solana staking dashboard and rewards display depend on the wallet-core stake state/selectors changed in this PR.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Additional Solana staking scenario sharing the provider consent modal and wallet-core stake state changed in this PR.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstaking/claim flow relies on the wallet-core stake state and actions changed in this PR.
- `suite/e2e/tests/staking/staking-form.test.ts` — Validates staking form inputs, percentage/max calculations, and crypto/fiat switching across ETH staking, which is backed by the stake state and form components touched in this change set.
- `suite/e2e/tests/yield/withdrawal.test.ts` — Exercises the yield withdrawal flow which uses the YieldEarnProviderConsentModal and useEarnProviderConsentActions that were changed in this PR.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `suite-common/wallet-core/src/stake/stakeReducerTypes.ts`
- `suite-common/wallet-core/src/stake/stakeSelectors.test.ts`

_Updated: 2026-08-31T11:01:08.771Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci-clone/cardano-account-scoped-voting-delegation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci-clone/cardano-account-scoped-voting-delegation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci-clone/cardano-account-scoped-voting-delegation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:02:16.818Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:01:57.070Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->