### PR TITLE
refactor(connect): follow-up cleanups for UI_EVENT/UI_REQUEST split

### DIFF
--- a/docs/features/onboarding/onboarding.md
+++ b/docs/features/onboarding/onboarding.md
@@ -207,7 +207,7 @@ Support for the WebUSB came pretty late for T1B1 (bootloader [1.6.0](https://git
 
 ##### UI.FIRMWARE_PROGRESS
 
-- Devices won’t dispatch any event after the user confirms the installation on a device. We only detect that the installation has started when we receive `UI.FIRMWARE_PROGRESS` which is triggered about 10 seconds too late on T1B1.
+- Devices won’t dispatch any event after the user confirms the installation on a device. We only detect that the installation has started when we receive `UI_EVENTS.FIRMWARE_PROGRESS` which is triggered about 10 seconds too late on T1B1.
 
 ##### Remembered wallet, multiple devices
 
@@ -266,7 +266,7 @@ When the user hits cancel on a device, `@SUITE/lock-device` is fired, `buttonReq
 
 #### T1B1
 
-After the user confirms setting new PIN on the device we'll receive `UI.REQUEST_PIN`, which will be stored in `modal` reducer (as every other request coming from a device). Based on this we display PIN matrix.
+After the user confirms setting new PIN on the device we'll receive `UI_REQUESTS.REQUEST_PIN`, which will be stored in `modal` reducer (as every other request coming from a device). Based on this we display PIN matrix.
 
 The user enters PIN twice, if there is a mismatch, process is stopped and an error shown with a button to try again.
 

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -4,6 +4,11 @@ import path from 'path';
 import TrezorConnect, {
     type Device,
     ThpPairingMethod,
+    UI_EVENT,
+    UI_EVENTS,
+    UI_REQUEST,
+    UI_REQUESTS,
+    UI_RESPONSE,
     type UiRequestThpPairing,
     initLog,
 } from '@trezor/connect';
@@ -232,52 +237,10 @@ const run = async () => {
         }
     });
 
-    TrezorConnect.on('UI_EVENT', async event => {
+    TrezorConnect.on(UI_EVENT, async event => {
         console.info('UI_EVENT', event);
 
-        if (event.type === 'ui-request_confirmation') {
-            return TrezorConnect.uiResponse({
-                type: 'ui-receive_confirmation',
-                payload: true,
-                requestId: event.requestId,
-            });
-        }
-
-        if (event.type === 'ui-request_passphrase') {
-            if (args['cancel-passphrase']) {
-                return TrezorConnect.cancel();
-            }
-            if (args['cancel-passphrase-ui']) {
-                // respond with no passphrase
-                // @ts-expect-error
-                return TrezorConnect.uiResponse({
-                    type: 'ui-receive_passphrase',
-                    requestId: event.requestId,
-                });
-            }
-
-            const value = args.passphrase || '';
-            TrezorConnect.uiResponse({
-                type: 'ui-receive_passphrase',
-                payload: { value, passphraseOnDevice: args['passphrase-on-device'] },
-                requestId: event.requestId,
-            });
-        }
-
-        if (event.type === 'ui-request_thp_pairing') {
-            const tag = await waitForPairingTag(event);
-            if (tag) {
-                TrezorConnect.uiResponse({
-                    type: 'ui-receive_thp_pairing_tag',
-                    payload: { tag },
-                    requestId: event.requestId,
-                });
-            } else {
-                return TrezorConnect.cancel();
-            }
-        }
-
-        if (event.type === 'ui-button') {
+        if (event.type === UI_EVENTS.BUTTON_REQUEST) {
             if (!isDebugLinkInteraction('button')) {
                 const resp = await waitForStdio(
                     `Confirm ${event.payload.code} (${event.payload.name}) on device or type [c] for Cancel:`,
@@ -287,6 +250,52 @@ const run = async () => {
                 }
             } else {
                 await debugLinkDecision();
+            }
+        }
+    });
+
+    TrezorConnect.on(UI_REQUEST, async event => {
+        console.info('UI_REQUEST', event);
+
+        if (event.type === UI_REQUESTS.REQUEST_CONFIRMATION) {
+            return TrezorConnect.uiResponse({
+                type: UI_RESPONSE.RECEIVE_CONFIRMATION,
+                payload: true,
+                requestId: event.requestId,
+            });
+        }
+
+        if (event.type === UI_REQUESTS.REQUEST_PASSPHRASE) {
+            if (args['cancel-passphrase']) {
+                return TrezorConnect.cancel();
+            }
+            if (args['cancel-passphrase-ui']) {
+                // respond with no passphrase
+                // @ts-expect-error
+                return TrezorConnect.uiResponse({
+                    type: UI_RESPONSE.RECEIVE_PASSPHRASE,
+                    requestId: event.requestId,
+                });
+            }
+
+            const value = args.passphrase || '';
+            TrezorConnect.uiResponse({
+                type: UI_RESPONSE.RECEIVE_PASSPHRASE,
+                payload: { value, passphraseOnDevice: args['passphrase-on-device'] },
+                requestId: event.requestId,
+            });
+        }
+
+        if (event.type === UI_REQUESTS.REQUEST_THP_PAIRING_TAG) {
+            const tag = await waitForPairingTag(event);
+            if (tag) {
+                TrezorConnect.uiResponse({
+                    type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
+                    payload: { tag },
+                    requestId: event.requestId,
+                });
+            } else {
+                return TrezorConnect.cancel();
             }
         }
     });

--- a/packages/connect-common/src/events/core.ts
+++ b/packages/connect-common/src/events/core.ts
@@ -11,7 +11,8 @@ import type {
     TransportRequestWebUSBDevice,
     TransportSetTransports,
 } from './transport';
-import type { UiEventMessage } from './ui-request';
+import type { UiEventMessage } from './ui-event';
+import type { UiRequestMessage } from './ui-request';
 import type { UiResponseEvent } from './ui-response';
 import type { ErrorCode, SerializedError, TrezorError } from '../constants/errors';
 
@@ -35,6 +36,7 @@ export type CoreEventMessage = {
     | DeviceEventMessage
     | TransportEventMessage
     | UiEventMessage
+    | UiRequestMessage
     | MethodResponseMessage
     | PopupEventMessage
 );

--- a/packages/connect-common/src/events/index.ts
+++ b/packages/connect-common/src/events/index.ts
@@ -6,5 +6,6 @@ export * from './core-call';
 export * from './networks';
 export * from './popup';
 export * from './transport';
+export * from './ui-event';
 export * from './ui-request';
 export * from './ui-response';

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -1,5 +1,5 @@
 import type { TransportInfo } from './transport';
-import { UI_EVENT } from './ui-request';
+import { UI_EVENT } from './ui-event';
 import type { PermissionRequest } from '../types/method';
 import type { ConnectDynamicSettings, Manifest } from '../types/settings';
 import type { MessageFactoryFn } from '../types/utils';

--- a/packages/connect-common/src/events/ui-event.ts
+++ b/packages/connect-common/src/events/ui-event.ts
@@ -1,0 +1,281 @@
+/*
+ * messages to UI emitted as UI_EVENT
+ */
+
+import type { DeviceModelInternal, FirmwareRelease, FirmwareType } from '@trezor/device-utils';
+import { createTypeGuardByType } from '@trezor/type-utils';
+import type { VersionArray } from '@trezor/utils';
+
+import type { DeviceButtonRequest } from './device';
+import type { Device } from '../types/device';
+import { type MessageFactoryFn } from '../types/utils';
+
+export const UI_EVENT = 'UI_EVENT';
+
+export const UI_EVENTS = {
+    // --- Transport ---
+
+    /** No transport layer (bridge/WebUSB) is available */
+    NO_TRANSPORT: 'ui-event_no_transport',
+
+    // --- Device state ---
+
+    /** Device is in bootloader mode (unexpected for the current method) */
+    DEVICE_IN_BOOTLOADER: 'ui-event_device_in_bootloader',
+    /** Device is NOT in bootloader mode (unexpected for the current method) */
+    DEVICE_NOT_IN_BOOTLOADER: 'ui-event_device_not_in_bootloader',
+    /** Device has not been initialized (no seed) */
+    DEVICE_NOT_INITIALIZED: 'ui-event_device_not_initialized',
+    /** Device is in seedless mode */
+    DEVICE_SEEDLESS: 'ui-event_device_seedless',
+    /** Device has no backup — user should be warned */
+    DEVICE_NEEDS_BACKUP: 'ui-event_device_needs_backup',
+
+    // --- Firmware status ---
+
+    /** Installed firmware is older than the minimum required version */
+    FIRMWARE_OLD: 'ui-event_firmware_old',
+    /** Installed firmware is outdated but still functional */
+    FIRMWARE_OUTDATED: 'ui-event_firmware_outdated',
+    /** Installed firmware is not supported by the current method */
+    FIRMWARE_NOT_SUPPORTED: 'ui-event_firmware_not_supported',
+    /** Installed firmware is not compatible with the current method */
+    FIRMWARE_NOT_COMPATIBLE: 'ui-event_firmware_not_compatible',
+    /** No firmware is installed on the device */
+    FIRMWARE_NOT_INSTALLED: 'ui-event_firmware_not_installed',
+
+    // --- Firmware update flow ---
+
+    /** Firmware download/flash progress update */
+    FIRMWARE_PROGRESS: 'ui-event_firmware_progress',
+    /** Firmware operation is taking unexpectedly long */
+    FIRMWARE_PROGRESS_UNEXPECTED_DELAY: 'ui-event_firmware_progress_unexpected_delay',
+    /** Firmware type changed (e.g. Universal ↔ Bitcoin-only) */
+    FIRMWARE_TYPE_CHANGED: 'ui-event_firmware_type_changed',
+    /** Waiting for device to reconnect during firmware installation */
+    FIRMWARE_RECONNECT: 'ui-event_firmware_reconnect',
+    /** Device disconnected during firmware installation */
+    FIRMWARE_DISCONNECT: 'ui-event_firmware_disconnect',
+    /**
+     * Firmware binary was downloaded. The host may store it locally
+     * and respond with RECEIVE_FIRMWARE, but the response is not awaited —
+     * the firmware update flow continues regardless.
+     */
+    FIRMWARE_DOWNLOADED: 'ui-event_firmware_downloaded',
+
+    // --- PIN / Passphrase ---
+
+    /** User entered an invalid PIN */
+    INVALID_PIN: 'ui-event_invalid_pin',
+    /** All PIN attempts have been exhausted — device is wiped */
+    INVALID_PIN_ATTEMPTS_DEPLETED: 'ui-event_invalid_pin_attempts_depleted',
+    /** Passphrase is being entered on the device */
+    PASSPHRASE_ON_DEVICE: 'ui-event_passphrase_on_device',
+
+    // --- Transaction ---
+
+    /** Account balance is insufficient for the transaction */
+    INSUFFICIENT_FUNDS: 'ui-event_insufficient_funds',
+
+    // --- Generic ---
+
+    /** Device is requesting a physical button press confirmation */
+    BUTTON_REQUEST: 'ui-event_button_request',
+    /** Progress update for bundled (multi-call) operations */
+    BUNDLE_PROGRESS: 'ui-event_bundle_progress',
+    /** Signal to close the UI popup/modal window */
+    CLOSE_UI_WINDOW: 'ui-event_close_ui_window',
+} as const;
+
+export type UiEventWithoutPayload =
+    | {
+          type: typeof UI_EVENTS.NO_TRANSPORT;
+          payload?: never;
+      }
+    | {
+          type: typeof UI_EVENTS.INSUFFICIENT_FUNDS;
+          payload?: never;
+      }
+    | {
+          type: typeof UI_EVENTS.CLOSE_UI_WINDOW;
+          payload?: never;
+      };
+
+export type UiEventDeviceAction =
+    | {
+          type: typeof UI_EVENTS.INVALID_PIN;
+          payload: {
+              device: Device;
+              type?: never;
+          };
+      }
+    | {
+          type: typeof UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED;
+          payload: {
+              device: Device;
+              type?: never;
+          };
+      }
+    | {
+          type: typeof UI_EVENTS.PASSPHRASE_ON_DEVICE;
+          payload: {
+              device: Device;
+              type?: never;
+          };
+      };
+
+export type UiRequestButtonData =
+    | {
+          type: 'address';
+          serializedPath: string;
+          address: string;
+      }
+    | {
+          type: 'message';
+          serializedPath: string;
+          coin: string;
+          message: string;
+      };
+
+// ButtonRequest_FirmwareUpdate is a artificial button request thrown by "uploadFirmware" method
+// at the beginning of the uploading process
+export interface UiEventButtonRequest {
+    type: typeof UI_EVENTS.BUTTON_REQUEST;
+    payload: DeviceButtonRequest['payload'] & {
+        data?: UiRequestButtonData;
+    };
+}
+
+export interface UiEventUnexpectedDeviceMode {
+    type:
+        | typeof UI_EVENTS.DEVICE_IN_BOOTLOADER
+        | typeof UI_EVENTS.DEVICE_NOT_IN_BOOTLOADER
+        | typeof UI_EVENTS.DEVICE_NOT_INITIALIZED
+        | typeof UI_EVENTS.DEVICE_SEEDLESS
+        | typeof UI_EVENTS.DEVICE_NEEDS_BACKUP;
+    payload: {
+        device: Device;
+    };
+}
+
+export interface UiEventFirmwareException {
+    type:
+        | typeof UI_EVENTS.FIRMWARE_OLD
+        | typeof UI_EVENTS.FIRMWARE_OUTDATED
+        | typeof UI_EVENTS.FIRMWARE_NOT_SUPPORTED
+        | typeof UI_EVENTS.FIRMWARE_NOT_COMPATIBLE
+        | typeof UI_EVENTS.FIRMWARE_NOT_INSTALLED;
+    payload: {
+        device: Device;
+    };
+}
+
+export interface UiEventBundleProgress<R> {
+    type: typeof UI_EVENTS.BUNDLE_PROGRESS;
+    payload: {
+        total: number;
+        progress: number;
+        response: R;
+        error?: string;
+    };
+}
+
+export interface UiEventFirmwareProgress {
+    type: typeof UI_EVENTS.FIRMWARE_PROGRESS;
+    payload: {
+        device: Device;
+        operation: 'downloading' | 'flashing' | 'start-flashing';
+        progress: number;
+    };
+}
+
+export interface UiEventFirmwareProgressUnexpectedDelay {
+    type: typeof UI_EVENTS.FIRMWARE_PROGRESS_UNEXPECTED_DELAY;
+    payload: Record<string, never>;
+}
+
+export interface UiEventFirmwareTypeChanged {
+    type: typeof UI_EVENTS.FIRMWARE_TYPE_CHANGED;
+    payload: {
+        device: Device;
+    };
+}
+
+/**
+ * Prompt user to reconnect device during firmware installation.
+ */
+export interface UiEventFirmwareReconnect {
+    type: typeof UI_EVENTS.FIRMWARE_RECONNECT;
+    payload: {
+        device: Device;
+        disconnected: boolean;
+        method: 'manual' | 'auto' | 'wait';
+        target: 'normal' | 'bootloader';
+        /** how many times this event was fired. resets when request is satisfied */
+        i: number;
+    };
+}
+
+export interface UiEventFirmwareDisconnect {
+    type: typeof UI_EVENTS.FIRMWARE_DISCONNECT;
+    payload: {
+        device: Device;
+    };
+}
+
+export type FirmwareStoreEvent = {
+    binary: ArrayBuffer;
+    binaryVersion: VersionArray;
+    internalModel: DeviceModelInternal;
+    release: FirmwareRelease | undefined;
+    firmwareType: FirmwareType;
+    releaseVersion?: number[];
+};
+
+export interface UiEventFirmwareDownloaded {
+    type: typeof UI_EVENTS.FIRMWARE_DOWNLOADED;
+    payload: FirmwareStoreEvent;
+}
+
+export type UiEvent =
+    | UiEventWithoutPayload
+    | UiEventDeviceAction
+    | UiEventButtonRequest
+    | UiEventUnexpectedDeviceMode
+    | UiEventBundleProgress<any>
+    | UiEventFirmwareProgress
+    | UiEventFirmwareProgressUnexpectedDelay
+    | UiEventFirmwareTypeChanged
+    | UiEventFirmwareException
+    | UiEventFirmwareReconnect
+    | UiEventFirmwareDisconnect
+    | UiEventFirmwareDownloaded;
+
+export type UiEventMessage = UiEvent & {
+    event: typeof UI_EVENT;
+    requestId?: string;
+    callId?: string;
+};
+
+export const isUiEventOfType = createTypeGuardByType<UiEvent>();
+
+// type CreateUiMessageOptions = {
+//     requestId?: string;
+//     callId?: string;
+// };
+
+export const createUiEventMessage = ((
+    type: UiEvent['type'],
+    payload?: UiEvent extends { payload: infer P } ? P : undefined,
+    options?: { requestId?: string; callId?: string },
+) => {
+    const { requestId, callId } = options ?? {};
+
+    return {
+        event: UI_EVENT,
+        type,
+        payload,
+        requestId,
+        callId,
+    };
+}) as MessageFactoryFn<typeof UI_EVENT, UiEvent>;

--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -1,150 +1,60 @@
 /*
- * messages to UI emitted as UI_EVENT
+ * messages to UI that require a UI_RESPONSE
  */
-import type { DeviceModelInternal, FirmwareRelease, FirmwareType } from '@trezor/device-utils';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { createTypeGuardByType } from '@trezor/type-utils';
-import type { VersionArray } from '@trezor/utils';
 
-import type { DeviceButtonRequest, DeviceThpPairingPayload } from './device';
+import type { DeviceThpPairingPayload } from './device';
 import type { DiscoveryAccount, DiscoveryAccountType } from '../types/account';
 import type { BitcoinNetworkInfo, CoinInfo } from '../types/coinInfo';
 import type { Device } from '../types/device';
 import type { FeeLevel } from '../types/fees';
 import { type MessageFactoryFn } from '../types/utils';
 
-export const UI_EVENT = 'UI_EVENT';
-export const UI_REQUEST = {
-    TRANSPORT: 'ui-no_transport',
-    BOOTLOADER: 'ui-device_bootloader_mode',
-    NOT_IN_BOOTLOADER: 'ui-device_not_in_bootloader_mode',
-    INITIALIZE: 'ui-device_not_initialized',
-    SEEDLESS: 'ui-device_seedless',
-    FIRMWARE_OLD: 'ui-device_firmware_old',
-    FIRMWARE_OUTDATED: 'ui-device_firmware_outdated',
-    FIRMWARE_NOT_SUPPORTED: 'ui-device_firmware_unsupported',
-    FIRMWARE_NOT_COMPATIBLE: 'ui-device_firmware_not_compatible',
-    FIRMWARE_NOT_INSTALLED: 'ui-device_firmware_not_installed',
-    FIRMWARE_PROGRESS: 'ui-firmware-progress',
-    FIRMWARE_PROGRESS_UNEXPECTED_DELAY: 'ui-firmware-progress-unexpected-delay',
-    FIRMWARE_TYPE_CHANGED: 'ui-firmware_type_changed',
-
-    /** connect is waiting for device to be automatically reconnected */
-    FIRMWARE_RECONNECT: 'ui-firmware_reconnect',
-    FIRMWARE_DISCONNECT: 'ui-firmware_disconnect',
-
-    FIRMWARE_DOWNLOADED: 'ui-firmware_downloaded',
-
-    DEVICE_NEEDS_BACKUP: 'ui-device_needs_backup',
-
-    CLOSE_UI_WINDOW: 'ui-close_window',
-
-    REQUEST_CONFIRMATION: 'ui-request_confirmation',
-    REQUEST_PIN: 'ui-request_pin',
-    INVALID_PIN: 'ui-invalid_pin',
-    INVALID_PIN_ATTEMPTS_DEPLETED: 'ui-invalid_pin_attempts_depleted',
-    REQUEST_PASSPHRASE: 'ui-request_passphrase',
-    REQUEST_PASSPHRASE_ON_DEVICE: 'ui-request_passphrase_on_device',
-    REQUEST_THP_PAIRING: 'ui-request_thp_pairing',
-    SELECT_ACCOUNT: 'ui-select_account',
-    SELECT_FEE: 'ui-select_fee',
-    INSUFFICIENT_FUNDS: 'ui-insufficient_funds',
-    REQUEST_BUTTON: 'ui-button',
-    REQUEST_WORD: 'ui-request_word',
-
-    BUNDLE_PROGRESS: 'ui-bundle_progress',
-    REQUEST_DISCOVERY_ACCOUNTS: 'ui-request_discovery_accounts',
+export const UI_REQUEST = 'UI_REQUEST';
+export const UI_REQUESTS = {
+    REQUEST_CONFIRMATION: 'ui-request_confirmation', // -> RECEIVE_CONFIRMATION
+    REQUEST_PIN: 'ui-request_pin', // -> RECEIVE_PIN
+    REQUEST_PASSPHRASE: 'ui-request_passphrase', // -> RECEIVE_PASSPHRASE
+    REQUEST_THP_PAIRING_TAG: 'ui-request_thp_pairing_tag', // -> RECEIVE_THP_PAIRING_TAG
+    REQUEST_ACCOUNT: 'ui-request_account', // -> RECEIVE_ACCOUNT
+    REQUEST_FEE: 'ui-request_fee', // -> RECEIVE_FEE
+    REQUEST_WORD: 'ui-request_word', // -> RECEIVE_WORD
+    REQUEST_DISCOVERY_ACCOUNTS: 'ui-request_discovery_accounts', // -> RECEIVE_DISCOVERY_ACCOUNTS
 } as const;
-
-export type UiRequestWithoutPayload =
-    | {
-          type: typeof UI_REQUEST.TRANSPORT;
-          payload?: never;
-      }
-    | {
-          type: typeof UI_REQUEST.INSUFFICIENT_FUNDS;
-          payload?: never;
-      }
-    | {
-          type: typeof UI_REQUEST.CLOSE_UI_WINDOW;
-          payload?: never;
-      };
 
 export type UiRequestDeviceAction =
     | {
-          type: typeof UI_REQUEST.REQUEST_PIN;
+          type: typeof UI_REQUESTS.REQUEST_PIN;
           payload: {
               device: Device;
               type?: PROTO.PinMatrixRequestType;
           };
       }
     | {
-          type: typeof UI_REQUEST.REQUEST_WORD;
+          type: typeof UI_REQUESTS.REQUEST_WORD;
           payload: {
               device: Device;
               type: PROTO.WordRequestType;
           };
       }
     | {
-          type: typeof UI_REQUEST.INVALID_PIN;
+          type: typeof UI_REQUESTS.REQUEST_PASSPHRASE;
           payload: {
               device: Device;
               type?: never;
           };
-      }
-    | {
-          type: typeof UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED;
-          payload: {
-              device: Device;
-              type?: never;
-          };
-      }
-    | {
-          type: typeof UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE;
-          payload: {
-              device: Device;
-              type?: never;
-          };
-      }
-    | {
-          type: typeof UI_REQUEST.REQUEST_PASSPHRASE;
-          payload: {
-              device: Device;
-              type?: never;
-          };
-      };
-
-export type UiRequestButtonData =
-    | {
-          type: 'address';
-          serializedPath: string;
-          address: string;
-      }
-    | {
-          type: 'message';
-          serializedPath: string;
-          coin: string;
-          message: string;
       };
 
 export interface UiRequestThpPairing {
-    type: typeof UI_REQUEST.REQUEST_THP_PAIRING;
+    type: typeof UI_REQUESTS.REQUEST_THP_PAIRING_TAG;
     payload: DeviceThpPairingPayload & {
         device: Device;
     };
 }
 
-// ButtonRequest_FirmwareUpdate is a artificial button request thrown by "uploadFirmware" method
-// at the beginning of the uploading process
-export interface UiRequestButton {
-    type: typeof UI_REQUEST.REQUEST_BUTTON;
-    payload: DeviceButtonRequest['payload'] & {
-        data?: UiRequestButtonData;
-    };
-}
-
 export interface UiRequestConfirmation {
-    type: typeof UI_REQUEST.REQUEST_CONFIRMATION;
+    type: typeof UI_REQUESTS.REQUEST_CONFIRMATION;
     payload: {
         view:
             | 'thp-pairing-start'
@@ -166,42 +76,8 @@ export interface UiRequestConfirmation {
     };
 }
 
-export type FirmwareStoreEvent = {
-    binary: ArrayBuffer;
-    binaryVersion: VersionArray;
-    internalModel: DeviceModelInternal;
-    release: FirmwareRelease | undefined;
-    firmwareType: FirmwareType;
-    releaseVersion?: number[];
-};
-
-export interface UiRequestFirmwareDownloaded {
-    type: typeof UI_REQUEST.FIRMWARE_DOWNLOADED;
-    payload: FirmwareStoreEvent;
-}
-
-export interface UiRequestUnexpectedDeviceMode {
-    type:
-        | typeof UI_REQUEST.BOOTLOADER
-        | typeof UI_REQUEST.NOT_IN_BOOTLOADER
-        | typeof UI_REQUEST.INITIALIZE
-        | typeof UI_REQUEST.SEEDLESS
-        | typeof UI_REQUEST.DEVICE_NEEDS_BACKUP;
-    payload: Device;
-}
-
-export interface FirmwareException {
-    type:
-        | typeof UI_REQUEST.FIRMWARE_OLD
-        | typeof UI_REQUEST.FIRMWARE_OUTDATED
-        | typeof UI_REQUEST.FIRMWARE_NOT_SUPPORTED
-        | typeof UI_REQUEST.FIRMWARE_NOT_COMPATIBLE
-        | typeof UI_REQUEST.FIRMWARE_NOT_INSTALLED;
-    payload: Device;
-}
-
 export interface UiRequestSelectAccount {
-    type: typeof UI_REQUEST.SELECT_ACCOUNT;
+    type: typeof UI_REQUESTS.REQUEST_ACCOUNT;
     payload:
         | {
               type: 'start' | 'progress' | 'end';
@@ -221,117 +97,48 @@ export interface UiRequestSelectAccount {
 }
 
 export interface UiRequestSelectFee {
-    type: typeof UI_REQUEST.SELECT_FEE;
+    type: typeof UI_REQUESTS.REQUEST_FEE;
     payload: {
         coinInfo: BitcoinNetworkInfo;
         feeLevels: FeeLevel[];
     };
 }
 
-export interface BundleProgress<R> {
-    type: typeof UI_REQUEST.BUNDLE_PROGRESS;
-    payload: {
-        total: number;
-        progress: number;
-        response: R;
-        error?: string;
-    };
-}
-
-export interface FirmwareProgress {
-    type: typeof UI_REQUEST.FIRMWARE_PROGRESS;
-    payload: {
-        device: Device;
-        operation: 'downloading' | 'flashing' | 'start-flashing';
-        progress: number;
-    };
-}
-
-export interface FirmwareProgressUnexpectedDelay {
-    type: typeof UI_REQUEST.FIRMWARE_PROGRESS_UNEXPECTED_DELAY;
-    payload: Record<string, never>;
-}
-
-export interface FirmwareTypeChanged {
-    type: typeof UI_REQUEST.FIRMWARE_TYPE_CHANGED;
-    payload: {
-        device: Device;
-    };
-}
-
-/**
- * Prompt user to reconnect device during firmware installation.
- */
-export interface FirmwareReconnect {
-    type: typeof UI_REQUEST.FIRMWARE_RECONNECT;
-    payload: {
-        device: Device;
-        disconnected: boolean;
-        method: 'manual' | 'auto' | 'wait';
-        target: 'normal' | 'bootloader';
-        /** how many times this event was fired. resets when request is satisfied */
-        i: number;
-    };
-}
-
-export interface FirmwareDisconnect {
-    type: typeof UI_REQUEST.FIRMWARE_DISCONNECT;
-    payload: {
-        device: Device;
-    };
-}
-
 export interface UiRequestDiscoveryAccounts {
-    type: typeof UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS;
+    type: typeof UI_REQUESTS.REQUEST_DISCOVERY_ACCOUNTS;
     payload: {
         coinInfo: CoinInfo;
     };
 }
 
-export type UiEvent =
-    | UiRequestWithoutPayload
+export type UiRequestEvent =
     | UiRequestDeviceAction
-    | UiRequestButton
     | UiRequestConfirmation
-    | UiRequestUnexpectedDeviceMode
     | UiRequestSelectAccount
     | UiRequestSelectFee
     | UiRequestThpPairing
-    | BundleProgress<any>
-    | FirmwareProgress
-    | FirmwareProgressUnexpectedDelay
-    | FirmwareTypeChanged
-    | FirmwareException
-    | FirmwareReconnect
-    | FirmwareDisconnect
-    | UiRequestFirmwareDownloaded
     | UiRequestDiscoveryAccounts;
 
-export const isUiEventOfType = createTypeGuardByType<UiEvent>();
+export const isUiRequestOfType = createTypeGuardByType<UiRequestEvent>();
 
-export type UiEventMessage = UiEvent & {
-    event: typeof UI_EVENT;
+export type UiRequestMessage = UiRequestEvent & {
+    event: typeof UI_REQUEST;
     requestId?: string;
     callId?: string;
 };
 
-// type CreateUiMessageOptions = {
-//     requestId?: string;
-//     callId?: string;
-// };
-
-export const createUiMessage = ((
-    type: UiEvent['type'],
-    payload?: UiEvent extends { payload: infer P } ? P : undefined,
+export const createUiRequestMessage = ((
+    type: UiRequestEvent['type'],
+    payload?: UiRequestEvent extends { payload: infer P } ? P : undefined,
     options?: { requestId?: string; callId?: string },
 ) => {
     const { requestId, callId } = options ?? {};
 
     return {
-        event: UI_EVENT,
+        event: UI_REQUEST,
         type,
         payload,
         requestId,
         callId,
     };
-}) as MessageFactoryFn<typeof UI_EVENT, UiEvent>;
+}) as MessageFactoryFn<typeof UI_REQUEST, UiRequestEvent>;

--- a/packages/connect-common/src/events/ui-response.ts
+++ b/packages/connect-common/src/events/ui-response.ts
@@ -93,7 +93,6 @@ export type UiResponseEvent =
     | UiResponseAccount
     | UiResponseFee
     | UiResponseFirmwares
-    | UiResponseDiscoveryAccounts
-    | UiResponseFirmwares;
+    | UiResponseDiscoveryAccounts;
 
 export type UiResponseMessage = UiResponseEvent & { event: typeof UI_REQUEST; requestId?: string };

--- a/packages/connect-common/src/events/ui-response.ts
+++ b/packages/connect-common/src/events/ui-response.ts
@@ -1,6 +1,6 @@
 import type { ThpPairingMethod } from '@trezor/protocol';
 
-import { type UI_EVENT } from './ui-request';
+import { type UI_REQUEST } from './ui-request';
 import type { DiscoveryAccount } from '../types/account';
 import type { FeeLevel } from '../types/fees';
 import type { LocalFirmwares } from '../types/settings';
@@ -96,4 +96,4 @@ export type UiResponseEvent =
     | UiResponseDiscoveryAccounts
     | UiResponseFirmwares;
 
-export type UiResponseMessage = UiResponseEvent & { event: typeof UI_EVENT; requestId?: string };
+export type UiResponseMessage = UiResponseEvent & { event: typeof UI_REQUEST; requestId?: string };

--- a/packages/connect-common/src/types/api/events.type-test.ts
+++ b/packages/connect-common/src/types/api/events.type-test.ts
@@ -7,7 +7,10 @@ import {
     DEVICE_EVENT,
     TRANSPORT_EVENT,
     UI_EVENT,
+    UI_EVENTS,
     UI_REQUEST,
+    UI_REQUESTS,
+    UI_RESPONSE,
 } from '../../index';
 
 export const events = (api: TrezorConnect) => {
@@ -99,12 +102,12 @@ export const events = (api: TrezorConnect) => {
     api.off('transport-start', () => {});
 
     api.on(UI_EVENT, event => {
-        if (event.type === UI_REQUEST.BUNDLE_PROGRESS) {
+        if (event.type === UI_EVENTS.BUNDLE_PROGRESS) {
             // event.payload.progress;
             // event.error.message;
             // event.payload.response;
         }
-        if (event.type === UI_REQUEST.REQUEST_BUTTON) {
+        if (event.type === UI_EVENTS.BUTTON_REQUEST) {
             if (event.payload.code === 'ButtonRequest_ConfirmOutput') {
                 //
             }
@@ -123,8 +126,10 @@ export const events = (api: TrezorConnect) => {
             }
             event.payload.device.label.toLowerCase();
         }
+    });
 
-        if (event.type === UI_REQUEST.REQUEST_PIN) {
+    api.on(UI_REQUEST, event => {
+        if (event.type === UI_REQUESTS.REQUEST_PIN) {
             if (event.payload.type === 'PinMatrixRequestType_Current') {
                 //
             }
@@ -134,43 +139,43 @@ export const events = (api: TrezorConnect) => {
             }
         }
 
-        if (event.type === UI_REQUEST.REQUEST_WORD) {
+        if (event.type === UI_REQUESTS.REQUEST_WORD) {
             if (event.payload.type === 'WordRequestType_Plain') {
                 //
             }
         }
 
-        if (event.type === 'ui-request_thp_pairing') {
+        if (event.type === UI_REQUESTS.REQUEST_THP_PAIRING_TAG) {
             if (event.payload.device.thp?.properties?.pairing_methods[0] === 'CodeEntry') {
                 api.uiResponse({
-                    type: 'ui-receive_thp_pairing_tag',
+                    type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                     payload: { selectedMethod: ThpPairingMethod.NFC },
                 });
 
                 api.uiResponse({
-                    type: 'ui-receive_thp_pairing_tag',
+                    type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                     payload: { selectedMethod: 'SkipPairing' },
                 });
 
                 api.uiResponse({
-                    type: 'ui-receive_thp_pairing_tag',
+                    type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                     // @ts-expect-error invalid string
                     payload: { selectedMethod: 'unknown method' },
                 });
 
                 api.uiResponse({
-                    type: 'ui-receive_thp_pairing_tag',
+                    type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                     // @ts-expect-error invalid enum
                     payload: { selectedMethod: 7 },
                 });
 
                 api.uiResponse({
-                    type: 'ui-receive_thp_pairing_tag',
+                    type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                     payload: { tag: '0000' },
                 });
 
                 api.uiResponse({
-                    type: 'ui-receive_thp_pairing_tag',
+                    type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                     // @ts-expect-error invalid tag
                     payload: { tag: 1234 },
                 });
@@ -180,10 +185,10 @@ export const events = (api: TrezorConnect) => {
     api.off(UI_EVENT, () => {});
 
     // event without payload
-    api.on(UI_REQUEST.REQUEST_BUTTON, () => {});
-    api.on(UI_REQUEST.REQUEST_BUTTON, _payload => {});
+    api.on(UI_EVENTS.BUTTON_REQUEST, () => {});
+    api.on(UI_EVENTS.BUTTON_REQUEST, _payload => {});
 
-    api.on(UI_REQUEST.BUNDLE_PROGRESS, event => {
+    api.on(UI_EVENTS.BUNDLE_PROGRESS, event => {
         // event.progress as number;
         event.error?.toLowerCase();
         if (event.response?.empty === false) {
@@ -191,23 +196,23 @@ export const events = (api: TrezorConnect) => {
         }
     });
 
-    api.on(UI_REQUEST.BUNDLE_PROGRESS, event => {
+    api.on(UI_EVENTS.BUNDLE_PROGRESS, event => {
         // event.progress as number;
         event.error?.toLowerCase();
         event.response.serializedPath.toLowerCase();
         event.response.address.toLowerCase();
     });
-    api.off(UI_REQUEST.BUNDLE_PROGRESS, () => {});
-    api.removeAllListeners(UI_REQUEST.BUNDLE_PROGRESS);
+    api.off(UI_EVENTS.BUNDLE_PROGRESS, () => {});
+    api.removeAllListeners(UI_EVENTS.BUNDLE_PROGRESS);
 
-    api.on(UI_REQUEST.REQUEST_BUTTON, event => {
+    api.on(UI_EVENTS.BUTTON_REQUEST, event => {
         // @ts-expect-error
         if (event.code === 'a') {
             //
         }
     });
-    api.off(UI_REQUEST.REQUEST_BUTTON, () => {});
-    api.removeAllListeners(UI_REQUEST.BUNDLE_PROGRESS);
+    api.off(UI_EVENTS.BUTTON_REQUEST, () => {});
+    api.removeAllListeners(UI_EVENTS.BUNDLE_PROGRESS);
 
     api.on(BLOCKCHAIN_EVENT, event => {
         if (event.type === BLOCKCHAIN.CONNECT) {

--- a/packages/connect-common/src/types/emitter.ts
+++ b/packages/connect-common/src/types/emitter.ts
@@ -9,7 +9,8 @@ import type {
 import type { DEVICE_EVENT, DeviceEvent, DeviceEventMessage } from '../events/device';
 import type { PopupEvent, PopupEventMessage } from '../events/popup';
 import type { TRANSPORT_EVENT, TransportEvent, TransportEventMessage } from '../events/transport';
-import type { UI_EVENT, UiEvent, UiEventMessage } from '../events/ui-request';
+import type { UI_EVENT, UiEvent, UiEventMessage } from '../events/ui-event';
+import type { UI_REQUEST, UiRequestEvent, UiRequestMessage } from '../events/ui-request';
 
 type EventPayloadMap<T extends { type: string; payload?: any }> = {
     [E in T as E['type']]: E extends { payload: infer P } ? P : undefined;
@@ -20,10 +21,12 @@ type ConnectEventMap = {
     [TRANSPORT_EVENT]: TransportEventMessage;
     [BLOCKCHAIN_EVENT]: BlockchainEventMessage;
     [UI_EVENT]: UiEventMessage | PopupEventMessage;
+    [UI_REQUEST]: UiRequestMessage;
 } & EventPayloadMap<DeviceEvent> &
     EventPayloadMap<TransportEvent> &
     EventPayloadMap<BlockchainEvent> &
     EventPayloadMap<UiEvent> &
+    EventPayloadMap<UiRequestEvent> &
     EventPayloadMap<PopupEvent>;
 
 export type ConnectEvents = keyof ConnectEventMap;

--- a/packages/connect-examples/electron-main-process/src/trezor-connect-ipc.js
+++ b/packages/connect-examples/electron-main-process/src/trezor-connect-ipc.js
@@ -5,6 +5,7 @@ import TrezorConnect, {
     TRANSPORT_EVENT,
     UI_EVENT,
     UI_REQUEST,
+    UI_REQUESTS,
     UI_RESPONSE,
 } from '@trezor/connect';
 
@@ -41,16 +42,22 @@ export const initTrezorConnect = sender => {
     });
 
     // Listen to UI_EVENT
-    // most common requests
+    // fire-and-forget notifications
     TrezorConnect.on(UI_EVENT, event => {
         sender.send('trezor-connect', event);
+    });
 
-        if (event.type === UI_REQUEST.REQUEST_PIN) {
+    // Listen to UI_REQUEST
+    // most common requests that require a response
+    TrezorConnect.on(UI_REQUEST, event => {
+        sender.send('trezor-connect', event);
+
+        if (event.type === UI_REQUESTS.REQUEST_PIN) {
             // example how to respond to pin request
             TrezorConnect.uiResponse({ type: UI_RESPONSE.RECEIVE_PIN, payload: '1234' });
         }
 
-        if (event.type === UI_REQUEST.REQUEST_PASSPHRASE) {
+        if (event.type === UI_REQUESTS.REQUEST_PASSPHRASE) {
             if (event.payload.device.features.capabilities.includes('Capability_PassphraseEntry')) {
                 // device does support entering passphrase on device
                 // let user choose where to enter
@@ -71,7 +78,7 @@ export const initTrezorConnect = sender => {
         // getAddress from device which is not backed up
         // there is a high risk of coin loss at this point
         // warn user about it
-        if (event.type === UI_REQUEST.REQUEST_CONFIRMATION) {
+        if (event.type === UI_REQUESTS.REQUEST_CONFIRMATION) {
             // payload: true - user decides to continue anyway
             TrezorConnect.uiResponse({ type: UI_RESPONSE.RECEIVE_CONFIRMATION, payload: true });
         }

--- a/packages/connect-explorer/src/pages/methods/bitcoin/sendTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/sendTransaction.mdx
@@ -100,5 +100,5 @@ Error
 
 ### Additional notes
 
-- [1] `UI.SELECT_ACCOUNT` and `UI.SELECT_FEE` events are emitted when using `trusted mode`
+- [1] `UI_REQUESTS.REQUEST_ACCOUNT` and `UI_REQUESTS.REQUEST_FEE` events are emitted when using `trusted mode`
 - [2] Account utxo selection, fee and change calculation is performed by [@trezor/utxo-lib](https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib/src/compose) module

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -85,6 +85,37 @@ The [migration guide](https://connect.trezor.io/10.0.0-beta.1/guides/migrating-t
 - **Thin packages lost their event/settings API.** `on`/`off`/`removeAllListeners`, `uiResponse` and `updateConnectSettings` are removed from the public tier (they were already non-functional in v10, since the host Core does not forward them); calling them now throws `TypeError`.
 - **Type/factory renames.** The exported `TrezorConnect` type is replaced by `TrezorConnectPublicAPI` / `TrezorConnectPrivilegedAPI`, and the `factory` function by `factoryPublic` / `factoryPrivileged`. The API-schema values (`TrezorConnectCallable`, `TrezorConnectBitcoin`, …) are no longer exported as runtime values — the names remain as types only.
 
+### UI events
+
+These affect hosts that run their own Core (`@trezor/connect`) and listen for UI messages; thin-client integrations no longer receive UI events directly (see the event/settings API removal above).
+
+- **`UI_REQUEST` split into `UI_EVENTS` and `UI_REQUESTS`.** The single `UI_REQUEST` constant object that held every UI message type has been split into two groups on distinct channels:
+    - `UI_EVENTS` — fire-and-forget notifications emitted on the `UI_EVENT` channel; no `uiResponse` is expected. Wire values are namespaced as `ui-event_*`.
+    - `UI_REQUESTS` — prompts that require a `TrezorConnect.uiResponse()` reply, emitted on the new `UI_REQUEST` channel. Wire values keep the `ui-request_*` form.
+
+    `UI_REQUEST` is now the request **channel** string (`'UI_REQUEST'`), no longer the map of message types — read message types from `UI_EVENTS` / `UI_REQUESTS` instead. A host that subscribes by channel must listen on **both** `UI_EVENT` and `UI_REQUEST`.
+
+- **Message-type renames:**
+
+    | Old                                       | New                                   |
+    | ----------------------------------------- | ------------------------------------- |
+    | `UI_REQUEST.SELECT_ACCOUNT`               | `UI_REQUESTS.REQUEST_ACCOUNT`         |
+    | `UI_REQUEST.SELECT_FEE`                   | `UI_REQUESTS.REQUEST_FEE`             |
+    | `UI_REQUEST.REQUEST_THP_PAIRING`          | `UI_REQUESTS.REQUEST_THP_PAIRING_TAG` |
+    | `UI_REQUEST.REQUEST_BUTTON`               | `UI_EVENTS.BUTTON_REQUEST`            |
+    | `UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE` | `UI_EVENTS.PASSPHRASE_ON_DEVICE`      |
+    | `UI_REQUEST.TRANSPORT`                    | `UI_EVENTS.NO_TRANSPORT`              |
+    | `UI_REQUEST.INITIALIZE`                   | `UI_EVENTS.DEVICE_NOT_INITIALIZED`    |
+    | `UI_REQUEST.BOOTLOADER`                   | `UI_EVENTS.DEVICE_IN_BOOTLOADER`      |
+    | `UI_REQUEST.NOT_IN_BOOTLOADER`            | `UI_EVENTS.DEVICE_NOT_IN_BOOTLOADER`  |
+    | `UI_REQUEST.SEEDLESS`                     | `UI_EVENTS.DEVICE_SEEDLESS`           |
+
+    The remaining types keep their key names but move into the matching group (e.g. `UI_REQUEST.REQUEST_PIN` → `UI_REQUESTS.REQUEST_PIN`, `UI_REQUEST.DEVICE_NEEDS_BACKUP` → `UI_EVENTS.DEVICE_NEEDS_BACKUP`).
+
+- **`UI_EVENTS` wire values changed.** Every `UI_EVENTS` string value is re-namespaced from `ui-*` to `ui-event_*` (e.g. `ui-no_transport` → `ui-event_no_transport`, `ui-device_bootloader_mode` → `ui-event_device_in_bootloader`). Reference the exported constants instead of hardcoding the strings.
+
+- **Device-carrying events are now wrapped.** UI events that carry a device (`DEVICE_NEEDS_BACKUP`, `FIRMWARE_OUTDATED`, and the device-mode / firmware-exception types) use a `{ device }` payload object instead of a bare `Device`; read `event.payload.device`.
+
 ### Methods & parameters
 
 - **`coin` accepts the coin shortcut only** (the `CoinSymbol` set — e.g. `btc`, `bch`, `ada`), narrowed from `string`. Network **names** and **labels** (e.g. `'Bitcoin'`, `'Bitcoin Cash'`) are no longer accepted and now fail both at compile time and at runtime. The shortcut itself is still matched case-insensitively at runtime, so `coin: 'BTC'` works — but the `CoinSymbol` type lists the canonical lowercase forms, so TypeScript users should pass lowercase to type-check. Resolution is uniform across all coin families. Migrate names/labels to the shortcut: `'Bitcoin' → 'btc'`, `'Bitcoin Cash' → 'bch'`, `'cardano' → 'ada'`, etc. Path-taking methods (`getAddress`, `getPublicKey`, …) derive the network from `path` when given a former name/label; methods without a path fallback (`getAccountInfo`, `selectAccount`, `verifyMessage`, `composeTransaction`, `signTransaction`, `signMessage`, `getOwnershipId`, `getOwnershipProof`, the `blockchain*` family) throw `Method_UnknownCoin`. Full list: [supported coins](https://connect.trezor.io/10.0.0-beta.1/details/coins).

--- a/packages/connect/e2e/common.setup.ts
+++ b/packages/connect/e2e/common.setup.ts
@@ -1,4 +1,4 @@
-import { UI_REQUEST, UI_RESPONSE } from '@trezor/connect-common';
+import { UI_EVENTS, UI_REQUESTS, UI_RESPONSE } from '@trezor/connect-common';
 import type { ApplySettings } from '@trezor/protobuf/src/definitions';
 import { BridgeTransport } from '@trezor/transport-common';
 import type { EmuStartOptsType, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
@@ -194,7 +194,7 @@ export const initTrezorConnect = async (
         console.log('Transport started: ', event.version);
     });
 
-    TrezorConnect.on(UI_REQUEST.REQUEST_CONFIRMATION, () => {
+    TrezorConnect.on(UI_REQUESTS.REQUEST_CONFIRMATION, () => {
         TrezorConnect.uiResponse({
             type: UI_RESPONSE.RECEIVE_CONFIRMATION,
             payload: true,
@@ -202,7 +202,7 @@ export const initTrezorConnect = async (
     });
 
     if (autoConfirm) {
-        TrezorConnect.on(UI_REQUEST.REQUEST_BUTTON, async e => {
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, async e => {
             if (e.code === 'ButtonRequest_PinEntry') return;
             if (screenCaptureEnabled) {
                 try {

--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-import TrezorConnect from '../../../src';
+import TrezorConnect, { UI_REQUESTS, UI_RESPONSE } from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();
@@ -208,9 +208,9 @@ describe('TrezorConnect.authorizeCoinjoin', () => {
             },
         });
 
-        TrezorConnect.on('ui-request_passphrase', () => {
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, () => {
             TrezorConnect.uiResponse({
-                type: 'ui-receive_passphrase',
+                type: UI_RESPONSE.RECEIVE_PASSPHRASE,
                 payload: {
                     passphraseOnDevice: false,
                     value: 'a',

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -2,7 +2,7 @@ import type { CoinSymbol } from '@trezor/connect-common';
 import type { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 import { Model } from '@trezor/trezor-user-env-link';
 
-import TrezorConnect from '../../../src';
+import TrezorConnect, { UI_REQUESTS, UI_RESPONSE } from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const getAddress = (showOnTrezor: boolean, coin: CoinSymbol = 'regtest') =>
@@ -14,27 +14,27 @@ const getAddress = (showOnTrezor: boolean, coin: CoinSymbol = 'regtest') =>
 
 const passphraseHandler = (value: string) => () => {
     TrezorConnect.uiResponse({
-        type: 'ui-receive_passphrase',
+        type: UI_RESPONSE.RECEIVE_PASSPHRASE,
         payload: {
             passphraseOnDevice: false,
             value,
         },
     });
-    TrezorConnect.removeAllListeners('ui-request_passphrase');
+    TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
 };
 
 const addressHandler = () => () => {
     TrezorConnect.uiResponse({
-        type: 'ui-receive_confirmation',
+        type: UI_RESPONSE.RECEIVE_CONFIRMATION,
         payload: true,
     });
-    TrezorConnect.removeAllListeners('ui-request_confirmation');
+    TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_CONFIRMATION);
 };
 
 const assertGetAddressWorks = async () => {
     // validate that further communication is possible without any glitch
-    TrezorConnect.on('ui-request_passphrase', passphraseHandler(''));
-    TrezorConnect.on('ui-request_confirmation', addressHandler());
+    TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, passphraseHandler(''));
+    TrezorConnect.on(UI_REQUESTS.REQUEST_CONFIRMATION, addressHandler());
     const getAddressResponse = await getAddress(false, 'test');
     expect(getAddressResponse).toMatchObject({
         success: true,
@@ -55,7 +55,7 @@ const runCancelScenario = async (
 
     // Let call A run to completion so its callId is no longer in callMethods
     const callIdA = crypto.randomUUID();
-    TrezorConnect.on('ui-request_passphrase', passphraseHandler(''));
+    TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, passphraseHandler(''));
     const responseA = await TrezorConnect.getAddress({
         path: "m/84'/1'/0'/0/0",
         coin: 'regtest',
@@ -190,7 +190,7 @@ describe('TrezorConnect.cancel', () => {
 
         const getAddressCall = getAddress(true);
         await new Promise<void>(resolve => {
-            TrezorConnect.on('ui-request_passphrase', () => resolve());
+            TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, () => resolve());
         });
         TrezorConnect.cancel();
 
@@ -218,7 +218,7 @@ describe('TrezorConnect.cancel', () => {
 
         // Wait for passphrase prompt then cancel only this call by its callId
         await new Promise<void>(resolve => {
-            TrezorConnect.on('ui-request_passphrase', () => resolve());
+            TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, () => resolve());
         });
         TrezorConnect.cancel({ callId });
 
@@ -265,7 +265,7 @@ describe('TrezorConnect.cancel', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
 
         const pinPromise = new Promise<void>(resolve => {
-            TrezorConnect.on('ui-request_pin', () => {
+            TrezorConnect.on(UI_REQUESTS.REQUEST_PIN, () => {
                 resolve();
             });
         });
@@ -298,7 +298,7 @@ describe('TrezorConnect.cancel', () => {
         await initTrezorConnect(controller);
 
         const wordPromise = new Promise<void>(resolve => {
-            TrezorConnect.on('ui-request_word', () => resolve());
+            TrezorConnect.on(UI_REQUESTS.REQUEST_WORD, () => resolve());
         });
         const recoveryDeviceCall = TrezorConnect.recoveryDevice({
             passphrase_protection: false,

--- a/packages/connect/e2e/tests/device/discoverAccounts.test.ts
+++ b/packages/connect/e2e/tests/device/discoverAccounts.test.ts
@@ -1,7 +1,7 @@
-import { UI_REQUEST } from '@trezor/connect-common';
+import { UI_EVENTS } from '@trezor/connect-common';
 import type { DiscoverAccountsProgress } from '@trezor/connect-common/src/types/api/account/discoverAccounts';
 
-import TrezorConnect, { type BundleProgress } from '../../../src';
+import TrezorConnect, { type UiEventBundleProgress } from '../../../src';
 import { getController, initTrezorConnect, setup } from '../../common.setup';
 
 let controller: ReturnType<typeof getController> | undefined;
@@ -46,7 +46,9 @@ describe(`TrezorConnect.discoverAccounts`, () => {
             throw new Error('Controller not found');
         }
 
-        const onBundleProgress = (_event: BundleProgress<DiscoverAccountsProgress>['payload']) => {
+        const onUiEventBundleProgress = (
+            _event: UiEventBundleProgress<DiscoverAccountsProgress>['payload'],
+        ) => {
             /*
             const { response, ...rest } = event;
             if ('error' in response) {
@@ -67,7 +69,7 @@ describe(`TrezorConnect.discoverAccounts`, () => {
             */
         };
 
-        TrezorConnect.on(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
+        TrezorConnect.on(UI_EVENTS.BUNDLE_PROGRESS, onUiEventBundleProgress);
         /*
         new Promise(resolve => setTimeout(resolve, 600)).then(() =>
             TrezorConnect.cancel({ reason: 'CANCELLED' }),
@@ -89,7 +91,7 @@ describe(`TrezorConnect.discoverAccounts`, () => {
             ],
         });
 
-        TrezorConnect.off(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
+        TrezorConnect.off(UI_EVENTS.BUNDLE_PROGRESS, onUiEventBundleProgress);
 
         expect(result).toMatchObject({});
     }, 180000);

--- a/packages/connect/e2e/tests/device/keepSession.test.ts
+++ b/packages/connect/e2e/tests/device/keepSession.test.ts
@@ -1,4 +1,4 @@
-import TrezorConnect, { type StaticSessionId } from '../../../src';
+import TrezorConnect, { type StaticSessionId, UI_REQUESTS, UI_RESPONSE } from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();
@@ -19,8 +19,11 @@ describe('keepSession common param', () => {
     });
 
     conditionalTest(['1', '<2.3.2'], 'keepSession preserves Cardano derivation', async () => {
-        TrezorConnect.on('ui-request_passphrase', () => {
-            TrezorConnect.uiResponse({ type: 'ui-receive_passphrase', payload: { value: 'a' } });
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, () => {
+            TrezorConnect.uiResponse({
+                type: UI_RESPONSE.RECEIVE_PASSPHRASE,
+                payload: { value: 'a' },
+            });
         });
 
         // Enable 'ada'. The call forces a session re-create with derive_cardano.
@@ -37,7 +40,7 @@ describe('keepSession common param', () => {
 
         // change device instance to simulate app reload
         // passphrase request should not be called
-        TrezorConnect.removeAllListeners('ui-request_passphrase');
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
         // modify instance in staticSessionId
         const staticSessionId = device.state.staticSessionId?.replace(
             ':0',

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -1,4 +1,4 @@
-import TrezorConnect from '../../../src';
+import TrezorConnect, { UI_REQUESTS, UI_RESPONSE } from '../../../src';
 import {
     conditionalTest,
     getController,
@@ -11,14 +11,14 @@ const controller = getController();
 
 const passphraseHandler = (value: string) => () => {
     TrezorConnect.uiResponse({
-        type: 'ui-receive_passphrase',
+        type: UI_RESPONSE.RECEIVE_PASSPHRASE,
         payload: {
             passphraseOnDevice: false,
             value,
             save: true, // NOTE: this field is used only in legacy test of T1B1 firmware
         },
     });
-    TrezorConnect.removeAllListeners('ui-request_passphrase');
+    TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
 };
 
 describe('TrezorConnect passphrase', () => {
@@ -65,7 +65,7 @@ describe('TrezorConnect passphrase', () => {
         });
 
         // get state of walletA using passphrase "a"
-        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, passphraseHandler('a'));
         const walletA = await TrezorConnect.getDeviceState({
             device: {
                 instance: 1,
@@ -94,7 +94,7 @@ describe('TrezorConnect passphrase', () => {
         });
 
         // get state of walletB using passphrase "b"
-        TrezorConnect.on('ui-request_passphrase', passphraseHandler('b'));
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, passphraseHandler('b'));
         const walletB = await TrezorConnect.getDeviceState({
             device: {
                 instance: 2,
@@ -158,7 +158,7 @@ describe('TrezorConnect passphrase', () => {
         });
 
         // use invalid state on default instance
-        TrezorConnect.on('ui-request_passphrase', passphraseHandler('wrong'));
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, passphraseHandler('wrong'));
         const invalidState = await TrezorConnect.getAddress({
             device: {
                 instance: 0,
@@ -176,7 +176,7 @@ describe('TrezorConnect passphrase', () => {
             code: 'Device_InvalidState',
             message: 'Passphrase is incorrect',
         });
-        TrezorConnect.removeAllListeners('ui-request_passphrase');
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
     });
 
     it('Using multiple passphrases with device restart', async () => {
@@ -187,7 +187,7 @@ describe('TrezorConnect passphrase', () => {
         if (!standard.success) throw new Error(standard.error.message);
 
         // get passphrase wallet state
-        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, passphraseHandler('a'));
         const passphrase = await TrezorConnect.getDeviceState({
             device: { instance: 1, state: undefined },
         });
@@ -197,7 +197,7 @@ describe('TrezorConnect passphrase', () => {
         await restartEmu(controller);
 
         // try to get passphrase wallet state, with now invalid sessionId
-        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, passphraseHandler('a'));
         const passphrase2 = await TrezorConnect.getDeviceState({
             device: {
                 instance: 1,
@@ -227,7 +227,7 @@ describe('TrezorConnect passphrase', () => {
     });
 
     it('Passphrase encoding', async () => {
-        TrezorConnect.on('ui-request_passphrase', passphraseHandler('příliš žluťoučký kůň'));
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, passphraseHandler('příliš žluťoučký kůň'));
 
         const xpub = await TrezorConnect.getPublicKey({
             device: {
@@ -247,15 +247,15 @@ describe('TrezorConnect passphrase', () => {
 
     // passphrase on device not available on T1B1
     conditionalTest(['1'], 'Input passphrase on device', async () => {
-        TrezorConnect.on('ui-request_passphrase', () => {
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, () => {
             TrezorConnect.uiResponse({
-                type: 'ui-receive_passphrase',
+                type: UI_RESPONSE.RECEIVE_PASSPHRASE,
                 payload: {
                     passphraseOnDevice: true,
                     value: '',
                 },
             });
-            TrezorConnect.removeAllListeners('ui-request_passphrase');
+            TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
             // Due to race condition with node-bridge, we have to wait a bit
             setTimeout(() => {
                 controller.send({ type: 'emulator-input', value: 'a' });

--- a/packages/connect/e2e/tests/device/pingDevice.test.ts
+++ b/packages/connect/e2e/tests/device/pingDevice.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-import TrezorConnect from '../../../src';
+import TrezorConnect, { UI_EVENTS } from '../../../src';
 import { conditionalTest, getController, initTrezorConnect, setup } from '../../common.setup';
 
 const controller = getController();
@@ -50,7 +50,7 @@ describe('TrezorConnect.pingDevice', () => {
 
     it('with button request', async () => {
         const buttonSpy = vi.fn();
-        TrezorConnect.on('ui-button', buttonSpy);
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, buttonSpy);
 
         const response = await TrezorConnect.pingDevice({
             button_protection: true,

--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -1,6 +1,13 @@
 import { vi } from 'vitest';
 
-import TrezorConnect, { type Device, type ThpSettings, type UiEvent } from '../../../src';
+import TrezorConnect, {
+    type Device,
+    type ThpSettings,
+    UI_EVENTS,
+    UI_REQUESTS,
+    UI_RESPONSE,
+    type UiRequestEvent,
+} from '../../../src';
 import { THP_CREDENTIALS } from '../../common-thp-credentials';
 import { getController, initTrezorConnect, restartEmu, setup } from '../../common.setup';
 
@@ -45,7 +52,7 @@ describe('THP pairing', () => {
     const getPairingInfo = ({
         device,
         nfcData,
-    }: Extract<UiEvent, { type: 'ui-request_thp_pairing' }>['payload']) =>
+    }: Extract<UiRequestEvent, { type: typeof UI_REQUESTS.REQUEST_THP_PAIRING_TAG }>['payload']) =>
         controller.getPairingInfo(device.thp!.channel, nfcData).catch(e => {
             console.error('DebugLinkGetPairingInfo', device.thp!.channel, e);
 
@@ -55,7 +62,7 @@ describe('THP pairing', () => {
     it('ThpPairing SkipPairing', async () => {
         const spy = vi.fn();
         const device = await waitForDevice({ pairingMethods: ['SkipPairing'] });
-        TrezorConnect.on('ui-request_thp_pairing', spy);
+        TrezorConnect.on(UI_REQUESTS.REQUEST_THP_PAIRING_TAG, spy);
 
         const address = await TrezorConnect.getAddress({
             device,
@@ -69,11 +76,11 @@ describe('THP pairing', () => {
     it('ThpPairing NFC', async () => {
         const device = await waitForDevice({ pairingMethods: ['NFC'] });
 
-        TrezorConnect.on('ui-request_thp_pairing', async event => {
+        TrezorConnect.on(UI_REQUESTS.REQUEST_THP_PAIRING_TAG, async event => {
             const state = await getPairingInfo(event);
-            TrezorConnect.removeAllListeners('ui-request_thp_pairing');
+            TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_THP_PAIRING_TAG);
             TrezorConnect.uiResponse({
-                type: 'ui-receive_thp_pairing_tag',
+                type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                 payload: { tag: state.nfc_secret_trezor },
             });
         });
@@ -102,7 +109,7 @@ describe('THP pairing', () => {
         });
 
         const pairingSpy = vi.fn();
-        TrezorConnect.on('ui-request_thp_pairing', pairingSpy);
+        TrezorConnect.on(UI_REQUESTS.REQUEST_THP_PAIRING_TAG, pairingSpy);
 
         const address = await TrezorConnect.getAddress({
             device,
@@ -123,10 +130,10 @@ describe('THP pairing', () => {
             // console.log('Credentials', event.credentials);
         });
 
-        TrezorConnect.on('ui-request_thp_pairing', async event => {
+        TrezorConnect.on(UI_REQUESTS.REQUEST_THP_PAIRING_TAG, async event => {
             const state = await getPairingInfo(event);
             TrezorConnect.uiResponse({
-                type: 'ui-receive_thp_pairing_tag',
+                type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                 payload: { tag: state.code_entry_code },
             });
         });
@@ -142,8 +149,8 @@ describe('THP pairing', () => {
         expect(credentialsSpy).toHaveBeenCalledTimes(2);
 
         // expect no pairing or button request from now on
-        TrezorConnect.removeAllListeners('ui-request_thp_pairing');
-        TrezorConnect.removeAllListeners('ui-button');
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_THP_PAIRING_TAG);
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
 
         // restart the device
         await restartEmu(controller);
@@ -181,10 +188,10 @@ describe('THP pairing', () => {
             statusChangeEvents.push(status);
         });
 
-        TrezorConnect.on('ui-request_thp_pairing', () => {
-            TrezorConnect.removeAllListeners('ui-request_thp_pairing');
+        TrezorConnect.on(UI_REQUESTS.REQUEST_THP_PAIRING_TAG, () => {
+            TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_THP_PAIRING_TAG);
             TrezorConnect.uiResponse({
-                type: 'ui-receive_thp_pairing_tag',
+                type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                 payload: { tag: '111111' },
             });
         });
@@ -212,7 +219,7 @@ describe('THP pairing', () => {
         let result;
 
         // 1. reject pairing tag request from host
-        TrezorConnect.on('ui-request_thp_pairing', cancelOnHost);
+        TrezorConnect.on(UI_REQUESTS.REQUEST_THP_PAIRING_TAG, cancelOnHost);
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
         expect(result.error.message).toMatch(CANCEL_ERR);
@@ -222,8 +229,8 @@ describe('THP pairing', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
 
         // 2. reject pairing tag request from Trezor
-        TrezorConnect.removeAllListeners('ui-request_thp_pairing');
-        TrezorConnect.on('ui-request_thp_pairing', () => {
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_THP_PAIRING_TAG);
+        TrezorConnect.on(UI_REQUESTS.REQUEST_THP_PAIRING_TAG, () => {
             controller.send({ type: 'emulator-press-no' });
         });
         result = await TrezorConnect.getFeatures({ device });
@@ -235,8 +242,8 @@ describe('THP pairing', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
 
         // 3. reject pairing confirmation from Trezor
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', () => {
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, () => {
             controller.send({ type: 'emulator-press-no' });
         });
         result = await TrezorConnect.getFeatures({ device });
@@ -245,21 +252,21 @@ describe('THP pairing', () => {
         expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(3));
 
         // 3. reject pairing confirmation from host
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', cancelOnHost);
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, cancelOnHost);
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
         expect(result.error.message).toMatch(FW_CANCEL_ERR); // canceled gracefully on Trezor
         expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(4));
 
         // check if pairing is still responsive
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.removeAllListeners('ui-request_thp_pairing');
-        TrezorConnect.on('ui-button', buttonRequestHandler());
-        TrezorConnect.on('ui-request_thp_pairing', async event => {
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_THP_PAIRING_TAG);
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, buttonRequestHandler());
+        TrezorConnect.on(UI_REQUESTS.REQUEST_THP_PAIRING_TAG, async event => {
             const state = await getPairingInfo(event);
             TrezorConnect.uiResponse({
-                type: 'ui-receive_thp_pairing_tag',
+                type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                 payload: { tag: state.code_entry_code },
             });
         });
@@ -280,13 +287,13 @@ describe('THP pairing', () => {
 
         const enterPassphraseOnHost = (value: string) => () => {
             TrezorConnect.uiResponse({
-                type: 'ui-receive_passphrase',
+                type: UI_RESPONSE.RECEIVE_PASSPHRASE,
                 payload: {
                     passphraseOnDevice: false,
                     value,
                 },
             });
-            TrezorConnect.removeAllListeners('ui-request_passphrase');
+            TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
         };
 
         let result;
@@ -295,11 +302,11 @@ describe('THP pairing', () => {
         result = await TrezorConnect.getFeatures({ device });
         expect(result).toMatchObject({ success: true });
 
-        TrezorConnect.on('ui-request_passphrase', enterPassphraseOnHost(''));
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, enterPassphraseOnHost(''));
 
         // 4. reject ButtonRequest from host
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', cancelOnHost);
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, cancelOnHost);
         result = await TrezorConnect.getAddress({
             device,
             path: "m/44'/0'/0'/1/1",
@@ -309,8 +316,8 @@ describe('THP pairing', () => {
         expect(result.error.message).toMatch(CANCEL_ERR);
 
         // 4. reject ButtonRequest from Trezor
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', () => {
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, () => {
             controller.send({ type: 'emulator-press-no' });
         });
         result = await TrezorConnect.getAddress({
@@ -322,10 +329,10 @@ describe('THP pairing', () => {
         expect(result.error.message).toMatch(FW_CANCEL_ERR);
 
         // 5. reject passphrase from host using TrezorConnect.cancel()
-        TrezorConnect.removeAllListeners('ui-request_passphrase');
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', buttonRequestHandler());
-        TrezorConnect.on('ui-request_passphrase', cancelOnHost);
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, buttonRequestHandler());
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, cancelOnHost);
         result = await TrezorConnect.getAddress({
             device: {
                 ...device,
@@ -338,10 +345,10 @@ describe('THP pairing', () => {
         expect(result.error.message).toMatch(CANCEL_ERR);
 
         // 6. reject passphrase from host using empty payload
-        TrezorConnect.removeAllListeners('ui-request_passphrase');
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-button', buttonRequestHandler());
-        TrezorConnect.on('ui-request_passphrase', () => {
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, buttonRequestHandler());
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, () => {
             // @ts-expect-error payload is missing
             TrezorConnect.uiResponse({
                 type: 'ui-receive_passphrase',
@@ -359,10 +366,10 @@ describe('THP pairing', () => {
         expect(result.error.code).toMatch('Method_Cancel');
 
         // 7. reject passphrase from Trezor
-        TrezorConnect.removeAllListeners('ui-request_passphrase');
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.on('ui-request_passphrase', enterPassphraseOnHost('a'));
-        TrezorConnect.on('ui-button', buttonRequestHandler('passphrase_host1')); // NOTE: .name may be changed in the future
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, enterPassphraseOnHost('a'));
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, buttonRequestHandler('passphrase_host1')); // NOTE: .name may be changed in the future
         result = await TrezorConnect.getAddress({
             device: {
                 ...device,
@@ -375,10 +382,10 @@ describe('THP pairing', () => {
         expect(result.error.message).toMatch(FW_CANCEL_ERR);
 
         // and finally check if device is still responsive
-        TrezorConnect.removeAllListeners('ui-button');
-        TrezorConnect.removeAllListeners('ui-request_passphrase');
-        TrezorConnect.on('ui-request_passphrase', enterPassphraseOnHost('a'));
-        TrezorConnect.on('ui-button', buttonRequestHandler());
+        TrezorConnect.removeAllListeners(UI_EVENTS.BUTTON_REQUEST);
+        TrezorConnect.removeAllListeners(UI_REQUESTS.REQUEST_PASSPHRASE);
+        TrezorConnect.on(UI_REQUESTS.REQUEST_PASSPHRASE, enterPassphraseOnHost('a'));
+        TrezorConnect.on(UI_EVENTS.BUTTON_REQUEST, buttonRequestHandler());
         result = await TrezorConnect.getAddress({
             device: {
                 ...device,

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -1,4 +1,4 @@
-import { UI_REQUEST } from '@trezor/connect-common';
+import { UI_EVENTS } from '@trezor/connect-common';
 import type { PermissionRequest } from '@trezor/connect-common';
 import type { VerifyAuthenticityProofResult } from '@trezor/device-authenticity';
 import {
@@ -33,7 +33,7 @@ export default class AuthenticateDevice extends AbstractMethod<
 
         super(message, params);
         this.useEmptyPassphrase = true;
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED, UI_EVENTS.DEVICE_SEEDLESS];
         this.skipFinalReload = false;
         this.useDeviceState = false;
     }

--- a/packages/connect/src/api/bleUnpair.ts
+++ b/packages/connect/src/api/bleUnpair.ts
@@ -1,4 +1,4 @@
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
@@ -16,7 +16,7 @@ export default class BleUnpair extends AbstractMethod<'bleUnpair', PROTO.BleUnpa
         const params = { all: payload.all };
 
         super(message, params);
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED, UI_EVENTS.DEVICE_SEEDLESS];
         this.useDeviceState = false;
     }
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -4,8 +4,8 @@ import {
     Bundle,
     CardanoGetAddress as CardanoGetAddressSchema,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { fromHardenedPathPart } from '@trezor/crypto-utils';
@@ -160,7 +160,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response,

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -4,8 +4,8 @@ import {
     Bundle,
     CardanoGetPublicKey as CardanoGetPublicKeySchema,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { fromHardenedPathPart } from '@trezor/crypto-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -107,7 +107,7 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response: message,

--- a/packages/connect/src/api/changeLanguage.ts
+++ b/packages/connect/src/api/changeLanguage.ts
@@ -3,7 +3,7 @@
 import {
     ChangeLanguage as ChangeLanguageSchema,
     type PermissionRequest,
-    UI_REQUEST,
+    UI_EVENTS,
 } from '@trezor/connect-common';
 import { Assert } from '@trezor/schema-utils';
 
@@ -18,7 +18,7 @@ export default class ChangeLanguage extends AbstractMethod<'changeLanguage', Cha
         Assert(ChangeLanguageSchema, payload);
 
         super(message, payload);
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED, UI_EVENTS.DEVICE_SEEDLESS];
         this.useEmptyPassphrase = true;
         this.skipFinalReload = false;
         this.useDeviceState = false;

--- a/packages/connect/src/api/cipherKeyValue.ts
+++ b/packages/connect/src/api/cipherKeyValue.ts
@@ -3,8 +3,8 @@
 import {
     CipherKeyValue as CipherKeyValueSchema,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { Bundle } from '@trezor/connect-common/src/types/params';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -63,7 +63,7 @@ export default class CipherKeyValue extends AbstractMethod<
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response,

--- a/packages/connect/src/api/common/AbstractMiscGetAddress.ts
+++ b/packages/connect/src/api/common/AbstractMiscGetAddress.ts
@@ -2,8 +2,8 @@ import {
     Bundle,
     GetAddress as GetAddressSchema,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { fromHardenedPathPart } from '@trezor/crypto-utils';
@@ -155,7 +155,7 @@ export abstract class AbstractMiscGetAddress<
 
             if (this.hasBundle) {
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: params.length,
                         progress: i,
                         response,

--- a/packages/connect/src/api/common/requestExistingAccounts.ts
+++ b/packages/connect/src/api/common/requestExistingAccounts.ts
@@ -2,10 +2,10 @@ import {
     type CoinInfo,
     type CoreEventMessage,
     type DiscoveryAccount,
-    UI_REQUEST,
+    UI_REQUESTS,
     UI_RESPONSE,
     type UiResponseDiscoveryAccounts,
-    createUiMessage,
+    createUiRequestMessage,
 } from '@trezor/connect-common';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
 
@@ -15,7 +15,7 @@ import type { IDevice } from '../../types/idevice';
 const REQUEST_TIMEOUT_MS = 200;
 
 /**
- * Sends UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS to the host (e.g. Suite) and waits for a response.
+ * Sends UI_REQUESTS.REQUEST_DISCOVERY_ACCOUNTS to the host (e.g. Suite) and waits for a response.
  * If the host provides existing accounts, returns them. Otherwise returns null so the caller
  * can fall back to device discovery.
  */
@@ -32,7 +32,7 @@ export const requestExistingAccounts = async ({
 }): Promise<DiscoveryAccount[] | null> => {
     const dfd = createUiPromise(UI_RESPONSE.RECEIVE_DISCOVERY_ACCOUNTS, device);
 
-    postMessage(createUiMessage(UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS, { coinInfo }));
+    postMessage(createUiRequestMessage(UI_REQUESTS.REQUEST_DISCOVERY_ACCOUNTS, { coinInfo }));
 
     const result = await Promise.race([
         dfd.promise.then((response: UiResponseDiscoveryAccounts) => response.payload),

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -12,8 +12,8 @@ import {
     type FirmwareRange,
     PAGING,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { arrayPartition, getSynchronize, versionUtils } from '@trezor/utils';
 
@@ -176,7 +176,7 @@ export default class DiscoverAccounts extends AbstractMethod<
             (Object.keys(this.progress).length || 1);
 
         sendCoreMessage(
-            createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+            createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                 total: 100,
                 progress: 100 * progress,
                 response,
@@ -226,11 +226,11 @@ export default class DiscoverAccounts extends AbstractMethod<
 
                 let error;
                 if (min === '0') {
-                    error = UI_REQUEST.FIRMWARE_NOT_SUPPORTED;
+                    error = UI_EVENTS.FIRMWARE_NOT_SUPPORTED;
                 } else if (!versionUtils.isNewerOrEqual(version, min)) {
-                    error = UI_REQUEST.FIRMWARE_OLD;
+                    error = UI_EVENTS.FIRMWARE_OLD;
                 } else if (max !== '0' && versionUtils.isNewer(version, max)) {
-                    error = UI_REQUEST.FIRMWARE_NOT_COMPATIBLE;
+                    error = UI_EVENTS.FIRMWARE_NOT_COMPATIBLE;
                 }
 
                 return error ? { ...item, error } : item;

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -3,8 +3,8 @@
 import {
     Bundle,
     GetAddress as GetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import type {
     EthereumNetworkInfoDefinitionValues,
@@ -175,7 +175,7 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response,

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -4,8 +4,8 @@ import {
     type EthereumNetworkInfo,
     GetPublicKey as GetPublicKeySchema,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
@@ -108,7 +108,7 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response,

--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/uploadFirmware.js
 
-import { DEVICE, UI_REQUEST, createUiMessage } from '@trezor/connect-common';
+import { DEVICE, UI_EVENTS, createUiEventMessage } from '@trezor/connect-common';
 import type { CoreEventMessage, FirmwareUpdateFlowType, PROTO } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { getFirmwareVersionArray } from '@trezor/device-utils';
@@ -26,7 +26,7 @@ const postProgressMessage = (
     postMessage: (message: CoreEventMessage) => void,
 ) => {
     postMessage(
-        createUiMessage(UI_REQUEST.FIRMWARE_PROGRESS, {
+        createUiEventMessage(UI_EVENTS.FIRMWARE_PROGRESS, {
             device: device.toMessageObject(),
             operation: 'flashing',
             progress,
@@ -39,7 +39,7 @@ const postFirmwareTypeChangedMessage = (
     postMessage: (message: CoreEventMessage) => void,
 ) => {
     postMessage(
-        createUiMessage(UI_REQUEST.FIRMWARE_TYPE_CHANGED, {
+        createUiEventMessage(UI_EVENTS.FIRMWARE_TYPE_CHANGED, {
             device: device.toMessageObject(),
         }),
     );
@@ -76,7 +76,7 @@ export const uploadFirmware = async ({
             const version = getFirmwareVersionArray(device.toMessageObject());
             if (version === null) return;
             if (isWithinRange(version, TIMEOUT_MIN_FW_VERSION, TIMEOUT_MAX_FW_VERSION)) {
-                postMessage(createUiMessage(UI_REQUEST.FIRMWARE_PROGRESS_UNEXPECTED_DELAY, {}));
+                postMessage(createUiEventMessage(UI_EVENTS.FIRMWARE_PROGRESS_UNEXPECTED_DELAY, {}));
             }
         }, FIRMWARE_ERASE_TIMEOUT_MILLISECONDS);
         await typedCall('FirmwareErase', 'Success', {});
@@ -112,7 +112,7 @@ export const uploadFirmware = async ({
         let response = await typedCall('FirmwareErase', ['FirmwareRequest', 'Success'], { length });
         // We are starting the flashing process.
         postMessage(
-            createUiMessage(UI_REQUEST.FIRMWARE_PROGRESS, {
+            createUiEventMessage(UI_EVENTS.FIRMWARE_PROGRESS, {
                 device: device.toMessageObject(),
                 operation: 'start-flashing',
                 progress,

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetAccountInfo.js
 
-import { UI_REQUEST, createUiMessage } from '@trezor/connect-common';
+import { UI_EVENTS, createUiEventMessage } from '@trezor/connect-common';
 import type {
     AccountInfo,
     AccountUtxo,
@@ -150,7 +150,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             if (!this.hasBundle || this.getDevice()?.getCurrentSession().isDisposed()) return;
             // send progress to UI
             context.sendCoreMessage(
-                createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                     total: this.params.length,
                     progress,
                     response,

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -6,7 +6,7 @@ import {
     type PROTO,
     type PermissionRequest,
 } from '@trezor/connect-common';
-import { UI_REQUEST, createUiMessage } from '@trezor/connect-common';
+import { UI_EVENTS, createUiEventMessage } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { GetAddress as GetAddressSchema } from '@trezor/connect-common/src/types/api/account/getAddress';
 import { Assert } from '@trezor/schema-utils';
@@ -174,7 +174,7 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response,

--- a/packages/connect/src/api/getFeatures.ts
+++ b/packages/connect/src/api/getFeatures.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetFeatures.js
 
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
@@ -12,8 +12,8 @@ export default class GetFeatures extends AbstractMethod<'getFeatures'> {
         this.useUi = false;
         this.allowDeviceMode = [
             ...this.allowDeviceMode,
-            UI_REQUEST.INITIALIZE,
-            UI_REQUEST.BOOTLOADER,
+            UI_EVENTS.DEVICE_NOT_INITIALIZED,
+            UI_EVENTS.DEVICE_IN_BOOTLOADER,
         ];
         this.useDeviceState = false;
         this.useEmptyPassphrase = true;

--- a/packages/connect/src/api/getFirmwareHash.ts
+++ b/packages/connect/src/api/getFirmwareHash.ts
@@ -1,4 +1,4 @@
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
@@ -19,7 +19,7 @@ export default class GetFirmwareHash extends AbstractMethod<
         super(message, params);
         this.useEmptyPassphrase = true;
         this.useDeviceState = false;
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED];
     }
     get requiredPermissions(): PermissionRequest[] {
         return [{ permission: 'management' }];

--- a/packages/connect/src/api/getOwnershipId.ts
+++ b/packages/connect/src/api/getOwnershipId.ts
@@ -2,8 +2,8 @@ import {
     Bundle,
     GetOwnershipId as GetOwnershipIdSchema,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -85,7 +85,7 @@ export default class GetOwnershipId extends AbstractMethod<
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response: message,

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -2,8 +2,8 @@ import {
     Bundle,
     GetOwnershipProof as GetOwnershipProofSchema,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -93,7 +93,7 @@ export default class GetOwnershipProof extends AbstractMethod<
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response: message,

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -4,8 +4,8 @@ import type { BitcoinNetworkInfo, PermissionRequest } from '@trezor/connect-comm
 import {
     Bundle,
     GetPublicKey as GetPublicKeySchema,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -121,7 +121,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response,

--- a/packages/connect/src/api/loadDevice.ts
+++ b/packages/connect/src/api/loadDevice.ts
@@ -1,4 +1,4 @@
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
@@ -24,7 +24,7 @@ export default class LoadDevice extends AbstractMethod<'loadDevice', PROTO.LoadD
         };
 
         super(message, params);
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED];
         this.useDeviceState = false;
         this.skipFinalReload = false;
     }

--- a/packages/connect/src/api/pingDevice.ts
+++ b/packages/connect/src/api/pingDevice.ts
@@ -1,4 +1,4 @@
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
@@ -17,7 +17,11 @@ export default class PingDevice extends AbstractMethod<'pingDevice', PROTO.Ping>
         };
 
         super(message, params);
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS, UI_REQUEST.BOOTLOADER];
+        this.allowDeviceMode = [
+            UI_EVENTS.DEVICE_NOT_INITIALIZED,
+            UI_EVENTS.DEVICE_SEEDLESS,
+            UI_EVENTS.DEVICE_IN_BOOTLOADER,
+        ];
         this.useDeviceState = false;
     }
 

--- a/packages/connect/src/api/recoveryDevice.ts
+++ b/packages/connect/src/api/recoveryDevice.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RecoveryDevice.js
 
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 import { RecoveryDevice as RecoveryDeviceSchema } from '@trezor/connect-common/src/types/api/management/recoveryDevice';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
@@ -27,7 +27,7 @@ export default class RecoveryDevice extends AbstractMethod<'recoveryDevice', PRO
         };
 
         super(message, params);
-        this.allowDeviceMode = [...this.allowDeviceMode, UI_REQUEST.INITIALIZE];
+        this.allowDeviceMode = [...this.allowDeviceMode, UI_EVENTS.DEVICE_NOT_INITIALIZED];
         this.useDeviceState = false;
         this.skipFinalReload = false;
         this.useEmptyPassphrase = true;

--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ResetDevice.js
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { TransportError } from '@trezor/connect-common/src/constants/errors';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -36,7 +36,7 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
         };
 
         super(message, params);
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED, UI_EVENTS.DEVICE_SEEDLESS];
         this.useDeviceState = false;
         this.skipFinalReload = false;
     }

--- a/packages/connect/src/api/sendTransaction.ts
+++ b/packages/connect/src/api/sendTransaction.ts
@@ -9,9 +9,11 @@ import {
     type PermissionRequest,
     type RefTransaction,
     type SignedTransaction,
-    UI_REQUEST,
+    UI_EVENTS,
+    UI_REQUESTS,
     UI_RESPONSE,
-    createUiMessage,
+    createUiEventMessage,
+    createUiRequestMessage,
 } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { promiseAllSequence } from '@trezor/utils/src/promiseAllSequence';
@@ -168,14 +170,14 @@ export default class SendTransaction extends AbstractMethod<'sendTransaction', P
 
             if (minFeeTx.type === 'final') {
                 context.sendCoreMessage(
-                    createUiMessage(UI_REQUEST.SELECT_FEE, {
+                    createUiRequestMessage(UI_REQUESTS.REQUEST_FEE, {
                         feeLevels: [{ label: 'custom', blocks: -1, feePerUnit }],
                         coinInfo: this.params.coinInfo,
                     }),
                 );
             } else {
                 // show error view
-                context.sendCoreMessage(createUiMessage(UI_REQUEST.INSUFFICIENT_FUNDS));
+                context.sendCoreMessage(createUiEventMessage(UI_EVENTS.INSUFFICIENT_FUNDS));
                 // wait few seconds...
                 await resolveAfter(2000);
 
@@ -186,7 +188,7 @@ export default class SendTransaction extends AbstractMethod<'sendTransaction', P
             // set select account view
             // this view will be updated from discovery events
             context.sendCoreMessage(
-                createUiMessage(UI_REQUEST.SELECT_FEE, {
+                createUiRequestMessage(UI_REQUESTS.REQUEST_FEE, {
                     feeLevels: composed.levels,
                     coinInfo: this.params.coinInfo,
                 }),
@@ -264,7 +266,7 @@ export default class SendTransaction extends AbstractMethod<'sendTransaction', P
         const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
 
         context.sendCoreMessage(
-            createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
+            createUiRequestMessage(UI_REQUESTS.REQUEST_ACCOUNT, {
                 type: 'complete',
                 accountTypes: unique(accounts.map(a => a.type)),
                 coinInfo,
@@ -292,8 +294,8 @@ export default class SendTransaction extends AbstractMethod<'sendTransaction', P
         if (this.discovery?.completed) {
             const { discovery } = this;
             context.sendCoreMessage(
-                createUiMessage(
-                    UI_REQUEST.SELECT_ACCOUNT,
+                createUiRequestMessage(
+                    UI_REQUESTS.REQUEST_ACCOUNT,
                     {
                         type: 'end',
                         coinInfo,
@@ -324,8 +326,8 @@ export default class SendTransaction extends AbstractMethod<'sendTransaction', P
 
         discovery.on('progress', accounts => {
             context.sendCoreMessage(
-                createUiMessage(
-                    UI_REQUEST.SELECT_ACCOUNT,
+                createUiRequestMessage(
+                    UI_REQUESTS.REQUEST_ACCOUNT,
                     {
                         type: 'progress',
                         coinInfo,
@@ -337,8 +339,8 @@ export default class SendTransaction extends AbstractMethod<'sendTransaction', P
         });
         discovery.on('complete', () => {
             context.sendCoreMessage(
-                createUiMessage(
-                    UI_REQUEST.SELECT_ACCOUNT,
+                createUiRequestMessage(
+                    UI_REQUESTS.REQUEST_ACCOUNT,
                     {
                         type: 'end',
                         coinInfo,
@@ -357,8 +359,8 @@ export default class SendTransaction extends AbstractMethod<'sendTransaction', P
         // set select account view
         // this view will be updated from discovery events
         context.sendCoreMessage(
-            createUiMessage(
-                UI_REQUEST.SELECT_ACCOUNT,
+            createUiRequestMessage(
+                UI_REQUESTS.REQUEST_ACCOUNT,
                 {
                     type: 'start',
                     accountTypes: discovery.types.map(t => t.type),

--- a/packages/connect/src/api/showDeviceTutorial.ts
+++ b/packages/connect/src/api/showDeviceTutorial.ts
@@ -1,4 +1,4 @@
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
@@ -8,7 +8,7 @@ export default class ShowDeviceTutorial extends AbstractMethod<'showDeviceTutori
         super(message, undefined);
         this.useEmptyPassphrase = true;
         this.useDeviceState = false;
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED];
     }
     get requiredPermissions(): PermissionRequest[] {
         return [];

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -3,8 +3,8 @@ import { base58 } from '@scure/base';
 import {
     Bundle,
     GetPublicKey as GetPublicKeySchema,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import type { PROTO, PermissionRequest } from '@trezor/connect-common';
 import { fromHardenedPathPart } from '@trezor/crypto-utils';
@@ -93,7 +93,7 @@ export default class SolanaGetPublicKey extends AbstractMethod<
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response: message,

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -4,8 +4,8 @@ import {
     Bundle,
     GetPublicKey as GetPublicKeySchema,
     type PermissionRequest,
-    UI_REQUEST,
-    createUiMessage,
+    UI_EVENTS,
+    createUiEventMessage,
 } from '@trezor/connect-common';
 import { fromHardenedPathPart } from '@trezor/crypto-utils';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -94,7 +94,7 @@ export default class TezosGetPublicKey extends AbstractMethod<
             if (this.hasBundle) {
                 // send progress
                 sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                    createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, {
                         total: this.params.length,
                         progress: i,
                         response: message,

--- a/packages/connect/src/api/thpGetCredentials.ts
+++ b/packages/connect/src/api/thpGetCredentials.ts
@@ -1,4 +1,4 @@
-import { DEVICE, type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { DEVICE, type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { MethodMessage } from '../core/AbstractMethod';
@@ -9,7 +9,7 @@ import { getThpCredentials } from '../device/thp';
 export default class ThpGetCredentials extends AbstractMethod<'thpGetCredentials'> {
     constructor(message: MethodMessage<'thpGetCredentials'>) {
         super(message, undefined);
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED, UI_EVENTS.DEVICE_SEEDLESS];
         this.useDeviceState = false;
     }
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/thpRemoveCredentials.ts
+++ b/packages/connect/src/api/thpRemoveCredentials.ts
@@ -1,4 +1,4 @@
-import { type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 import type { ThpCredentials } from '@trezor/protocol';
 
 import type { MethodMessage } from '../core/AbstractMethod';
@@ -13,7 +13,7 @@ export default class ThpRemoveCredentials extends AbstractMethod<'thpRemoveCrede
 
         super(message, params);
         this.useDevice = message.payload.device !== undefined;
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_NOT_INITIALIZED, UI_EVENTS.DEVICE_SEEDLESS];
         this.useDeviceState = false;
     }
     get requiredPermissions(): PermissionRequest[] {

--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/WipeDevice.js
 
-import { DEVICE, type PermissionRequest, UI_REQUEST } from '@trezor/connect-common';
+import { DEVICE, type PermissionRequest, UI_EVENTS } from '@trezor/connect-common';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
@@ -10,7 +10,11 @@ export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
     constructor(message: MethodMessage<'wipeDevice'>) {
         super(message, undefined);
 
-        this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS, UI_REQUEST.BOOTLOADER];
+        this.allowDeviceMode = [
+            UI_EVENTS.DEVICE_NOT_INITIALIZED,
+            UI_EVENTS.DEVICE_SEEDLESS,
+            UI_EVENTS.DEVICE_IN_BOOTLOADER,
+        ];
         this.useDeviceState = false;
         this.skipFinalReload = false;
     }

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -1,4 +1,4 @@
-import { ERRORS, UI_REQUEST, asCoinSymbol } from '@trezor/connect-common';
+import { ERRORS, UI_EVENTS, asCoinSymbol } from '@trezor/connect-common';
 import type {
     CallMethodPayload,
     CallMethodResponse,
@@ -31,7 +31,9 @@ export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?
 export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethodResponse<M>;
 
 export type DeviceMode =
-    typeof UI_REQUEST.SEEDLESS | typeof UI_REQUEST.BOOTLOADER | typeof UI_REQUEST.INITIALIZE;
+    | typeof UI_EVENTS.DEVICE_SEEDLESS
+    | typeof UI_EVENTS.DEVICE_IN_BOOTLOADER
+    | typeof UI_EVENTS.DEVICE_NOT_INITIALIZED;
 
 export type MethodContext = {
     sendCoreMessage: (message: CoreEventMessage) => void;
@@ -176,7 +178,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         return out;
     }
 
-    public allowDeviceMode: DeviceMode[]; // used in device management (like ResetDevice allow !UI_REQUEST.INITIALIZED)
+    public allowDeviceMode: DeviceMode[]; // used in device management (like ResetDevice allow !UI_EVENTS.DEVICE_NOT_INITIALIZED)
 
     protected requiredDeviceCapabilities: Capability[] = [];
     protected requiredFirmwareCapabilities: FirmwareCapability[] = [];
@@ -205,7 +207,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             typeof payload.device?.useEmptyPassphrase === 'boolean'
                 ? payload.device.useEmptyPassphrase
                 : false;
-        this.allowDeviceMode = [UI_REQUEST.SEEDLESS]; // Allow seedless by default
+        this.allowDeviceMode = [UI_EVENTS.DEVICE_SEEDLESS]; // Allow seedless by default
 
         // default values for all methods
         this.useDevice = true;
@@ -254,14 +256,14 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         const range = firmwareRange[device.features.internal_model];
 
         if (device.firmwareStatus === 'none') {
-            return UI_REQUEST.FIRMWARE_NOT_INSTALLED;
+            return UI_EVENTS.FIRMWARE_NOT_INSTALLED;
         }
         if (!range) {
             // range not known only for custom (unknown) models
             return;
         }
         if (range.min === '0') {
-            return UI_REQUEST.FIRMWARE_NOT_SUPPORTED;
+            return UI_EVENTS.FIRMWARE_NOT_SUPPORTED;
         }
 
         const version = device.getVersion();
@@ -273,11 +275,11 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             (device.firmwareStatus === 'required' ||
                 !versionUtils.isNewerOrEqual(version, range.min))
         ) {
-            return UI_REQUEST.FIRMWARE_OLD;
+            return UI_EVENTS.FIRMWARE_OLD;
         }
 
         if (range.max !== '0' && versionUtils.isNewer(version, range.max)) {
-            return UI_REQUEST.FIRMWARE_NOT_COMPATIBLE;
+            return UI_EVENTS.FIRMWARE_NOT_COMPATIBLE;
         }
     }
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -178,7 +178,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         return out;
     }
 
-    public allowDeviceMode: DeviceMode[]; // used in device management (like ResetDevice allow !UI_EVENTS.DEVICE_NOT_INITIALIZED)
+    public allowDeviceMode: DeviceMode[]; // used in device management (e.g. ResetDevice allows UI_EVENTS.DEVICE_NOT_INITIALIZED)
 
     protected requiredDeviceCapabilities: Capability[] = [];
     protected requiredFirmwareCapabilities: FirmwareCapability[] = [];

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -10,12 +10,15 @@ import {
     RESPONSE_EVENT,
     SET_ENABLED_NETWORKS,
     UI_EVENT,
+    UI_EVENTS,
     UI_REQUEST,
+    UI_REQUESTS,
     UI_RESPONSE,
     createDeviceMessage,
     createResponseMessage,
     createTransportMessage,
-    createUiMessage,
+    createUiEventMessage,
+    createUiRequestMessage,
 } from '@trezor/connect-common';
 import type {
     ConnectSettings,
@@ -60,7 +63,9 @@ type CoreContext = ReturnType<Core['getCoreContext']>;
 const createSendCoreMessageWithCallId =
     (sendCoreMessage: CoreContext['sendCoreMessage'], callId?: string) =>
     (message: CoreEventMessage) => {
-        const isUiRequestMessage = message.event === UI_EVENT && message.type.startsWith('ui-');
+        const isUiRequestMessage =
+            (message.event === UI_EVENT || message.event === UI_REQUEST) &&
+            message.type.startsWith('ui-');
         const hasCallId = 'callId' in message && Boolean(message.callId);
 
         if (callId && isUiRequestMessage && !hasCallId) {
@@ -128,8 +133,8 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
 
             // request confirmation view
             sendCoreMessage(
-                createUiMessage(
-                    UI_REQUEST.REQUEST_CONFIRMATION,
+                createUiRequestMessage(
+                    UI_REQUESTS.REQUEST_CONFIRMATION,
                     {
                         view: 'no-backup',
                     },
@@ -146,13 +151,21 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
             }
         }
         // show notification
-        sendCoreMessage(createUiMessage(UI_REQUEST.DEVICE_NEEDS_BACKUP, device.toMessageObject()));
+        sendCoreMessage(
+            createUiEventMessage(UI_EVENTS.DEVICE_NEEDS_BACKUP, {
+                device: device.toMessageObject(),
+            }),
+        );
     }
 
     // notify if firmware is outdated but not required
     if (device.firmwareStatus === 'outdated') {
         // show notification
-        sendCoreMessage(createUiMessage(UI_REQUEST.FIRMWARE_OUTDATED, device.toMessageObject()));
+        sendCoreMessage(
+            createUiEventMessage(UI_EVENTS.FIRMWARE_OUTDATED, {
+                device: device.toMessageObject(),
+            }),
+        );
     }
 
     // Make sure that device will display pin/passphrase
@@ -284,7 +297,7 @@ const onCallDevice = async (
     } catch (error) {
         if (error.code === 'Transport_Missing') {
             // show message about transport
-            sendCoreMessage(createUiMessage(UI_REQUEST.TRANSPORT));
+            sendCoreMessage(createUiEventMessage(UI_EVENTS.NO_TRANSPORT));
         }
         // TODO: this should not be returned here before user agrees on "read" perms...
         sendCoreMessage(createResponseMessage(responseID, false, { error }));
@@ -438,7 +451,7 @@ const cleanup = ({ uiPromises, logger }: CoreContext) => {
  * @memberof Core
  */
 const closePopup = ({ sendCoreMessage }: CoreContext) => {
-    sendCoreMessage(createUiMessage(UI_REQUEST.CLOSE_UI_WINDOW));
+    sendCoreMessage(createUiEventMessage(UI_EVENTS.CLOSE_UI_WINDOW));
 };
 
 /**
@@ -461,7 +474,7 @@ const onDeviceButtonHandler =
             createDeviceMessage(DEVICE.BUTTON, { ...request, device: device.toMessageObject() }),
         );
         sendCoreMessage(
-            createUiMessage(UI_REQUEST.REQUEST_BUTTON, {
+            createUiEventMessage(UI_EVENTS.BUTTON_REQUEST, {
                 ...request,
                 device: device.toMessageObject(),
                 data,
@@ -477,8 +490,8 @@ const onDevicePinHandler =
         const uiPromise = uiPromises.create(UI_RESPONSE.RECEIVE_PIN, device);
         // request pin view
         sendCoreMessage(
-            createUiMessage(
-                UI_REQUEST.REQUEST_PIN,
+            createUiRequestMessage(
+                UI_REQUESTS.REQUEST_PIN,
                 { device: device.toMessageObject(), type },
                 { requestId: uiPromise.requestId },
             ),
@@ -506,8 +519,8 @@ const onDeviceWordHandler =
         // create ui promise
         const uiPromise = uiPromises.create(UI_RESPONSE.RECEIVE_WORD, device);
         sendCoreMessage(
-            createUiMessage(
-                UI_REQUEST.REQUEST_WORD,
+            createUiRequestMessage(
+                UI_REQUESTS.REQUEST_WORD,
                 { device: device.toMessageObject(), type },
                 { requestId: uiPromise.requestId },
             ),
@@ -536,8 +549,8 @@ const onDevicePassphraseHandler =
         const uiPromise = uiPromises.create(UI_RESPONSE.RECEIVE_PASSPHRASE, device);
         // request passphrase view
         sendCoreMessage(
-            createUiMessage(
-                UI_REQUEST.REQUEST_PASSPHRASE,
+            createUiRequestMessage(
+                UI_REQUESTS.REQUEST_PASSPHRASE,
                 { device: device.toMessageObject() },
                 { requestId: uiPromise.requestId },
             ),
@@ -579,8 +592,8 @@ const onThpPairingHandler =
         const uiPromise = uiPromises.create(UI_RESPONSE.RECEIVE_THP_PAIRING_TAG, device);
 
         sendCoreMessage(
-            createUiMessage(
-                UI_REQUEST.REQUEST_THP_PAIRING,
+            createUiRequestMessage(
+                UI_REQUESTS.REQUEST_THP_PAIRING_TAG,
                 {
                     device: device.toMessageObject(),
                     ...payload,
@@ -645,7 +658,7 @@ const registerDeviceEvents =
         );
         device.on(DEVICE.PASSPHRASE_ON_DEVICE, () => {
             context.sendCoreMessage(
-                createUiMessage(UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE, {
+                createUiEventMessage(UI_EVENTS.PASSPHRASE_ON_DEVICE, {
                     device: device.toMessageObject(),
                 }),
             );

--- a/packages/connect/src/core/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.test.ts
@@ -1,3 +1,4 @@
+import { UI_EVENTS } from '@trezor/connect-common';
 import { parseConnectSettings } from '@trezor/connect-common/src/data/connectSettings';
 import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
@@ -203,7 +204,7 @@ const setupTest = () => {
     };
 
     const postMessage = ({ type, payload }: any) => {
-        if (type === 'ui-firmware-progress') {
+        if (type === UI_EVENTS.FIRMWARE_PROGRESS) {
             // T1B1, without automatic reboot to bootloader
             if (payload.operation === 'downloading' && payload.progress === 100) {
                 api.emitInterfaceChange([]);
@@ -212,7 +213,7 @@ const setupTest = () => {
                 api.emitInterfaceChange([]);
             }
         }
-        if (type === 'ui-firmware_reconnect') {
+        if (type === UI_EVENTS.FIRMWARE_RECONNECT) {
             if (payload.target === 'bootloader') {
                 api.emitInterfaceChange([{ path: '1' }]);
             }

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -6,7 +6,14 @@ import type {
     FirmwareUpdateFlowType,
     FirmwareUpdateResponse,
 } from '@trezor/connect-common';
-import { FirmwareType, UI_REQUEST, UI_RESPONSE, createUiMessage } from '@trezor/connect-common';
+import {
+    FirmwareType,
+    UI_EVENTS,
+    UI_REQUESTS,
+    UI_RESPONSE,
+    createUiEventMessage,
+    createUiRequestMessage,
+} from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { getFirmwareOrBootloaderVersionArray } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
@@ -64,8 +71,8 @@ const waitForThpPairingConfirmation = async ({
 }) => {
     const uiPromise = uiPromises.create(UI_RESPONSE.RECEIVE_CONFIRMATION, device);
     postMessage(
-        createUiMessage(
-            UI_REQUEST.REQUEST_CONFIRMATION,
+        createUiRequestMessage(
+            UI_REQUESTS.REQUEST_CONFIRMATION,
             {
                 view: thpPairingError ? 'thp-pairing-failed' : 'thp-pairing-start',
             },
@@ -118,7 +125,7 @@ const waitForReconnectedDevice = async (
         log.debug('onCallFirmwareUpdate', 'waiting for device to disconnect');
 
         postMessage(
-            createUiMessage(UI_REQUEST.FIRMWARE_RECONNECT, {
+            createUiEventMessage(UI_EVENTS.FIRMWARE_RECONNECT, {
                 device: device.toMessageObject(),
                 disconnected: false,
                 method,
@@ -141,7 +148,7 @@ const waitForReconnectedDevice = async (
     let skipWaitTime = false;
     do {
         postMessage(
-            createUiMessage(UI_REQUEST.FIRMWARE_RECONNECT, {
+            createUiEventMessage(UI_EVENTS.FIRMWARE_RECONNECT, {
                 device: device.toMessageObject(),
                 disconnected: true,
                 method,
@@ -249,7 +256,7 @@ type WaitForBluetoothRebootParams = {
 const waitForBluetoothReboot = ({ device, target, postMessage }: WaitForBluetoothRebootParams) =>
     new Promise<void>(resolve => {
         postMessage(
-            createUiMessage(UI_REQUEST.FIRMWARE_RECONNECT, {
+            createUiEventMessage(UI_EVENTS.FIRMWARE_RECONNECT, {
                 device: device.toMessageObject(),
                 disconnected: false,
                 method: 'auto',
@@ -440,7 +447,7 @@ export const onCallFirmwareUpdate = async ({
 
     // We start downloading, it could be more than 1 FW in case we need `intermediary`.
     postMessage(
-        createUiMessage(UI_REQUEST.FIRMWARE_PROGRESS, {
+        createUiEventMessage(UI_EVENTS.FIRMWARE_PROGRESS, {
             device: device.toMessageObject(),
             operation: 'downloading',
             progress: 0,
@@ -483,7 +490,7 @@ export const onCallFirmwareUpdate = async ({
     }
 
     postMessage(
-        createUiMessage(UI_REQUEST.FIRMWARE_PROGRESS, {
+        createUiEventMessage(UI_EVENTS.FIRMWARE_PROGRESS, {
             device: device.toMessageObject(),
             operation: 'downloading',
             progress: 100,
@@ -497,7 +504,7 @@ export const onCallFirmwareUpdate = async ({
         isFirmwareCacheUsedForSelectedSource(settingsStore.get('firmwareChannel')) &&
         finalBinaryInfo.release
     ) {
-        const message = createUiMessage(UI_REQUEST.FIRMWARE_DOWNLOADED, {
+        const message = createUiEventMessage(UI_EVENTS.FIRMWARE_DOWNLOADED, {
             binary: finalBinaryInfo.binary,
             binaryVersion: finalBinaryInfo.binaryVersion,
             releaseVersion: finalBinaryInfo.release?.version,

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -15,7 +15,7 @@ import type {
     PROTO,
     UnavailableCapabilities,
 } from '@trezor/connect-common';
-import { DEVICE, ERRORS, FIRMWARE, UI_REQUEST } from '@trezor/connect-common';
+import { DEVICE, ERRORS, FIRMWARE, UI_EVENTS } from '@trezor/connect-common';
 import type { CreateLogger } from '@trezor/connect-common/src/types/settings';
 import type { FirmwareRelease, TranslationMetadata } from '@trezor/device-utils';
 import {
@@ -1026,14 +1026,14 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         // both allow and require cases might generate single unexpected mode
         if (this.features) {
             // allow cases
-            if (this.isBootloader() && !allow.includes(UI_REQUEST.BOOTLOADER)) {
-                return UI_REQUEST.BOOTLOADER;
+            if (this.isBootloader() && !allow.includes(UI_EVENTS.DEVICE_IN_BOOTLOADER)) {
+                return UI_EVENTS.DEVICE_IN_BOOTLOADER;
             }
-            if (!this.isInitialized() && !allow.includes(UI_REQUEST.INITIALIZE)) {
-                return UI_REQUEST.INITIALIZE;
+            if (!this.isInitialized() && !allow.includes(UI_EVENTS.DEVICE_NOT_INITIALIZED)) {
+                return UI_EVENTS.DEVICE_NOT_INITIALIZED;
             }
-            if (this.isSeedless() && !allow.includes(UI_REQUEST.SEEDLESS)) {
-                return UI_REQUEST.SEEDLESS;
+            if (this.isSeedless() && !allow.includes(UI_EVENTS.DEVICE_SEEDLESS)) {
+                return UI_EVENTS.DEVICE_SEEDLESS;
             }
         }
 

--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -1,4 +1,4 @@
-import { UI_REQUEST, createUiMessage } from '@trezor/connect-common';
+import { UI_EVENTS, createUiEventMessage } from '@trezor/connect-common';
 import type { StaticSessionId } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { toHardenedPathPart } from '@trezor/crypto-utils';
@@ -82,7 +82,7 @@ const validateDeviceState = async (context: WorkflowContext) => {
         } catch (error) {
             if (error.message.includes('PIN invalid')) {
                 context.sendCoreMessage(
-                    createUiMessage(UI_REQUEST.INVALID_PIN, {
+                    createUiEventMessage(UI_EVENTS.INVALID_PIN, {
                         device: context.device.toMessageObject(),
                     }),
                 );
@@ -95,7 +95,7 @@ const validateDeviceState = async (context: WorkflowContext) => {
     return validate(context).catch(error => {
         if (error.message.includes('PIN invalid')) {
             context.sendCoreMessage(
-                createUiMessage(UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED, {
+                createUiEventMessage(UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED, {
                     device: context.device.toMessageObject(),
                 }),
             );

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -6,6 +6,7 @@ import {
     SET_ENABLED_NETWORKS,
     TRANSPORT_EVENT,
     UI_EVENT,
+    UI_REQUEST,
     createErrorMessage,
 } from '@trezor/connect-common';
 import type {
@@ -115,7 +116,11 @@ export abstract class CoreInModule implements TrezorConnectCore<ConnectSettings>
                 break;
 
             case UI_EVENT:
-                // pass UI event up
+                this.eventEmitter.emit(event, message);
+                this.eventEmitter.emit(type, payload);
+                break;
+
+            case UI_REQUEST:
                 this.eventEmitter.emit(event, message);
                 this.eventEmitter.emit(type, payload);
                 break;

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -2,8 +2,7 @@ import TrezorConnect, {
     type ConnectSettings,
     type ConnectSettingsTransport,
     type LocalFirmwares,
-    UI_EVENT,
-    UI_REQUEST,
+    UI_EVENTS,
     UI_RESPONSE,
 } from '@trezor/connect';
 import { initLog } from '@trezor/connect-common';
@@ -232,11 +231,8 @@ export const init: ModuleInit = ({ mainThreadEmitter }) => {
         //     mainThreadEmitter.emit('module/trezor-connect/device-event', event);
         // });
 
-        TrezorConnect.on(UI_EVENT, event => {
-            const { type } = event;
-            if (type === UI_REQUEST.FIRMWARE_DOWNLOADED) {
-                mainThreadEmitter.emit('module/trezor-connect/firmware-store', event.payload);
-            }
+        TrezorConnect.on(UI_EVENTS.FIRMWARE_DOWNLOADED, event => {
+            mainThreadEmitter.emit('module/trezor-connect/firmware-store', event);
         });
     };
 

--- a/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
@@ -1,6 +1,6 @@
 import { firmwareActions, firmwareUpdate } from '@suite-common/firmware';
 import { mockGetFirmwareReleaseConfigInfo, mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { FirmwareType, UI_REQUEST } from '@trezor/connect';
+import { FirmwareType, UI_EVENTS } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 const bootloaderDevice = mockSuiteDevice({ mode: 'bootloader', connected: true });
@@ -252,10 +252,10 @@ export const actions = [
 // various cases to test reducer through actions
 export const reducerActions = [
     {
-        description: 'UI_REQUEST.FIRMWARE_PROGRESS',
+        description: 'UI_EVENTS.FIRMWARE_PROGRESS',
         initialState: {},
         action: {
-            type: UI_REQUEST.FIRMWARE_PROGRESS,
+            type: UI_EVENTS.FIRMWARE_PROGRESS,
             payload: {
                 operation: 'flashing',
                 progress: 50,

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -119,7 +119,7 @@ const goToSuite =
         const device = selectSelectedDevice(getState());
         const onboardingAnalytics = selectOnboardingAnalytics(getState());
         // Clear modals that might block navigation. They aren't relevant anyway, as there is no <ModalSwitcher /> in onboarding.
-        // After device interaction, Connect sends UI_REQUEST.CLOSE_UI_WINDOW to close any open modal. On Web this is
+        // After device interaction, Connect sends UI_EVENTS.CLOSE_UI_WINDOW to close any open modal. On Web this is
         // instant, so nothing blocks navigation, but on Desktop there is delay, so we must clear the modal manually to
         // ensure navigation to 'suite-index'. Particularly, setting PIN leaves ButtonRequest_Success hanging for a moment.
         dispatch(closeModal());

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -279,7 +279,7 @@ export const signAndPushSendFormTransactionThunk = createThunk<
         ).unwrap();
 
         // TransactionReviewModal has 2 steps: signing and pushing
-        // TrezorConnect emits UI.CLOSE_UI.WINDOW after the signing process
+        // TrezorConnect emits UI_EVENTS.CLOSE_UI_WINDOW after the signing process
         // this action is blocked by preserveModal()
         dispatch(preserveModal());
 
@@ -318,7 +318,7 @@ export const signAndPushSendFormTransactionThunk = createThunk<
                 return { type: signResponse.error.message };
             }
 
-            // Close the modal manually since UI.CLOSE_UI.WINDOW was
+            // Close the modal manually since UI_EVENTS.CLOSE_UI_WINDOW was
             // blocked by preserveModal() above.
             dispatch(closeModal());
 

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -307,7 +307,7 @@ export const signTransaction =
         );
 
         // TransactionReviewModal has 2 steps: signing and pushing
-        // TrezorConnect emits UI.CLOSE_UI.WINDOW after the signing process
+        // TrezorConnect emits UI_EVENTS.CLOSE_UI_WINDOW after the signing process
         // this action is blocked by preserveModal()
         dispatch(preserveModal());
 
@@ -343,7 +343,7 @@ export const signTransaction =
             if (serializedTx?.error?.message === 'tx-timeout') {
                 return;
             }
-            // close modal manually since UI.CLOSE_UI.WINDOW was blocked
+            // close modal manually since UI_EVENTS.CLOSE_UI_WINDOW was blocked
             dispatch(closeModal());
 
             const { stakeType } = formValues;

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -38,8 +38,7 @@ export const FirmwareInstallation = ({
     // in normal mode, till it is paired again.
     const isDeviceNotSelected =
         isWebUsbTransport &&
-        reconnectEvent &&
-        reconnectEvent.disconnected &&
+        reconnectEvent?.disconnected &&
         reconnectEvent.i > 2 && // Add some latency for cases when the device is already paired or is restarting.
         status !== 'done';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/DeviceConfirmationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/DeviceConfirmationModal.tsx
@@ -1,5 +1,5 @@
 import { type MODAL_CONTEXT_DEVICE_CONFIRMATION } from '@suite/modal';
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_REQUESTS } from '@trezor/connect';
 
 import { NoBackupModal } from './NoBackupModal';
 import { SelectAccountModal } from './SelectAccountModal';
@@ -12,9 +12,9 @@ export const DeviceConfirmationModal = ({
     data,
 }: ReduxModalProps<typeof MODAL_CONTEXT_DEVICE_CONFIRMATION>) => {
     switch (windowType) {
-        case UI_REQUEST.SELECT_ACCOUNT:
+        case UI_REQUESTS.REQUEST_ACCOUNT:
             return data ? <SelectAccountModal data={data} /> : null;
-        case UI_REQUEST.SELECT_FEE:
+        case UI_REQUESTS.REQUEST_FEE:
             return data ? <SelectFeeModal data={data} /> : null;
         case 'no-backup':
             return <NoBackupModal />;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction.tsx
@@ -9,7 +9,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/device';
 import { Column, H3, Paragraph } from '@trezor/components';
-import TrezorConnect, { UI_REQUEST, UI_RESPONSE } from '@trezor/connect';
+import TrezorConnect, { UI_REQUESTS, UI_RESPONSE } from '@trezor/connect';
 
 import { useSelector } from 'src/hooks/suite';
 import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
@@ -25,7 +25,8 @@ export const ConfirmPassphraseBeforeAction = () => {
 
     // Global passphrase modal: the device is ready once Connect raises REQUEST_PASSPHRASE.
     const isDeviceLoading = !(
-        modal.context === MODAL_CONTEXT_DEVICE && modal.windowType === UI_REQUEST.REQUEST_PASSPHRASE
+        modal.context === MODAL_CONTEXT_DEVICE &&
+        modal.windowType === UI_REQUESTS.REQUEST_PASSPHRASE
     );
 
     const intl = useIntl();

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DeviceContextModal.tsx
@@ -5,7 +5,7 @@ import { messages } from '@suite/intl';
 import { type MODAL_CONTEXT_DEVICE } from '@suite/modal';
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { selectSelectedDevice } from '@suite-common/device';
-import TrezorConnect, { UI_REQUEST } from '@trezor/connect';
+import TrezorConnect, { UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -36,13 +36,13 @@ export const DeviceContextModal = ({
 
     switch (windowType) {
         // T1B1 firmware
-        case UI_REQUEST.REQUEST_PIN:
-        case UI_REQUEST.INVALID_PIN:
+        case UI_REQUESTS.REQUEST_PIN:
+        case UI_EVENTS.INVALID_PIN:
             return <PinModal device={device} />;
-        case UI_REQUEST.REQUEST_PASSPHRASE:
+        case UI_REQUESTS.REQUEST_PASSPHRASE:
             return <ConfirmPassphraseBeforeAction />;
         // T2T1 firmware
-        case UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE:
+        case UI_EVENTS.PASSPHRASE_ON_DEVICE:
         case 'ButtonRequest_PassphraseEntry':
             return <PassphraseOnDeviceModal device={device} />;
         case 'ButtonRequest_ConfirmOutput':

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -14,7 +14,7 @@ import {
     selectIsDiscoveryStatusConfirmEmptyPassphrase,
     submitPassphrase,
 } from '@suite-common/wallet-core';
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS } from '@trezor/connect';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -55,13 +55,13 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
 
     const onBackToInitial = () => {
         dispatch(cancelDiscoveryThunk(device));
-        dispatch({ type: UI_REQUEST.CLOSE_UI_WINDOW });
+        dispatch({ type: UI_EVENTS.CLOSE_UI_WINDOW });
         dispatch(goto({ routeName: 'suite-switch-device', params: { cancelable: true } }));
     };
 
     const onCancel = () => {
         dispatch(cancelDiscoveryThunk(device));
-        dispatch({ type: UI_REQUEST.CLOSE_UI_WINDOW });
+        dispatch({ type: UI_EVENTS.CLOSE_UI_WINDOW });
     };
 
     const onSubmit = useCallback(

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -6,7 +6,7 @@ import {
 } from '@suite-common/connect-popup';
 import { selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { Card, Column, H3, Icon, Modal, Paragraph, Row } from '@trezor/components';
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS } from '@trezor/connect';
 import { WarningIcon } from '@trezor/icons';
 
 import { ConnectCallSource } from 'src/components/suite/ConnectCallSource';
@@ -140,19 +140,19 @@ export const ConnectErrorModal = () => {
             return <Translation id="TR_CONNECT_ERROR_GENERIC_DESCRIPTION" />;
         }
 
-        if (popupCall.error?.message === UI_REQUEST.BOOTLOADER)
+        if (popupCall.error?.message === UI_EVENTS.DEVICE_IN_BOOTLOADER)
             return <Translation id="TR_DEVICE_IN_BOOTLOADER" />;
-        if (popupCall.error?.message === UI_REQUEST.NOT_IN_BOOTLOADER)
+        if (popupCall.error?.message === UI_EVENTS.DEVICE_NOT_IN_BOOTLOADER)
             return <Translation id="TR_RECONNECT_IN_BOOTLOADER" />;
-        if (popupCall.error?.message === UI_REQUEST.SEEDLESS)
+        if (popupCall.error?.message === UI_EVENTS.DEVICE_SEEDLESS)
             return <Translation id="TR_YOUR_DEVICE_IS_SEEDLESS" />;
-        if (popupCall.error?.message === UI_REQUEST.INITIALIZE)
+        if (popupCall.error?.message === UI_EVENTS.DEVICE_NOT_INITIALIZED)
             return <Translation id="TR_DEVICE_NOT_INITIALIZED" />;
-        if (popupCall.error?.message === UI_REQUEST.FIRMWARE_NOT_INSTALLED)
+        if (popupCall.error?.message === UI_EVENTS.FIRMWARE_NOT_INSTALLED)
             return <Translation id="TR_NO_FIRMWARE" />;
-        if (popupCall.error?.message === UI_REQUEST.FIRMWARE_NOT_SUPPORTED)
+        if (popupCall.error?.message === UI_EVENTS.FIRMWARE_NOT_SUPPORTED)
             return <Translation id="TR_UNSUPPORTED_COINS_DESCRIPTION" />;
-        if (popupCall.error?.message === UI_REQUEST.FIRMWARE_OLD)
+        if (popupCall.error?.message === UI_EVENTS.FIRMWARE_OLD)
             return <Translation id="TR_FIRMWARE_UPDATE_REQUIRED_EXPLAINED" />;
         if (popupCall.error?.message) return popupCall.error.message;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UserContextModal.tsx
@@ -8,7 +8,7 @@ import {
 } from '@suite/tor-desktop';
 import { blockchainActions, selectCustomBackends } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
 import {
@@ -105,7 +105,7 @@ export const UserContextModal = ({ payload }: ReduxModalProps<typeof MODAL_CONTE
             return <ImportTransactionModal {...payload} onCancel={onCancel} />;
         case 'pin-mismatch':
             return <PinMismatchModal />;
-        case UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED:
+        case UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED:
             return <PinInvalidModal onCancel={onCancel} />;
         case 'application-log':
             return <ApplicationLogModal onCancel={onCancel} />;

--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { type OnboardingAnalytics } from '@suite/analytics';
 import { type BackupType } from '@suite-common/suite-types';
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_REQUESTS } from '@trezor/connect';
 
 import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
 import { type GoToSuiteOptions } from 'src/actions/onboarding/onboardingActions';
@@ -18,7 +18,7 @@ export const useOnboarding = () => {
     const modal = useSelector(state => state.modal);
 
     const showPinMatrix =
-        modal.context === '@modal/context-device' && modal.windowType === UI_REQUEST.REQUEST_PIN;
+        modal.context === '@modal/context-device' && modal.windowType === UI_REQUESTS.REQUEST_PIN;
 
     const actions = useMemo(
         () => ({

--- a/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
+++ b/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
@@ -6,7 +6,7 @@ import { routerAppChanged } from '@suite/router';
 import { deviceActions } from '@suite-common/device';
 import { firmwareActions } from '@suite-common/firmware';
 import { forgetDisconnectedDevices } from '@suite-common/wallet-core';
-import { UI_REQUEST, isUiEventOfType } from '@trezor/connect';
+import { UI_EVENTS, isUiEventOfType } from '@trezor/connect';
 
 import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
 import { type AppState } from 'src/types/suite';
@@ -32,7 +32,7 @@ const onboardingMiddleware =
         }
 
         // seed is wiped when switching firmware type so we need to forget all device instances as well
-        if (isUiEventOfType(action, UI_REQUEST.FIRMWARE_TYPE_CHANGED)) {
+        if (isUiEventOfType(action, UI_EVENTS.FIRMWARE_TYPE_CHANGED)) {
             api.dispatch(
                 forgetDisconnectedDevices({
                     device: firmware.cachedDevice || action.payload.device,

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts
@@ -21,7 +21,7 @@ import {
 } from '@suite-common/suite-types/mocks';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
 import { defaultTrezorUIEventHandlerThunk, observeSelectedDevice } from '@suite-common/wallet-core';
-import { UI_EVENT, UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
+import { UI_EVENT, UI_EVENTS, UI_REQUEST, UI_REQUESTS } from '@trezor/connect';
 import { noopCreateLogger } from '@trezor/connect-common';
 
 import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
@@ -96,7 +96,9 @@ describe('buttonRequest middleware', () => {
             type: UI_EVENTS.BUTTON_REQUEST,
             payload: { code: 'ButtonRequest_ProtectCall' },
         });
-        emitTestEvent(UI_EVENT, {
+        // REQUEST_PIN requires a response, so in production it travels on the
+        // UI_REQUEST channel (createUiRequestMessage) — emit it there.
+        emitTestEvent(UI_REQUEST, {
             type: UI_REQUESTS.REQUEST_PIN,
             payload: { type: 'PinMatrixRequestType_NewFirst', device },
         });

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts
@@ -21,7 +21,7 @@ import {
 } from '@suite-common/suite-types/mocks';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
 import { defaultTrezorUIEventHandlerThunk, observeSelectedDevice } from '@suite-common/wallet-core';
-import { UI_EVENT, UI_REQUEST } from '@trezor/connect';
+import { UI_EVENT, UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
 import { noopCreateLogger } from '@trezor/connect-common';
 
 import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
@@ -93,11 +93,11 @@ describe('buttonRequest middleware', () => {
         const { emitTestEvent } = testMocks.getTrezorConnectMock();
         // fake few ui events, just like when user is changing PIN
         emitTestEvent(UI_EVENT, {
-            type: UI_REQUEST.REQUEST_BUTTON,
+            type: UI_EVENTS.BUTTON_REQUEST,
             payload: { code: 'ButtonRequest_ProtectCall' },
         });
         emitTestEvent(UI_EVENT, {
-            type: UI_REQUEST.REQUEST_PIN,
+            type: UI_REQUESTS.REQUEST_PIN,
             payload: { type: 'PinMatrixRequestType_NewFirst', device },
         });
 
@@ -120,14 +120,14 @@ describe('buttonRequest middleware', () => {
             { type: connectInitThunk.fulfilled.type, payload: undefined },
             { type: lockDevice.type, payload: true },
             { type: defaultTrezorUIEventHandlerThunk.pending.type },
-            { type: UI_REQUEST.REQUEST_BUTTON, payload: { code: 'ButtonRequest_ProtectCall' } },
+            { type: UI_EVENTS.BUTTON_REQUEST, payload: { code: 'ButtonRequest_ProtectCall' } },
             {
                 type: deviceActions.addButtonRequest.type,
                 payload: { buttonRequest: { code: 'ButtonRequest_ProtectCall' }, device },
             },
             { type: defaultTrezorUIEventHandlerThunk.pending.type },
             {
-                type: UI_REQUEST.REQUEST_PIN,
+                type: UI_REQUESTS.REQUEST_PIN,
                 payload: { type: 'PinMatrixRequestType_NewFirst', device },
             },
             {

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -2,7 +2,7 @@ import { type Dispatch, type UnknownAction } from '@reduxjs/toolkit';
 import { type MiddlewareAPI } from 'redux';
 
 import { PAYMENT_REQUEST_BUTTON_NAMES, selectAccountByKey } from '@suite-common/wallet-core';
-import { UI_REQUEST, isUiEventOfType } from '@trezor/connect';
+import { UI_EVENTS, isUiEventOfType } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import { type AppState } from 'src/types/suite';
@@ -92,7 +92,7 @@ const buttonRequest =
     (next: Dispatch<UnknownAction>) =>
     (action: UnknownAction): UnknownAction => {
         if (
-            isUiEventOfType(action, UI_REQUEST.FIRMWARE_DISCONNECT) &&
+            isUiEventOfType(action, UI_EVENTS.FIRMWARE_DISCONNECT) &&
             action.payload.device.descriptor.apiType === 'bluetooth' &&
             action.payload.device.descriptor.id
         ) {
@@ -107,7 +107,7 @@ const buttonRequest =
         // ugly hack to make Cardano review modal work
         // ugly hack to make Ethereum staking and bump fee review modal on specific devices work
         // root cause of this bug is wrong button request ButtonRequest_Other from CardanoSignTx - should be ButtonRequest_SignTx
-        if (isUiEventOfType(action, UI_REQUEST.REQUEST_BUTTON)) {
+        if (isUiEventOfType(action, UI_EVENTS.BUTTON_REQUEST)) {
             if (shouldRemapToSignTx(action.payload.code, action.payload.name, api.getState())) {
                 api.dispatch({
                     ...action,

--- a/packages/suite/src/support/createConnectInitHooks.ts
+++ b/packages/suite/src/support/createConnectInitHooks.ts
@@ -3,7 +3,7 @@ import { type Dispatch } from '@reduxjs/toolkit';
 import { openModal, preserveModal } from '@suite/modal';
 import { recoveryActions, selectRecoveryStatus } from '@suite/recovery';
 import { type ConnectInitHooks } from '@suite-common/suite-types';
-import { DEVICE, UI_REQUEST } from '@trezor/connect';
+import { DEVICE, UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
 
 import { bluetoothOnDeviceConnectedThunk } from '../actions/bluetooth/bluetoothOnDeviceConnectedThunk';
 import { markDeviceAsRecentlyConnectedThunk } from '../actions/wallet/markDeviceAsRecentlyConnectedThunk';
@@ -27,11 +27,11 @@ export const createConnectInitHooks = ({
         },
     },
     uiEvent: {
-        [UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
-            dispatch(openModal({ type: UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED }));
+        [UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED]: () => {
+            dispatch(openModal({ type: UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED }));
             dispatch(preserveModal());
         },
-        [UI_REQUEST.REQUEST_WORD]: () => {
+        [UI_REQUESTS.REQUEST_WORD]: () => {
             if (selectRecoveryStatus(getState()) === 'waiting-for-confirmation') {
                 // Since the device asked for a first word, we can safely assume we've received confirmation from the user
                 dispatch(recoveryActions.setStatus('in-progress'));

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -19,7 +19,8 @@ import TrezorConnect, {
     type CallMethodKeys,
     type CallMethodPayload,
     type PermissionRequest,
-    UI_REQUEST,
+    UI_EVENTS,
+    UI_REQUESTS,
 } from '@trezor/connect';
 import { isMacOs } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
@@ -179,11 +180,11 @@ export const useConnectPopupDesktop = () => {
 
         return (
             [
-                UI_REQUEST.REQUEST_PIN,
-                UI_REQUEST.INVALID_PIN,
-                UI_REQUEST.REQUEST_PASSPHRASE,
-                UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE,
-                UI_REQUEST.REQUEST_WORD,
+                UI_REQUESTS.REQUEST_PIN,
+                UI_EVENTS.INVALID_PIN,
+                UI_REQUESTS.REQUEST_PASSPHRASE,
+                UI_EVENTS.PASSPHRASE_ON_DEVICE,
+                UI_REQUESTS.REQUEST_WORD,
             ] as string[]
         ).includes(modal.windowType);
     });

--- a/packages/suite/src/support/suite/useConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupModals.tsx
@@ -75,7 +75,7 @@ export const useConnectPopupModals = () => {
                 (modalContext === MODAL_CONTEXT_NONE || isReplaceableByConnectModal)
             ) {
                 dispatch(openModal({ type }));
-                // Prevent UI_REQUEST.CLOSE_UI_WINDOW from unrelated TrezorConnect
+                // Prevent UI_EVENTS.CLOSE_UI_WINDOW from unrelated TrezorConnect
                 // calls (e.g. discovery finishing in the background) from closing
                 // the connect popup modal.
                 dispatch(preserveModal());

--- a/packages/suite/src/support/suite/useConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupModals.tsx
@@ -48,7 +48,7 @@ export const useConnectPopupModals = () => {
             ].includes(modalType);
 
         // During a connect popup call the device may request interaction
-        // (e.g. REQUEST_BUTTON / REQUEST_PIN).  This replaces the current
+        // (e.g. BUTTON_REQUEST / REQUEST_PIN).  This replaces the current
         // MODAL_CONTEXT_USER modal with a MODAL_CONTEXT_DEVICE modal that
         // inherits preserve=true.  After the device interaction finishes,
         // CLOSE_UI_WINDOW is blocked by preserve, leaving the device modal

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInstallationStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/FirmwareInstallationStep.tsx
@@ -23,8 +23,7 @@ export const FirmwareInstallationStep = ({ install, onSuccess }: FirmwareInstall
     const getInnerActionComponent = () => {
         if (
             isWebUsbTransport &&
-            reconnectEvent &&
-            reconnectEvent.disconnected &&
+            reconnectEvent?.disconnected &&
             reconnectEvent.i > 2 && // Add some latency for cases when the device is already paired or is restarting.
             status !== 'done'
         ) {

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -16,7 +16,7 @@ import {
 import { usePin } from '@suite-common/device';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { Box, H2, Image, Modal, Paragraph } from '@trezor/components';
-import TrezorConnect, { UI_REQUEST } from '@trezor/connect';
+import TrezorConnect, { UI_REQUESTS } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { CheckIcon, WarningIcon } from '@trezor/icons';
 import { ConfirmOnDevicePill } from '@trezor/product-components';
@@ -118,7 +118,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 // and we want to allow devices that have unsupported FW to be able to check the seed.
                 if (isT1B1) {
                     switch (modal.windowType) {
-                        case UI_REQUEST.REQUEST_PIN:
+                        case UI_REQUESTS.REQUEST_PIN:
                             return (
                                 <PinMatrix
                                     pin={pin}
@@ -239,7 +239,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 if (
                     isT1B1 &&
                     modal.context === MODAL_CONTEXT_DEVICE &&
-                    modal.windowType === UI_REQUEST.REQUEST_PIN
+                    modal.windowType === UI_REQUESTS.REQUEST_PIN
                 ) {
                     return (
                         <Modal.Button onClick={handlePinSubmit} data-testid="@pin/submit-button">

--- a/suite-common/connect-init/src/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/connectInitThunks.test.ts
@@ -19,6 +19,7 @@ import TrezorConnect, {
     TRANSPORT_EVENT,
     UI_EVENT,
     UI_EVENTS,
+    UI_REQUEST,
     UI_REQUESTS,
 } from '@trezor/connect';
 
@@ -341,7 +342,9 @@ describe('TrezorConnect Actions', () => {
         expect(onInvalidPinDepleted).toHaveBeenCalledTimes(1);
         expect(onRequestWord).not.toHaveBeenCalled();
 
-        emitTestEvent(UI_EVENT, { type: UI_REQUESTS.REQUEST_WORD, payload: {} });
+        // REQUEST_WORD requires a response, so in production it travels on the
+        // UI_REQUEST channel (createUiRequestMessage) — emit it there.
+        emitTestEvent(UI_REQUEST, { type: UI_REQUESTS.REQUEST_WORD, payload: {} });
 
         expect(onInvalidPinDepleted).toHaveBeenCalledTimes(1);
         expect(onRequestWord).toHaveBeenCalledTimes(1);

--- a/suite-common/connect-init/src/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/connectInitThunks.test.ts
@@ -18,7 +18,8 @@ import TrezorConnect, {
     DEVICE_EVENT,
     TRANSPORT_EVENT,
     UI_EVENT,
-    UI_REQUEST,
+    UI_EVENTS,
+    UI_REQUESTS,
 } from '@trezor/connect';
 
 import {
@@ -261,7 +262,7 @@ describe('TrezorConnect Actions', () => {
 
             expect(actions).toEqual([
                 expect.objectContaining({ type: defaultTrezorUIEventHandlerThunk.pending.type }),
-                expect.objectContaining({ type: UI_REQUEST.REQUEST_BUTTON }),
+                expect.objectContaining({ type: UI_EVENTS.BUTTON_REQUEST }),
                 expect.objectContaining({ type: '@suite/device/addButtonRequest' }),
                 expect.objectContaining({ type: defaultTrezorUIEventHandlerThunk.fulfilled.type }),
             ]);
@@ -269,7 +270,7 @@ describe('TrezorConnect Actions', () => {
         });
 
         emitTestEvent(UI_EVENT, {
-            type: UI_REQUEST.REQUEST_BUTTON,
+            type: UI_EVENTS.BUTTON_REQUEST,
             payload: { code: 'ButtonRequest_ProtectCall' },
             callId: 'unscoped-call-id',
         });
@@ -277,7 +278,7 @@ describe('TrezorConnect Actions', () => {
         registerScopedCallId(scopedCallId);
         try {
             emitTestEvent(UI_EVENT, {
-                type: UI_REQUEST.REQUEST_BUTTON,
+                type: UI_EVENTS.BUTTON_REQUEST,
                 payload: { code: 'ButtonRequest_ProtectCall' },
                 callId: scopedCallId,
             });
@@ -323,8 +324,8 @@ describe('TrezorConnect Actions', () => {
             connectInitHooks: {
                 deviceEvent: {},
                 uiEvent: {
-                    [UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED]: onInvalidPinDepleted,
-                    [UI_REQUEST.REQUEST_WORD]: onRequestWord,
+                    [UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED]: onInvalidPinDepleted,
+                    [UI_REQUESTS.REQUEST_WORD]: onRequestWord,
                 },
             },
         });
@@ -333,20 +334,20 @@ describe('TrezorConnect Actions', () => {
         const { emitTestEvent } = testMocks.getTrezorConnectMock();
 
         emitTestEvent(UI_EVENT, {
-            type: UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED,
+            type: UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED,
             payload: {},
         });
 
         expect(onInvalidPinDepleted).toHaveBeenCalledTimes(1);
         expect(onRequestWord).not.toHaveBeenCalled();
 
-        emitTestEvent(UI_EVENT, { type: UI_REQUEST.REQUEST_WORD, payload: {} });
+        emitTestEvent(UI_EVENT, { type: UI_REQUESTS.REQUEST_WORD, payload: {} });
 
         expect(onInvalidPinDepleted).toHaveBeenCalledTimes(1);
         expect(onRequestWord).toHaveBeenCalledTimes(1);
 
         emitTestEvent(UI_EVENT, {
-            type: UI_REQUEST.REQUEST_BUTTON,
+            type: UI_EVENTS.BUTTON_REQUEST,
             payload: { code: 'ButtonRequest_ProtectCall' },
         });
 

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -38,6 +38,7 @@ import TrezorConnect, {
     DEVICE_EVENT,
     TRANSPORT_EVENT,
     UI_EVENT,
+    UI_REQUEST,
 } from '@trezor/connect';
 import { asCoinSymbol } from '@trezor/connect-common';
 import { getSynchronize, isArrayMember } from '@trezor/utils';
@@ -127,6 +128,15 @@ export const connectInitThunk = createThunk<
     });
 
     TrezorConnect.on(UI_EVENT, ({ event: _, ...action }) => {
+        // A bare `callId` is not proof of ownership — it doubles as the
+        // cancellation token — so defer only events a scoped flow has registered.
+        if ('callId' in action && action.callId && isScopedCallId(action.callId)) {
+            return;
+        }
+        dispatch(defaultTrezorUIEventHandlerThunk(action));
+    });
+
+    TrezorConnect.on(UI_REQUEST, ({ event: _, ...action }) => {
         // A bare `callId` is not proof of ownership — it doubles as the
         // cancellation token — so defer only events a scoped flow has registered.
         if ('callId' in action && action.callId && isScopedCallId(action.callId)) {

--- a/suite-common/connect-popup/src/connectPopupMiddleware.ts
+++ b/suite-common/connect-popup/src/connectPopupMiddleware.ts
@@ -15,9 +15,10 @@ import TrezorConnect, {
     type CoinInfo,
     type DiscoveryAccount,
     type DiscoveryAccountType,
-    UI_REQUEST,
+    UI_EVENTS,
+    UI_REQUESTS,
     UI_RESPONSE,
-    isUiEventOfType,
+    isUiRequestOfType,
 } from '@trezor/connect';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
@@ -97,7 +98,7 @@ export const prepareConnectPopupMiddleware = createMiddlewareWithExtraDeps<
 >(async (action, { dispatch, next, getState }) => {
     await next(action);
 
-    if (action.type === UI_REQUEST.INSUFFICIENT_FUNDS) {
+    if (action.type === UI_EVENTS.INSUFFICIENT_FUNDS) {
         dispatch(
             notificationsActions.addToast({
                 type: 'not-enough-funds-error',
@@ -105,7 +106,7 @@ export const prepareConnectPopupMiddleware = createMiddlewareWithExtraDeps<
         );
     }
 
-    if (isUiEventOfType(action, UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS)) {
+    if (isUiRequestOfType(action, UI_REQUESTS.REQUEST_DISCOVERY_ACCOUNTS)) {
         const discovery = selectDiscoveryForSelectedDevice(getState());
 
         if (discovery && discovery.status !== 'complete') {

--- a/suite-common/device/src/usePinHook.ts
+++ b/suite-common/device/src/usePinHook.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { type ButtonRequest } from '@suite-common/suite-types';
-import TrezorConnect, { UI_REQUEST, UI_RESPONSE } from '@trezor/connect';
+import TrezorConnect, { UI_EVENTS, UI_RESPONSE } from '@trezor/connect';
 
 const NEW_PIN_REQUEST_TYPES = ['PinMatrixRequestType_NewFirst', 'PinMatrixRequestType_NewSecond'];
 const NEW_WIPE_CODE_REQUEST_TYPES = [
@@ -34,7 +34,7 @@ export const usePin = (buttonRequests: ButtonRequest[], requestId?: string) => {
         setSubmitted(false);
     }, [buttonRequests.length]);
 
-    const invalidPinAttempts = buttonRequests.filter(r => r.code === UI_REQUEST.INVALID_PIN).length;
+    const invalidPinAttempts = buttonRequests.filter(r => r.code === UI_EVENTS.INVALID_PIN).length;
 
     return {
         isSettingNewWipeCode,

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -6,18 +6,22 @@ import {
     DEVICE,
     type DeviceButtonRequest,
     type FirmwareChannel,
-    type FirmwareProgress,
-    type FirmwareProgressUnexpectedDelay,
-    type FirmwareReconnect,
     type FirmwareType,
-    UI_REQUEST,
+    UI_EVENTS,
+    UI_REQUESTS,
+    type UiEventFirmwareProgress,
+    type UiEventFirmwareProgressUnexpectedDelay,
+    type UiEventFirmwareReconnect,
     type UiRequestConfirmation,
 } from '@trezor/connect';
 
 import { firmwareActions } from './firmwareActions';
 
 type FirmwareUpdateUiEvent =
-    DeviceButtonRequest | FirmwareProgress | FirmwareReconnect | FirmwareProgressUnexpectedDelay;
+    | DeviceButtonRequest
+    | UiEventFirmwareProgress
+    | UiEventFirmwareReconnect
+    | UiEventFirmwareProgressUnexpectedDelay;
 
 type FirmwareUpdateCommon = {
     // Device before installation begun. Used to display the original firmware type and version during the installation.
@@ -105,7 +109,7 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(
                 state.firmwareChannel = payload;
             })
             .addMatcher<UiRequestConfirmation>(
-                action => action.type === UI_REQUEST.REQUEST_CONFIRMATION,
+                action => action.type === UI_REQUESTS.REQUEST_CONFIRMATION,
                 (state, action) => {
                     if (state.status === 'started' && action.payload.view === 'thp-pairing-start') {
                         state.status = 'thp-pairing';
@@ -114,9 +118,9 @@ export const prepareFirmwareReducer = createReducerWithExtraDeps(
             )
             .addMatcher<FirmwareUpdateUiEvent>(
                 (action: FirmwareUpdateUiEvent) =>
-                    action.type === UI_REQUEST.FIRMWARE_RECONNECT ||
-                    action.type === UI_REQUEST.FIRMWARE_PROGRESS ||
-                    action.type === UI_REQUEST.FIRMWARE_PROGRESS_UNEXPECTED_DELAY ||
+                    action.type === UI_EVENTS.FIRMWARE_RECONNECT ||
+                    action.type === UI_EVENTS.FIRMWARE_PROGRESS ||
+                    action.type === UI_EVENTS.FIRMWARE_PROGRESS_UNEXPECTED_DELAY ||
                     action.type === DEVICE.BUTTON,
                 (state, action) => {
                     // DEVICE.BUTTON can be dispatched outside the firmware update flow and that should not change the uiEvent,

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -15,7 +15,7 @@ import {
     type Device,
     type DeviceButtonRequestPayload,
     FirmwareType,
-    UI_REQUEST,
+    UI_EVENTS,
 } from '@trezor/connect';
 import {
     DeviceModelInternal,
@@ -130,13 +130,13 @@ export const useFirmwareInstallation = () => {
 
     const [reconnectEvent, buttonEvent, progressEvent] = useMemo(() => {
         if (firmware.uiEvent) {
-            if (firmware.uiEvent.type === UI_REQUEST.FIRMWARE_RECONNECT) {
+            if (firmware.uiEvent.type === UI_EVENTS.FIRMWARE_RECONNECT) {
                 return [firmware.uiEvent.payload];
             }
             if (firmware.uiEvent.type === DEVICE.BUTTON) {
                 return [undefined, firmware.uiEvent.payload];
             }
-            if (firmware.uiEvent.type === UI_REQUEST.FIRMWARE_PROGRESS) {
+            if (firmware.uiEvent.type === UI_EVENTS.FIRMWARE_PROGRESS) {
                 return [undefined, undefined, firmware.uiEvent.payload];
             }
         }
@@ -148,8 +148,8 @@ export const useFirmwareInstallation = () => {
     // Until then, access device as normal.
     const originalDevice = firmware.cachedDevice || device;
 
-    // To instruct user to reboot to bootloader manually, UI.FIRMWARE_DISCONNECT event is emitted first,
-    // and UI_REQUEST.FIRMWARE_RECONNECT is emitted after the device disconnects.
+    // To instruct user to reboot to bootloader manually, UI_EVENTS.FIRMWARE_DISCONNECT event is emitted first,
+    // and UI_EVENTS.FIRMWARE_RECONNECT is emitted after the device disconnects.
     const showManualReconnectPrompt = reconnectEvent?.method === 'manual';
     const deviceIsWaitingForConfirmationToInitiateConnection =
         reconnectEvent?.method === 'auto' && reconnectEvent.target === 'bootloader';
@@ -191,7 +191,7 @@ export const useFirmwareInstallation = () => {
     const showConfirmationPill =
         (!showReconnectPrompt && progressEvent?.operation === 'downloading') ||
         isThpConfirmationRequested ||
-        firmware.uiEvent?.type === UI_REQUEST.FIRMWARE_RECONNECT ||
+        firmware.uiEvent?.type === UI_EVENTS.FIRMWARE_RECONNECT ||
         firmware.uiEvent?.type === 'button';
 
     const updateStatus = useMemo<FirmwareOperationStatus>(() => {

--- a/suite-common/suite-types/src/connectInit.ts
+++ b/suite-common/suite-types/src/connectInit.ts
@@ -1,9 +1,17 @@
-import type { ConnectSettings, DEVICE, Device, Manifest, UI_REQUEST } from '@trezor/connect';
+import type {
+    ConnectSettings,
+    DEVICE,
+    Device,
+    Manifest,
+    UI_EVENTS,
+    UI_REQUESTS,
+} from '@trezor/connect';
 import type { POPUP } from '@trezor/connect-common';
 
 import type { TrezorDevice } from './device';
 
-type UiRequestType = (typeof UI_REQUEST)[keyof typeof UI_REQUEST];
+type UiRequestType =
+    (typeof UI_EVENTS)[keyof typeof UI_EVENTS] | (typeof UI_REQUESTS)[keyof typeof UI_REQUESTS];
 type PopupEventType = (typeof POPUP)[keyof typeof POPUP];
 
 export type ConnectInitDeviceEventHooks = Partial<

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -10,6 +10,8 @@ import type {
     KnownDevice,
     PROTO,
     StaticSessionId,
+    UI_EVENTS,
+    UI_REQUESTS,
     UnknownDevice as UnknownDeviceBase,
     UnreadableDevice as UnreadableDeviceBase,
 } from '@trezor/connect';
@@ -20,15 +22,15 @@ import type { VersionArray } from '@trezor/utils';
 // suite (deviceReducer) stores them in slightly different shape:
 // - device field from @trezor/connect is excluded
 // - code field (ButtonRequestType) is extended/combined with PinMatrixRequestType and WordRequestType (from DeviceMessage)
-// - code field also uses two custom ButtonRequests - 'ui-request_pin' and 'ui-invalid_pin' (TODO: it shouldn't)
+// - code field also uses two custom ButtonRequests - UI_REQUESTS.REQUEST_PIN and UI_EVENTS.INVALID_PIN (TODO: it shouldn't)
 
 // TODO: Suite should not define its own type for ButtonRequest. There should be
 // sufficient type exported from @trezor/connect;
 
 export type ButtonRequest = Omit<DeviceEvent['payload'], 'device' | 'code'> & {
     code?:
-        | 'ui-request_pin'
-        | 'ui-invalid_pin'
+        | (typeof UI_REQUESTS)['REQUEST_PIN']
+        | (typeof UI_EVENTS)['INVALID_PIN']
         | DeviceButtonRequest['payload']['code']
         | NonNullable<PROTO.PinMatrixRequest>['type'];
     // Firmware screen identifier (e.g. 'confirm_payment_request'). Stored from the button request

--- a/suite-common/suite-types/src/modal.ts
+++ b/suite-common/suite-types/src/modal.ts
@@ -3,7 +3,7 @@ import { type ActionCreatorWithPayload, type ActionCreatorWithoutPayload } from 
 import { type RequestEnableTorResponse } from '@suite-common/suite-config';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type AddressType, type EvmSelectedFee } from '@suite-common/wallet-types';
-import { type UI_REQUEST } from '@trezor/connect';
+import { type UI_EVENTS } from '@trezor/connect';
 import { type Deferred } from '@trezor/utils';
 
 import { type TrezorDevice } from './device';
@@ -75,7 +75,7 @@ export type UserContextPayload =
           type: 'pin-mismatch';
       }
     | {
-          type: typeof UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED;
+          type: typeof UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED;
       }
     | {
           type: 'device-authenticity-check-opt-out';

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -6,7 +6,8 @@ import {
     DEVICE,
     type DeviceThpCredentialsChanged,
     type DeviceThpPairingStatusChanged,
-    UI_REQUEST,
+    UI_EVENTS,
+    UI_REQUESTS,
     isUiEventOfType,
 } from '@trezor/connect';
 import type { ThpCredentials } from '@trezor/protocol';
@@ -86,7 +87,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState, ThpReducer
                 state.autoconnectStep = null;
             })
             .addMatcher(
-                action => action.type === UI_REQUEST.REQUEST_THP_PAIRING,
+                action => action.type === UI_REQUESTS.REQUEST_THP_PAIRING_TAG,
                 (state, action: { type: string; requestId?: string }) => {
                     state.step = 'CodeEntry';
                     state.pairingRequestId = action.requestId;
@@ -135,7 +136,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState, ThpReducer
                 },
             )
             .addMatcher(
-                action => isUiEventOfType(action, UI_REQUEST.REQUEST_BUTTON),
+                action => isUiEventOfType(action, UI_EVENTS.BUTTON_REQUEST),
                 (state, action) => {
                     const actionName = action.payload.name as THPButtonRequestName;
                     switch (actionName) {
@@ -153,7 +154,7 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState, ThpReducer
             )
             // This is the THP flow in Firmware Update
             .addMatcher(
-                action => action.type === UI_REQUEST.REQUEST_CONFIRMATION,
+                action => action.type === UI_REQUESTS.REQUEST_CONFIRMATION,
                 (state, action: { type: string; requestId?: string }) => {
                     if (state.step !== 'CodeInvalid') {
                         state.step = 'BeforeConnectionInfo';

--- a/suite-common/thp/src/thpUtils.ts
+++ b/suite-common/thp/src/thpUtils.ts
@@ -1,6 +1,6 @@
 import { type UnknownAction } from '@reduxjs/toolkit';
 
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS } from '@trezor/connect';
 import { isNotNullOrUndefined } from '@trezor/utils';
 
 type ThpPairingRequestPayload = {
@@ -8,14 +8,14 @@ type ThpPairingRequestPayload = {
 };
 
 type ThpPairingRequestAction = {
-    type: typeof UI_REQUEST.REQUEST_BUTTON;
+    type: typeof UI_EVENTS.BUTTON_REQUEST;
     payload: ThpPairingRequestPayload;
 };
 
 export const isThpPairingUIRequestButtonAction = (
     action: UnknownAction,
 ): action is ThpPairingRequestAction =>
-    action.type === UI_REQUEST.REQUEST_BUTTON &&
+    action.type === UI_EVENTS.BUTTON_REQUEST &&
     typeof action.payload === 'object' &&
     isNotNullOrUndefined(action.payload) &&
     'name' in action.payload &&

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -28,12 +28,12 @@ import { type TrezorConnectBackendType } from '@suite-common/wallet-config';
 import { type DiscoveryStatus, type GetTradedAccountKeysDep } from '@suite-common/wallet-types';
 import TrezorConnect, {
     type AccountInfo,
-    type BundleProgress,
     type DeviceState,
     type DeviceUniquePath,
     type StaticSessionId,
-    UI_REQUEST,
+    UI_EVENTS,
     UI_RESPONSE,
+    type UiEventBundleProgress,
 } from '@trezor/connect';
 import { type DiscoverAccountsProgress } from '@trezor/connect-common/src/types/api/account/discoverAccounts';
 import type { Bip43Path } from '@trezor/crypto-utils';
@@ -61,7 +61,7 @@ const DEVICE_CANCELLATION_CODES = ['Method_Cancel', 'Failure_ActionCancelled'];
 type DiscoveryReportingThunkState = TokenDefinitionsRootState & WalletCoreCompoundRootState;
 type DiscoveryReportingDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 
-type ProgressEvent = BundleProgress<DiscoverAccountsProgress>['payload'];
+type ProgressEvent = UiEventBundleProgress<DiscoverAccountsProgress>['payload'];
 
 function assertDeviceIsAuthorized(device?: TrezorDevice): asserts device is AuthorizedDevice {
     if (!device?.state?.staticSessionId) {
@@ -481,7 +481,7 @@ export const runDiscoveryThunk = createThunk<
                 dispatch(discoveryActions.updateDiscovery(discoveryPayload, device.path));
             };
 
-            TrezorConnect.on(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
+            TrezorConnect.on(UI_EVENTS.BUNDLE_PROGRESS, onBundleProgress);
 
             // NOTE: sync set discovery status to progress to make sure that there aren't some hanging states
             // before asnyc onBundleProgress is called which sets progress
@@ -505,7 +505,7 @@ export const runDiscoveryThunk = createThunk<
                 callId,
             });
 
-            TrezorConnect.off(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
+            TrezorConnect.off(UI_EVENTS.BUNDLE_PROGRESS, onBundleProgress);
 
             if (!isDiscoveryInProgress(selectDiscoveryByDevicePath(getState(), device.path))) {
                 return;
@@ -749,7 +749,7 @@ export const runAdditionalDiscoveryThunk = createThunk<
             dispatch(discoveryActions.updateDiscovery(discoveryPayload, device.path));
         };
 
-        TrezorConnect.on(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
+        TrezorConnect.on(UI_EVENTS.BUNDLE_PROGRESS, onBundleProgress);
 
         // have Connect check the discovered account with persisted xpub hashes, but those are valid only for standard wallet
         const entropyCheckResult = selectEntropyCheckResultByDeviceId(getState(), device.id);
@@ -768,7 +768,7 @@ export const runAdditionalDiscoveryThunk = createThunk<
             entropyCheckResult,
         });
 
-        TrezorConnect.off(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
+        TrezorConnect.off(UI_EVENTS.BUNDLE_PROGRESS, onBundleProgress);
 
         dispatch(
             discoveryActions.updateDiscovery(

--- a/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
@@ -3,8 +3,8 @@ import { type FetchAndSaveMetadataDep } from '@suite-common/metadata-types';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type ConnectInitHooksDeps, type TrezorDevice } from '@suite-common/suite-types';
 import { type GetTradedAccountKeysDep } from '@suite-common/wallet-types';
-import TrezorConnect, { UI_EVENT, UI_REQUEST } from '@trezor/connect';
-import { type PopupEventMessage, type UiEventMessage } from '@trezor/connect-common';
+import TrezorConnect, { UI_EVENT, UI_REQUEST, UI_REQUESTS } from '@trezor/connect';
+import type { PopupEventMessage, UiEventMessage, UiRequestMessage } from '@trezor/connect-common';
 
 import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
@@ -42,21 +42,23 @@ export const runPassphraseWalletAddingDiscoveryThunk = createThunk<
     `${DISCOVERY_MODULE_PREFIX}/runPassphraseWalletAddingDiscovery`,
     async ({ device }, { dispatch }) => {
         const callId = crypto.randomUUID();
-        const onUiEvent = (message: UiEventMessage | PopupEventMessage) => {
+        const onUiEvent = (message: UiEventMessage | PopupEventMessage | UiRequestMessage) => {
             const { event: _, ...action } = message;
             if (!('callId' in action) || !action.callId) return;
             if (action.callId !== callId) return;
-            if (action.type === UI_REQUEST.REQUEST_PASSPHRASE) return;
+            if (action.type === UI_REQUESTS.REQUEST_PASSPHRASE) return;
             dispatch(defaultTrezorUIEventHandlerThunk(action));
         };
 
         // Claim this callId so the global handler defers its events to the scoped listener.
         registerScopedCallId(callId);
         TrezorConnect.on(UI_EVENT, onUiEvent);
+        TrezorConnect.on(UI_REQUEST, onUiEvent);
         try {
             await dispatch(runDiscoveryThunk({ device, callId })).unwrap();
         } finally {
             TrezorConnect.off(UI_EVENT, onUiEvent);
+            TrezorConnect.off(UI_REQUEST, onUiEvent);
             unregisterScopedCallId(callId);
         }
     },

--- a/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.test.ts
+++ b/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.test.ts
@@ -1,23 +1,23 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore } from '@suite-common/test-utils';
-import { UI_REQUEST } from '@trezor/connect';
-import { createUiMessage } from '@trezor/connect-common';
+import { UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
+import { createUiEventMessage, createUiRequestMessage } from '@trezor/connect-common';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 
 import { defaultTrezorUIEventHandlerThunk } from './defaultTrezorUIEventHandlerThunk';
 
 const device = mockSuiteDevice();
 
-const requestWordEvent = createUiMessage(UI_REQUEST.REQUEST_WORD, {
+const requestWordEvent = createUiRequestMessage(UI_REQUESTS.REQUEST_WORD, {
     device,
     type: 'WordRequestType_Plain',
 });
 
-const pinDepletedEvent = createUiMessage(UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED, {
+const pinDepletedEvent = createUiEventMessage(UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED, {
     device,
 });
 
-const firmwareDownloadedEvent = createUiMessage(UI_REQUEST.FIRMWARE_DOWNLOADED, {
+const firmwareDownloadedEvent = createUiEventMessage(UI_EVENTS.FIRMWARE_DOWNLOADED, {
     binary: new ArrayBuffer(0),
     binaryVersion: [1, 0, 0],
     internalModel: DeviceModelInternal.T2T1,
@@ -33,13 +33,13 @@ const setupStore = (uiEventHooks: Record<string, () => void>) =>
 describe('defaultTrezorUIEventHandlerThunk - connectInitHooks.uiEvent', () => {
     it('calls the hook registered for the dispatched event type and still dispatches the event', async () => {
         const requestWordHook = jest.fn();
-        const store = setupStore({ [UI_REQUEST.REQUEST_WORD]: requestWordHook });
+        const store = setupStore({ [UI_REQUESTS.REQUEST_WORD]: requestWordHook });
 
         await store.dispatch(defaultTrezorUIEventHandlerThunk(requestWordEvent));
 
         expect(requestWordHook).toHaveBeenCalledTimes(1);
         expect(store.getActions()).toContainEqual(
-            expect.objectContaining({ type: UI_REQUEST.REQUEST_WORD }),
+            expect.objectContaining({ type: UI_REQUESTS.REQUEST_WORD }),
         );
     });
 
@@ -47,8 +47,8 @@ describe('defaultTrezorUIEventHandlerThunk - connectInitHooks.uiEvent', () => {
         const requestWordHook = jest.fn();
         const pinDepletedHook = jest.fn();
         const store = setupStore({
-            [UI_REQUEST.REQUEST_WORD]: requestWordHook,
-            [UI_REQUEST.INVALID_PIN_ATTEMPTS_DEPLETED]: pinDepletedHook,
+            [UI_REQUESTS.REQUEST_WORD]: requestWordHook,
+            [UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED]: pinDepletedHook,
         });
 
         await store.dispatch(defaultTrezorUIEventHandlerThunk(pinDepletedEvent));
@@ -59,13 +59,13 @@ describe('defaultTrezorUIEventHandlerThunk - connectInitHooks.uiEvent', () => {
 
     it('ignores FIRMWARE_DOWNLOADED completely: the event is dropped and no hook runs', async () => {
         const firmwareHook = jest.fn();
-        const store = setupStore({ [UI_REQUEST.FIRMWARE_DOWNLOADED]: firmwareHook });
+        const store = setupStore({ [UI_EVENTS.FIRMWARE_DOWNLOADED]: firmwareHook });
 
         await store.dispatch(defaultTrezorUIEventHandlerThunk(firmwareDownloadedEvent));
 
         expect(firmwareHook).not.toHaveBeenCalled();
         expect(store.getActions()).not.toContainEqual(
-            expect.objectContaining({ type: UI_REQUEST.FIRMWARE_DOWNLOADED }),
+            expect.objectContaining({ type: UI_EVENTS.FIRMWARE_DOWNLOADED }),
         );
     });
 

--- a/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.ts
+++ b/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.ts
@@ -1,13 +1,13 @@
 import { type DeviceRootState, deviceActions, selectSelectedDevice } from '@suite-common/device';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type ConnectInitHooksDeps } from '@suite-common/suite-types';
-import { UI_REQUEST } from '@trezor/connect';
-import type { PopupEventMessage, UiEventMessage } from '@trezor/connect-common';
+import { UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
+import type { PopupEventMessage, UiEventMessage, UiRequestMessage } from '@trezor/connect-common';
 import { type Without } from '@trezor/type-utils';
 
 const MODULE = '@common/wallet-core/uiEvent';
 
-export type UiEventAction = Without<UiEventMessage | PopupEventMessage, 'event'>;
+export type UiEventAction = Without<UiEventMessage | PopupEventMessage | UiRequestMessage, 'event'>;
 
 export type DefaultTrezorUIEventHandlerThunkState = DeviceRootState;
 export type DefaultTrezorUIEventHandlerThunkDeps = WithServices<ConnectInitHooksDeps>;
@@ -22,7 +22,7 @@ export const defaultTrezorUIEventHandlerThunk = createThunk<
 >(`${MODULE}/defaultTrezorUIEventHandler`, (action, { dispatch, getState, extra }) => {
     const { connectInitHooks } = extra.services;
 
-    if (action.type === UI_REQUEST.FIRMWARE_DOWNLOADED) {
+    if (action.type === UI_EVENTS.FIRMWARE_DOWNLOADED) {
         // We are in web therefore we ignore `FIRMWARE_DOWNLOADED` action.
         return;
     }
@@ -30,8 +30,8 @@ export const defaultTrezorUIEventHandlerThunk = createThunk<
     dispatch(action);
 
     switch (action.type) {
-        case UI_REQUEST.REQUEST_PIN:
-        case UI_REQUEST.INVALID_PIN:
+        case UI_REQUESTS.REQUEST_PIN:
+        case UI_EVENTS.INVALID_PIN:
             dispatch(
                 deviceActions.addButtonRequest({
                     // todo: note that this is not 'threadsafe', currently selected device is not necessarily the device
@@ -43,7 +43,7 @@ export const defaultTrezorUIEventHandlerThunk = createThunk<
                 }),
             );
             break;
-        case UI_REQUEST.REQUEST_BUTTON: {
+        case UI_EVENTS.BUTTON_REQUEST: {
             const { device: _, ...request } = action.payload;
             dispatch(
                 deviceActions.addButtonRequest({

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -1,4 +1,4 @@
-import type { BundleProgress, DeviceUniquePath, StaticSessionId } from '@trezor/connect';
+import type { DeviceUniquePath, StaticSessionId, UiEventBundleProgress } from '@trezor/connect';
 
 type CommonDiscoveryStatus = {
     isAddingHiddenWallet?: boolean; // to control visibility of special loader
@@ -30,8 +30,8 @@ export type DiscoveryStatus = CommonDiscoveryStatus &
           }
         | {
               status: 'progress';
-              total: BundleProgress<any>['payload']['total'];
-              progress: BundleProgress<any>['payload']['progress'];
+              total: UiEventBundleProgress<any>['payload']['total'];
+              progress: UiEventBundleProgress<any>['payload']['progress'];
           }
         | {
               status: 'confirm-empty-passphrase';

--- a/suite-native/bluetooth/src/bluetoothSlice.ts
+++ b/suite-native/bluetooth/src/bluetoothSlice.ts
@@ -7,7 +7,7 @@ import {
     prepareInitialState,
 } from '@suite-common/bluetooth';
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
-import { type FirmwareDisconnect, UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS, type UiEventFirmwareDisconnect } from '@trezor/connect';
 import { bluetoothManager } from '@trezor/transport-native-bluetooth';
 
 import { type BluetoothDevice, type BluetoothPermissionStatus } from './types';
@@ -40,7 +40,7 @@ const bluetoothSlice = createSliceWithExtraDeps({
     extraReducers: (builder, extra: BluetoothReducerDeps) => {
         const commonReducer = prepareBluetoothReducerCreator<BluetoothDevice>()(extra);
         builder
-            .addCase(UI_REQUEST.FIRMWARE_DISCONNECT, (_, action: FirmwareDisconnect) => {
+            .addCase(UI_EVENTS.FIRMWARE_DISCONNECT, (_, action: UiEventFirmwareDisconnect) => {
                 const { descriptor } = action.payload.device;
                 const deviceId = descriptor.apiType === 'bluetooth' ? descriptor.id : undefined;
                 if (deviceId) {

--- a/suite-native/device-authorization/src/components/PinFormControlButtons.tsx
+++ b/suite-native/device-authorization/src/components/PinFormControlButtons.tsx
@@ -14,7 +14,7 @@ import { Box, Button, HStack, IconButton } from '@suite-native/atoms';
 import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
-import TrezorConnect, { DEVICE, UI_REQUEST, UI_RESPONSE } from '@trezor/connect';
+import TrezorConnect, { DEVICE, UI_EVENTS, UI_RESPONSE } from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { PIN_HELP_URL } from '@trezor/urls';
 
@@ -85,11 +85,11 @@ export const PinFormControlButtons = ({ onSuccess }: PinFormControlButtonsProps)
     }, [openLink, reset, showAlert]);
 
     useEffect(() => {
-        // UI_REQUEST.INVALID_PIN is emitted when user enters wrong PIN for first 3 attempts.
+        // UI_EVENTS.INVALID_PIN is emitted when user enters wrong PIN for first 3 attempts.
         // See https://github.com/trezor/trezor-suite/blob/0498c2ef4c0a61ff56fc60cff0f545636592814d/packages/connect/src/core/index.ts#L598
-        TrezorConnect.on(UI_REQUEST.INVALID_PIN, handleInvalidPin);
+        TrezorConnect.on(UI_EVENTS.INVALID_PIN, handleInvalidPin);
 
-        return () => TrezorConnect.off(UI_REQUEST.INVALID_PIN, handleInvalidPin);
+        return () => TrezorConnect.off(UI_EVENTS.INVALID_PIN, handleInvalidPin);
     }, [handleInvalidPin]);
 
     const onSubmit = handleSubmit(values => {

--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.test.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.test.ts
@@ -1,5 +1,5 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
 
 import {
     type DeviceAuthorizationState,
@@ -22,9 +22,9 @@ describe('deviceAuthorizationSlice', () => {
         });
     });
 
-    describe('UI_REQUEST.REQUEST_PIN', () => {
+    describe('UI_REQUESTS.REQUEST_PIN', () => {
         it('should set deviceAuthorizationStep to PinRequested', () => {
-            const state = deviceAuthorizationReducer(undefined, { type: UI_REQUEST.REQUEST_PIN });
+            const state = deviceAuthorizationReducer(undefined, { type: UI_REQUESTS.REQUEST_PIN });
 
             expect(state).toEqual({
                 deviceAuthorizationStep: DeviceAuthorizationStep.PinRequested,
@@ -32,10 +32,10 @@ describe('deviceAuthorizationSlice', () => {
         });
     });
 
-    describe('UI_REQUEST.REQUEST_PASSPHRASE', () => {
+    describe('UI_REQUESTS.REQUEST_PASSPHRASE', () => {
         it('should set deviceAuthorizationStep to PassphraseRequested when device has staticSessionId', () => {
             const state = deviceAuthorizationReducer(undefined, {
-                type: UI_REQUEST.REQUEST_PASSPHRASE,
+                type: UI_REQUESTS.REQUEST_PASSPHRASE,
                 payload: {
                     device: mockSuiteDevice({
                         state: { staticSessionId: 'testWallet@testDevice:0' },
@@ -57,7 +57,7 @@ describe('deviceAuthorizationSlice', () => {
             });
 
             const state = deviceAuthorizationReducer(prevState, {
-                type: UI_REQUEST.REQUEST_PASSPHRASE,
+                type: UI_REQUESTS.REQUEST_PASSPHRASE,
             });
 
             expect(state).toEqual({
@@ -67,7 +67,7 @@ describe('deviceAuthorizationSlice', () => {
 
         it('should set deviceAuthorizationStep to Idle when device staticSessionId from connect is undefined', () => {
             const state = deviceAuthorizationReducer(undefined, {
-                type: UI_REQUEST.REQUEST_PASSPHRASE,
+                type: UI_REQUESTS.REQUEST_PASSPHRASE,
                 payload: {
                     device: { ...mockSuiteDevice(), state: { staticSessionId: undefined } },
                 },
@@ -79,14 +79,14 @@ describe('deviceAuthorizationSlice', () => {
         });
     });
 
-    describe('UI_REQUEST.CLOSE_UI_WINDOW', () => {
+    describe('UI_EVENTS.CLOSE_UI_WINDOW', () => {
         it('should reset deviceAuthorizationStep to Idle from any state', () => {
             const prevState = getDeviceAuthorizationState({
                 deviceAuthorizationStep: DeviceAuthorizationStep.PassphraseRequested,
             });
 
             const state = deviceAuthorizationReducer(prevState, {
-                type: UI_REQUEST.CLOSE_UI_WINDOW,
+                type: UI_EVENTS.CLOSE_UI_WINDOW,
             });
 
             expect(state).toEqual({
@@ -100,7 +100,7 @@ describe('deviceAuthorizationSlice', () => {
             'should set deviceAuthorizationStep to PinRequested for %s code',
             code => {
                 const state = deviceAuthorizationReducer(undefined, {
-                    type: UI_REQUEST.REQUEST_BUTTON,
+                    type: UI_EVENTS.BUTTON_REQUEST,
                     payload: { code },
                 });
 
@@ -120,7 +120,7 @@ describe('deviceAuthorizationSlice', () => {
                 });
 
                 const state = deviceAuthorizationReducer(prevState, {
-                    type: UI_REQUEST.REQUEST_BUTTON,
+                    type: UI_EVENTS.BUTTON_REQUEST,
                     payload: { code },
                 });
 
@@ -136,7 +136,7 @@ describe('deviceAuthorizationSlice', () => {
             'should set deviceAuthorizationStep to ContinueOnTrezorRequested for %s button request',
             name => {
                 const state = deviceAuthorizationReducer(undefined, {
-                    type: UI_REQUEST.REQUEST_BUTTON,
+                    type: UI_EVENTS.BUTTON_REQUEST,
                     payload: { name },
                 });
 

--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
 
 import {
     isFlowEndingButtonRequest,
@@ -41,11 +41,11 @@ export const deviceAuthorizationSlice = createSlice({
     reducers: {},
     extraReducers: builder => {
         builder
-            .addCase(UI_REQUEST.REQUEST_PIN, (state, action) => {
+            .addCase(UI_REQUESTS.REQUEST_PIN, (state, action) => {
                 state.deviceAuthorizationStep = DeviceAuthorizationStep.PinRequested;
                 state.pinRequestId = (action as typeof action & { requestId?: string }).requestId;
             })
-            .addCase(UI_REQUEST.REQUEST_PASSPHRASE, (state, action) => {
+            .addCase(UI_REQUESTS.REQUEST_PASSPHRASE, (state, action) => {
                 state.passphraseRequestId = (
                     action as typeof action & { requestId?: string }
                 ).requestId;
@@ -57,12 +57,12 @@ export const deviceAuthorizationSlice = createSlice({
                     state.deviceAuthorizationStep = DeviceAuthorizationStep.Idle;
                 }
             })
-            .addCase(UI_REQUEST.CLOSE_UI_WINDOW, state => {
+            .addCase(UI_EVENTS.CLOSE_UI_WINDOW, state => {
                 state.deviceAuthorizationStep = DeviceAuthorizationStep.Idle;
                 state.passphraseRequestId = undefined;
                 state.pinRequestId = undefined;
             })
-            .addCase(UI_REQUEST.REQUEST_BUTTON, (state, action) => {
+            .addCase(UI_EVENTS.BUTTON_REQUEST, (state, action) => {
                 if (isPinButtonRequestCode(action)) {
                     state.deviceAuthorizationStep = DeviceAuthorizationStep.PinRequested;
                 } else if (isSuiteSyncButtonRequest(action)) {

--- a/suite-native/device-authorization/src/utils.ts
+++ b/suite-native/device-authorization/src/utils.ts
@@ -1,6 +1,6 @@
 import { type UnknownAction } from '@reduxjs/toolkit';
 
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
 import type { UiRequestDeviceAction } from '@trezor/connect';
 import { isNotNullOrUndefined } from '@trezor/utils';
 
@@ -10,7 +10,7 @@ export const pinButtonRequestCodes = [
 ] as const;
 
 export const isPinButtonRequestCode = (action: UnknownAction): action is UiRequestDeviceAction =>
-    action.type === UI_REQUEST.REQUEST_BUTTON &&
+    action.type === UI_EVENTS.BUTTON_REQUEST &&
     typeof action.payload === 'object' &&
     isNotNullOrUndefined(action.payload) &&
     'code' in action.payload &&
@@ -19,8 +19,8 @@ export const isPinButtonRequestCode = (action: UnknownAction): action is UiReque
 export const isPassphraseButtonRequestCode = (
     action: UnknownAction,
 ): action is UiRequestDeviceAction =>
-    action.type === UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE ||
-    (action.type === UI_REQUEST.REQUEST_BUTTON &&
+    action.type === UI_EVENTS.PASSPHRASE_ON_DEVICE ||
+    (action.type === UI_EVENTS.BUTTON_REQUEST &&
         typeof action.payload === 'object' &&
         isNotNullOrUndefined(action.payload) &&
         'code' in action.payload &&
@@ -29,7 +29,7 @@ export const isPassphraseButtonRequestCode = (
         action.payload.name === 'passphrase_host1');
 
 export const isPassphraseRequest = (action: UnknownAction): action is UiRequestDeviceAction =>
-    action.type === UI_REQUEST.REQUEST_PASSPHRASE;
+    action.type === UI_REQUESTS.REQUEST_PASSPHRASE;
 
 export const flowEndingButtonRequests = [
     'ButtonRequest_ConfirmOutput',
@@ -39,7 +39,7 @@ export const flowEndingButtonRequests = [
 ] as const;
 
 export const isFlowEndingButtonRequest = (action: UnknownAction) =>
-    action.type === UI_REQUEST.REQUEST_BUTTON &&
+    action.type === UI_EVENTS.BUTTON_REQUEST &&
     typeof action.payload === 'object' &&
     isNotNullOrUndefined(action.payload) &&
     'code' in action.payload &&
@@ -48,7 +48,7 @@ export const isFlowEndingButtonRequest = (action: UnknownAction) =>
     );
 
 export const isSuiteSyncButtonRequest = (action: UnknownAction) =>
-    action.type === UI_REQUEST.REQUEST_BUTTON &&
+    action.type === UI_EVENTS.BUTTON_REQUEST &&
     typeof action.payload === 'object' &&
     isNotNullOrUndefined(action.payload) &&
     'name' in action.payload &&

--- a/suite-native/device/src/__fixtures__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__fixtures__/deviceConnectionFixtures.ts
@@ -17,7 +17,7 @@ import {
 } from '@suite-native/navigation';
 import type { RootStackParamList } from '@suite-native/navigation';
 import { type AppSettingsState, appSettingsReducer } from '@suite-native/settings';
-import { FirmwareType, UI_REQUEST } from '@trezor/connect';
+import { FirmwareType, UI_EVENTS } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 const INIT_ACTION = { type: 'foo' };
@@ -159,14 +159,14 @@ const buildInitialState = ({
 // THP Pairing Fixtures
 export const thpPairingBlockedFixtures: NoNavigationFixture[] = [
     {
-        description: 'blocks non-THP UI_REQUEST.REQUEST_BUTTON actions',
+        description: 'blocks non-THP UI_EVENTS.BUTTON_REQUEST actions',
         initialState: buildInitialState(),
-        action: { type: UI_REQUEST.REQUEST_BUTTON },
+        action: { type: UI_EVENTS.BUTTON_REQUEST },
     },
     {
-        description: 'blocks UI_REQUEST.REQUEST_BUTTON with invalid payload name',
+        description: 'blocks UI_EVENTS.BUTTON_REQUEST with invalid payload name',
         initialState: buildInitialState(),
-        action: { type: UI_REQUEST.REQUEST_BUTTON, payload: { name: 'non-valid-name' } },
+        action: { type: UI_EVENTS.BUTTON_REQUEST, payload: { name: 'non-valid-name' } },
     },
     {
         description: 'blocks unrelated action types',
@@ -180,7 +180,7 @@ export const thpPairingBlockedFixtures: NoNavigationFixture[] = [
                 isFirmwareInstallationRunning: true,
             },
         }),
-        action: { type: UI_REQUEST.REQUEST_BUTTON, payload: { name: 'thp_pairing_request' } },
+        action: { type: UI_EVENTS.BUTTON_REQUEST, payload: { name: 'thp_pairing_request' } },
     },
     {
         description: 'blocks thp_connection_request when firmware installation is running',
@@ -189,7 +189,7 @@ export const thpPairingBlockedFixtures: NoNavigationFixture[] = [
                 isFirmwareInstallationRunning: true,
             },
         }),
-        action: { type: UI_REQUEST.REQUEST_BUTTON, payload: { name: 'thp_connection_request' } },
+        action: { type: UI_EVENTS.BUTTON_REQUEST, payload: { name: 'thp_connection_request' } },
     },
 ];
 
@@ -197,7 +197,7 @@ export const thpPairingNavigationFixtures: NavigationFixture[] = [
     {
         description: 'navigates to ThpConfirmation on thp_pairing_request',
         initialState: buildInitialState(),
-        action: { type: UI_REQUEST.REQUEST_BUTTON, payload: { name: 'thp_pairing_request' } },
+        action: { type: UI_EVENTS.BUTTON_REQUEST, payload: { name: 'thp_pairing_request' } },
         expectedNavigation: {
             route: RootStackRoutes.AuthorizeDeviceStack,
             params: {
@@ -208,7 +208,7 @@ export const thpPairingNavigationFixtures: NavigationFixture[] = [
     {
         description: 'navigates to ThpConfirmation on thp_connection_request',
         initialState: buildInitialState(),
-        action: { type: UI_REQUEST.REQUEST_BUTTON, payload: { name: 'thp_connection_request' } },
+        action: { type: UI_EVENTS.BUTTON_REQUEST, payload: { name: 'thp_connection_request' } },
         expectedNavigation: {
             route: RootStackRoutes.AuthorizeDeviceStack,
             params: {

--- a/suite-native/module-device-onboarding/src/hooks/useInitiateThpConnection.ts
+++ b/suite-native/module-device-onboarding/src/hooks/useInitiateThpConnection.ts
@@ -10,7 +10,7 @@ import {
     type RootStackParamList,
     type StackToTabCompositeProps,
 } from '@suite-native/navigation';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { UI_RESPONSE } from '@trezor/connect';
 
 type NavigationProp = StackToTabCompositeProps<
     DeviceOnboardingStackParamList,
@@ -26,7 +26,11 @@ export const useInitiateThpConnection = () => {
 
     const initiateThpConnection = () => {
         // Device is acquired by the FW installation hook, just respond as expected.
-        TrezorConnect.uiResponse({ type: 'ui-receive_confirmation', payload: true, requestId });
+        TrezorConnect.uiResponse({
+            type: UI_RESPONSE.RECEIVE_CONFIRMATION,
+            payload: true,
+            requestId,
+        });
     };
 
     useEffect(() => {

--- a/suite-native/module-device-settings/src/hooks/useInitiateThpConnection.ts
+++ b/suite-native/module-device-settings/src/hooks/useInitiateThpConnection.ts
@@ -9,7 +9,7 @@ import {
     FirmwareUpdateStackRoutes,
     type StackNavigationProps,
 } from '@suite-native/navigation';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { UI_RESPONSE } from '@trezor/connect';
 
 type NavigationProp = StackNavigationProps<
     FirmwareUpdateStackParamList,
@@ -24,7 +24,11 @@ export const useInitiateThpConnection = () => {
 
     const initiateThpConnection = useCallback(() => {
         // Device is acquired by the FW installation hook, just respond as expected.
-        TrezorConnect.uiResponse({ type: 'ui-receive_confirmation', payload: true, requestId });
+        TrezorConnect.uiResponse({
+            type: UI_RESPONSE.RECEIVE_CONFIRMATION,
+            payload: true,
+            requestId,
+        });
     }, [requestId]);
 
     useEffect(() => {

--- a/suite-native/passphrase/src/useHandleUiRequestPassphraseOnDevice.ts
+++ b/suite-native/passphrase/src/useHandleUiRequestPassphraseOnDevice.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 
-import TrezorConnect, { UI_REQUEST } from '@trezor/connect';
+import TrezorConnect, { UI_EVENTS } from '@trezor/connect';
 
 export const useHandleUiRequestPassphraseOnDevice = (callback: () => void) => {
     useEffect(() => {
-        TrezorConnect.on(UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE, callback);
+        TrezorConnect.on(UI_EVENTS.PASSPHRASE_ON_DEVICE, callback);
 
-        return () => TrezorConnect.off(UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE, callback);
+        return () => TrezorConnect.off(UI_EVENTS.PASSPHRASE_ON_DEVICE, callback);
     }, [callback]);
 };

--- a/suite-native/thp/src/components/ThpCodeEntryScreenContent.tsx
+++ b/suite-native/thp/src/components/ThpCodeEntryScreenContent.tsx
@@ -5,7 +5,7 @@ import { selectThpPairingRequestId, selectThpStep } from '@suite-common/thp';
 import { useAlert } from '@suite-native/alerts';
 import { CenteredTitleHeader, Loader, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { UI_RESPONSE } from '@trezor/connect';
 
 import { SecurityCodeInput } from './SecurityCodeInput';
 
@@ -24,7 +24,7 @@ export const ThpCodeEntryScreenContent = ({ onRetry }: ThpCodeEntryScreenContent
     const onSubmit = (tag: string) => {
         setIsLoading(true);
         TrezorConnect.uiResponse({
-            type: 'ui-receive_thp_pairing_tag',
+            type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
             payload: { tag },
             requestId,
         });

--- a/suite/coinjoin/src/coinjoinMiddleware.ts
+++ b/suite/coinjoin/src/coinjoinMiddleware.ts
@@ -22,7 +22,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { RoundPhase, SessionPhase } from '@trezor/coinjoin';
-import { UI_REQUEST, isUiEventOfType } from '@trezor/connect';
+import { UI_EVENTS, isUiEventOfType } from '@trezor/connect';
 import { arrayDistinct, typedObjectKeys } from '@trezor/utils';
 
 import * as coinjoinAccountActions from './coinjoinAccountActions';
@@ -51,7 +51,7 @@ export const coinjoinMiddleware =
         const allowedModals = ['coinjoin-success', 'more-rounds-needed', 'critical-coinjoin-phase'];
 
         if (
-            isUiEventOfType(action, UI_REQUEST.CLOSE_UI_WINDOW) &&
+            isUiEventOfType(action, UI_EVENTS.CLOSE_UI_WINDOW) &&
             'payload' in modal &&
             allowedModals.includes(modal.payload?.type)
         ) {

--- a/suite/firmware-upgrade/src/useFirmwareDesktopUpdate.ts
+++ b/suite/firmware-upgrade/src/useFirmwareDesktopUpdate.ts
@@ -7,7 +7,7 @@ import {
     selectFirmware,
     useFirmwareInstallation,
 } from '@suite-common/firmware';
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS } from '@trezor/connect';
 
 const INTERVAL_CHECK_SLOW_INSTALLATION_MS = 1_000;
 const TIME_THRESHOLD_SLOW_INSTALLATION_MS = 30_000;
@@ -29,7 +29,7 @@ export const useFirmwareDesktopUpdate = () => {
     useEffect(() => {
         if (
             !startTime &&
-            firmware.uiEvent?.type === UI_REQUEST.FIRMWARE_PROGRESS &&
+            firmware.uiEvent?.type === UI_EVENTS.FIRMWARE_PROGRESS &&
             firmware.uiEvent.payload.operation === 'start-flashing'
         ) {
             setStartTime(new Date().getTime());
@@ -46,7 +46,7 @@ export const useFirmwareDesktopUpdate = () => {
 
             if (now - startTime > TIME_THRESHOLD_SLOW_INSTALLATION_MS) {
                 if (
-                    firmware.uiEvent?.type === UI_REQUEST.FIRMWARE_PROGRESS &&
+                    firmware.uiEvent?.type === UI_EVENTS.FIRMWARE_PROGRESS &&
                     firmware.uiEvent.payload.progress < PERCENTAGE_THRESHOLD_SLOW_INSTALLATION
                 ) {
                     setIsSlow(true);

--- a/suite/firmware-upgrade/src/useFirmwareInstallationProgressCheck.ts
+++ b/suite/firmware-upgrade/src/useFirmwareInstallationProgressCheck.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_EVENTS } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { useFirmwareDesktopUpdate } from './useFirmwareDesktopUpdate';
@@ -9,7 +9,7 @@ export const useFirmwareInstallationProgressCheck = () => {
     const { originalDevice, uiEvent } = useFirmwareDesktopUpdate();
     const isT1B1 = originalDevice?.features?.internal_model === DeviceModelInternal.T1B1;
 
-    const isUnexpectedDelay = uiEvent?.type === UI_REQUEST.FIRMWARE_PROGRESS_UNEXPECTED_DELAY;
+    const isUnexpectedDelay = uiEvent?.type === UI_EVENTS.FIRMWARE_PROGRESS_UNEXPECTED_DELAY;
 
     const [isDismissed, setIsDismissed] = useState(false);
     const handleDismissProgressCheck = () => setIsDismissed(true);

--- a/suite/modal/src/__fixtures__/modalReducer.ts
+++ b/suite/modal/src/__fixtures__/modalReducer.ts
@@ -1,5 +1,5 @@
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { DEVICE, UI_REQUEST } from '@trezor/connect';
+import { DEVICE, UI_EVENTS, UI_REQUESTS } from '@trezor/connect';
 
 import {
     MODAL_CLOSE,
@@ -87,11 +87,11 @@ export default [
         },
     },
     {
-        description: 'UI_REQUEST.REQUEST_PIN',
+        description: 'UI_REQUESTS.REQUEST_PIN',
         initialState,
         actions: [
             {
-                type: UI_REQUEST.REQUEST_PIN,
+                type: UI_REQUESTS.REQUEST_PIN,
                 payload: {
                     device: CONNECT_DEVICE,
                 },
@@ -100,15 +100,15 @@ export default [
         result: {
             ...deviceContextState,
             device: CONNECT_DEVICE,
-            windowType: UI_REQUEST.REQUEST_PIN,
+            windowType: UI_REQUESTS.REQUEST_PIN,
         },
     },
     {
-        description: 'UI_REQUEST.INVALID_PIN',
+        description: 'UI_EVENTS.INVALID_PIN',
         initialState,
         actions: [
             {
-                type: UI_REQUEST.INVALID_PIN,
+                type: UI_EVENTS.INVALID_PIN,
                 payload: {
                     device: CONNECT_DEVICE,
                 },
@@ -117,15 +117,15 @@ export default [
         result: {
             ...deviceContextState,
             device: CONNECT_DEVICE,
-            windowType: UI_REQUEST.INVALID_PIN,
+            windowType: UI_EVENTS.INVALID_PIN,
         },
     },
     {
-        description: 'UI_REQUEST.REQUEST_PASSPHRASE',
+        description: 'UI_REQUESTS.REQUEST_PASSPHRASE',
         initialState,
         actions: [
             {
-                type: UI_REQUEST.REQUEST_PASSPHRASE,
+                type: UI_REQUESTS.REQUEST_PASSPHRASE,
                 payload: {
                     device: CONNECT_DEVICE,
                 },
@@ -134,15 +134,15 @@ export default [
         result: {
             ...deviceContextState,
             device: CONNECT_DEVICE,
-            windowType: UI_REQUEST.REQUEST_PASSPHRASE,
+            windowType: UI_REQUESTS.REQUEST_PASSPHRASE,
         },
     },
     {
-        description: 'UI_REQUEST.REQUEST_BUTTON',
+        description: 'UI_EVENTS.BUTTON_REQUEST',
         initialState,
         actions: [
             {
-                type: UI_REQUEST.REQUEST_BUTTON,
+                type: UI_EVENTS.BUTTON_REQUEST,
                 payload: {
                     device: CONNECT_DEVICE,
                     code: 'ButtonRequest_SignTx',
@@ -156,11 +156,11 @@ export default [
         },
     },
     {
-        description: 'UI_REQUEST.REQUEST_WORD',
+        description: 'UI_REQUESTS.REQUEST_WORD',
         initialState: undefined,
         actions: [
             {
-                type: UI_REQUEST.REQUEST_WORD,
+                type: UI_REQUESTS.REQUEST_WORD,
                 payload: {
                     device: CONNECT_DEVICE,
                     type: 'WordRequestType_Plain',
@@ -174,11 +174,11 @@ export default [
         },
     },
     {
-        description: 'UI_REQUEST.REQUEST_CONFIRMATION',
+        description: 'UI_REQUESTS.REQUEST_CONFIRMATION',
         initialState,
         actions: [
             {
-                type: UI_REQUEST.REQUEST_CONFIRMATION,
+                type: UI_REQUESTS.REQUEST_CONFIRMATION,
                 payload: {
                     view: 'no-backup',
                 },
@@ -190,29 +190,29 @@ export default [
         },
     },
     {
-        description: 'UI_REQUEST.CLOSE_UI_WINDOW',
+        description: 'UI_EVENTS.CLOSE_UI_WINDOW',
         initialState: deviceContextState,
         actions: [
             {
-                type: UI_REQUEST.CLOSE_UI_WINDOW,
+                type: UI_EVENTS.CLOSE_UI_WINDOW,
             },
         ],
         result: initialState,
     },
     {
         description:
-            'UI_REQUEST.CLOSE_UI_WINDOW with preserve=true keeps device context modal open (preserve cleared)',
+            'UI_EVENTS.CLOSE_UI_WINDOW with preserve=true keeps device context modal open (preserve cleared)',
         initialState: { ...deviceContextState, preserve: true },
         actions: [
             {
-                type: UI_REQUEST.CLOSE_UI_WINDOW,
+                type: UI_EVENTS.CLOSE_UI_WINDOW,
             },
         ],
         result: { ...deviceContextState, preserve: false },
     },
     {
         description:
-            'UI_REQUEST.CLOSE_UI_WINDOW with preserve=true keeps device confirmation context modal open (preserve cleared)',
+            'UI_EVENTS.CLOSE_UI_WINDOW with preserve=true keeps device confirmation context modal open (preserve cleared)',
         initialState: {
             context: MODAL_CONTEXT_DEVICE_CONFIRMATION,
             windowType: 'no-backup' as const,
@@ -220,7 +220,7 @@ export default [
         },
         actions: [
             {
-                type: UI_REQUEST.CLOSE_UI_WINDOW,
+                type: UI_EVENTS.CLOSE_UI_WINDOW,
             },
         ],
         result: {
@@ -230,7 +230,7 @@ export default [
         },
     },
     {
-        description: 'UI_REQUEST.CLOSE_UI_WINDOW with preserve=true keeps user context modal open',
+        description: 'UI_EVENTS.CLOSE_UI_WINDOW with preserve=true keeps user context modal open',
         initialState: {
             context: MODAL_CONTEXT_USER,
             payload: { type: 'application-log' as const },
@@ -238,7 +238,7 @@ export default [
         },
         actions: [
             {
-                type: UI_REQUEST.CLOSE_UI_WINDOW,
+                type: UI_EVENTS.CLOSE_UI_WINDOW,
             },
         ],
         result: {

--- a/suite/modal/src/constants.ts
+++ b/suite/modal/src/constants.ts
@@ -1,4 +1,4 @@
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_REQUESTS } from '@trezor/connect';
 
 export const MODAL_CLOSE = '@modal/close' as const;
 export const MODAL_CONTEXT_NONE = '@modal/context-none' as const;
@@ -11,7 +11,7 @@ export const MODAL_REMOVE_PRESERVE = '@modal/remove_preserve' as const;
 export const MODAL_PRESERVE_ON_TX_TIMEOUT = '@modal/preserve-on-tx-timeout' as const;
 
 export const REFETCH_FEES_EXCLUDED_MODAL_WINDOW_TYPES = [
-    UI_REQUEST.REQUEST_PASSPHRASE,
+    UI_REQUESTS.REQUEST_PASSPHRASE,
     // both are TransactionReviewModal, which should be final and not be subject to sudden change!
     'ButtonRequest_ConfirmOutput',
     'ButtonRequest_SignTx',

--- a/suite/modal/src/modalActions.ts
+++ b/suite/modal/src/modalActions.ts
@@ -16,7 +16,7 @@ import { selectModalConfirmationRequestId } from './modalSelectors';
 export const closeModal = createAction(MODAL_CLOSE);
 
 /**
- * Don't close modals on UI.CLOSE_UI.WINDOW event (closing via modal US), but wait for explicit closing instead
+ * Don't close modals on UI_EVENTS.CLOSE_UI_WINDOW event, but wait for explicit closing instead
  * (usually coming from a redux action from device, or other sources not directly controlled by Suite UI)
  */
 export const preserveModal = createAction(MODAL_PRESERVE);

--- a/suite/modal/src/modalReducer.ts
+++ b/suite/modal/src/modalReducer.ts
@@ -5,12 +5,14 @@ import { type TrezorDevice, type UserContextPayload } from '@suite-common/suite-
 import { THP_BUTTON_REQUESTS_NAMES } from '@suite-common/thp';
 import {
     type Device,
-    UI_REQUEST,
+    UI_EVENTS,
+    UI_REQUESTS,
     type UiRequestButtonData,
     type UiRequestConfirmation,
     type UiRequestSelectAccount,
     type UiRequestSelectFee,
     isUiEventOfType,
+    isUiRequestOfType,
 } from '@trezor/connect';
 import { isArrayMember } from '@trezor/utils';
 
@@ -41,13 +43,13 @@ export type ModalState =
       }
     | {
           context: typeof MODAL_CONTEXT_DEVICE_CONFIRMATION;
-          windowType: typeof UI_REQUEST.SELECT_ACCOUNT;
+          windowType: typeof UI_REQUESTS.REQUEST_ACCOUNT;
           data?: UiRequestSelectAccount['payload'];
           requestId?: string;
       }
     | {
           context: typeof MODAL_CONTEXT_DEVICE_CONFIRMATION;
-          windowType: typeof UI_REQUEST.SELECT_FEE;
+          windowType: typeof UI_REQUESTS.REQUEST_FEE;
           data?: UiRequestSelectFee['payload'];
           requestId?: string;
       }
@@ -87,12 +89,11 @@ export const modalReducer = (state: State = initialState, action: UnknownAction)
 
     // assign device to modal context
     if (
+        isUiRequestOfType(action, UI_REQUESTS.REQUEST_PIN, UI_REQUESTS.REQUEST_PASSPHRASE) ||
         isUiEventOfType(
             action,
-            UI_REQUEST.REQUEST_PIN,
-            UI_REQUEST.INVALID_PIN,
-            UI_REQUEST.REQUEST_PASSPHRASE,
-            UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE,
+            UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED,
+            UI_EVENTS.PASSPHRASE_ON_DEVICE,
         )
     ) {
         return {
@@ -104,7 +105,7 @@ export const modalReducer = (state: State = initialState, action: UnknownAction)
         };
     }
 
-    if (isUiEventOfType(action, UI_REQUEST.REQUEST_BUTTON)) {
+    if (isUiEventOfType(action, UI_EVENTS.BUTTON_REQUEST)) {
         // THP ButtonRequests handled separately in the `thpReducer`
         if (
             action.payload.name !== undefined &&
@@ -122,12 +123,12 @@ export const modalReducer = (state: State = initialState, action: UnknownAction)
         };
     }
 
-    if (isUiEventOfType(action, UI_REQUEST.FIRMWARE_PROGRESS)) {
+    if (isUiEventOfType(action, UI_EVENTS.FIRMWARE_PROGRESS)) {
         // firmware update first sends UI_REQUEST.REQUEST_BUTTON. Clear it after first progress is received
         return initialState;
     }
 
-    if (isUiEventOfType(action, UI_REQUEST.REQUEST_CONFIRMATION)) {
+    if (isUiRequestOfType(action, UI_REQUESTS.REQUEST_CONFIRMATION)) {
         return {
             context: MODAL_CONTEXT_DEVICE_CONFIRMATION,
             windowType: action.payload.view,
@@ -136,7 +137,7 @@ export const modalReducer = (state: State = initialState, action: UnknownAction)
         };
     }
 
-    if (isUiEventOfType(action, UI_REQUEST.REQUEST_WORD)) {
+    if (isUiRequestOfType(action, UI_REQUESTS.REQUEST_WORD)) {
         return {
             context: MODAL_CONTEXT_DEVICE,
             device: action.payload.device,
@@ -146,19 +147,19 @@ export const modalReducer = (state: State = initialState, action: UnknownAction)
         };
     }
 
-    if (isUiEventOfType(action, UI_REQUEST.SELECT_ACCOUNT)) {
+    if (isUiRequestOfType(action, UI_REQUESTS.REQUEST_ACCOUNT)) {
         return {
             context: MODAL_CONTEXT_DEVICE_CONFIRMATION,
-            windowType: UI_REQUEST.SELECT_ACCOUNT,
+            windowType: UI_REQUESTS.REQUEST_ACCOUNT,
             data: action.payload,
             preserve: state.preserve,
         };
     }
 
-    if (isUiEventOfType(action, UI_REQUEST.SELECT_FEE)) {
+    if (isUiRequestOfType(action, UI_REQUESTS.REQUEST_FEE)) {
         return {
             context: MODAL_CONTEXT_DEVICE_CONFIRMATION,
-            windowType: UI_REQUEST.SELECT_FEE,
+            windowType: UI_REQUESTS.REQUEST_FEE,
             data: action.payload,
             preserve: state.preserve,
         };
@@ -176,7 +177,7 @@ export const modalReducer = (state: State = initialState, action: UnknownAction)
         return initialState;
     }
 
-    if (isUiEventOfType(action, UI_REQUEST.CLOSE_UI_WINDOW)) {
+    if (isUiEventOfType(action, UI_EVENTS.CLOSE_UI_WINDOW)) {
         if (
             state.context === MODAL_CONTEXT_DEVICE ||
             state.context === MODAL_CONTEXT_DEVICE_CONFIRMATION

--- a/suite/modal/src/modalReducer.ts
+++ b/suite/modal/src/modalReducer.ts
@@ -90,11 +90,7 @@ export const modalReducer = (state: State = initialState, action: UnknownAction)
     // assign device to modal context
     if (
         isUiRequestOfType(action, UI_REQUESTS.REQUEST_PIN, UI_REQUESTS.REQUEST_PASSPHRASE) ||
-        isUiEventOfType(
-            action,
-            UI_EVENTS.INVALID_PIN_ATTEMPTS_DEPLETED,
-            UI_EVENTS.PASSPHRASE_ON_DEVICE,
-        )
+        isUiEventOfType(action, UI_EVENTS.INVALID_PIN, UI_EVENTS.PASSPHRASE_ON_DEVICE)
     ) {
         return {
             context: MODAL_CONTEXT_DEVICE,

--- a/suite/thp/src/connection/ThpPairingCodeEntry.tsx
+++ b/suite/thp/src/connection/ThpPairingCodeEntry.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { selectThpPairingRequestId } from '@suite-common/thp';
 import { PinInput, Row, Spinner } from '@trezor/components';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { UI_RESPONSE } from '@trezor/connect';
 import { type SignedSpacingValue } from '@trezor/theme';
 
 const SPINNER_SIZE = 32;
@@ -23,7 +23,7 @@ export const ThpPairingCodeEntry = ({ disabled, lastCode }: ThpPairingPinEntryPr
         (tag: string) => {
             setLoading(true);
             TrezorConnect.uiResponse({
-                type: 'ui-receive_thp_pairing_tag',
+                type: UI_RESPONSE.RECEIVE_THP_PAIRING_TAG,
                 payload: { tag },
                 requestId,
             });

--- a/suite/thp/src/startThpSessionThunk.ts
+++ b/suite/thp/src/startThpSessionThunk.ts
@@ -1,6 +1,6 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { type ThpRootState, selectThpConfirmationRequestId } from '@suite-common/thp';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { UI_RESPONSE } from '@trezor/connect';
 
 import { THP_PREFIX } from './thpActions';
 
@@ -10,6 +10,10 @@ export const startThpSessionThunk = createThunk<void, void, { state: StartThpSes
     `${THP_PREFIX}/startThpSessionThunk`,
     (_, { getState }) => {
         const requestId = selectThpConfirmationRequestId(getState());
-        TrezorConnect.uiResponse({ type: 'ui-receive_confirmation', payload: true, requestId });
+        TrezorConnect.uiResponse({
+            type: UI_RESPONSE.RECEIVE_CONFIRMATION,
+            payload: true,
+            requestId,
+        });
     },
 );


### PR DESCRIPTION
## Description

Follow-up cleanups stacked on top of #31418 (`fix/connect-uievent-requestid`), addressing review findings from the `UI_EVENT` → `UI_EVENTS`/`UI_REQUESTS` split. **This PR targets the #31418 branch**, not `develop`. Rebased onto the latest #31418 tip.

Each item is a separate commit:

1. **`docs(connect)`** — clarify the `allowDeviceMode` comment in `AbstractMethod.ts`: the stray negation (`allow !DEVICE_NOT_INITIALIZED`) reads as a double negative now that the constant name carries the `NOT`, so it's reworded to plainly state that ResetDevice allows the not-initialized mode.
2. **`refactor(connect-common)`** — drop the duplicate `UiResponseFirmwares` member from the `UiResponseEvent` union (`ui-response.ts`). No-op (`A | A === A`), just a cleanup.
3. **`docs(suite)`** — update the stale `REQUEST_BUTTON` reference to `BUTTON_REQUEST` in the `useConnectPopupModals` comment.
4. **`test(connect)`** — the changed unit tests injected request-type prompts (`REQUEST_WORD`, `REQUEST_PIN`) on the `UI_EVENT` channel, whereas production now emits them via `createUiRequestMessage` on the **`UI_REQUEST`** channel. Because the test mock routes strictly by channel and `connectInitThunk` registers two identical listeners, the tests passed without ever exercising the new `TrezorConnect.on(UI_REQUEST, …)` subscription this PR adds. Emit them on the correct channel so the new routing is actually covered.
5. **`docs(connect)`** — document the split as a breaking change in `packages/connect/CHANGELOG.md` (new **UI events** subsection): the `UI_REQUEST` object → channel-string change, the two channels, the message-type renames, the re-namespaced `ui-event_*` wire values, and the `{ device }` payload wrapper.

## Related

- Stacked on #31418

## Testing

- `connectInitThunks.test.ts` — 13/13 ✅
- `buttonRequestMiddleware.test.ts` — ✅ (Node 24)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-uievent-split-followups&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->