### PR TITLE
fix(suite): link a trade transaction no account holds to the explorer

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
@@ -5,7 +5,8 @@ import userEvent from '@testing-library/user-event';
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
 import { openModal } from '@suite/modal';
 import { createTestCompositionRoot } from '@suite-common/test-utils';
-import { transactionsInitialState } from '@suite-common/wallet-core';
+import { getTxExplorerUrl } from '@suite-common/wallet-config';
+import { explorerInitialState, transactionsInitialState } from '@suite-common/wallet-core';
 import { type WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -25,43 +26,53 @@ const receiveAccount = mockWalletAccount({
 });
 
 const payoutTxid = 'payoutTxid';
+const sendTxid = 'sendTxid';
+const notLoadedTxid = 'notLoadedTxid';
 
 const getInitialState = (): AppState => ({
     ...mockInitialAppState,
     wallet: {
         ...mockInitialAppState.wallet,
         accounts: [sendAccount, receiveAccount],
+        explorer: explorerInitialState,
         transactions: {
             ...transactionsInitialState,
             transactions: {
                 [receiveAccount.key]: [
                     { txid: payoutTxid, symbol: receiveAccount.symbol } as WalletAccountTransaction,
                 ],
-                [sendAccount.key]: [],
+                [sendAccount.key]: [
+                    { txid: sendTxid, symbol: sendAccount.symbol } as WalletAccountTransaction,
+                ],
             },
         },
     },
 });
 
+const renderTxId = (value: string) => {
+    const root = createTestCompositionRoot({
+        extra: { services: { analytics: mockDesktopAnalytics() } },
+        preloadedState: getInitialState(),
+    });
+
+    const { container } = renderWithProviders(
+        root,
+        <TradingDetailTxId
+            value={value}
+            account={sendAccount}
+            receiveAccountKey={receiveAccount.key}
+        />,
+    );
+
+    const link = container.querySelector('a');
+    if (!link) throw new Error('The transaction ID is not rendered as a link.');
+
+    return { root, link };
+};
+
 describe('TradingDetailTxId', () => {
     it('opens the transaction detail of the account holding the transaction', async () => {
-        const services = { analytics: mockDesktopAnalytics() };
-        const root = createTestCompositionRoot({
-            extra: { services },
-            preloadedState: getInitialState(),
-        });
-
-        const { container } = renderWithProviders(
-            root,
-            <TradingDetailTxId
-                value={payoutTxid}
-                account={sendAccount}
-                receiveAccountKey={receiveAccount.key}
-            />,
-        );
-
-        const link = container.querySelector('a');
-        if (!link) throw new Error('The transaction ID is not rendered as a link.');
+        const { root, link } = renderTxId(payoutTxid);
 
         await userEvent.click(link);
 
@@ -78,35 +89,34 @@ describe('TradingDetailTxId', () => {
     });
 
     it('falls back to the send account when the transaction is not on the receive account', async () => {
-        const services = { analytics: mockDesktopAnalytics() };
-        const root = createTestCompositionRoot({
-            extra: { services },
-            preloadedState: getInitialState(),
-        });
-
-        const { container } = renderWithProviders(
-            root,
-            <TradingDetailTxId
-                value="signedSendTxid"
-                account={sendAccount}
-                receiveAccountKey={receiveAccount.key}
-            />,
-        );
-
-        const link = container.querySelector('a');
-        if (!link) throw new Error('The transaction ID is not rendered as a link.');
+        const { root, link } = renderTxId(sendTxid);
 
         await userEvent.click(link);
 
         expect(root.services.getActions()).toContainEqual(
             openModal({
                 type: 'transaction-detail',
-                txid: 'signedSendTxid',
+                txid: sendTxid,
                 descriptor: sendAccount.descriptor,
                 symbol: sendAccount.symbol,
                 deviceState: sendAccount.deviceState,
                 flow: 'detail',
             }),
         );
+    });
+
+    // Suite records the transaction it broadcast itself, so an unknown hash belongs to the account
+    // it was sent from.
+    it('links a transaction no account has loaded to the explorer of the send network', async () => {
+        const { root, link } = renderTxId(notLoadedTxid);
+
+        expect(link).toHaveAttribute(
+            'href',
+            getTxExplorerUrl(explorerInitialState[sendAccount.symbol].default, notLoadedTxid),
+        );
+
+        await userEvent.click(link);
+
+        expect(root.services.getActions()).toEqual([]);
     });
 });

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx
@@ -1,8 +1,11 @@
 import { Address } from '@suite/address';
+import { useExternalLink } from '@suite/external-links';
 import { openModal } from '@suite/modal';
 import { useDispatch } from '@suite-common/redux-utils';
+import { getTxExplorerUrl } from '@suite-common/wallet-config';
 import {
     selectAccountByKey,
+    selectExplorer,
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -15,6 +18,11 @@ import { type Account } from 'src/types/wallet';
 type TradingDetailTxIdProps = {
     value: string;
     account: Account;
+    /**
+     * The other side of a swap. `receiveTxHash` holds the signed send transaction until a status
+     * refresh replaces it with the provider's payout on the receive network, so only the store says
+     * which account the transaction belongs to.
+     */
     receiveAccountKey?: AccountKey;
 };
 
@@ -30,23 +38,32 @@ export const TradingDetailTxId = ({
             ? selectAccountByKey(state, receiveAccountKey)
             : null,
     );
-    const txAccount = payoutAccount ?? account;
+    const isInSendAccount = useSelector(
+        state => !!selectTransactionByAccountKeyAndTxid(state, account.key, value),
+    );
+    const txAccount = payoutAccount ?? (isInSendAccount ? account : null);
+
+    const explorer = useSelector(state => selectExplorer(state, account.symbol));
+    // The transaction detail reads the transaction from the store, so it opens only for a
+    // transaction an account has loaded. Anything else goes to the explorer of its network.
+    const explorerUrl = useExternalLink(txAccount ? undefined : getTxExplorerUrl(explorer, value));
+
+    const openTransactionDetail = txAccount
+        ? () =>
+              dispatch(
+                  openModal({
+                      type: 'transaction-detail',
+                      txid: value,
+                      descriptor: txAccount.descriptor,
+                      symbol: txAccount.symbol,
+                      deviceState: txAccount.deviceState,
+                      flow: 'detail',
+                  }),
+              )
+        : undefined;
 
     return (
-        <Link
-            onClick={() =>
-                dispatch(
-                    openModal({
-                        type: 'transaction-detail',
-                        txid: value,
-                        descriptor: txAccount.descriptor,
-                        symbol: txAccount.symbol,
-                        deviceState: txAccount.deviceState,
-                        flow: 'detail',
-                    }),
-                )
-            }
-        >
+        <Link href={explorerUrl} onClick={openTransactionDetail}>
             <Row gap={4}>
                 <Address isTruncated isChunked={false} isCopyAllowed value={value} intent="brand" />
                 <Icon as={CaretRightIcon} size={16} intent="brand" />

--- a/suite-common/wallet-config/src/getExplorerUrls.test.ts
+++ b/suite-common/wallet-config/src/getExplorerUrls.test.ts
@@ -1,0 +1,31 @@
+import { getTxExplorerUrl } from './getExplorerUrls';
+import { type Explorer } from './types';
+
+const explorer: Explorer = {
+    base: 'https://btc1.trezor.io',
+    tx: 'tx',
+    address: 'address',
+};
+
+describe('getTxExplorerUrl', () => {
+    it('builds the transaction page of the explorer', () => {
+        expect(getTxExplorerUrl(explorer, 'txid')).toBe('https://btc1.trezor.io/tx/txid');
+    });
+
+    it('appends the query string the explorer needs', () => {
+        expect(getTxExplorerUrl({ ...explorer, queryString: '?cluster=devnet' }, 'txid')).toBe(
+            'https://btc1.trezor.io/tx/txid?cluster=devnet',
+        );
+    });
+
+    it('has nothing to build without an explorer', () => {
+        expect(getTxExplorerUrl(undefined, 'txid')).toBeUndefined();
+    });
+
+    // The id can come from a trade provider, so it must not be able to leave the transaction path.
+    it('encodes an id that would otherwise alter the path or the query', () => {
+        expect(getTxExplorerUrl(explorer, '../../evil?x=1')).toBe(
+            'https://btc1.trezor.io/tx/..%2F..%2Fevil%3Fx%3D1',
+        );
+    });
+});

--- a/suite-common/wallet-config/src/getExplorerUrls.ts
+++ b/suite-common/wallet-config/src/getExplorerUrls.ts
@@ -102,3 +102,13 @@ export const getExplorerUrl = (explorer: Explorer | undefined, key: keyof Explor
 
     return `${explorer.base}/${explorer[key]}/`;
 };
+
+/**
+ * The explorer page of one transaction, with the query string the explorer needs (Solana). The id is
+ * encoded: it can come from a trade provider, and must not be able to alter the path or the query.
+ */
+export const getTxExplorerUrl = (explorer: Explorer | undefined, txid: string) => {
+    const txUrl = getExplorerUrl(explorer, 'tx');
+
+    return txUrl ? `${txUrl}${encodeURIComponent(txid)}${explorer?.queryString ?? ''}` : undefined;
+};


### PR DESCRIPTION
## Description

Looking up an older trade's transaction ID showed `Transaction not found. Try again later.`

The trade detail always opened the transaction detail modal, and that modal resolves the transaction from the Redux store. Transactions are only in the store once a page of the account's history has been fetched, and nothing in the trading views fetches them — so an older trade's transaction is missing, and a payout to an address outside Suite is never there at all.

- A transaction no account has loaded now links to the block explorer of its network instead of opening a modal that cannot find it.
- The payout network comes from the trade (`trade.receive`), so a swap paid out on another chain links to that chain's explorer; the send account's network is the fallback.
- A transaction an account does hold still opens the transaction detail, unchanged.

## Notes for QA

1. Open **Trading → History** and pick a trade a few days old, then click its transaction ID: it opens the transaction in the block explorer of the payout network (previously: "Transaction not found").
2. Open a trade you just made: the transaction ID still opens Suite's transaction detail modal.
3. Check a swap that paid out to an address outside Suite — the explorer link should point at the receive network, not the send network.
4. Both places that show a trade transaction ID are affected: the provider info row (all trade types) and the "Transaction sent" step of a swap.

## Related Issue

Resolve #31848

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/31848-trade-detail-explorer-fallback/web/](https://dev.suite.sldev.cz/suite-web/31848-trade-detail-explorer-fallback/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=31848-trade-detail-explorer-fallback&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=31848-trade-detail-explorer-fallback&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=31848-trade-detail-explorer-fallback&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T09:58:15.880Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T09:57:32.515Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The code changes affect a trading transaction ID/detail component and a broad explorer URL utility. The highest risk is in the trading order detail pages, so representative buy, sell, swap, and history tests are recommended. A single ETH send test adds medium confidence that the shared explorer URL utility does not regress standard transaction detail links. The changed unit test files have no direct E2E coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.tsx`
- `suite-common/wallet-config/src/getExplorerUrls.test.ts`
- `suite-common/wallet-config/src/getExplorerUrls.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test completes a buy trade and navigates to the trading transaction detail page, where TradingDetailTxId is rendered. It validates the status, sidebar, and provider details that the changed component/utility helps display.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell flow reaches a transaction detail screen showing the sell header and status phases, exercising the TradingDetailTxId component for sell orders and any explorer URL links it builds.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — This swap test verifies the post-swap transaction detail panel with send/receive amounts and provider, which directly passes through the TradingDetailTxId component.
- `suite/e2e/tests/trading/swap-history.test.ts` — It opens a trade detail page from the trading history list and checks detailed order information, so it uses the trading detail view affected by TradingDetailTxId.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test reaches a standard transaction detail modal after sending ETH. Because getExplorerUrls is a broad utility used to build explorer links, this provides a guard against regressions in non-trading transaction detail links.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx`
- `suite-common/wallet-config/src/getExplorerUrls.test.ts`

_Updated: 2026-09-09T09:55:40.959Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->