### PR TITLE
fix(suite): allow closing PIN modal during network activation

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/useNetworkActivationQueue.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/useNetworkActivationQueue.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { preserveModal } from '@suite/modal';
+import { preserveModal, removePreserveModal } from '@suite/modal';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
@@ -36,7 +36,17 @@ export const useNetworkActivationQueue = (device: TrezorDevice) => {
     const [activationErrors, setActivationErrors] = useState<
         Partial<Record<NetworkSymbol, string>>
     >({});
+    const hasPreservedModalRef = useRef(false);
     const isRollingBackRef = useRef(false);
+
+    useEffect(
+        () => () => {
+            if (hasPreservedModalRef.current) {
+                dispatch(removePreserveModal());
+            }
+        },
+        [dispatch],
+    );
 
     useEffect(() => {
         const staticSessionId = device.state?.staticSessionId;
@@ -61,6 +71,7 @@ export const useNetworkActivationQueue = (device: TrezorDevice) => {
 
         // Setting discovery to a running state before enabling the network prevents
         // discoveryMiddleware from starting a duplicate discovery call.
+        hasPreservedModalRef.current = true;
         dispatch(preserveModal());
         dispatch(
             discoveryActions.startDiscovery(device.path, {


### PR DESCRIPTION
## Description

Release the Add Account network activation modal preservation lock when the activation UI is replaced by a device interaction modal. This prevents the inherited preservation flag from keeping the PIN-entry modal open after the user cancels the device call.

## Notes for QA

1. Lock a Trezor Safe 5 device.
2. Open Add Account and enable a disabled network.
3. When Suite shows the on-device PIN-entry prompt, cancel it using the close button in the confirmation pill.
4. Verify that the device modal closes and Suite remains usable.

Also verify that enabling a network with an unlocked device still completes normally.

## Related Issue

Follow-up to https://github.com/trezor/trezor-suite/pull/31467#issuecomment-5475411076

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change touches a hook inside the Add Account modal that queues network activations. Because the static mapping covers 136 tests, the file is almost certainly a broad transitive dependency; only tests that explicitly drive the Add Account modal are recommended. The highest-confidence test is the add-account-types spec, with the global receive/send flow as a secondary coverage point.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/useNetworkActivationQueue.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test directly exercises the Add Account modal, including network search, account type selection, and account creation—exactly the UI flow where useNetworkActivationQueue lives. A regression in network activation queueing would likely manifest here as failed account creation or incorrect network state.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — The test triggers the global add-account flow via the receive asset picker and verifies the add-account network search input. Since it uses the same Add Account modal infrastructure, changes to network activation queueing could affect whether the modal opens networks correctly or creates the expected account.

</details>

_Updated: 2026-08-31T11:05:42.092Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/add-account-pin-modal-cancel/web/](https://dev.suite.sldev.cz/suite-web/fix/add-account-pin-modal-cancel/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/add-account-pin-modal-cancel&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/add-account-pin-modal-cancel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:08:21.849Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:07:22.350Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->