### PR TITLE
fix(suite-native-31460): add the trade detail status stepper

### DIFF
--- a/suite-native/link/src/components/Link.tsx
+++ b/suite-native/link/src/components/Link.tsx
@@ -10,7 +10,7 @@ import Animated, {
 import type { RequireAtLeastOne } from 'type-fest';
 
 import { HStack } from '@suite-native/atoms';
-import { type CSSColor, Icon, type IconName } from '@suite-native/icons';
+import { type CSSColor, Icon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import type { Color, TypographyStyle } from '@trezor/theme';
 
@@ -23,7 +23,6 @@ type LinkProps = RequireAtLeastOne<
         onPress?: () => void;
         isUnderlined?: boolean;
         showExternalIcon?: boolean;
-        externalIconName?: IconName;
         textColor?: Color;
         textPressedColor?: Color;
         textVariant?: TypographyStyle;
@@ -57,7 +56,6 @@ export const Link = ({
     label,
     isUnderlined = false,
     showExternalIcon = false,
-    externalIconName = 'arrowLineUpRight',
     textColor = 'contentBrand',
     textPressedColor = 'contentBrandPressed',
     textVariant = 'body-md',
@@ -110,7 +108,7 @@ export const Link = ({
                     {label}
                 </Animated.Text>
                 {showExternalIcon && (
-                    <Icon.Animated name={externalIconName} color={animatedColor} size="medium" />
+                    <Icon.Animated name="arrowLineUpRight" color={animatedColor} size="medium" />
                 )}
             </HStack>
         </Pressable>

--- a/suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusProviderLink.tsx
+++ b/suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusProviderLink.tsx
@@ -1,14 +1,9 @@
-import { Box, HStack, Text } from '@suite-native/atoms';
+import { Box, HStack, Text, TextButton } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { Link } from '@suite-native/link';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { useOpenLink } from '@suite-native/link';
 
 import { ProviderLogo } from '../ProviderLogo';
 import { TradeStatusSubItem } from './TradeStatusSubItem';
-
-const providerStatusLinkTextStyle = prepareNativeStyle(() => ({
-    flexShrink: 1,
-}));
 
 type TradeStatusProviderLinkProps = {
     logo?: string;
@@ -21,7 +16,7 @@ export const TradeStatusProviderLink = ({
     providerName,
     statusUrl,
 }: TradeStatusProviderLinkProps) => {
-    const { applyStyle } = useNativeStyles();
+    const openLink = useOpenLink();
     const isStatusUrlAvailable = !!statusUrl;
     const providerLogo = logo ? <ProviderLogo logo={logo} size="body-sm" /> : null;
 
@@ -47,22 +42,18 @@ export const TradeStatusProviderLink = ({
         <HStack spacing="sp8" alignItems="center">
             {!!logo && <ProviderLogo logo={logo} size="body-sm" />}
             <Box flexShrink={1}>
-                <Link
-                    href={statusUrl}
-                    externalIconName="arrowSquareOut"
+                <TextButton
+                    size="small"
+                    intent="brand"
                     isUnderlined
-                    textVariant="body-sm"
-                    showExternalIcon
-                    numberOfLines={1}
-                    ellipsizeMode="tail"
-                    style={applyStyle(providerStatusLinkTextStyle)}
-                    label={
-                        <Translation
-                            id="moduleTrading.tradeHistory.detail.statusStepper.provider.checkStatus"
-                            values={{ providerName }}
-                        />
-                    }
-                />
+                    iconRight="arrowSquareOut"
+                    onPress={() => openLink(statusUrl)}
+                >
+                    <Translation
+                        id="moduleTrading.tradeHistory.detail.statusStepper.provider.checkStatus"
+                        values={{ providerName }}
+                    />
+                </TextButton>
             </Box>
         </HStack>
     );


### PR DESCRIPTION
## Description

- Revert Link changes
- Use `TextButton` for the trade provider status link with an external-link icon.


## Notes for QA

- No QA

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31460

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all React Native components in suite-native (mobile), specifically the Link component and a trading status provider link. The provided test catalog consists entirely of suite/web E2E Playwright tests for the desktop/web application. There is no overlap between these mobile-native changes and the available web/desktop E2E test suite, so no relevant tests can be recommended from the given list. Native/mobile test coverage would need to be evaluated separately.

<details><summary><b>Changed files (5)</b></summary>

- `suite-native/link/package.json`
- `suite-native/link/src/components/Link.tsx`
- `suite-native/link/src/stories/Link.stories.tsx`
- `suite-native/link/tsconfig.json`
- `suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusProviderLink.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `suite-native/link/package.json`
- `suite-native/link/src/components/Link.tsx`
- `suite-native/link/src/stories/Link.stories.tsx`
- `suite-native/link/tsconfig.json`
- `suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusProviderLink.tsx`

_Updated: 2026-08-31T11:14:59.137Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31460-post-trade---add-the-trade-detail-status-stepper/web/](https://dev.suite.sldev.cz/suite-web/fix/31460-post-trade---add-the-trade-detail-status-stepper/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31460-post-trade---add-the-trade-detail-status-stepper&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31460-post-trade---add-the-trade-detail-status-stepper&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31460-post-trade---add-the-trade-detail-status-stepper&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:17:39.934Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:17:35.388Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->