### PR TITLE
fix(suite): reduce earn claim account badge size

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx
@@ -42,7 +42,11 @@ export const EarnYieldClaimRewardsBannerAccountsTooltip = ({
                     {rewards.map(({ account, fiat }) => (
                         <Fragment key={account.key}>
                             <Text>
-                                <AccountLabel account={account} showAccountTypeBadge />
+                                <AccountLabel
+                                    account={account}
+                                    showAccountTypeBadge
+                                    accountTypeBadgeSize="small"
+                                />
                             </Text>
 
                             <HiddenPlaceholder>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reduces the account type badge size in the Claim rewards accounts tooltip for better visual consistency.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31811

## Screenshots:

<img width="521" height="234" alt="image" src="https://github.com/user-attachments/assets/88b510d0-9128-4360-aca4-3bce77706806" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a tooltip component in the Earn yield dashboard, but it is statically imported by a very large number of tests (136), indicating it is likely pulled in via a shared dashboard layout. No E2E test directly exercises this tooltip, and most mapped tests are unrelated. Running the yield withdrawal test as a smoke check on the earn dashboard is the most targeted option; broad test execution is unnecessary.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/yield/withdrawal.test.ts` — The changed file is a tooltip component rendered inside the Earn yield dashboard. The yield withdrawal test is the only E2E test that loads the earn dashboard and interacts with yield positions, so it provides a sanity check that the surrounding dashboard still renders and functions correctly.

</details>

_Updated: 2026-08-31T11:30:56.750Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/earn-claim-account-badge-size/web/](https://dev.suite.sldev.cz/suite-web/fix/earn-claim-account-badge-size/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/earn-claim-account-badge-size&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/earn-claim-account-badge-size&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:34:02.003Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T11:33:49.041Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->