### PR TITLE
feat(e2e): add clipboard capture, add ADA and extend BTC sign&verify …

### DIFF
--- a/suite/e2e/support/helpers/clipboard.ts
+++ b/suite/e2e/support/helpers/clipboard.ts
@@ -1,0 +1,26 @@
+import { type Page, expect } from '@playwright/test';
+
+type ClipboardCaptureWindow = Window & { __clipboardCapture?: string };
+
+// Deployed Suite (CI and release on sldev.cz) sends Permissions-Policy clipboard-read=().
+// Playwright cannot override that, so we capture writeText instead of reading the clipboard.
+export const captureClipboardWrites = async (page: Page) => {
+    await page.evaluate(() => {
+        const { clipboard } = navigator;
+        const originalWriteText = clipboard.writeText.bind(clipboard);
+
+        Object.defineProperty(clipboard, 'writeText', {
+            configurable: true,
+            value: (text: string) => {
+                (window as ClipboardCaptureWindow).__clipboardCapture = text;
+
+                return originalWriteText(text).catch(() => undefined);
+            },
+        });
+    });
+
+    return (expected: string) =>
+        expect
+            .poll(() => page.evaluate(() => (window as ClipboardCaptureWindow).__clipboardCapture))
+            .toBe(expected);
+};

--- a/suite/e2e/tests/wallet/sign-and-verify-ada.test.ts
+++ b/suite/e2e/tests/wallet/sign-and-verify-ada.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '../../support/fixtures';
+
+const STAKE_PATH = "m/1852'/1815'/0'/2/0";
+const MESSAGE = 'Test';
+const COSE_SIGNATURE =
+    '84582aa201276761646472657373581de1122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277a166686173686564f444546573745840963bdbe05f28f91bf33379e371c450509cd07efc0c830b89dfb9e63e71866fcbeaa95cae8d6dab34fb7e7eb37a319f6d399245c165397418e0e551c2af49e606';
+const COSE_PUB_KEY =
+    'a4010103272006215820bc65be1b0b9d7531778a1317c2aa6de936963c3f9ac7d5ee9e9eda25e0c97c5e';
+
+test.describe('Sign and verify ADA', { tag: ['@T3W1', '@T3T1', '@nightlyOnly'] }, () => {
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
+
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['ada'] });
+    });
+
+    test('Signs message and shows Cardano COSE public key', async ({
+        page,
+        walletPage,
+        devicePrompt,
+        device,
+    }) => {
+        await walletPage.openAccount({ symbol: 'ada' });
+        await walletPage.walletExtraDropDown.click();
+        await walletPage.signAndVerifyButton.click();
+        await page.getByTestId('@sign-verify/message').fill(MESSAGE);
+        await page.getByTestId('@sign-verify/sign-address/input').click();
+        await page.getByTestId(`@sign-verify/sign-address/option/${STAKE_PATH}`).click();
+        await page.getByTestId('@sign-verify/cardano-pubkey-format/true').click();
+        await page.getByTestId('@sign-verify/submit').click();
+
+        await test.step('Confirm message payload on device', async () => {
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Confirm message' },
+                    body: [['Message text (4 bytes)'], [MESSAGE]],
+                    actions: { right_button: 'Confirm' },
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Confirm reward address warning on device', async () => {
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Confirm message' },
+                    body: [device.wrapText('Address is a reward address.', { wrapByWords: true })],
+                    actions: { right_button: 'Confirm' },
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Confirm stake credential path on device', async () => {
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Confirm message' },
+                    body: [['Address stake credential is a path:'], device.wrapText(STAKE_PATH)],
+                    actions: { right_button: 'Confirm' },
+                },
+                T3T1: {
+                    body: [
+                        ['Address stake credential is', '\n', 'a path:'],
+                        device.wrapText(STAKE_PATH),
+                    ],
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Confirm signing path on device', async () => {
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Confirm message' },
+                    body: [['Sign message with path'], ["m/1852'/1815'/0'/2", '\n', '/0']],
+                    actions: { right_button: 'Confirm' },
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Verify COSE signature and public key in Suite', async () => {
+            await expect(page.getByTestId('@sign-verify/signature')).toHaveValue(COSE_SIGNATURE);
+            await expect(page.getByTestId('@sign-verify/pubKey')).toHaveValue(COSE_PUB_KEY);
+            await expect(page.getByTestId('@sign-verify/outcome/signed')).toBeVisible();
+        });
+    });
+});

--- a/suite/e2e/tests/wallet/sign-and-verify.test.ts
+++ b/suite/e2e/tests/wallet/sign-and-verify.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../support/fixtures';
+import { captureClipboardWrites } from '../../support/helpers/clipboard';
 
 const PATH = "m/84'/0'/0'/0/3";
 const ADDRESS = 'bc1q6hr68ewf72l6r7cj6ut286x0xkwg5706jq450u';
@@ -55,6 +56,30 @@ test.describe('Sign and verify', { tag: ['@T3W1', '@T3T1'] }, () => {
         await expect(page.getByTestId('@sign-verify/signature')).toHaveValue(SIGNATURE);
         await expect(page.getByTestId('@sign-verify/outcome/signed')).toBeVisible();
         await expect(page.getByTestId('@sign-verify/clear')).toBeVisible();
+
+        const expectCopiedText = await captureClipboardWrites(page);
+
+        await page.getByTestId('@sign-verify/copy-address').click();
+        await expectCopiedText(ADDRESS);
+        await expect(page.getByTestId('@toast/copy-to-clipboard')).toBeVisible();
+
+        await page.getByTestId('@sign-verify/copy-message').click();
+        await expectCopiedText(MESSAGE);
+
+        await page.getByTestId('@sign-verify/copy-signature').click();
+        await expectCopiedText(SIGNATURE);
+
+        await page.getByTestId('@sign-verify/clear').click();
+        await expect(page.getByTestId('@sign-verify/outcome/signed')).toBeHidden();
+        await expect(page.getByTestId('@sign-verify/clear')).toBeHidden();
+        await expect(page.getByTestId('@sign-verify/submit')).toBeVisible();
+        await expect(page.getByTestId('@sign-verify/submitted-address')).toBeHidden();
+        await expect(page.getByTestId('@sign-verify/sign-address/input')).toBeVisible();
+        await expect(page.getByTestId('@sign-verify/message')).toHaveValue('');
+        await expect(page.getByTestId('@sign-verify/signature')).toHaveValue('');
+        await expect(page.getByTestId('@sign-verify/copy-address')).toBeHidden();
+        await expect(page.getByTestId('@sign-verify/copy-message')).toBeHidden();
+        await expect(page.getByTestId('@sign-verify/copy-signature')).toBeHidden();
     });
 
     test('Signs message with Electrum-compatible signature format', async ({
@@ -81,21 +106,11 @@ test.describe('Sign and verify', { tag: ['@T3W1', '@T3T1'] }, () => {
         await devicePrompt.waitForPromptAndConfirm(); // Confirm message
         await expect(page.getByTestId('@sign-verify/signature')).toHaveValue(ELECTRUM_SIGNATURE);
 
-        await page.evaluate(() => {
-            const clipboard = navigator.clipboard as any;
-            const original = clipboard.writeText.bind(clipboard);
-            clipboard.writeText = (text: string) => {
-                (window as any).__clipboardCapture = text;
-
-                return original(text).catch(() => undefined);
-            };
-        });
+        const expectCopiedText = await captureClipboardWrites(page);
 
         // Regression guard for #20504.
         await page.getByTestId('@sign-verify/copy-signature').click();
-        await expect
-            .poll(() => page.evaluate(() => (window as any).__clipboardCapture as string))
-            .toBe(ELECTRUM_SIGNATURE);
+        await expectCopiedText(ELECTRUM_SIGNATURE);
     });
 
     test('Verify message signed with standard Bitcoin signature format', async ({
@@ -114,5 +129,26 @@ test.describe('Sign and verify', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         await expect(page.getByTestId('@toast/verify-message-success')).toBeVisible();
         await expect(page.getByTestId('@sign-verify/outcome/verified')).toBeVisible();
+    });
+
+    test.describe('Altered message', () => {
+        test.use({ ignoreToastErrors: ['Message verification error'] });
+
+        test('Verify fails when the message does not match the signature', async ({ page }) => {
+            await page.getByTestId('@sign-verify/navigation/verify').click();
+            await page.getByTestId('@sign-verify/message').fill(`${MESSAGE}!`);
+            await page.getByTestId('@sign-verify/select-address').fill(ADDRESS);
+            await page.getByTestId('@sign-verify/signature').fill(SIGNATURE);
+            await page.getByTestId('@sign-verify/submit').click();
+
+            await expect(page.getByTestId('@sign-verify/outcome/failed')).toHaveTranslation(
+                'TR_VERIFICATION_FAILED_BADGE',
+            );
+            await expect(page.getByTestId('@toast/verify-message-error')).toBeVisible();
+            await expect(page.getByTestId('@sign-verify/outcome/verified')).toBeHidden();
+            await expect(page.getByTestId('@toast/verify-message-success')).toBeHidden();
+            await expect(page.getByTestId('@sign-verify/submit')).toBeVisible();
+            await expect(page.getByTestId('@sign-verify/clear')).toBeHidden();
+        });
     });
 });


### PR DESCRIPTION
## Description
Extend Sign & Verify e2e: Cardano COSE sign, BTC copy/clear and failed verify on an altered message, plus a clipboard helper for deployed Suite.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/sign-and-verify-e2e-improvments/web/](https://dev.suite.sldev.cz/suite-web/sign-and-verify-e2e-improvments/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=sign-and-verify-e2e-improvments&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=sign-and-verify-e2e-improvments&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T14:40:30.974Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T14:40:14.042Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->