### PR TITLE
fix(trading): drop leftover swap quotes when the send account is cleared

### DIFF
--- a/suite-common/trading/src/reducers/exchangeReducer.test.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.test.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { createTestStore } from '@suite-common/test-utils';
+import { type AccountKey } from '@suite-common/wallet-types';
 
 import {
     changellyExchangeQuote,
@@ -85,6 +86,24 @@ describe('tradingExchangeReducer', () => {
             const state = actions.reduce(tradingExchangeReducer, undefined);
 
             expect(state?.selectedQuote?.swapSlippage).toBe('3');
+        });
+    });
+
+    describe('setTradingAccountKey', () => {
+        it('clears selected quote and quotes when the account key is cleared', () => {
+            const actions = [
+                tradingExchangeActions.saveSelectedQuote(changellyExchangeQuote),
+                tradingExchangeActions.saveQuotes([changellyExchangeQuote]),
+                tradingExchangeActions.setTradingAccountKey('account-1' as AccountKey),
+                tradingExchangeActions.setTradingAccountKey(undefined),
+            ];
+
+            const state = actions.reduce(tradingExchangeReducer, undefined);
+
+            expect(state?.tradingAccountKey).toBeUndefined();
+            expect(state?.selectedQuote).toBeUndefined();
+            expect(state?.quotes).toEqual([]);
+            expect(state?.quotesRequest).toBeUndefined();
         });
     });
 });

--- a/suite-common/trading/src/reducers/exchangeReducer.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.ts
@@ -83,6 +83,11 @@ const tradingExchangeSlice = createSlice({
             if (action.payload !== state.tradingAccountKey) {
                 state.amountLimits = undefined;
             }
+            if (action.payload === undefined) {
+                state.quotes = [];
+                state.quotesRequest = undefined;
+                state.selectedQuote = undefined;
+            }
             state.tradingAccountKey = action.payload;
         },
         setReceiveAccountKey(

--- a/suite-common/trading/src/selectors/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.test.ts
@@ -11,10 +11,11 @@ import {
 
 import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { mockAccountKey, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 
 import {
+    type TradingFormAccountRootState,
     type TradingRootStateWithDeviceAndAccounts,
     bestBuyQuotePerPaymentMethodProjection,
     bestSellQuotePerPaymentMethodProjection,
@@ -71,6 +72,7 @@ import {
     selectTradingExchangeSelectedQuoteIsDex,
     selectTradingExchangeSelectedQuoteSwapSlippage,
     selectTradingExchangeSellCryptoIds,
+    selectTradingFormCryptoId,
     selectTradingIsSlip24Allowed,
     selectTradingLastErrorMessageByTradeType,
     selectTradingModalAccountKey,
@@ -1574,6 +1576,61 @@ describe('tradingSelectors', () => {
         expect(selectTradingPrefilledFromAccount(state)).toEqual({
             cryptoId: 'bitcoin',
             descriptor: 'btc-desc',
+        });
+    });
+
+    describe(selectTradingFormCryptoId.name, () => {
+        const eligibleBtc = mockWalletAccount({
+            symbol: asNetworkSymbol('btc'),
+            deviceState: accountBtc.deviceState as StaticSessionId,
+            balance: '1000000',
+            formattedBalance: '0.01',
+        });
+        const eligibleEth = mockWalletAccount({
+            symbol: asNetworkSymbol('eth'),
+            deviceState: accountEth.deviceState as StaticSessionId,
+            balance: '1000000000000000000',
+            formattedBalance: '1',
+            tokens: [],
+        });
+
+        let formState: TradingFormAccountRootState;
+
+        beforeEach(() => {
+            formState = {
+                ...state,
+                tokenDefinitions: {},
+                wallet: {
+                    ...state.wallet,
+                    accounts: [eligibleBtc, eligibleEth],
+                    trading: {
+                        ...state.wallet.trading,
+                        exchange: {
+                            ...state.wallet.trading.exchange,
+                            tradingAccountKey: eligibleBtc.key,
+                        },
+                    },
+                },
+            };
+        });
+
+        it('should ignore leftover prefilled cryptoId after prefilled.key is cleared', () => {
+            formState.wallet.trading.prefilledFromAccount = {
+                key: undefined,
+                cryptoId: 'ethereum' as CryptoId,
+            };
+
+            expect(selectTradingFormCryptoId(formState, 'exchange')).toBe('bitcoin');
+        });
+
+        it('should use prefilled cryptoId when prefilled.key matches the form account', () => {
+            formState.wallet.trading.exchange.tradingAccountKey = eligibleEth.key;
+            formState.wallet.trading.prefilledFromAccount = {
+                key: eligibleEth.key,
+                cryptoId: 'ethereum' as CryptoId,
+            };
+
+            expect(selectTradingFormCryptoId(formState, 'exchange')).toBe('ethereum');
         });
     });
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -1127,13 +1127,13 @@ export const selectTradingFormAccount = createMemoizedFormAccountSelector(
 );
 
 export const selectTradingFormCryptoId = createMemoizedFormAccountSelector(
-    [selectTradingFormAccount, selectPreferredTradingAccount, selectTradingPrefilledFromAccount],
-    (account, preferredAccount, prefilled): CryptoId | undefined => {
+    [selectTradingFormAccount, selectTradingPrefilledFromAccount],
+    (account, prefilled): CryptoId | undefined => {
         if (!account) {
             return undefined;
         }
 
-        if (prefilled.cryptoId && account.key === preferredAccount?.key) {
+        if (prefilled.key && prefilled.cryptoId && account.key === prefilled.key) {
             return prefilled.cryptoId;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. **Clear quotes** when `tradingAccountKey` is cleared — kills Dashboard → Back (Review can’t remount a leftover ETH quote).
2. **Ignore leftover `prefilled.cryptoId`** unless `prefilled.key` still matches the form account — stops ETH-on-Bitcoin after Buy → Swap.

## Related Issue

Resolve #31933

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-accountkey-mismatch/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-accountkey-mismatch/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the trading exchange reducer and its selectors, which are central to swap/exchange flows. Unit tests already cover the changed files directly, so the main e2e risk is regressions in swap quotes, composed transactions, status transitions, and trade history. Run a small, representative set of high-priority swap e2e tests, plus one buy and one sell test as a medium-priority guard for shared selector behavior.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/trading/src/reducers/exchangeReducer.test.ts`
- `suite-common/trading/src/reducers/exchangeReducer.ts`
- `suite-common/trading/src/selectors/tradingSelectors.test.ts`
- `suite-common/trading/src/selectors/tradingSelectors.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — This test explicitly asserts that Redux state 'wallet.trading.composedTransactionInfo' is populated after confirming a swap offer, which is managed by the exchangeReducer. It also exercises the full swap status flow and device confirmation values derived from trading state.
- `suite/e2e/tests/trading/swap-coins.test.ts` — End-to-end SOL-to-BTC swap covering quote fetching, best offer selection, trade status transitions (SENDING/CONFIRMING/CONVERTING/SUCCESS), and provider support links, all of which depend on the exchange reducer and trading selectors.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Cross-chain ETH-to-SOL swap validates the composed transaction, device prompt amounts/addresses, and transaction detail updates, directly exercising the exchange reducer's swap state and selectors.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Focused swap-form test that verifies quote sync, best offer display, fee calculation, fraction/Max buttons, fiat/crypto switching, and validation errors, all of which are driven by tradingSelectors and exchange reducer state.
- `suite/e2e/tests/trading/swap-history.test.ts` — Reads and filters seeded trade history by status and type and opens trade detail pages, so it directly depends on the reducer's stored swap/exchange history and selectors that derive list/status data.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Buy flow uses shared trading quotes, confirmation state, and transaction detail status from the trading module. Selector changes could affect how quotes, provider info, or trade payloads are derived.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Sell flow exercises trading confirmation details, send state, and transaction status progression through the shared trading state; a regression in selectors or reducer logic could appear here.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/trading/src/reducers/exchangeReducer.test.ts`
- `suite-common/trading/src/selectors/tradingSelectors.test.ts`

_Updated: 2026-09-11T13:37:05.974Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-accountkey-mismatch&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-accountkey-mismatch&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-accountkey-mismatch&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T13:39:40.914Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T13:39:06.368Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->