### PR TITLE
[CI clone] Do not fall back to Everstake DRep on invalid DRep ID (#31861)

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -1,9 +1,10 @@
 import { type AdaPools } from '@suite-common/earn-staking-api';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
 import type { VotingDelegationOption } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type CardanoAction } from '@suite-common/wallet-types';
 import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
-import TrezorConnect, { PROTO } from '@trezor/connect';
+import TrezorConnect, { type CardanoCertificate, PROTO } from '@trezor/connect';
 
 import { prepareTxPlan } from './stakeFormCardanoActions';
 
@@ -93,6 +94,60 @@ const mockComposeSuccess = () => {
         payload: [{ type: 'final', fee: '174301', deposit: '2000000' }],
     });
 };
+
+const getVoteDelegationCertificate = () => {
+    const [params] = cardanoComposeTransactionMock.mock.calls.at(-1) ?? [];
+
+    return params?.certificates?.find(
+        (certificate: CardanoCertificate) =>
+            certificate.type === PROTO.CardanoCertificateType.VOTE_DELEGATION,
+    );
+};
+
+const prepare = (action: CardanoAction, votingDelegation?: VotingDelegationOption) =>
+    prepareTxPlan({
+        account: mockWalletAccount(
+            {
+                symbol: 'ada',
+                index: 0,
+                balance: '10000000',
+                availableBalance: '10000000',
+                utxo: [],
+                addresses: {
+                    change: [
+                        {
+                            address: 'addr1_change',
+                            path: "m/1852'/1815'/0'/1/0",
+                            transfers: 0,
+                            balance: '0',
+                            sent: '0',
+                            received: '0',
+                        },
+                    ],
+                    used: [],
+                    unused: [],
+                },
+            },
+            {
+                ...networkSpecificDefaultCardano,
+                misc: {
+                    staking: {
+                        address: 'stake1_address',
+                        isActive: true,
+                        rewards: '1000000',
+                        poolId: null,
+                        drep: null,
+                    },
+                },
+            },
+        ),
+        action,
+        cardanoPools: [],
+        votingDelegation,
+    });
+
+const CUSTOM_DREP_BECH32 = 'drep14w46h2at4w46h2at4w46h2at4w46h2at4w46h2at4w46kxzm6ac';
+const CUSTOM_DREP_HEX = 'abababababababababababababababababababababababababababab';
 
 describe('prepareTxPlan', () => {
     beforeEach(() => {
@@ -190,5 +245,47 @@ describe('prepareTxPlan', () => {
 
         expect(txData).toBeNull();
         expect(TrezorConnect.cardanoComposeTransaction).not.toHaveBeenCalled();
+    });
+
+    describe.each(['delegate', 'voteDelegate'] as const)('%s', action => {
+        it.each(['not-a-drep', '', CARDANO_EVERSTAKE_DREP.hex])(
+            'returns null without composing when the custom drepId %p is invalid',
+            async drepId => {
+                await expect(prepare(action, { type: 'another_drep', drepId })).resolves.toBeNull();
+                expect(cardanoComposeTransactionMock).not.toHaveBeenCalled();
+            },
+        );
+
+        it('delegates the vote to the custom DRep when the drepId is valid', async () => {
+            await prepare(action, { type: 'another_drep', drepId: CUSTOM_DREP_BECH32 });
+
+            expect(getVoteDelegationCertificate()?.dRep).toEqual({
+                type: PROTO.CardanoDRepType.KEY_HASH,
+                keyHash: CUSTOM_DREP_HEX,
+                scriptHash: undefined,
+            });
+        });
+
+        it.each([{ type: 'everstake' } as const, undefined])(
+            'delegates the vote to Everstake for %p',
+            async votingDelegation => {
+                await prepare(action, votingDelegation);
+
+                expect(getVoteDelegationCertificate()?.dRep).toEqual({
+                    type: PROTO.CardanoDRepType.KEY_HASH,
+                    keyHash: CARDANO_EVERSTAKE_DREP.hex,
+                    scriptHash: undefined,
+                });
+            },
+        );
+    });
+
+    describe.each(['deregister', 'withdrawal'] as const)('%s', action => {
+        it('composes despite an invalid custom drepId', async () => {
+            await expect(
+                prepare(action, { type: 'another_drep', drepId: 'not-a-drep' }),
+            ).resolves.not.toBeNull();
+            expect(getVoteDelegationCertificate()).toBeUndefined();
+        });
     });
 });

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -153,9 +153,11 @@ export const prepareTxPlan = async ({
         votingDelegation?.type === 'current' && hasCardanoLiveVoteDelegation(account);
 
     if ((action === 'delegate' || action === 'voteDelegate') && !isKeepingCurrentVote) {
-        const isVotingToAnotherDrep =
-            votingDelegation?.type === 'another_drep' &&
-            validateCardanoDrep(votingDelegation.drepId);
+        const isVotingToAnotherDrep = votingDelegation?.type === 'another_drep';
+
+        if (isVotingToAnotherDrep && !validateCardanoDrep(votingDelegation.drepId)) {
+            return null;
+        }
 
         const drepBech32 = isVotingToAnotherDrep
             ? votingDelegation.drepId

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -7,6 +7,7 @@ import { deviceActions } from '@suite-common/device';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { tradingActions } from '@suite-common/trading';
 import {
+    DEFAULT_VOTING_OPTION,
     WALLET_SETTINGS,
     accountsActions,
     blockchainActions,
@@ -115,6 +116,7 @@ const walletMiddleware =
             api.dispatch(sendFormActions.dispose());
             api.dispatch(tradingActions.setVerifiedAddress(undefined));
             api.dispatch(stakeActions.dispose());
+            api.dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
         }
 
         if (action.type === WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS) {


### PR DESCRIPTION
## Description

**CI clone of #31861** — opened only so the pipeline can run. The original PR comes from a fork (`everstake/trezor-suite`) whose workflows are not authorized to execute here.

- Original PR: https://github.com/trezor/trezor-suite/pull/31861
- Original author: @myasiura-stack (commit authorship is preserved — this branch is the exact same commit as the original PR head, `2332803002`)
- Original issue: https://github.com/trezor/trezor-suite/issues/30038

Review discussion belongs on #31861. This clone will be discarded once the pipeline result is known.

## What the change does

When a custom Cardano DRep ID failed validation, the composed transaction silently fell back to Everstake's DRep, so the signed transaction could delegate the governance vote to a target the user never chose. `prepareTxPlan` now returns `null` in that case instead of substituting the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is focused on Cardano staking form actions and the wallet middleware that processes wallet actions. The highest-risk, most user-visible path is the Cardano staking flow (stake, claim, unstake). Running the three ADA staking E2E tests provides targeted coverage of the changed action logic and the middleware that dispatches it, without over-broadening to unrelated wallet flows.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts`
- `packages/suite/src/middlewares/wallet/walletMiddleware.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test exercises the full Cardano reward-claim flow, which dispatches Cardano stake-form actions from stakeFormCardanoActions.ts and relies on walletMiddleware to process wallet actions. A regression in either file would directly break claim transaction construction, device confirmation, or post-claim balance updates.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test covers the end-to-end ADA staking flow, including deposit amount handling and stake transaction creation that is driven by stakeFormCardanoActions.ts. It also depends on walletMiddleware dispatching/intercepting wallet actions correctly.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test validates the Cardano unstake and reclaim-deposit flow, which uses the same stake-form action logic in stakeFormCardanoActions.ts and routes through walletMiddleware. Issues here would be immediately visible as failed unstake transactions or incorrect dashboard state.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`

_Updated: 2026-08-31T14:26:32.880Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-invalid-drep-everstake-fallback/web/](https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-invalid-drep-everstake-fallback/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci-clone/cardano-invalid-drep-everstake-fallback&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci-clone/cardano-invalid-drep-everstake-fallback&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T14:29:42.395Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T14:28:51.556Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->