### PR TITLE
fix(trading): keep selected fiat currency after trade redirect

### DIFF
--- a/suite-common/trading/src/utils/currencyUtils.test.ts
+++ b/suite-common/trading/src/utils/currencyUtils.test.ts
@@ -38,6 +38,11 @@ describe('currencyUtils', () => {
             expect(mapFiatCurrencyCodeToBaseCurrencyCode('xyz')).toBeUndefined();
             expect(mapFiatCurrencyCodeToBaseCurrencyCode('invalid')).toBeUndefined();
         });
+
+        it('should return lowercase code for uppercase API currency code', () => {
+            expect(mapFiatCurrencyCodeToBaseCurrencyCode('EUR')).toBe('eur');
+            expect(mapFiatCurrencyCodeToBaseCurrencyCode('Czk')).toBe('czk');
+        });
     });
 
     describe('buildTradingBaseCurrencyOptionFromFiat', () => {
@@ -61,6 +66,13 @@ describe('currencyUtils', () => {
                 label: 'USD',
             });
         });
+
+        it('should keep the currency for uppercase API currency code', () => {
+            expect(buildTradingBaseCurrencyOptionFromFiat('EUR')).toStrictEqual({
+                value: 'eur',
+                label: 'EUR',
+            });
+        });
     });
 
     describe('getCurrencyLabel', () => {
@@ -70,6 +82,10 @@ describe('currencyUtils', () => {
 
         it('should return uppercase code otherwise', () => {
             expect(getCurrencyLabel('xyz')).toBe('XYZ');
+        });
+
+        it('should return label for uppercase API currency code', () => {
+            expect(getCurrencyLabel('EUR')).toBe('Euro');
         });
     });
 
@@ -82,6 +98,10 @@ describe('currencyUtils', () => {
         it('should return usd for unsupported currency', () => {
             expect(getSupportedFiatCurrencyWithFallback('btc')).toBe('usd');
             expect(getSupportedFiatCurrencyWithFallback('xyz')).toBe('usd');
+        });
+
+        it('should return lowercase code for uppercase API currency code', () => {
+            expect(getSupportedFiatCurrencyWithFallback('EUR')).toBe('eur');
         });
     });
 });

--- a/suite-common/trading/src/utils/currencyUtils.ts
+++ b/suite-common/trading/src/utils/currencyUtils.ts
@@ -10,10 +10,15 @@ import {
 } from '../currency';
 import { type TradingFiatCurrencyOption } from '../types';
 
-export const getCurrencyLabel = (currencyCode: FiatCurrencyCode | string): string =>
-    isSupportedFiatCurrency(currencyCode)
-        ? supportedFiatCurrenciesMap[currencyCode]
+const normalizeCurrencyCode = (currencyCode: string) => currencyCode.toLowerCase();
+
+export const getCurrencyLabel = (currencyCode: FiatCurrencyCode | string): string => {
+    const normalizedCode = normalizeCurrencyCode(currencyCode);
+
+    return isSupportedFiatCurrency(normalizedCode)
+        ? supportedFiatCurrenciesMap[normalizedCode]
         : currencyCode.toUpperCase();
+};
 
 export const buildTradingFiatOption = (currency: FiatCurrencyCode): TradingFiatCurrencyOption => ({
     value: currency,
@@ -27,7 +32,9 @@ export const mapFiatCurrencyCodeToBaseCurrencyCode = (
         return undefined;
     }
 
-    return isBaseCurrencyCode(fiatCurrencyCode) ? fiatCurrencyCode : undefined;
+    const normalizedCode = normalizeCurrencyCode(fiatCurrencyCode);
+
+    return isBaseCurrencyCode(normalizedCode) ? normalizedCode : undefined;
 };
 
 export const buildTradingBaseCurrencyOptionFromFiat = (
@@ -43,8 +50,10 @@ export const buildTradingBaseCurrencyOptionFromFiat = (
 };
 
 export const getSupportedFiatCurrencyWithFallback = (currencyCode: string): FiatCurrencyCode => {
-    if (isSupportedFiatCurrency(currencyCode)) {
-        return currencyCode;
+    const normalizedCode = normalizeCurrencyCode(currencyCode);
+
+    if (isSupportedFiatCurrency(normalizedCode)) {
+        return normalizedCode;
     }
 
     return DEFAULT_FIAT_CURRENCY_FALLBACK;


### PR DESCRIPTION
## Description

Invity API returns uppercase fiat currency codes (`EUR`), internally we use lowercase (`eur`). The currency helpers matched case-sensitively, so an uppercase code silently fell back to `usd`.

Hit whenever a provider redirects back into the app (e.g. BTC Direct `v1/register-identifier`): the return URL carries `EUR` ([`sellUtils.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/utils/wallet/trading/sellUtils.ts)), `useTradingSellFormRedirectValues` restores it through `buildTradingBaseCurrencyOptionFromFiat('EUR')` → `isBaseCurrencyCode` misses → `usd`. Offers were then refetched in USD and providers without USD support vanished from the list.

Helpers now normalize the code before the lookup — fixes the sell redirect, buy redirect and quote-derived fiat values at once. Fallback for genuinely unsupported codes unchanged.

Reopened resurrection of #30939, which was closed unmerged. The issue was closed by #31170 (buy redirect account — a different bug that only referenced the same issue number), so this fix never landed.

## Notes for QA

- Sell -> EUR -> BTC Direct -> link identifier -> after redirect back, currency stays EUR and BTC Direct is still offered.
- Same for the buy redirect.
- Unsupported currency still falls back to USD.
- The partner is not needed to reproduce: the return is driven purely by the URL. Opening `/coinmarket-redirect#sell-offers/btc/normal/0/qf/CZ/EUR/100/bitcoin/bankTransfer/custom/1/2/3/4` (account coords adjusted to a real account) is byte-for-byte what BTC Direct sends back. Before the fix it lands in USD, after it in EUR.

## Related Issue

Resolve #29566

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change touches a broadly shared trading currency utility (22 static dependents) plus its unit tests. Because the exact modified functions are unknown, the safest E2E strategy is a small, representative set covering buy/sell/swap amount formatting and fee calculation, where currency utility regressions would be most visible. If the change only adds new helpers, these tests still provide a sanity check on unchanged formatting paths.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/trading/src/utils/currencyUtils.test.ts`
- `suite-common/trading/src/utils/currencyUtils.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Validates best-offer crypto/fiat amounts, confirmation preview amounts, and post-watch amount display in the buy flow—areas most likely to call shared currency formatting utilities.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Exercises crypto amount input validation, percentage/max amount calculations, and balance formatting that directly depend on trading currency/amount utilities.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests crypto/fiat input switching, amount conversion, fraction buttons, and best-offer amount display in the swap form, all of which are sensitive to currency utility behavior.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Verifies fee amount formatting and total amount calculations in swap confirmation; changes to currency utilities could alter how fees and totals are rendered.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Checks custom Ethereum fee calculations and crypto/fiat fee display; relies on the same formatting/conversion primitives exposed by trading currency utilities.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/utils/currencyUtils.test.ts`

_Updated: 2026-08-31T13:54:04.626Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/29566-trading-fiat-currency-case/web/](https://dev.suite.sldev.cz/suite-web/29566-trading-fiat-currency-case/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=29566-trading-fiat-currency-case&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=29566-trading-fiat-currency-case&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=29566-trading-fiat-currency-case&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T13:54:56.251Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->