### PR TITLE
WIP: fix(suite): let the only connected device take the selection during a…

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -15,6 +15,9 @@ const SUITE_DEVICE_UNACQUIRED = mockSuiteDevice({
     type: 'unacquired',
     path: '2',
 });
+// The reducer already holds the incoming device by the time the selection is decided, because
+// `deviceConnectThunks` dispatches `connectDevice` first.
+const SUITE_DEVICE_UNACQUIRED_ENTRY = { ...SUITE_DEVICE_UNACQUIRED, connected: true };
 const SUITE_DEVICE_CONNECTED = mockSuiteDevice({ path: '1', connected: true });
 const SUITE_DEVICE_REMEMBERED = mockSuiteDevice({ connected: false });
 const CONNECT_DEVICE = mockConnectDevice({ path: '1' });
@@ -246,21 +249,61 @@ const selectNewlyConnectedDevice: SelectNewlyConnectedDeviceFixture[] = [
     {
         description: `selects a newly connected device when the selected wallet has no device connected`,
         state: {
-            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
+            device: {
+                devices: [SUITE_DEVICE_REMEMBERED, SUITE_DEVICE_UNACQUIRED_ENTRY],
+                selectedDevice: SUITE_DEVICE_REMEMBERED,
+            },
             suite: {},
         },
         newlyConnectedDevice: SUITE_DEVICE_UNACQUIRED,
         expectedNextActionType: selectNewlyConnectedDeviceThunk.fulfilled.type,
     },
     {
-        description: `doesn't select a newly connected device during a firmware installation`,
+        description: `doesn't select a newly connected device during a firmware installation while another device is present`,
         state: {
-            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
+            device: {
+                devices: [
+                    SUITE_DEVICE_CONNECTED,
+                    SUITE_DEVICE_REMEMBERED,
+                    SUITE_DEVICE_UNACQUIRED_ENTRY,
+                ],
+                selectedDevice: SUITE_DEVICE_REMEMBERED,
+            },
             firmware: { status: 'started' },
             suite: {},
         },
         newlyConnectedDevice: SUITE_DEVICE_UNACQUIRED,
         expectedNextActionType: selectNewlyConnectedDeviceThunk.rejected.type,
+    },
+    {
+        // The device being updated cannot be recognised when it comes back, so it does not take the
+        // selection from a wallet - only an empty one, in the fixture below.
+        description: `doesn't move the selection during a firmware installation`,
+        state: {
+            device: {
+                devices: [SUITE_DEVICE_REMEMBERED, SUITE_DEVICE_UNACQUIRED_ENTRY],
+                selectedDevice: SUITE_DEVICE_REMEMBERED,
+            },
+            firmware: { status: 'started' },
+            suite: {},
+        },
+        newlyConnectedDevice: SUITE_DEVICE_UNACQUIRED,
+        expectedNextActionType: selectNewlyConnectedDeviceThunk.rejected.type,
+    },
+    {
+        // The updated device leaves no selection behind while it reboots, and the only device
+        // present fills it - the update itself goes on the same rule.
+        description: `selects the only device present during a firmware installation`,
+        state: {
+            device: {
+                devices: [SUITE_DEVICE_UNACQUIRED_ENTRY],
+                selectedDevice: undefined,
+            },
+            firmware: { status: 'started' },
+            suite: {},
+        },
+        newlyConnectedDevice: SUITE_DEVICE_UNACQUIRED,
+        expectedNextActionType: selectNewlyConnectedDeviceThunk.fulfilled.type,
     },
 ];
 

--- a/suite-common/device/src/getShouldSelectConnectedDevice.test.ts
+++ b/suite-common/device/src/getShouldSelectConnectedDevice.test.ts
@@ -15,6 +15,10 @@ const withDescriptor = (device: TrezorDevice, descriptor: Descriptor): TrezorDev
     descriptor,
 });
 
+// Every device in bootloader mode reports this as its USB serial number, so `descriptor.id` says
+// nothing about which device it is.
+const BOOTLOADER_DESCRIPTOR: Descriptor = { apiType: 'usb', id: '000000000000000000000000' };
+
 const DEVICE_A = withDescriptor(
     mockSuiteDevice({ path: '1', connected: true }, { device_id: 'device-a' }),
     descriptorA,
@@ -24,9 +28,10 @@ const DEVICE_A_REMEMBERED = withDescriptor(
     descriptorA,
 );
 // Reconnecting in bootloader mode, so without an `id`, on a path assigned by the new connection.
+// Its serial number is the placeholder every device in bootloader mode reports.
 const DEVICE_A_BOOTLOADER = withDescriptor(
     mockSuiteDevice({ path: '3', type: 'unacquired', connected: true }),
-    descriptorA,
+    BOOTLOADER_DESCRIPTOR,
 );
 const DEVICE_B = withDescriptor(
     mockSuiteDevice({ path: '2', connected: true }, { device_id: 'device-b' }),
@@ -35,6 +40,18 @@ const DEVICE_B = withDescriptor(
 const DEVICE_B_UNACQUIRED = withDescriptor(
     mockSuiteDevice({ path: '2', type: 'unacquired', connected: true }),
     descriptorB,
+);
+
+// A device with no firmware sits in bootloader mode from the start: no `id` of its own, and a
+// `descriptor.id` shared with every other device in bootloader mode.
+const DEVICE_WITHOUT_FIRMWARE = withDescriptor(
+    mockSuiteDevice({ path: '1', type: 'unacquired', connected: true }),
+    BOOTLOADER_DESCRIPTOR,
+);
+// The same device once the installation rebooted it into firmware mode, reporting both now.
+const DEVICE_AFTER_FRESH_INSTALLATION = withDescriptor(
+    mockSuiteDevice({ path: '4', connected: true }, { device_id: 'device-freshly-installed' }),
+    { apiType: 'usb', id: 'descriptor-freshly-installed' },
 );
 
 const NO_FIRMWARE_UPDATE = { status: 'initial' } as const;
@@ -81,7 +98,7 @@ describe('getShouldSelectConnectedDevice', () => {
                 physicalDeviceWallets: [DEVICE_A, DEVICE_B],
                 firmware: NO_FIRMWARE_UPDATE,
             }),
-        ).toEqual({ shouldSelect: false, reason: 'selected-device-connected' });
+        ).toEqual({ shouldSelect: false, reason: 'other-device-connected' });
     });
 
     it('selects a connected device when the selected wallet has no device present', () => {
@@ -90,6 +107,24 @@ describe('getShouldSelectConnectedDevice', () => {
                 incomingDevice: DEVICE_B,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
+    });
+
+    // What #30929 asked for: a Bluetooth device connecting while the selected wallet is a remembered
+    // one whose device is elsewhere. The transport is nothing the rules look at, hence one case.
+    it('selects a device connecting over Bluetooth when nothing else is present', () => {
+        const deviceOverBluetooth = withDescriptor(DEVICE_B, {
+            apiType: 'bluetooth',
+            id: 'bluetooth-b',
+        });
+
+        expect(
+            getShouldSelectConnectedDevice({
+                incomingDevice: deviceOverBluetooth,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, deviceOverBluetooth],
                 firmware: NO_FIRMWARE_UPDATE,
             }),
         ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
@@ -140,7 +175,7 @@ describe('getShouldSelectConnectedDevice', () => {
                 physicalDeviceWallets: [DEVICE_A_BOOTLOADER, DEVICE_B_UNACQUIRED],
                 firmware: NO_FIRMWARE_UPDATE,
             }),
-        ).toEqual({ shouldSelect: false, reason: 'selected-device-connected' });
+        ).toEqual({ shouldSelect: false, reason: 'other-device-connected' });
     });
 
     // A device in bootloader mode reports `id: null` rather than omitting it.
@@ -149,7 +184,10 @@ describe('getShouldSelectConnectedDevice', () => {
             getShouldSelectConnectedDevice({
                 incomingDevice: { ...DEVICE_B, id: null } as TrezorDevice,
                 selectedDevice: { ...DEVICE_A_REMEMBERED, id: null } as TrezorDevice,
-                physicalDeviceWallets: [{ ...DEVICE_A_REMEMBERED, id: null } as TrezorDevice],
+                physicalDeviceWallets: [
+                    { ...DEVICE_A_REMEMBERED, id: null } as TrezorDevice,
+                    { ...DEVICE_B, id: null } as TrezorDevice,
+                ],
                 firmware: NO_FIRMWARE_UPDATE,
             }),
         ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
@@ -160,148 +198,114 @@ describe('getShouldSelectConnectedDevice', () => {
 // its `id`, so every state of the flow has to keep an unrelated device from being taken for it,
 // not only the installation itself.
 describe('getShouldSelectConnectedDevice during a firmware update', () => {
-    it('does not select an unrelated device while the installation is running', () => {
+    // The updated device disconnects and reconnects with nothing to recognise it by, so being the
+    // only device present is what tells it apart - the same rule `onCallFirmwareUpdate` follows to
+    // find the device it is updating.
+    it('keeps the selection while another device is present as well', () => {
         expect(
             getShouldSelectConnectedDevice({
                 incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_REMEMBERED,
-                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
-                firmware: { status: 'started', cachedDevice: DEVICE_A },
-            }),
-        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
-    });
-
-    it('does not select an unrelated device while the updated device pairs over THP', () => {
-        expect(
-            getShouldSelectConnectedDevice({
-                incomingDevice: DEVICE_B_UNACQUIRED,
-                selectedDevice: DEVICE_A_REMEMBERED,
-                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
-                firmware: { status: 'thp-pairing', cachedDevice: DEVICE_A },
-            }),
-        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
-    });
-
-    it('does not select an unrelated device while the seed backup is being confirmed', () => {
-        expect(
-            getShouldSelectConnectedDevice({
-                incomingDevice: DEVICE_B_UNACQUIRED,
-                selectedDevice: DEVICE_A_REMEMBERED,
-                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
-                firmware: { status: 'check-seed', cachedDevice: DEVICE_A },
-            }),
-        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
-    });
-
-    // `done` is set the moment Connect resolves, while the device still reboots to normal mode.
-    it('does not select an unrelated device after the update is done', () => {
-        expect(
-            getShouldSelectConnectedDevice({
-                incomingDevice: DEVICE_B_UNACQUIRED,
-                selectedDevice: DEVICE_A_REMEMBERED,
-                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
-                firmware: { status: 'done', cachedDevice: DEVICE_A },
-            }),
-        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
-    });
-
-    // A half-updated device is the one most likely to reconnect erratically.
-    it('does not select an unrelated device after the update failed', () => {
-        expect(
-            getShouldSelectConnectedDevice({
-                incomingDevice: DEVICE_B_UNACQUIRED,
-                selectedDevice: DEVICE_A_REMEMBERED,
-                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
-                firmware: { status: 'error', cachedDevice: DEVICE_A },
-            }),
-        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
-    });
-
-    it('does not select an unrelated device when no device was cached', () => {
-        expect(
-            getShouldSelectConnectedDevice({
-                incomingDevice: DEVICE_B_UNACQUIRED,
-                selectedDevice: DEVICE_A_REMEMBERED,
-                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
+                physicalDeviceWallets: [DEVICE_A, DEVICE_B_UNACQUIRED],
                 firmware: { status: 'started' },
             }),
         ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
     });
 
-    it('does not match two devices whose descriptor reports no id', () => {
-        const noDescriptorId: Descriptor = { apiType: 'usb', id: null };
+    it.each(['started', 'thp-pairing', 'check-seed', 'done', 'error'] as const)(
+        'keeps the selection with another device present, in status %s',
+        status => {
+            expect(
+                getShouldSelectConnectedDevice({
+                    incomingDevice: DEVICE_B_UNACQUIRED,
+                    selectedDevice: undefined,
+                    physicalDeviceWallets: [DEVICE_A, DEVICE_B_UNACQUIRED],
+                    firmware: { status },
+                }),
+            ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+        },
+    );
 
+    // A fresh installation on a device with no firmware: it was in bootloader mode all along, so
+    // nothing about it before the installation matches what comes back afterwards. The wallet keeps
+    // the selection, because a wallet losing it to a device that cannot be matched by id is what the
+    // onboarding reads as the user having swapped devices.
+    it('leaves the selection where it is when it cannot recognise what came back', () => {
         expect(
             getShouldSelectConnectedDevice({
-                incomingDevice: withDescriptor(DEVICE_B_UNACQUIRED, noDescriptorId),
-                selectedDevice: DEVICE_A_REMEMBERED,
-                physicalDeviceWallets: [DEVICE_A_REMEMBERED],
-                firmware: {
-                    status: 'started',
-                    cachedDevice: withDescriptor(DEVICE_A, noDescriptorId),
-                },
+                incomingDevice: DEVICE_AFTER_FRESH_INSTALLATION,
+                // The entry it connected under before the reboot, no longer present.
+                selectedDevice: { ...DEVICE_WITHOUT_FIRMWARE, connected: false },
+                physicalDeviceWallets: [DEVICE_AFTER_FRESH_INSTALLATION],
+                firmware: { status: 'done' },
             }),
         ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
     });
 
-    it('selects the updated device when it reconnects in bootloader mode without its id', () => {
+    it('selects the device that comes back from a fresh installation with nothing selected', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                incomingDevice: DEVICE_AFTER_FRESH_INSTALLATION,
+                selectedDevice: undefined,
+                physicalDeviceWallets: [DEVICE_AFTER_FRESH_INSTALLATION],
+                firmware: { status: 'check-seed' },
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'no-selected-device' });
+    });
+
+    // In bootloader mode it reports no `id`, so the wallet it is being updated for keeps the
+    // selection until it comes back reporting one, in the test below.
+    it('leaves the selection on the wallet while its device sits in bootloader mode', () => {
         expect(
             getShouldSelectConnectedDevice({
                 incomingDevice: DEVICE_A_BOOTLOADER,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_A_BOOTLOADER],
-                firmware: { status: 'started', cachedDevice: DEVICE_A },
-            }),
-        ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
-    });
-
-    // The updated device is removed from the list while it reboots unless it is remembered, which
-    // leaves nothing selected - and an empty selection must not become a way in for another device.
-    it('does not select an unrelated device while nothing is selected', () => {
-        expect(
-            getShouldSelectConnectedDevice({
-                incomingDevice: DEVICE_B_UNACQUIRED,
-                selectedDevice: undefined,
-                physicalDeviceWallets: [DEVICE_B_UNACQUIRED],
-                firmware: { status: 'done', cachedDevice: DEVICE_A },
+                firmware: { status: 'started' },
             }),
         ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
     });
 
-    it('selects the updated device while nothing is selected', () => {
+    // What #31911 was about: the onboarding installation leaves no selection behind, so the device
+    // that comes back has to be able to fill it, unrecognisable as it is.
+    it('fills an empty selection with the device that comes back from a fresh installation', () => {
         expect(
             getShouldSelectConnectedDevice({
-                incomingDevice: DEVICE_A,
+                incomingDevice: DEVICE_AFTER_FRESH_INSTALLATION,
                 selectedDevice: undefined,
-                physicalDeviceWallets: [DEVICE_A],
-                firmware: { status: 'done', cachedDevice: DEVICE_A },
+                physicalDeviceWallets: [DEVICE_AFTER_FRESH_INSTALLATION],
+                firmware: { status: 'done' },
             }),
         ).toEqual({ shouldSelect: true, reason: 'no-selected-device' });
     });
 
-    // `descriptor.id` is scoped to the transport, so a device updated over USB and reconnecting
-    // over Bluetooth is recognised by its `id` instead.
-    it('selects the updated device when it comes back over another transport', () => {
-        const bluetoothDescriptor: Descriptor = { apiType: 'bluetooth', id: 'bluetooth-a' };
-
-        expect(
-            getShouldSelectConnectedDevice({
-                incomingDevice: withDescriptor(DEVICE_A, bluetoothDescriptor),
-                selectedDevice: undefined,
-                physicalDeviceWallets: [withDescriptor(DEVICE_A, bluetoothDescriptor)],
-                firmware: { status: 'done', cachedDevice: DEVICE_A },
-            }),
-        ).toEqual({ shouldSelect: true, reason: 'no-selected-device' });
-    });
-
-    it('selects the updated device when it comes back acquired with its id', () => {
+    it('selects the updated device when it comes back with its id', () => {
         expect(
             getShouldSelectConnectedDevice({
                 incomingDevice: DEVICE_A,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_A],
-                firmware: { status: 'done', cachedDevice: DEVICE_A },
+                firmware: { status: 'done' },
             }),
         ).toEqual({ shouldSelect: true, reason: 'same-device' });
+    });
+
+    // What the update actually suspends: an empty selection, which the updated device leaves behind
+    // while it reboots, is not a way in for another device until the flow is closed and the status
+    // returns to `initial`.
+    it('holds an empty selection against another device until the flow is closed', () => {
+        const params = {
+            incomingDevice: DEVICE_B_UNACQUIRED,
+            selectedDevice: undefined,
+            physicalDeviceWallets: [DEVICE_A, DEVICE_B_UNACQUIRED],
+        };
+
+        expect(
+            getShouldSelectConnectedDevice({ ...params, firmware: { status: 'started' } }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+
+        expect(getShouldSelectConnectedDevice({ ...params, firmware: NO_FIRMWARE_UPDATE })).toEqual(
+            { shouldSelect: true, reason: 'no-selected-device' },
+        );
     });
 });

--- a/suite-common/device/src/getShouldSelectConnectedDevice.ts
+++ b/suite-common/device/src/getShouldSelectConnectedDevice.ts
@@ -14,11 +14,9 @@ export type SelectDeviceReason =
 export type KeepSelectionReason =
     /** Nothing connected, so there is nothing to select. */
     | 'no-connected-device'
-    /** The selected wallet already has its device present. */
-    | 'selected-device-connected'
-    /** Another device is present, so it is not clear which one the user means. */
+    /** Another device is present, the selected one included, so the intent is ambiguous. */
     | 'other-device-connected'
-    /** A firmware update is running and this is not the device being updated. */
+    /** A firmware update is running and the device cannot be recognised as the one being updated. */
     | 'other-device-firmware-update';
 
 /** Paired with its reason, so that a reason cannot end up on the verdict it does not belong to. */
@@ -28,8 +26,9 @@ export type DeviceSelectionDecision =
 
 /** Only the firmware state this decision needs, so that the caller may pass the whole reducer. */
 type FirmwareState = {
+    /** The whole flow, not just the installation: the device also reconnects while pairing over
+     * THP, once the update is `done` and after it failed. */
     status: FirmwareStatus | 'error';
-    cachedDevice?: TrezorDevice;
 };
 
 type GetShouldSelectConnectedDeviceParams = {
@@ -43,34 +42,6 @@ type GetShouldSelectConnectedDeviceParams = {
 };
 
 /**
- * Neither identifier alone recognises a device that comes back, so both are compared:
- *
- * - `descriptor.id` is stable across reconnects, unlike `path`, which is assigned per connection,
- *   and it is reported in bootloader mode, unlike `id`. It is scoped to the transport that reports
- *   it, though - a device reached over USB and over Bluetooth has a different one of each.
- * - `id` is the same on every transport, but a device in bootloader mode does not report it.
- *
- * What is left uncovered is a device in bootloader mode arriving on another transport than it left
- * on, which has nothing in common with the device it was. It is then taken for an unrelated device,
- * which is the safe way to be wrong here: nothing is selected, rather than the wrong wallet.
- */
-const isSamePhysicalDevice = (
-    a: Device | TrezorDevice | undefined,
-    b: Device | TrezorDevice | undefined,
-) => {
-    const descriptorId = a?.descriptor?.id;
-
-    // A nullish `descriptor.id` means "unknown", not "no id": it is optional in the transport
-    // layer and old bridge does not report it at all. Two unknowns must never look like a match.
-    if (descriptorId != null && descriptorId === b?.descriptor?.id) {
-        return true;
-    }
-
-    // Same as above: a device that reports no `id` must not match another one that reports none.
-    return a?.id != null && a.id === b?.id;
-};
-
-/**
  * Decides whether a newly connected device takes over the selection from the currently selected
  * wallet. Pure, so that the rules can be read and tested in one place - the caller only feeds it
  * the state it needs.
@@ -81,45 +52,56 @@ export const getShouldSelectConnectedDevice = ({
     physicalDeviceWallets,
     firmware,
 }: GetShouldSelectConnectedDeviceParams): DeviceSelectionDecision => {
-    // This function should be called when there is an incoming device being connected, but just to cover all cases:
+    // Nothing connected: not how this is called, covered for completeness.
     if (incomingDevice === undefined) {
         return { shouldSelect: false, reason: 'no-connected-device' };
     }
 
-    // Checked before anything else: while an update runs, no device may take the selection - except
-    // the device being updated, which is what the comparison is for. It disconnects and reconnects
-    // in bootloader mode, and while it is away the selection can end up empty, which would
-    // otherwise let any device take it. Its reconnect is also the only chance to select it again.
-    // `status` covers the whole flow, not just the installation: the device also reconnects while
-    // pairing over THP, after the update is `done` and after it failed.
-    const isDeviceBeingUpdated = isSamePhysicalDevice(firmware.cachedDevice, incomingDevice);
+    // Counted by path: an unacquired device has no `id` and one in bootloader mode reports none.
+    // Deduplicated, as one physical device can hold several wallets, all on the same path.
+    const connectedDevicePaths = [
+        ...new Set(
+            physicalDeviceWallets.filter(wallet => wallet.connected).map(wallet => wallet.path),
+        ),
+    ];
 
-    if (firmware.status !== 'initial' && !isDeviceBeingUpdated) {
+    const isIncomingDeviceOnlyDeviceConnected =
+        incomingDevice.path !== '' &&
+        connectedDevicePaths.length === 1 &&
+        connectedDevicePaths[0] === incomingDevice.path;
+
+    // A device that turned up next to the one being updated. The updated device reconnects in
+    // bootloader mode, unidentifiable, so only being the one device present tells it apart - the rule
+    // `onCallFirmwareUpdate` goes on too, with `deviceList.getOnlyDevice`. Before the selection is
+    // read, because the rebooting device is dropped from the list and empties it.
+    if (firmware.status !== 'initial' && !isIncomingDeviceOnlyDeviceConnected) {
         return { shouldSelect: false, reason: 'other-device-firmware-update' };
     }
 
+    // Nothing selected: the first device of a fresh Suite, or the selection the update emptied.
     if (selectedDevice === undefined) {
         return { shouldSelect: true, reason: 'no-selected-device' };
     }
 
-    // Compared only when the incoming device reports an `id`, otherwise two devices that both
-    // lack one - an unacquired device has none and a device in bootloader mode reports `null` -
-    // would look like a match.
+    // The device of the selected wallet, back from a reconnect or an update. Compared only when it
+    // reports an `id`, or two devices that both lack one would look like a match.
     if (incomingDevice.id != null && incomingDevice.id === selectedDevice.id) {
         return { shouldSelect: true, reason: 'same-device' };
     }
 
-    if (selectedDevice.connected) {
-        return { shouldSelect: false, reason: 'selected-device-connected' };
+    // The only device present during an update, unidentifiable. It fills an empty selection, above,
+    // but does not take one from a wallet: the onboarding compares the id that disconnected with the
+    // one present and would report the user has swapped devices.
+    if (firmware.status !== 'initial') {
+        return { shouldSelect: false, reason: 'other-device-firmware-update' };
     }
 
-    // Wallets are matched by path, because an unacquired device has no `id` yet and a device
-    // reconnecting in bootloader mode reports none either.
-    const isOnlyConnectedDevice = physicalDeviceWallets.every(
-        wallet => !wallet.connected || wallet.path === incomingDevice.path,
-    );
+    // The selected wallet has no device present, so this one takes over. Not if that device is
+    // connected after all - it is counted too, and the paths then differ.
+    if (isIncomingDeviceOnlyDeviceConnected) {
+        return { shouldSelect: true, reason: 'only-connected-device' };
+    }
 
-    return isOnlyConnectedDevice
-        ? { shouldSelect: true, reason: 'only-connected-device' }
-        : { shouldSelect: false, reason: 'other-device-connected' };
+    // More than one device connected, so which one the user means is not clear.
+    return { shouldSelect: false, reason: 'other-device-connected' };
 };

--- a/suite-common/wallet-core/src/discovery/selectNewlyConnectedDeviceThunk.test.ts
+++ b/suite-common/wallet-core/src/discovery/selectNewlyConnectedDeviceThunk.test.ts
@@ -1,0 +1,128 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
+import { firmwareActions, prepareFirmwareReducer } from '@suite-common/firmware';
+import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { configureMockStore } from '@suite-common/test-utils';
+
+import { selectNewlyConnectedDeviceThunk } from './selectDeviceThunk';
+import { handleDeviceDisconnect } from '../device/deviceThunks';
+
+const deviceReducer = prepareDeviceReducer({
+    actionTypes: {
+        setDeviceMetadata: mockActionType('setDeviceMetadata'),
+        setDeviceMetadataPasswords: mockActionType('setDeviceMetadataPasswords'),
+        storageLoad: mockActionType('storageLoad'),
+    },
+    reducers: {
+        setDeviceMetadataPasswordsReducer: mockReducer(),
+        setDeviceMetadataReducer: mockReducer(),
+        storageLoadDevices: mockReducer(),
+    },
+});
+const firmwareReducer = prepareFirmwareReducer({
+    actionTypes: { storageLoad: mockActionType('storageLoad') },
+});
+
+const reducer = combineReducers({ device: deviceReducer, firmware: firmwareReducer });
+
+// A device with no firmware, as the onboarding meets it: in bootloader mode from the start, so
+// without a `device_id` of its own.
+const DEVICE_WITHOUT_FIRMWARE = mockConnectDevice(
+    { path: '1', mode: 'bootloader', descriptor: { apiType: 'usb', id: 'descriptor-bootloader' } },
+    { device_id: null, bootloader_mode: true, firmware_present: false },
+);
+// The same device once the installation rebooted it into firmware mode, reporting the `device_id` it
+// was given on its first boot and a new path, assigned by the new connection.
+const DEVICE_AFTER_FRESH_INSTALLATION = mockConnectDevice(
+    { path: '2', descriptor: { apiType: 'usb', id: 'descriptor-installed' } },
+    { device_id: 'device-freshly-installed' },
+);
+
+const REMEMBERED_WALLET = mockSuiteDevice(
+    {
+        path: '',
+        connected: false,
+        remember: true,
+        descriptor: { apiType: 'usb', id: 'descriptor-a' },
+    },
+    { device_id: 'device-a' },
+);
+
+// The whole slice, so that the parts the reducer keeps besides the devices are there as well.
+const getDeviceState = (devices: TrezorDevice[], selectedDevice?: TrezorDevice) => ({
+    ...deviceReducer(undefined, { type: 'test-init' }),
+    devices,
+    selectedDevice,
+});
+
+const initStore = (preloadedState?: Parameters<typeof configureMockStore>[0]['preloadedState']) =>
+    configureMockStore({ extra: undefined, reducer, preloadedState });
+
+describe('selectNewlyConnectedDeviceThunk during a firmware update', () => {
+    // What #31911 was about: the device the onboarding installs firmware on is not remembered, so it
+    // is dropped while it reboots and takes the selection with it. Nothing recognises it when it
+    // comes back - it reports a `device_id` it did not have before - so being the only device
+    // present has to be enough, or the onboarding waits for a device that is already connected.
+    it('fills the selection the rebooting device left behind', async () => {
+        const store = initStore();
+
+        store.dispatch(deviceActions.connectDevice({ device: DEVICE_WITHOUT_FIRMWARE }));
+        await store.dispatch(selectNewlyConnectedDeviceThunk({ device: DEVICE_WITHOUT_FIRMWARE }));
+
+        expect(store.getState().device.selectedDevice?.path).toBe('1');
+
+        store.dispatch(firmwareActions.setStatus('started'));
+
+        const connected = store.getState().device.devices[0];
+        if (!connected) throw new Error('the connected device is missing from the reducer');
+        store.dispatch(deviceActions.deviceDisconnect(connected));
+        store.dispatch(handleDeviceDisconnect(connected));
+
+        expect(store.getState().device.selectedDevice).toBeUndefined();
+
+        store.dispatch(deviceActions.connectDevice({ device: DEVICE_AFTER_FRESH_INSTALLATION }));
+        const action = await store.dispatch(
+            selectNewlyConnectedDeviceThunk({ device: DEVICE_AFTER_FRESH_INSTALLATION }),
+        );
+
+        expect(action.type).toBe(selectNewlyConnectedDeviceThunk.fulfilled.type);
+        expect(store.getState().device.selectedDevice?.id).toBe('device-freshly-installed');
+    });
+
+    // The onboarding tells the user another Trezor is connected when the id it saw disconnect is not
+    // the id present, so a wallet must not lose the selection to a device that cannot be matched.
+    it('leaves the selection on the wallet when it cannot recognise what came back', async () => {
+        const store = initStore({
+            device: getDeviceState([REMEMBERED_WALLET], REMEMBERED_WALLET),
+            firmware: { status: 'started' },
+        });
+
+        store.dispatch(deviceActions.connectDevice({ device: DEVICE_AFTER_FRESH_INSTALLATION }));
+        const action = await store.dispatch(
+            selectNewlyConnectedDeviceThunk({ device: DEVICE_AFTER_FRESH_INSTALLATION }),
+        );
+
+        expect(action.type).toBe(selectNewlyConnectedDeviceThunk.rejected.type);
+        expect(action.payload).toBe('other-device-firmware-update');
+        expect(store.getState().device.selectedDevice?.id).toBe('device-a');
+    });
+
+    // Only the flow suspends it: once it is over, a device connecting alone takes the selection over
+    // from a wallet whose own device is not present, which is what the auto-selection is for.
+    it('takes the selection over once the flow is closed', async () => {
+        const store = initStore({
+            device: getDeviceState([REMEMBERED_WALLET], REMEMBERED_WALLET),
+        });
+
+        store.dispatch(deviceActions.connectDevice({ device: DEVICE_AFTER_FRESH_INSTALLATION }));
+        const action = await store.dispatch(
+            selectNewlyConnectedDeviceThunk({ device: DEVICE_AFTER_FRESH_INSTALLATION }),
+        );
+
+        expect(action.type).toBe(selectNewlyConnectedDeviceThunk.fulfilled.type);
+        expect(store.getState().device.selectedDevice?.id).toBe('device-freshly-installed');
+    });
+});


### PR DESCRIPTION
## Description

A device being updated cannot be recognised when it comes back: in bootloader mode it reports no
`id` and the same `descriptor.id` placeholder as every other device in that state. The comparison
against the cached device therefore took the updated device for an unrelated one and refused it the
selection, and the onboarding update ended up on "You're using a different Trezor" instead of
carrying on.

Being the only device present is what tells it apart, and it is the rule the update itself goes on
(`onCallFirmwareUpdate` finds its device with `deviceList.getOnlyDevice`), so the identity
comparison is gone. While an update runs, that device may only fill an empty selection - the one the
rebooting device leaves behind - and never take the selection from a wallet, which the onboarding
would read as the user having swapped devices. With another device present, the selection stays
where it is, as before.

## Notes for QA

Please cover **every update flow**, watching what wallet is selected during and after it:

- fresh installation in the onboarding, on a device with no firmware (the reported bug: the
  onboarding used to end up on "You're using a different Trezor" and never return to the update)
- update in the onboarding on a device with older firmware
- standalone update from Settings > Device, in all three flows: reboot and upgrade, reboot and wait,
  and the manual disconnect/reconnect one on older firmware
- firmware type switch (universal <-> bitcoin-only) and a custom firmware installation
- Safe 7 over Bluetooth, where the device also reconnects while pairing over THP
- an update that fails or is cancelled on the device

Then the selection rules themselves:

- **a newly connected device is selected when it is the only one connected** - with a remembered
  wallet selected and no device present, connecting one (over USB and over Bluetooth) selects it
- during an update with a second device connected, that second device must not take the selection
- the "You're using a different Trezor" screen must not appear during an update at all - neither
  stuck on it, nor flashing over the installation screen for a moment

## Related Issue

Resolve #31911

Follow-up: #31938 - the onboarding still compares device ids across events that change `device_id`
(wipe, recovery, a fresh installation). This PR keeps the id under comparison from changing during an
update; the comparison itself is left for that ticket.

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The core risk is in suite-common/device/src/getShouldSelectConnectedDevice.ts, a global utility that decides when Suite auto-selects a connected device. Because it statically maps to 136 tests, only the flows that explicitly depend on session takeover, reconnect, remembered-wallet loading, and disconnected-state behavior are recommended. The fixture file is not exercised by any E2E test and the unit test change is self-covered.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `suite-common/device/src/getShouldSelectConnectedDevice.test.ts`
- `suite-common/device/src/getShouldSelectConnectedDevice.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises device session acquisition, reclamation, and the 'Use Here' vs 'Connected' status transitions. Changes to getShouldSelectConnectedDevice could alter when Suite auto-selects a reconnected session, making this the most direct regression target.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — The flow depends on correctly deciding whether to re-select the connected device after power-off/power-on and whether the cached passphrase wallet is selected. A change in auto-selection logic could break reconnection or re-prompt behavior.
- `suite/e2e/tests/settings/forget-device.test.ts` — Tests forget/unpair flows for TS5/TS7 devices across connected and disconnected states. Auto-selection logic affects what happens after the device is forgotten and reconnected, so regressions here are plausible.
- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — Validates that a remembered wallet loads and renders correctly without a live device, then lets the user navigate accounts. getShouldSelectConnectedDevice likely influences whether Suite tries to auto-select a missing device on reload.
- `suite/e2e/tests/wallet/without-device.test.ts` — Covers device-disconnected state, connection modals, and send-flow guards. A change in selection heuristics could affect how quickly Suite recognizes disconnection or whether it prompts to reconnect.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`

_Updated: 2026-08-31T14:53:53.709Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/31911-fresh-firmware-device-selection/web/](https://dev.suite.sldev.cz/suite-web/31911-fresh-firmware-device-selection/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=31911-fresh-firmware-device-selection&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=31911-fresh-firmware-device-selection&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=31911-fresh-firmware-device-selection&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T08:55:36.871Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T14:55:43.519Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
