### PR TITLE
fix(suite-common): preserve native value for EVM fee bumps

### DIFF
--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -6,6 +6,7 @@ import {
     type WalletAccountTransaction,
     asAccountDescriptor,
 } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import * as fixtures from './__fixtures__/transactionUtils';
 import {
@@ -41,9 +42,87 @@ const btcSymbol = asNetworkSymbol('btc');
 const { getWalletTransaction } = testMocks;
 
 const ACCOUNT_DESCRIPTOR = '0x37567E60ab231b7D7f26B5b34FDD719098E4Ee1b';
+const RBF_ACCOUNT_DESCRIPTOR = '0x1111111111111111111111111111111111111111';
+const CONTRACT_ADDRESS = '0x2222222222222222222222222222222222222222';
+const TOKEN_RECIPIENT = '0x3333333333333333333333333333333333333333';
+const TOKEN_CONTRACT = '0x4444444444444444444444444444444444444444';
+const TRANSFER_FROM_DATA =
+    '0x23b872dd' +
+    '0000000000000000000000001111111111111111111111111111111111111111' +
+    '0000000000000000000000003333333333333333333333333333333333333333' +
+    '000000000000000000000000000000000000000000000000000000001dcd6500';
+const ERC4626_DEPOSIT_DATA =
+    '0x6e553f65' +
+    '00000000000000000000000000000000000000000000000000000000000f4240' +
+    '0000000000000000000000001111111111111111111111111111111111111111';
 // A stranger who signed (and paid for) a transaction that blockbook indexes against the account
 // because one of its token transfers names the account as the sender.
 const FOREIGN_SIGNER = '0x0F6666bC699aec39b846E898473e9CAec5a6b821';
+
+const ethereumAccount = mockWalletAccount({
+    symbol: ethSymbol,
+    descriptor: asAccountDescriptor(RBF_ACCOUNT_DESCRIPTOR),
+});
+
+const getPendingTokenMovingContractTransaction = ({
+    data,
+    nativeValue,
+    tokenAmount,
+}: {
+    data: string;
+    nativeValue: string;
+    tokenAmount: string;
+}) =>
+    getWalletTransaction({
+        descriptor: asAccountDescriptor(RBF_ACCOUNT_DESCRIPTOR),
+        symbol: ethSymbol,
+        type: 'sent',
+        txid: '0xpending-contract-call',
+        blockHeight: -1,
+        amount: nativeValue,
+        rbf: true,
+        ethereumSpecific: {
+            status: -1,
+            nonce: 45,
+            gasLimit: 100_000,
+            gasPrice: '1000000000',
+            data,
+        },
+        details: {
+            ...getWalletTransaction().details,
+            vin: [
+                {
+                    n: 0,
+                    addresses: [RBF_ACCOUNT_DESCRIPTOR],
+                    isAddress: true,
+                    isOwn: true,
+                    isAccountOwned: true,
+                },
+            ],
+            vout: [
+                {
+                    n: 0,
+                    addresses: [CONTRACT_ADDRESS],
+                    isAddress: true,
+                    value: nativeValue,
+                },
+            ],
+            totalOutput: nativeValue,
+        },
+        tokens: [
+            {
+                type: 'sent',
+                standard: 'ERC20',
+                amount: tokenAmount,
+                from: RBF_ACCOUNT_DESCRIPTOR,
+                to: TOKEN_RECIPIENT,
+                contract: TOKEN_CONTRACT,
+                name: 'USD Coin',
+                symbol: 'USDC',
+                decimals: 6,
+            },
+        ],
+    });
 
 type EvmTransactionParams = {
     nonce: number;
@@ -489,6 +568,50 @@ describe('transaction utils', () => {
             it(f.description, () => {
                 expect(getRbfParams(f.tx as any, f.account as any)).toEqual(f.result);
             });
+        });
+
+        it('preserves zero native value for a token-moving transferFrom call', () => {
+            const transaction = getPendingTokenMovingContractTransaction({
+                data: TRANSFER_FROM_DATA,
+                nativeValue: '0',
+                tokenAmount: '500000000',
+            });
+
+            expect(getRbfParams(transaction, ethereumAccount)).toEqual({
+                type: 'ethereum',
+                txid: transaction.txid,
+                outputs: [
+                    {
+                        type: 'payment',
+                        address: CONTRACT_ADDRESS,
+                        amount: '0',
+                        formattedAmount: '0',
+                    },
+                ],
+                ethereumNonce: 45,
+                transactionData: TRANSFER_FROM_DATA,
+                gasPrice: '1',
+                maxFeePerGas: '',
+                maxPriorityFeePerGas: '',
+            });
+        });
+
+        it('keeps the token amount for an ERC-4626 deposit call', () => {
+            const transaction = getPendingTokenMovingContractTransaction({
+                data: ERC4626_DEPOSIT_DATA,
+                nativeValue: '0',
+                tokenAmount: '1000000',
+            });
+
+            expect(getRbfParams(transaction, ethereumAccount)?.outputs).toEqual([
+                {
+                    type: 'payment',
+                    address: CONTRACT_ADDRESS,
+                    token: TOKEN_CONTRACT,
+                    amount: '1000000',
+                    formattedAmount: '1',
+                },
+            ]);
         });
     });
 

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -997,6 +997,11 @@ const getEthereumRbfParams = (
     const firstVoutAddresses = firstVout.addresses!;
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
     const toAddress: string = firstVoutAddresses[0];
+    const nativeOutput = {
+        address: toAddress,
+        amount: firstVout.value!,
+        formattedAmount: formatNetworkAmount(firstVout.value!, account.symbol),
+    };
 
     let output;
     switch (txSignature) {
@@ -1028,8 +1033,9 @@ const getEthereumRbfParams = (
             };
             break;
         }
-        default: {
-            // Token-moving contract calls report value=0 in vout; pull the amount from tokens[0].
+        case 'deposit':
+        case 'withdraw':
+        case 'redeem': {
             const tokenTransfer = tx.tokens?.[0];
             if (tokenTransfer) {
                 output = {
@@ -1042,12 +1048,12 @@ const getEthereumRbfParams = (
                     ),
                 };
             } else {
-                output = {
-                    address: toAddress,
-                    amount: vout[0]!.value!,
-                    formattedAmount: formatNetworkAmount(vout[0]!.value!, account.symbol),
-                };
+                output = nativeOutput;
             }
+            break;
+        }
+        default: {
+            output = nativeOutput;
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the issue where bumping the fee of an EVM contract call could interpret the token amount as native ETH. The replacement transaction now preserves the original native value.

## Notes for QA

Bump the fee of a pending `transferFrom` transaction with native value 0. The device must not show the token amount as ETH.

Data: https://calldata.dev/encode#v=1&d=I7hy3QAAAAAAAAAAAAAAAJ6jchtb87ZLRBjDi2AxVNLVl_rjAAAAAAAAAAAAAAAAnqNyG1vztktEGMOLYDFU0tWX-uMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9CQA&f=dHJhbnNmZXJGcm9tKGFkZHJlc3MgZnJvbSxhZGRyZXNzIHRvLHVpbnQyNTYgYW1vdW50KQ

_Update the values and use the generated calldata_

Contract: `0xdAC17F958D2ee523a2206206994597C13D831ec7`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31428

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** transactionUtils.ts is a broad shared utility (136 static references), so the risk is diffuse. I recommend a narrow, transaction-focused E2E subset that exercises actual transaction listing, search, pending-state transitions, and export rather than broad regression. The companion unit test change suggests the utility's expected behavior is being modified, reinforcing the need to validate the end-to-end transaction flows that consume it.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/pagination.test.ts` — Directly exercises paginated transaction list rendering and address display on a BTC legacy account. Changes to transactionUtils.ts could affect how transactions are fetched, sorted, or formatted for display, which this test asserts concretely.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Covers pending transaction grouping, counts, status labels, and the pending-to-confirmed transition. This state management and transaction metadata handling is likely implemented or assisted by transactionUtils.ts.
- `suite/e2e/tests/wallet/transactions.test.ts` — Tests transaction search by address and transaction summary display. transactionUtils.ts likely provides transaction filtering, sorting, or address extraction utilities that this flow depends on.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exports transaction history in multiple formats (PDF/CSV/JSON). This may rely on transactionUtils.ts for normalizing or formatting transaction data before export, though the test primarily checks file presence rather than content.

</details>

_Updated: 2026-08-31T17:12:13.748Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/bump-fee-fix/web/](https://dev.suite.sldev.cz/suite-web/feat/bump-fee-fix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bump-fee-fix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/bump-fee-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bump-fee-fix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-08-31T17:14:46.608Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-31T17:14:50.762Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->