### PR TITLE
Trading: merge provider quote updates from watchtrade response

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -204,7 +204,7 @@
         "@testing-library/user-event": "^14.6.4",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.19",
+        "@types/invity-api": "^1.1.20",
         "@types/pako": "^2.0.4",
         "@types/pdfmake": "^0.3.1",
         "@types/react": "19.2.14",

--- a/suite-common/flags/package.json
+++ b/suite-common/flags/package.json
@@ -14,6 +14,6 @@
         "@trezor/env-utils": "workspace:*"
     },
     "devDependencies": {
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -47,7 +47,7 @@
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
         "@testing-library/react": "^16.3.2",
-        "@types/invity-api": "^1.1.19",
+        "@types/invity-api": "^1.1.20",
         "react-intl": "^8.1.3"
     }
 }

--- a/suite-common/trading/src/thunks/common/watchTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.test.ts
@@ -6,6 +6,9 @@ import { type Account, type AccountKey } from '@suite-common/wallet-types';
 
 import { watchTradeThunk } from './watchTradeThunk';
 import { accountBtc } from '../../__fixtures__/utils';
+import { tradingBuyActions } from '../../reducers/buyReducer';
+import { tradingExchangeActions } from '../../reducers/exchangeReducer';
+import { tradingSellActions } from '../../reducers/sellReducer';
 import { type TradingState, initialState } from '../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../reducers/tradingReducer';
 import { tradeApi } from '../../tradeApi';
@@ -88,7 +91,7 @@ describe('watchTradeThunk', () => {
         });
     });
 
-    it('should remain in the status when there is same the status in response', async () => {
+    it('should not update when response fields are unchanged', async () => {
         const trade = {
             date: dateISO,
             key: 'tradeKey',
@@ -96,6 +99,7 @@ describe('watchTradeThunk', () => {
             data: {
                 status: 'LOGIN_REQUEST',
                 paymentId: 'tradeKey',
+                fiatStringAmount: '100',
             },
         } as TradingTransactionBuy;
 
@@ -106,6 +110,7 @@ describe('watchTradeThunk', () => {
         tradeApi.watchTrade = () =>
             Promise.resolve({
                 status: 'LOGIN_REQUEST',
+                fiatStringAmount: '100',
             } as any);
 
         await store.dispatch(
@@ -168,6 +173,121 @@ describe('watchTradeThunk', () => {
         });
     });
 
+    it('should clear a previously persisted error once watchTrade succeeds', async () => {
+        const trade = {
+            date: dateISO,
+            key: 'tradeKey',
+            tradeType: 'buy',
+            data: {
+                status: 'ERROR',
+                paymentId: 'tradeKey',
+                error: 'Some error occurred',
+            },
+        } as TradingTransactionBuy;
+
+        const store = getStore({
+            trades: [trade],
+        });
+
+        tradeApi.watchTrade = () =>
+            Promise.resolve({
+                status: 'SUBMITTED',
+            } as any);
+
+        await store.dispatch(
+            watchTradeThunk({
+                account,
+                trade,
+                refreshCount,
+            }),
+        );
+
+        const actions = store.getActions();
+        const saveTradeAction = actions.find(action => action.type === '@trading/saveTrade');
+
+        expect(saveTradeAction?.payload).toEqual({
+            tradeType: 'buy',
+            date: dateISO,
+            key: 'tradeKey',
+            data: {
+                status: 'SUBMITTED',
+                paymentId: 'tradeKey',
+                error: undefined,
+            },
+            receiveAccountKey: undefined,
+            selectedAccountKey: account.key,
+        });
+    });
+
+    it('should update buy trade quote fields when status is unchanged', async () => {
+        const trade = {
+            date: dateISO,
+            key: 'tradeKey',
+            tradeType: 'buy',
+            data: {
+                status: 'SUBMITTED',
+                paymentId: 'tradeKey',
+                fiatStringAmount: '100',
+                receiveStringAmount: '0.001',
+                rate: 100000,
+                paymentMethod: 'creditCard',
+                paymentMethodName: 'Credit Card',
+            },
+        } as TradingTransactionBuy;
+
+        const store = getStore({
+            trades: [trade],
+            buy: {
+                ...initialState.buy,
+                selectedQuote: trade.data,
+            },
+        });
+
+        tradeApi.watchTrade = () =>
+            Promise.resolve({
+                status: 'SUBMITTED',
+                fiatStringAmount: '110',
+                receiveStringAmount: '0.0011',
+                rate: 100000,
+                paymentMethod: 'applePay',
+                paymentMethodName: 'Apple Pay',
+            } as any);
+
+        await store.dispatch(
+            watchTradeThunk({
+                account,
+                trade,
+                refreshCount,
+            }),
+        );
+
+        const actions = store.getActions();
+        const saveTradeAction = actions.find(action => action.type === '@trading/saveTrade');
+        const saveSelectedQuoteAction = actions.find(
+            action => action.type === tradingBuyActions.saveSelectedQuote.type,
+        );
+
+        expect(saveTradeAction?.payload).toEqual({
+            tradeType: 'buy',
+            date: dateISO,
+            key: 'tradeKey',
+            data: {
+                status: 'SUBMITTED',
+                paymentId: 'tradeKey',
+                fiatStringAmount: '110',
+                receiveStringAmount: '0.0011',
+                rate: 100000,
+                paymentMethod: 'applePay',
+                paymentMethodName: 'Apple Pay',
+            },
+            receiveAccountKey: undefined,
+            selectedAccountKey: account.key,
+        });
+        expect(saveSelectedQuoteAction?.payload).toEqual(
+            (saveTradeAction?.payload as { data: unknown } | undefined)?.data,
+        );
+    });
+
     describe('should update sell trade data', () => {
         it.each([
             [
@@ -181,6 +301,15 @@ describe('watchTradeThunk', () => {
                 'when cryptoStringAmount is in the response',
                 {
                     cryptoStringAmount: 'cryptoStringAmount',
+                },
+            ],
+            [
+                'when quote fields are in the response',
+                {
+                    fiatStringAmount: '250',
+                    rate: 50000,
+                    paymentMethod: 'bankTransfer',
+                    paymentMethodName: 'Bank Transfer',
                 },
             ],
             ['when neither destinationAddress nor cryptoStringAmount is not in the response', {}],
@@ -229,6 +358,104 @@ describe('watchTradeThunk', () => {
                 sendAccountKey: 'sendAccountKey',
             });
         });
+
+        it('should clear a stale destinationPaymentExtraId when the response omits it', async () => {
+            const trade = {
+                date: dateISO,
+                key: 'tradeKey',
+                tradeType: 'sell',
+                data: {
+                    status: 'SUBMITTED',
+                    orderId: 'tradeKey',
+                    destinationAddress: 'oldDestinationAddress',
+                    destinationPaymentExtraId: 'oldDestinationPaymentExtraId',
+                },
+                sendAccountKey: 'sendAccountKey' as AccountKey,
+            } as TradingTransactionSell;
+
+            const store = getStore({
+                trades: [trade],
+            });
+
+            tradeApi.watchTrade = () =>
+                Promise.resolve({
+                    status: 'SUBMITTED',
+                    destinationAddress: 'newDestinationAddress',
+                } as any);
+
+            await store.dispatch(
+                watchTradeThunk({
+                    account,
+                    trade,
+                    refreshCount,
+                }),
+            );
+
+            const actions = store.getActions();
+            const saveTradeAction = actions.find(action => action.type === '@trading/saveTrade');
+
+            expect(saveTradeAction?.payload).toEqual({
+                tradeType: 'sell',
+                date: dateISO,
+                key: 'tradeKey',
+                data: {
+                    status: 'SUBMITTED',
+                    orderId: 'tradeKey',
+                    destinationAddress: 'newDestinationAddress',
+                    destinationPaymentExtraId: undefined,
+                },
+                sendAccountKey: 'sendAccountKey',
+            });
+        });
+
+        it('should update selected quote when orderId matches', async () => {
+            const trade = {
+                date: dateISO,
+                key: 'tradeKey',
+                tradeType: 'sell',
+                data: {
+                    status: 'LOGIN_REQUEST',
+                    orderId: 'tradeKey',
+                    cryptoStringAmount: '0.1',
+                },
+                sendAccountKey: 'sendAccountKey' as AccountKey,
+            } as TradingTransactionSell;
+
+            const store = getStore({
+                trades: [trade],
+                sell: {
+                    ...initialState.sell,
+                    selectedQuote: trade.data,
+                },
+            });
+
+            tradeApi.watchTrade = () =>
+                Promise.resolve({
+                    status: 'CONFIRM',
+                    cryptoStringAmount: '0.12',
+                    fiatStringAmount: '500',
+                } as any);
+
+            await store.dispatch(
+                watchTradeThunk({
+                    account,
+                    trade,
+                    refreshCount,
+                }),
+            );
+
+            const actions = store.getActions();
+            const saveSelectedQuoteAction = actions.find(
+                action => action.type === tradingSellActions.saveSelectedQuote.type,
+            );
+
+            expect(saveSelectedQuoteAction?.payload).toEqual({
+                status: 'CONFIRM',
+                orderId: 'tradeKey',
+                cryptoStringAmount: '0.12',
+                fiatStringAmount: '500',
+            });
+        });
     });
 
     describe('should update exchange trade data', () => {
@@ -238,6 +465,15 @@ describe('watchTradeThunk', () => {
                 {
                     sendAddress: 'sendAddress',
                     partnerPaymentExtraId: 'partnerPaymentExtraId',
+                },
+            ],
+            [
+                'when quote fields are in the response',
+                {
+                    sendStringAmount: '0.5',
+                    receiveStringAmount: '100',
+                    rate: 200,
+                    receiveTxHash: '0xabc',
                 },
             ],
             ['when sendAddress is not in the response', {}],
@@ -283,6 +519,64 @@ describe('watchTradeThunk', () => {
                     ...responseData,
                 },
             });
+        });
+
+        it('should update quote fields when status is unchanged', async () => {
+            const trade = {
+                date: dateISO,
+                key: 'tradeKey',
+                tradeType: 'exchange',
+                data: {
+                    status: 'CONFIRM',
+                    orderId: 'tradeKey',
+                    sendStringAmount: '1',
+                    receiveStringAmount: '50',
+                    rate: 50,
+                },
+                sendAccountKey: 'sendAccountKey' as AccountKey,
+            } as TradingTransactionExchange;
+
+            const store = getStore({
+                trades: [trade],
+                exchange: {
+                    ...initialState.exchange,
+                    selectedQuote: trade.data,
+                },
+            });
+
+            tradeApi.watchTrade = () =>
+                Promise.resolve({
+                    status: 'CONFIRM',
+                    sendStringAmount: '1.01',
+                    receiveStringAmount: '49.5',
+                    rate: 49,
+                } as any);
+
+            await store.dispatch(
+                watchTradeThunk({
+                    account,
+                    trade,
+                    refreshCount,
+                }),
+            );
+
+            const actions = store.getActions();
+            const saveTradeAction = actions.find(action => action.type === '@trading/saveTrade');
+            const saveSelectedQuoteAction = actions.find(
+                action => action.type === tradingExchangeActions.saveSelectedQuote.type,
+            );
+
+            const savedTradeData = (saveTradeAction?.payload as { data: unknown } | undefined)
+                ?.data;
+
+            expect(savedTradeData).toEqual({
+                status: 'CONFIRM',
+                orderId: 'tradeKey',
+                sendStringAmount: '1.01',
+                receiveStringAmount: '49.5',
+                rate: 49,
+            });
+            expect(saveSelectedQuoteAction?.payload).toEqual(savedTradeData);
         });
     });
 });

--- a/suite-common/trading/src/thunks/common/watchTradeThunk.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.ts
@@ -1,11 +1,18 @@
 import { createThunk } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
 import { exhaustive } from '@trezor/type-utils';
+import { typedObjectKeys } from '@trezor/utils';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
+import { tradingBuyActions } from '../../reducers/buyReducer';
+import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingSellActions } from '../../reducers/sellReducer';
 import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
-import { selectTradingSellSelectedQuote } from '../../selectors/tradingSelectors';
+import {
+    selectTradingBuySelectedQuote,
+    selectTradingExchangeSelectedQuote,
+    selectTradingSellSelectedQuote,
+} from '../../selectors/tradingSelectors';
 import { tradeApi } from '../../tradeApi';
 import {
     type TradingTradeMapProps,
@@ -30,18 +37,42 @@ type WatchTradeDataResultProps<T extends TradingType> = {
     response: TradingWatchTradeResponsePropsMap[T];
 };
 
+const getDefinedWatchUpdates = <T extends TradingType>(
+    response: TradingWatchTradeResponsePropsMap[T],
+): Partial<TradingTradeMapProps[T]> =>
+    Object.fromEntries(
+        Object.entries(response).filter(([, value]) => value !== undefined),
+    ) as Partial<TradingTradeMapProps[T]>;
+
 const watchTradeData = async <T extends TradingType>({
     trade,
     refreshCount,
 }: WatchTradeDataProps): Promise<WatchTradeDataResultProps<T> | undefined> => {
     const response = await tradeApi.watchTrade<T>(trade.data, trade.tradeType, refreshCount);
 
-    if (!response || !response.status || response.status === trade.data.status) return;
+    if (!response) {
+        return;
+    }
+
+    const updates = {
+        ...getDefinedWatchUpdates(response),
+        // always apply, even if undefined
+        status: response.status,
+        error: response.error,
+    };
+    const updateKeys = typedObjectKeys(updates);
+
+    const hasChanges = updateKeys.some(
+        key => trade.data[key as keyof typeof trade.data] !== updates[key],
+    );
+
+    if (!hasChanges) {
+        return;
+    }
 
     const tradeData = {
         ...trade.data,
-        status: response.status,
-        error: response.error,
+        ...updates,
     } as TradingTradeMapProps[T];
 
     return {
@@ -66,7 +97,15 @@ export const watchTradeThunk = createThunk<void, WatchTradeThunk, { state: Watch
                     refreshCount,
                 });
 
-                if (!data) return;
+                if (!data) {
+                    return;
+                }
+
+                const selectedQuote = selectTradingBuySelectedQuote(getState());
+
+                if (selectedQuote?.paymentId === data.tradeData.paymentId) {
+                    dispatch(tradingBuyActions.saveSelectedQuote(data.tradeData));
+                }
 
                 dispatch(
                     tradingActions.saveTrade({
@@ -81,27 +120,26 @@ export const watchTradeThunk = createThunk<void, WatchTradeThunk, { state: Watch
 
                 return;
             }
+
             case 'sell': {
                 const data = await watchTradeData<typeof tradeType>({
                     trade,
                     refreshCount,
                 });
 
-                if (!data) return;
+                if (!data) {
+                    return;
+                }
 
                 if (data.response.destinationAddress) {
-                    data.tradeData.destinationAddress = data.response.destinationAddress;
+                    // make sure destinationPaymentExtraId is not stale even when empty
                     data.tradeData.destinationPaymentExtraId =
                         data.response.destinationPaymentExtraId;
                 }
 
-                if (data.response.cryptoStringAmount) {
-                    data.tradeData.cryptoStringAmount = data.response.cryptoStringAmount;
-                }
-
                 const selectedQuote = selectTradingSellSelectedQuote(getState());
 
-                if (data.tradeData && selectedQuote?.orderId === data.tradeData.orderId) {
+                if (selectedQuote?.orderId === data.tradeData.orderId) {
                     dispatch(tradingSellActions.saveSelectedQuote(data.tradeData));
                 }
 
@@ -117,17 +155,21 @@ export const watchTradeThunk = createThunk<void, WatchTradeThunk, { state: Watch
 
                 return;
             }
+
             case 'exchange': {
                 const data = await watchTradeData<typeof tradeType>({
                     trade,
                     refreshCount,
                 });
 
-                if (!data) return;
+                if (!data) {
+                    return;
+                }
 
-                if (data.response.sendAddress) {
-                    data.tradeData.sendAddress = data.response.sendAddress;
-                    data.tradeData.partnerPaymentExtraId = data.response.partnerPaymentExtraId;
+                const selectedQuote = selectTradingExchangeSelectedQuote(getState());
+
+                if (selectedQuote?.orderId === data.tradeData.orderId) {
+                    dispatch(tradingExchangeActions.saveSelectedQuote(data.tradeData));
                 }
 
                 dispatch(
@@ -143,6 +185,7 @@ export const watchTradeThunk = createThunk<void, WatchTradeThunk, { state: Watch
 
                 return;
             }
+
             /* istanbul ignore next */
             default:
                 return exhaustive(tradeType);

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -23,7 +23,7 @@
         "@trezor/network-stellar": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:^",
-        "@types/invity-api": "^1.1.19",
+        "@types/invity-api": "^1.1.20",
         "react": "19.2.3"
     }
 }

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -105,6 +105,6 @@
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
         "@trezor/requirements": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-analytics/package.json
+++ b/suite-native/trading-analytics/package.json
@@ -25,6 +25,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -46,6 +46,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-browser-auth/package.json
+++ b/suite-native/trading-browser-auth/package.json
@@ -45,6 +45,6 @@
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-fixtures/package.json
+++ b/suite-native/trading-fixtures/package.json
@@ -25,6 +25,6 @@
     },
     "devDependencies": {
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-history/package.json
+++ b/suite-native/trading-history/package.json
@@ -64,6 +64,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-provider-utils/package.json
+++ b/suite-native/trading-provider-utils/package.json
@@ -34,6 +34,6 @@
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-quote-utils/package.json
+++ b/suite-native/trading-quote-utils/package.json
@@ -28,6 +28,6 @@
     "devDependencies": {
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-slippage/package.json
+++ b/suite-native/trading-slippage/package.json
@@ -38,6 +38,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -44,6 +44,6 @@
     "devDependencies": {
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite-native/trading-types/package.json
+++ b/suite-native/trading-types/package.json
@@ -20,6 +20,6 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -68,7 +68,7 @@
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "@types/invity-api": "^1.1.19",
+        "@types/invity-api": "^1.1.20",
         "@types/lodash": "^4.17.16",
         "@walletconnect/sign-client": "^2.23.10",
         "@walletconnect/types": "^2.23.10",

--- a/suite/trading/package.json
+++ b/suite/trading/package.json
@@ -30,6 +30,6 @@
         "styled-components": "^6.3.9"
     },
     "devDependencies": {
-        "@types/invity-api": "^1.1.19"
+        "@types/invity-api": "^1.1.20"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10981,7 +10981,7 @@ __metadata:
   resolution: "@suite-common/flags@workspace:suite-common/flags"
   dependencies:
     "@trezor/env-utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
   languageName: unknown
   linkType: soft
 
@@ -11570,7 +11570,7 @@ __metadata:
     "@trezor/react-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
     react-intl: "npm:^8.1.3"
     react-redux: "npm:9.3.0"
@@ -11740,7 +11740,7 @@ __metadata:
     "@trezor/network-stellar": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:^"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
   languageName: unknown
   linkType: soft
@@ -14043,7 +14043,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
     react-native: "npm:0.86.0"
     react-native-gesture-handler: "npm:~2.32.0"
@@ -14625,7 +14625,7 @@ __metadata:
     "@suite-native/test-utils-store": "workspace:*"
     "@suite-native/trading-atoms": "workspace:*"
     "@suite-native/trading-fixtures": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
     react-redux: "npm:9.3.0"
   languageName: unknown
@@ -14660,7 +14660,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
     react-native: "npm:0.86.0"
     react-native-gesture-handler: "npm:~2.32.0"
@@ -14696,7 +14696,7 @@ __metadata:
     "@suite-native/transaction-management": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     expo-linking: "npm:~57.0.3"
     expo-web-browser: "npm:~57.0.1"
     react: "npm:19.2.3"
@@ -14752,7 +14752,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
   languageName: unknown
   linkType: soft
 
@@ -14800,7 +14800,7 @@ __metadata:
     "@trezor/styles-native": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     expo-file-system: "npm:~57.0.1"
     expo-sharing: "npm:~57.0.6"
     react: "npm:19.2.3"
@@ -14830,7 +14830,7 @@ __metadata:
     "@trezor/styles-native": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
     react-native: "npm:0.86.0"
     react-native-reanimated: "npm:4.5.0"
@@ -14851,7 +14851,7 @@ __metadata:
     "@suite-native/trading-fixtures": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
     react-native: "npm:0.86.0"
     react-redux: "npm:9.3.0"
@@ -14915,7 +14915,7 @@ __metadata:
     "@trezor/styles-native": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
     react-native: "npm:0.86.0"
     react-redux: "npm:9.3.0"
@@ -14952,7 +14952,7 @@ __metadata:
     "@trezor/device-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react-native: "npm:0.86.0"
   languageName: unknown
   linkType: soft
@@ -14969,7 +14969,7 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
   languageName: unknown
   linkType: soft
 
@@ -16027,7 +16027,7 @@ __metadata:
     "@trezor/icons": "workspace:*"
     "@trezor/product-components": "workspace:*"
     "@trezor/theme": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     react: "npm:19.2.3"
     styled-components: "npm:^6.3.9"
   languageName: unknown
@@ -17905,7 +17905,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     "@types/lodash": "npm:^4.17.16"
     "@walletconnect/sign-client": "npm:^2.23.10"
     "@walletconnect/types": "npm:^2.23.10"
@@ -18120,7 +18120,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.19"
+    "@types/invity-api": "npm:^1.1.20"
     "@types/pako": "npm:^2.0.4"
     "@types/pdfmake": "npm:^0.3.1"
     "@types/react": "npm:19.2.14"
@@ -18919,10 +18919,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.19":
-  version: 1.1.19
-  resolution: "@types/invity-api@npm:1.1.19"
-  checksum: 10/45fee2e4e68537a544ee34800f7a1c5c799154b59748504014b3fcbae469d9954d4971e7dd265eb39f7cc0a7ac543cc0f8a94b5377b04e45d1cf4285159e17a1
+"@types/invity-api@npm:^1.1.20":
+  version: 1.1.20
+  resolution: "@types/invity-api@npm:1.1.20"
+  checksum: 10/b8855417eda97f5a821355927527a52ce33d9df8b692d20ddece2db85e3d91b9e8f77c178515db8da202ff158dc4d24d3c3e114fe02dd87a5356664ba127c5e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- `watchTradeThunk` should watch for all changes, not only `status` ones.
- bumped invity-api dep to 1.1.20

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #30368

## Screenshots: 

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/30368-trading-merge-provider-quote-updates-from-watchtrade-response/web/](https://dev.suite.sldev.cz/suite-web/30368-trading-merge-provider-quote-updates-from-watchtrade-response/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=30368-trading-merge-provider-quote-updates-from-watchtrade-response&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=30368-trading-merge-provider-quote-updates-from-watchtrade-response&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=30368-trading-merge-provider-quote-updates-from-watchtrade-response&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T07:04:52.557Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T07:05:20.167Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->