### PR TITLE
fix(suite-native): resolve Ethereum network module in Metro

### DIFF
--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -71,6 +71,7 @@ const config = {
                 '@evolu/common/local-first': `${rootNodeModulesPath}/@evolu/common/dist/src/local-first/index.js`,
                 '@evolu/common/polyfills': `${rootNodeModulesPath}/@evolu/common/dist/src/Polyfills.js`,
                 '@evolu/react-native/polyfills': `${rootNodeModulesPath}/@evolu/react-native/dist/src/Polyfills.js`,
+                '@trezor/network-ethereum-suite-common/network-module': `${rootNodeModulesPath}/@trezor/network-ethereum-suite-common/src/EthereumNetworkSuiteCommonNetworkModule.ts`,
                 '@solana/kit/program-client-core': `${rootNodeModulesPath}/@solana/kit/dist/program-client-core.native.mjs`,
                 'crc/calculators/crc32': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc32.js`,
                 'crc/calculators/crc16xmodem': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc16xmodem.js`,


### PR DESCRIPTION
## Description

- add the missing Metro resolver override for `@trezor/network-ethereum-suite-common/network-module`
- keep package exports disabled in Suite Native while resolving the new network module subpath to its source file
- fix the shared JavaScript bundle failure in Android and iOS EAS builds after `ad4b281542708cbfd0516f6abdf96f3d8241b303`

The EAS archive contains the target source file, so this is a Metro package-exports resolution issue rather than a `.easignore` issue.

## Notes for QA

No product behavior changes are expected. The fix was verified with successful local Expo exports for both Android and iOS using the develop configuration.

Additional checks:

- Prettier
- ESLint
- `git diff --check`

## Related Issue

Resolve N/A

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/fix-native-easignore&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->