### PR TITLE
feat(suite-native-31453): add Solana timeout counter to trade form

### DIFF
--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.test.tsx
@@ -1,5 +1,6 @@
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getTranslation } from '@suite-native/intl';
 
 import { ReviewOutputsContent, type ReviewOutputsContentProps } from './ReviewOutputsContent';
 import { renderWithTradingProvider } from '../../test-utils/tradingTestUtils';
@@ -52,6 +53,13 @@ describe('ReviewOutputsContent', () => {
         mockUseTradingOutputsReviewScreenControls.mockReturnValue({
             isTransactionAlreadySigned: false,
             confirmOnTrezorRef: { current: null },
+            showTimer: false,
+            secondsLeft: 0,
+            isPastDeadline: false,
+            isBroadcasting: false,
+            onRetry: jest.fn(),
+            isRetryDisabled: false,
+            handleSendTransaction: jest.fn(),
         });
     });
 
@@ -65,9 +73,40 @@ describe('ReviewOutputsContent', () => {
         mockUseTradingOutputsReviewScreenControls.mockReturnValue({
             isTransactionAlreadySigned: true,
             confirmOnTrezorRef: { current: null },
+            showTimer: false,
+            secondsLeft: 0,
+            isPastDeadline: false,
+            isBroadcasting: false,
+            onRetry: jest.fn(),
+            isRetryDisabled: false,
+            handleSendTransaction: jest.fn(),
         });
         const { getByTestId } = await renderReviewOutputsContent({});
 
         expect(getByTestId('@trading/outputs-review/footer')).toBeOnTheScreen();
+    });
+
+    it('should display the transaction validity timer', async () => {
+        mockUseTradingOutputsReviewScreenControls.mockReturnValue({
+            isTransactionAlreadySigned: true,
+            confirmOnTrezorRef: { current: null },
+            showTimer: true,
+            secondsLeft: 30,
+            isPastDeadline: false,
+            isBroadcasting: false,
+            onRetry: jest.fn(),
+            isRetryDisabled: false,
+            handleSendTransaction: jest.fn(),
+        });
+
+        const { getByText } = await renderReviewOutputsContent({});
+
+        expect(
+            getByText(
+                getTranslation('transactionManagement.txValidityTimer.countdown', {
+                    seconds: 30,
+                }),
+            ),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.tsx
@@ -5,6 +5,7 @@ import { Box, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorWrapper } from '@suite-native/confirm-on-trezor';
 import { Translation } from '@suite-native/intl';
 import { type ExchangeFlowType, ScreenHeader } from '@suite-native/navigation';
+import { TxValidityTimer } from '@suite-native/transaction-management';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { ReviewOutputsBody } from './ReviewOutputsBody';
@@ -21,10 +22,7 @@ const spacerStyle = prepareNativeStyle(_ => ({
 }));
 
 export type ReviewOutputsContentProps = UseTradingOutputsReviewScreenControlsProps &
-    Pick<
-        UseTradingTransactionReturnProps,
-        'isTransactionSendConsentRequested' | 'resolveTransactionSendConsent'
-    > & {
+    Pick<UseTradingTransactionReturnProps, 'isTransactionSendConsentRequested'> & {
         accountKey: AccountKey;
         tokenContract?: TokenAddress;
         orderId: string;
@@ -52,13 +50,24 @@ export const ReviewOutputsContent = memo(
         exchangeFlowType,
     }: ReviewOutputsContentProps) => {
         const { applyStyle } = useNativeStyles();
-        const { isTransactionAlreadySigned, confirmOnTrezorRef } =
-            useTradingOutputsReviewScreenControls({
-                orderId,
-                accountKey,
-                signAndSendTransaction,
-                reportToAnalytics,
-            });
+        const {
+            isTransactionAlreadySigned,
+            confirmOnTrezorRef,
+            showTimer,
+            secondsLeft,
+            isPastDeadline,
+            isBroadcasting,
+            onRetry,
+            isRetryDisabled,
+            handleSendTransaction,
+        } = useTradingOutputsReviewScreenControls({
+            orderId,
+            accountKey,
+            exchangeFlowType,
+            signAndSendTransaction,
+            resolveTransactionSendConsent,
+            reportToAnalytics,
+        });
         const shouldDisplayReviewList = useDelayedReviewOutputListDisplayFlag();
 
         return (
@@ -78,17 +87,30 @@ export const ReviewOutputsContent = memo(
                     justifyContent="space-between"
                     testID="@trading/outputs-review"
                 >
-                    <ReviewOutputsBody
-                        accountKey={accountKey}
-                        tokenContract={tokenContract}
-                        exchangeFlowType={exchangeFlowType}
-                        shouldDisplayReviewList={shouldDisplayReviewList}
-                        tradingType={tradingType}
-                    />
+                    <VStack spacing="sp16">
+                        {showTimer && (
+                            <TxValidityTimer
+                                secondsLeft={secondsLeft}
+                                isPastDeadline={isPastDeadline}
+                                isBroadcasting={isBroadcasting}
+                                onRetry={onRetry}
+                                isRetryDisabled={isRetryDisabled}
+                            />
+                        )}
+                        <ReviewOutputsBody
+                            accountKey={accountKey}
+                            tokenContract={tokenContract}
+                            exchangeFlowType={exchangeFlowType}
+                            shouldDisplayReviewList={shouldDisplayReviewList}
+                            tradingType={tradingType}
+                        />
+                    </VStack>
                     {isTransactionAlreadySigned ? (
                         <ReviewOutputsFooter
                             isConsentRequested={isTransactionSendConsentRequested}
-                            resolveConsent={resolveTransactionSendConsent}
+                            isPastDeadline={isPastDeadline}
+                            isSendInProgress={isBroadcasting}
+                            onSend={handleSendTransaction}
                             testID="@trading/outputs-review/footer"
                         />
                     ) : (

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.test.tsx
@@ -15,8 +15,10 @@ describe('ReviewOutputsFooter', () => {
     ) =>
         await renderWithTradingProvider(
             <ReviewOutputsFooter
-                resolveConsent={jest.fn()}
+                onSend={jest.fn()}
                 isConsentRequested={true}
+                isPastDeadline={false}
+                isSendInProgress={false}
                 testID="TEST_ID"
                 {...props}
             />,
@@ -40,23 +42,24 @@ describe('ReviewOutputsFooter', () => {
         ).toBeDisabled();
     });
 
-    it('should resolveConsent on press', async () => {
-        const resolveConsent = jest.fn();
-        const { getByTestId } = await renderReviewOutputsFooter({ resolveConsent });
+    it('should be disabled when the transaction validity deadline has passed', async () => {
+        const { getByTestId } = await renderReviewOutputsFooter({ isPastDeadline: true });
 
-        await userEvent.press(getByTestId('TEST_ID/submit-button'));
-
-        expect(resolveConsent).toHaveBeenCalledWith(true);
-        expect(getByTestId('TEST_ID/submit-button/loading')).toBeOnTheScreen();
+        expect(getByTestId('TEST_ID/submit-button')).toBeDisabled();
     });
 
-    it('should resolveConsent only once', async () => {
-        const resolveConsent = jest.fn();
-        const { getByTestId } = await renderReviewOutputsFooter({ resolveConsent });
+    it('should call onSend on press', async () => {
+        const onSend = jest.fn();
+        const { getByTestId } = await renderReviewOutputsFooter({ onSend });
 
         await userEvent.press(getByTestId('TEST_ID/submit-button'));
-        await userEvent.press(getByTestId('TEST_ID/submit-button'));
 
-        expect(resolveConsent).toHaveBeenCalledTimes(1);
+        expect(onSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('should display loading state while sending', async () => {
+        const { getByTestId } = await renderReviewOutputsFooter({ isSendInProgress: true });
+
+        expect(getByTestId('TEST_ID/submit-button/loading')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import Animated, { SlideInDown } from 'react-native-reanimated';
 
 import { Button } from '@suite-native/atoms';
@@ -6,23 +5,26 @@ import { Translation } from '@suite-native/intl';
 import { ScrollToEndOnMount } from '@suite-native/scrollview';
 
 export type ReviewOutputsFooterProps = {
-    resolveConsent: (approved: boolean) => void;
+    onSend: () => void;
     isConsentRequested: boolean;
+    isPastDeadline: boolean;
+    isSendInProgress: boolean;
     testID?: string;
 };
 
 export const ReviewOutputsFooter = ({
     isConsentRequested,
-    resolveConsent,
+    isPastDeadline,
+    isSendInProgress,
+    onSend,
     testID,
 }: ReviewOutputsFooterProps) => {
-    const [isSendInProgress, setSendInProgress] = useState(false);
-
     const handleSendTransaction = () => {
-        if (!isSendInProgress) {
-            setSendInProgress(true);
-            resolveConsent(true);
+        if (isSendInProgress || isPastDeadline) {
+            return;
         }
+
+        onSend();
     };
 
     const buttonTestID = testID ? `${testID}/submit-button` : undefined;
@@ -32,7 +34,7 @@ export const ReviewOutputsFooter = ({
             <ScrollToEndOnMount>
                 <Button
                     isLoading={isSendInProgress}
-                    isDisabled={!isConsentRequested}
+                    isDisabled={!isConsentRequested || isPastDeadline}
                     accessibilityRole="button"
                     testID={buttonTestID}
                     onPress={handleSendTransaction}

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.test.ts
@@ -1,9 +1,14 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
-import { initialWalletSettingsState, sendFormActions } from '@suite-common/wallet-core';
-import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import {
+    type SendState,
+    initialWalletSettingsState,
+    sendFormActions,
+} from '@suite-common/wallet-core';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { localeReducer } from '@suite-native/intl';
+import { type ExchangeFlowType } from '@suite-native/navigation';
 import {
     type TestStore,
     act,
@@ -11,26 +16,67 @@ import {
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
-import { getWalletState } from '@suite-native/trading-fixtures';
+import { createPrecomposedTxFinal, getWalletState } from '@suite-native/trading-fixtures';
 import { tradingSlice } from '@suite-native/trading-state';
 import { prepareSendFormReducer } from '@suite-native/transaction-management';
+import TrezorConnect from '@trezor/connect';
 
 import { useTradingOutputsReviewScreenControls } from './useTradingOutputsReviewScreenControls';
 import { type TradingExchangeSignAndSendTransactionProps } from '../exchange/useExchangeFlow';
+import { type TradingTransactionSignAndSendProps } from '../general/useTradingTransaction';
 
 const mockReportToAnalytics = jest.fn();
+const mockResolveTransactionSendConsent = jest.fn();
 
-const mockSignAndSendTransaction = jest.fn(() => Promise.resolve(true));
+const mockSignAndSendTransaction = jest.fn<Promise<boolean>, [TradingTransactionSignAndSendProps]>(
+    () => Promise.resolve(true),
+);
 
 const mockUseConfirmOnTrezorController = {
     confirmOnTrezorRef: { current: null },
     closeSheet: jest.fn(),
+    revealConfirmOnTrezorSheet: jest.fn(),
 };
 
 const mockPopToTop = jest.fn();
 const mockPop = jest.fn();
 const mockUseOutputsReviewBackInterceptor = jest.fn();
 const mockShowAlert = jest.fn();
+type MockTxValidityTimerParams = {
+    networkType?: string;
+    createdTimestamp: number;
+    isBroadcasting: boolean;
+    onRetry: () => void | Promise<void>;
+};
+
+type MockTxValidityTimerResult = {
+    showTimer: boolean;
+    secondsLeft: number;
+    isPastDeadline: boolean;
+    isBroadcasting: boolean;
+    onRetry: () => void | Promise<void>;
+    isRetryDisabled: boolean;
+};
+
+const mockUseTxValidityTimer = jest.fn(
+    (_params: MockTxValidityTimerParams): MockTxValidityTimerResult => ({
+        showTimer: false,
+        secondsLeft: 0,
+        isPastDeadline: false,
+        isBroadcasting: false,
+        onRetry: jest.fn(),
+        isRetryDisabled: false,
+    }),
+);
+let mockIsPastDeadline = false;
+
+jest.mock('@trezor/connect', () => ({
+    __esModule: true,
+    ...jest.requireActual('@trezor/connect'),
+    default: {
+        cancel: jest.fn(),
+    },
+}));
 
 jest.mock('@suite-native/confirm-on-trezor', () => ({
     ...jest.requireActual('@suite-native/confirm-on-trezor'),
@@ -49,6 +95,7 @@ jest.mock('@suite-native/transaction-management', () => ({
     ...jest.requireActual('@suite-native/transaction-management'),
     useOutputsReviewBackInterceptor: (onReviewCanceled: () => void) =>
         mockUseOutputsReviewBackInterceptor(onReviewCanceled),
+    useTxValidityTimer: (params: MockTxValidityTimerParams) => mockUseTxValidityTimer(params),
 }));
 
 jest.mock('@suite-native/alerts', () => ({
@@ -59,6 +106,7 @@ jest.mock('@suite-native/alerts', () => ({
 
 describe('useTradingOutputsReviewScreenControls', () => {
     let store: TestStore;
+    const mockTrezorConnectCancel = TrezorConnect.cancel as jest.Mock;
 
     const reducer = {
         locale: localeReducer,
@@ -75,25 +123,41 @@ describe('useTradingOutputsReviewScreenControls', () => {
         }),
     } as const;
 
-    const createTestStore = (tradeType: 'exchange' | 'sell' = 'exchange') => {
+    const createTestStore = (
+        tradeType: 'exchange' | 'sell' = 'exchange',
+        sendOverrides: Partial<SendState> = {},
+    ) => {
         const { settings, accounts, send, trading } = getWalletState({ tradeType });
 
         return createLightStore({
             reducer,
             preloadedState: {
-                wallet: { settings, accounts, send, trading },
+                wallet: { settings, accounts, send: { ...send, ...sendOverrides }, trading },
             },
         });
     };
 
-    const renderUseTradingOutputsReviewScreenControls = async () =>
-        await renderHookWithStoreProvider(
+    const renderUseTradingOutputsReviewScreenControls = ({
+        accountKey,
+        exchangeFlowType = 'swap',
+    }: {
+        accountKey?: AccountKey;
+        exchangeFlowType?: ExchangeFlowType;
+    } = {}) =>
+        renderHookWithStoreProvider(
             () =>
                 useTradingOutputsReviewScreenControls({
                     orderId: 'orderId',
-                    accountKey: mockAccountKey({ symbol: 'btc', descriptor: 'btc1normal' }),
+                    accountKey:
+                        accountKey ??
+                        store
+                            .getState()
+                            .wallet.accounts.find((account: Account) => account.symbol === 'btc')!
+                            .key,
                     signAndSendTransaction: mockSignAndSendTransaction,
+                    resolveTransactionSendConsent: mockResolveTransactionSendConsent,
                     reportToAnalytics: mockReportToAnalytics,
+                    exchangeFlowType,
                 }),
             {
                 store,
@@ -102,6 +166,23 @@ describe('useTradingOutputsReviewScreenControls', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockIsPastDeadline = false;
+        mockSignAndSendTransaction.mockResolvedValue(true);
+        mockUseTxValidityTimer.mockImplementation(
+            ({
+                networkType,
+                createdTimestamp,
+                isBroadcasting,
+                onRetry,
+            }: MockTxValidityTimerParams) => ({
+                showTimer: networkType === 'solana' && createdTimestamp > 0,
+                secondsLeft: 30,
+                isPastDeadline: mockIsPastDeadline,
+                isBroadcasting,
+                onRetry,
+                isRetryDisabled: false,
+            }),
+        );
         store = createTestStore();
     });
 
@@ -284,6 +365,94 @@ describe('useTradingOutputsReviewScreenControls', () => {
             await renderUseTradingOutputsReviewScreenControls();
 
             expect(mockUseConfirmOnTrezorController.closeSheet).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Solana transaction validity', () => {
+        const createSolanaReviewStore = (isSigned = true) => {
+            const serializedTx = isSigned
+                ? { symbol: 'sol' as const, tx: 'signed-solana-tx' }
+                : undefined;
+
+            store = createTestStore('exchange', {
+                precomposedTx: createPrecomposedTxFinal({
+                    createdTimestamp: Date.now() + 1_000,
+                }),
+                serializedTx,
+            });
+
+            return store
+                .getState()
+                .wallet.accounts.find((account: Account) => account.networkType === 'solana')!.key;
+        };
+
+        it('should configure the validity timer for a fresh Solana transaction', async () => {
+            const accountKey = createSolanaReviewStore();
+
+            const { result } = await renderUseTradingOutputsReviewScreenControls({ accountKey });
+
+            expect(mockUseTxValidityTimer).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    networkType: 'solana',
+                    createdTimestamp: expect.any(Number),
+                }),
+            );
+            expect(result.current.showTimer).toBe(true);
+        });
+
+        it('should ignore the transaction timestamp for a sign-data flow', async () => {
+            const accountKey = createSolanaReviewStore();
+
+            await renderUseTradingOutputsReviewScreenControls({
+                accountKey,
+                exchangeFlowType: 'sign-data',
+            });
+
+            expect(mockUseTxValidityTimer).toHaveBeenLastCalledWith(
+                expect.objectContaining({ createdTimestamp: 0 }),
+            );
+        });
+
+        it('should release the old consent and sign again on retry', async () => {
+            const accountKey = createSolanaReviewStore();
+            const { result } = await renderUseTradingOutputsReviewScreenControls({ accountKey });
+
+            await act(async () => {
+                await result.current.onRetry();
+            });
+
+            expect(mockResolveTransactionSendConsent).toHaveBeenCalledWith(false);
+            expect(mockTrezorConnectCancel).toHaveBeenCalledWith('tx-timeout');
+            expect(
+                mockUseConfirmOnTrezorController.revealConfirmOnTrezorSheet,
+            ).toHaveBeenCalledTimes(1);
+            expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(1);
+            expect(store.getState().wallet.send.serializedTx).toBeUndefined();
+        });
+
+        it('should start broadcasting only for a valid transaction', async () => {
+            const accountKey = createSolanaReviewStore();
+            const { result } = await renderUseTradingOutputsReviewScreenControls({ accountKey });
+
+            await act(() => {
+                result.current.handleSendTransaction();
+            });
+
+            expect(mockResolveTransactionSendConsent).toHaveBeenCalledWith(true);
+            expect(result.current.isBroadcasting).toBe(true);
+        });
+
+        it('should not broadcast an expired transaction', async () => {
+            mockIsPastDeadline = true;
+            const accountKey = createSolanaReviewStore();
+            const { result } = await renderUseTradingOutputsReviewScreenControls({ accountKey });
+
+            await act(() => {
+                result.current.handleSendTransaction();
+            });
+
+            expect(mockResolveTransactionSendConsent).not.toHaveBeenCalledWith(true);
+            expect(result.current.isBroadcasting).toBe(false);
         });
     });
 

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.ts
@@ -1,11 +1,13 @@
-import { useCallback, useEffect, useEffectEvent, useRef } from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
 import { useDispatch } from '@suite-common/redux-utils';
+import { sendFormActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { useConfirmOnTrezorController } from '@suite-native/confirm-on-trezor';
+import { type ExchangeFlowType } from '@suite-native/navigation';
 import type {
     TradingExchangeAnalyticReportCallback,
     TradingSellAnalyticReportCallback,
@@ -16,34 +18,47 @@ import {
     selectIsTransactionAlreadySigned,
     useOutputsReviewBackInterceptor,
 } from '@suite-native/transaction-management';
+import TrezorConnect from '@trezor/connect';
 
 import { useTradingOutputsReviewErrorAlert } from './useTradingOutputsReviewErrorAlert';
-import type { TradingExchangeSignAndSendTransactionProps } from '../exchange/useExchangeFlow';
-import type { UseTradingTransactionReturnProps } from '../general/useTradingTransaction';
+import { useTradingTxValidityTimer } from './useTradingTxValidityTimer';
+import type {
+    TradingTransactionSignAndSendProps,
+    UseTradingTransactionReturnProps,
+} from '../general/useTradingTransaction';
 
 export type UseTradingOutputsReviewScreenControlsProps = Pick<
     UseTradingTransactionReturnProps,
-    'signAndSendTransaction'
+    'resolveTransactionSendConsent' | 'signAndSendTransaction'
 > & {
     orderId: string;
     accountKey: AccountKey;
+    exchangeFlowType?: ExchangeFlowType;
     reportToAnalytics: TradingExchangeAnalyticReportCallback | TradingSellAnalyticReportCallback;
 };
 
 export const useTradingOutputsReviewScreenControls = ({
     orderId,
     accountKey,
+    exchangeFlowType,
     signAndSendTransaction,
+    resolveTransactionSendConsent,
     reportToAnalytics,
 }: UseTradingOutputsReviewScreenControlsProps) => {
     const allowAlertRef = useRef(true);
     const signingExecutedRef = useRef(false);
+    const activeSigningAttemptIdRef = useRef(0);
+
+    const [isBroadcasting, setIsBroadcasting] = useState(false);
 
     const navigation = useNavigation<TradingOutputsReviewScreenNavigationProp>();
     const dispatch = useDispatch();
 
-    const { confirmOnTrezorRef, closeSheet } = useConfirmOnTrezorController();
+    const { confirmOnTrezorRef, closeSheet, revealConfirmOnTrezorSheet } =
+        useConfirmOnTrezorController();
     const showOutputsReviewErrorAlert = useTradingOutputsReviewErrorAlert(accountKey);
+
+    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
 
     const reportVisit = useEffectEvent(() => {
         reportToAnalytics('sign-and-send', 'visit');
@@ -52,54 +67,66 @@ export const useTradingOutputsReviewScreenControls = ({
         reportVisit();
     }, []);
 
-    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
-
     const onReviewCanceled = useCallback(() => {
+        activeSigningAttemptIdRef.current += 1;
+        resolveTransactionSendConsent(false);
+        TrezorConnect.cancel('tx-timeout');
         navigation.popToTop();
         reportToAnalytics('sign-and-send', 'cancel');
-    }, [navigation, reportToAnalytics]);
+    }, [navigation, reportToAnalytics, resolveTransactionSendConsent]);
     useOutputsReviewBackInterceptor(onReviewCanceled);
 
-    const nextStep: TradingExchangeSignAndSendTransactionProps['nextStep'] = useCallback(() => {
+    const nextStep: TradingTransactionSignAndSendProps['nextStep'] = useCallback(() => {
         navigation.popToTop();
         reportToAnalytics('sign-and-send', 'continue');
         dispatch(tradingActions.setTradeOrderIdToBeOpened(orderId));
     }, [dispatch, navigation, orderId, reportToAnalytics]);
 
-    const onError: TradingExchangeSignAndSendTransactionProps['onError'] = useCallback(
-        function handleSigningError(_error) {
-            if (allowAlertRef.current) {
-                showOutputsReviewErrorAlert(
-                    () => {
-                        reportToAnalytics('sign-and-send', 'retry');
-                        signAndSendTransaction({
-                            nextStep,
-                            onError: handleSigningError,
-                        });
-                    },
-                    () => {
-                        navigation.popToTop();
-                        reportToAnalytics('sign-and-send', 'cancel');
-                    },
-                );
-            }
-        },
-        [
-            signAndSendTransaction,
-            nextStep,
-            navigation,
-            reportToAnalytics,
-            showOutputsReviewErrorAlert,
-        ],
-    );
+    const startSigning = useCallback(() => {
+        signingExecutedRef.current = true;
+
+        const runSigningAttempt = () => {
+            const signingAttemptId = activeSigningAttemptIdRef.current + 1;
+            activeSigningAttemptIdRef.current = signingAttemptId;
+
+            const handleSigningError: TradingTransactionSignAndSendProps['onError'] = () => {
+                if (
+                    !allowAlertRef.current ||
+                    signingAttemptId !== activeSigningAttemptIdRef.current
+                ) {
+                    return;
+                }
+
+                setIsBroadcasting(false);
+                showOutputsReviewErrorAlert(() => {
+                    reportToAnalytics('sign-and-send', 'retry');
+                    runSigningAttempt();
+                }, onReviewCanceled);
+            };
+
+            return signAndSendTransaction({ nextStep, onError: handleSigningError });
+        };
+
+        return runSigningAttempt();
+    }, [
+        nextStep,
+        onReviewCanceled,
+        reportToAnalytics,
+        showOutputsReviewErrorAlert,
+        signAndSendTransaction,
+    ]);
+
+    const startInitialSigning = useEffectEvent(() => {
+        if (!signingExecutedRef.current && !isTransactionAlreadySigned) {
+            startSigning();
+        }
+    });
 
     useEffect(() => {
-        if (!signingExecutedRef.current && !isTransactionAlreadySigned) {
-            signingExecutedRef.current = true;
-            signAndSendTransaction({ nextStep, onError });
-        }
-    }, [nextStep, onError, signAndSendTransaction, isTransactionAlreadySigned]);
+        startInitialSigning();
+    }, []);
 
+    // TODO: We should handle the close by event callback from the signing process.
     useEffect(() => {
         if (isTransactionAlreadySigned) {
             closeSheet();
@@ -110,12 +137,50 @@ export const useTradingOutputsReviewScreenControls = ({
     useEffect(
         () => () => {
             allowAlertRef.current = false;
+            activeSigningAttemptIdRef.current += 1;
         },
         [],
     );
 
+    const handleRetry = useCallback(async () => {
+        activeSigningAttemptIdRef.current += 1;
+        resolveTransactionSendConsent(false);
+        TrezorConnect.cancel('tx-timeout');
+        dispatch(sendFormActions.clearSignedTransactionData());
+        setIsBroadcasting(false);
+        revealConfirmOnTrezorSheet();
+
+        await startSigning();
+    }, [dispatch, resolveTransactionSendConsent, revealConfirmOnTrezorSheet, startSigning]);
+
+    const { isPastDeadline, isRetryDisabled, onRetry, secondsLeft, showTimer } =
+        useTradingTxValidityTimer({
+            accountKey,
+            exchangeFlowType,
+            isBroadcasting,
+            isTransactionAlreadySigned,
+            onRetry: handleRetry,
+            onCancel: onReviewCanceled,
+        });
+
+    const handleSendTransaction = useCallback(() => {
+        if (isPastDeadline || isBroadcasting) {
+            return;
+        }
+
+        setIsBroadcasting(true);
+        resolveTransactionSendConsent(true);
+    }, [isBroadcasting, resolveTransactionSendConsent, isPastDeadline]);
+
     return {
         isTransactionAlreadySigned,
         confirmOnTrezorRef,
+        handleSendTransaction,
+        showTimer,
+        secondsLeft,
+        isPastDeadline,
+        isBroadcasting,
+        onRetry,
+        isRetryDisabled,
     };
 };

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingTxValidityTimer.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingTxValidityTimer.ts
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+    type AccountsRootState,
+    type SendRootState,
+    selectAccountByKey,
+    selectSendPrecomposedTx,
+} from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { type ExchangeFlowType } from '@suite-native/navigation';
+import { useTxValidityTimer } from '@suite-native/transaction-management';
+
+type UseTradingTxValidityTimerProps = {
+    accountKey: AccountKey;
+    exchangeFlowType?: ExchangeFlowType;
+    isBroadcasting: boolean;
+    isTransactionAlreadySigned: boolean;
+    onRetry: () => void | Promise<void>;
+    onCancel: () => void;
+};
+
+export const useTradingTxValidityTimer = ({
+    accountKey,
+    exchangeFlowType,
+    isBroadcasting,
+    isTransactionAlreadySigned,
+    onRetry,
+    onCancel,
+}: UseTradingTxValidityTimerProps) => {
+    const [reviewOpenedAt] = useState(() => Date.now());
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const precomposedTx = useSelector((state: SendRootState) => selectSendPrecomposedTx(state));
+
+    const precomposedTxTimestamp = precomposedTx?.createdTimestamp ?? 0;
+    const isPrecomposedTxFromCurrentReview = precomposedTxTimestamp >= reviewOpenedAt;
+    const isTxValidityTimerEnabled = exchangeFlowType !== 'sign-data';
+    const createdTimestamp =
+        isTxValidityTimerEnabled && isPrecomposedTxFromCurrentReview ? precomposedTxTimestamp : 0;
+
+    return useTxValidityTimer({
+        networkType: account?.networkType,
+        createdTimestamp,
+        isBroadcasting,
+        isTransactionAlreadySigned,
+        onRetry,
+        onCancel,
+    });
+};


### PR DESCRIPTION
## Description

- Add a transaction validity timer to the native trading review screen for Solana transactions.

## Notes for QA
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

- Focus on Solana trade review flows.
- Verify that expired transactions cannot be sent and that retry starts a fresh signing attempt.
- Non solana trades should work as before

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31453

## Screenshots:
<!--- Keep just title, empty for later add -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/31453-add-solana-timeout-counter-to-trade-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->