### PR TITLE
chore(suite-native): enable Metro package exports resolution

### DIFF
--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -14,6 +14,8 @@ const defaultSourceExts = [...jsonExpoConfig.resolver.sourceExts, 'md'];
 const additionalSourceExts = process.env.RN_SRC_EXT ? process.env.RN_SRC_EXT.split(',') : [];
 const sourceExts = [...additionalSourceExts, ...defaultSourceExts];
 
+const cjsOnlyPackages = ['@sinclair/typebox', 'kysely'];
+
 /**
  * Metro configuration
  * https://facebook.github.io/metro/docs/configuration
@@ -50,12 +52,21 @@ const config = {
                 originModulePath: context.originModulePath,
             });
 
-            if (moduleName === '@sinclair/typebox' || moduleName.startsWith('@sinclair/typebox/')) {
-                // TypeBox subpaths ('./value', './errors') resolve to the CJS build while the
-                // package root resolves to ESM, which puts two TypeBox instances in the bundle.
-                // Custom kinds registered in one instance's `TypeRegistry` are then invisible to
-                // the validator from the other one. Pin the whole package to the CJS build.
-                // See: https://github.com/expo/expo/issues/37171
+            // Packages whose ESM build Metro would pick via `exports`, but which we need to
+            // resolve to their CommonJS build instead:
+            // - `@sinclair/typebox`: subpaths ('./value', './errors') resolve to CJS while the
+            //   package root resolves to ESM, so two TypeBox instances end up in the bundle.
+            //   Custom kinds registered in one instance's `TypeRegistry` are then invisible to
+            //   the validator from the other one. See https://github.com/expo/expo/issues/37171
+            // - `kysely`: its ESM `FileMigrationProvider` calls `await import()` with a computed
+            //   specifier, which Hermes refuses to compile ('Invalid expression encountered').
+            //   The CJS build emits a plain `require()` there.
+            if (
+                cjsOnlyPackages.some(
+                    packageName =>
+                        moduleName === packageName || moduleName.startsWith(`${packageName}/`),
+                )
+            ) {
                 return context.resolveRequest(
                     { ...context, isESMImport: false },
                     moduleName,

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -30,7 +30,6 @@ const config = {
         }),
     },
     resolver: {
-        unstable_enablePackageExports: false,
         blockList: [/libDev/],
         extraNodeModules: {
             // modules needed for trezor-connect
@@ -51,49 +50,23 @@ const config = {
                 originModulePath: context.originModulePath,
             });
 
-            const rootNodeModulesPath = context.nodeModulesPaths[1];
+            if (moduleName === '@sinclair/typebox' || moduleName.startsWith('@sinclair/typebox/')) {
+                // TypeBox subpaths ('./value', './errors') resolve to the CJS build while the
+                // package root resolves to ESM, which puts two TypeBox instances in the bundle.
+                // Custom kinds registered in one instance's `TypeRegistry` are then invisible to
+                // the validator from the other one. Pin the whole package to the CJS build.
+                // See: https://github.com/expo/expo/issues/37171
+                return context.resolveRequest(
+                    { ...context, isESMImport: false },
+                    moduleName,
+                    platform,
+                );
+            }
+
             const getSourceFile = filePath => ({
                 filePath: require.resolve(filePath),
                 type: 'sourceFile',
             });
-
-            const overrides = {
-                // TODO: unstable_enablePackageExports: true
-                // See: https://github.com/trezor/trezor-suite/issues/20733
-                // modules exports defined in the package `exports` map.
-                '@bufbuild/protobuf/codegenv2': `${rootNodeModulesPath}/@bufbuild/protobuf/dist/cjs/codegenv2/index.js`,
-                '@bufbuild/protobuf/wire': `${rootNodeModulesPath}/@bufbuild/protobuf/dist/cjs/wire/index.js`,
-                '@bufbuild/protobuf/wkt': `${rootNodeModulesPath}/@bufbuild/protobuf/dist/cjs/wkt/index.js`,
-                '@evolu/react-native': `${rootNodeModulesPath}/@evolu/react-native/dist/src/index.js`,
-                '@evolu/react-native/expo-sqlite': `${rootNodeModulesPath}/@evolu/react-native/dist/src/exports/expo-sqlite.js`,
-                '@evolu/common': `${rootNodeModulesPath}/@evolu/common/dist/src/index.js`,
-                '@evolu/common/evolu': `${rootNodeModulesPath}/@evolu/common/dist/src/Evolu/Internal.js`,
-                '@evolu/common/local-first': `${rootNodeModulesPath}/@evolu/common/dist/src/local-first/index.js`,
-                '@evolu/common/polyfills': `${rootNodeModulesPath}/@evolu/common/dist/src/Polyfills.js`,
-                '@evolu/react-native/polyfills': `${rootNodeModulesPath}/@evolu/react-native/dist/src/Polyfills.js`,
-                '@trezor/network-ethereum-suite-common/network-module': `${rootNodeModulesPath}/@trezor/network-ethereum-suite-common/src/EthereumNetworkSuiteCommonNetworkModule.ts`,
-                '@solana/kit/program-client-core': `${rootNodeModulesPath}/@solana/kit/dist/program-client-core.native.mjs`,
-                'crc/calculators/crc32': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc32.js`,
-                'crc/calculators/crc16xmodem': `${rootNodeModulesPath}/crc/cjs-default-unwrap/calculators/crc16xmodem.js`,
-                'bignumber.js': `${rootNodeModulesPath}/bignumber.js/dist/bignumber.cjs`,
-                uuid: `${rootNodeModulesPath}/uuid/dist/index.js`,
-
-                // web3-validator package is by default trying to use non-existing minified index file. This fixes that.
-                // Can be removed once web3-validator fixup PR is merged: https://github.com/web3/web3.js/pull/7016.
-                'web3-validator': `${rootNodeModulesPath}/web3-validator/lib/commonjs/index.js`,
-            };
-
-            if (overrides[moduleName]) {
-                return getSourceFile(overrides[moduleName]);
-            }
-
-            // @trezor/network-* packages have exports paths defined in package.json
-            const networkModuleMatch = moduleName.match(/^@trezor\/network-([a-z]+)\/([^/]+)$/);
-            if (networkModuleMatch) {
-                const source = `${rootNodeModulesPath}/@trezor/network-${networkModuleMatch[1]}/src/${networkModuleMatch[2]}/index.ts`;
-
-                return getSourceFile(source);
-            }
 
             if (moduleName.startsWith('@emurgo/cardano')) {
                 // Cardano libs doesn't have main field in package.json which will cause error in metro


### PR DESCRIPTION
## Description

Metro has enabled `package.json` `exports` resolution by default since 0.82 (RN 0.79) and we are on Metro 0.84.4 / RN 0.86, so `unstable_enablePackageExports: false` was an explicit opt-out of the current default.

This drops it along with the 17 `resolveRequest` overrides and the `@trezor/network-*` regex that only existed to work around it (3 of those entries were already dead: `uuid` isn't in the native bundle, `web3-validator` isn't in `yarn.lock`, and `@evolu/common/evolu` no longer exists).

 Two packages have to be pinned to their CommonJS build instead: `@sinclair/typebox`, because its root resolves to ESM while `./errors` and `./value` resolve to CJS, which puts two TypeBox instances in the bundle and splits `TypeRegistry` so the custom kinds registered by `utxo-lib` and `schema-utils` (`Buffer`, `Uint`, `Hex`, `ArrayBuffer`, `Predicate`) become invisible to the validator (expo/expo#37171, same workaround as in `packages/connect-examples/mobile-expo/metro.config.js`); and `kysely`, whose ESM `FileMigrationProvider` calls `await import()` with a computed specifier that Hermes refuses to compile.


Tested on an-hoc builds
- ios: [build 374](https://expo.dev/accounts/trezorcompany-develop/projects/trezor-suite-preview/builds/041d29c7-41a8-49ed-8a4d-810dc32f494e)
- android: [build 423](https://expo.dev/accounts/trezorcompany-develop/projects/trezor-suite-preview/builds/f40d762c-26c0-4dc9-8713-34f374aa7a4a)


## Notes for QA

Only the React Native app's bundler resolution changes, no product code is touched, but the change is broad because many dependencies now resolve to a different build flavour (ESM instead of CJS) of the same library. So please smoke-test on a real device on both iOS and Android, signing a transaction or getting an address and suite-sync.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20733

## Screenshots:

N/A — no UI changes.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=enable-package-exports-metro&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->