### PR TITLE
fix(suite): send name lookups on the account's backend identity

### DIFF
--- a/networks/ethereum/network-ethereum-suite-common/src/namedAddress/ethereumNamedAddressResolver.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/namedAddress/ethereumNamedAddressResolver.ts
@@ -16,12 +16,12 @@ export const ethereumNamedAddressResolver: NamedAddressResolver<EthereumNetworkS
     isNameLike,
     isAddressLike,
 
-    resolveNamedAddress: async (value, symbol) =>
-        (await loadResolver()).resolveNamedAddress(value, symbol),
+    resolveNamedAddress: async (value, symbol, options) =>
+        (await loadResolver()).resolveNamedAddress(value, symbol, options),
 
-    reverseResolveAddress: async (address, symbol) =>
-        (await loadResolver()).reverseResolveAddressOnchain(address, symbol),
+    reverseResolveAddress: async (address, symbol, options) =>
+        (await loadResolver()).reverseResolveAddressOnchain(address, symbol, options),
 
-    resolveNamedProfile: async (value, symbol, textKeys) =>
-        (await loadResolver()).resolveNamedProfileOnchain(value, symbol, textKeys),
+    resolveNamedProfile: async (value, symbol, options) =>
+        (await loadResolver()).resolveNamedProfileOnchain(value, symbol, options),
 };

--- a/networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddress.test.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddress.test.ts
@@ -40,7 +40,18 @@ describe('resolveNamedAddress', () => {
         mockResolveViaBlockbook.mockResolvedValue(VITALIK_ADDRESS);
 
         await expect(resolveNamedAddress('vitalik.eth', 'eth')).resolves.toBe(VITALIK_ADDRESS);
-        expect(mockResolveViaBlockbook).toHaveBeenCalledWith('vitalik.eth', 'eth');
+        expect(mockResolveViaBlockbook).toHaveBeenCalledWith('vitalik.eth', 'eth', undefined);
+    });
+
+    it('carries the backend identity into both paths', async () => {
+        mockResolveOnchain.mockRejectedValue(new Error('Backend not connected'));
+        mockResolveViaBlockbook.mockResolvedValue(VITALIK_ADDRESS);
+
+        await resolveNamedAddress('vitalik.eth', 'eth', { identity: 'deviceState' });
+
+        const options = { identity: 'deviceState' };
+        expect(mockResolveOnchain).toHaveBeenCalledWith('vitalik.eth', 'eth', options);
+        expect(mockResolveViaBlockbook).toHaveBeenCalledWith('vitalik.eth', 'eth', options);
     });
 
     it('propagates the Blockbook failure when both paths fail', async () => {

--- a/networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddress.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddress.ts
@@ -1,4 +1,5 @@
 import type { EthereumNetworkSymbol } from '@trezor/network-ethereum/constants';
+import type { NamedAddressResolveOptions } from '@trezor/network-module-suite-common-types';
 
 import { resolveViaBlockbook } from './resolveNamedAddressBB';
 import { resolveNamedAddressOnchain } from './universalResolver';
@@ -10,11 +11,15 @@ import { resolveNamedAddressOnchain } from './universalResolver';
  * A `null` result is a definitive "no record" answer, so only a thrown error — an unreachable
  * or erroring backend — is worth retrying through Blockbook.
  */
-export const resolveNamedAddress = async (value: string, symbol: EthereumNetworkSymbol) => {
+export const resolveNamedAddress = async (
+    value: string,
+    symbol: EthereumNetworkSymbol,
+    options?: NamedAddressResolveOptions,
+) => {
     try {
-        return await resolveNamedAddressOnchain(value, symbol);
+        return await resolveNamedAddressOnchain(value, symbol, options);
     } catch {
-        return resolveViaBlockbook(value, symbol);
+        return resolveViaBlockbook(value, symbol, options);
     }
 };
 

--- a/networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddressBB.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddressBB.ts
@@ -1,5 +1,6 @@
 import TrezorConnect from '@trezor/connect';
 import type { EthereumNetworkSymbol } from '@trezor/network-ethereum/constants';
+import type { NamedAddressResolveOptions } from '@trezor/network-module-suite-common-types';
 
 /**
  * Forward-resolve a named input (ENS or other TLD) to its onchain address via Blockbook.
@@ -11,12 +12,18 @@ import type { EthereumNetworkSymbol } from '@trezor/network-ethereum/constants';
  *
  * @param value - ENS name or other TLD name.
  * @param symbol - Network symbol the name should be resolved on (e.g. `eth`).
+ * @param options - Carries the backend identity the lookup should ride on.
  * @returns The resolved onchain address.
  */
-export const resolveViaBlockbook = async (value: string, symbol: EthereumNetworkSymbol) => {
+export const resolveViaBlockbook = async (
+    value: string,
+    symbol: EthereumNetworkSymbol,
+    options?: NamedAddressResolveOptions,
+) => {
     const result = await TrezorConnect.getAccountInfo({
         descriptor: value,
         coin: symbol,
+        identity: options?.identity,
         details: 'basic',
     });
 

--- a/networks/ethereum/network-ethereum-suite-common/src/namedAddress/universalResolver.test.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/namedAddress/universalResolver.test.ts
@@ -154,7 +154,7 @@ describe('universalResolver', () => {
             succeedWith(MULTICALL_ADDRESS_AND_TEXT);
 
             await expect(
-                resolveNamedProfileOnchain('vitalik.eth', 'eth', ['description']),
+                resolveNamedProfileOnchain('vitalik.eth', 'eth', { textKeys: ['description'] }),
             ).resolves.toEqual({
                 address: VITALIK_ADDRESS,
                 texts: { description: DESCRIPTION },
@@ -166,7 +166,7 @@ describe('universalResolver', () => {
             succeedWith(MULTICALL_EMPTY_TEXT);
 
             await expect(
-                resolveNamedProfileOnchain('vitalik.eth', 'eth', ['description']),
+                resolveNamedProfileOnchain('vitalik.eth', 'eth', { textKeys: ['description'] }),
             ).resolves.toEqual({ address: VITALIK_ADDRESS, texts: {} });
         });
 
@@ -200,6 +200,16 @@ describe('universalResolver', () => {
                     coin: 'tsep',
                     to: '0xeeeeeeee14d718c2b47d9923deab1335e144eeee',
                 }),
+            );
+        });
+
+        it('sends the lookup on the given backend identity', async () => {
+            succeedWith(MULTICALL_ADDRESS_ONLY);
+
+            await resolveNamedAddressOnchain('vitalik.eth', 'eth', { identity: 'deviceState' });
+
+            expect(mockBlockchainEvmRpcCall).toHaveBeenCalledWith(
+                expect.objectContaining({ identity: 'deviceState' }),
             );
         });
 
@@ -350,6 +360,16 @@ describe('universalResolver', () => {
 
             await expect(reverseResolveAddressOnchain(VITALIK_ADDRESS, 'eth')).resolves.toBe(
                 'nick.eth',
+            );
+        });
+
+        it('sends the lookup on the given backend identity', async () => {
+            succeedWith(REVERSE_SUCCESS);
+
+            await reverseResolveAddressOnchain(VITALIK_ADDRESS, 'eth', { identity: 'deviceState' });
+
+            expect(mockBlockchainEvmRpcCall).toHaveBeenCalledWith(
+                expect.objectContaining({ identity: 'deviceState' }),
             );
         });
 

--- a/networks/ethereum/network-ethereum-suite-common/src/namedAddress/universalResolver.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/namedAddress/universalResolver.ts
@@ -12,7 +12,10 @@ import { namehash, normalize, packetToBytes, toCoinType } from 'viem/ens';
 import { Calldata, EVM_ABI } from '@suite-common/calldata';
 import TrezorConnect from '@trezor/connect';
 import type { EthereumNetworkSymbol } from '@trezor/network-ethereum/constants';
-import type { NamedAddressProfile } from '@trezor/network-module-suite-common-types';
+import type {
+    NamedAddressProfile,
+    NamedAddressResolveOptions,
+} from '@trezor/network-module-suite-common-types';
 import { BigNumber } from '@trezor/utils';
 
 import { getNamedAddressChainId } from './namedAddressUtils';
@@ -147,7 +150,11 @@ const isRevertError = (error: unknown) => {
     return /revert/i.test(error instanceof Error ? error.message : String(error));
 };
 
-const callUniversalResolver = async (symbol: EthereumNetworkSymbol, data: Hex) => {
+const callUniversalResolver = async (
+    symbol: EthereumNetworkSymbol,
+    data: Hex,
+    identity?: string,
+) => {
     // The loser of the race has to be cleaned up: an uncleared timer keeps the event loop
     // busy for the full timeout after every single resolution.
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -156,6 +163,7 @@ const callUniversalResolver = async (symbol: EthereumNetworkSymbol, data: Hex) =
         const response = await Promise.race([
             TrezorConnect.blockchainEvmRpcCall({
                 coin: symbol,
+                identity,
                 from: ZERO_ADDRESS,
                 to: UNIVERSAL_RESOLVER_ADDRESS,
                 data,
@@ -183,6 +191,7 @@ const resolveProfileData = async (
     name: string,
     symbol: EthereumNetworkSymbol,
     profileData: Hex,
+    identity?: string,
 ) => {
     const response = await callUniversalResolver(
         symbol,
@@ -193,6 +202,7 @@ const resolveProfileData = async (
             }),
             'resolve',
         ),
+        identity,
     );
 
     const [result] = decodeFunctionResult({
@@ -225,6 +235,7 @@ const resolveProfileViaMulticall = async (
     node: Hex,
     symbol: EthereumNetworkSymbol,
     textKeys: readonly string[],
+    identity?: string,
 ): Promise<NamedAddressProfile> => {
     const profileCalls = [
         buildCalldata(Calldata.evm.ens.addr.encode({ node }), 'addr'),
@@ -235,6 +246,7 @@ const resolveProfileViaMulticall = async (
         name,
         symbol,
         buildCalldata(Calldata.evm.ens.multicall.encode({ data: profileCalls }), 'multicall'),
+        identity,
     );
 
     const [addressResult, ...textResults] = decodeFunctionResult({
@@ -265,12 +277,18 @@ const resolveProfileViaMulticall = async (
     return { address: addressResult ? decodeAddressResult(addressResult) : null, texts };
 };
 
-const resolveAddressOnly = async (name: string, node: Hex, symbol: EthereumNetworkSymbol) => {
+const resolveAddressOnly = async (
+    name: string,
+    node: Hex,
+    symbol: EthereumNetworkSymbol,
+    identity?: string,
+) => {
     try {
         const result = await resolveProfileData(
             name,
             symbol,
             buildCalldata(Calldata.evm.ens.addr.encode({ node }), 'addr'),
+            identity,
         );
 
         return decodeAddressResult(result);
@@ -291,7 +309,12 @@ const resolveAddressOnly = async (name: string, node: Hex, symbol: EthereumNetwo
 export const resolveNamedProfileOnchain = async (
     value: string,
     symbol: EthereumNetworkSymbol,
-    textKeys: readonly string[] = [],
+    {
+        textKeys = [],
+        identity,
+    }: NamedAddressResolveOptions & {
+        textKeys?: readonly string[];
+    } = {},
 ): Promise<NamedAddressProfile> => {
     // A name no conformant resolver could hold — `isNameLike` accepts shapes ENSIP-15
     // rejects, such as an empty label. Answering "no record" beats falling through to a backend
@@ -306,7 +329,7 @@ export const resolveNamedProfileOnchain = async (
     const node = namehash(name);
 
     try {
-        return await resolveProfileViaMulticall(name, node, symbol, textKeys);
+        return await resolveProfileViaMulticall(name, node, symbol, textKeys, identity);
     } catch (error) {
         if (isNameUnresolvable(error)) return EMPTY_PROFILE;
 
@@ -318,7 +341,7 @@ export const resolveNamedProfileOnchain = async (
 
         // `multicall` is optional for a resolver, and a malformed batch response decodes just as
         // badly as a missing one. Either way the address is still reachable on its own.
-        return { address: await resolveAddressOnly(name, node, symbol), texts: {} };
+        return { address: await resolveAddressOnly(name, node, symbol, identity), texts: {} };
     }
 };
 
@@ -327,8 +350,11 @@ export const resolveNamedProfileOnchain = async (
  *
  * @returns The resolved address, or `null` when the name has no address record.
  */
-export const resolveNamedAddressOnchain = async (value: string, symbol: EthereumNetworkSymbol) =>
-    (await resolveNamedProfileOnchain(value, symbol)).address;
+export const resolveNamedAddressOnchain = async (
+    value: string,
+    symbol: EthereumNetworkSymbol,
+    options?: NamedAddressResolveOptions,
+) => (await resolveNamedProfileOnchain(value, symbol, options)).address;
 
 /**
  * Reverse-resolve an address to its primary name.
@@ -338,6 +364,7 @@ export const resolveNamedAddressOnchain = async (value: string, symbol: Ethereum
 export const reverseResolveAddressOnchain = async (
     address: string,
     symbol: EthereumNetworkSymbol,
+    options?: NamedAddressResolveOptions,
 ) => {
     const data = buildCalldata(
         Calldata.evm.ens.reverse.encode({
@@ -352,7 +379,7 @@ export const reverseResolveAddressOnchain = async (
         const [primary] = decodeFunctionResult({
             abi: EVM_ABI.ens.reverse,
             functionName: 'reverse',
-            data: await callUniversalResolver(symbol, data),
+            data: await callUniversalResolver(symbol, data, options?.identity),
         });
 
         return primary || null;

--- a/networks/network-module/network-module-suite-common-types/src/NamedAddressResolver.ts
+++ b/networks/network-module/network-module-suite-common-types/src/NamedAddressResolver.ts
@@ -3,6 +3,16 @@ export type NamedAddressProfile = {
     texts: Record<string, string>;
 };
 
+/** Concerns of the request itself, as opposed to what is being resolved. */
+export type NamedAddressResolveOptions = {
+    /**
+     * Backend identity the lookup rides on. Suite opens one backend connection per identity, so
+     * passing the sending account's keeps a recipient lookup on that account's circuit rather
+     * than on the shared default one.
+     */
+    identity?: string;
+};
+
 /**
  * Resolution between human-readable names and onchain addresses (ENS and its equivalents).
  *
@@ -19,14 +29,22 @@ export type NamedAddressResolver<TSymbol extends string> = {
     isAddressLike(value: string): boolean;
 
     /** Resolves to `null` when the name exists but holds no address record. */
-    resolveNamedAddress(value: string, symbol: TSymbol): Promise<string | null>;
+    resolveNamedAddress(
+        value: string,
+        symbol: TSymbol,
+        options?: NamedAddressResolveOptions,
+    ): Promise<string | null>;
 
     /** Resolves to `null` when the address has no primary name. */
-    reverseResolveAddress(address: string, symbol: TSymbol): Promise<string | null>;
+    reverseResolveAddress(
+        address: string,
+        symbol: TSymbol,
+        options?: NamedAddressResolveOptions,
+    ): Promise<string | null>;
 
     resolveNamedProfile(
         value: string,
         symbol: TSymbol,
-        textKeys?: readonly string[],
+        options?: NamedAddressResolveOptions & { textKeys?: readonly string[] },
     ): Promise<NamedAddressProfile>;
 };

--- a/networks/network-module/network-module-suite-common-types/src/index.ts
+++ b/networks/network-module/network-module-suite-common-types/src/index.ts
@@ -1,6 +1,10 @@
 export { addressType } from './AddressValidator';
 export type { AddressType, AddressValidator } from './AddressValidator';
-export type { NamedAddressProfile, NamedAddressResolver } from './NamedAddressResolver';
+export type {
+    NamedAddressProfile,
+    NamedAddressResolveOptions,
+    NamedAddressResolver,
+} from './NamedAddressResolver';
 export { asProtocol } from './Protocol';
 export type { Protocol } from './Protocol';
 export type {

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -38,6 +38,7 @@ import {
     checkIsAddressNotUsedNotChecksummed,
     convertAmountSubunitsToUnits,
     isProgramDerivedAccount,
+    tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { Icon, IconButton, Input, Link, Row, Text } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
@@ -105,6 +106,9 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
             selectNetworkModuleRepositoryDep,
         );
     const { descriptor, networkType, symbol } = account;
+    // Every backend call below rides the sending account's connection, so a recipient lookup
+    // cannot be correlated across accounts through the shared default one.
+    const identity = tryGetAccountIdentity(account);
     const namedAddress = getNamedAddressSupport(networkModuleRepository, symbol);
     const inputName = `outputs.${outputId}.address` as const;
     // NOTE: compose errors are always associated with the amount.
@@ -137,7 +141,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         isResolving,
         resolvedAddress: resolvedNamedAddress,
         reverseResolvedName,
-    } = useResolveNamedAddress(address, symbol);
+    } = useResolveNamedAddress(address, symbol, identity);
     // Reverse resolution runs for every hex address typed; it is a bonus lookup, so it must not
     // announce itself or occupy the bottom text the way a name the user typed does.
     const isResolvingNamedAddress = namedAddressMode === 'forward' && isResolving;
@@ -452,6 +456,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                                   networkModuleRepository,
                                   value: checkedAddress,
                                   symbol,
+                                  identity,
                               }),
                           )
                           .catch(() => null)
@@ -464,6 +469,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 const result = await TrezorConnect.getAccountInfo({
                     descriptor: resolvedAddress ?? checkedAddress,
                     coin: asCoinSymbol(symbol),
+                    identity,
                 });
 
                 if (!result.success) {
@@ -520,6 +526,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     const result = await TrezorConnect.getAccountInfo({
                         descriptor: value,
                         coin: asCoinSymbol(symbol),
+                        identity,
                         details: 'basic',
                     });
 

--- a/suite-common/wallet-core/src/named-address/namedAddressQuery.test.ts
+++ b/suite-common/wallet-core/src/named-address/namedAddressQuery.test.ts
@@ -22,8 +22,8 @@ const networkModuleRepository = {
     get: () => ({ namedAddressResolver }),
 } as unknown as NetworkModuleRepository;
 
-const queryOptions = (value: string, symbol: NetworkSymbol | null) =>
-    getResolveNamedAddressQueryOptions({ networkModuleRepository, value, symbol });
+const queryOptions = (value: string, symbol: NetworkSymbol | null, identity?: string) =>
+    getResolveNamedAddressQueryOptions({ networkModuleRepository, value, symbol, identity });
 
 const RESOLVED_HEX = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
 
@@ -58,6 +58,14 @@ describe('getResolveNamedAddressQueryOptions', () => {
         it('keys each value separately', () => {
             expect(queryOptions('vitalik.eth', 'eth').queryKey).not.toEqual(
                 queryOptions('nick.eth', 'eth').queryKey,
+            );
+        });
+
+        // The answer is public and identical whoever asks, so accounts share one entry instead
+        // of each paying for the same lookup.
+        it('keys the same value alike across backend identities', () => {
+            expect(queryOptions('vitalik.eth', 'eth', 'deviceA').queryKey).toEqual(
+                queryOptions('vitalik.eth', 'eth', 'deviceB').queryKey,
             );
         });
 
@@ -96,7 +104,9 @@ describe('getResolveNamedAddressQueryOptions', () => {
 
             await queryClient.ensureQueryData(queryOptions('  vitalik.eth  ', 'eth'));
 
-            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'eth');
+            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'eth', {
+                identity: undefined,
+            });
         });
 
         it('refetches once the entry is invalidated', async () => {
@@ -135,8 +145,22 @@ describe('getResolveNamedAddressQueryOptions', () => {
 
             await queryClient.ensureQueryData(queryOptions(RESOLVED_HEX, 'eth'));
 
-            expect(mockReverseResolveAddress).toHaveBeenCalledWith(RESOLVED_HEX, 'eth');
+            expect(mockReverseResolveAddress).toHaveBeenCalledWith(RESOLVED_HEX, 'eth', {
+                identity: undefined,
+            });
             expect(mockResolveNamedAddress).not.toHaveBeenCalled();
+        });
+
+        it('hands the backend identity to both modes', async () => {
+            mockResolveNamedAddress.mockResolvedValue(RESOLVED_HEX);
+            mockReverseResolveAddress.mockResolvedValue('vitalik.eth');
+
+            await queryClient.ensureQueryData(queryOptions('vitalik.eth', 'eth', 'deviceState'));
+            await queryClient.ensureQueryData(queryOptions(RESOLVED_HEX, 'eth', 'deviceState'));
+
+            const options = { identity: 'deviceState' };
+            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'eth', options);
+            expect(mockReverseResolveAddress).toHaveBeenCalledWith(RESOLVED_HEX, 'eth', options);
         });
 
         it('rejects rather than resolving an unsupported symbol', async () => {

--- a/suite-common/wallet-core/src/named-address/namedAddressQuery.ts
+++ b/suite-common/wallet-core/src/named-address/namedAddressQuery.ts
@@ -32,6 +32,8 @@ export const getResolveMode = (
 export type ResolveNamedAddressQueryParams = NetworkModuleRepositoryDep & {
     value: string;
     symbol: NetworkSymbol | null | undefined;
+    /** Backend identity the lookup rides on; see `getAccountIdentity`. */
+    identity?: string;
 };
 
 /**
@@ -46,11 +48,12 @@ export const getResolveNamedAddressQueryOptions = ({
     networkModuleRepository,
     value,
     symbol,
+    identity,
 }: ResolveNamedAddressQueryParams) => {
     const trimmedValue = value.trim();
     const { resolver } = getNamedAddressSupport(networkModuleRepository, symbol);
 
-    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is symbol + value; the resolver is the network module those two select, and a live object never belongs in a key
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is symbol + value; the resolver is the network module those two select, and a live object never belongs in a key. The backend identity picks the connection, not the answer, so accounts share one entry rather than each paying for the same lookup
     return {
         queryKey: commonQueryKeys.resolveNamedAddress(symbol ?? 'unknown', trimmedValue),
         queryFn: () => {
@@ -63,8 +66,8 @@ export const getResolveNamedAddressQueryOptions = ({
             }
 
             return mode === 'forward'
-                ? resolver.resolveNamedAddress(trimmedValue, symbol)
-                : resolver.reverseResolveAddress(trimmedValue, symbol);
+                ? resolver.resolveNamedAddress(trimmedValue, symbol, { identity })
+                : resolver.reverseResolveAddress(trimmedValue, symbol, { identity });
         },
         staleTime: STALE_TIME_MS,
         gcTime: GC_TIME_MS,

--- a/suite-common/wallet-core/src/named-address/useResolveNamedAddress.test.tsx
+++ b/suite-common/wallet-core/src/named-address/useResolveNamedAddress.test.tsx
@@ -33,8 +33,8 @@ const networkModuleRepository = {
     get: () => ({ namedAddressResolver }),
 } as unknown as NetworkModuleRepository;
 
-const renderResolveHook = (value: string, symbol: NetworkSymbol | null) =>
-    renderHookWithQueryClient(() => useResolveNamedAddress(value, symbol), {
+const renderResolveHook = (value: string, symbol: NetworkSymbol | null, identity?: string) =>
+    renderHookWithQueryClient(() => useResolveNamedAddress(value, symbol, identity), {
         wrapper: ({ children }: { children: ReactNode }) => (
             <ServicesProvider services={{ networkModuleRepository }}>{children}</ServicesProvider>
         ),
@@ -99,7 +99,9 @@ describe('useResolveNamedAddress', () => {
             expect(result.current.resolvedAddress).toBe(RESOLVED_HEX);
             expect(result.current.reverseResolvedName).toBeUndefined();
             expect(result.current.isResolveError).toBe(false);
-            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'eth');
+            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'eth', {
+                identity: undefined,
+            });
         });
 
         it('resolves a named input on tsep', async () => {
@@ -109,7 +111,20 @@ describe('useResolveNamedAddress', () => {
 
             await waitFor(() => expect(result.current.isSuccess).toBe(true));
             expect(result.current.resolvedAddress).toBe(RESOLVED_HEX);
-            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'tsep');
+            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'tsep', {
+                identity: undefined,
+            });
+        });
+
+        it('resolves on the given backend identity', async () => {
+            mockResolveNamedAddress.mockResolvedValue(RESOLVED_HEX);
+
+            const { result } = renderResolveHook('vitalik.eth', 'eth', 'deviceState');
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'eth', {
+                identity: 'deviceState',
+            });
         });
 
         it('trims whitespace before resolving', async () => {
@@ -118,7 +133,9 @@ describe('useResolveNamedAddress', () => {
             const { result } = renderResolveHook('  vitalik.eth  ', 'eth');
 
             await waitFor(() => expect(result.current.isSuccess).toBe(true));
-            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'eth');
+            expect(mockResolveNamedAddress).toHaveBeenCalledWith('vitalik.eth', 'eth', {
+                identity: undefined,
+            });
         });
     });
 
@@ -134,7 +151,9 @@ describe('useResolveNamedAddress', () => {
 
             expect(result.current.reverseResolvedName).toBe('vitalik.eth');
             expect(result.current.resolvedAddress).toBeUndefined();
-            expect(mockReverseResolveAddress).toHaveBeenCalledWith(RESOLVED_HEX, 'eth');
+            expect(mockReverseResolveAddress).toHaveBeenCalledWith(RESOLVED_HEX, 'eth', {
+                identity: undefined,
+            });
             expect(mockResolveNamedAddress).not.toHaveBeenCalled();
         });
 

--- a/suite-common/wallet-core/src/named-address/useResolveNamedAddress.ts
+++ b/suite-common/wallet-core/src/named-address/useResolveNamedAddress.ts
@@ -6,7 +6,11 @@ import { useDebouncedValue } from '@trezor/react-utils';
 import { getResolveMode, getResolveNamedAddressQueryOptions } from './namedAddressQuery';
 import { getNamedAddressSupport } from './namedAddressResolver';
 
-export const useResolveNamedAddress = (value: string, symbol: NetworkSymbol | null | undefined) => {
+export const useResolveNamedAddress = (
+    value: string,
+    symbol: NetworkSymbol | null | undefined,
+    identity?: string,
+) => {
     const { networkModuleRepository } = useServices(selectNetworkModuleRepositoryDep);
     // Normalize at the entry so the queryKey, debounce comparison and queryable check
     // all agree on a single canonical form — "test.eth" and "test.eth " must share cache.
@@ -25,6 +29,7 @@ export const useResolveNamedAddress = (value: string, symbol: NetworkSymbol | nu
             networkModuleRepository,
             value: debouncedValue,
             symbol,
+            identity,
         }),
         // `enabled` guarantees a supported symbol whenever the query runs.
         enabled: !isDebouncing && debouncedMode !== 'idle',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Original ENS branch seemed to miss parts to make it work with Tor proxying. This PR ensures proxied ENS resolution

## Notes for QA

1) Enable Tor in a desktop app with blockbook backend.
2) Try forward and reverse resolution

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="883" height="932" alt="Screenshot 2026-09-01 at 11 47 11" src="https://github.com/user-attachments/assets/723bde25-d19d-48a9-af31-9b3c6e2a38fa" />
<img width="881" height="926" alt="Screenshot 2026-09-01 at 11 47 03" src="https://github.com/user-attachments/assets/867d89f4-7e6d-4d2a-923c-7f1a494a9db1" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/53gur0/ens-identity/web/](https://dev.suite.sldev.cz/suite-web/53gur0/ens-identity/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=53gur0/ens-identity&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=53gur0/ens-identity&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=53gur0/ens-identity&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T09:33:25.554Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T09:33:01.484Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set refactors Ethereum named-address (ENS) resolution and wires it into the shared send Address component. Only one existing E2E test directly exercises an EVM send address input; run it as the primary regression guard and add the global receive/send test as a lightweight integration sanity check. The underlying resolver logic is covered by accompanying unit tests, but no E2E currently performs an actual ENS lookup.

<details><summary><b>Changed files (13)</b></summary>

- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/ethereumNamedAddressResolver.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddress.test.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddress.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddressBB.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/universalResolver.test.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/universalResolver.ts`
- `networks/network-module/network-module-suite-common-types/src/NamedAddressResolver.ts`
- `networks/network-module/network-module-suite-common-types/src/index.ts`
- `packages/suite/src/views/wallet/send/Outputs/Address.tsx`
- `suite-common/wallet-core/src/named-address/namedAddressQuery.test.ts`
- `suite-common/wallet-core/src/named-address/namedAddressQuery.ts`
- `suite-common/wallet-core/src/named-address/useResolveNamedAddress.test.tsx`
- `suite-common/wallet-core/src/named-address/useResolveNamedAddress.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly fills the Ethereum send form with a recipient address, exercising the modified Address.tsx component and the named-address resolution hooks (useResolveNamedAddress/namedAddressQuery) on the network where ENS-like resolution is supported.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — The test opens the global send form through a different entry point and verifies the shared send UI renders correctly, providing a sanity check that the Address.tsx integration was not broadly regressed, even though the actual send uses regtest rather than EVM resolution.

</details>

⚠️ **Changes with no test coverage (6)**
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/ethereumNamedAddressResolver.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddress.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/resolveNamedAddressBB.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/universalResolver.ts`
- `networks/network-module/network-module-suite-common-types/src/NamedAddressResolver.ts`
- `networks/network-module/network-module-suite-common-types/src/index.ts`

_Updated: 2026-09-01T09:34:12.022Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->