### PR TITLE
fix(suite-native): handle Method_Cancel correctly in unpairBluetoothDevice

### DIFF
--- a/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
+++ b/suite-native/bluetooth/src/hooks/useBluetoothDevice.ts
@@ -44,7 +44,8 @@ export const useBluetoothDevice = () => {
             } else if (
                 unwrappedResult.error.code === 'Failure_ActionCancelled' ||
                 unwrappedResult.error.code === 'Failure_PinCancelled' ||
-                unwrappedResult.error.code === 'Method_Interrupted'
+                unwrappedResult.error.code === 'Method_Interrupted' ||
+                unwrappedResult.error.code === 'Method_Cancel'
             ) {
                 onCancel();
             }


### PR DESCRIPTION
## Description

Ensure `onCancel` is called also for `Method_Cancel` error code.

## Related Issue

Resolve #31790


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/unpair-bluetooth-device&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->