### PR TITLE
fix(suite-common): backend reconnect guard for disabled state

### DIFF
--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts
@@ -2,23 +2,33 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
 import { configureMockStore } from '@suite-common/test-utils';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import TrezorConnect from '@trezor/connect';
 
 import { blockchainInitialState, prepareBlockchainReducer } from './blockchainReducer';
 import { setCustomBackendThunk } from './blockchainThunks';
+import {
+    initialWalletSettingsState,
+    prepareWalletSettingsReducer,
+} from '../settings/walletSettingsReducer';
 
 const blockchainReducer = prepareBlockchainReducer({
     actionTypes: { storageLoad: mockActionType('storageLoad') },
     reducers: { storageLoadBlockchain: mockReducer() },
 });
+const walletSettingsReducer = prepareWalletSettingsReducer({
+    actionTypes: { storageLoad: mockActionType('storageLoad') },
+    reducers: { storageLoadWalletSettings: mockReducer() },
+});
 const electrumUrl = '127.0.0.1:50001:t';
 
-const initStore = () =>
+const initStore = (enabledNetworks: NetworkSymbol[]) =>
     configureMockStore({
         extra: undefined,
         reducer: combineReducers({
             wallet: combineReducers({
                 blockchain: blockchainReducer,
+                settings: walletSettingsReducer,
             }),
         }),
         preloadedState: {
@@ -32,6 +42,10 @@ const initStore = () =>
                             urls: { electrum: [electrumUrl] },
                         },
                     },
+                },
+                settings: {
+                    ...initialWalletSettingsState,
+                    enabledNetworks,
                 },
             },
         },
@@ -47,7 +61,7 @@ describe(setCustomBackendThunk.name, () => {
         const reconnect = jest
             .spyOn(TrezorConnect, 'blockchainUnsubscribeFiatRates')
             .mockResolvedValue({ success: true, payload: { subscribed: false } });
-        const store = initStore();
+        const store = initStore(['btc']);
 
         await store.dispatch(setCustomBackendThunk('btc'));
 
@@ -60,5 +74,23 @@ describe(setCustomBackendThunk.name, () => {
             setCustomBackend.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
         const reconnectOrder = reconnect.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY;
         expect(setCustomBackendOrder).toBeLessThan(reconnectOrder);
+    });
+
+    it('applies the custom backend of a disabled network without connecting to it', async () => {
+        const setCustomBackend = jest
+            .spyOn(TrezorConnect, 'blockchainSetCustomBackend')
+            .mockResolvedValue({ success: true, payload: true });
+        const reconnect = jest
+            .spyOn(TrezorConnect, 'blockchainUnsubscribeFiatRates')
+            .mockResolvedValue({ success: true, payload: { subscribed: false } });
+        const store = initStore([]);
+
+        await store.dispatch(setCustomBackendThunk('btc'));
+
+        expect(setCustomBackend).toHaveBeenCalledWith({
+            coin: 'btc',
+            blockchainLink: { type: 'electrum', url: [electrumUrl] },
+        });
+        expect(reconnect).not.toHaveBeenCalled();
     });
 });

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -55,6 +55,7 @@ import {
 import {
     type WalletSettingsRootState,
     selectBitcoinAmountUnit,
+    selectEnabledNetworks,
 } from '../settings/walletSettingsReducer';
 
 export const DEFAULT_NETWORK_SYNC_INTERVAL = 60 * 1000; // 1 minute
@@ -105,7 +106,7 @@ const setBackendsToConnect = (backends: CustomBackend[]) =>
         ),
     );
 
-type SetCustomBackendThunkState = BlockchainRootState;
+type SetCustomBackendThunkState = BlockchainRootState & WalletSettingsRootState;
 
 export const setCustomBackendThunk = createThunk<
     unknown,
@@ -116,7 +117,10 @@ export const setCustomBackendThunk = createThunk<
     const backends = [getBackendFromSettings(symbol, blockchain[symbol].backends)];
     const result = await setBackendsToConnect(backends);
 
-    await dispatch(reconnectBlockchainThunk({ symbol }));
+    // a disabled network has nothing to sync, so do not open a connection to its backend
+    if (selectEnabledNetworks(getState()).includes(symbol)) {
+        await dispatch(reconnectBlockchainThunk({ symbol }));
+    }
 
     return result;
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Guards backend reconnection for disabled networks.

## Notes for QA

If backend is disabled and custom URL is being sent we shouldn't send any requests to this backend just yet.

## Related Issue

Resolve N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in a shared blockchain thunk module that orchestrates backend connections and discovery. Because the accompanying unit test file was also modified, the highest e2e risk is integration behavior with custom backends and discovery. A small set of backend-focused tests provides strong confidence without running the full 138-test static mapping.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly exercises custom Blockbook backend configuration, backend connection state, discovery completion, and account loading errors—precisely the integration surface impacted by blockchain thunk changes.
- `suite/e2e/tests/settings/electrum.test.ts` — Configures a custom Electrum backend for regtest and verifies discovery and balance, covering an alternative backend path that relies on the same blockchain thunk orchestration.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests end-to-end discovery against custom Blockbook backends for BTC and LTC, making it a strong regression detector for backend/discovery thunk behavior.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — Covers network enable/disable flows, asset activation, and the custom backend indicator, sharing discovery/backend infrastructure with the changed thunks.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates multiple coins and reloads mid-discovery, exercising the discovery state machine that blockchain thunks help drive; a regression could leave discovery stuck or desynced.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts`

_Updated: 2026-09-01T09:39:14.795Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/custom-backend-req&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/custom-backend-req&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/custom-backend-req&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/custom-backend-req/web/](https://dev.suite.sldev.cz/suite-web/fix/custom-backend-req/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T09:42:19.222Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T09:41:55.638Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->