### PR TITLE
fix(suite): scope cardano account voting delegation and reset after sign

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -1,8 +1,8 @@
 import { type AdaPools } from '@suite-common/earn-staking-api';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
-import type { VotingDelegationOption } from '@suite-common/wallet-core';
-import { type Account, type CardanoAction } from '@suite-common/wallet-types';
+import type { AccountVotingDelegation } from '@suite-common/wallet-core';
+import { type Account, type AccountKey, type CardanoAction } from '@suite-common/wallet-types';
 import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
 import TrezorConnect, { type CardanoCertificate, PROTO } from '@trezor/connect';
 
@@ -21,16 +21,30 @@ jest.mock('@trezor/connect', () => {
     };
 });
 
+const cardanoComposeTransactionMock = TrezorConnect.cardanoComposeTransaction as jest.Mock;
+
 const PREDEFINED_DREP_ID = 'drep_always_abstain';
+const OTHER_ACCOUNT_KEY = 'other-ada-account-key' as AccountKey;
 const NON_EVERSTAKE_POOL_ID = 'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy';
+
+const CHANGE_ADDRESS = {
+    address: 'addr1change',
+    path: "m/1852'/1815'/0'/1/0",
+    transfers: 0,
+    balance: '0',
+    sent: '0',
+    received: '0',
+};
+
+type CreateCardanoAccountProps = {
+    drepId: string | null;
+    isStakingActive?: boolean;
+};
 
 const createCardanoAccount = ({
     drepId,
     isStakingActive = true,
-}: {
-    drepId: string | null;
-    isStakingActive?: boolean;
-}): Account =>
+}: CreateCardanoAccountProps): Account =>
     ({
         key: 'ada-account-key',
         index: 0,
@@ -54,22 +68,11 @@ const createCardanoAccount = ({
         },
     }) as unknown as Account;
 
-const migratePool = (account: Account, votingDelegation: VotingDelegationOption) =>
+const migratePool = (account: Account, votingDelegation: AccountVotingDelegation) =>
     prepareTxPlan({ account, action: 'delegate', cardanoPools: [], votingDelegation });
 
 const getCertificateTypes = (txData: Awaited<ReturnType<typeof prepareTxPlan>>) =>
     txData?.certificates.map(certificate => certificate.type);
-
-const cardanoComposeTransactionMock = TrezorConnect.cardanoComposeTransaction as jest.Mock;
-
-const CHANGE_ADDRESS = {
-    address: 'addr1change',
-    path: "m/1852'/1815'/0'/1/0",
-    transfers: 0,
-    balance: '0',
-    sent: '0',
-    received: '0',
-};
 
 const cardanoPools: AdaPools['pools'] = [];
 
@@ -104,43 +107,48 @@ const getVoteDelegationCertificate = () => {
     );
 };
 
-const prepare = (action: CardanoAction, votingDelegation?: VotingDelegationOption) =>
-    prepareTxPlan({
-        account: mockWalletAccount(
-            {
-                symbol: 'ada',
-                index: 0,
-                balance: '10000000',
-                availableBalance: '10000000',
-                utxo: [],
-                addresses: {
-                    change: [
-                        {
-                            address: 'addr1_change',
-                            path: "m/1852'/1815'/0'/1/0",
-                            transfers: 0,
-                            balance: '0',
-                            sent: '0',
-                            received: '0',
-                        },
-                    ],
-                    used: [],
-                    unused: [],
-                },
-            },
-            {
-                ...networkSpecificDefaultCardano,
-                misc: {
-                    staking: {
-                        address: 'stake1_address',
-                        isActive: true,
-                        rewards: '1000000',
-                        poolId: null,
-                        drep: null,
+const createStakeReadyAccount = () =>
+    mockWalletAccount(
+        {
+            symbol: 'ada',
+            index: 0,
+            balance: '10000000',
+            availableBalance: '10000000',
+            utxo: [],
+            addresses: {
+                change: [
+                    {
+                        address: 'addr1_change',
+                        path: "m/1852'/1815'/0'/1/0",
+                        transfers: 0,
+                        balance: '0',
+                        sent: '0',
+                        received: '0',
                     },
+                ],
+                used: [],
+                unused: [],
+            },
+        },
+        {
+            ...networkSpecificDefaultCardano,
+            misc: {
+                staking: {
+                    address: 'stake1_address',
+                    isActive: true,
+                    rewards: '1000000',
+                    poolId: null,
+                    drep: null,
                 },
             },
-        ),
+        },
+    );
+
+const STAKE_READY_ACCOUNT_KEY = createStakeReadyAccount().key;
+
+const prepare = (action: CardanoAction, votingDelegation?: AccountVotingDelegation) =>
+    prepareTxPlan({
+        account: createStakeReadyAccount(),
         action,
         cardanoPools: [],
         votingDelegation,
@@ -203,7 +211,7 @@ describe('prepareTxPlan', () => {
         const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
 
         const certificateTypes = getCertificateTypes(
-            await migratePool(account, { type: 'current' }),
+            await migratePool(account, { accountKey: account.key, option: { type: 'current' } }),
         );
 
         expect(certificateTypes).not.toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
@@ -214,7 +222,7 @@ describe('prepareTxPlan', () => {
         const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
 
         const certificateTypes = getCertificateTypes(
-            await migratePool(account, { type: 'everstake' }),
+            await migratePool(account, { accountKey: account.key, option: { type: 'everstake' } }),
         );
 
         expect(certificateTypes).toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
@@ -227,7 +235,7 @@ describe('prepareTxPlan', () => {
         });
 
         const certificateTypes = getCertificateTypes(
-            await migratePool(account, { type: 'current' }),
+            await migratePool(account, { accountKey: account.key, option: { type: 'current' } }),
         );
 
         expect(certificateTypes).toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
@@ -240,7 +248,7 @@ describe('prepareTxPlan', () => {
             account,
             action: 'voteDelegate',
             cardanoPools: [],
-            votingDelegation: { type: 'current' },
+            votingDelegation: { accountKey: account.key, option: { type: 'current' } },
         });
 
         expect(txData).toBeNull();
@@ -251,13 +259,21 @@ describe('prepareTxPlan', () => {
         it.each(['not-a-drep', '', CARDANO_EVERSTAKE_DREP.hex])(
             'returns null without composing when the custom drepId %p is invalid',
             async drepId => {
-                await expect(prepare(action, { type: 'another_drep', drepId })).resolves.toBeNull();
+                await expect(
+                    prepare(action, {
+                        accountKey: STAKE_READY_ACCOUNT_KEY,
+                        option: { type: 'another_drep', drepId },
+                    }),
+                ).resolves.toBeNull();
                 expect(cardanoComposeTransactionMock).not.toHaveBeenCalled();
             },
         );
 
         it('delegates the vote to the custom DRep when the drepId is valid', async () => {
-            await prepare(action, { type: 'another_drep', drepId: CUSTOM_DREP_BECH32 });
+            await prepare(action, {
+                accountKey: STAKE_READY_ACCOUNT_KEY,
+                option: { type: 'another_drep', drepId: CUSTOM_DREP_BECH32 },
+            });
 
             expect(getVoteDelegationCertificate()?.dRep).toEqual({
                 type: PROTO.CardanoDRepType.KEY_HASH,
@@ -266,26 +282,73 @@ describe('prepareTxPlan', () => {
             });
         });
 
-        it.each([{ type: 'everstake' } as const, undefined])(
-            'delegates the vote to Everstake for %p',
-            async votingDelegation => {
-                await prepare(action, votingDelegation);
+        it.each([
+            { accountKey: STAKE_READY_ACCOUNT_KEY, option: { type: 'everstake' } } as const,
+            undefined,
+        ])('delegates the vote to Everstake for %p', async votingDelegation => {
+            await prepare(action, votingDelegation);
 
-                expect(getVoteDelegationCertificate()?.dRep).toEqual({
-                    type: PROTO.CardanoDRepType.KEY_HASH,
-                    keyHash: CARDANO_EVERSTAKE_DREP.hex,
-                    scriptHash: undefined,
-                });
-            },
-        );
+            expect(getVoteDelegationCertificate()?.dRep).toEqual({
+                type: PROTO.CardanoDRepType.KEY_HASH,
+                keyHash: CARDANO_EVERSTAKE_DREP.hex,
+                scriptHash: undefined,
+            });
+        });
     });
 
     describe.each(['deregister', 'withdrawal'] as const)('%s', action => {
         it('composes despite an invalid custom drepId', async () => {
             await expect(
-                prepare(action, { type: 'another_drep', drepId: 'not-a-drep' }),
+                prepare(action, {
+                    accountKey: STAKE_READY_ACCOUNT_KEY,
+                    option: { type: 'another_drep', drepId: 'not-a-drep' },
+                }),
             ).resolves.not.toBeNull();
             expect(getVoteDelegationCertificate()).toBeUndefined();
+        });
+    });
+
+    describe('a selection confirmed for another account', () => {
+        const everstakeDrep = {
+            type: PROTO.CardanoDRepType.KEY_HASH,
+            keyHash: CARDANO_EVERSTAKE_DREP.hex,
+            scriptHash: undefined,
+        };
+
+        it("delegates the vote to Everstake instead of keeping this account's live delegation", async () => {
+            const account = createCardanoAccount({ drepId: PREDEFINED_DREP_ID });
+
+            const certificateTypes = getCertificateTypes(
+                await migratePool(account, {
+                    accountKey: OTHER_ACCOUNT_KEY,
+                    option: { type: 'current' },
+                }),
+            );
+
+            expect(certificateTypes).toContain(PROTO.CardanoCertificateType.VOTE_DELEGATION);
+            expect(getVoteDelegationCertificate()?.dRep).toEqual(everstakeDrep);
+        });
+
+        it.each(['delegate', 'voteDelegate'] as const)(
+            'delegates the %s vote to Everstake instead of its custom DRep',
+            async action => {
+                await prepare(action, {
+                    accountKey: OTHER_ACCOUNT_KEY,
+                    option: { type: 'another_drep', drepId: CUSTOM_DREP_BECH32 },
+                });
+
+                expect(getVoteDelegationCertificate()?.dRep).toEqual(everstakeDrep);
+            },
+        );
+
+        it('composes with Everstake instead of failing on its invalid custom drepId', async () => {
+            await expect(
+                prepare('delegate', {
+                    accountKey: OTHER_ACCOUNT_KEY,
+                    option: { type: 'another_drep', drepId: 'not-a-drep' },
+                }),
+            ).resolves.not.toBeNull();
+            expect(getVoteDelegationCertificate()?.dRep).toEqual(everstakeDrep);
         });
     });
 });

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -23,9 +23,10 @@ import {
     MIN_CARDANO_FOR_WITHDRAWALS,
 } from '@suite-common/wallet-constants';
 import {
+    type AccountVotingDelegation,
     type StakeRootState,
-    type VotingDelegationOption,
     selectCardanoPoolsInfo,
+    selectStakeVotingDelegation,
 } from '@suite-common/wallet-core';
 import {
     type Account,
@@ -105,7 +106,7 @@ type PrepareTxPlanParams = {
     account: Account;
     action: CardanoAction;
     cardanoPools: AdaPools['pools'];
-    votingDelegation?: VotingDelegationOption;
+    votingDelegation?: AccountVotingDelegation;
 };
 
 export const prepareTxPlan = async ({
@@ -149,18 +150,24 @@ export const prepareTxPlan = async ({
         );
     }
 
+    // The signing path reads the selection straight from the store, so a selection left over from
+    // another account must never reach the certificates. Everything below derives from the option
+    // confirmed for this very account, falling back to Everstake.
+    const confirmedOption =
+        votingDelegation?.accountKey === account.key ? votingDelegation.option : undefined;
+
     const isKeepingCurrentVote =
-        votingDelegation?.type === 'current' && hasCardanoLiveVoteDelegation(account);
+        confirmedOption?.type === 'current' && hasCardanoLiveVoteDelegation(account);
 
     if ((action === 'delegate' || action === 'voteDelegate') && !isKeepingCurrentVote) {
-        const isVotingToAnotherDrep = votingDelegation?.type === 'another_drep';
+        const isVotingToAnotherDrep = confirmedOption?.type === 'another_drep';
 
-        if (isVotingToAnotherDrep && !validateCardanoDrep(votingDelegation.drepId)) {
+        if (isVotingToAnotherDrep && !validateCardanoDrep(confirmedOption.drepId)) {
             return null;
         }
 
         const drepBech32 = isVotingToAnotherDrep
-            ? votingDelegation.drepId
+            ? confirmedOption.drepId
             : CARDANO_EVERSTAKE_DREP.bech32;
 
         const dRep = parseDrepBech32(drepBech32);
@@ -212,7 +219,7 @@ const getTransactionData = (
     formValues: StakeFormState,
     selectedAccount: SelectedAccountStatus,
     cardanoPools: AdaPools['pools'],
-    votingDelegation?: VotingDelegationOption,
+    votingDelegation?: AccountVotingDelegation,
 ) => {
     const { stakeType } = formValues;
 
@@ -269,8 +276,9 @@ type ComposeTransactionThunkState = SelectedAccountRootState & StakeRootState;
 export const composeTransaction =
     (formValues: StakeFormState, formState: ComposeActionContext) =>
     async (_: Dispatch<UnknownAction>, getState: () => ComposeTransactionThunkState) => {
-        const { selectedAccount, stake } = getState().wallet;
+        const { selectedAccount } = getState().wallet;
         const cardanoPools = selectCardanoPoolsInfo(getState());
+        const votingDelegation = selectStakeVotingDelegation(getState());
 
         if (!selectedAccount.account) return;
 
@@ -280,7 +288,7 @@ export const composeTransaction =
             formValues,
             selectedAccount,
             cardanoPools,
-            stake.votingDelegation,
+            votingDelegation,
         );
         const { txPlan } = txData || {};
         if (txPlan?.type !== 'final') return;
@@ -368,8 +376,9 @@ export const signTransaction =
         getState: () => SignTransactionThunkState,
         extra: SignTransactionThunkDeps,
     ) => {
-        const { selectedAccount, stake } = getState().wallet;
+        const { selectedAccount } = getState().wallet;
         const cardanoPools = selectCardanoPoolsInfo(getState());
+        const votingDelegation = selectStakeVotingDelegation(getState());
         if (!selectedAccount?.account) return;
 
         const device = selectSelectedDevice(getState());
@@ -386,7 +395,7 @@ export const signTransaction =
             formValues,
             selectedAccount,
             cardanoPools,
-            stake.votingDelegation,
+            votingDelegation,
         );
 
         if (!txData) {

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -245,6 +245,10 @@ const pushTransaction =
                     type: events.stakingConfirmEvent.name,
                     payload: { action: stakeType, networkSymbol: account.symbol },
                 });
+
+                // The confirmed selection is spent by this transaction; keeping it would let it
+                // reach the next plan composed for this account.
+                dispatch(stakeActions.clearAccountVotingDelegation());
             }
 
             // notification from the backend may be delayed.

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/StakingEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/StakingEarnProviderConsentModal.tsx
@@ -57,7 +57,7 @@ export const StakingEarnProviderConsentModal = ({
             }
             onConfirm={proceedToEarnFlow}
             onCancel={onCancelClick}
-            networkType={account.networkType}
+            account={account}
         >
             <VotingDelegations account={account} />
         </EarnProviderConsentModalLayout>

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/UpdateEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/UpdateEarnProviderConsentModal.tsx
@@ -58,7 +58,7 @@ export const UpdateEarnProviderConsentModal = ({
             }
             onConfirm={proceedToEarnFlow}
             onCancel={onCancelClick}
-            networkType={account.networkType}
+            account={account}
         >
             <VotingDelegations account={account} />
         </EarnProviderConsentModalLayout>

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
@@ -126,7 +126,7 @@ export const YieldEarnProviderConsentModal = ({
             }
             onConfirm={handleOnConfirm}
             onCancel={handleOnCancel}
-            networkType={account.networkType}
+            account={account}
         >
             <VotingDelegations account={account} />
         </EarnProviderConsentModalLayout>

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
@@ -1,8 +1,8 @@
 import { type ReactNode, useMemo, useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { type NetworkType } from '@suite-common/wallet-config';
 import { selectVotingDelegationOption } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
 import { validateCardanoDrep } from '@suite-common/wallet-utils';
 import { Card, Checkbox, Column, Modal } from '@trezor/components';
 
@@ -15,7 +15,7 @@ interface EarnProviderConsentModalLayoutProps {
     consentText: ReactNode;
     onConfirm: () => void;
     onCancel: () => void;
-    networkType: NetworkType;
+    account: Account;
     children?: ReactNode;
 }
 
@@ -26,12 +26,14 @@ export const EarnProviderConsentModalLayout = ({
     consentText,
     onConfirm,
     onCancel,
-    networkType,
+    account,
     children,
 }: EarnProviderConsentModalLayoutProps) => {
     const [hasAgreed, setHasAgreed] = useState(false);
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
-    const isCardanoNetworkType = networkType === 'cardano';
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
+    const isCardanoNetworkType = account.networkType === 'cardano';
 
     const isDrepValid = useMemo(() => {
         if (!isCardanoNetworkType || selectedVotingDelegation.type !== 'another_drep') {

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
@@ -8,11 +8,7 @@ import {
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    DEFAULT_VOTING_OPTION,
-    selectVotingDelegationOption,
-    stakeActions,
-} from '@suite-common/wallet-core';
+import { selectVotingDelegationOption, stakeActions } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -39,7 +35,9 @@ export const useEarnProviderConsentActions = ({
 }: UseEarnProviderConsentActionsProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
 
     const report = (action: EarnModalAction) => {
         if (flow === EarnFlow.Yield) return;
@@ -94,7 +92,7 @@ export const useEarnProviderConsentActions = ({
     const onCancelClick = () => {
         onCancel();
 
-        dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
+        dispatch(stakeActions.clearAccountVotingDelegation());
         report('cancel');
     };
 

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
@@ -19,7 +19,7 @@ type StakeRegistrationDepositCardProps = {
 export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepositCardProps) => {
     const { symbol, key } = account;
 
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
+    const selectedVotingDelegation = useSelector(state => selectVotingDelegationOption(state, key));
 
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, key ?? ''));
     const isUpdateProviderFlow = isStakingActive && account.networkType === 'cardano';

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx
@@ -4,7 +4,7 @@ import { configureMockStore } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
 import { DEFAULT_VOTING_OPTION, stakeActions, stakeInitialState } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
 
 import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
 
@@ -13,10 +13,11 @@ import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState
 
 const CUSTOM_DREP_ID = 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs';
 const PREDEFINED_DREP_ID = 'drep_always_abstain';
+const ACCOUNT_KEY = 'ada-account-key' as AccountKey;
 
 const createCardanoAccount = (drepId: string | null): Account =>
     ({
-        key: 'ada-account-key',
+        key: ACCOUNT_KEY,
         index: 0,
         symbol: asNetworkSymbol('ada'),
         networkType: 'cardano',
@@ -45,7 +46,10 @@ describe('VotingDelegations', () => {
         const store = renderVotingDelegations(createCardanoAccount(CUSTOM_DREP_ID));
 
         expect(store.getActions()).toContainEqual(
-            stakeActions.setVotingDelegationOption({ type: 'current' }),
+            stakeActions.setAccountVotingDelegation({
+                accountKey: ACCOUNT_KEY,
+                option: { type: 'current' },
+            }),
         );
     });
 
@@ -53,7 +57,10 @@ describe('VotingDelegations', () => {
         const store = renderVotingDelegations(createCardanoAccount(CARDANO_EVERSTAKE_DREP.bech32));
 
         expect(store.getActions()).toContainEqual(
-            stakeActions.setVotingDelegationOption({ type: 'current' }),
+            stakeActions.setAccountVotingDelegation({
+                accountKey: ACCOUNT_KEY,
+                option: { type: 'current' },
+            }),
         );
     });
 
@@ -61,7 +68,10 @@ describe('VotingDelegations', () => {
         const store = renderVotingDelegations(createCardanoAccount(PREDEFINED_DREP_ID));
 
         expect(store.getActions()).toContainEqual(
-            stakeActions.setVotingDelegationOption({ type: 'current' }),
+            stakeActions.setAccountVotingDelegation({
+                accountKey: ACCOUNT_KEY,
+                option: { type: 'current' },
+            }),
         );
     });
 
@@ -69,7 +79,10 @@ describe('VotingDelegations', () => {
         const store = renderVotingDelegations(createCardanoAccount(null));
 
         expect(store.getActions()).toContainEqual(
-            stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION),
+            stakeActions.setAccountVotingDelegation({
+                accountKey: ACCOUNT_KEY,
+                option: DEFAULT_VOTING_OPTION,
+            }),
         );
     });
 });

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx
@@ -14,13 +14,12 @@ type VotingDelegationsProps = {
 };
 
 export const VotingDelegations = ({ account }: VotingDelegationsProps) => {
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
-
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
     const accountVotingDelegation = useSeededCardanoVotingDelegation(account);
 
-    const isCardanoAccount = account.networkType === 'cardano';
-
-    if (!isCardanoAccount) return null;
+    if (account.networkType !== 'cardano') return null;
 
     return (
         <Card>
@@ -43,7 +42,7 @@ export const VotingDelegations = ({ account }: VotingDelegationsProps) => {
                 hasDivider={false}
             >
                 <VotingDelegationsOptions
-                    networkType={account.networkType}
+                    account={account}
                     hasKeepCurrentOption={!!accountVotingDelegation}
                 />
             </CollapsibleBox>

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
-import { type NetworkType } from '@suite-common/wallet-config';
 import {
     type VotingDelegationOption,
     selectVotingDelegationOption,
     stakeActions,
 } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
 import { validateCardanoDrep } from '@suite-common/wallet-utils';
 import { Column, Input, Radio, Text } from '@trezor/components';
 
@@ -23,48 +23,69 @@ const VOTING_OPTION_KEYS = ['everstake', 'another_drep'] as const;
 const VOTING_OPTION_KEYS_WITH_CURRENT = ['current', ...VOTING_OPTION_KEYS] as const;
 
 export interface VotingDelegationsOptionsProps {
-    networkType: NetworkType;
+    account: Account;
     hasTitle?: boolean;
     hasKeepCurrentOption?: boolean;
 }
 
 export const VotingDelegationsOptions = ({
-    networkType,
+    account,
     hasTitle = false,
     hasKeepCurrentOption = false,
 }: VotingDelegationsOptionsProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
-    const [hasError, setHasError] = useState<boolean>(false);
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
 
-    if (networkType !== 'cardano') return null;
+    if (account.networkType !== 'cardano') return null;
+
+    // Derived rather than kept in state: the store is the only place a DRep id lives, so a selection
+    // cleared or seeded from elsewhere cannot leave a stale error behind.
+    const hasError =
+        selectedVotingDelegation.type === 'another_drep' &&
+        selectedVotingDelegation.drepId !== '' &&
+        !validateCardanoDrep(selectedVotingDelegation.drepId);
 
     const handleOptionSelect = (type: VotingDelegationOption['type']) => {
-        setHasError(false);
-
         switch (type) {
             case 'everstake':
-                dispatch(stakeActions.setVotingDelegationOption({ type: 'everstake' }));
+                dispatch(
+                    stakeActions.setAccountVotingDelegation({
+                        accountKey: account.key,
+                        option: { type: 'everstake' },
+                    }),
+                );
                 break;
 
             case 'another_drep':
                 dispatch(
-                    stakeActions.setVotingDelegationOption({ type: 'another_drep', drepId: '' }),
+                    stakeActions.setAccountVotingDelegation({
+                        accountKey: account.key,
+                        option: { type: 'another_drep', drepId: '' },
+                    }),
                 );
                 break;
 
             case 'current':
-                dispatch(stakeActions.setVotingDelegationOption({ type: 'current' }));
+                dispatch(
+                    stakeActions.setAccountVotingDelegation({
+                        accountKey: account.key,
+                        option: { type: 'current' },
+                    }),
+                );
                 break;
         }
     };
 
     const handleDrepIdChange = (value: string) => {
-        const isDrepValid = validateCardanoDrep(value);
-        setHasError(!isDrepValid);
-
-        dispatch(stakeActions.setVotingDelegationOption({ type: 'another_drep', drepId: value }));
+        dispatch(
+            stakeActions.setAccountVotingDelegation({
+                accountKey: account.key,
+                option: { type: 'another_drep', drepId: value },
+            }),
+        );
     };
 
     const optionKeys = hasKeepCurrentOption ? VOTING_OPTION_KEYS_WITH_CURRENT : VOTING_OPTION_KEYS;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -5,11 +5,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
-import {
-    DEFAULT_VOTING_OPTION,
-    selectVotingDelegationOption,
-    stakeActions,
-} from '@suite-common/wallet-core';
+import { selectVotingDelegationOption, stakeActions } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { getCardanoAccountDrepId, validateCardanoDrep } from '@suite-common/wallet-utils';
 import { Card, Column, Modal, Tooltip } from '@trezor/components';
@@ -35,11 +31,14 @@ export const StakeChangeDelegateModalLoaded = ({
     onCancel,
     selectedAccount,
 }: StakeChangeDelegateModalProps) => {
+    const { account } = selectedAccount;
+
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
-    const { account } = selectedAccount;
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
 
     const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
@@ -54,7 +53,7 @@ export const StakeChangeDelegateModalLoaded = ({
     const drepIdOptionValue = useSeededCardanoVotingDelegation(account);
 
     const handleCancel = () => {
-        dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
+        dispatch(stakeActions.clearAccountVotingDelegation());
 
         onCancel?.();
 
@@ -145,7 +144,7 @@ export const StakeChangeDelegateModalLoaded = ({
                         <Column gap={20} hasDivider>
                             <CurrentDelegate account={account} />
                             <VotingDelegationsOptions
-                                networkType={account.networkType}
+                                account={account}
                                 hasTitle
                                 hasKeepCurrentOption={!!drepIdOptionValue}
                             />

--- a/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts
+++ b/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts
@@ -1,11 +1,13 @@
-import { renderHook } from '@testing-library/react';
+import { type UnknownAction } from '@reduxjs/toolkit';
+import { act, renderHook } from '@testing-library/react';
 
 import { configureMockStore } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
-import { stakeActions, stakeInitialState } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { DEFAULT_VOTING_OPTION, stakeActions, stakeInitialState } from '@suite-common/wallet-core';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
 
+import { stakeReducer } from 'src/reducers/wallet';
 import { renderHookWithProviders } from 'src/support/test-utils/hooksHelper';
 
 import {
@@ -16,11 +18,13 @@ import { mockInitialAppState } from '../../../mocks/mockInitialAppState';
 
 const CUSTOM_DREP_ID = 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs';
 const PREDEFINED_DREP_ID = 'drep_always_abstain';
+const ACCOUNT_KEY = 'ada-account-key' as AccountKey;
+const OTHER_ACCOUNT_KEY = 'other-ada-account-key' as AccountKey;
 
 const createCardanoAccount = (
     drepId: string | null,
     isStakingActive = true,
-    key = 'ada-account-key',
+    key = ACCOUNT_KEY,
 ): Account =>
     ({
         key,
@@ -101,12 +105,19 @@ describe('useCardanoAccountVotingDelegation', () => {
 
 describe('useSeededCardanoVotingDelegation', () => {
     const renderSeededHook = (account: Account) => {
+        const preloadedState = {
+            ...mockInitialAppState,
+            wallet: { ...mockInitialAppState.wallet, stake: stakeInitialState },
+        };
+
         const store = configureMockStore({
             extra: undefined,
-            preloadedState: {
-                ...mockInitialAppState,
-                wallet: { ...mockInitialAppState.wallet, stake: stakeInitialState },
-            },
+            preloadedState,
+            // The real stake reducer, so that seeding reads back the selection it just wrote.
+            reducer: (state = preloadedState, action: UnknownAction) => ({
+                ...state,
+                wallet: { ...state.wallet, stake: stakeReducer(state.wallet.stake, action) },
+            }),
             serializableCheck: { ignoredActions: [] },
         });
 
@@ -125,7 +136,10 @@ describe('useSeededCardanoVotingDelegation', () => {
         const { store } = renderSeededHook(createCardanoAccount(CUSTOM_DREP_ID));
 
         expect(store.getActions()).toEqual([
-            stakeActions.setVotingDelegationOption({ type: 'current' }),
+            stakeActions.setAccountVotingDelegation({
+                accountKey: ACCOUNT_KEY,
+                option: { type: 'current' },
+            }),
         ]);
     });
 
@@ -137,11 +151,38 @@ describe('useSeededCardanoVotingDelegation', () => {
         expect(store.getActions()).toHaveLength(1);
     });
 
+    it('seeds again once the selection is cleared while still mounted', () => {
+        const seedCurrent = stakeActions.setAccountVotingDelegation({
+            accountKey: ACCOUNT_KEY,
+            option: { type: 'current' },
+        });
+        const { store } = renderSeededHook(createCardanoAccount(CUSTOM_DREP_ID));
+
+        act(() => {
+            store.dispatch(stakeActions.clearAccountVotingDelegation());
+        });
+
+        expect(store.getActions()).toEqual([
+            seedCurrent,
+            stakeActions.clearAccountVotingDelegation(),
+            seedCurrent,
+        ]);
+    });
+
     it('seeds again for a different account', () => {
         const { store, rerender } = renderSeededHook(createCardanoAccount(null));
 
-        rerender({ account: createCardanoAccount(CUSTOM_DREP_ID, true, 'other-ada-account-key') });
+        rerender({ account: createCardanoAccount(CUSTOM_DREP_ID, true, OTHER_ACCOUNT_KEY) });
 
-        expect(store.getActions()).toHaveLength(2);
+        expect(store.getActions()).toEqual([
+            stakeActions.setAccountVotingDelegation({
+                accountKey: ACCOUNT_KEY,
+                option: DEFAULT_VOTING_OPTION,
+            }),
+            stakeActions.setAccountVotingDelegation({
+                accountKey: OTHER_ACCOUNT_KEY,
+                option: { type: 'current' },
+            }),
+        ]);
     });
 });

--- a/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.ts
+++ b/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.ts
@@ -1,14 +1,15 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import {
     DEFAULT_VOTING_OPTION,
     type VotingDelegationOption,
+    selectStakeVotingDelegation,
     stakeActions,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { hasCardanoLiveVoteDelegation } from '@suite-common/wallet-utils';
 
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useCardanoAccountVotingDelegation = (
     account: Account,
@@ -27,20 +28,30 @@ export const useSeededCardanoVotingDelegation = (
     const dispatch = useDispatch();
     const accountVotingDelegation = useCardanoAccountVotingDelegation(account);
     const isCardanoAccount = account.networkType === 'cardano';
-    // Seeds an initial value only: later backend updates must not overwrite the user's selection.
-    const seededAccountKey = useRef<string | undefined>(undefined);
+    // Seeding is driven by the store rather than by a mount-once ref, so that a selection cleared
+    // while this stays mounted - after signing, or on an account switch - is seeded again instead
+    // of silently reading as Everstake.
+    const isSelectionConfirmedForAccount = useSelector(
+        state => selectStakeVotingDelegation(state)?.accountKey === account.key,
+    );
 
     useEffect(() => {
-        if (!isCardanoAccount || seededAccountKey.current === account.key) return;
-
-        seededAccountKey.current = account.key;
+        // Fills an empty slot only: later backend updates must not overwrite the user's selection.
+        if (!isCardanoAccount || isSelectionConfirmedForAccount) return;
 
         dispatch(
-            stakeActions.setVotingDelegationOption(
-                accountVotingDelegation ?? DEFAULT_VOTING_OPTION,
-            ),
+            stakeActions.setAccountVotingDelegation({
+                accountKey: account.key,
+                option: accountVotingDelegation ?? DEFAULT_VOTING_OPTION,
+            }),
         );
-    }, [dispatch, isCardanoAccount, account.key, accountVotingDelegation]);
+    }, [
+        dispatch,
+        isCardanoAccount,
+        isSelectionConfirmedForAccount,
+        account.key,
+        accountVotingDelegation,
+    ]);
 
     return accountVotingDelegation;
 };

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 import {
     hasPendingStakeTypeTransaction,
     selectCardanoPoolsInfo,
-    selectVotingDelegationOption,
+    selectStakeVotingDelegation,
 } from '@suite-common/wallet-core';
 import {
     type ActionAvailability,
@@ -20,7 +20,7 @@ export const useCardanoStaking = (): CardanoStaking => {
     const isCardano = account?.networkType === 'cardano';
 
     const cardanoPools = useSelector(selectCardanoPoolsInfo);
-    const votingDelegation = useSelector(selectVotingDelegationOption);
+    const votingDelegation = useSelector(selectStakeVotingDelegation);
     const hasPendingTx = useSelector(state =>
         account ? hasPendingStakeTypeTransaction(state, account.key) : false,
     );

--- a/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
+++ b/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
@@ -2,11 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo } from 'reac
 import { useForm } from 'react-hook-form';
 
 import { getStakeFormsDefaultValues, getStakingContractAddress } from '@suite-common/staking';
-import {
-    selectBaseCurrency,
-    selectRawNetworkFeeInfo,
-    selectVotingDelegationOption,
-} from '@suite-common/wallet-core';
+import { selectBaseCurrency, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import {
     type ChangeDelegateFormState,
     type SelectedAccountLoaded,
@@ -38,7 +34,6 @@ export const useChangeDelegateForm = ({
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
-    const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
     const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account.networkType,
@@ -62,9 +57,8 @@ export const useChangeDelegateForm = ({
             network,
             feeInfo,
             formValues: defaultValues,
-            selectedVotingDelegation,
         }),
-        [account, network, feeInfo, defaultValues, selectedVotingDelegation],
+        [account, network, feeInfo, defaultValues],
     );
 
     const methods = useForm<ChangeDelegateFormState>({

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -7,7 +7,6 @@ import { deviceActions } from '@suite-common/device';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { tradingActions } from '@suite-common/trading';
 import {
-    DEFAULT_VOTING_OPTION,
     WALLET_SETTINGS,
     accountsActions,
     blockchainActions,
@@ -116,7 +115,7 @@ const walletMiddleware =
             api.dispatch(sendFormActions.dispose());
             api.dispatch(tradingActions.setVerifiedAddress(undefined));
             api.dispatch(stakeActions.dispose());
-            api.dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
+            api.dispatch(stakeActions.clearAccountVotingDelegation());
         }
 
         if (action.type === WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS) {

--- a/suite-common/wallet-core/src/stake/stakeActions.ts
+++ b/suite-common/wallet-core/src/stake/stakeActions.ts
@@ -1,7 +1,11 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type PrecomposedTransactionFinal, type StakeFormState } from '@suite-common/wallet-types';
+import {
+    type AccountKey,
+    type PrecomposedTransactionFinal,
+    type StakeFormState,
+} from '@suite-common/wallet-types';
 
 export const STAKE_MODULE_PREFIX = '@common/wallet-core/stake';
 
@@ -18,11 +22,20 @@ type RequestPushTransactionPayload = {
 export type VotingDelegationOption =
     { type: 'everstake' } | { type: 'another_drep'; drepId: string } | { type: 'current' };
 
-const setVotingDelegationOption = createAction(
-    `${STAKE_MODULE_PREFIX}/setVotingDelegationOption`,
-    (payload: VotingDelegationOption) => ({
+export type AccountVotingDelegation = {
+    accountKey: AccountKey;
+    option: VotingDelegationOption;
+};
+
+const setAccountVotingDelegation = createAction(
+    `${STAKE_MODULE_PREFIX}/setAccountVotingDelegation`,
+    (payload: AccountVotingDelegation) => ({
         payload,
     }),
+);
+
+const clearAccountVotingDelegation = createAction(
+    `${STAKE_MODULE_PREFIX}/clearAccountVotingDelegation`,
 );
 
 const requestSignTransaction = createAction(
@@ -51,7 +64,8 @@ const dispose = createAction(`${STAKE_MODULE_PREFIX}/dispose`);
 export const stakeActions = {
     requestSignTransaction,
     requestPushTransaction,
-    setVotingDelegationOption,
+    setAccountVotingDelegation,
+    clearAccountVotingDelegation,
     setResolvedEthereumNonce,
     dispose,
 };

--- a/suite-common/wallet-core/src/stake/stakeReducer.test.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.test.ts
@@ -1,0 +1,60 @@
+import { type AccountKey } from '@suite-common/wallet-types';
+
+import { type AccountVotingDelegation, stakeActions } from './stakeActions';
+import { DEFAULT_VOTING_OPTION } from './stakeConstants';
+import { prepareStakeReducer, stakeInitialState } from './stakeReducer';
+import type { StakeState } from './stakeReducerTypes';
+
+const stakeReducer = prepareStakeReducer(undefined);
+
+const ACCOUNT_KEY = 'ada-account-key' as AccountKey;
+const OTHER_ACCOUNT_KEY = 'other-ada-account-key' as AccountKey;
+
+const anotherDrep: AccountVotingDelegation = {
+    accountKey: ACCOUNT_KEY,
+    option: { type: 'another_drep', drepId: 'drep1abc' },
+};
+
+const stateWith = (votingDelegation?: AccountVotingDelegation): StakeState => ({
+    ...stakeInitialState,
+    votingDelegation,
+});
+
+describe('stakeReducer voting delegation', () => {
+    it('stores the option together with the account it was confirmed for', () => {
+        const state = stakeReducer(
+            stakeInitialState,
+            stakeActions.setAccountVotingDelegation(anotherDrep),
+        );
+
+        expect(state.votingDelegation).toEqual(anotherDrep);
+    });
+
+    it('replaces a selection confirmed for another account', () => {
+        const state = stakeReducer(
+            stateWith({ accountKey: OTHER_ACCOUNT_KEY, option: DEFAULT_VOTING_OPTION }),
+            stakeActions.setAccountVotingDelegation(anotherDrep),
+        );
+
+        expect(state.votingDelegation).toEqual(anotherDrep);
+    });
+
+    it('drops the selection when it is cleared', () => {
+        const state = stakeReducer(
+            stateWith(anotherDrep),
+            stakeActions.clearAccountVotingDelegation(),
+        );
+
+        expect(state.votingDelegation).toBeUndefined();
+    });
+
+    it('keeps the selection on dispose, so backing out of the review modal does not discard it', () => {
+        const state = stakeReducer(
+            { ...stateWith(anotherDrep), serializedTx: { tx: 'tx', symbol: 'ada' } },
+            stakeActions.dispose(),
+        );
+
+        expect(state.votingDelegation).toEqual(anotherDrep);
+        expect(state.serializedTx).toBeUndefined();
+    });
+});

--- a/suite-common/wallet-core/src/stake/stakeReducer.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducer.ts
@@ -8,7 +8,7 @@ import type { StakeState } from './stakeReducerTypes';
 export const stakeInitialState: StakeState = {
     precomposedTx: undefined,
     serializedTx: undefined,
-    votingDelegation: { type: 'everstake' },
+    votingDelegation: undefined,
     data: stakeDataInitialState,
 };
 
@@ -43,8 +43,11 @@ export const prepareStakeReducer = createReducerWithExtraDeps(stakeInitialState,
                 delete state.serializedTx;
             }
         })
-        .addCase(stakeActions.setVotingDelegationOption, (state, action) => {
+        .addCase(stakeActions.setAccountVotingDelegation, (state, action) => {
             state.votingDelegation = action.payload;
+        })
+        .addCase(stakeActions.clearAccountVotingDelegation, state => {
+            delete state.votingDelegation;
         })
         .addCase(stakeActions.dispose, state => {
             delete state.precomposedTx;

--- a/suite-common/wallet-core/src/stake/stakeReducerTypes.ts
+++ b/suite-common/wallet-core/src/stake/stakeReducerTypes.ts
@@ -1,6 +1,6 @@
 import type { PrecomposedTransactionFinal, StakeFormState } from '@suite-common/wallet-types';
 
-import type { VotingDelegationOption } from './stakeActions';
+import type { AccountVotingDelegation } from './stakeActions';
 import type { StakeDataState } from './stakeDataSlice';
 import type { SerializedTx } from '../send/sendFormTypes';
 
@@ -9,7 +9,7 @@ export interface StakeState {
     precomposedForm?: StakeFormState;
     serializedTx?: SerializedTx; // payload for TrezorConnect.pushTransaction
     resolvedEthereumNonce?: string; // EVM nonce resolved at signing time, shown in the review modal
-    votingDelegation: VotingDelegationOption;
+    votingDelegation?: AccountVotingDelegation;
     data: StakeDataState;
 }
 

--- a/suite-common/wallet-core/src/stake/stakeSelectors.test.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.test.ts
@@ -1,7 +1,16 @@
+import { type AccountKey } from '@suite-common/wallet-types';
+
+import { type AccountVotingDelegation } from './stakeActions';
+import { DEFAULT_VOTING_OPTION } from './stakeConstants';
 import { type StakeDataState, stakeDataInitialState } from './stakeDataSlice';
 import { stakeInitialState } from './stakeReducer';
 import type { StakeRootState } from './stakeReducerTypes';
-import { selectCardanoPoolsInfo, selectEthNextRewardPayout } from './stakeSelectors';
+import {
+    selectCardanoPoolsInfo,
+    selectEthNextRewardPayout,
+    selectStakeVotingDelegation,
+    selectVotingDelegationOption,
+} from './stakeSelectors';
 
 const buildStakeState = (data: Partial<StakeDataState['data']>): StakeRootState => ({
     wallet: {
@@ -63,5 +72,56 @@ describe('selectCardanoPoolsInfo', () => {
         const state = createState(pools);
 
         expect(selectCardanoPoolsInfo(state)).toBe(pools);
+    });
+});
+
+describe('selectVotingDelegationOption', () => {
+    const accountKey = 'descriptor-a-ada-session' as AccountKey;
+    const otherAccountKey = 'descriptor-b-ada-session' as AccountKey;
+    const anotherDrep: AccountVotingDelegation['option'] = {
+        type: 'another_drep',
+        drepId: 'drep1abc',
+    };
+
+    const createState = (votingDelegation?: AccountVotingDelegation): StakeRootState => ({
+        wallet: { stake: { ...stakeInitialState, votingDelegation } },
+    });
+
+    // `toBe` throughout: components read this through `useSelector`, so both branches have to return
+    // a reference that only changes when the selection does.
+    it('falls back to Everstake when no option was confirmed', () => {
+        expect(selectVotingDelegationOption(createState(), accountKey)).toBe(DEFAULT_VOTING_OPTION);
+    });
+
+    it('returns the option confirmed for the queried account', () => {
+        const state = createState({ accountKey, option: anotherDrep });
+
+        expect(selectVotingDelegationOption(state, accountKey)).toBe(anotherDrep);
+    });
+
+    it('falls back to Everstake when the option belongs to another account', () => {
+        const state = createState({ accountKey: otherAccountKey, option: anotherDrep });
+
+        expect(selectVotingDelegationOption(state, accountKey)).toBe(DEFAULT_VOTING_OPTION);
+    });
+});
+
+describe('selectStakeVotingDelegation', () => {
+    it('returns the confirmed selection as stored, for prepareTxPlan to accept or reject', () => {
+        const votingDelegation: AccountVotingDelegation = {
+            accountKey: 'descriptor-a-ada-session' as AccountKey,
+            option: { type: 'current' },
+        };
+        const state: StakeRootState = {
+            wallet: { stake: { ...stakeInitialState, votingDelegation } },
+        };
+
+        expect(selectStakeVotingDelegation(state)).toBe(votingDelegation);
+    });
+
+    it('returns undefined when nothing was confirmed', () => {
+        const state: StakeRootState = { wallet: { stake: stakeInitialState } };
+
+        expect(selectStakeVotingDelegation(state)).toBeUndefined();
     });
 });

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -1,13 +1,14 @@
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import {
     getCardanoAccountPoolId,
     secondsToDays,
     selectBestCardanoPool,
 } from '@suite-common/wallet-utils';
 
-import type { VotingDelegationOption } from './stakeActions';
+import type { AccountVotingDelegation, VotingDelegationOption } from './stakeActions';
+import { DEFAULT_VOTING_OPTION } from './stakeConstants';
 import type { StakeRootState } from './stakeReducerTypes';
 
 export const selectStake = (state: StakeRootState) => state.wallet.stake;
@@ -75,8 +76,25 @@ export const selectPoolStatsApy = (
     }
 };
 
-export const selectVotingDelegationOption = (state: StakeRootState): VotingDelegationOption =>
-    selectStake(state).votingDelegation;
+/**
+ * The selection the user last confirmed, together with the account it was confirmed for. Composing
+ * paths pass it to `prepareTxPlan`, which honours it only for that very account; anything reading it
+ * to render a selection wants `selectVotingDelegationOption` instead.
+ */
+export const selectStakeVotingDelegation = (
+    state: StakeRootState,
+): AccountVotingDelegation | undefined => selectStake(state).votingDelegation;
+
+export const selectVotingDelegationOption = (
+    state: StakeRootState,
+    accountKey: AccountKey,
+): VotingDelegationOption => {
+    const votingDelegation = selectStakeVotingDelegation(state);
+
+    return votingDelegation?.accountKey === accountKey
+        ? votingDelegation.option
+        : DEFAULT_VOTING_OPTION;
+};
 
 export const selectStakePrecomposedForm = (state: StakeRootState) =>
     selectStake(state).precomposedForm;


### PR DESCRIPTION
## Description

The selected Cardano dRep was kept as one global value, so it stayed selected after switching accounts and after the delegation was already signed. It is now tied to the account it was chosen for, cleared once the staking transaction is pushed, and no longer reset when the voting section collapses.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30036

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/scope-cardano-account-voting-delegation/web/](https://dev.suite.sldev.cz/suite-web/fix/scope-cardano-account-voting-delegation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on Cardano staking/delegation and the earn provider consent modal family. The highest-risk regressions are in the Cardano stake/unstake/claim flows, so the ADA staking tests are the priority. ETH initial stake and yield withdrawal provide medium confidence that the shared consent modal and staking state plumbing still work. Broad-coverage files like walletMiddleware and wallet-core stake selectors are exercised indirectly by these focused tests; no additional broad suite runs are warranted.

<details><summary><b>Changed files (24)</b></summary>

- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts`
- `packages/suite/src/actions/wallet/stakeActions.ts`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/StakingEarnProviderConsentModal.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/UpdateEarnProviderConsentModal.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts`
- `packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.tsx`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx`
- `packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts`
- `packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.ts`
- `packages/suite/src/hooks/earn/useCardanoStaking.ts`
- `packages/suite/src/hooks/wallet/useChangeDelegateForm.ts`
- `packages/suite/src/middlewares/wallet/walletMiddleware.ts`
- `suite-common/wallet-core/src/stake/stakeActions.ts`
- `suite-common/wallet-core/src/stake/stakeReducer.test.ts`
- `suite-common/wallet-core/src/stake/stakeReducer.ts`
- `suite-common/wallet-core/src/stake/stakeReducerTypes.ts`
- `suite-common/wallet-core/src/stake/stakeSelectors.test.ts`
- `suite-common/wallet-core/src/stake/stakeSelectors.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Directly exercises the Cardano staking flow, including stake key registration, stake delegation, vote delegation, pool ID confirmation, and the Cardano deposit amount display. The changed VotingDelegations components, useCardanoStaking hook, stakeFormCardanoActions, StakeRegistrationDepositCard, and EarnProviderConsent modal infrastructure are all on this code path.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Validates the Cardano unstaking flow and the transition between staked/unstaked account states, which relies on the Cardano staking actions, hooks, and wallet-core stake reducer/selectors changed in this PR.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano staking reward claims, including reward amount handling and the claim button state. This exercises the Cardano staking data layer and UI components touched by the changes.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Covers the first-time staking flow including the 'staking in a nutshell' / EarnProviderConsent modal infrastructure and staking state management that were changed. While ETH-specific, the consent modal and staking Redux plumbing are shared with the Cardano changes.
- `suite/e2e/tests/yield/withdrawal.test.ts` — Exercises the earn/yield flow and the YieldEarnProviderConsentModal variant of the changed EarnProviderConsent modal family, as well as transaction simulation and device confirmation paths that share the earn modal infrastructure.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx`
- `packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts`
- `suite-common/wallet-core/src/stake/stakeReducer.test.ts`
- `suite-common/wallet-core/src/stake/stakeReducerTypes.ts`
- `suite-common/wallet-core/src/stake/stakeSelectors.test.ts`

_Updated: 2026-09-01T09:50:08.955Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/scope-cardano-account-voting-delegation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/scope-cardano-account-voting-delegation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/scope-cardano-account-voting-delegation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T09:52:19.024Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T09:51:51.663Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->