### PR TITLE
chore(network-stellar): upgrade @stellar/stellar-sdk to v17

### DIFF
--- a/networks/stellar/network-stellar/package.json
+++ b/networks/stellar/network-stellar/package.json
@@ -49,7 +49,7 @@
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../../scripts/publish/replace-imports.sh ./lib"
     },
     "dependencies": {
-        "@stellar/stellar-sdk": "16.1.0",
+        "@stellar/stellar-sdk": "17.0.0",
         "@trezor/utils": "workspace:*"
     }
 }

--- a/networks/stellar/network-stellar/src/runtime/transactions/identify.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/identify.ts
@@ -24,13 +24,26 @@ const isoToTimestamp = (isoDate: string): number => {
 };
 
 const convertMemo = (memo: Memo): string | undefined => {
+    // Memo<T>'s `value` getter type is keyed by T, but T isn't narrowed by switching on
+    // `memo.type` here (it's a generic class, not a discriminated union), so `.value`'s static
+    // type is still the full union across all memo types (including null, for MemoNone). The
+    // case-specific `as` casts below reflect the real runtime type for each memo type (see
+    // stellar-sdk's own memo.d.ts); `== null` covers both undefined and null defensively.
     switch (memo.type) {
-        case 'text':
+        // Memo.id's value is already a decimal string, not bytes; toString() is a no-op here
         case 'id':
-            return memo.value?.toString();
+            return memo.value == null ? undefined : (memo.value as string);
+        // Memo.value is a Uint8Array for text/hash/return; Buffer.from() is required so
+        // toString(encoding) decodes it correctly instead of silently returning garbage
+        case 'text':
+            return memo.value == null
+                ? undefined
+                : Buffer.from(memo.value as Uint8Array).toString('utf-8');
         case 'hash':
         case 'return':
-            return memo.value?.toString('hex');
+            return memo.value == null
+                ? undefined
+                : Buffer.from(memo.value as Uint8Array).toString('hex');
         default:
             return undefined;
     }
@@ -45,7 +58,7 @@ export const identifyTransaction = (rawTx: Horizon.ServerApi.TransactionRecord) 
 
     let parsedTx: Transaction;
     try {
-        const envelope = TransactionBuilder.fromXDR(rawTx.envelope_xdr, Networks.PUBLIC);
+        const envelope = TransactionBuilder.fromXdr(rawTx.envelope_xdr, Networks.PUBLIC);
         parsedTx = envelope instanceof FeeBumpTransaction ? envelope.innerTransaction : envelope;
     } catch {
         // A single unparseable record must not fail the whole account history

--- a/networks/stellar/network-stellar/src/runtime/transactions/parse.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/parse.ts
@@ -8,7 +8,7 @@ import {
 export const parseTransactionFromXDR = (xdrBase64: string, isTestnet: boolean) => {
     let parsed;
     try {
-        parsed = TransactionBuilder.fromXDR(
+        parsed = TransactionBuilder.fromXdr(
             xdrBase64,
             isTestnet ? Networks.TESTNET : Networks.PUBLIC,
         );

--- a/networks/stellar/network-stellar/src/runtime/transactions/transactions.test.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/transactions.test.ts
@@ -23,7 +23,7 @@ const NONCE = '6216415363851494999';
 
 const buildSorobanData = () =>
     new xdr.SorobanTransactionData({
-        ext: new xdr.SorobanTransactionDataExt(0),
+        ext: xdr.SorobanTransactionDataExt.v0(),
         resources: new xdr.SorobanResources({
             footprint: new xdr.LedgerFootprint({ readOnly: [], readWrite: [] }),
             instructions: 0,
@@ -168,8 +168,8 @@ describe('transactions', () => {
         });
 
         it('exposes the SorobanTransactionData as hex', () => {
-            const ext = tx.tx.ext();
-            const expected = 'sorobanData' in ext ? ext.sorobanData().toXDR('hex') : undefined;
+            const { ext } = tx.tx;
+            const expected = ext.type === 'sorobanData' ? ext.sorobanData.toXdr('hex') : undefined;
             expect(result.sorobanData).toBe(expected);
         });
     });

--- a/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
+++ b/networks/stellar/network-stellar/src/runtime/transactions/transform.ts
@@ -12,13 +12,18 @@ import {
     type Operation,
     type Signer,
     type Transaction,
-    type xdr,
+    xdr,
 } from '@stellar/stellar-sdk';
 
 import { toStroops } from '../../constants';
 
 // The protobuf Soroban enums mirror the Stellar XDR enums, so the XDR discriminant
-// (`x.switch().value`) is used directly as the protobuf `type`.
+// (`XxxType.fromName(x.type).value`) is used directly as the protobuf `type`.
+//
+// @stellar/stellar-sdk 17 rebuilt the xdr namespace: unions are now discriminated on a
+// string `.type` (e.g. `'scvBool'`) rather than a `.switch()` accessor, and their arms are
+// plain readonly properties (`val.u32`) instead of accessor methods (`val.u32()`). 64-bit
+// integers surface as native `bigint`.
 
 /**
  * Reads an SCAddress (account or contract) into its Stellar string form (G.../C...).
@@ -30,70 +35,64 @@ const readScAddress = (address: xdr.ScAddress) => Address.fromScAddress(address)
  * bytes-typed fields (bytes, string) are hex strings; 64-bit ints are decimal strings.
  */
 const readScVal = (val: xdr.ScVal): any => {
-    const type = val.switch().value;
+    const type = xdr.ScValType.fromName(val.type).value;
 
-    switch (val.switch().name) {
+    switch (val.type) {
         case 'scvBool':
-            return { type, b: val.b() };
+            return { type, b: val.b };
         case 'scvVoid':
             return { type };
         case 'scvU32':
-            return { type, u32: val.u32() };
+            return { type, u32: val.u32 };
         case 'scvI32':
-            return { type, i32: val.i32() };
+            return { type, i32: val.i32 };
         case 'scvU64':
-            return { type, u64: val.u64().toString() };
+            return { type, u64: val.u64.toString() };
         case 'scvI64':
-            return { type, i64: val.i64().toString() };
+            return { type, i64: val.i64.toString() };
         case 'scvTimepoint':
-            return { type, timepoint: val.timepoint().toString() };
+            return { type, timepoint: val.timepoint.toString() };
         case 'scvDuration':
-            return { type, duration: val.duration().toString() };
-        case 'scvU128': {
-            const parts = val.u128();
-
-            return { type, u128: { hi: parts.hi().toString(), lo: parts.lo().toString() } };
-        }
-        case 'scvI128': {
-            const parts = val.i128();
-
-            return { type, i128: { hi: parts.hi().toString(), lo: parts.lo().toString() } };
-        }
-        case 'scvU256': {
-            const parts = val.u256();
-
+            return { type, duration: val.duration.toString() };
+        case 'scvU128':
+            return {
+                type,
+                u128: { hi: val.u128.hi.toString(), lo: val.u128.lo.toString() },
+            };
+        case 'scvI128':
+            return {
+                type,
+                i128: { hi: val.i128.hi.toString(), lo: val.i128.lo.toString() },
+            };
+        case 'scvU256':
             return {
                 type,
                 u256: {
-                    hi_hi: parts.hiHi().toString(),
-                    hi_lo: parts.hiLo().toString(),
-                    lo_hi: parts.loHi().toString(),
-                    lo_lo: parts.loLo().toString(),
+                    hi_hi: val.u256.hiHi.toString(),
+                    hi_lo: val.u256.hiLo.toString(),
+                    lo_hi: val.u256.loHi.toString(),
+                    lo_lo: val.u256.loLo.toString(),
                 },
             };
-        }
-        case 'scvI256': {
-            const parts = val.i256();
-
+        case 'scvI256':
             return {
                 type,
                 i256: {
-                    hi_hi: parts.hiHi().toString(),
-                    hi_lo: parts.hiLo().toString(),
-                    lo_hi: parts.loHi().toString(),
-                    lo_lo: parts.loLo().toString(),
+                    hi_hi: val.i256.hiHi.toString(),
+                    hi_lo: val.i256.hiLo.toString(),
+                    lo_hi: val.i256.loHi.toString(),
+                    lo_lo: val.i256.loLo.toString(),
                 },
             };
-        }
         case 'scvBytes':
-            return { type, bytes: val.bytes().toString('hex') };
+            return { type, bytes: Buffer.from(val.bytes.value).toString('hex') };
         case 'scvString':
             // The bytes in an SCString are not necessarily valid UTF-8, so keep them as hex.
-            return { type, string: val.str().toString('hex') };
+            return { type, string: Buffer.from(val.str.bytes).toString('hex') };
         case 'scvSymbol':
-            return { type, symbol: val.sym().toString() };
+            return { type, symbol: val.sym.toString() };
         case 'scvVec': {
-            const vec = val.vec();
+            const { vec } = val;
             // A null vector is not a valid Soroban value; rejecting it avoids signing bytes
             // that differ from the input XDR (the firmware always encodes the vector as present).
             if (!vec) {
@@ -103,7 +102,7 @@ const readScVal = (val: xdr.ScVal): any => {
             return { type, vec: vec.map(readScVal) };
         }
         case 'scvMap': {
-            const map = val.map();
+            const { map } = val;
             if (!map) {
                 throw new Error('SCV_MAP with a null map is not supported');
             }
@@ -111,15 +110,15 @@ const readScVal = (val: xdr.ScVal): any => {
             return {
                 type,
                 map: map.map(entry => ({
-                    key: readScVal(entry.key()),
-                    value: readScVal(entry.val()),
+                    key: readScVal(entry.key),
+                    value: readScVal(entry.val),
                 })),
             };
         }
         case 'scvAddress':
-            return { type, address: readScAddress(val.address()) };
+            return { type, address: readScAddress(val.address) };
         default:
-            throw new Error(`Unsupported SCVal type: ${val.switch().name}`);
+            throw new Error(`Unsupported SCVal type: ${val.type}`);
     }
 };
 
@@ -127,22 +126,22 @@ const readScVal = (val: xdr.ScVal): any => {
  * Reads InvokeContractArgs (contract address, function name and arguments) from XDR.
  */
 const readInvokeContractArgs = (data: xdr.InvokeContractArgs) => ({
-    contract_address: readScAddress(data.contractAddress()),
-    function_name: data.functionName().toString(),
-    args: data.args().map(readScVal),
+    contract_address: readScAddress(data.contractAddress),
+    function_name: data.functionName.toString(),
+    args: data.args.map(readScVal),
 });
 
 /**
  * Reads a HostFunction from XDR. Only the invoke-contract host function is supported.
  */
 const readHostFunction = (hostFunction: xdr.HostFunction) => {
-    if (hostFunction.switch().name !== 'hostFunctionTypeInvokeContract') {
-        throw new Error(`Unsupported host function type: ${hostFunction.switch().name}`);
+    if (hostFunction.type !== 'hostFunctionTypeInvokeContract') {
+        throw new Error(`Unsupported host function type: ${hostFunction.type}`);
     }
 
     return {
-        type: hostFunction.switch().value,
-        invoke_contract: readInvokeContractArgs(hostFunction.invokeContract()),
+        type: xdr.HostFunctionType.fromName(hostFunction.type).value,
+        invoke_contract: readInvokeContractArgs(hostFunction.invokeContract),
     };
 };
 
@@ -150,13 +149,13 @@ const readHostFunction = (hostFunction: xdr.HostFunction) => {
  * Reads a SorobanAuthorizedFunction from XDR. Only the contract-fn variant is supported.
  */
 const readAuthorizedFunction = (fn: xdr.SorobanAuthorizedFunction) => {
-    if (fn.switch().name !== 'sorobanAuthorizedFunctionTypeContractFn') {
-        throw new Error(`Unsupported SorobanAuthorizedFunction type: ${fn.switch().name}`);
+    if (fn.type !== 'sorobanAuthorizedFunctionTypeContractFn') {
+        throw new Error(`Unsupported SorobanAuthorizedFunction type: ${fn.type}`);
     }
 
     return {
-        type: fn.switch().value,
-        contract_fn: readInvokeContractArgs(fn.contractFn()),
+        type: xdr.SorobanAuthorizedFunctionType.fromName(fn.type).value,
+        contract_fn: readInvokeContractArgs(fn.contractFn),
     };
 };
 
@@ -164,19 +163,19 @@ const readAuthorizedFunction = (fn: xdr.SorobanAuthorizedFunction) => {
  * Reads a SorobanAuthorizedInvocation tree from XDR (recurses into sub-invocations).
  */
 const readAuthorizedInvocation = (invocation: xdr.SorobanAuthorizedInvocation): any => ({
-    function: readAuthorizedFunction(invocation.function()),
-    sub_invocations: invocation.subInvocations().map(readAuthorizedInvocation),
+    function: readAuthorizedFunction(invocation.function),
+    sub_invocations: invocation.subInvocations.map(readAuthorizedInvocation),
 });
 
 /**
  * Reads SorobanAddressCredentials from XDR.
  */
 const readAddressCredentials = (credentials: xdr.SorobanAddressCredentials) => ({
-    address: readScAddress(credentials.address()),
+    address: readScAddress(credentials.address),
     // Nonce is a random sint64; keep it as a string to preserve full precision.
-    nonce: credentials.nonce().toString(),
-    signature_expiration_ledger: credentials.signatureExpirationLedger(),
-    signature: readScVal(credentials.signature()),
+    nonce: credentials.nonce.toString(),
+    signature_expiration_ledger: credentials.signatureExpirationLedger,
+    signature: readScVal(credentials.signature),
 });
 
 /**
@@ -184,16 +183,16 @@ const readAddressCredentials = (credentials: xdr.SorobanAddressCredentials) => (
  * supported; the legacy (to-be-deprecated) address credentials are intentionally rejected.
  */
 const readCredentials = (credentials: xdr.SorobanCredentials) => {
-    switch (credentials.switch().name) {
+    switch (credentials.type) {
         case 'sorobanCredentialsSourceAccount':
-            return { type: credentials.switch().value };
+            return { type: xdr.SorobanCredentialsType.fromName(credentials.type).value };
         case 'sorobanCredentialsAddressV2':
             return {
-                type: credentials.switch().value,
-                address_v2: readAddressCredentials(credentials.addressV2()),
+                type: xdr.SorobanCredentialsType.fromName(credentials.type).value,
+                address_v2: readAddressCredentials(credentials.addressV2),
             };
         default:
-            throw new Error(`Unsupported SorobanCredentials type: ${credentials.switch().name}`);
+            throw new Error(`Unsupported SorobanCredentials type: ${credentials.type}`);
     }
 };
 
@@ -201,8 +200,8 @@ const readCredentials = (credentials: xdr.SorobanCredentials) => {
  * Reads a SorobanAuthorizationEntry from XDR.
  */
 const readAuthorizationEntry = (entry: xdr.SorobanAuthorizationEntry) => ({
-    credentials: readCredentials(entry.credentials()),
-    root_invocation: readAuthorizedInvocation(entry.rootInvocation()),
+    credentials: readCredentials(entry.credentials),
+    root_invocation: readAuthorizedInvocation(entry.rootInvocation),
 });
 
 /**
@@ -223,7 +222,7 @@ const transformSigner = (signer: Signer) => {
 
     if ('ed25519PublicKey' in signer) {
         const keyPair = Keypair.fromPublicKey(signer.ed25519PublicKey);
-        const key = keyPair.rawPublicKey().toString('hex');
+        const key = Buffer.from(keyPair.rawPublicKey()).toString('hex');
 
         return { type: 0, key, weight };
     }
@@ -263,17 +262,23 @@ const transformAsset = (asset: Asset) => {
  * Transforms Memo to TrezorConnect.StellarTransaction.Memo
  */
 const transformMemo = (memo: Memo) => {
+    // Memo<T>'s `value` getter type is keyed by T, but T isn't narrowed by switching on
+    // `memo.type` here (it's a generic class, not a discriminated union), so `.value`'s static
+    // type is still the full union across all memo types. Buffer.from()'s overloads don't accept
+    // that union directly; the case-specific `as` casts below reflect the real runtime type for
+    // each memo type (see stellar-sdk's own memo.d.ts).
     switch (memo.type) {
         case MemoText:
-            return { type: 1, text: memo.value!.toString('utf-8') };
+            return { type: 1, text: Buffer.from(memo.value! as Uint8Array).toString('utf-8') };
         case MemoID:
-            return { type: 2, id: memo.value!.toString('utf-8') };
+            // Memo.id's value is already a decimal string, not bytes
+            return { type: 2, id: memo.value! as string };
         case MemoHash:
             // stringify is not necessary, Buffer is also accepted
-            return { type: 3, hash: memo.value!.toString('hex') };
+            return { type: 3, hash: Buffer.from(memo.value! as Uint8Array).toString('hex') };
         case MemoReturn:
             // stringify is not necessary, Buffer is also accepted
-            return { type: 4, hash: memo.value!.toString('hex') };
+            return { type: 4, hash: Buffer.from(memo.value! as Uint8Array).toString('hex') };
         default:
             return { type: 0 };
     }
@@ -338,12 +343,14 @@ export const transformTransaction = (transaction: Transaction) => {
         }
 
         // transform "price" field to { n: number, d: number }
+        // Note: @stellar/stellar-sdk 17 rebuilt the xdr namespace so union/struct fields
+        // (body, value, price, n, d) are plain readonly properties, not accessor methods
         if (typeof operation.price === 'string') {
-            const xdrOperationBody = transaction.tx.operations()[i]?.body().value();
+            const xdrOperationBody = transaction.tx.operations[i]?.body?.value;
             if (xdrOperationBody && 'price' in xdrOperationBody) {
                 operation.price = {
-                    n: xdrOperationBody.price().n(),
-                    d: xdrOperationBody.price().d(),
+                    n: xdrOperationBody.price.n,
+                    d: xdrOperationBody.price.d,
                 };
             }
         }
@@ -368,9 +375,12 @@ export const transformTransaction = (transaction: Transaction) => {
             operation.assetType = transformAsset(allowTrustAsset).type;
         }
 
-        if (operation.type === 'manageData' && operation.value) {
+        if (operation.type === 'manageData') {
+            // stellar-sdk 17 returns undefined here for a "remove data" operation (no value =
+            // delete the entry), where 16 returned null; normalize back to null so the
+            // null-means-removal contract noted above (re: setOptions) still holds.
             // stringify is not necessary, Buffer is also accepted
-            operation.value = operation.value.toString('hex');
+            operation.value = operation.value ? Buffer.from(operation.value).toString('hex') : null;
         }
         if (operation.type === 'manageBuyOffer') {
             operation.amount = operation.buyAmount;
@@ -384,9 +394,8 @@ export const transformTransaction = (transaction: Transaction) => {
     // Soroban transactions carry a transaction extension (SorobanTransactionData) that the
     // device signs over; expose it as raw XDR (hex) for the StellarTxExt message. Only the v1
     // envelope (TransactionExt) has it; the legacy v0 envelope never does.
-    const ext = transaction.tx.ext();
-    const sorobanData =
-        'sorobanData' in ext && ext.switch() === 1 ? ext.sorobanData().toXDR('hex') : undefined;
+    const { ext } = transaction.tx;
+    const sorobanData = ext.type === 'sorobanData' ? ext.sorobanData.toXdr('hex') : undefined;
 
     return {
         source: transaction.source,

--- a/packages/connect-plugin-stellar/README.md
+++ b/packages/connect-plugin-stellar/README.md
@@ -36,7 +36,7 @@ const tx = new Transaction(..., Networks.TESTNET);
 await TrezorConnect.stellarSignTransaction({
     device,
     path,
-    xdrBase64: tx.toXDR(),
+    xdrBase64: tx.toXdr(),
     testnet: true,
 });
 ```

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -336,7 +336,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                 isTestnet: testnet,
             });
 
-            const xdrBase64 = transaction.toXDR();
+            const xdrBase64 = transaction.toXdr();
 
             response = await TrezorConnect.stellarSignTransaction({
                 device: {
@@ -355,7 +355,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                 const signature = Buffer.from(response.payload.signature, 'hex').toString('base64');
                 transaction.addSignature(selectedAccount.descriptor, signature);
 
-                return { serializedTx: transaction.toEnvelope().toXDR('hex') };
+                return { serializedTx: transaction.toEnvelope().toXdr('hex') };
             }
         } else {
             return rejectWithValue({

--- a/suite-common/wallet-core/src/token/stellarTokenThunks.ts
+++ b/suite-common/wallet-core/src/token/stellarTokenThunks.ts
@@ -85,7 +85,7 @@ const manageTrustline = async (
         asset,
         isTestnet: testnet,
     });
-    const xdrBase64 = transaction.toXDR();
+    const xdrBase64 = transaction.toXdr();
 
     const response = await TrezorConnect.stellarSignTransaction({
         device: {
@@ -108,7 +108,7 @@ const manageTrustline = async (
 
     const signature = Buffer.from(response.payload.signature, 'hex').toString('base64');
     transaction.addSignature(account.descriptor, signature);
-    const serializedTx = transaction.toEnvelope().toXDR('hex');
+    const serializedTx = transaction.toEnvelope().toXdr('hex');
 
     // Submit transaction to the network
     const pushResponse = await TrezorConnect.pushTransaction({

--- a/suite-common/walletconnect/src/adapters/stellar.ts
+++ b/suite-common/walletconnect/src/adapters/stellar.ts
@@ -101,7 +101,7 @@ const stellarSignXDRThunk = createThunk<
         transaction.addSignature(account.descriptor, signature);
 
         return {
-            signedXDR: transaction.toEnvelope().toXDR('base64'),
+            signedXDR: transaction.toEnvelope().toXdr('base64'),
         };
     },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3476,6 +3476,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@exodus/bytes@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "@exodus/bytes@npm:1.15.1"
+  peerDependencies:
+    "@noble/hashes": ^1.8.0 || ^2.0.0
+  peerDependenciesMeta:
+    "@noble/hashes":
+      optional: true
+  checksum: 10/7dde00ae8040ec032ba3c287d210d7d555986caaf81a1215311c180422697d739a1952eb9d91e841132b18a19a910cdd02e4914136db3cc87baaa0fdd84b1e87
+  languageName: node
+  linkType: hard
+
 "@exodus/patch-broken-hermes-typed-arrays@npm:^1.0.0-alpha.1":
   version: 1.0.0-alpha.1
   resolution: "@exodus/patch-broken-hermes-typed-arrays@npm:1.0.0-alpha.1"
@@ -10145,24 +10157,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stellar/js-xdr@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@stellar/js-xdr@npm:4.0.0"
-  checksum: 10/d300c723e18f9d99c666499f8744a31981390ef8d780b2a321e019cbd23436a2de5b3d999e7af5e9ed334b14801497c0a19ad86ab052aff420415f2d89785a7b
+"@stellar/js-xdr@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@stellar/js-xdr@npm:5.0.0"
+  checksum: 10/90dcb6b98f5d2c1a95b5030dc78b77a6a81e78953a5d70d3cc3cf5dadcc285af4cb678136600b903a810e25e383520a1bf034b9f0def0456b71288d16149eec0
   languageName: node
   linkType: hard
 
-"@stellar/stellar-sdk@npm:16.1.0":
-  version: 16.1.0
-  resolution: "@stellar/stellar-sdk@npm:16.1.0"
+"@stellar/stellar-sdk@npm:17.0.0":
+  version: 17.0.0
+  resolution: "@stellar/stellar-sdk@npm:17.0.0"
   dependencies:
+    "@exodus/bytes": "npm:^1.15.1"
     "@noble/ed25519": "npm:^3.1.0"
     "@noble/hashes": "npm:^2.2.0"
-    "@stellar/js-xdr": "npm:4.0.0"
+    "@stellar/js-xdr": "npm:^5.0.0"
+    "@types/json-schema": "npm:^7.0.15"
     axios: "npm:1.18.0"
-    base32.js: "npm:^0.1.0"
     bignumber.js: "npm:^11.1.4"
-    buffer: "npm:^6.0.3"
     commander: "npm:^14.0.3"
     eventsource: "npm:^4.1.0"
     feaxios: "npm:^0.0.23"
@@ -10170,7 +10182,7 @@ __metadata:
     uint8array-extras: "npm:^1.5.0"
   bin:
     stellar-js: bin/stellar-js
-  checksum: 10/ebe5506ca704ebc5e10ba835a9ad6bf5dba036f397379512082d2743c63edcd73898a1ebf10534fd59c028da42e694fbe63403b6ccbe132a29f5448c599df754
+  checksum: 10/bd07c847f63538685af45ee086cb183eb0406c9328d1f9cd24925042d7820ecb8072a20779096a740123521c94fde868e3382ab8b77e94eb5542fe8f047a8b93
   languageName: node
   linkType: hard
 
@@ -17402,7 +17414,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/network-stellar@workspace:networks/stellar/network-stellar"
   dependencies:
-    "@stellar/stellar-sdk": "npm:16.1.0"
+    "@stellar/stellar-sdk": "npm:17.0.0"
     "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
@@ -22315,13 +22327,6 @@ __metadata:
   version: 5.0.1
   resolution: "base-x@npm:5.0.1"
   checksum: 10/6e4f847ef842e0a71c6b6020a6ec482a2a5e727f5a98534dbfd5d5a4e8afbc0d1bdf1fd57174b3f0455d107f10a932c3c7710bec07e2878f80178607f8f605c8
-  languageName: node
-  linkType: hard
-
-"base32.js@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "base32.js@npm:0.1.0"
-  checksum: 10/7d7401a8f5c4ec45336ff72c97ee554b9bc22c2153b301acf657e6f9e25928a6205b2cfc55731072ba5686515e4903e2d3e462bea49db5f1515bbd01da1276ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Internal branch of PR #31616

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on Stellar transaction parsing, token thunks, send-form thunks, and WalletConnect Stellar adapter. Only one E2E test touches Stellar user flows, so the minimal high-confidence run is that single test. The Stellar runtime transaction files and send-form thunks lack E2E coverage in the provided test set; they are primarily covered by the included unit test (transactions.test.ts) and should be validated there.

<details><summary><b>Changed files (8)</b></summary>

- `networks/stellar/network-stellar/package.json`
- `networks/stellar/network-stellar/src/runtime/transactions/identify.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/parse.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/transactions.test.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/transform.ts`
- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`
- `suite-common/wallet-core/src/token/stellarTokenThunks.ts`
- `suite-common/walletconnect/src/adapters/stellar.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This is the only identified E2E test that exercises Stellar (XLM) functionality: it enables the disabled Stellar network from the receive account picker and selects a Stellar receive account, directly exercising the stellar token/account discovery paths affected by suite-common/wallet-core/src/token/stellarTokenThunks.ts.

</details>

⚠️ **Changes with no test coverage (7)**
- `networks/stellar/network-stellar/package.json`
- `networks/stellar/network-stellar/src/runtime/transactions/identify.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/parse.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/transactions.test.ts`
- `networks/stellar/network-stellar/src/runtime/transactions/transform.ts`
- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`
- `suite-common/walletconnect/src/adapters/stellar.ts`

_Updated: 2026-09-07T11:21:21.559Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/theahaco/chore/stellar-sdk-v17/web/](https://dev.suite.sldev.cz/suite-web/theahaco/chore/stellar-sdk-v17/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=theahaco/chore/stellar-sdk-v17&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=theahaco/chore/stellar-sdk-v17&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=theahaco/chore/stellar-sdk-v17&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T11:22:50.205Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T11:22:53.244Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->