### PR TITLE
fix(suite): redact cardano staking errors from sentry

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -6,7 +6,7 @@ import { type Account, type CardanoAction } from '@suite-common/wallet-types';
 import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
 import TrezorConnect, { type CardanoCertificate, PROTO } from '@trezor/connect';
 
-import { prepareTxPlan } from './stakeFormCardanoActions';
+import { CardanoComposeError, prepareTxPlan } from './stakeFormCardanoActions';
 
 jest.mock('@trezor/connect', () => {
     const actual = jest.requireActual('@trezor/connect');
@@ -184,6 +184,27 @@ describe('prepareTxPlan', () => {
                 }),
             ]),
         );
+    });
+
+    it('rejects with the error code only, so a rejected payload cannot leave the device', async () => {
+        const utxoAddress = 'addr1q9utxo';
+        cardanoComposeTransactionMock.mockResolvedValue({
+            success: false,
+            error: {
+                code: 'Failure_UnknownCode',
+                message: `Invalid parameter "account.utxo" (= [{"address":"${utxoAddress}"}]): Expected string`,
+            },
+        });
+
+        const rejection = await prepareTxPlan({
+            account: mockNeverStakedAccount(),
+            action: 'delegate',
+            cardanoPools,
+        }).catch((error: unknown) => error);
+
+        expect(rejection).toBeInstanceOf(CardanoComposeError);
+        expect(rejection).toMatchObject({ code: 'Failure_UnknownCode' });
+        expect((rejection as Error).message).not.toContain(utxoAddress);
     });
 
     it('does not compose a withdrawal when there is nothing to withdraw', async () => {

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -59,8 +59,26 @@ import {
     validateCardanoDrep,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type FeeLevel, PROTO } from '@trezor/connect';
+import { type ErrorCode } from '@trezor/connect-common/src/constants/errors';
 import type { EstimatedFee } from '@trezor/network-solana/types'; // TODO should be Cardano instead?
 import { BigNumber } from '@trezor/utils';
+
+/**
+ * TrezorConnect error messages may embed the rejected payload verbatim — `@trezor/schema-utils`
+ * builds `Invalid parameter "account.utxo" (= [{"txid":…,"address":…}])` out of the params it
+ * validates. Such a message must never travel any further, because an uncaught rejection ends up
+ * in Sentry through its global unhandled-rejection handler. Only the error code, a fixed enum,
+ * is safe to carry.
+ */
+export class CardanoComposeError extends Error {
+    readonly code: ErrorCode;
+
+    constructor(code: ErrorCode) {
+        super(`cardanoComposeTransaction failed (${code})`);
+        this.name = 'CardanoComposeError';
+        this.code = code;
+    }
+}
 
 const calculateTransaction = (
     availableBalance: string,
@@ -203,7 +221,7 @@ export const prepareTxPlan = async ({
         testnet: isTestnet(account.symbol),
     });
 
-    if (!response.success) throw new Error(response.error.message);
+    if (!response.success) throw new CardanoComposeError(response.error.code);
 
     return { txPlan: response.payload[0], certificates, withdrawals, selectedPool };
 };

--- a/packages/suite/src/hooks/earn/useCardanoStaking.test.tsx
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.test.tsx
@@ -104,6 +104,26 @@ describe('useCardanoStaking', () => {
         expect(result.current.isStakingDisabled).toBe(true);
     });
 
+    it('keeps only the error code of a failed compose, never the message that may embed the payload', async () => {
+        const utxoAddress = 'addr1q9utxo';
+        cardanoComposeTransactionMock.mockResolvedValue({
+            success: false,
+            error: {
+                code: 'Failure_UnknownCode',
+                message: `Invalid parameter "account.utxo" (= [{"address":"${utxoAddress}"}]): Expected string`,
+            },
+        });
+
+        const { result } = renderCardanoStaking(mockNeverStakedAccount());
+
+        await act(() => result.current.calculateFeeAndDeposit('delegate'));
+
+        expect(result.current.delegatingAvailable).toEqual({
+            status: false,
+            reason: 'Failure_UnknownCode',
+        });
+    });
+
     it('does not make withdrawing available when there is nothing to withdraw', async () => {
         const { result } = renderCardanoStaking(mockNeverStakedAccount());
 

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -11,7 +11,10 @@ import {
     type CardanoStaking,
 } from '@suite-common/wallet-types';
 
-import { prepareTxPlan } from 'src/actions/wallet/stake/stakeFormCardanoActions';
+import {
+    CardanoComposeError,
+    prepareTxPlan,
+} from 'src/actions/wallet/stake/stakeFormCardanoActions';
 import { useSelector } from 'src/hooks/suite';
 
 export const useCardanoStaking = (): CardanoStaking => {
@@ -83,7 +86,9 @@ export const useCardanoStaking = (): CardanoStaking => {
                 // Deserialization failed in Ed25519KeyHash because: Invalid cbor: expected tuple 'hash length' of length 28 but got length Len(0).
                 const actionAvailability: ActionAvailability = {
                     status: false,
-                    reason: err.message,
+                    // A TrezorConnect failure is kept as its code only, never as its message, which
+                    // may embed the composed account payload.
+                    reason: err instanceof CardanoComposeError ? err.code : err.message,
                 };
                 setDelegatingAvailable(actionAvailability);
                 seWithdrawingAvailable(actionAvailability);

--- a/packages/suite/src/hooks/earn/useClaimForm.ts
+++ b/packages/suite/src/hooks/earn/useClaimForm.ts
@@ -124,10 +124,18 @@ export const useClaimForm = ({ account }: UseClaimFormsProps): ClaimContextValue
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(signTransaction(values, composedTx));
+            try {
+                const result = await dispatch(signTransaction(values, composedTx));
 
-            if (result?.success) {
-                clearForm();
+                if (result?.success) {
+                    clearForm();
+                }
+            } catch (error) {
+                // The sign thunk reaches TrezorConnect, whose rejection messages may embed the
+                // composed account payload, and `signTx` is submitted fire-and-forget. Handling the
+                // rejection here keeps it from being reported verbatim by Sentry's global
+                // unhandled-rejection handler. Only the error name, never its message, is safe to log.
+                console.warn('Stake signing failed', error instanceof Error ? error.name : error);
             }
         }
     }, [getValues, composedLevels, dispatch, clearForm, selectedFee]);

--- a/packages/suite/src/hooks/earn/useStakeForm.ts
+++ b/packages/suite/src/hooks/earn/useStakeForm.ts
@@ -351,11 +351,21 @@ export const useStakeForm = ({ account }: UseStakeFormProps): StakeContextValues
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
             setIsLoading(true);
-            const result = await dispatch(signTransaction(values, composedTx));
+            try {
+                const result = await dispatch(signTransaction(values, composedTx));
 
-            setIsLoading(false);
-            if (result?.success) {
-                clearForm();
+                if (result?.success) {
+                    clearForm();
+                }
+            } catch (error) {
+                // The sign thunk reaches TrezorConnect, whose rejection messages may embed the
+                // composed account payload, and `signTx` is also called fire-and-forget from
+                // `onSubmit`. Handling the rejection here keeps it from being reported verbatim by
+                // Sentry's global unhandled-rejection handler. Only the error name, never its
+                // message, is safe to log.
+                console.warn('Stake signing failed', error instanceof Error ? error.name : error);
+            } finally {
+                setIsLoading(false);
             }
         }
     }, [getValues, composedLevels, dispatch, clearForm, selectedFee]);

--- a/packages/suite/src/hooks/earn/useWithdrawalForm.ts
+++ b/packages/suite/src/hooks/earn/useWithdrawalForm.ts
@@ -274,10 +274,18 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(signTransaction(values, composedTx));
+            try {
+                const result = await dispatch(signTransaction(values, composedTx));
 
-            if (result?.success) {
-                clearForm();
+                if (result?.success) {
+                    clearForm();
+                }
+            } catch (error) {
+                // The sign thunk reaches TrezorConnect, whose rejection messages may embed the
+                // composed account payload, and `signTx` is submitted fire-and-forget. Handling the
+                // rejection here keeps it from being reported verbatim by Sentry's global
+                // unhandled-rejection handler. Only the error name, never its message, is safe to log.
+                console.warn('Stake signing failed', error instanceof Error ? error.name : error);
             }
         }
     }, [getValues, composedLevels, dispatch, clearForm, selectedFee]);

--- a/packages/suite/src/hooks/wallet/form/useStakeCompose.test.tsx
+++ b/packages/suite/src/hooks/wallet/form/useStakeCompose.test.tsx
@@ -1,0 +1,95 @@
+import { useForm } from 'react-hook-form';
+import { IntlProvider } from 'react-intl';
+
+import { act } from '@testing-library/react';
+
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type ComposeActionContext, type StakeFormState } from '@suite-common/wallet-types';
+import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
+
+import { composeTransaction } from 'src/actions/wallet/stakeActions';
+
+import { useStakeCompose } from './useStakeCompose';
+
+jest.mock('src/actions/wallet/stakeActions', () => ({
+    composeTransaction: jest.fn(),
+}));
+
+const composeTransactionMock = composeTransaction as jest.Mock;
+
+const composeActionContext = (): ComposeActionContext => ({
+    account: mockWalletAccount({ symbol: asNetworkSymbol('ada') }, networkSpecificDefaultCardano),
+    network: getNetwork(asNetworkSymbol('ada')),
+    feeInfo: {
+        blockHeight: 0,
+        blockTime: 20,
+        minFee: 44,
+        maxFee: 44,
+        minPriorityFee: 0,
+        levels: [],
+    },
+});
+
+const renderStakeCompose = () => {
+    const store = configureMockStore({ extra: undefined, preloadedState: {} });
+
+    return renderHookWithStoreProvider(
+        () => {
+            const methods = useForm<StakeFormState>();
+
+            return useStakeCompose({ ...methods, state: composeActionContext() });
+        },
+        {
+            store,
+            wrapper: ({ children }) => <IntlProvider locale="en">{children}</IntlProvider>,
+        },
+    );
+};
+
+describe('useStakeCompose', () => {
+    beforeEach(() => {
+        composeTransactionMock.mockReset();
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('settles a rejected compose instead of letting it escape as an unhandled rejection', async () => {
+        const utxoAddress = 'addr1q9utxo';
+        composeTransactionMock.mockReturnValue(() =>
+            Promise.reject(
+                new Error(`Invalid parameter "account.utxo" (= [{"address":"${utxoAddress}"}])`),
+            ),
+        );
+
+        const { result } = renderStakeCompose();
+
+        await act(async () => {
+            await expect(result.current.composeRequest()).resolves.toBeUndefined();
+        });
+
+        expect(composeTransactionMock).toHaveBeenCalled();
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.composedLevels).toBeUndefined();
+    });
+
+    it('does not log the rejection message, which may embed the composed account payload', async () => {
+        const utxoAddress = 'addr1q9utxo';
+        composeTransactionMock.mockReturnValue(() =>
+            Promise.reject(
+                new Error(`Invalid parameter "account.utxo" (= [{"address":"${utxoAddress}"}])`),
+            ),
+        );
+
+        const { result } = renderStakeCompose();
+
+        await act(async () => {
+            await result.current.composeRequest();
+        });
+
+        expect(JSON.stringify(jest.mocked(console.warn).mock.calls)).not.toContain(utxoAddress);
+    });
+});

--- a/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
@@ -78,6 +78,15 @@ export const useStakeCompose = <TFieldValues extends StakeFormState>({
                 const values = getValues();
 
                 return dispatch(composeTransaction(values, state));
+            }).catch(error => {
+                // The compose thunk reaches TrezorConnect, whose rejection messages may embed the
+                // composed account payload. `composeRequest` is fired without a `.catch` from the
+                // effects below, so a rejection escaping here would become an unhandled rejection
+                // and get reported verbatim by Sentry's global handler. Only the error name, never
+                // its message, is safe to log.
+                console.warn('Stake compose failed', error instanceof Error ? error.name : error);
+
+                return undefined;
             });
 
             // RACE-CONDITION NOTE:

--- a/suite-common/sentry/jest.config.js
+++ b/suite-common/sentry/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/sentry/package.json
+++ b/suite-common/sentry/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -1,4 +1,5 @@
 export * from './constants';
 export { ignoreErrorsCommon } from './ignoreErrors';
+export { redactInvalidParameterValue } from './redactInvalidParameterValue';
 export { redactSentryEvent } from './redactSentryEvent';
 export type { ChainableBeforeSend } from './types';

--- a/suite-common/sentry/src/redactInvalidParameterValue.test.ts
+++ b/suite-common/sentry/src/redactInvalidParameterValue.test.ts
@@ -1,0 +1,108 @@
+import type { ErrorEvent } from '@sentry/core';
+
+import { redactInvalidParameterValue } from './redactInvalidParameterValue';
+
+const ADDRESS = 'addr1q9xy8z0uv0h9k5v6v7v8v9wawbwcwdwewfwgwhwiwjwkwlwmwnwowpwqwrws';
+const TXID = 'a49b8d0d0f00f6db8bd5f2f5e5b0a5f0ef7b0ee0f1a2b3c4d5e6f7a8b9c0d1e2';
+
+// The exact shape `@trezor/schema-utils` gives an `InvalidParameter` thrown while validating
+// `cardanoComposeTransaction` params.
+const INVALID_PARAMETER_MESSAGE =
+    `Invalid parameter "account.utxo" ` +
+    `(= [{"txid":"${TXID}","address":"${ADDRESS}","amount":"4200000"}])` +
+    `: Expected string`;
+
+const asErrorEvent = (event: Partial<ErrorEvent>) => event as ErrorEvent;
+
+const getExceptionValue = (event: ErrorEvent | null) => event?.exception?.values?.[0]?.value;
+
+describe('redactInvalidParameterValue', () => {
+    it('strips the account payload that @trezor/schema-utils embeds in a validation error', () => {
+        const event = asErrorEvent({
+            exception: { values: [{ type: 'Error', value: INVALID_PARAMETER_MESSAGE }] },
+        });
+
+        expect(getExceptionValue(redactInvalidParameterValue(event))).toBe(
+            'Invalid parameter "account.utxo" (= <redacted>)',
+        );
+    });
+
+    it('strips the payload from a message truncated before its closing parenthesis', () => {
+        const event = asErrorEvent({
+            exception: {
+                values: [{ type: 'Error', value: INVALID_PARAMETER_MESSAGE.slice(0, 80) }],
+            },
+        });
+
+        expect(getExceptionValue(redactInvalidParameterValue(event))).toBe(
+            'Invalid parameter "account.utxo" (= <redacted>)',
+        );
+    });
+
+    it.each([
+        [
+            'a nested breadcrumb',
+            asErrorEvent({ breadcrumbs: [{ message: INVALID_PARAMETER_MESSAGE }] }),
+        ],
+        [
+            'an extra',
+            asErrorEvent({ extra: { arguments: [{ reason: INVALID_PARAMETER_MESSAGE }] } }),
+        ],
+        [
+            'the event message',
+            asErrorEvent({ message: INVALID_PARAMETER_MESSAGE, logger: 'console' }),
+        ],
+    ])('strips the payload from %s', (_name, event) => {
+        const redacted = JSON.stringify(redactInvalidParameterValue(event));
+
+        expect(redacted).not.toContain(ADDRESS);
+        expect(redacted).not.toContain(TXID);
+        expect(redacted).toContain('<redacted>');
+    });
+
+    it.each([
+        [
+            'contains the closing sequence itself',
+            'Invalid parameter "account.label" (= "spent (= 1): here"): Expected string',
+        ],
+        [
+            'contains the closing sequence and is truncated before the real one',
+            'Invalid parameter "account.label" (= "spent (= 1): here',
+        ],
+        [
+            'is followed by a second, truncated validation error',
+            'Invalid parameter "a" (= 1): Expected string, Invalid parameter "account.label" (= "here"',
+        ],
+    ])('strips a payload that %s', (_name, value) => {
+        const event = asErrorEvent({ exception: { values: [{ type: 'Error', value }] } });
+
+        expect(getExceptionValue(redactInvalidParameterValue(event))).not.toContain('here');
+    });
+
+    it('keeps two validation errors in one event separate instead of merging them', () => {
+        const event = asErrorEvent({
+            exception: {
+                values: [
+                    { type: 'Error', value: INVALID_PARAMETER_MESSAGE },
+                    { type: 'Error', value: 'Device disconnected' },
+                ],
+            },
+        });
+
+        const redacted = redactInvalidParameterValue(event);
+
+        expect(redacted?.exception?.values?.[1]?.value).toBe('Device disconnected');
+    });
+
+    it('leaves an unrelated event untouched', () => {
+        const event = asErrorEvent({
+            exception: { values: [{ type: 'Error', value: 'Device disconnected' }] },
+        });
+
+        expect(redactInvalidParameterValue(event)).toEqual(event);
+    });
+
+    it('passes a filtered-out event through', () => {
+        expect(redactInvalidParameterValue(null)).toBeNull();
+    });
+});

--- a/suite-common/sentry/src/redactInvalidParameterValue.ts
+++ b/suite-common/sentry/src/redactInvalidParameterValue.ts
@@ -1,0 +1,69 @@
+import type { ErrorEvent } from '@sentry/core';
+
+import { type ChainableBeforeSend } from './types';
+
+// `@trezor/schema-utils` builds parameter validation errors as
+// `Invalid parameter "account.utxo" (= [{"txid":…}]): Expected string`, embedding the rejected
+// value in the message. TrezorConnect passes that message back to its caller, so an error escaping
+// a call can carry account data (descriptors, addresses, UTXOs, amounts) into a Sentry event.
+// Callers are expected to drop such messages, this is the last line of defense. The field name is
+// kept, because it is what makes the report actionable.
+// Only the prefix is matched by a regex. A pattern spanning the value up to its closing `): `
+// would rescan the rest of the message for every `Invalid parameter "` inside it, which is
+// quadratic in the length of a message an attacker can influence.
+const INVALID_PARAMETER_PREFIX = /Invalid parameter "[^"]*" \(= /;
+
+const REDACTED = '<redacted>';
+
+// Deeper than Sentry's own `normalizeDepth`, so the whole event is covered.
+const MAX_DEPTH = 10;
+
+const redactInvalidParameterValueFromString = (value: string) => {
+    const prefix = INVALID_PARAMETER_PREFIX.exec(value);
+
+    if (prefix === null) {
+        return value;
+    }
+
+    // Everything past the prefix is dropped, the trailing reason included. Keeping the reason
+    // would mean locating the closing `): ` and so trusting the embedded value not to contain one,
+    // and a message Sentry truncated (see `maxValueLength`) has no closing sequence at all.
+    return `${value.slice(0, prefix.index + prefix[0].length)}${REDACTED})`;
+};
+
+// Rebuilding is only safe for structures a plain object can round-trip. Anything else (a class
+// instance, a Date) is left as it is rather than flattened into a plain object.
+const isPlainObject = (value: object) => {
+    const prototype = Object.getPrototypeOf(value);
+
+    return prototype === Object.prototype || prototype === null;
+};
+
+const redactStrings = (value: unknown, depth: number): unknown => {
+    if (typeof value === 'string') {
+        return redactInvalidParameterValueFromString(value);
+    }
+
+    if (value === null || typeof value !== 'object' || depth >= MAX_DEPTH) {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(item => redactStrings(item, depth + 1));
+    }
+
+    if (!isPlainObject(value)) {
+        return value;
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [key, redactStrings(item, depth + 1)]),
+    );
+};
+
+/**
+ * Strips values embedded in TrezorConnect parameter validation errors from anywhere in a Sentry
+ * event (exception message, stack, breadcrumbs, extras).
+ */
+export const redactInvalidParameterValue: ChainableBeforeSend = event =>
+    event === null ? null : (redactStrings(event, 0) as ErrorEvent);

--- a/suite-native/sentry/src/sentry.ts
+++ b/suite-native/sentry/src/sentry.ts
@@ -1,7 +1,11 @@
 import { captureConsoleIntegration } from '@sentry/core';
 import * as Sentry from '@sentry/react-native';
 
-import { ALLOW_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
+import {
+    ALLOW_REPORT_TAG,
+    redactInvalidParameterValue,
+    redactSentryEvent,
+} from '@suite-common/sentry';
 import { getEnv, isDebugEnv, isDetoxTestBuild, isProduction } from '@suite-native/config';
 
 import { ignoreErrors } from './ignoreErrors';
@@ -66,7 +70,7 @@ export const initSentry = () => {
         enableStallTracking: isPerformanceEnabledOnAppStart,
         enableUserInteractionTracing: false,
         enableLogs: true,
-        beforeSend: redactSentryEvent,
+        beforeSend: event => redactSentryEvent(redactInvalidParameterValue(event)),
         beforeSendTransaction: beforeSendPerformanceTransaction,
         ignoreErrors,
 

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -11,6 +11,7 @@ import {
     COINJOIN_NETWORK_TAG,
     COINJOIN_REPORT_TAG,
     type ChainableBeforeSend,
+    redactInvalidParameterValue,
     redactSentryEvent,
 } from '@suite-common/sentry';
 import { isDevEnv } from '@suite-common/suite-utils';
@@ -69,7 +70,7 @@ const redactCoinjoinData: ChainableBeforeSend = event => {
 };
 
 const beforeSend: ChainableBeforeSend = event =>
-    redactSentryEvent(redactUserPath(redactCoinjoinData(event)));
+    redactSentryEvent(redactInvalidParameterValue(redactUserPath(redactCoinjoinData(event))));
 
 const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
     // filter out analytics requests and image fetches


### PR DESCRIPTION
## Description

Redact sensitive data from Sentry reports when Cardano staking compose/sign fails.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30046

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set concentrates on Cardano staking actions/hooks and generic earn form hooks (stake, claim, withdrawal, compose), plus Sentry redaction/configuration files. Highest regression risk is in Cardano staking flows and generic staking/yield form composition. Run the targeted Cardano stake/claim/unstake, Ethereum/Solana initial stake, staking-form, and yield withdrawal tests for direct coverage. The Sentry-related files have no E2E test coverage and do not directly affect user-facing flows, so they are listed as uncovered.

<details><summary><b>Changed files (15)</b></summary>

- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts`
- `packages/suite/src/hooks/earn/useCardanoStaking.test.tsx`
- `packages/suite/src/hooks/earn/useCardanoStaking.ts`
- `packages/suite/src/hooks/earn/useClaimForm.ts`
- `packages/suite/src/hooks/earn/useStakeForm.ts`
- `packages/suite/src/hooks/earn/useWithdrawalForm.ts`
- `packages/suite/src/hooks/wallet/form/useStakeCompose.test.tsx`
- `packages/suite/src/hooks/wallet/form/useStakeCompose.ts`
- `suite-common/sentry/package.json`
- `suite-common/sentry/src/index.ts`
- `suite-common/sentry/src/redactInvalidParameterValue.test.ts`
- `suite-common/sentry/src/redactInvalidParameterValue.ts`
- `suite-native/sentry/src/sentry.ts`
- `suite/sentry/src/config.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Directly exercises the Cardano reward-claim flow and relies on the changed Cardano staking hooks/actions (useClaimForm, useCardanoStaking, stakeFormCardanoActions). A regression here would immediately break ADA staking rewards.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Covers the full Cardano staking submission flow, which is the primary user path affected by changes to stakeFormCardanoActions and useCardanoStaking.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Validates Cardano unstaking behavior and reuses the changed Cardano staking hooks/form composition logic.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Exercises the generic stake form composition path (useStakeForm/useStakeCompose) on Ethereum, ensuring the non-Cardano staking flow still builds and submits transactions correctly.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests the generic stake form composition path on Solana, providing chain-agnostic coverage of useStakeForm/useStakeCompose beyond Ethereum and Cardano.
- `suite/e2e/tests/staking/staking-form.test.ts` — Focuses on staking form validation, percentage/max calculations, and crypto/fiat input handling, which are core responsibilities of useStakeForm/useStakeCompose.
- `suite/e2e/tests/yield/withdrawal.test.ts` — Directly exercises useWithdrawalForm in the yield vault withdrawal flow, the main user path impacted by changes to that hook.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Reuses useStakeForm/useStakeCompose on an already-staked Ethereum account, serving as a sanity check that the generic stake form still works in the 'stake more' state.

</details>

⚠️ **Changes with no test coverage (9)**
- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts`
- `packages/suite/src/hooks/earn/useCardanoStaking.test.tsx`
- `packages/suite/src/hooks/wallet/form/useStakeCompose.test.tsx`
- `suite-common/sentry/package.json`
- `suite-common/sentry/src/index.ts`
- `suite-common/sentry/src/redactInvalidParameterValue.test.ts`
- `suite-common/sentry/src/redactInvalidParameterValue.ts`
- `suite-native/sentry/src/sentry.ts`
- `suite/sentry/src/config.ts`

_Updated: 2026-09-01T12:24:24.584Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/redact-cardano-staking-error-in-sentry/web/](https://dev.suite.sldev.cz/suite-web/fix/redact-cardano-staking-error-in-sentry/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/redact-cardano-staking-error-in-sentry&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/redact-cardano-staking-error-in-sentry&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/redact-cardano-staking-error-in-sentry&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:27:24.667Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:26:29.741Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->