### PR TITLE
fix(suite): scroll switch-device overlay inside its backdrop

### DIFF
--- a/packages/components/src/components/Modal/ModalBackdrop.tsx
+++ b/packages/components/src/components/Modal/ModalBackdrop.tsx
@@ -20,6 +20,7 @@ export type ModalBackdropProps = {
     padding?: Padding;
     zIndex?: ZIndexValues;
     opaque?: boolean;
+    isContentScrollable?: boolean;
     'data-testid'?: string;
 };
 
@@ -47,6 +48,7 @@ export const ModalBackdrop = ({
     padding = 8,
     zIndex = zIndices.modal,
     opaque = false,
+    isContentScrollable = false,
     'data-testid': dataTest,
 }: ModalBackdropProps) => {
     const modalTarget = useModalTarget();
@@ -62,6 +64,7 @@ export const ModalBackdrop = ({
                             justifyContent={mapAlignmentToJustifyContent(alignment)}
                             gap={16}
                             height="100%"
+                            overflow={isContentScrollable ? 'hidden auto' : undefined}
                         >
                             <InnerWrapper onMouseDown={e => e.stopPropagation()}>
                                 {children}

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
@@ -47,6 +47,7 @@ export const SwitchDeviceModal = ({
             alignment={{ x: 'start', y: 'start' }}
             padding={8}
             opaque={isInConnectPopup}
+            isContentScrollable
         >
             <TrafficLightOffset expand={false}>
                 <Container data-testid={`${dataTest}/switch-device`}>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

With many remembered devices, the device list grows taller than the window. Nothing in the overlay scrolls, so the overflow escapes to PageWrapper (height: 100dvh; overflow-x: hidden, which makes the block axis auto) and scrolls the whole app out from under the viewport-sized backdrop — cutting the blurred background off halfway down the window.

Adds an opt-in isContentScrollable prop to Modal.Backdrop that scrolls overflowing content inside the backdrop, and uses it in SwitchDeviceModal.


Before:

https://github.com/user-attachments/assets/01330051-077a-4718-89e9-c5445aa1ad04


After:

https://github.com/user-attachments/assets/ecf45aab-b022-4686-9096-672eb601f572




## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30127

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files are modal-related: SwitchDeviceModal is a specific user-facing modal and ModalBackdrop is a shared overlay component used by it. The highest regression risk is in any flow that opens the device switcher to add, eject, switch, or label wallets. I therefore recommend a tight set of device-switcher-centric tests; they exercise SwitchDeviceModal directly and also cover ModalBackdrop as the modal overlay. ModalBackdrop is broadly imported, but without a specific modal behavior change there is no need to run the full static mapping.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/Modal/ModalBackdrop.tsx`
- `packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test explicitly opens the device switcher and asserts the wallet fiat amount inside it; a regression in SwitchDeviceModal or its ModalBackdrop would be directly visible there.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — The test ejects the current wallet and adds a standard wallet through the device switcher, so it exercises the full open/close and interaction flow of SwitchDeviceModal.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — It edits standard and hidden wallet labels directly inside the device switcher and reloads the page, which relies on SwitchDeviceModal rendering and persisting wallet entries correctly.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — The test adds and switches between multiple passphrase wallets using the device switcher and asserts Suite Sync banner behavior per wallet, making SwitchDeviceModal central to the flow.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — It specifically verifies wallet numbering and labels as wallets are added and ejected through the device switcher, so any change to the switcher modal structure is likely to break it.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — The test adds hidden wallets, switches between them, and verifies receive addresses, all initiated from the device switcher modal.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test is explicitly about the device switching panel, asserting session status labels and the solve-issues flow inside SwitchDeviceModal.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — The test opens the device switcher to trigger a router location-change analytics event, so a broken SwitchDeviceModal would block this path even though the assertions are about analytics.
- `suite/e2e/tests/trading/navigation.test.ts` — It creates a hidden wallet via the device switcher before navigating to trading forms; SwitchDeviceModal must render correctly for the setup to succeed.

</details>

_Updated: 2026-09-01T11:58:21.760Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/switch-device-overlay-scroll&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/switch-device-overlay-scroll&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:02:05.669Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:01:19.450Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/switch-device-overlay-scroll/web/](https://dev.suite.sldev.cz/suite-web/fix/switch-device-overlay-scroll/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->