### PR TITLE
WIP: TEST - remove global shallow compare

### DIFF
--- a/packages/perf-e2e/src/markdown.test.ts
+++ b/packages/perf-e2e/src/markdown.test.ts
@@ -1,0 +1,117 @@
+import {
+    type ReportedMeasurement,
+    formatMarkdownReport,
+    mergeMeasurements,
+    perfReportComment,
+    readSectionMeasurements,
+} from './markdown';
+
+const measurement = (key: string, current = 100): ReportedMeasurement => ({
+    key,
+    runs: 1,
+    report: {
+        scenario: key,
+        overLimit: false,
+        unlimited: false,
+        metrics: [
+            {
+                key: 'totalBlockingTimeMs',
+                label: 'Total Blocking Time',
+                unit: 'ms',
+                baseline: 90,
+                current,
+                limit: 200,
+                ratioToLimit: current / 200,
+                exceededLimit: false,
+            },
+        ],
+    },
+});
+
+const LABEL = 'desktop / group 1';
+
+const publish = (existingBody: string | undefined, measurements: ReportedMeasurement[]) =>
+    perfReportComment({
+        existingBody,
+        label: LABEL,
+        section: formatMarkdownReport(
+            mergeMeasurements(
+                readSectionMeasurements({ body: existingBody, label: LABEL }),
+                measurements,
+            ),
+            { heading: LABEL },
+        ),
+    });
+
+describe(readSectionMeasurements.name, () => {
+    it('reads back what a section was rendered from', () => {
+        const body = publish(undefined, [measurement('wallet-discovery')]);
+
+        expect(readSectionMeasurements({ body, label: LABEL })).toEqual([
+            measurement('wallet-discovery'),
+        ]);
+    });
+
+    it('reads nothing from a body without the section', () => {
+        expect(readSectionMeasurements({ body: 'nothing here', label: LABEL })).toEqual([]);
+    });
+
+    it('reads nothing from another label, so sections cannot bleed into one another', () => {
+        const body = publish(undefined, [measurement('wallet-discovery')]);
+
+        expect(readSectionMeasurements({ body, label: 'web / group 2' })).toEqual([]);
+    });
+});
+
+describe(mergeMeasurements.name, () => {
+    it('keeps what was reported before and adds what is new', () => {
+        expect(
+            mergeMeasurements([measurement('account-switch')], [measurement('wallet-discovery')]),
+        ).toEqual([measurement('account-switch'), measurement('wallet-discovery')]);
+    });
+
+    it('lets the newer measurement of a scenario win', () => {
+        expect(
+            mergeMeasurements(
+                [measurement('account-switch', 100)],
+                [measurement('account-switch', 300)],
+            ),
+        ).toEqual([measurement('account-switch', 300)]);
+    });
+});
+
+// The orchestrator runs a Playwright process per test file, so one job publishes several times under
+// the same section label, each time knowing only its own file's scenarios.
+describe('publishing a section twice', () => {
+    it('holds the scenarios of both publishes', () => {
+        const first = publish(undefined, [measurement('multi-account-discovery')]);
+        const second = publish(first, [measurement('wallet-discovery')]);
+
+        expect(second).toContain('multi-account-discovery');
+        expect(second).toContain('wallet-discovery');
+        expect(
+            readSectionMeasurements({ body: second, label: LABEL }).map(({ key }) => key),
+        ).toEqual(['multi-account-discovery', 'wallet-discovery']);
+    });
+
+    it('renders one section, not one per publish', () => {
+        const second = publish(publish(undefined, [measurement('a')]), [measurement('b')]);
+
+        expect(second.match(/PERF-E2E-SECTION:[^:]+:START/g)).toHaveLength(1);
+    });
+
+    it('leaves the section of another job alone', () => {
+        const other = perfReportComment({
+            existingBody: undefined,
+            label: 'web / group 2',
+            section: formatMarkdownReport([measurement('web-scenario')], {
+                heading: 'web / group 2',
+            }),
+        });
+        const body = publish(other, [measurement('wallet-discovery')]);
+
+        expect(
+            readSectionMeasurements({ body, label: 'web / group 2' }).map(({ key }) => key),
+        ).toEqual(['web-scenario']);
+    });
+});

--- a/packages/perf-e2e/src/markdown.ts
+++ b/packages/perf-e2e/src/markdown.ts
@@ -63,6 +63,76 @@ const sectionMarkers = (label: string) => ({
     end: `<!-- PERF-E2E-SECTION:${safeLabel(label)}:END -->`,
 });
 
+/**
+ * The measurements a section was rendered from, carried inside it so the next publisher can add to
+ * them instead of replacing them. The orchestrator runs a Playwright process per test file, so one
+ * job publishes several times under the same section label, each time knowing only its own file's
+ * scenarios.
+ */
+const DATA_START = '<!-- PERF-E2E-DATA:';
+const DATA_END = ' -->';
+
+const encodeMeasurements = (measurements: readonly ReportedMeasurement[]) =>
+    `${DATA_START}${Buffer.from(JSON.stringify(measurements), 'utf8').toString('base64')}${DATA_END}`;
+
+const decodeMeasurements = (encoded: string): ReportedMeasurement[] => {
+    try {
+        const parsed: unknown = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+
+        return Array.isArray(parsed) ? (parsed as ReportedMeasurement[]) : [];
+    } catch {
+        // A section written by an older run, or one somebody edited by hand. Nothing to keep, and
+        // failing here would cost the measurements this run does have.
+        return [];
+    }
+};
+
+/**
+ * What a section already reported, or nothing when it is absent or unreadable.
+ */
+export const readSectionMeasurements = ({
+    body = '',
+    label,
+}: {
+    body?: string;
+    label: string;
+}): ReportedMeasurement[] => {
+    const { start, end } = sectionMarkers(label);
+    const startIndex = body.indexOf(start);
+    const endIndex = body.indexOf(end);
+
+    if (startIndex === -1 || endIndex <= startIndex) {
+        return [];
+    }
+
+    const section = body.slice(startIndex, endIndex);
+    const dataStart = section.indexOf(DATA_START);
+
+    if (dataStart === -1) {
+        return [];
+    }
+
+    const dataEnd = section.indexOf(DATA_END, dataStart);
+
+    return dataEnd === -1
+        ? []
+        : decodeMeasurements(section.slice(dataStart + DATA_START.length, dataEnd));
+};
+
+/**
+ * The fresher measurement of a scenario wins, everything else the section held is kept. Sorted, so
+ * that the table does not reshuffle between publishes of the same section.
+ */
+export const mergeMeasurements = (
+    previous: readonly ReportedMeasurement[],
+    incoming: readonly ReportedMeasurement[],
+): ReportedMeasurement[] => {
+    const merged = new Map(previous.map(measurement => [measurement.key, measurement]));
+    incoming.forEach(measurement => merged.set(measurement.key, measurement));
+
+    return [...merged.values()].sort((a, b) => a.key.localeCompare(b.key));
+};
+
 /** For a table cell, where an unescaped pipe would start a new column. */
 const escapeCell = (value: string) => value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
 
@@ -237,6 +307,7 @@ export const formatMarkdownReport = (
         ...overLimit.flatMap(measurement => overLimitShowcase(measurement, budgetsPath)),
         '',
         '</details>',
+        encodeMeasurements(measurements),
     ].join('\n');
 };
 

--- a/packages/suite/src/hooks/suite/useSelector.ts
+++ b/packages/suite/src/hooks/suite/useSelector.ts
@@ -1,8 +1,4 @@
-import {
-    type TypedUseSelectorHook,
-    shallowEqual,
-    useSelector as useReduxSelector,
-} from 'react-redux';
+import { type TypedUseSelectorHook, useSelector as useReduxSelector } from 'react-redux';
 
 import { type AppState } from 'src/types/suite';
 
@@ -12,5 +8,5 @@ import { type AppState } from 'src/types/suite';
  * Memoized using shallowEqual equality comparison
  * https://react-redux.js.org/api/hooks#equality-comparisons-and-updates
  */
-export const useSelector: TypedUseSelectorHook<AppState> = (selector, equalityFn = shallowEqual) =>
-    useReduxSelector(selector, equalityFn);
+export const useSelector: TypedUseSelectorHook<AppState> = selector =>
+    useReduxSelector(selector, () => false);

--- a/suite/e2e/performance/perfReportPublisher.ts
+++ b/suite/e2e/performance/perfReportPublisher.ts
@@ -5,8 +5,9 @@ import {
     PERF_REPORT_MARKER,
     type ReportedMeasurement,
     formatMarkdownReport,
+    mergeMeasurements,
     perfReportComment,
-    perfReportSection,
+    readSectionMeasurements,
 } from '@trezor/perf-e2e';
 
 /**
@@ -34,16 +35,30 @@ type PublishArgs = {
     log: (message: string) => void;
 };
 
-export const publishPerfReport = async ({ measurements, budgetsPath, log }: PublishArgs) => {
+/**
+ * Rendered from what the section already reported plus this run's measurements. The section is read
+ * again on every attempt, so a publish that lands between the read and the write is merged in rather
+ * than dropped.
+ */
+const buildSection = (existingBody: string | undefined, args: PublishArgs & { label: string }) =>
+    formatMarkdownReport(
+        mergeMeasurements(
+            readSectionMeasurements({ body: existingBody, label: args.label }),
+            args.measurements,
+        ),
+        {
+            heading: sectionHeading(),
+            runUrl: resolveRunUrl(),
+            budgetsPath: args.budgetsPath,
+        },
+    );
+
+export const publishPerfReport = async (args: PublishArgs) => {
+    const { measurements, log } = args;
     const label = sectionKey();
-    const section = formatMarkdownReport(measurements, {
-        heading: sectionHeading(),
-        runUrl: resolveRunUrl(),
-        budgetsPath,
-    });
 
     try {
-        writeStepSummary(section);
+        writeStepSummary(buildSection(undefined, { ...args, label }));
     } catch (error) {
         log(`Failed to write the performance report to the run summary: ${error}`);
     }
@@ -51,8 +66,21 @@ export const publishPerfReport = async ({ measurements, budgetsPath, log }: Publ
     try {
         const result = await upsertStickyPrComment({
             marker: PERF_REPORT_MARKER,
-            buildBody: existingBody => perfReportComment({ existingBody, label, section }),
-            holdsOwnContent: body => body.includes(perfReportSection({ label, section })),
+            buildBody: existingBody =>
+                perfReportComment({
+                    existingBody,
+                    label,
+                    section: buildSection(existingBody, { ...args, label }),
+                }),
+            // Only this run's own measurements are checked for: another job merging into the same
+            // section is not a loss, and demanding the whole section back would retry forever.
+            holdsOwnContent: body => {
+                const written = readSectionMeasurements({ body, label });
+
+                return measurements.every(measurement =>
+                    written.some(({ key }) => key === measurement.key),
+                );
+            },
         });
         log(`Performance report pull request comment: ${result}.`);
     } catch (error) {

--- a/suite/e2e/performance/perfReporter.ts
+++ b/suite/e2e/performance/perfReporter.ts
@@ -15,6 +15,10 @@ import {
     suggestLimits,
 } from '@trezor/perf-e2e';
 
+// TEMPORARY, remove before merge: a change under `suite/e2e/` outside `suite/e2e/tests/` makes
+// `determine-test-strategy` run the whole e2e suite, instead of the handful of specs the LLM picks
+// for a production change. The performance specs only run that way, and without them there are no
+// measurements and no report on the pull request.
 import { BASELINES, LIMITS } from './budgets';
 import { publishPerfReport } from './perfReportPublisher';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** useSelector.ts is a global Redux hook used across the entire suite, so most tests only transitively depend on it. The main risk from changes here is altered equality comparison or memoization, which can cause components to miss state updates or re-render incorrectly. The recommended tests focus on state changes that must visibly propagate to the UI across settings, dashboard, analytics, onboarding, and discovery — the areas most likely to reveal such regressions without running the full suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/suite/useSelector.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Toggling discreet mode is a single Redux state change that must propagate to many dashboard components (portfolio, assets, account values, device switcher). A regression in useSelector equality or memoization would likely cause some components to not re-render and fail the hidden-balance assertions.
- `suite/e2e/tests/settings/general.test.ts` — This test changes multiple settings (fiat, theme, language, analytics) and asserts both UI updates and analytics events. Settings components rely heavily on useSelector to read current values; a selector regression would break the observed state-to-UI propagation.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — Tests analytics consent state across reloads, including session/instance ID persistence and event firing. These flows read analytics state via selectors and verify state-driven behavior, making them sensitive to selector subscription changes.
- `suite/e2e/tests/suite/initial-run.test.ts` — Validates onboarding/initial-run state persistence across page reloads. This exercises how persisted Redux state is re-selected after hydration, which depends on useSelector behavior.
- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery is a long-running Redux state machine; the test asserts status transitions and account visibility after a mid-discovery reload. Selector memoization or equality changes could cause discovery state to not propagate to the UI correctly.

</details>

_Updated: 2026-09-01T10:54:04.371Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-remove-shallow-compare/web/](https://dev.suite.sldev.cz/suite-web/test-remove-shallow-compare/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-remove-shallow-compare&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-remove-shallow-compare&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T13:10:21.346Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T13:10:07.554Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->