### PR TITLE
fix(suite): show address below receive label

### DIFF
--- a/suite/receive/src/AddressCardDetail.tsx
+++ b/suite/receive/src/AddressCardDetail.tsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { AddressLabeling, copyAddressToClipboard } from '@suite/address';
+import { Address, AddressLabeling, copyAddressToClipboard } from '@suite/address';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
@@ -8,15 +8,13 @@ import { type ReceiveRootState, selectCurrentFreshAddress } from '@suite-common/
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { isUtxoBased } from '@suite-common/wallet-utils';
-import { Box, Button, Column, Flex, Row, Text, useMediaQuery } from '@trezor/components';
+import { Box, Button, Column, Grid, Row, Text, useMediaQuery } from '@trezor/components';
 import { CopyIcon, ShareNetworkIcon, ShieldCheckIcon } from '@trezor/icons';
 import { belowBreakpoint, breakpoints } from '@trezor/theme';
 
 import { CoinQrCode } from './CoinQrCode';
 import { type ReceiveAddressItem } from './address/buildReceiveAddressItems';
 import { canShareAddress, shareAddress } from './sharing/share';
-
-const QR_SIZE = 148;
 
 type AddressCardDetailProps = {
     item: ReceiveAddressItem;
@@ -66,14 +64,14 @@ export const AddressCardDetail = ({
     }
 
     const isUtxo = isUtxoBased(account);
+    const hasLabel = !!item.label;
 
     return (
         <Box padding={24}>
-            <Flex
-                direction={isBelowTablet ? 'column' : 'row'}
+            <Grid
+                columns={isBelowTablet ? '1fr' : 'minmax(max-content, 1fr) auto'}
                 gap={24}
                 alignItems="stretch"
-                justifyContent="space-between"
             >
                 <Column gap={32} alignItems="flex-start" justifyContent="space-between">
                     <Column gap={isUtxo ? 8 : 16} alignItems="flex-start">
@@ -92,15 +90,27 @@ export const AddressCardDetail = ({
                                 <Translation id="RECEIVE_ADDRESS_TITLE" />
                             </Text>
                         )}
-                        <Text typographyStyle="headline-md" data-testid="@wallet/receive/address">
-                            <AddressLabeling
-                                accountDescriptor={account.descriptor}
-                                networkSymbol={account.symbol}
-                                deviceStaticSessionId={account.deviceState}
-                                address={item.address}
-                                label={item.label}
-                            />
-                        </Text>
+                        <Column gap={8} alignItems="flex-start">
+                            <Text
+                                typographyStyle={hasLabel ? 'headline-sm' : 'headline-md'}
+                                data-testid="@wallet/receive/address"
+                            >
+                                <AddressLabeling
+                                    accountDescriptor={account.descriptor}
+                                    networkSymbol={account.symbol}
+                                    deviceStaticSessionId={account.deviceState}
+                                    address={item.address}
+                                    label={item.label}
+                                />
+                            </Text>
+                            {hasLabel && (
+                                <Address
+                                    value={item.address}
+                                    isTruncated
+                                    typographyStyle="headline-sm"
+                                />
+                            )}
+                        </Column>
                     </Column>
                     <Row gap={12} flexWrap="wrap">
                         <Button
@@ -137,10 +147,15 @@ export const AddressCardDetail = ({
                         </Button>
                     </Row>
                 </Column>
-                <Box aspectRatio="1" width={QR_SIZE} height={QR_SIZE} flex="none">
+                <Box
+                    aspectRatio="1"
+                    width={isBelowTablet ? 148 : undefined}
+                    height={isBelowTablet ? 148 : '100%'}
+                    maxHeight={200}
+                >
                     <CoinQrCode value={item.address} symbol={account.symbol} />
                 </Box>
-            </Flex>
+            </Grid>
         </Box>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Displays the shortened receive address underneath its label instead of replacing it.

## Notes for QA



## Related Issue

Resolve #31436.

## Screenshots:
<img width="1228" height="678" alt="image" src="https://github.com/user-attachments/assets/72930e2a-cdab-4415-b2fa-147b6c939c68" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** AddressCardDetail is part of the receive address UI, so changes could affect address display, copy/verify interactions, QR codes, and address labels. No static coverage mapping exists, so I inferred the most relevant tests: a direct receive flow test and two tests that exercise receive/address-label rendering through related entry points. This small set targets the highest-risk user-visible paths without broad, low-value coverage.

<details><summary><b>Changed files (1)</b></summary>

- `suite/receive/src/AddressCardDetail.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — Inferred (no static mapping): this test directly exercises the receive address flow for BTC, ETH, SOL and TRX, including copying the address, opening the address-copied modal, verifying the address on device, matching clipboard to device display, and checking the QR code — all of which likely render through AddressCardDetail.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Inferred: the global receive path opens the receive form, selects an account, displays the generated address, and compares the on-screen address with the device — a flow that uses the receive address UI and therefore could be affected by changes to AddressCardDetail.
- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — Inferred: this test edits Bitcoin address labels on the receive screen and asserts the label text and success icon are rendered correctly, which likely surfaces in the address card component that AddressCardDetail implements.

</details>

_Updated: 2026-09-01T10:56:03.640Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/receive-address-hidden-with-label/web/](https://dev.suite.sldev.cz/suite-web/fix/receive-address-hidden-with-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/receive-address-hidden-with-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/receive-address-hidden-with-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T10:59:07.423Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T10:58:51.136Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->