### PR TITLE
fix(suite-native-31952): fix E2E provider selection

### DIFF
--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -145,7 +145,7 @@ export abstract class TradingFormActions extends TradingActions {
         await waitForVisible(providersPicker);
     }
 
-    async selectProvider(providerName: string, filter: 'DEX' | 'CEX' | 'FIXED') {
+    async selectProvider(providerName: string, filter: 'dex' | 'cex' | 'all') {
         const providersPicker = this.getElementById('provider-picker');
         await waitForVisible(providersPicker, { timeout: this.SHORT_TIMEOUT });
         await providersPicker.tap();

--- a/suite-native/app/e2e/tests/tradingDexExchangeFlow.test.ts
+++ b/suite-native/app/e2e/tests/tradingDexExchangeFlow.test.ts
@@ -24,7 +24,7 @@ const prepareDexExchangeForm = async () => {
     await tradingExchangeActions.selectSendAsset('USDC', 'Ethereum', 'USD Coin');
     await tradingExchangeActions.selectReceiveAsset('USDT', 'Ethereum', 'Tether');
     await tradingExchangeActions.setSendCryptoAmount('6');
-    await tradingExchangeActions.selectProvider(dexProviderName, 'DEX');
+    await tradingExchangeActions.selectProvider(dexProviderName, 'dex');
     await tradingExchangeActions.expectValidExchangeForm();
 };
 


### PR DESCRIPTION
## Description

- Updates the trading E2E provider filter values to match the supported lowercase options.

## Notes for QA

- No QA

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31952

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31952-fix-e2e-provider-selection&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->