### PR TITLE
refactor(suite): extract yield form logic

### DIFF
--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -49,9 +49,7 @@ export const YieldDepositForm = () => {
         approvalAction,
         canRevokeAllowance,
         hasWrappedTokenBalance,
-        isAmountEmpty,
-        isAmountTooHigh,
-        isAmountInvalidDecimals,
+        amountIssues,
         isApprovalInsufficient,
         isSubmittingApprove,
         isSubmittingAction,
@@ -96,6 +94,10 @@ export const YieldDepositForm = () => {
         isWrappedNativeVault: flow.isWrappedNativeVault,
     });
     const hasAllowanceError = allowanceStatus === 'error';
+    const isAmountEmpty = amountIssues.includes('amount-empty');
+    const isAmountTooHigh = amountIssues.includes('amount-too-high');
+    const isAmountInvalidDecimals = amountIssues.includes('amount-invalid-decimals');
+    const hasBlockingAmountIssue = amountIssues.length > 0;
 
     const shouldCheckWrapAmount = !isAmountInvalidDecimals && !!wrapPendingTransaction;
     const shouldCheckApproveAmount = !isAmountInvalidDecimals && !!approvalPendingTransaction;
@@ -327,10 +329,7 @@ export const YieldDepositForm = () => {
                                             receivingAmount={liveAmount || '0'}
                                             isSubmitting={isSubmittingAction}
                                             isSubmitDisabled={
-                                                isWrapDisabled ||
-                                                isAmountEmpty ||
-                                                isAmountTooHigh ||
-                                                isAmountInvalidDecimals
+                                                isWrapDisabled || hasBlockingAmountIssue
                                             }
                                             warning={renderWrapWarning()}
                                             pendingTransaction={wrapPendingTransaction}
@@ -438,9 +437,7 @@ export const YieldDepositForm = () => {
                                             ) : undefined
                                         }
                                         isDisabled={
-                                            isAmountEmpty ||
-                                            isAmountTooHigh ||
-                                            isAmountInvalidDecimals ||
+                                            hasBlockingAmountIssue ||
                                             isApprovalInsufficient ||
                                             isSubmittingAction ||
                                             !!depositPendingTransaction

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { type UseFormReturn, useForm, useWatch } from 'react-hook-form';
+import { type UseFormReturn } from 'react-hook-form';
 
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { setConnectionModal, setConnectionMode, useDevice } from '@suite/device';
@@ -8,7 +8,6 @@ import { openModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     type YieldAllowanceStatus,
     type YieldApproveModalState,
@@ -18,11 +17,9 @@ import {
     type YieldFlowToken,
     type YieldPendingTransactionState,
     type YieldPositionFlowType,
-    getMaxWrapAmount,
     handleYieldApproveCancelThunk,
     handleYieldApproveSuccessTxidThunk,
     initYieldAllowanceThunk,
-    isStablecoinYieldSessionResumable,
     isYieldWithdrawFlow,
     selectStablecoinYieldSession,
     stablecoinYieldActions,
@@ -42,16 +39,13 @@ import { submitWrapNativeTokenThunk } from 'src/actions/wallet/wrapNativeTokenTh
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { useEnsureYieldDeviceSession } from './useEnsureYieldDeviceSession';
-import { useYieldFiatInput } from './useYieldFiatInput';
 import { useYieldFlowData } from './useYieldFlowData';
+import { type AmountIssue, useYieldForm } from './useYieldForm';
 import { useYieldPendingTransactionTracking } from './useYieldPendingTransactionTracking';
 import { type YieldAmountCardFiatToggleProps } from '../common/YieldAmountCard';
 import {
     type YieldApprovalAction,
     getYieldApprovalAction,
-    getYieldFiatRateToken,
-    getYieldModifyAmountInput,
-    getYieldUnwrapDefaultAmount,
     isAmountGreaterThan,
     shouldInitializeYieldAllowance,
 } from '../yieldFlowUtils';
@@ -78,9 +72,6 @@ export type UseYieldFlowResult = {
     flowKey: string;
     maxAmount: string;
     flowType: YieldPositionFlowType;
-    inputTokenSymbol: string;
-    otherUnitTokenSymbol: string;
-    canToggleWithdrawUnit: boolean;
     liveAmount: string;
     actionAmount: string | null;
     completedAmount: string;
@@ -95,9 +86,7 @@ export type UseYieldFlowResult = {
     approvalAction: YieldApprovalAction;
     canRevokeAllowance: boolean;
     hasWrappedTokenBalance: boolean;
-    isAmountEmpty: boolean;
-    isAmountTooHigh: boolean;
-    isAmountInvalidDecimals: boolean;
+    amountIssues: AmountIssue[];
     isApprovalInsufficient: boolean;
     isSubmittingApprove: boolean;
     isSubmittingAction: boolean;
@@ -140,23 +129,31 @@ export const useYieldFlow = ({
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { device } = useDevice();
-    const methods = useForm<YieldFlowFormValues>({
-        mode: 'onChange',
-        defaultValues: {
-            amountInput: '',
-            fiatInput: '',
-        },
-    });
-    const methodsRef = useCurrentRef(methods);
     const initAllowancePromiseRef = useRef<{ abort: () => void } | null>(null);
-    const unwrapDefaultAmountRef = useRef<string | null>(null);
 
     const yieldFlowData = useYieldFlowData({ account, vault });
     const { token, receiptToken, apy } = yieldFlowData;
-
     const depositedAmount = yieldFlowData.depositedAmount ?? '0';
     const depositedSharesAmount = yieldFlowData.depositedSharesAmount ?? '0';
     const flowKey = yieldFlowData.flowKey ?? '';
+
+    const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
+    // Fresh rather than commit-lagging: callbacks read the current step and pending transaction
+    // when invoked, including before the next effect commit.
+    const sessionRef = useFreshRef(session);
+
+    const {
+        methods,
+        liveAmount,
+        maxAmount,
+        setAmountInput,
+        amountIssues,
+        fiatToggle,
+        setMaxAmount,
+        resetAmounts,
+    } = useYieldForm({ flowType, flowData: yieldFlowData, account, vault, flowKey, session });
+    const methodsRef = useCurrentRef(methods);
+    const resetAmountsRef = useCurrentRef(resetAmounts);
 
     const allowanceFlowDataRef = useCurrentRef({
         account,
@@ -166,10 +163,6 @@ export const useYieldFlow = ({
     });
 
     const ensureDeviceSession = useEnsureYieldDeviceSession({ flowType, flowKey });
-    const session = useSelector(state => selectStablecoinYieldSession(state, flowType, flowKey));
-    // Fresh rather than commit-lagging: the entry effect below reads the session to decide whether
-    // the flow resumes, and a value one commit behind would restart a session it should keep.
-    const sessionRef = useFreshRef(session);
 
     const isWrappedNativeVault = isWrappedNativeToken(account.symbol, vault.token.address);
     const hasWrappedTokenBalance = isAmountGreaterThan({
@@ -178,63 +171,8 @@ export const useYieldFlow = ({
     });
     const hasWrappedTokenBalanceRef = useCurrentRef(hasWrappedTokenBalance);
 
-    const isSharesInput = flowType === 'redeem';
-    const canToggleWithdrawUnit = isYieldWithdrawFlow(flowType) && !!token && !!receiptToken;
-
-    // Fiat entry prices the amount by the token currently shown (native for wrap/unwrap, the vault
-    // asset for deposit/withdraw, none while redeeming shares).
-    const rateToken = getYieldFiatRateToken({
-        step: session.step,
-        flowType,
-        accountSymbol: account.symbol,
-        token,
-    });
-    const { fiatToggle, setMaxAmount, resetAmounts } = useYieldFiatInput({
-        methods,
-        symbol: rateToken?.symbol,
-        tokenAddress: rateToken?.tokenAddress,
-        decimals: token?.decimals ?? getNetwork(account.symbol).decimals,
-        vaultId: vault.id,
-    });
-    const resetAmountsRef = useCurrentRef(resetAmounts);
-
-    const getMaxAmount = () => {
-        if (flowType === 'deposit') {
-            if (session.step === 'wrap') {
-                // Max leaves the gas reserve aside while the balance covers it, otherwise it fills
-                // the whole balance. Either way the field shows the full balance and the user may
-                // wrap up to it (see `amountTooHighThreshold`), with a recommendation.
-                return getMaxWrapAmount(account.formattedBalance);
-            }
-
-            return token?.balance ?? '';
-        }
-        if (session.step === 'unwrap') {
-            return token?.balance ?? '';
-        }
-        if (isSharesInput) {
-            return depositedSharesAmount;
-        }
-
-        return depositedAmount;
-    };
-    const maxAmount = getMaxAmount();
-
-    const inputTokenSymbol = isSharesInput ? (receiptToken?.symbol ?? '') : (token?.symbol ?? '');
-    const otherUnitTokenSymbol = isSharesInput
-        ? (token?.symbol ?? '')
-        : (receiptToken?.symbol ?? '');
-
     useEffect(() => {
         if (!flowKey) return;
-
-        // A session that is mid-flow survives disposal (see `isStablecoinYieldSessionResumable`),
-        // so re-entering the flow resumes it — step, approval and pending state included — instead
-        // of starting over. `enterSession` makes that call on the live state, including the wrap
-        // step a fresh wrapped-native deposit can open past.
-        const resumedSession = isStablecoinYieldSessionResumable(sessionRef.current)
-            ? sessionRef.current
-            : null;
 
         dispatch(
             stablecoinYieldActions.enterSession({
@@ -245,28 +183,10 @@ export const useYieldFlow = ({
             }),
         );
 
-        // A resumed flow shows the amount it was left with: the one locked by the transaction in
-        // flight, or the one its confirmed transaction moved on to the next step.
-        resetAmountsRef.current(
-            resumedSession
-                ? (resumedSession.action.pendingTransaction?.amount ??
-                      resumedSession.action.amount ??
-                      '')
-                : '',
-        );
-
         return () => {
             dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
         };
-    }, [
-        flowKey,
-        flowType,
-        dispatch,
-        isWrappedNativeVault,
-        hasWrappedTokenBalanceRef,
-        resetAmountsRef,
-        sessionRef,
-    ]);
+    }, [flowKey, flowType, dispatch, isWrappedNativeVault, hasWrappedTokenBalanceRef]);
 
     const { allowanceStatus } = session.approval;
 
@@ -358,85 +278,6 @@ export const useYieldFlow = ({
         vault,
     });
 
-    // Sync form value on step transitions driven by Redux (e.g. completeApproval, enterModifyMode from thunk)
-    const prevStepRef = useRef<YieldFlowStepId | null>(null);
-
-    useEffect(() => {
-        const prevStep = prevStepRef.current;
-        const nextStep = session.step;
-
-        if (prevStep !== null && prevStep !== nextStep) {
-            if (prevStep === 'wrap' && nextStep === 'approve') {
-                resetAmountsRef.current(session.action.amount ?? '');
-            }
-
-            if (nextStep === 'wrap') {
-                methodsRef.current.reset({ amountInput: '', fiatInput: '' });
-            }
-
-            if (prevStep === 'approve' && nextStep === 'action') {
-                const actionAmount = session.action.amount ?? '';
-                const cappedAmount = isAmountGreaterThan({
-                    amount: actionAmount,
-                    threshold: maxAmount,
-                })
-                    ? maxAmount
-                    : actionAmount;
-                resetAmountsRef.current(cappedAmount);
-            }
-
-            if (prevStep === 'action' && nextStep === 'approve') {
-                resetAmountsRef.current(
-                    getYieldModifyAmountInput({
-                        liveAmount: methodsRef.current.getValues('amountInput'),
-                        actionAmount: session.action.amount,
-                        maxAmount,
-                    }),
-                );
-            }
-        }
-
-        prevStepRef.current = nextStep;
-    }, [session.step, session.action.amount, methodsRef, resetAmountsRef, maxAmount]);
-
-    // The withdraw flow's unwrap step must default to the amount just withdrawn (in asset units),
-    // not the account's whole wrapped-native balance — otherwise it would sweep in unrelated WETH
-    // the user never meant to unwrap (trezor/trezor-suite#30559).
-    const pricePerShareState = vault.state?.pricePerShareState;
-    const unwrapDefaultAmount = useMemo(() => {
-        if (!token || !receiptToken || !isYieldWithdrawFlow(flowType)) {
-            return token?.balance ?? '';
-        }
-
-        return getYieldUnwrapDefaultAmount({
-            flowType,
-            withdrawnAmount: session.result.completedAmount,
-            token,
-            receiptToken,
-            pricePerShareState,
-            fallbackAmount: token.balance,
-        });
-    }, [flowType, pricePerShareState, receiptToken, session.result.completedAmount, token]);
-
-    useEffect(() => {
-        if (session.step !== 'unwrap') {
-            unwrapDefaultAmountRef.current = null;
-
-            return;
-        }
-
-        const currentAmount = methodsRef.current.getValues('amountInput');
-
-        if (
-            unwrapDefaultAmountRef.current === null ||
-            currentAmount === unwrapDefaultAmountRef.current
-        ) {
-            resetAmountsRef.current(unwrapDefaultAmount);
-        }
-
-        unwrapDefaultAmountRef.current = unwrapDefaultAmount;
-    }, [methodsRef, resetAmountsRef, session.step, unwrapDefaultAmount]);
-
     const flow = useMemo(
         () => ({ currentStep: session.step, isWrappedNativeVault }),
         [session.step, isWrappedNativeVault],
@@ -474,13 +315,6 @@ export const useYieldFlow = ({
     const enterModifyApproval = useCallback(() => {
         dispatch(stablecoinYieldActions.enterModifyMode({ flowType, flowKey }));
     }, [dispatch, flowType, flowKey]);
-
-    const setAmountInput = useCallback(
-        (amount: string) => {
-            methodsRef.current.setValue('amountInput', amount);
-        },
-        [methodsRef],
-    );
 
     const openDeviceConnectionModal = useCallback(() => {
         if (device?.descriptor?.apiType === 'bluetooth') {
@@ -727,7 +561,7 @@ export const useYieldFlow = ({
                 amount,
             }),
         );
-        methodsRef.current.reset({ amountInput: '', fiatInput: '' });
+        resetAmountsRef.current('');
     }, [
         account,
         flowKey,
@@ -736,14 +570,12 @@ export const useYieldFlow = ({
         dispatch,
         token,
         vault,
-        methodsRef,
+        resetAmountsRef,
         session.approval.allowanceAmount,
         ensureDeviceSession,
         isDeviceConnected,
         openDeviceConnectionModal,
     ]);
-
-    const liveAmount = useWatch({ control: methods.control, name: 'amountInput' });
 
     const approvalAction = getYieldApprovalAction({
         liveAmount,
@@ -850,20 +682,8 @@ export const useYieldFlow = ({
         [dispatch, flowKey, flowType],
     );
 
-    const isAmountEmpty =
-        !liveAmount || !isAmountGreaterThan({ amount: liveAmount, threshold: '0' });
     const allowanceAmount = session.approval.allowanceAmount ?? '0';
     const canRevokeAllowance = isAmountGreaterThan({ amount: allowanceAmount, threshold: '0' });
-    // On the wrap step the hard cap is the full native balance: `maxAmount` holds the gas reserve
-    // aside for the Max button only while the balance covers it, and manually eating into the
-    // reserve is a non-blocking recommendation rather than an "insufficient funds" error.
-    const amountTooHighThreshold =
-        flowType === 'deposit' && session.step === 'wrap' ? account.formattedBalance : maxAmount;
-    const isAmountTooHigh = isAmountGreaterThan({
-        amount: liveAmount,
-        threshold: amountTooHighThreshold,
-    });
-    const isAmountInvalidDecimals = !!methods.formState.errors.amountInput;
     const isApprovalInsufficient =
         !session.approval.isModifyMode &&
         session.approval.allowanceStatus === 'loaded' &&
@@ -883,9 +703,6 @@ export const useYieldFlow = ({
         flowKey,
         maxAmount,
         flowType,
-        inputTokenSymbol,
-        otherUnitTokenSymbol,
-        canToggleWithdrawUnit,
         liveAmount,
         actionAmount: session.action.amount,
         completedAmount: session.result.completedAmount,
@@ -900,9 +717,7 @@ export const useYieldFlow = ({
         approvalAction,
         canRevokeAllowance,
         hasWrappedTokenBalance,
-        isAmountEmpty,
-        isAmountTooHigh,
-        isAmountInvalidDecimals,
+        amountIssues,
         isApprovalInsufficient,
         isSubmittingApprove:
             session.approval.isSubmitting ||

--- a/packages/suite/src/components/earn/yield/hooks/useYieldForm.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldForm.test.ts
@@ -1,0 +1,273 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import {
+    type ResolvedYieldFlowData,
+    type StablecoinYieldSessionState,
+    type YieldPositionFlowType,
+    initialStablecoinYieldSessionState,
+} from '@suite-common/wallet-core';
+import { toTokenSymbol } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { useYieldForm } from './useYieldForm';
+
+const FLOW_KEY = 'yield-flow';
+const TOKEN_ADDRESS = '0x0000000000000000000000000000000000000001';
+const RECEIPT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000002';
+const ETH_RATE = 2;
+
+const account = mockWalletAccount({
+    symbol: 'eth',
+    formattedBalance: '0.2',
+});
+const vault = {
+    id: 'ethereum-weth-vault',
+    network: 'ethereum',
+    chainId: 1,
+    providerId: 'morpho',
+    metadata: {
+        name: 'WETH Vault',
+        underMaintenance: false,
+        deprecated: false,
+    },
+    token: {
+        address: TOKEN_ADDRESS,
+        symbol: 'WETH',
+        name: 'Wrapped Ether',
+        decimals: 18,
+        network: 'ethereum',
+        coinGeckoId: 'weth',
+    },
+    outputToken: {
+        address: RECEIPT_TOKEN_ADDRESS,
+        symbol: 'mvWETH',
+        name: 'Morpho Vault WETH',
+        decimals: 18,
+        network: 'ethereum',
+        coinGeckoId: 'weth',
+    },
+    rewardRate: {
+        total: 0.05,
+        rateType: 'APY',
+        components: [],
+    },
+    status: {
+        enter: true,
+        exit: true,
+    },
+} satisfies YieldDtoV2 as unknown as YieldDtoV2;
+const token = {
+    networkSymbol: account.symbol,
+    symbol: 'WETH',
+    decimals: 18,
+    contractAddress: TOKEN_ADDRESS,
+    coingeckoId: 'weth',
+    balance: '25',
+};
+const receiptToken = {
+    networkSymbol: account.symbol,
+    symbol: 'mvWETH',
+    decimals: 18,
+    contractAddress: RECEIPT_TOKEN_ADDRESS,
+    coingeckoId: 'weth',
+};
+const flowData = {
+    resolutionStatus: 'resolved',
+    account,
+    vault,
+    token,
+    receiptToken,
+    flowData: { account, vault, token, receiptToken },
+    flowKey: FLOW_KEY,
+    apy: 5,
+    depositedAmount: '10',
+    depositedSharesAmount: '4',
+    isWrappedNativeVault: true,
+    wrappedNativeSymbol: 'ETH',
+    bonusRewardTokenSymbol: null,
+    providerName: 'Morpho',
+    tokenSymbol: toTokenSymbol('WETH'),
+    vaultName: 'WETH Vault',
+    vaultTokenName: 'Morpho Vault WETH',
+    vaultTokenSymbol: 'mvWETH',
+} satisfies ResolvedYieldFlowData;
+
+const createMockSession = (): StablecoinYieldSessionState => ({
+    ...initialStablecoinYieldSessionState,
+    approval: { ...initialStablecoinYieldSessionState.approval },
+    action: { ...initialStablecoinYieldSessionState.action },
+    result: {
+        ...initialStablecoinYieldSessionState.result,
+        completedRewards: [...initialStablecoinYieldSessionState.result.completedRewards],
+    },
+});
+
+let mockSession = createMockSession();
+
+const getMockState = () => ({
+    wallet: {
+        settings: { localCurrency: 'usd' },
+        fiat: {
+            current: {
+                'eth-usd': { rate: ETH_RATE },
+                [`eth-${TOKEN_ADDRESS}-usd`]: { rate: ETH_RATE },
+            },
+        },
+    },
+});
+
+// Reads the mutable `mockSession` at render time, so reassign-then-rerender takes effect.
+const renderYieldForm = (flowType: YieldPositionFlowType = 'deposit') =>
+    renderHook(() =>
+        useYieldForm({
+            flowType,
+            flowData,
+            account,
+            vault,
+            flowKey: FLOW_KEY,
+            session: mockSession,
+        }),
+    );
+
+jest.mock('src/hooks/suite', () => ({
+    useSelector: (selector: (state: ReturnType<typeof getMockState>) => unknown) =>
+        selector(getMockState()),
+}));
+
+jest.mock('@suite-common/dependency-injection', () => ({
+    useServices: () => ({ analytics: { report: jest.fn() } }),
+}));
+
+jest.mock('@suite/analytics', () => ({ selectDesktopAnalyticsDep: () => ({}) }));
+
+describe('useYieldForm', () => {
+    beforeEach(() => {
+        mockSession = createMockSession();
+    });
+
+    it('derives the step-aware max amount and wrap balance threshold', () => {
+        mockSession.step = 'wrap';
+        const { result } = renderYieldForm();
+
+        expect(result.current.maxAmount).toBe('0.195');
+        expect(result.current.amountIssues).toEqual(['amount-empty']);
+
+        act(() => result.current.setAmountInput('0.2'));
+
+        expect(result.current.amountIssues).toEqual([]);
+
+        act(() => result.current.setAmountInput('0.200000000000000001'));
+
+        expect(result.current.amountIssues).toEqual(['amount-too-high']);
+    });
+
+    it.each([
+        { flowType: 'deposit', expected: '25' },
+        { flowType: 'withdraw', expected: '10' },
+        { flowType: 'redeem', expected: '4' },
+    ] as const)('derives the $flowType action max amount', ({ flowType, expected }) => {
+        mockSession.step = 'action';
+        const { result } = renderYieldForm(flowType);
+
+        expect(result.current.maxAmount).toBe(expected);
+    });
+
+    it('uses the token balance as the unwrap max amount', () => {
+        mockSession.step = 'unwrap';
+        const { result } = renderYieldForm('withdraw');
+
+        expect(result.current.maxAmount).toBe('25');
+    });
+
+    it('uses the validation error of the active fiat or crypto input', () => {
+        mockSession.step = 'wrap';
+        const { result } = renderYieldForm();
+
+        act(() => result.current.fiatToggle?.onToggle());
+        act(() => result.current.methods.setError('fiatInput', { type: 'decimals' }));
+
+        expect(result.current.amountIssues).toContain('amount-invalid-decimals');
+
+        act(() => result.current.fiatToggle?.onToggle());
+
+        expect(result.current.amountIssues).not.toContain('amount-invalid-decimals');
+
+        act(() => result.current.methods.setError('amountInput', { type: 'decimals' }));
+
+        expect(result.current.amountIssues).toContain('amount-invalid-decimals');
+    });
+
+    it('keeps blocking on a stale crypto decimals error after toggling to fiat', () => {
+        mockSession.step = 'action';
+        const { result } = renderYieldForm();
+
+        act(() => result.current.setAmountInput('1'));
+        act(() => result.current.methods.setError('amountInput', { type: 'decimals' }));
+        act(() => result.current.fiatToggle?.onToggle());
+
+        expect(result.current.fiatToggle?.currency).toBe('fiat');
+        expect(result.current.amountIssues).toContain('amount-invalid-decimals');
+    });
+
+    it('fills both amount fields when an approval advances in fiat mode', () => {
+        mockSession.step = 'approve';
+        const { result, rerender } = renderYieldForm();
+
+        act(() => result.current.fiatToggle?.onToggle());
+
+        mockSession = {
+            ...mockSession,
+            step: 'action',
+            action: { ...mockSession.action, amount: '3' },
+        };
+        rerender();
+
+        expect(result.current.methods.getValues()).toEqual({
+            amountInput: '3',
+            fiatInput: '6.00',
+        });
+    });
+
+    it('restores the pending amount when re-entering a resumable flow', () => {
+        mockSession = {
+            ...mockSession,
+            step: 'action',
+            action: {
+                ...mockSession.action,
+                pendingTransaction: {
+                    type: 'deposit',
+                    txid: 'pending-txid',
+                    amount: '7',
+                },
+            },
+        };
+
+        const { result } = renderYieldForm();
+
+        expect(result.current.methods.getValues('amountInput')).toBe('7');
+    });
+
+    it('resets the form when the flow key changes', () => {
+        const { result, rerender } = renderHook(
+            ({ currentFlowKey }) =>
+                useYieldForm({
+                    flowType: 'deposit',
+                    flowData,
+                    account,
+                    vault,
+                    flowKey: currentFlowKey,
+                    session: mockSession,
+                }),
+            { initialProps: { currentFlowKey: FLOW_KEY } },
+        );
+
+        act(() => result.current.setAmountInput('5'));
+        rerender({ currentFlowKey: 'other-flow' });
+
+        expect(result.current.methods.getValues()).toEqual({
+            amountInput: '',
+            fiatInput: '',
+        });
+    });
+});

--- a/packages/suite/src/components/earn/yield/hooks/useYieldForm.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldForm.ts
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { type UseFormReturn, useForm, useWatch } from 'react-hook-form';
+
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    type ResolvedYieldFlowData,
+    type StablecoinYieldSessionState,
+    type YieldFlowFormValues,
+    type YieldFlowStepId,
+    type YieldPositionFlowType,
+    getMaxWrapAmount,
+    isStablecoinYieldSessionResumable,
+    isYieldWithdrawFlow,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { useCurrentRef, useFreshRef } from '@trezor/react-utils';
+
+import { useYieldFiatInput } from './useYieldFiatInput';
+import { type YieldAmountCardFiatToggleProps } from '../common/YieldAmountCard';
+import {
+    getYieldFiatRateToken,
+    getYieldModifyAmountInput,
+    getYieldUnwrapDefaultAmount,
+    isAmountGreaterThan,
+} from '../yieldFlowUtils';
+
+export type AmountIssue = 'amount-empty' | 'amount-too-high' | 'amount-invalid-decimals';
+
+type UseYieldFormProps = {
+    flowType: YieldPositionFlowType;
+    flowData: ResolvedYieldFlowData;
+    account: Account;
+    vault: YieldDtoV2;
+    flowKey: string;
+    session: StablecoinYieldSessionState;
+};
+
+type UseYieldFormResult = {
+    methods: UseFormReturn<YieldFlowFormValues>;
+    liveAmount: string;
+    maxAmount: string;
+    setAmountInput: (amount: string) => void;
+    amountIssues: AmountIssue[];
+    fiatToggle: YieldAmountCardFiatToggleProps | undefined;
+    setMaxAmount: (cryptoMax: string) => void;
+    resetAmounts: (cryptoAmount: string) => void;
+};
+
+export const useYieldForm = ({
+    flowType,
+    flowData,
+    account,
+    vault,
+    flowKey,
+    session,
+}: UseYieldFormProps): UseYieldFormResult => {
+    const methods = useForm<YieldFlowFormValues>({
+        mode: 'onChange',
+        defaultValues: {
+            amountInput: '',
+            fiatInput: '',
+        },
+    });
+    const methodsRef = useCurrentRef(methods);
+    const unwrapDefaultAmountRef = useRef<string | null>(null);
+
+    const { token, receiptToken } = flowData;
+    const depositedAmount = flowData.depositedAmount ?? '0';
+    const depositedSharesAmount = flowData.depositedSharesAmount ?? '0';
+
+    // Fresh rather than commit-lagging: entry reset must read the current resumable session amount.
+    const sessionRef = useFreshRef(session);
+    const isSharesInput = flowType === 'redeem';
+
+    const rateToken = getYieldFiatRateToken({
+        step: session.step,
+        flowType,
+        accountSymbol: account.symbol,
+        token,
+    });
+    const { fiatToggle, setMaxAmount, resetAmounts } = useYieldFiatInput({
+        methods,
+        symbol: rateToken?.symbol,
+        tokenAddress: rateToken?.tokenAddress,
+        decimals: token?.decimals ?? getNetwork(account.symbol).decimals,
+        vaultId: vault.id,
+    });
+    const resetAmountsRef = useCurrentRef(resetAmounts);
+
+    const getMaxAmount = (): string => {
+        if (flowType === 'deposit') {
+            if (session.step === 'wrap') {
+                return getMaxWrapAmount(account.formattedBalance);
+            }
+
+            return token?.balance ?? '';
+        }
+
+        if (session.step === 'unwrap') {
+            return token?.balance ?? '';
+        }
+
+        if (isSharesInput) {
+            return depositedSharesAmount;
+        }
+
+        return depositedAmount;
+    };
+    const maxAmount = getMaxAmount();
+
+    // Changing `flowType` triggers the reset because withdraw↔redeem changes the input unit.
+    useEffect(() => {
+        if (!flowKey) {
+            return;
+        }
+
+        const resumedSession = isStablecoinYieldSessionResumable(sessionRef.current)
+            ? sessionRef.current
+            : null;
+
+        resetAmountsRef.current(
+            resumedSession
+                ? (resumedSession.action.pendingTransaction?.amount ??
+                      resumedSession.action.amount ??
+                      '')
+                : '',
+        );
+    }, [flowKey, flowType, resetAmountsRef, sessionRef]);
+
+    const prevStepRef = useRef<YieldFlowStepId | null>(null);
+
+    // Redux thunks can transition steps outside this hook, so synchronize the form reactively.
+    useEffect(() => {
+        const prevStep = prevStepRef.current;
+        const nextStep = session.step;
+
+        if (prevStep !== null && prevStep !== nextStep) {
+            if (prevStep === 'wrap' && nextStep === 'approve') {
+                resetAmountsRef.current(session.action.amount ?? '');
+            }
+
+            if (nextStep === 'wrap') {
+                resetAmountsRef.current('');
+            }
+
+            if (prevStep === 'approve' && nextStep === 'action') {
+                const actionAmount = session.action.amount ?? '';
+                const cappedAmount = isAmountGreaterThan({
+                    amount: actionAmount,
+                    threshold: maxAmount,
+                })
+                    ? maxAmount
+                    : actionAmount;
+
+                resetAmountsRef.current(cappedAmount);
+            }
+
+            if (prevStep === 'action' && nextStep === 'approve') {
+                resetAmountsRef.current(
+                    getYieldModifyAmountInput({
+                        liveAmount: methodsRef.current.getValues('amountInput'),
+                        actionAmount: session.action.amount,
+                        maxAmount,
+                    }),
+                );
+            }
+        }
+
+        prevStepRef.current = nextStep;
+    }, [session.step, session.action.amount, methodsRef, resetAmountsRef, maxAmount]);
+
+    // The unwrap step defaults to the amount just withdrawn, not the whole wrapped-native balance
+    // — that would sweep in unrelated WETH (trezor/trezor-suite#30559).
+    const pricePerShareState = vault.state?.pricePerShareState;
+    const unwrapDefaultAmount = useMemo(() => {
+        if (!token || !receiptToken || !isYieldWithdrawFlow(flowType)) {
+            return token?.balance ?? '';
+        }
+
+        return getYieldUnwrapDefaultAmount({
+            flowType,
+            withdrawnAmount: session.result.completedAmount,
+            token,
+            receiptToken,
+            pricePerShareState,
+            fallbackAmount: token.balance,
+        });
+    }, [flowType, pricePerShareState, receiptToken, session.result.completedAmount, token]);
+
+    useEffect(() => {
+        if (session.step !== 'unwrap') {
+            unwrapDefaultAmountRef.current = null;
+
+            return;
+        }
+
+        const currentAmount = methodsRef.current.getValues('amountInput');
+
+        if (
+            unwrapDefaultAmountRef.current === null ||
+            currentAmount === unwrapDefaultAmountRef.current
+        ) {
+            resetAmountsRef.current(unwrapDefaultAmount);
+        }
+
+        unwrapDefaultAmountRef.current = unwrapDefaultAmount;
+    }, [methodsRef, resetAmountsRef, session.step, unwrapDefaultAmount]);
+
+    const setAmountInput = useCallback(
+        (amount: string) => {
+            methodsRef.current.setValue('amountInput', amount);
+        },
+        [methodsRef],
+    );
+
+    const liveAmount = useWatch({ control: methods.control, name: 'amountInput' });
+    // Max reserves gas, but manually entering the full native balance is allowed.
+    const amountTooHighThreshold =
+        flowType === 'deposit' && session.step === 'wrap' ? account.formattedBalance : maxAmount;
+    // Errors on `amountInput` always block because it is submitted; hidden fiat errors block only
+    // in fiat mode (trezor/trezor-suite#30900).
+    const hasBlockingAmountError =
+        !!methods.formState.errors.amountInput ||
+        (fiatToggle?.currency === 'fiat' && !!methods.formState.errors.fiatInput);
+    const amountIssues: AmountIssue[] = [];
+
+    if (!liveAmount || !isAmountGreaterThan({ amount: liveAmount, threshold: '0' })) {
+        amountIssues.push('amount-empty');
+    }
+
+    if (isAmountGreaterThan({ amount: liveAmount, threshold: amountTooHighThreshold })) {
+        amountIssues.push('amount-too-high');
+    }
+
+    if (hasBlockingAmountError) {
+        amountIssues.push('amount-invalid-decimals');
+    }
+
+    return {
+        methods,
+        liveAmount,
+        maxAmount,
+        setAmountInput,
+        amountIssues,
+        fiatToggle,
+        setMaxAmount,
+        resetAmounts,
+    };
+};

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -5,7 +5,11 @@ import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { getYieldFlowStepSequence, splitYieldPendingTransaction } from '@suite-common/wallet-core';
+import {
+    getYieldFlowStepSequence,
+    getYieldWithdrawInputToken,
+    splitYieldPendingTransaction,
+} from '@suite-common/wallet-core';
 import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
@@ -32,13 +36,8 @@ export const YieldWithdrawForm = () => {
         maxAmount,
         errorMessage,
         pendingTransaction,
-        isAmountEmpty,
-        isAmountTooHigh,
-        isAmountInvalidDecimals,
+        amountIssues,
         isSubmittingAction,
-        inputTokenSymbol,
-        otherUnitTokenSymbol,
-        canToggleWithdrawUnit,
         flowType,
         completedInput,
         completedOutput,
@@ -68,7 +67,16 @@ export const YieldWithdrawForm = () => {
     );
     const unwrapPendingTransaction =
         pendingTransaction?.type === 'unwrap' ? pendingTransaction : undefined;
-    const withdrawInputUnit = flowType === 'redeem' ? 'shares' : 'asset';
+    const isSharesInput = flowType === 'redeem';
+    const withdrawInputUnit = isSharesInput ? 'shares' : 'asset';
+    const inputTokenSymbol = getYieldWithdrawInputToken({
+        flowData: { account, vault, token, receiptToken },
+        flowType,
+    }).symbol;
+    const otherUnitTokenSymbol = isSharesInput ? token.symbol : receiptToken.symbol;
+    const isAmountTooHigh = amountIssues.includes('amount-too-high');
+    const isAmountInvalidDecimals = amountIssues.includes('amount-invalid-decimals');
+    const hasBlockingAmountIssue = amountIssues.length > 0;
 
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
     const withdrawActionToken = flowType === 'redeem' ? receiptToken : token;
@@ -250,18 +258,16 @@ export const YieldWithdrawForm = () => {
                                     }
                                     warning={getWithdrawWarning()}
                                     isDisabled={
-                                        isAmountEmpty ||
-                                        isAmountTooHigh ||
-                                        isAmountInvalidDecimals ||
+                                        hasBlockingAmountIssue ||
                                         isSubmittingAction ||
                                         !!withdrawPendingTransaction
                                     }
                                     isPending={isSubmittingAction}
                                     pendingTransaction={withdrawPendingTransaction}
-                                    // Toggling the unit switches `flowType`, disposing the
-                                    // session — mid-submit that drops a broadcast transaction.
                                     unitToggle={
-                                        canToggleWithdrawUnit && !isSubmittingAction
+                                        // Switching flow mid-submit can dispose its session before
+                                        // the pending transaction is stored.
+                                        !isSubmittingAction
                                             ? {
                                                   otherTokenSymbol: otherUnitTokenSymbol,
                                                   onClick: handleToggleWithdrawInputUnit,
@@ -310,10 +316,7 @@ export const YieldWithdrawForm = () => {
                                         onMaxClick={() => setMaxAmount(token.balance)}
                                         isSubmitting={isSubmittingAction}
                                         isSubmitDisabled={
-                                            isUnwrapDisabled ||
-                                            isAmountEmpty ||
-                                            isAmountTooHigh ||
-                                            isAmountInvalidDecimals
+                                            isUnwrapDisabled || hasBlockingAmountIssue
                                         }
                                         warning={
                                             shouldCheckUnwrapAmount && isAmountTooHigh ? (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extracts yield form logic from `useYieldFlow` into a dedicated `useYieldForm` hook.

- Moves form state, validation, max-amount logic, fiat handling, and resets.
- Updates deposit and withdraw consumers.
- Adds regression tests for validation and session restoration.
## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30915

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies yield/earn deposit and withdrawal form components and their shared hooks. Only one E2E test directly covers this functionality (yield withdrawal). The broad static mapping of 138 tests per file appears spurious, reflecting shared build/module imports rather than functional coverage. Run the yield/withdrawal test as the primary validation; no other E2E tests have specific evidence of being affected.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldForm.test.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldForm.ts`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/yield/withdrawal.test.ts` — Directly exercises the yield/earn withdrawal flow including the USDC Prime Vault position, withdrawal amount entry, transaction simulation modal, and device confirmation. The changed YieldWithdrawForm, useYieldFlow, and useYieldForm hooks are in the exact code path this test covers.

</details>

_Updated: 2026-09-01T11:08:56.064Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/extract-yield-form/web/](https://dev.suite.sldev.cz/suite-web/refactor/extract-yield-form/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/extract-yield-form&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/extract-yield-form&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T11:11:10.641Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T11:11:08.599Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->