### PR TITLE
Hotfix/bluetooth mem leak

### DIFF
--- a/packages/transport-bluetooth/CHANGELOG.md
+++ b/packages/transport-bluetooth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.4.4
+
+- fix: macos scan filters on the Trezor service UUID instead of retaining every nearby BLE advertiser (memory growth)
+
 ### 0.4.3
 
 - feat: add linux pairing Agent and handle pairing PIN request

--- a/packages/transport-bluetooth/CHANGELOG.md
+++ b/packages/transport-bluetooth/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - fix: macos scan filters on the Trezor service UUID instead of retaining every nearby BLE advertiser (memory growth)
 - fix: notification stream tasks are owned by a central registry and aborted when their websocket client disconnects, BLE subscriptions are released with the last stream
+- fix: scanning stops when the last websocket client disconnects, regardless of which client started it
+- fix: stop_scan resets the scanning flag even when called by another client or when the adapter call fails
 - fix: broadcast listeners survive lagged channels instead of exiting silently
 
 ### 0.4.3

--- a/packages/transport-bluetooth/CHANGELOG.md
+++ b/packages/transport-bluetooth/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 0.4.4
 
 - fix: macos scan filters on the Trezor service UUID instead of retaining every nearby BLE advertiser (memory growth)
+- fix: notification stream tasks are owned by a central registry and aborted when their websocket client disconnects, BLE subscriptions are released with the last stream
+- fix: broadcast listeners survive lagged channels instead of exiting silently
 
 ### 0.4.3
 

--- a/packages/transport-bluetooth/Cargo.lock
+++ b/packages/transport-bluetooth/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "trezor-bluetooth"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bluez-async",
  "btleplug",

--- a/packages/transport-bluetooth/Cargo.toml
+++ b/packages/transport-bluetooth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trezor-bluetooth"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 
 [profile.release]

--- a/packages/transport-bluetooth/src/server/adapter_manager.rs
+++ b/packages/transport-bluetooth/src/server/adapter_manager.rs
@@ -17,7 +17,11 @@ use tokio::{
 
 use crate::server::{
     device::{DeviceConnectionStatus, TrezorDevice},
-    types::{AbortProcess, AdapterState, ChannelMessage, KnownDevice, NotificationEvent},
+    notification_registry::{NotificationRegistry, RemovedStream},
+    types::{
+        AbortProcess, AdapterState, ChannelMessage, KnownDevice, NotificationCharacteristic,
+        NotificationEvent,
+    },
     utils, ConnectionBroadcast,
 };
 
@@ -36,6 +40,7 @@ pub struct AdapterManager {
     discovered_id: DashSet<String>,
     serviceless_peripherals: DashMap<String, ServicelessDevice>,
     serviceless_peripherals_prune_ts: Arc<Mutex<u128>>,
+    notification_streams: NotificationRegistry,
 }
 
 struct ManagerState {
@@ -100,6 +105,7 @@ impl AdapterManager {
             discovered_id: DashSet::new(),
             serviceless_peripherals: DashMap::new(),
             serviceless_peripherals_prune_ts: Arc::new(Mutex::new(0)),
+            notification_streams: NotificationRegistry::default(),
         })
     }
 
@@ -555,6 +561,12 @@ impl AdapterManager {
                         }
                     }
                     CentralEvent::DeviceDisconnected(id) => {
+                        // The BLE subscriptions died with the connection, abort
+                        // the notification streams reading from this peripheral.
+                        self_ref
+                            .close_notification_streams(None, Some(&id.to_string()), None)
+                            .await;
+
                         if let Some(mut device) = self_ref.get_device(&id).await {
                             info!("DeviceDisconnected: {:?} : {:?}", id, device);
 
@@ -636,6 +648,11 @@ impl AdapterManager {
     }
 
     pub async fn remove_listener(&self, listener: &ConnectionBroadcast) {
+        // Notification streams forward to this connection only, so they must
+        // not outlive it no matter how many other clients stay connected.
+        self.close_notification_streams(Some(listener.get_peer()), None, None)
+            .await;
+
         let mut state = self.manager_state.lock().await;
         state.listeners.retain(|item| !item.same_channel(listener));
 
@@ -648,6 +665,63 @@ impl AdapterManager {
     pub async fn is_listeners_empty(&self) -> bool {
         let state = self.manager_state.lock().await;
         state.listeners.is_empty()
+    }
+
+    pub fn register_notification_stream(
+        &self,
+        peer: String,
+        device_id: String,
+        characteristic: NotificationCharacteristic,
+        task: JoinHandle<()>,
+    ) {
+        self.notification_streams
+            .register(peer, device_id, characteristic, task);
+    }
+
+    /// Aborts matching notification stream tasks and releases BLE
+    /// subscriptions that lost their last stream. `None` filters match
+    /// everything.
+    pub async fn close_notification_streams(
+        &self,
+        peer: Option<&str>,
+        device_id: Option<&str>,
+        characteristic: Option<&NotificationCharacteristic>,
+    ) {
+        let removed = self
+            .notification_streams
+            .remove(peer, device_id, characteristic);
+
+        for stream in removed {
+            info!(
+                "{} {:?} stream terminated",
+                stream.device_id, stream.characteristic
+            );
+            if stream.unsubscribe {
+                self.unsubscribe_characteristic(&stream).await;
+            }
+        }
+    }
+
+    // Best effort BLE-level unsubscribe. The peripheral may already be gone
+    // (device disconnected), errors are only logged.
+    async fn unsubscribe_characteristic(&self, stream: &RemovedStream) {
+        let Ok(peripheral) = self.get_peripheral_or_die(&stream.device_id).await else {
+            return;
+        };
+        let uuid = stream.characteristic.to_uuid();
+        let Some(characteristic) = peripheral
+            .characteristics()
+            .into_iter()
+            .find(|c| c.uuid == uuid)
+        else {
+            return;
+        };
+        if let Err(err) = peripheral.unsubscribe(&characteristic).await {
+            info!(
+                "Unsubscribe {} {:?} error: {err}",
+                stream.device_id, stream.characteristic
+            );
+        }
     }
 
     async fn dispatch_adapter_event(&self) {
@@ -671,5 +745,64 @@ impl AdapterManager {
         for listener in &listeners {
             listener.send(message.clone());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    // Sets the flag when the task future is dropped, i.e. when it was aborted.
+    struct SetOnDrop(Arc<AtomicBool>);
+    impl Drop for SetOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn pending_stream_task(aborted: Arc<AtomicBool>) -> JoinHandle<()> {
+        // The guard is captured by the future itself, so it is dropped even
+        // when the task is aborted before its first poll.
+        let guard = SetOnDrop(aborted);
+        tokio::spawn(async move {
+            let _guard = guard;
+            std::future::pending::<()>().await;
+        })
+    }
+
+    // Finding 2 of https://github.com/trezor/trezor-suite/issues/31948:
+    // a disconnecting client must not leave its notification stream task
+    // alive just because another client is still connected.
+    #[tokio::test]
+    async fn remove_listener_aborts_streams_of_disconnected_client_only() {
+        let manager = AdapterManager::new().await.expect("manager");
+        let client_a = ConnectionBroadcast::new("a".to_string()).expect("broadcast");
+        let client_b = ConnectionBroadcast::new("b".to_string()).expect("broadcast");
+        manager.add_listener(client_a.clone()).await;
+        manager.add_listener(client_b.clone()).await;
+
+        let aborted_a = Arc::new(AtomicBool::new(false));
+        let aborted_b = Arc::new(AtomicBool::new(false));
+        manager.register_notification_stream(
+            "a".to_string(),
+            "dev1".to_string(),
+            NotificationCharacteristic::Read,
+            pending_stream_task(aborted_a.clone()),
+        );
+        manager.register_notification_stream(
+            "b".to_string(),
+            "dev1".to_string(),
+            NotificationCharacteristic::Read,
+            pending_stream_task(aborted_b.clone()),
+        );
+
+        // Client "a" disconnects while client "b" stays connected.
+        manager.remove_listener(&client_a).await;
+        // Give the runtime a moment to drop the aborted task.
+        sleep(Duration::from_millis(50)).await;
+
+        assert!(aborted_a.load(Ordering::SeqCst));
+        assert!(!aborted_b.load(Ordering::SeqCst));
     }
 }

--- a/packages/transport-bluetooth/src/server/adapter_manager.rs
+++ b/packages/transport-bluetooth/src/server/adapter_manager.rs
@@ -656,15 +656,28 @@ impl AdapterManager {
         let mut state = self.manager_state.lock().await;
         state.listeners.retain(|item| !item.same_channel(listener));
 
-        if state.listeners.is_empty() {
-            if let Some(adapter_loader) = state.adapter_loader.take() {
-                adapter_loader.abort();
+        if !state.listeners.is_empty() {
+            return;
+        }
+
+        if let Some(adapter_loader) = state.adapter_loader.take() {
+            adapter_loader.abort();
+        }
+
+        let was_scanning = state.is_scanning;
+        state.is_scanning = false;
+        drop(state); // unlock for get_adapter_or_die
+
+        // Scanning must not outlive the last client, even when the client
+        // that originally started it disconnected earlier.
+        if was_scanning {
+            info!("All clients disconnected, stopping scanning");
+            if let Ok(adapter) = self.get_adapter_or_die().await {
+                if let Err(err) = adapter.stop_scan().await {
+                    info!("remove_listener/adapter.stop_scan: {err}");
+                }
             }
         }
-    }
-    pub async fn is_listeners_empty(&self) -> bool {
-        let state = self.manager_state.lock().await;
-        state.listeners.is_empty()
     }
 
     pub fn register_notification_stream(
@@ -804,5 +817,26 @@ mod tests {
 
         assert!(aborted_a.load(Ordering::SeqCst));
         assert!(!aborted_b.load(Ordering::SeqCst));
+    }
+
+    // Finding 3 of https://github.com/trezor/trezor-suite/issues/31948:
+    // scanning must stop with the last client, not with the client that
+    // originally started it.
+    #[tokio::test]
+    async fn scanning_stops_with_the_last_listener() {
+        let manager = AdapterManager::new().await.expect("manager");
+        let client_a = ConnectionBroadcast::new("a".to_string()).expect("broadcast");
+        let client_b = ConnectionBroadcast::new("b".to_string()).expect("broadcast");
+        manager.add_listener(client_a.clone()).await;
+        manager.add_listener(client_b.clone()).await;
+        manager.set_scanning(true).await;
+
+        // The client that started the scan disconnects first.
+        manager.remove_listener(&client_a).await;
+        assert!(manager.is_scanning().await);
+
+        // The last client disconnects.
+        manager.remove_listener(&client_b).await;
+        assert!(!manager.is_scanning().await);
     }
 }

--- a/packages/transport-bluetooth/src/server/connection_broadcast.rs
+++ b/packages/transport-bluetooth/src/server/connection_broadcast.rs
@@ -25,6 +25,10 @@ impl ConnectionBroadcast {
         self.sender.clone()
     }
 
+    pub fn get_peer(&self) -> &str {
+        &self.peer
+    }
+
     pub fn subscribe(&self) -> Receiver<ChannelMessage> {
         self.sender.subscribe()
     }

--- a/packages/transport-bluetooth/src/server/connection_handler.rs
+++ b/packages/transport-bluetooth/src/server/connection_handler.rs
@@ -8,7 +8,10 @@ use hyper_tungstenite::{tungstenite::Message, HyperWebsocket};
 use hyper_util::rt::TokioIo;
 use log::info;
 use std::sync::Arc;
-use tokio::{net::TcpListener, sync::Mutex};
+use tokio::{
+    net::TcpListener,
+    sync::{broadcast::error::RecvError, Mutex},
+};
 
 use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
@@ -57,7 +60,18 @@ async fn handle_ws_connection(
     let ws_write_event = ws_write.clone();
     let ws_write_peer = peer.clone();
     let channel_message_listener = tokio::spawn(async move {
-        while let Ok(event) = receiver.recv().await {
+        loop {
+            let event = match receiver.recv().await {
+                Ok(event) => event,
+                Err(RecvError::Lagged(skipped)) => {
+                    // Keep the loop alive, exiting here would silently stop
+                    // event delivery while the websocket stays open.
+                    info!("ChannelMessage listener lagged, {skipped} events skipped");
+                    continue;
+                }
+                Err(RecvError::Closed) => break,
+            };
+
             match event {
                 ChannelMessage::Notification(event) => {
                     info!("Sending notification to peer {ws_write_peer}");
@@ -65,7 +79,7 @@ async fn handle_ws_connection(
                         Ok(json) => json,
                         Err(err) => {
                             info!("Error serialize notification {err:?}");
-                            return;
+                            continue;
                         }
                     };
 

--- a/packages/transport-bluetooth/src/server/methods/close_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/close_device.rs
@@ -1,23 +1,26 @@
+use log::info;
+
 use crate::server::{
     adapter_manager::AdapterManager,
-    types::{AbortProcess, ChannelMessage, CloseDeviceParams, MethodResult, WsResponsePayload},
+    types::{CloseDeviceParams, MethodResult, WsResponsePayload},
     ConnectionBroadcast,
 };
 
-use log::info;
-
 pub async fn close_device(
-    _manager: AdapterManager,
+    manager: AdapterManager,
     broadcast: ConnectionBroadcast,
     params: CloseDeviceParams,
 ) -> MethodResult {
     let id = params.id;
     info!("close_device {id}");
 
-    broadcast.send(ChannelMessage::Abort(AbortProcess::NotificationStream(
-        id,
-        params.characteristic,
-    )));
+    manager
+        .close_notification_streams(
+            Some(broadcast.get_peer()),
+            Some(&id),
+            params.characteristic.as_ref(),
+        )
+        .await;
 
     Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/methods/open_device.rs
+++ b/packages/transport-bluetooth/src/server/methods/open_device.rs
@@ -1,14 +1,12 @@
 use btleplug::api::{CharPropFlags, Peripheral as _};
 use futures::StreamExt;
 use log::info;
-use tokio::time::{sleep, Duration};
 
 use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
-    device::{CHARACTERISTIC_BATTERY_LEVEL, CHARACTERISTIC_PUSH_NOTIFICATION, CHARACTERISTIC_TX},
     types::{
-        AbortProcess, ChannelMessage, MethodError, MethodResult, NotificationCharacteristic,
-        NotificationEvent, OpenDeviceParams, WsResponsePayload,
+        ChannelMessage, MethodError, MethodResult, NotificationCharacteristic, NotificationEvent,
+        OpenDeviceParams, WsResponsePayload,
     },
     utils, ConnectionBroadcast,
 };
@@ -19,7 +17,9 @@ pub async fn open_device(
     params: OpenDeviceParams,
 ) -> MethodResult {
     let id = params.id;
-    let characteristic = params.characteristic;
+    let characteristic = params
+        .characteristic
+        .unwrap_or(NotificationCharacteristic::Read);
     info!("open_device {id} characteristic {characteristic:?}");
 
     manager.get_powered_adapter_or_die().await?;
@@ -29,22 +29,14 @@ pub async fn open_device(
         return Err(MethodError::Adapter(AdapterError::PeripheralNotConnected));
     }
 
-    let characteristic = characteristic.unwrap_or(NotificationCharacteristic::Read);
-    let characteristic_uuid = match characteristic {
-        NotificationCharacteristic::Read => CHARACTERISTIC_TX,
-        NotificationCharacteristic::TrezorPushNotification => CHARACTERISTIC_PUSH_NOTIFICATION,
-        NotificationCharacteristic::BatteryLevel => CHARACTERISTIC_BATTERY_LEVEL,
-    };
-
-    // try to terminate/abort previous read (if any)
-    broadcast.send(ChannelMessage::Abort(AbortProcess::NotificationStream(
-        id.clone(),
-        Some(characteristic.clone()),
-    )));
-    sleep(Duration::from_millis(5)).await;
+    // Terminate a previous stream of the same characteristic (if any).
+    manager
+        .close_notification_streams(Some(broadcast.get_peer()), Some(&id), Some(&characteristic))
+        .await;
 
     utils::wait_for_characteristics(&peripheral).await?;
 
+    let characteristic_uuid = characteristic.to_uuid();
     let Some(tx) = peripheral
         .characteristics()
         .into_iter()
@@ -61,11 +53,10 @@ pub async fn open_device(
     let mut notification_stream = peripheral.notifications().await?;
     let device_id = id.clone();
     let current_ch = characteristic.clone();
-    let current_uuid = characteristic_uuid.clone();
     let stream_task = tokio::spawn(async move {
         info!("{device_id} start {current_ch:?} stream");
         while let Some(data) = notification_stream.next().await {
-            if data.uuid != current_uuid {
+            if data.uuid != characteristic_uuid {
                 continue;
             }
             info!("{device_id} {current_ch:?} data");
@@ -80,44 +71,19 @@ pub async fn open_device(
                 info!("{device_id} error in {current_ch:?} stream {err}");
             }
         }
+        info!("{device_id} {current_ch:?} stream ended");
     });
 
-    let manager_ref = manager.clone();
-    let current_id = id.clone();
-    let current_ch = characteristic.clone();
-    let mut receiver = broadcast.subscribe();
-    tokio::spawn(async move {
-        while let Ok(event) = receiver.recv().await {
-            // TODO: if websocket client connection is related to this device
-            // AbortProcess::ClientDisconnected
-            if let ChannelMessage::Abort(AbortProcess::ClientDisconnected(_client)) = event {
-                if manager_ref.is_listeners_empty().await {
-                    stream_task.abort();
-                    let _ = peripheral.unsubscribe(&tx).await;
-                    info!("All clients disconnected, {id} {current_ch:?} stream terminated");
-                }
-                break;
-            }
-
-            // check if id should be disconnected
-            let maybe_id = match event {
-                ChannelMessage::Abort(AbortProcess::NotificationStream(id, maybe_ch)) => {
-                    let matches_ch = maybe_ch.map_or(true, |ch| ch == current_ch);
-                    matches_ch.then_some(id)
-                }
-                ChannelMessage::Abort(AbortProcess::DeviceDisconnected(id)) => Some(id),
-                _ => None,
-            };
-
-            // check current_id == maybe_id
-            if let Some(id) = maybe_id.filter(|id| id == &current_id) {
-                stream_task.abort();
-                let _ = peripheral.unsubscribe(&tx).await;
-                info!("{id} {current_ch:?} stream terminated");
-                break;
-            }
-        }
-    });
+    // The registry aborts the task when this stream, its device or this
+    // websocket connection is closed. The previous per-connection watcher
+    // leaked the task and its BLE subscription whenever any other client was
+    // still connected (https://github.com/trezor/trezor-suite/issues/31948).
+    manager.register_notification_stream(
+        broadcast.get_peer().to_string(),
+        id,
+        characteristic,
+        stream_task,
+    );
 
     Ok(WsResponsePayload::Success { success: true })
 }

--- a/packages/transport-bluetooth/src/server/methods/start_scan.rs
+++ b/packages/transport-bluetooth/src/server/methods/start_scan.rs
@@ -7,6 +7,7 @@ use tokio::time::{sleep, Duration};
 
 use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
+    device::SERVICE_UUID,
     types::{
         AbortProcess, AdapterState, ChannelMessage, MethodResult, NotificationEvent,
         WsResponsePayload,
@@ -14,11 +15,36 @@ use crate::server::{
     ConnectionBroadcast,
 };
 
+fn trezor_scan_filter() -> ScanFilter {
+    // Unfiltered discovery retains every nearby BLE advertiser inside btleplug
+    // for the lifetime of the adapter and grows without bound
+    // (https://github.com/trezor/trezor-suite/issues/31948).
+    //
+    // macos: CoreBluetooth matches the filter inside the system daemon, against
+    // advertisement, scan response and the hashed overflow area, so only Trezor
+    // peripherals are ever surfaced. Some macs fail to update advertised
+    // services in peripheral properties (the reason the previous filter was
+    // removed in #21093) — the serviceless retry in AdapterManager still
+    // handles those once the peripheral is delivered.
+    //
+    // linux: never pass service uuids to discovery — a uuid filter crashes
+    // bluetoothd on bluez 5.87, and paired devices may not advertise services
+    // at all. windows: ScanFilter does not work reliably
+    // (https://github.com/deviceplug/btleplug/issues/249).
+    if cfg!(target_os = "macos") {
+        ScanFilter {
+            services: vec![SERVICE_UUID],
+        }
+    } else {
+        ScanFilter::default()
+    }
+}
+
 async fn start_scanning(adapter: &Adapter) -> Result<(), AdapterError> {
     // stop previous process just to be sure
     stop_scanning(adapter).await;
 
-    if let Err(err) = adapter.start_scan(ScanFilter::default()).await {
+    if let Err(err) = adapter.start_scan(trezor_scan_filter()).await {
         info!("Start scan error {err}");
         return Err(err.into());
     }

--- a/packages/transport-bluetooth/src/server/methods/start_scan.rs
+++ b/packages/transport-bluetooth/src/server/methods/start_scan.rs
@@ -3,7 +3,10 @@ use btleplug::{
     platform::Adapter,
 };
 use log::info;
-use tokio::time::{sleep, Duration};
+use tokio::{
+    sync::broadcast::error::RecvError,
+    time::{sleep, Duration},
+};
 
 use crate::server::{
     adapter_manager::{AdapterError, AdapterManager},
@@ -82,20 +85,25 @@ pub async fn start_scan(manager: AdapterManager, broadcast: ConnectionBroadcast)
     let mut receiver = broadcast.subscribe();
     let manager_ref = manager.clone();
     tokio::spawn(async move {
-        while let Ok(event) = receiver.recv().await {
+        loop {
+            let event = match receiver.recv().await {
+                Ok(event) => event,
+                Err(RecvError::Lagged(skipped)) => {
+                    // Keep watching, exiting here would strand the scan state.
+                    info!("start_scan loop lagged, {skipped} events skipped");
+                    continue;
+                }
+                Err(RecvError::Closed) => break,
+            };
+
             match event {
                 ChannelMessage::Abort(AbortProcess::Scan) => {
-                    stop_scanning(&adapter).await;
-                    manager_ref.set_scanning(false).await;
+                    // Scanning itself was already stopped by the stop_scan method.
                     info!("Abort start_scan loop");
                     break;
                 }
                 ChannelMessage::Abort(AbortProcess::ClientDisconnected(_client)) => {
-                    if manager_ref.is_listeners_empty().await {
-                        info!("All clients disconnected, stopping scanning");
-                        stop_scanning(&adapter).await;
-                        manager_ref.set_scanning(false).await;
-                    }
+                    // Last-client cleanup is owned by AdapterManager::remove_listener.
                     break;
                 }
                 ChannelMessage::Notification(NotificationEvent::AdapterStateChanged { state }) => {

--- a/packages/transport-bluetooth/src/server/methods/stop_scan.rs
+++ b/packages/transport-bluetooth/src/server/methods/stop_scan.rs
@@ -11,6 +11,11 @@ pub async fn stop_scan(manager: AdapterManager, broadcast: ConnectionBroadcast) 
     // notify other threads
     broadcast.send(ChannelMessage::Abort(AbortProcess::Scan));
 
+    // Reset the flag right away — it must not stay set when the adapter call
+    // below fails, nor when the scan was started by another client (the abort
+    // message above never reaches watchers of other connections).
+    manager.set_scanning(false).await;
+
     let adapter = manager.get_powered_adapter_or_die().await?;
     if let Err(err) = adapter.stop_scan().await {
         info!("stop_scan/adapter.stop_scan error: {err}");

--- a/packages/transport-bluetooth/src/server/mod.rs
+++ b/packages/transport-bluetooth/src/server/mod.rs
@@ -4,6 +4,7 @@ pub mod connection_handler;
 pub mod device;
 pub mod message_handler;
 pub mod methods;
+pub mod notification_registry;
 pub mod platform;
 pub mod types;
 pub mod utils;

--- a/packages/transport-bluetooth/src/server/notification_registry.rs
+++ b/packages/transport-bluetooth/src/server/notification_registry.rs
@@ -1,0 +1,221 @@
+use std::sync::{Arc, Mutex};
+
+use tokio::task::JoinHandle;
+
+use crate::server::types::NotificationCharacteristic;
+
+// One BLE notification stream created by `open_device`, owned by a single
+// websocket connection (`peer`).
+struct StreamEntry {
+    peer: String,
+    device_id: String,
+    characteristic: NotificationCharacteristic,
+    task: JoinHandle<()>,
+}
+
+/// A stream removed from the registry. `unsubscribe` is true when no other
+/// connection keeps a stream for the same (device, characteristic) open, so
+/// the caller should also drop the shared BLE-level subscription.
+pub struct RemovedStream {
+    pub device_id: String,
+    pub characteristic: NotificationCharacteristic,
+    pub unsubscribe: bool,
+}
+
+/// Central registry of notification stream tasks keyed by
+/// (connection, device, characteristic). Every stream task must be registered
+/// here so it is aborted when its websocket connection, device or stream is
+/// closed — regardless of how many other clients stay connected.
+#[derive(Clone, Default)]
+pub struct NotificationRegistry {
+    entries: Arc<Mutex<Vec<StreamEntry>>>,
+}
+
+impl NotificationRegistry {
+    // A connection keeps at most one stream per (device, characteristic),
+    // a previously registered one is aborted and replaced.
+    pub fn register(
+        &self,
+        peer: String,
+        device_id: String,
+        characteristic: NotificationCharacteristic,
+        task: JoinHandle<()>,
+    ) {
+        let Ok(mut entries) = self.entries.lock() else {
+            task.abort();
+            return;
+        };
+
+        let existing = entries.iter_mut().find(|entry| {
+            entry.peer == peer
+                && entry.device_id == device_id
+                && entry.characteristic == characteristic
+        });
+        if let Some(entry) = existing {
+            entry.task.abort();
+            entry.task = task;
+        } else {
+            entries.push(StreamEntry {
+                peer,
+                device_id,
+                characteristic,
+                task,
+            });
+        }
+    }
+
+    // Abort and remove every stream matching all given filters. `None`
+    // matches everything.
+    pub fn remove(
+        &self,
+        peer: Option<&str>,
+        device_id: Option<&str>,
+        characteristic: Option<&NotificationCharacteristic>,
+    ) -> Vec<RemovedStream> {
+        let Ok(mut entries) = self.entries.lock() else {
+            return Vec::new();
+        };
+
+        let mut kept = Vec::new();
+        let mut removed = Vec::new();
+        for entry in entries.drain(..) {
+            let matches = peer.map_or(true, |peer| entry.peer == peer)
+                && device_id.map_or(true, |id| entry.device_id == id)
+                && characteristic.map_or(true, |ch| entry.characteristic == *ch);
+            if matches {
+                entry.task.abort();
+                removed.push(entry);
+            } else {
+                kept.push(entry);
+            }
+        }
+        *entries = kept;
+
+        removed
+            .into_iter()
+            .map(|entry| {
+                // The BLE subscription is shared between connections, release
+                // it only with the last stream of the same device and
+                // characteristic.
+                let unsubscribe = !entries.iter().any(|other| {
+                    other.device_id == entry.device_id
+                        && other.characteristic == entry.characteristic
+                });
+
+                RemovedStream {
+                    device_id: entry.device_id,
+                    characteristic: entry.characteristic,
+                    unsubscribe,
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_task() -> JoinHandle<()> {
+        tokio::spawn(std::future::pending::<()>())
+    }
+
+    fn stream_count(registry: &NotificationRegistry) -> usize {
+        registry
+            .entries
+            .lock()
+            .map(|entries| entries.len())
+            .unwrap_or(0)
+    }
+
+    #[tokio::test]
+    async fn aborts_client_streams_and_releases_last_ble_subscription() {
+        let registry = NotificationRegistry::default();
+        registry.register(
+            "a".into(),
+            "dev1".into(),
+            NotificationCharacteristic::Read,
+            dummy_task(),
+        );
+        registry.register(
+            "b".into(),
+            "dev1".into(),
+            NotificationCharacteristic::Read,
+            dummy_task(),
+        );
+        registry.register(
+            "b".into(),
+            "dev1".into(),
+            NotificationCharacteristic::BatteryLevel,
+            dummy_task(),
+        );
+
+        // Client "b" disconnects, its Read stream is shared with client "a".
+        let removed = registry.remove(Some("b"), None, None);
+        assert_eq!(removed.len(), 2);
+        let read = removed
+            .iter()
+            .find(|stream| stream.characteristic == NotificationCharacteristic::Read)
+            .unwrap();
+        assert!(!read.unsubscribe);
+        let battery = removed
+            .iter()
+            .find(|stream| stream.characteristic == NotificationCharacteristic::BatteryLevel)
+            .unwrap();
+        assert!(battery.unsubscribe);
+
+        // Client "a" disconnects as the last subscriber.
+        let removed = registry.remove(Some("a"), None, None);
+        assert_eq!(removed.len(), 1);
+        assert!(removed[0].unsubscribe);
+        assert_eq!(stream_count(&registry), 0);
+    }
+
+    #[tokio::test]
+    async fn replaces_reopened_stream() {
+        let registry = NotificationRegistry::default();
+        registry.register(
+            "a".into(),
+            "dev1".into(),
+            NotificationCharacteristic::Read,
+            dummy_task(),
+        );
+        registry.register(
+            "a".into(),
+            "dev1".into(),
+            NotificationCharacteristic::Read,
+            dummy_task(),
+        );
+
+        assert_eq!(stream_count(&registry), 1);
+    }
+
+    #[tokio::test]
+    async fn removes_streams_of_disconnected_device() {
+        let registry = NotificationRegistry::default();
+        registry.register(
+            "a".into(),
+            "dev1".into(),
+            NotificationCharacteristic::Read,
+            dummy_task(),
+        );
+        registry.register(
+            "b".into(),
+            "dev1".into(),
+            NotificationCharacteristic::Read,
+            dummy_task(),
+        );
+        registry.register(
+            "a".into(),
+            "dev2".into(),
+            NotificationCharacteristic::Read,
+            dummy_task(),
+        );
+
+        let removed = registry.remove(None, Some("dev1"), None);
+
+        assert_eq!(removed.len(), 2);
+        assert!(removed.iter().all(|stream| stream.unsubscribe));
+        assert_eq!(stream_count(&registry), 1);
+    }
+}

--- a/packages/transport-bluetooth/src/server/types.rs
+++ b/packages/transport-bluetooth/src/server/types.rs
@@ -1,11 +1,17 @@
-use crate::server::{adapter_manager::AdapterError, device::TrezorDevice};
+use crate::server::{
+    adapter_manager::AdapterError,
+    device::{
+        TrezorDevice, CHARACTERISTIC_BATTERY_LEVEL, CHARACTERISTIC_PUSH_NOTIFICATION,
+        CHARACTERISTIC_TX,
+    },
+};
 use btleplug::api::CentralState;
+use uuid::Uuid;
 
 #[derive(serde::Serialize, Clone, Debug)]
 pub enum AbortProcess {
     ClientDisconnected(String), // websocket client disconnected
     DeviceDisconnected(String), // device disconnected
-    NotificationStream(String, Option<NotificationCharacteristic>), // device closed/disconnected
     Scan,                       // stop scan
 }
 
@@ -50,6 +56,16 @@ pub enum NotificationCharacteristic {
     Read,
     TrezorPushNotification,
     BatteryLevel,
+}
+
+impl NotificationCharacteristic {
+    pub fn to_uuid(&self) -> Uuid {
+        match self {
+            NotificationCharacteristic::Read => CHARACTERISTIC_TX,
+            NotificationCharacteristic::TrezorPushNotification => CHARACTERISTIC_PUSH_NOTIFICATION,
+            NotificationCharacteristic::BatteryLevel => CHARACTERISTIC_BATTERY_LEVEL,
+        }
+    }
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `trezor-bluetooth` process growth in memory usage even over 600MB signalling that there's probably memory leak.
- The fix should be done based on [comment](https://github.com/trezor/trezor-suite/issues/31948#issuecomment-5492860141) on that issue by @prusnak 
- I've tested it locally (successfully connect a new Trezor device and the mem. usage stayed still over time):
  <img width="514" height="66" alt="Snímek obrazovky 2026-09-01 v 13 48 55" src="https://github.com/user-attachments/assets/9317049a-ae46-46b6-a859-be760ce09b5e" />
- It's been done by Fable Max. I'm not proficient in Rust, I'm not able to bear code ownership of this fix.


[Slack Context](https://satoshilabs.slack.com/archives/CKZHV2G13/p1788258400505879)

## Notes for QA

Please, test connecting Trezor device to desktop app (new connection / via existing connections), check it works as before expect `trezor-bluetooth` process use only several MB (a long background run would be ideal to match the user report).  

## Related Issue

Resolve #31948





<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-09-01T12:25:34.959Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/hotfix/bluetooth-mem-leak/web/](https://dev.suite.sldev.cz/suite-web/hotfix/bluetooth-mem-leak/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=hotfix/bluetooth-mem-leak&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=hotfix/bluetooth-mem-leak&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:28:45.584Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:28:31.476Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->