### PR TITLE
fix(suite-native-31261): update swap offer amount in slippage menu

### DIFF
--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -97,6 +97,7 @@
     "devDependencies": {
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
+        "@suite-common/tx-simulation": "workspace:*",
         "@suite-native/bluetooth": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/test-utils": "workspace:*",

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -12,12 +12,12 @@ import {
 import { AnimatedVStack, BannerInline, VStack } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { KycPolicyWarning, hasKycPolicyWarning } from '@suite-native/trading-provider-utils';
-import { SlippagePicker } from '@suite-native/trading-slippage';
 
 import { ExchangeEIP712Info } from './ExchangeEIP712Info';
 import { ExchangeFromAccountTradePreviewCard } from './ExchangeFromAccountTradePreviewCard';
 import { ExchangeInfo } from './ExchangeInfo';
 import { ExchangePreviewIssueBanner } from './ExchangePreviewIssueBanner';
+import { ExchangeSlippagePicker } from './ExchangeSlippagePicker';
 import { ExchangeToAccountTradePreviewCard } from './ExchangeToAccountTradePreviewCard';
 import { LastErrorMessage } from '../../general/Error/LastErrorMessage';
 
@@ -67,11 +67,17 @@ export const ExchangePreviewView = memo(
                     <ExchangeToAccountTradePreviewCard quote={quote} />
                     {hasEIP712SignData ? (
                         <ExchangeEIP712Info exchange={quote?.exchange}>
-                            <SlippagePicker onSlippageConfirmed={onSlippageConfirmed} />
+                            <ExchangeSlippagePicker
+                                quote={quote}
+                                onSlippageConfirmed={onSlippageConfirmed}
+                            />
                         </ExchangeEIP712Info>
                     ) : (
                         <ExchangeInfo quote={quote} isTxnError={isTxnError}>
-                            <SlippagePicker onSlippageConfirmed={onSlippageConfirmed} />
+                            <ExchangeSlippagePicker
+                                quote={quote}
+                                onSlippageConfirmed={onSlippageConfirmed}
+                            />
                         </ExchangeInfo>
                     )}
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSlippagePicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSlippagePicker.test.tsx
@@ -1,0 +1,40 @@
+import type { ExchangeTrade } from 'invity-api';
+
+import { getTranslation } from '@suite-native/intl';
+import { mercuryoDexQuote } from '@suite-native/trading-fixtures';
+
+import { ExchangeSlippagePicker } from './ExchangeSlippagePicker';
+import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
+
+describe('ExchangeSlippagePicker', () => {
+    const renderExchangeSlippagePicker = async (quote: ExchangeTrade | undefined) =>
+        await renderWithTradingProvider(
+            <ExchangeSlippagePicker quote={quote} onSlippageConfirmed={jest.fn()} />,
+            {
+                tradeType: 'exchange',
+                overrides: {
+                    wallet: {
+                        trading: {
+                            exchange: {
+                                selectedQuote: quote,
+                            },
+                        },
+                    },
+                },
+            },
+        );
+
+    it('should render null when receive amount is undefined', async () => {
+        const { toJSON } = await renderExchangeSlippagePicker(undefined);
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render SlippagePicker when receive amount is defined', async () => {
+        const { getByText } = await renderExchangeSlippagePicker(mercuryoDexQuote);
+
+        expect(
+            getByText(getTranslation('moduleTrading.slippage.maxSlippageLabel')),
+        ).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSlippagePicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSlippagePicker.tsx
@@ -1,0 +1,25 @@
+import type { ExchangeTrade } from 'invity-api';
+
+import { SlippagePicker } from '@suite-native/trading-slippage';
+
+import { useExchangeReceiveAmount } from '../../../hooks/exchange/useExchangeReceiveAmount';
+
+type ExchangeSlippagePickerProps = {
+    quote: ExchangeTrade | undefined;
+    onSlippageConfirmed: () => Promise<void>;
+};
+
+export const ExchangeSlippagePicker = ({
+    quote,
+    onSlippageConfirmed,
+}: ExchangeSlippagePickerProps) => {
+    const { receiveAmount } = useExchangeReceiveAmount(quote);
+
+    if (receiveAmount === undefined) {
+        return null;
+    }
+
+    return (
+        <SlippagePicker receiveAmount={receiveAmount} onSlippageConfirmed={onSlippageConfirmed} />
+    );
+};

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
@@ -2,12 +2,10 @@ import { useSelector } from 'react-redux';
 
 import type { ExchangeTrade } from 'invity-api';
 
-import { getSimulatedReceiveAmount } from '@suite-common/trading';
 import { Translation } from '@suite-native/intl';
-import { useChangeStringsExtractor } from '@suite-native/trading-quote-utils';
 import { selectExchangeSelectedReceiveAccount } from '@suite-native/trading-state';
 
-import { useDexExchangeTxSimulation } from '../../../hooks/exchange/useDexExchangeTxSimulation';
+import { useExchangeReceiveAmount } from '../../../hooks/exchange/useExchangeReceiveAmount';
 import { TradingAccountCard } from '../../general/TradingAccountCard';
 
 export type ExchangeToAccountTradePreviewCardProps = {
@@ -18,16 +16,13 @@ export const ExchangeToAccountTradePreviewCard = ({
     quote,
 }: ExchangeToAccountTradePreviewCardProps) => {
     const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
-    const { toValue } = useChangeStringsExtractor(quote);
-    const { isLoading: isSimulationLoading, data: simulationResult } = useDexExchangeTxSimulation();
-
-    const simulatedReceiveAmount = getSimulatedReceiveAmount(simulationResult, quote?.receive);
+    const { isLoading: isSimulationLoading, receiveAmount } = useExchangeReceiveAmount(quote);
 
     return (
         <TradingAccountCard
             title={<Translation id="moduleTrading.tradingExchangePreviewScreen.toAccount" />}
             account={toAccount?.account}
-            amount={simulatedReceiveAmount ?? toValue}
+            amount={receiveAmount}
             isAmountLoading={isSimulationLoading}
             direction="to"
             cryptoId={quote?.receive}

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeReceiveAmount.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeReceiveAmount.test.ts
@@ -1,0 +1,72 @@
+import type { NetworkTxSimulationResult } from '@suite-common/tx-simulation';
+import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+
+import { useDexExchangeTxSimulation } from './useDexExchangeTxSimulation';
+import { useExchangeReceiveAmount } from './useExchangeReceiveAmount';
+
+jest.mock('./useDexExchangeTxSimulation', () => ({
+    useDexExchangeTxSimulation: jest.fn(),
+}));
+
+const mockUseDexExchangeTxSimulation = jest.mocked(useDexExchangeTxSimulation);
+
+const simulationResult = {
+    method: 'ethereumSignTransaction',
+    payload: {
+        needsDisclaimer: false,
+        simulation: {
+            status: 'Success',
+            account_summary: {
+                assets_diffs: [
+                    {
+                        asset_type: 'NATIVE',
+                        asset: {
+                            type: 'NATIVE',
+                            chain_id: 1,
+                            chain_name: 'ethereum',
+                            decimals: 18,
+                        },
+                        in: [{ raw_value: '0xde0b6b3a7640000', value: '1' }],
+                        out: [],
+                    },
+                ],
+            },
+        },
+    },
+} as unknown as NetworkTxSimulationResult;
+
+describe('useExchangeReceiveAmount', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseDexExchangeTxSimulation.mockReturnValue({
+            isEnabled: true,
+            isLoading: false,
+            error: null,
+            data: undefined,
+        });
+    });
+
+    it('returns the quote receive amount when simulation data is unavailable', async () => {
+        const { result } = await renderHookWithBasicProvider(() =>
+            useExchangeReceiveAmount(mercuryoFixedWorstQuote),
+        );
+
+        expect(result.current.receiveAmount).toBe(mercuryoFixedWorstQuote.receiveStringAmount);
+    });
+
+    it('prefers the simulated receive amount', async () => {
+        mockUseDexExchangeTxSimulation.mockReturnValue({
+            isEnabled: true,
+            isLoading: false,
+            error: null,
+            data: simulationResult,
+        });
+
+        const { result } = await renderHookWithBasicProvider(() =>
+            useExchangeReceiveAmount(mercuryoFixedWorstQuote),
+        );
+
+        expect(result.current.receiveAmount).toBe('1');
+    });
+});

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeReceiveAmount.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeReceiveAmount.ts
@@ -1,0 +1,15 @@
+import type { ExchangeTrade } from 'invity-api';
+
+import { getSimulatedReceiveAmount } from '@suite-common/trading';
+
+import { useDexExchangeTxSimulation } from './useDexExchangeTxSimulation';
+
+export const useExchangeReceiveAmount = (quote: ExchangeTrade | undefined) => {
+    const { isLoading, data: simulationResult } = useDexExchangeTxSimulation();
+    const simulatedReceiveAmount = getSimulatedReceiveAmount(simulationResult, quote?.receive);
+
+    return {
+        isLoading,
+        receiveAmount: simulatedReceiveAmount ?? quote?.receiveStringAmount,
+    };
+};

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -109,6 +109,9 @@
         {
             "path": "../../suite-common/test-utils"
         },
+        {
+            "path": "../../suite-common/tx-simulation"
+        },
         { "path": "../bluetooth" },
         { "path": "../settings" },
         { "path": "../test-utils" },

--- a/suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx
@@ -22,6 +22,7 @@ describe('SlippageBottomSheet', () => {
         const result = await renderWithSlippageTestProvider(
             <SlippageBottomSheet
                 isVisible={false}
+                receiveAmount="1"
                 onClose={mockOnClose}
                 onSlippageConfirmed={mockOnSlippageConfirmed}
             />,

--- a/suite-native/trading-slippage/src/components/SlippageBottomSheet.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageBottomSheet.tsx
@@ -29,12 +29,14 @@ import { useSlippageForm } from '../hooks/useSlippageForm';
 
 type SlippageBottomSheetProps = {
     isVisible: boolean;
+    receiveAmount: string;
     onClose: () => void;
     onSlippageConfirmed: () => Promise<void>;
 };
 
 export const SlippageBottomSheet = ({
     isVisible,
+    receiveAmount,
     onClose,
     onSlippageConfirmed,
 }: SlippageBottomSheetProps) => {
@@ -83,7 +85,7 @@ export const SlippageBottomSheet = ({
             isCloseDisplayed
         >
             <Form form={form}>
-                <VStack spacing="sp24" paddingBottom="sp24">
+                <VStack spacing="sp24">
                     <Text>
                         <Translation id="moduleTrading.slippage.description" />
                     </Text>
@@ -111,7 +113,7 @@ export const SlippageBottomSheet = ({
                             ))}
                         </HStack>
                     </VStack>
-                    <SlippageSummary />
+                    <SlippageSummary receiveAmount={receiveAmount} />
                     <Box alignSelf="flex-start">
                         <TextButton
                             onPress={() => openLink(TREZOR_TRADING_DEX_SLIPPAGE_URL)}

--- a/suite-native/trading-slippage/src/components/SlippagePicker.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippagePicker.test.tsx
@@ -28,7 +28,10 @@ describe('SlippagePicker', () => {
 
     const renderSlippagePicker = async (quote: ExchangeTrade = mercuryoDexQuote) => {
         const result = await renderWithSlippageTestProvider(
-            <SlippagePicker onSlippageConfirmed={mockOnSlippageConfirmed} />,
+            <SlippagePicker
+                receiveAmount={mercuryoDexQuote.receiveStringAmount!}
+                onSlippageConfirmed={mockOnSlippageConfirmed}
+            />,
             { quote },
         );
 

--- a/suite-native/trading-slippage/src/components/SlippagePicker.tsx
+++ b/suite-native/trading-slippage/src/components/SlippagePicker.tsx
@@ -16,6 +16,7 @@ import { SlippageBottomSheet } from './SlippageBottomSheet';
 export const SLIPPAGE_PICKER_TEST_ID = '@trading/exchange/slippage-picker';
 
 type SlippagePickerProps = {
+    receiveAmount: string;
     onSlippageConfirmed: () => Promise<void>;
 };
 
@@ -23,7 +24,7 @@ const slippagePickerStyle = prepareNativeStyle(({ spacings }) => ({
     height: spacings.sp56,
 }));
 
-export const SlippagePicker = ({ onSlippageConfirmed }: SlippagePickerProps) => {
+export const SlippagePicker = ({ receiveAmount, onSlippageConfirmed }: SlippagePickerProps) => {
     const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
     const isDex = useSelector(selectTradingExchangeSelectedQuoteIsDex);
     const swapSlippage = useSelector(selectTradingExchangeSelectedQuoteSwapSlippage);
@@ -64,6 +65,7 @@ export const SlippagePicker = ({ onSlippageConfirmed }: SlippagePickerProps) => 
             </TradeInfoRow>
             <SlippageBottomSheet
                 isVisible={isSheetVisible}
+                receiveAmount={receiveAmount}
                 onClose={hideSheet}
                 onSlippageConfirmed={onSlippageConfirmed}
             />

--- a/suite-native/trading-slippage/src/components/SlippageSummary.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageSummary.test.tsx
@@ -11,7 +11,19 @@ import { renderWithSlippageTestProvider } from '../test-utils/testUtils';
 
 const validationSchema = yup.object({ slippage: yup.string() });
 
-const TestWrapper = ({ slippage = '1' }: { slippage?: string }) => {
+type TestWrapperProps = {
+    receiveAmount?: string;
+    slippage?: string;
+};
+
+type RenderSlippageSummaryOptions = TestWrapperProps & {
+    quote?: ExchangeTrade;
+};
+
+const TestWrapper = ({
+    receiveAmount = mercuryoDexQuote.receiveStringAmount!,
+    slippage = '1',
+}: TestWrapperProps) => {
     const form = useForm<SlippageFormValues>({
         defaultValues: { slippage },
         validation: validationSchema,
@@ -19,13 +31,20 @@ const TestWrapper = ({ slippage = '1' }: { slippage?: string }) => {
 
     return (
         <Form form={form}>
-            <SlippageSummary />
+            <SlippageSummary receiveAmount={receiveAmount} />
         </Form>
     );
 };
 
-const renderSlippageSummary = async (slippage?: string, quote?: ExchangeTrade) =>
-    await renderWithSlippageTestProvider(<TestWrapper slippage={slippage} />, { quote });
+const renderSlippageSummary = async ({
+    slippage,
+    quote,
+    receiveAmount,
+}: RenderSlippageSummaryOptions = {}) =>
+    await renderWithSlippageTestProvider(
+        <TestWrapper slippage={slippage} receiveAmount={receiveAmount} />,
+        { quote },
+    );
 
 describe('SlippageSummary', () => {
     it('should render all row labels', async () => {
@@ -42,28 +61,39 @@ describe('SlippageSummary', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should show offered amount and symbol from the quote', async () => {
+    it('should show offered amount and symbol', async () => {
         const { getByText } = await renderSlippageSummary();
 
         expect(getByText(`${mercuryoDexQuote.receiveStringAmount} BTC`)).toBeOnTheScreen();
     });
 
+    it('should calculate values from the provided receive amount', async () => {
+        const { getByText } = await renderSlippageSummary({
+            slippage: '1',
+            receiveAmount: '1',
+        });
+
+        expect(getByText('1 BTC')).toBeOnTheScreen();
+        expect(getByText('-0.01 BTC')).toBeOnTheScreen();
+        expect(getByText('0.99 BTC')).toBeOnTheScreen();
+    });
+
     it('should calculate deduction and minimum receive from slippage', async () => {
-        const { getByText } = await renderSlippageSummary('1');
+        const { getByText } = await renderSlippageSummary({ slippage: '1' });
 
         expect(getByText('-0.00000836 BTC')).toBeOnTheScreen();
         expect(getByText('0.00082718 BTC')).toBeOnTheScreen();
     });
 
     it('should use swapSlippage from the quote when form value is empty', async () => {
-        const { getByText } = await renderSlippageSummary('');
+        const { getByText } = await renderSlippageSummary({ slippage: '' });
 
         expect(getByText('-0.00000836 BTC')).toBeOnTheScreen();
         expect(getByText('0.00082718 BTC')).toBeOnTheScreen();
     });
 
     it('should recalculate values when slippage changes', async () => {
-        const { getByText } = await renderSlippageSummary('3');
+        const { getByText } = await renderSlippageSummary({ slippage: '3' });
 
         expect(getByText('-0.00002507 BTC')).toBeOnTheScreen();
         expect(getByText('0.00081047 BTC')).toBeOnTheScreen();
@@ -73,16 +103,8 @@ describe('SlippageSummary', () => {
         it('should throw when swapSlippage is undefined', async () => {
             const quote = { ...mercuryoDexQuote, swapSlippage: undefined };
 
-            await expect(renderSlippageSummary(undefined, quote)).rejects.toThrow(
+            await expect(renderSlippageSummary({ quote })).rejects.toThrow(
                 'swapSlippage is required in quote for SlippageSummary',
-            );
-        });
-
-        it('should throw when receiveStringAmount is undefined', async () => {
-            const quote = { ...mercuryoDexQuote, receiveStringAmount: undefined };
-
-            await expect(renderSlippageSummary(undefined, quote)).rejects.toThrow(
-                'receiveStringAmount is required in quote for SlippageSummary',
             );
         });
     });

--- a/suite-native/trading-slippage/src/components/SlippageSummary.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageSummary.tsx
@@ -7,11 +7,14 @@ import { Translation } from '@suite-native/intl';
 import { useFormatCryptoValue } from '@suite-native/trading-atoms';
 import { BigNumber } from '@trezor/utils';
 
-export const SlippageSummary = () => {
+type SlippageSummaryProps = {
+    receiveAmount: string;
+};
+
+export const SlippageSummary = ({ receiveAmount }: SlippageSummaryProps) => {
     const { control, formState } = useFormContext<SlippageFormValues>();
     const formatCryptoValue = useFormatCryptoValue();
-    const { receive, receiveStringAmount, swapSlippage } =
-        useSelector(selectTradingExchangeSelectedQuote) ?? {};
+    const { receive, swapSlippage } = useSelector(selectTradingExchangeSelectedQuote) ?? {};
 
     const slippageValue = useWatch({ control, name: 'slippage' });
 
@@ -19,18 +22,17 @@ export const SlippageSummary = () => {
         throw new Error('swapSlippage is required in quote for SlippageSummary');
     }
 
-    if (receiveStringAmount === undefined) {
-        throw new Error('receiveStringAmount is required in quote for SlippageSummary');
-    }
-
     const previewSlippage =
         !formState.errors.slippage && slippageValue !== ''
             ? BigNumber(slippageValue)
             : BigNumber(swapSlippage);
 
-    const receiveAmount = BigNumber(receiveStringAmount);
-    const slippageDeduction = previewSlippage.dividedBy(100).multipliedBy(receiveAmount).negated();
-    const minimumReceive = receiveAmount.plus(slippageDeduction);
+    const receiveAmountBigNumber = BigNumber(receiveAmount);
+    const slippageDeduction = previewSlippage
+        .dividedBy(100)
+        .multipliedBy(receiveAmountBigNumber)
+        .negated();
+    const minimumReceive = receiveAmountBigNumber.plus(slippageDeduction);
 
     return (
         <VStack spacing="sp12">
@@ -38,7 +40,7 @@ export const SlippageSummary = () => {
                 <Text variant="body-md" color="contentSecondary">
                     <Translation id="moduleTrading.slippage.summary.offered" />
                 </Text>
-                <Text variant="body-md">{formatCryptoValue(receiveStringAmount, receive)}</Text>
+                <Text variant="body-md">{formatCryptoValue(receiveAmount, receive)}</Text>
             </HStack>
             <HStack justifyContent="space-between">
                 <Text variant="body-md" color="contentSecondary">

--- a/yarn.lock
+++ b/yarn.lock
@@ -13900,6 +13900,7 @@ __metadata:
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/trading": "workspace:*"
+    "@suite-common/tx-simulation": "workspace:*"
     "@suite-common/validators": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"


### PR DESCRIPTION
## Description

- Use the simulated receive amount consistently in the exchange preview and slippage menu.
- Pass the resolved receive amount into slippage calculations and summary display.

## Notes for QA
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

- Verify that the slippage menu offer amount updates to the simulated swap receive amount.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31261

## Screenshots:
<!--- Keep just title, empty for later add -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files live under `suite-native/`, which is the React Native mobile application. The 127 candidate tests are Playwright E2E tests for the desktop/web `suite` app and do not exercise native mobile components or hooks. There is no direct coverage, and while a few web trading tests (e.g. DEX slippage flows) touch conceptually similar user flows, they run against completely different code paths and UI implementations. Running the desktop/web E2E suite would provide little to no signal for this change set; native unit/component tests and mobile E2E tests should be used instead.

<details><summary><b>Changed files (14)</b></summary>

- `suite-native/module-trading/package.json`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSlippagePicker.test.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSlippagePicker.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`
- `suite-native/module-trading/src/hooks/exchange/useExchangeReceiveAmount.test.ts`
- `suite-native/module-trading/src/hooks/exchange/useExchangeReceiveAmount.ts`
- `suite-native/module-trading/tsconfig.json`
- `suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx`
- `suite-native/trading-slippage/src/components/SlippageBottomSheet.tsx`
- `suite-native/trading-slippage/src/components/SlippagePicker.test.tsx`
- `suite-native/trading-slippage/src/components/SlippagePicker.tsx`
- `suite-native/trading-slippage/src/components/SlippageSummary.test.tsx`
- `suite-native/trading-slippage/src/components/SlippageSummary.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (14)**
- `suite-native/module-trading/package.json`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSlippagePicker.test.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSlippagePicker.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`
- `suite-native/module-trading/src/hooks/exchange/useExchangeReceiveAmount.test.ts`
- `suite-native/module-trading/src/hooks/exchange/useExchangeReceiveAmount.ts`
- `suite-native/module-trading/tsconfig.json`
- `suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx`
- `suite-native/trading-slippage/src/components/SlippageBottomSheet.tsx`
- `suite-native/trading-slippage/src/components/SlippagePicker.test.tsx`
- `suite-native/trading-slippage/src/components/SlippagePicker.tsx`
- `suite-native/trading-slippage/src/components/SlippageSummary.test.tsx`
- `suite-native/trading-slippage/src/components/SlippageSummary.tsx`

_Updated: 2026-09-03T05:09:11.496Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31261-swap-offer-amount-doesnt-change-in-slippage-menu/web/](https://dev.suite.sldev.cz/suite-web/fix/31261-swap-offer-amount-doesnt-change-in-slippage-menu/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31261-swap-offer-amount-doesnt-change-in-slippage-menu&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31261-swap-offer-amount-doesnt-change-in-slippage-menu&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31261-swap-offer-amount-doesnt-change-in-slippage-menu&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T05:12:29.365Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T05:12:16.835Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->