### PR TITLE
[CI clone] Extend Cardano fake pending tx deadline to 15 minutes (#31850)

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsThunks.test.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.test.ts
@@ -12,30 +12,32 @@ const account = {
     networkType: 'cardano',
 } as unknown as Account;
 
+const BLOCK_HEIGHT = 100;
+
 const initStore = () =>
     configureMockStore({
         preloadedState: {
             wallet: {
-                blockchain: { ada: { blockHeight: 100 } },
+                blockchain: { ada: { blockHeight: BLOCK_HEIGHT } },
             },
         },
     });
 
+const dispatchFakePendingTx = async (store: ReturnType<typeof initStore>) => {
+    await store.dispatch(
+        addFakePendingCardanoTxThunk({
+            precomposedTransaction: { totalSpent: '2170000', fee: '170000' },
+            txid: 'test-txid',
+            account,
+        }),
+    );
+
+    return store.getActions().find(transactionsActions.addTransaction.match);
+};
+
 describe('addFakePendingCardanoTxThunk', () => {
     it('stores the pending tx with the fee excluded from the amount, matching the confirmed tx from blockfrost', async () => {
-        const store = initStore();
-
-        await store.dispatch(
-            addFakePendingCardanoTxThunk({
-                precomposedTransaction: { totalSpent: '2170000', fee: '170000' },
-                txid: 'test-txid',
-                account,
-            }),
-        );
-
-        const addTransactionAction = store
-            .getActions()
-            .find(transactionsActions.addTransaction.match);
+        const addTransactionAction = await dispatchFakePendingTx(initStore());
 
         expect(addTransactionAction?.payload.transactions).toEqual([
             expect.objectContaining({
@@ -45,8 +47,19 @@ describe('addFakePendingCardanoTxThunk', () => {
                 fee: '170000',
                 totalSpent: '2170000',
                 blockHash: undefined,
-                deadline: 110,
+                deadline: 145,
             }),
         ]);
+    });
+
+    it('keeps the pending tx alive for 15 minutes worth of Cardano blocks, as Blockfrost only reports the tx once it is confirmed and indexed', async () => {
+        const addTransactionAction = await dispatchFakePendingTx(initStore());
+
+        const [transaction] = addTransactionAction?.payload.transactions ?? [];
+        const cardanoBlockTimeSeconds = 20;
+
+        expect(transaction?.deadline).toBe(
+            BLOCK_HEIGHT + Math.ceil((15 * 60) / cardanoBlockTimeSeconds),
+        );
     });
 });

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -61,6 +61,11 @@ import { ethereumGetCurrentNonceThunk } from '../send/sendFormEthereumThunks';
 import { type SendRootState } from '../send/sendFormReducer';
 import { selectSendSignedTx } from '../send/sendFormSelectors';
 
+// How long a locally added fake pending tx is kept in the UI.
+const FAKE_TX_TTL_SECONDS = 15 * 60;
+// Cardano's average block interval, not reported by @trezor/connect.
+const CARDANO_BLOCK_TIME_SECONDS = 20;
+
 /**
  * Replace existing transaction in the reducer (RBF)
  * There might be multiple occurrences of the same transaction assigned to multiple accounts in the storage:
@@ -419,7 +424,6 @@ export const addFakePendingEvmTxThunk = createThunk<
         const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);
         const rawFeeInfo = selectRawNetworkFeeInfo(getState(), account.symbol);
 
-        const FAKE_TX_TTL_SECONDS = 15 * 60; // keep fake tx for 15 minutes
         const deadline = FAKE_TX_TTL_SECONDS / rawFeeInfo!.blockTime;
 
         const sig = getEvmTransactionTextSignature(precomposedForm.transactionData);
@@ -485,7 +489,7 @@ export const addFakePendingCardanoTxThunk = createThunk<
                 totalInput: '0',
                 totalOutput: '0',
             },
-            deadline: blockHeight + 10,
+            deadline: blockHeight + Math.ceil(FAKE_TX_TTL_SECONDS / CARDANO_BLOCK_TIME_SECONDS),
         };
         dispatch(transactionsActions.addTransaction({ transactions: [fakeTx], account }));
     },
@@ -511,7 +515,6 @@ export const addFakePendingTronTxThunk = createThunk<
     ({ txid, account, amount, fee, type, target, tronSpecific }, { dispatch, getState }) => {
         if (account.networkType !== 'tron') return;
 
-        const FAKE_TX_TTL_SECONDS = 15 * 60;
         const blockTime = selectRawNetworkFeeInfo(getState(), account.symbol)?.blockTime ?? 0;
         const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol) ?? 0;
         const deadline = blockHeight + Math.ceil(FAKE_TX_TTL_SECONDS / blockTime);


### PR DESCRIPTION
## Description

**CI clone of #31850** — opened only so the pipeline can run. The original PR comes from a fork (`everstake/trezor-suite`) whose workflows are not authorized to execute here.

- Original PR: https://github.com/trezor/trezor-suite/pull/31850
- Original author: @myasiura-stack (commit authorship is preserved — this branch is the exact same commit as the original PR head, `1ab5bbcff2`)
- Original issue: https://github.com/trezor/trezor-suite/issues/30034

Review discussion belongs on #31850. This clone will be discarded once the pipeline result is known.

## What the change does

The Cardano branch of the transactions thunk evicted the fake pending tx after a hardcoded 10 blocks, so slower txs disappeared from history before confirming. It now uses the same 15-minute TTL as the EVM and Tron thunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files affect core transaction thunks that sit on the hot path of nearly every send, stake, swap, and transaction-list flow. Because the static coverage map is very broad (138 tests), I selected a tight, high-signal subset focused on actual transaction creation, signing, broadcast, and state transitions across the major networks and use cases. The unit test file provides direct thunk coverage but has no E2E equivalent, so it is listed as uncovered at the E2E level.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/transactions/transactionsThunks.test.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test explicitly broadcasts Bitcoin regtest transactions and asserts pending/confirmed state transitions, mining behavior, and toast notifications. A regression in transactionsThunks.ts that affects transaction creation, broadcast, or state updates would be caught here immediately.
- `suite/e2e/tests/wallet/send-base.test.ts` — Exercises the full EVM send flow on Base with custom fees, device confirmation, serialized transaction Redux state, and post-send transaction details. This directly depends on the transaction thunks for composing, signing, and broadcasting.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Validates ETH transaction construction, custom EIP-1559 fee handling, device prompt details, and fee calculation. Changes to transaction thunks that alter composed transaction data or fee logic would likely fail here.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Covers BTC send with locktime, OP_RETURN outputs, multi-output handling, and broadcasting. This is a direct end-to-end exercise of the Bitcoin transaction thunk path and transaction output construction.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests Solana send-max logic, fee/reserve handling, device confirmation, and broadcast. Transaction thunks for Solana account balance computation and send serialization are central to this flow.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Staking submission signs and broadcasts an Ethereum transaction through the earn flow, verifying composed transaction info and post-submission status. It shares the generic transaction signing/broadcast infrastructure affected by the thunks.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — A cross-chain swap that triggers device signing, broadcast interception, toast confirmation, and transaction status progression. This is a representative trading transaction path that relies on the same underlying send/broadcast thunks.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Focuses on DOGE send validation and error handling for amounts exceeding safe integer limits, plus device confirmation details. It exercises transaction signing error handling in the thunks.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests an LTC send spending a MimbleWimble peg-out output via the send form and device confirmation. It covers UTXO coin transaction construction and broadcast logic.
- `suite/e2e/tests/wallet/transactions.test.ts` — Verifies transaction list rendering, graph time-range filters, and transaction search. The data displayed here is produced and updated by transaction fetching/state thunks, so regressions in state shape or updates would be visible.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/transactions/transactionsThunks.test.ts`

_Updated: 2026-09-01T12:29:23.422Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-fake-pending-tx-deadline/web/](https://dev.suite.sldev.cz/suite-web/ci-clone/cardano-fake-pending-tx-deadline/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci-clone/cardano-fake-pending-tx-deadline&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci-clone/cardano-fake-pending-tx-deadline&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci-clone/cardano-fake-pending-tx-deadline&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:32:36.748Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:32:32.335Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->