### PR TITLE
fix(perf-e2e): merge measurements into a report section instead of replacing it

### DIFF
--- a/packages/perf-e2e/src/markdown.test.ts
+++ b/packages/perf-e2e/src/markdown.test.ts
@@ -1,0 +1,117 @@
+import {
+    type ReportedMeasurement,
+    formatMarkdownReport,
+    mergeMeasurements,
+    perfReportComment,
+    readSectionMeasurements,
+} from './markdown';
+
+const measurement = (key: string, current = 100): ReportedMeasurement => ({
+    key,
+    runs: 1,
+    report: {
+        scenario: key,
+        overLimit: false,
+        unlimited: false,
+        metrics: [
+            {
+                key: 'totalBlockingTimeMs',
+                label: 'Total Blocking Time',
+                unit: 'ms',
+                baseline: 90,
+                current,
+                limit: 200,
+                ratioToLimit: current / 200,
+                exceededLimit: false,
+            },
+        ],
+    },
+});
+
+const LABEL = 'desktop / group 1';
+
+const publish = (existingBody: string | undefined, measurements: ReportedMeasurement[]) =>
+    perfReportComment({
+        existingBody,
+        label: LABEL,
+        section: formatMarkdownReport(
+            mergeMeasurements(
+                readSectionMeasurements({ body: existingBody, label: LABEL }),
+                measurements,
+            ),
+            { heading: LABEL },
+        ),
+    });
+
+describe(readSectionMeasurements.name, () => {
+    it('reads back what a section was rendered from', () => {
+        const body = publish(undefined, [measurement('wallet-discovery')]);
+
+        expect(readSectionMeasurements({ body, label: LABEL })).toEqual([
+            measurement('wallet-discovery'),
+        ]);
+    });
+
+    it('reads nothing from a body without the section', () => {
+        expect(readSectionMeasurements({ body: 'nothing here', label: LABEL })).toEqual([]);
+    });
+
+    it('reads nothing from another label, so sections cannot bleed into one another', () => {
+        const body = publish(undefined, [measurement('wallet-discovery')]);
+
+        expect(readSectionMeasurements({ body, label: 'web / group 2' })).toEqual([]);
+    });
+});
+
+describe(mergeMeasurements.name, () => {
+    it('keeps what was reported before and adds what is new', () => {
+        expect(
+            mergeMeasurements([measurement('account-switch')], [measurement('wallet-discovery')]),
+        ).toEqual([measurement('account-switch'), measurement('wallet-discovery')]);
+    });
+
+    it('lets the newer measurement of a scenario win', () => {
+        expect(
+            mergeMeasurements(
+                [measurement('account-switch', 100)],
+                [measurement('account-switch', 300)],
+            ),
+        ).toEqual([measurement('account-switch', 300)]);
+    });
+});
+
+// The orchestrator runs a Playwright process per test file, so one job publishes several times under
+// the same section label, each time knowing only its own file's scenarios.
+describe('publishing a section twice', () => {
+    it('holds the scenarios of both publishes', () => {
+        const first = publish(undefined, [measurement('multi-account-discovery')]);
+        const second = publish(first, [measurement('wallet-discovery')]);
+
+        expect(second).toContain('multi-account-discovery');
+        expect(second).toContain('wallet-discovery');
+        expect(
+            readSectionMeasurements({ body: second, label: LABEL }).map(({ key }) => key),
+        ).toEqual(['multi-account-discovery', 'wallet-discovery']);
+    });
+
+    it('renders one section, not one per publish', () => {
+        const second = publish(publish(undefined, [measurement('a')]), [measurement('b')]);
+
+        expect(second.match(/PERF-E2E-SECTION:[^:]+:START/g)).toHaveLength(1);
+    });
+
+    it('leaves the section of another job alone', () => {
+        const other = perfReportComment({
+            existingBody: undefined,
+            label: 'web / group 2',
+            section: formatMarkdownReport([measurement('web-scenario')], {
+                heading: 'web / group 2',
+            }),
+        });
+        const body = publish(other, [measurement('wallet-discovery')]);
+
+        expect(
+            readSectionMeasurements({ body, label: 'web / group 2' }).map(({ key }) => key),
+        ).toEqual(['web-scenario']);
+    });
+});

--- a/packages/perf-e2e/src/markdown.ts
+++ b/packages/perf-e2e/src/markdown.ts
@@ -63,6 +63,76 @@ const sectionMarkers = (label: string) => ({
     end: `<!-- PERF-E2E-SECTION:${safeLabel(label)}:END -->`,
 });
 
+/**
+ * The measurements a section was rendered from, carried inside it so the next publisher can add to
+ * them instead of replacing them. The orchestrator runs a Playwright process per test file, so one
+ * job publishes several times under the same section label, each time knowing only its own file's
+ * scenarios.
+ */
+const DATA_START = '<!-- PERF-E2E-DATA:';
+const DATA_END = ' -->';
+
+const encodeMeasurements = (measurements: readonly ReportedMeasurement[]) =>
+    `${DATA_START}${Buffer.from(JSON.stringify(measurements), 'utf8').toString('base64')}${DATA_END}`;
+
+const decodeMeasurements = (encoded: string): ReportedMeasurement[] => {
+    try {
+        const parsed: unknown = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+
+        return Array.isArray(parsed) ? (parsed as ReportedMeasurement[]) : [];
+    } catch {
+        // A section written by an older run, or one somebody edited by hand. Nothing to keep, and
+        // failing here would cost the measurements this run does have.
+        return [];
+    }
+};
+
+/**
+ * What a section already reported, or nothing when it is absent or unreadable.
+ */
+export const readSectionMeasurements = ({
+    body = '',
+    label,
+}: {
+    body?: string;
+    label: string;
+}): ReportedMeasurement[] => {
+    const { start, end } = sectionMarkers(label);
+    const startIndex = body.indexOf(start);
+    const endIndex = body.indexOf(end);
+
+    if (startIndex === -1 || endIndex <= startIndex) {
+        return [];
+    }
+
+    const section = body.slice(startIndex, endIndex);
+    const dataStart = section.indexOf(DATA_START);
+
+    if (dataStart === -1) {
+        return [];
+    }
+
+    const dataEnd = section.indexOf(DATA_END, dataStart);
+
+    return dataEnd === -1
+        ? []
+        : decodeMeasurements(section.slice(dataStart + DATA_START.length, dataEnd));
+};
+
+/**
+ * The fresher measurement of a scenario wins, everything else the section held is kept. Sorted, so
+ * that the table does not reshuffle between publishes of the same section.
+ */
+export const mergeMeasurements = (
+    previous: readonly ReportedMeasurement[],
+    incoming: readonly ReportedMeasurement[],
+): ReportedMeasurement[] => {
+    const merged = new Map(previous.map(measurement => [measurement.key, measurement]));
+    incoming.forEach(measurement => merged.set(measurement.key, measurement));
+
+    return [...merged.values()].sort((a, b) => a.key.localeCompare(b.key));
+};
+
 /** For a table cell, where an unescaped pipe would start a new column. */
 const escapeCell = (value: string) => value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
 
@@ -237,6 +307,7 @@ export const formatMarkdownReport = (
         ...overLimit.flatMap(measurement => overLimitShowcase(measurement, budgetsPath)),
         '',
         '</details>',
+        encodeMeasurements(measurements),
     ].join('\n');
 };
 

--- a/suite/e2e/performance/perfReportPublisher.ts
+++ b/suite/e2e/performance/perfReportPublisher.ts
@@ -5,8 +5,9 @@ import {
     PERF_REPORT_MARKER,
     type ReportedMeasurement,
     formatMarkdownReport,
+    mergeMeasurements,
     perfReportComment,
-    perfReportSection,
+    readSectionMeasurements,
 } from '@trezor/perf-e2e';
 
 /**
@@ -34,16 +35,30 @@ type PublishArgs = {
     log: (message: string) => void;
 };
 
-export const publishPerfReport = async ({ measurements, budgetsPath, log }: PublishArgs) => {
+/**
+ * Rendered from what the section already reported plus this run's measurements. The section is read
+ * again on every attempt, so a publish that lands between the read and the write is merged in rather
+ * than dropped.
+ */
+const buildSection = (existingBody: string | undefined, args: PublishArgs & { label: string }) =>
+    formatMarkdownReport(
+        mergeMeasurements(
+            readSectionMeasurements({ body: existingBody, label: args.label }),
+            args.measurements,
+        ),
+        {
+            heading: sectionHeading(),
+            runUrl: resolveRunUrl(),
+            budgetsPath: args.budgetsPath,
+        },
+    );
+
+export const publishPerfReport = async (args: PublishArgs) => {
+    const { measurements, log } = args;
     const label = sectionKey();
-    const section = formatMarkdownReport(measurements, {
-        heading: sectionHeading(),
-        runUrl: resolveRunUrl(),
-        budgetsPath,
-    });
 
     try {
-        writeStepSummary(section);
+        writeStepSummary(buildSection(undefined, { ...args, label }));
     } catch (error) {
         log(`Failed to write the performance report to the run summary: ${error}`);
     }
@@ -51,8 +66,21 @@ export const publishPerfReport = async ({ measurements, budgetsPath, log }: Publ
     try {
         const result = await upsertStickyPrComment({
             marker: PERF_REPORT_MARKER,
-            buildBody: existingBody => perfReportComment({ existingBody, label, section }),
-            holdsOwnContent: body => body.includes(perfReportSection({ label, section })),
+            buildBody: existingBody =>
+                perfReportComment({
+                    existingBody,
+                    label,
+                    section: buildSection(existingBody, { ...args, label }),
+                }),
+            // Only this run's own measurements are checked for: another job merging into the same
+            // section is not a loss, and demanding the whole section back would retry forever.
+            holdsOwnContent: body => {
+                const written = readSectionMeasurements({ body, label });
+
+                return measurements.every(measurement =>
+                    written.some(({ key }) => key === measurement.key),
+                );
+            },
         });
         log(`Performance report pull request comment: ${result}.`);
     } catch (error) {


### PR DESCRIPTION
## Description

The performance report comment kept losing measurements. The orchestrator runs a Playwright process
**per test file**, so a job holding more than one measured spec publishes several times under the
same section label, each process knowing only its own file's scenarios - and the section was
replaced whole on every publish. The last file to finish left its scenarios alone in the comment and
the earlier ones were gone, which reads as another run having overwritten the report.

Seen on #31950: `desktop / group 1` published `multi-account-discovery` at 11:41 and then
`wallet-discovery` + `account-switch` at 11:42, and only the second set survived
([run 33502005766](https://github.com/trezor/trezor-suite/actions/runs/33502005766)).

A section now carries the measurements it was rendered from, base64 in a comment inside it, and each
publisher merges its own into what is already there: the fresher measurement of a scenario wins,
everything else stays. Because the sticky comment upsert re-reads the section on every attempt, a
publish that lands between another job's read and write is merged in on the retry instead of being
lost - the same race across jobs is covered by the same mechanism.

## Notes for QA

Nothing to test in the app - this only changes the report comment CI writes on a pull request. This
PR's own e2e run is the check: the perf comment should end up with **all** the scenarios of a group
in its section, e.g. `multi-account-discovery`, `wallet-discovery` and `account-switch` together
under `desktop / group 1`, rather than only the ones from the file that happened to finish last.

## Related Issue

Follow-up to #31719.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-perf-report-section-merge/web/](https://dev.suite.sldev.cz/suite-web/fix-perf-report-section-merge/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-perf-report-section-merge&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:37:44.233Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T12:37:42.772Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->