### PR TITLE
feat(trading): align CEX price alert with DEX

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
@@ -214,16 +214,18 @@ describe('TradingOfferExchange', () => {
         expect(screen.getByTestId('@trading/offer/confirm-on-trezor-and-send')).toBeEnabled();
     });
 
-    it('keeps the confirmation button next to a passive banner when the simulation is off', () => {
+    it('gates the swap behind the banner even when the simulation is off', () => {
         renderOfferExchange({ isSimulationEnabled: false, issue: PRICE_IMPACT_ISSUE });
 
         expect(screen.getByTestId('@trading/offer/issue-banner')).toBeInTheDocument();
-        expect(screen.queryByTestId('@trading/offer/continue-anyway')).not.toBeInTheDocument();
-        expect(screen.getByTestId('@trading/offer/confirm-on-trezor-and-send')).toBeInTheDocument();
-        expect(screen.queryByTestId('@trading/offer/back-to-trade-form')).not.toBeInTheDocument();
+        expect(screen.getByTestId('@trading/offer/continue-anyway')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('@trading/offer/confirm-on-trezor-and-send'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByTestId('@trading/offer/back-to-trade-form')).toBeInTheDocument();
     });
 
-    it('replaces the confirmation button with back to trade form on a simulated issue', async () => {
+    it('replaces the confirmation button with back to trade form on an issue', async () => {
         renderOfferExchange({ issue: PRICE_IMPACT_ISSUE });
 
         expect(

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -89,7 +89,6 @@ export const TradingOfferExchange = () => {
         simulationResult,
         selectedTrade.receive,
     );
-    const hasIssueToResolve = isSimulationEnabled && issue !== null;
 
     const reportConfirmAndSendStep = (action: TradeExchangeAction) => {
         analytics.report({
@@ -164,14 +163,13 @@ export const TradingOfferExchange = () => {
                     {issue && (
                         <TradingOfferExchangeIssueBanner
                             issue={issue}
-                            isSimulationEnabled={isSimulationEnabled}
                             isContinueDisabled={isConfirmDisabled || disabled}
                             isContinueLoading={isLoading || disabled}
                             onContinueAnywayClick={() => handleClick(() => onConfirmAndSendClick())}
                         />
                     )}
 
-                    {hasIssueToResolve ? (
+                    {issue ? (
                         <Button
                             data-testid="@trading/offer/back-to-trade-form"
                             intent="neutral"

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeIssueBanner.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeIssueBanner.test.tsx
@@ -46,13 +46,7 @@ const slippageTooLowIssue: ExchangeIssue = {
 
 const onContinueAnywayClick = jest.fn();
 
-const renderIssueBanner = ({
-    issue,
-    isSimulationEnabled = true,
-}: {
-    issue: ExchangeIssue;
-    isSimulationEnabled?: boolean;
-}) => {
+const renderIssueBanner = ({ issue }: { issue: ExchangeIssue }) => {
     const services = { analytics: mockDesktopAnalytics() };
     const root = createTestCompositionRoot({
         extra: { services },
@@ -62,7 +56,6 @@ const renderIssueBanner = ({
         root,
         <TradingOfferExchangeIssueBanner
             issue={issue}
-            isSimulationEnabled={isSimulationEnabled}
             isContinueDisabled={false}
             isContinueLoading={false}
             onContinueAnywayClick={onContinueAnywayClick}
@@ -110,12 +103,5 @@ describe('TradingOfferExchangeIssueBanner', () => {
         await userEvent.click(screen.getByTestId('@trading/offer/continue-anyway'));
 
         expect(onContinueAnywayClick).toHaveBeenCalledTimes(1);
-    });
-
-    it('renders a passive banner without continue anyway when the simulation is off', () => {
-        renderIssueBanner({ issue: priceImpactIssue, isSimulationEnabled: false });
-
-        expect(screen.getByText('TR_TRADING_PRICE_IMPACT_TITLE 15%')).toBeInTheDocument();
-        expect(screen.queryByTestId('@trading/offer/continue-anyway')).not.toBeInTheDocument();
     });
 });

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeIssueBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeIssueBanner.tsx
@@ -62,7 +62,6 @@ const getIssueContent = (
 
 type TradingOfferExchangeIssueBannerProps = {
     issue: ExchangeIssue;
-    isSimulationEnabled: boolean;
     isContinueDisabled: boolean;
     isContinueLoading: boolean;
     onContinueAnywayClick: () => void;
@@ -70,7 +69,6 @@ type TradingOfferExchangeIssueBannerProps = {
 
 export const TradingOfferExchangeIssueBanner = ({
     issue,
-    isSimulationEnabled,
     isContinueDisabled,
     isContinueLoading,
     onContinueAnywayClick,
@@ -95,16 +93,14 @@ export const TradingOfferExchangeIssueBanner = ({
             description={description}
             data-testid="@trading/offer/issue-banner"
             rightContent={
-                isSimulationEnabled ? (
-                    <Banner.Button
-                        isDisabled={isContinueDisabled}
-                        isLoading={isContinueLoading}
-                        onClick={onContinueAnywayClick}
-                        data-testid="@trading/offer/continue-anyway"
-                    >
-                        <Translation id="TR_TRADING_CONTINUE_ANYWAY" />
-                    </Banner.Button>
-                ) : undefined
+                <Banner.Button
+                    isDisabled={isContinueDisabled}
+                    isLoading={isContinueLoading}
+                    onClick={onContinueAnywayClick}
+                    data-testid="@trading/offer/continue-anyway"
+                >
+                    <Translation id="TR_TRADING_CONTINUE_ANYWAY" />
+                </Banner.Button>
             }
         />
     );

--- a/suite/e2e/support/pageObjects/trading/confirmationModal.ts
+++ b/suite/e2e/support/pageObjects/trading/confirmationModal.ts
@@ -25,6 +25,7 @@ export class TradingConfirmationModal {
     readonly transactionId: Locator;
     readonly copyTransactionIdButton: Locator;
     readonly issueBanner: Locator;
+    readonly continueAnywayButton: Locator;
     readonly finishButton: Locator;
     readonly confirmAndSendButton: Locator;
     readonly buyButton: Locator;
@@ -67,6 +68,7 @@ export class TradingConfirmationModal {
             .getByTestId('@trading/form/info')
             .getByRole('button', { name: 'Copy' });
         this.issueBanner = this.page.getByTestId('@trading/offer/issue-banner');
+        this.continueAnywayButton = this.page.getByTestId('@trading/offer/continue-anyway');
         this.finishButton = this.page.getByTestId('@trading/offer/continue-transaction-button');
         this.confirmAndSendButton = this.page.getByTestId(
             '@trading/offer/confirm-on-trezor-and-send',
@@ -101,7 +103,15 @@ export class TradingConfirmationModal {
 
     @step()
     async openConfirmAndSendModal() {
-        await this.confirmAndSendButton.click({ timeout: 30_000 });
+        // Swap quotes and fiat rates are both live, so a price alert can legitimately show up on
+        // any offer. It replaces the confirm button, and the swap continues from the banner.
+        await expect(this.section).toBeVisible();
+        const isPriceAlertShown = await this.issueBanner.isVisible();
+        const continueButton = isPriceAlertShown
+            ? this.continueAnywayButton
+            : this.confirmAndSendButton;
+
+        await continueButton.click({ timeout: 30_000 });
         await expect(this.modal).toBeVisible();
         await expect(this.devicePrompt.sendButton).toBeDisabled();
     }


### PR DESCRIPTION
## Description

- Show the exchange issue banner action for CEX price alerts even when simulation is off.
- Replace the confirm action with Back to trade form whenever an exchange issue is present.
- Remove the passive CEX-only alert state so CEX and DEX follow the same warning flow.
- Update unit tests and the trading confirmation modal page object for the banner-driven confirm path.

## Notes for QA

- In Wallet > Trade > Exchange confirmation, open a CEX offer with a price alert and verify the banner shows Continue anyway while Confirm on Trezor and send is hidden.
- In Wallet > Trade > Exchange confirmation, click Continue anyway on that alerted CEX offer and verify the device confirmation modal opens.
- In Wallet > Trade > Exchange confirmation, open an offer without a price alert and verify Confirm on Trezor and send is shown directly.

## Related Issue

Resolve #31722

## Screenshots:

<img width="482" height="749" alt="Snímek obrazovky 2026-09-01 v 14 28 08" src="https://github.com/user-attachments/assets/dc9f9d4b-2288-4969-8e03-97727253f1a0" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/31722-align-cex-price-alert-clean&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/31722-align-cex-price-alert-clean&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T05:59:17.130Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T05:59:02.990Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/31722-align-cex-price-alert-clean/web/](https://dev.suite.sldev.cz/suite-web/feat/31722-align-cex-price-alert-clean/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->