### PR TITLE
Review suggestions for #31646: EIP-7702 signing hardening (1 commit / finding)

### DIFF
--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTransaction.mdx
@@ -106,6 +106,11 @@ from the transaction and setting its `nonce` to the transaction `nonce + 1`, and
 signed authorization into the returned `serializedTx`. Firmware currently supports at most one
 authorization per transaction. Delegating to the zero address revokes an existing delegation.
 
+Firmware accepts only a short allowlist of delegate contracts (currently Ambire and MetaMask);
+authorizing any other non-zero delegate is rejected on-device. The device also enforces further
+constraints on the transaction and network at signing time, so an authorization that is valid per
+this API contract may still be refused by the device.
+
 The device also has to be configured up front, using
 [trezorctl](https://trezor.io/guides/trezorctl):
 

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignTransaction.mdx
@@ -27,7 +27,7 @@ import signTransaction7702 from '../../../data/methods/ethereum/signTransaction7
 export const paramDescriptions = {
     path: 'minimum length is `3`. [read more](/details/path)',
     transaction:
-        'type of [`EthereumTransactionEIP1559`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/ethereum/common.ts)`|`[`EthereumSignTransaction`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/ethereum/common.ts) "0x" prefix for each field is optional',
+        'type of [`EthereumTransaction`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/ethereum/common.ts)`|`[`EthereumTransactionEIP1559`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/ethereum/common.ts) "0x" prefix for each field is optional',
     chunkify:
         'determines if recipient address will be displayed in chunks of 4 characters. Default is set to `false`',
     to: "recipient's address, contract address or `null` in case of contract creation",

--- a/packages/connect/src/api/ethereum/ethereumSignTx.test.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.test.ts
@@ -95,5 +95,17 @@ describe('helpers/ethereumSignTx', () => {
                 'exceeds the safe integer range',
             );
         });
+
+        it('rejects a malformed tuple instead of zero-padding it', () => {
+            // A short tuple (three elements) must not be silently padded into a zero-filled
+            // authorization the device never signed.
+            expect(() => parseAuth7702List([{ items: ['01', delegate, '01'] }])).toThrow(
+                'Malformed EIP-7702 authorization tuple',
+            );
+            // A tuple with more than six elements is equally rejected.
+            expect(() =>
+                parseAuth7702List([{ items: ['01', delegate, '01', '01', r, s, '00'] }]),
+            ).toThrow('Malformed EIP-7702 authorization tuple');
+        });
     });
 });

--- a/packages/connect/src/api/ethereum/ethereumSignTx.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.ts
@@ -60,6 +60,8 @@ const bytesHexToNumber = (hex: string) => {
 };
 
 // The device returns each EIP-7702 authorization as a tuple [chain_id, delegate, nonce, y_parity, r, s].
+const AUTH7702_TUPLE_LENGTH = 6;
+
 export const parseAuth7702List = (
     list: PROTO.EthereumTxRequest['auth7702_list'],
 ): SignedAuthorization[] | undefined => {
@@ -67,7 +69,25 @@ export const parseAuth7702List = (
     if (tuples.length === 0) return undefined;
 
     return tuples.map(({ items }) => {
-        const [chainId = '', delegate = '', nonce = '', yParity = '', r = '', s = ''] = items;
+        // A well-formed authorization always has all six elements (zero integers are minimal-
+        // encoded as empty byte strings but stay present). Fail loudly on a short tuple instead of
+        // padding it with zeros, which would serialize an authorization the device never signed.
+        if (items.length !== AUTH7702_TUPLE_LENGTH) {
+            throw ERRORS.TypedError(
+                'Runtime',
+                'Malformed EIP-7702 authorization tuple returned by the device.',
+            );
+        }
+        // The guard above ensures all six elements are present; assert the shape so the type
+        // checker (noUncheckedIndexedAccess) does not treat each element as possibly undefined.
+        const [chainId, delegate, nonce, yParity, r, s] = items as [
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+        ];
 
         return {
             chainId: bytesHexToNumber(chainId),


### PR DESCRIPTION
## Review suggestions for #31646 (EIP-7702 → `ethereumSignTransaction`)

Not meant to be merged as-is — this is a **suggestion branch** stacked on top of `montreal` (the branch behind #31646) with **one commit per review finding** so you can cherry-pick whatever you like and drop the rest. Base is `montreal`, so the diff shows only these fixes.

Findings come from a review of #31646 (my own pass + two independent adversarial passes), cross-checked against GitHub Copilot's inline comments — several converge.

### Fixes (correctness)
1. **`fix(connect): gate EIP-7702 transactions on firmware 2.12.5+`** — the removed `ethereumSignAuth7702` version gate wasn't replaced, so on T1B1 / Core `2.4.2..2.12.4` the device signed & displayed a plain type-2 tx (old FW ignores the unknown `auth7702` field) before `run()` threw. Adds an `eip7702` firmware capability (T1B1 unsupported, Core min 2.12.5), selected when an authorization is present → clean up-front `FIRMWARE_OLD` / `FIRMWARE_NOT_SUPPORTED`.
2. **`fix(connect): reject EIP-7702 authorization nonce above MAX_SAFE_INTEGER`** — the device signs auth nonce = tx nonce + 1, which `parseAuth7702List` reads back via `Number()`; a tx nonce ≥ 2^53 would round and re-serialize a different authorization than was signed. Reject it before signing. Defensive (such a nonce is never a valid account nonce), but keeps signed value and serialization in agreement.
3. **`fix(connect): reject malformed EIP-7702 authorization tuples from the device`** — `parseAuth7702List` only dropped empty tuples and padded short ones with `''` defaults; require exactly 6 elements and throw otherwise, instead of serializing a zero-filled authorization.
4. **`fix(connect): reject an empty EIP-7702 authorizationList`** — `authorizationList: []` passed the schema, skipped the experimental opt-in and silently produced a type-2 tx. Reject an empty list. *(debatable — drop if you consider `[]` = "no authorizations")*
5. **`chore(protobuf): point trezor-common submodule at the EIP-7702 proto commit`** — **the gitlink points to `bda8ff94`, whose `messages-ethereum.proto` does NOT yet contain the EIP-7702 fields.** They're added by its direct successor **`89b4a785`** ("integrate EIP-7702 delegation into EthereumSignTxEIP1559"), which is what the regenerated protobufs here actually correspond to. As committed the generated protobufs aren't reproducible from the submodule and `yarn update:protobuf` would drop the `auth7702` changes. Bumps the gitlink to `89b4a785` (exactly one commit ahead, touching only that proto). **Verify this is the intended trezor-common commit before merging into your branch.**

### Fixes (docs)
6. **`docs(connect-explorer): fix ethereumSignTransaction transaction param type`** — `transaction` was described as `EthereumTransactionEIP1559 | EthereumSignTransaction`; the union is `EthereumTransaction | EthereumTransactionEIP1559` (pre-existing typo).
7. **`docs(connect-explorer): state EIP-7702 minimum firmware 2.12.5`** — device requirements only mentioned T1B1.
8. **`docs(connect-explorer): note the EIP-7702 delegate allowlist and device checks`** — docs implied any EIP-1559 payload is valid; the device only accepts an allowlist (Ambire/MetaMask) and applies further checks. **Conservative wording** — I did **not** enumerate specific firmware constraints (reviewers listed a few, e.g. non-zero value / calldata, that I couldn't verify against trezor-firmware#7512 and that may not actually hold for a set-code tx).

### Not addressed here (need your call / external info)
- **EIP-7702 device e2e runs only in nightly, not on PRs** — matches how nostr experimental methods are handled; the serialization path is covered on every PR by the exact-byte unit test. No code change; flagging so PR-green isn't read as "e2e ran".
- **e2e `skip: ['<2.12.5']` vs `2-latest`** — worth confirming firmware#7512 actually ships in `2.12.5` (not later), else `2-latest` coverage may narrow to `2-main`.
- **Exact device-side reject rules for the docs** — needs verification against the firmware source before documenting specifics.

> Note: deps aren't installed in my worktree, so I couldn't run type-check/lint/tests locally — please let CI validate. TS target is ES2023, so the `1n` literal and `BigInt` usage are fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/eip7702-signtx-review-fixes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/eip7702-signtx-review-fixes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/eip7702-signtx-review-fixes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches TrezorConnect's Ethereum transaction signing implementation and its unit tests. Because ethereumSignTx.ts is a shared dependency used by many E2E flows, the main risks are transaction composition, EIP-1559 fee field presentation, and contract-call data handling. Run the direct ethereumSignTransaction API test plus representative send and swap-fee tests first; add contract-interaction tests for staking and token approvals to catch data-field regressions.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/api/ethereum/ethereumSignTx.test.ts`
- `packages/connect/src/api/ethereum/ethereumSignTx.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Focused on custom Ethereum fee handling inside the trading swap flow; asserts exact gas limit, max fee per gas, max priority fee per gas, and calculated max fee values shown on the device prompt, all produced by ethereumSignTx.ts.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Inferred from the LLM analysis. This test directly calls TrezorConnect.ethereumSignTransaction, which is implemented by the changed ethereumSignTx.ts, making it the most precise end-to-end coverage for the modified signing logic.
- `suite/e2e/tests/wallet/send-base.test.ts` — Inferred from the LLM analysis. Sends ETH on the Base network with custom EIP-1559 fees, covering chain-specific transaction construction paths and fee display in ethereumSignTx.ts beyond mainnet Ethereum.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly exercises a mainnet Ethereum send transaction with custom EIP-1559 fee parameters and verifies the resulting device prompt fields, which are generated by ethereumSignTx.ts.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — Covers Ethereum contract interactions for both unstaking and claiming through the Everstake pool, including device prompts with specific amounts and fees that depend on ethereumSignTx.ts.
- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — Tests an ERC-20 token approval transaction on Ethereum, a contract-call transaction whose transaction data and fee display flow through ethereumSignTx.ts.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/api/ethereum/ethereumSignTx.test.ts`

_Updated: 2026-09-05T17:07:21.825Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/eip7702-signtx-review-fixes/web/](https://dev.suite.sldev.cz/suite-web/mroz22/eip7702-signtx-review-fixes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-05T17:09:05.488Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-05T17:09:14.834Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->