### PR TITLE
fix(transport): protocol-v1 restart-detection is dead code, corrupts payload on retransmit

### DIFF
--- a/packages/transport-common/src/utils/receive.test.ts
+++ b/packages/transport-common/src/utils/receive.test.ts
@@ -133,6 +133,115 @@ describe('receive', () => {
         expect(spyWarn).toHaveBeenCalledTimes(1);
     });
 
+    test('protocol-v1 handle packet loss', async () => {
+        const apiRead = getApiRead([
+            '3f23230002000000060a',
+            '3f046d65',
+            '3f23230002000000060a', // first chunk again
+            '3f046d65',
+            '3f6f77',
+        ]);
+        const spyWarn = jest.spyOn(console, 'warn').mockImplementation();
+        const result = await receive(apiRead, protocolV1);
+        expect(result).toMatchObject({
+            success: true,
+            payload: { messageType: 2 },
+        });
+        expect(apiRead).toHaveBeenCalledTimes(5);
+        expect(spyWarn).toHaveBeenCalledTimes(1);
+        if (result.success) {
+            expect(result.payload.payload.subarray(0, result.payload.length).toString('hex')).toBe(
+                '0a046d656f77',
+            );
+        }
+    });
+
+    test('protocol-v1 continuation chunk that coincidentally starts with the message header bytes is not mistaken for a restart', async () => {
+        // Regression test: comparing only the 3-byte protocol-v1 header (3f 23 23) against a
+        // continuation chunk's leading bytes would false-positive on any genuine continuation
+        // chunk whose payload happens to start with 23 23, discarding real data. The fix must
+        // compare against the full saved first-packet bytes, so a match on only the first 3
+        // bytes is not enough to trigger a restart.
+        const apiRead = getApiRead([
+            '3f23230002000000060a', // first packet: header 3f2323, type 0002, length 6, payload byte 0a
+            '3f232301020304', // continuation: chunkHeader 3f + payload 23 23 01 02 03 04 (7 bytes)
+        ]);
+        const spyWarn = jest.spyOn(console, 'warn').mockImplementation();
+        const result = await receive(apiRead, protocolV1);
+        expect(result).toMatchObject({
+            success: true,
+            payload: { messageType: 2 },
+        });
+        expect(apiRead).toHaveBeenCalledTimes(2);
+        expect(spyWarn).not.toHaveBeenCalled();
+        if (result.success) {
+            // 1 payload byte from the first packet (0a) + 5 bytes from the continuation
+            // (23 23 01 02 03 - Buffer.copy truncates to the remaining 5-byte capacity of the
+            // 6-byte result buffer, dropping the continuation's trailing 04, which is expected
+            // and unrelated to this fix)
+            expect(result.payload.payload.subarray(0, result.payload.length).toString('hex')).toBe(
+                '0a2323010203',
+            );
+        }
+    });
+
+    test('protocol-v1 SHORT continuation chunk that coincidentally shares the header prefix is not mistaken for a restart', async () => {
+        // Regression test: comparing only a length-capped prefix (min(chunk length, first
+        // packet length)) would still false-positive when a short continuation chunk's entire
+        // content happens to equal the first bytes of a longer first packet. Real chunked
+        // transports pad every packet - first and continuation alike - to the same fixed chunk
+        // size (see `createChunks`), so a genuine retransmit is always the SAME length as the
+        // original first packet; the fix must require an exact length match (not just a
+        // prefix match) before comparing content, so a differently-sized continuation - even
+        // one that is a byte-for-byte prefix of the first packet - is never mistaken for one.
+        const apiRead = getApiRead([
+            '3f23230002000000030a', // first packet (10 bytes): header 3f2323, type 0002, length 3, payload byte 0a
+            '3f2323', // SHORT continuation (3 bytes): chunkHeader 3f + payload 23 23 - identical prefix, different length
+        ]);
+        const spyWarn = jest.spyOn(console, 'warn').mockImplementation();
+        const result = await receive(apiRead, protocolV1);
+        expect(result).toMatchObject({
+            success: true,
+            payload: { messageType: 2 },
+        });
+        expect(apiRead).toHaveBeenCalledTimes(2);
+        expect(spyWarn).not.toHaveBeenCalled();
+        if (result.success) {
+            expect(result.payload.payload.subarray(0, result.payload.length).toString('hex')).toBe(
+                '0a2323',
+            );
+        }
+    });
+
+    test('protocol-bridge multi-read message is not mistaken for a restart on every chunk', async () => {
+        // Regression test: protocol-bridge has no chunk framing at all (getHeaders returns two
+        // empty buffers), so a naive header-match restart check (empty buffer compared against
+        // an empty slice) is always "equal" and would treat every single chunk as a restart,
+        // resetting offset forever and never completing reception.
+        const result = buildMessage({
+            name: 'StellarPaymentOp',
+            // @ts-expect-error: indexing with noUncheckedIndexedAccess
+            data: fixtures[0].in,
+            protocol: bridgeProtocol,
+        });
+        // split the encoded message into two reads, well past the 6-byte bridge header
+        const splitAt = 10;
+        const apiRead = getApiRead([
+            result.subarray(0, splitAt).toString('hex'),
+            result.subarray(splitAt).toString('hex'),
+        ]);
+        const spyWarn = jest.spyOn(console, 'warn').mockImplementation();
+        const decoded = await receiveAndParse(apiRead, bridgeProtocol);
+        expect(apiRead).toHaveBeenCalledTimes(2);
+        expect(spyWarn).not.toHaveBeenCalled();
+        if (!decoded.success) {
+            throw new Error('Decoding failed');
+        }
+        expect(decoded.payload.type).toEqual('StellarPaymentOp');
+        // @ts-expect-error: indexing with noUncheckedIndexedAccess
+        expect(decoded.payload.message).toEqual(fixtures[0].in);
+    });
+
     test('protocol-v2 receive one chunk', async () => {
         const result = await receive(getApiRead(['2833da0004527eb068']), protocolV2);
         expect(result).toMatchObject({

--- a/packages/transport-common/src/utils/receive.ts
+++ b/packages/transport-common/src/utils/receive.ts
@@ -26,9 +26,9 @@ export async function receive<T extends Receiver>(
     }
 
     try {
-        const data = readResult.payload;
+        const firstPacketBytes = readResult.payload;
         const { length, messageType, payload, header } = protocol.decode(readResult.payload);
-        const [, chunkHeader] = protocol.getHeaders(data);
+        const [, chunkHeader] = protocol.getHeaders(firstPacketBytes);
 
         const result: Buffer = Buffer.alloc(length);
         payload.copy(result);
@@ -40,15 +40,34 @@ export async function receive<T extends Receiver>(
                 return readResult;
             }
             const data = readResult.payload;
-            const dataChunkHeader = data.subarray(0, chunkHeader.length);
-            if (dataChunkHeader.compare(chunkHeader) !== 0) {
-                if (header.compare(data.subarray(0, header.length)) === 0) {
+            // Check for a retransmitted first packet before checking the chunk header. On
+            // protocol-v1 the chunk header is itself a byte-prefix of the message header, so a
+            // chunk-header-first check can never distinguish a genuine continuation chunk from a
+            // retransmitted first packet - the branch below would never fire and a restart would
+            // silently corrupt the payload instead of being recovered.
+            //
+            // Compare against the full saved first-packet bytes (not just the short protocol
+            // header), and require an exact length match first. Real chunked transports pad
+            // every packet - first and continuation alike - to the same fixed chunk size (see
+            // `createChunks`), so a genuine retransmit is always byte-identical in both length
+            // and content to the original first packet, while a differently-sized continuation
+            // can never be one. Requiring the full buffer to match (not just a shared prefix)
+            // makes a coincidental false-positive on real, differently-sized continuation data
+            // effectively impossible, rather than merely unlikely.
+            // `header.length === 0` (e.g. protocol-bridge, which has no chunk framing at all) is
+            // guarded out entirely, matching that protocol's original behaviour of never treating
+            // any input as a restart.
+            if (header.length > 0) {
+                if (data.length === firstPacketBytes.length && data.equals(firstPacketBytes)) {
                     offset = payload.length;
                     console.warn('Restart message reception');
 
                     continue;
                 }
+            }
 
+            const dataChunkHeader = data.subarray(0, chunkHeader.length);
+            if (dataChunkHeader.compare(chunkHeader) !== 0) {
                 throw new Error(`Unexpected chunkHeader ${dataChunkHeader.toString('hex')}`);
             }
 


### PR DESCRIPTION
## the bug

`packages/transport-common/src/utils/receive.ts:41-53`'s "device resent the first packet, restart reassembly" recovery branch can never execute on protocol-v1.

```ts
const dataChunkHeader = data.subarray(0, chunkHeader.length);
if (dataChunkHeader.compare(chunkHeader) !== 0) {      // never true on v1
    if (header.compare(data.subarray(0, header.length)) === 0) {
        offset = payload.length;
        console.warn('Restart message reception');
        continue;
    }
    throw new Error(`Unexpected chunkHeader ...`);
}
```

For protocol-v1 (`packages/protocol/src/protocol-v1/encode.ts:5-17`), `header = 3f2323` and `chunkHeader = 3f` (1 byte) - and `chunkHeader` is a byte-prefix of `header`. Every v1 packet, continuation or a retransmitted first packet, starts with `0x3f`. So `dataChunkHeader.compare(chunkHeader)` is always `0` and the outer `if` - which guards the entire restart-recovery branch - never fires. protocol-v2 is unaffected: its continuation control byte (`0x80 || channel`) can never equal a first-packet control byte.

Net effect: if a device resends its first packet mid-message (the exact scenario this code was written to handle - it was added by #27709), the retransmitted header bytes get spliced into the payload as if they were continuation data, silently corrupting the reassembled protobuf message. No error, no warning - `console.warn('Restart message reception')` never fires on v1.

protocol-v1 is the default transport protocol for non-THP devices (Trezor One / classic-protocol devices, bootloader mode) on both the direct USB/WebUSB lane and the bridge lane's fallback.

## repro

Ported the real `protocol-v1/{constants,encode,decode}.ts` logic + `receive()`, encoded a multi-chunk message, simulated a device resending its first packet mid-stream:

```
clean stream       -> payload matches original, 0 warnings
device restart     -> payload CORRUPTED (header bytes spliced into the message body), 0 warnings
```

The existing test suite already had a `protocol-v2 handle packet loss` test (`receive.test.ts:154`) verifying this exact recovery scenario for v2 - there was no v1 equivalent, which is why this went unnoticed.

## the fix (iterated through 3 real Codex adversarial review rounds)

Naive fix (reorder to check message-header match before chunk-header): shipped a **new** false-positive - Codex's review caught that a genuine v1 continuation chunk whose payload happens to start `0x23 0x23` would coincidentally match the 3-byte header and get wrongly treated as a restart, silently discarding real data. It also caught that `protocol-bridge` (`getHeaders()` returns two empty buffers) would make the reordered check *always* true, resetting `offset` on every iteration - an infinite-progress hang on any multi-read bridge message.

Final fix: compare against the **full saved first-packet bytes**, requiring both an **exact length match** and a **full-buffer match** (`data.length === firstPacketBytes.length && data.equals(firstPacketBytes)`) - not a prefix match. Real chunked transports (`createChunks`, `send.ts`) pad every packet, first and continuation alike, to the same fixed chunk size, so a genuine retransmit is always byte-identical in both length and content to the original first packet, while a differently-sized or differently-content continuation chunk never coincidentally is. Protocols with no chunk framing at all (`header.length === 0`, i.e. protocol-bridge) skip the restart-check entirely, preserving their original behaviour exactly.

## receipts

New tests (`receive.test.ts`), each independently verified to fail against the specific prior (broken) implementation and pass against the final fix:

- `protocol-v1 handle packet loss` - mirrors the existing v2 test; fails against current `main`, passes with the fix.
- `protocol-v1 continuation chunk that coincidentally starts with the message header bytes is not mistaken for a restart` - guards the false-positive Codex's first review pass caught.
- `protocol-v1 SHORT continuation chunk that coincidentally shares the header prefix is not mistaken for a restart` - guards the false-positive Codex's second review pass caught (the intermediate min-length-comparison fix failed this exact test; verified directly by temporarily reverting to that version and re-running).
- `protocol-bridge multi-read message is not mistaken for a restart on every chunk` - guards the bridge regression Codex's first review pass caught.

```
$ yarn jest src/utils/receive.test.ts
Test Suites: 1 passed, 1 total
Tests:       219 passed, 219 total

$ yarn jest   # full transport-common package
Test Suites: 7 passed, 7 total
Tests:       273 passed, 273 total

$ yarn type-check   # clean, no output
$ yarn g:eslint packages/transport-common/src/utils/receive.ts packages/transport-common/src/utils/receive.test.ts   # clean, no output
```

Three rounds of synchronous Codex (gpt-5.6) adversarial review, each catching a real issue in the prior version before the final SHIP verdict. Full diff scope is the two touched files only.

## risk

Low-medium. Touches a hot path (every multi-chunk v1/v2/bridge read goes through `receive()`), but the final fix is narrowly scoped, each protocol's existing behaviour is preserved except for the v1 dead-code path this PR intentionally makes reachable, and the diff is covered by 4 new tests plus the full existing 273-test package suite.

## dupe-check

`gh issue/pr list --repo trezor/trezor-suite --state all --search "Restart message reception" / "protocol-v1 packet loss" / "receive restart chunk" / "receive packet loss"` - nothing found except #27709 (merged), which introduced this exact branch with a v2-only test, no v1 coverage. No open PR touches `utils/receive.ts`.
