### PR TITLE
fix(connect): firmware rollout bucketing excludes ~1% of devices at any rollout percentage, including 100

### DIFF
--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -390,8 +390,13 @@ const calculateShouldOfferRelease = (
         // unless rolloutProbability is 0, in that case we should never offer it.
         return rolloutProbability > 0;
     } else {
-        // If deviceId is provided, use the deterministic approach.
-        const deterministicValueToCompare = getIntegerInRangeFromString(deviceId, 101);
+        // If deviceId is provided, use the deterministic approach. `rolloutProbability` is a
+        // 0..100 percentage compared with `<`, so the bucket count must be 100 (values 0..99) -
+        // passing 101 here would bucket one extra value (100) that can never satisfy `< 100`,
+        // permanently excluding ~1% of devices from being offered a release at ANY rollout
+        // percentage including 100. See the sibling usage in
+        // suite-common/message-system/src/experimentUtils.ts for the same pattern done right.
+        const deterministicValueToCompare = getIntegerInRangeFromString(deviceId, 100);
 
         return deterministicValueToCompare < rolloutProbability;
     }

--- a/packages/connect/src/data/getReleaseInfo.firmware.test.ts
+++ b/packages/connect/src/data/getReleaseInfo.firmware.test.ts
@@ -42,6 +42,44 @@ const fixtures = [
         },
     },
     {
+        // Regression test: `calculateShouldOfferRelease` used to bucket device ids into 101
+        // buckets (0..100 via `getIntegerInRangeFromString(deviceId, 101)`) but compared the
+        // result against a 0..100 rollout_probability with `<`, so bucket 100 could never
+        // satisfy `< 100` at ANY rollout percentage, including 100. This device_id was found by
+        // brute-forcing the real project hash function for one that lands in bucket 100 under
+        // the buggy max=101 - verified independently outside this test suite. Every other
+        // fixture in this file uses the default mocked device_id ('device-id'), which happens
+        // not to land in the excluded bucket, which is exactly why this bug went unnoticed.
+        desc: 'A device id that hashes into the excluded bucket is still offered at rollout_probability 100',
+        releasesOfDevice: releasesT2T1,
+        features: getDeviceFeatures({
+            bootloader_mode: null,
+            major_version: 2,
+            minor_version: 8,
+            patch_version: 7,
+            device_id: '36647600C9CEB95187D31BC5',
+        }),
+        release: latestT2T1,
+        conditions: {
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
+            rollout_probability: 100,
+        },
+        isBitcoinOnlyAvailable: true,
+        firmwareType: FirmwareType.Universal,
+        result: {
+            releaseConditions: {
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
+                rollout_probability: 100,
+                shouldBeOffered: true,
+            },
+            release: latestT2T1,
+            intermediary: undefined,
+            isRequired: false,
+            isNewer: true,
+            translations: latestT2T1.translations,
+        },
+    },
+    {
         desc: 'Having newer version makes release `isNewer` and probability 0 `shouldBeOffered` false',
         releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({


### PR DESCRIPTION
## the bug

`packages/connect/src/data/firmwareInfo.ts:394` (`calculateShouldOfferRelease`):

```ts
const deterministicValueToCompare = getIntegerInRangeFromString(deviceId, 101); // buckets 0..100
return deterministicValueToCompare < rolloutProbability;                        // p is 0..100
```

`getIntegerInRangeFromString(str, max)` returns a uniformly-distributed integer in `0..max-1`. With `max=101` that's 101 buckets (`0..100`), compared against a `0..100` percentage via `<`. Bucket `100` can never satisfy `< 100` - so any device whose id hashes into that bucket is permanently excluded from being offered a release **at any rollout percentage, including 100%** (e.g. a security-fix release meant to reach every device).

The correct pattern already exists in this repo for the identical use case: `suite-common/message-system/src/experimentUtils.ts:24` passes `getIntegerInRangeFromString(combinedId, 100)` for percentage-bucketing. 100 buckets (`0..99`) is what a `0..100` percentage compared with `<` actually needs.

## repro

Independently verified against the real project source (`packages/utils/src/getIntegerInRangeFromString.ts`), not a ported copy - brute-forced a synthetic device id (via `crypto.randomBytes`, not sourced from any real device) that hashes into the excluded bucket:

```
device_id: 36647600C9CEB95187D31BC5
getIntegerInRangeFromString(id, 101) -> 100   (buggy bucket count: excluded at every rollout %, including 100)
getIntegerInRangeFromString(id, 100) -> 24    (fixed bucket count: correctly offered from rollout 25%+)
```

## why the existing test suite didn't catch this

Every existing fixture in `getReleaseInfo.firmware.test.ts` uses the default mocked `device_id` (`'device-id'`, from `setupJest.ts`), which happens not to land in the excluded bucket - so `shouldBeOffered: true` at `rollout_probability: 100` passed for years despite the bug, on every fixture that exercised it. `getIntegerInRangeFromString.test.ts` itself calls the helper with `101` and pins `result >= 0 && result < 101` as correct - and that's true, the *helper* is correct and generic (its own docstring: "if 101, then range is 0 to 100"). The bug is entirely in this one caller passing the wrong bucket count for its specific percentage-comparison semantics.

## the fix

`getIntegerInRangeFromString(deviceId, 101)` -> `getIntegerInRangeFromString(deviceId, 100)`.

Adds a regression fixture to `getReleaseInfo.firmware.test.ts` (same pattern as every other fixture in that file) using the device id above, asserting `shouldBeOffered: true` at `rollout_probability: 100`. Independently verified this fixture **fails against current `develop`** and **passes after the fix**.

## receipts

```
$ yarn jest src/data/getReleaseInfo.firmware.test.ts src/data/getReleaseInfo.required.test.ts src/data/getReleaseInfo.bootloader.test.ts src/data/getReleaseInfo.fresh.test.ts src/data/firmwareInfo.test.ts
Test Suites: 5 passed, 5 total
Tests:       18 passed, 18 total

$ yarn jest   # full packages/connect suite
Test Suites: 51 passed, 1 skipped, 52 total
Tests:       547 passed, 1 skipped, 548 total   (the skip is pre-existing and unrelated)

$ yarn type-check   # clean, no output
$ yarn g:eslint packages/connect/src/data/firmwareInfo.ts packages/connect/src/data/getReleaseInfo.firmware.test.ts   # clean, no output
```

Codex (gpt-5.6) adversarial review, verdict **SHIP**: independently re-derived the fixture's hash (bucket 100 under max=101, bucket 24 under max=100, matching exactly), confirmed `getIntegerInRangeFromString` has only one other production caller (`experimentUtils.ts`, unaffected by this change), confirmed the default `'device-id'` fixture's bucket shifts (89→14) but every fixture using it only asserts at `rollout_probability` 0 or 100 so no existing test's outcome can flip, and confirmed the new test id is synthetic.

One honest note Codex raised, worth calling out for reviewers: correcting the bucket count reshuffles which bucket *every* device id falls into, so a device mid-way through a partial (non-0/non-100) rollout could shift to either side of the threshold when this ships. That's an inherent, one-time consequence of fixing a biased distribution, not a new bug - the alternative (special-casing only bucket 100) would preserve already-deployed rollout cohorts but leave every *other* bucket's width still biased.

## risk

Low-medium. Single-line logic change in a well-isolated, already-tested function; the only externally-observable behavior change is that firmware updates (including security fixes at 100% rollout) now correctly reach 100% of devices instead of ~99%, and partial-rollout devices may shift which side of the threshold they land on (see above).

## dupe-check

`gh issue/pr list --repo trezor/trezor-suite --state all --search "getIntegerInRangeFromString" / "calculateShouldOfferRelease" / "rolloutProbability" / "firmware update not offered rollout"` - nothing found except #18435 (merged, introduced the feature) and #30320 (merged, unrelated test-file relocation). No open PR touches `firmwareInfo.ts` or `getIntegerInRangeFromString.ts`.
