### PR TITLE
fix(wallet-core): exclude single-account types from rediscovery condition

### DIFF
--- a/suite-common/wallet-core/src/selectors.test.ts
+++ b/suite-common/wallet-core/src/selectors.test.ts
@@ -96,6 +96,12 @@ describe(selectDiscoveryAccountsParam.name, () => {
         expect(getSolKnown([mockSolAccount({ index: 0 })])).toEqual([{ type: 'normal', skip: 1 }]);
     });
 
+    it('skips a used account of a single-account type', () => {
+        expect(getSolKnown([mockSolAccount({ accountType: 'root', index: 0 })])).toEqual([
+            { type: 'root' },
+        ]);
+    });
+
     it('skips a completely discovered account type', () => {
         expect(
             getSolKnown([
@@ -159,6 +165,19 @@ describe(selectShouldRediscover.name, () => {
                 device,
             ),
         ).toBe(true);
+    });
+
+    it('returns false when the used account is the only one its type can have', () => {
+        const device = mockDeviceWithPathAndState();
+        expect(
+            selectShouldRediscover(
+                getState({
+                    device,
+                    accounts: [mockSolAccount({ accountType: 'root', index: 0, empty: false })],
+                }),
+                device,
+            ),
+        ).toBe(false);
     });
 
     it('returns false when the account chain is already fully discovered', () => {

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -6,6 +6,7 @@ import {
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import {
+    type Network,
     type NetworkSymbol,
     isSingleAccountType,
     networks,
@@ -103,23 +104,29 @@ const getDeviceAccountsPerEnabledNetwork = (
     return symbols.map(symbol => ({ symbol, accounts: symbolMap[symbol] }));
 };
 
-const getAccountChainsPerAccountType = (accounts: Account[]) =>
+const getAccountChainsPerAccountType = (network: Network, accounts: Account[]) =>
     Object.entries(arrayToDictionary(accounts, acc => acc.accountType, true)).map(
-        ([type, accs]) => ({
-            type,
+        ([type, accs]) => {
             // account with the highest index
-            lastAccount: accs.reduce((last, current) =>
+            const lastAccount = accs.reduce((last, current) =>
                 current.index > last.index ? current : last,
-            ),
-            // failed account with the lowest index; a failed account may sit below other known
-            // accounts when a known-accounts refresh fails for some of them (e.g. flaky backend)
-            firstFailedAccount: accs
-                .filter(isAccountFailed)
-                .reduce<Account | undefined>(
-                    (first, current) => (!first || current.index < first.index ? current : first),
-                    undefined,
-                ),
-        }),
+            );
+
+            return {
+                type,
+                lastAccount,
+                // failed account with the lowest index; a failed account may sit below other known
+                // accounts when a known-accounts refresh fails for some of them (e.g. flaky backend)
+                firstFailedAccount: accs
+                    .filter(isAccountFailed)
+                    .reduce<Account | undefined>(
+                        (first, current) =>
+                            !first || current.index < first.index ? current : first,
+                        undefined,
+                    ),
+                canDiscoverNextAccount: !lastAccount.empty && !isSingleAccountType(network, type),
+            };
+        },
     );
 
 export const selectDiscoveryAccountsParam = (
@@ -145,13 +152,12 @@ export const selectDiscoveryAccountsParam = (
                 gap: bitcoinGap,
             } as DiscoveryAccountsParam[number];
 
-        const known = getAccountChainsPerAccountType(accounts).map(
-            ({ type, lastAccount, firstFailedAccount }) => {
+        const known = getAccountChainsPerAccountType(network, accounts).map(
+            ({ type, lastAccount, firstFailedAccount, canDiscoverNextAccount }) => {
                 // some account failed; rediscover the whole chain from the first failed one
                 if (firstFailedAccount) return { type, skip: firstFailedAccount.index };
                 // last account is a used one; skip it and try to discover next one
-                else if (!lastAccount.empty && !isSingleAccountType(network, type))
-                    return { type, skip: lastAccount.index + 1 };
+                else if (canDiscoverNextAccount) return { type, skip: lastAccount.index + 1 };
                 // last account is an empty one or the only account of its type; skip this type completely
                 else return { type };
             },
@@ -200,10 +206,11 @@ export const selectShouldRediscover = (
     if (!device.discovered) return true;
 
     return getDeviceAccountsPerEnabledNetwork(state, staticSessionId).some(
-        ({ accounts }) =>
+        ({ symbol, accounts }) =>
             !accounts ||
-            getAccountChainsPerAccountType(accounts).some(
-                ({ lastAccount }) => !lastAccount.failed && !lastAccount.empty,
+            getAccountChainsPerAccountType(networks[symbol], accounts).some(
+                ({ lastAccount, canDiscoverNextAccount }) =>
+                    !lastAccount.failed && canDiscoverNextAccount,
             ),
     );
 };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Two selectors decide whether discovery still has something to find, and only one of them learned about single-account types when the Solana root path was added (31fe1d9f72). For a used Solana `root` account they disagree forever: one asks for a rediscovery, the other tells discovery to skip that type. The run changes nothing, the condition stays true, and since account updates trigger discovery, it restarts every few seconds.

Both selectors now read the same shared field.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #31946

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are in suite-common/wallet-core selectors, a broad utility imported by 138 E2E tests. Because the file is global, only tests that directly exercise selector-driven behavior should be run. The highest-risk areas are account search/filtering, account type/count logic, and multi-coin discovery state. Five targeted tests provide good coverage without running the entire suite. The unit-test file selectors.test.ts has no E2E coverage, but changes there are validated by unit tests themselves.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/selectors.test.ts`
- `suite-common/wallet-core/src/selectors.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — This test directly exercises account search and filtering in the wallet sidebar, which is implemented through wallet account selectors from suite-common/wallet-core. A change to selectors.ts could break account visibility, filtering, or search results.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Adding accounts of different types and verifying account counts/type labels depends on wallet account selectors that derive visible accounts and their metadata from Redux state. Selector regressions would directly manifest here.
- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin discovery completion and account visibility across BTC, ETH, LTC, etc. rely heavily on discovery and account selectors. This test validates the end-to-end behavior of selector-driven discovery state transitions.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test covers wallet discovery, ejection, and standard wallet re-addition, including verifying BTC balance visibility. It exercises selector-derived account and balance state after discovery.
- `suite/e2e/tests/wallet/multi-account-discovery-perf.test.ts` — Multi-account discovery across funded networks verifies that selector-based account enumeration and balance resolution perform correctly when many accounts are discovered together.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/selectors.test.ts`

_Updated: 2026-09-01T13:41:23.942Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/discovery-loop/web/](https://dev.suite.sldev.cz/suite-web/fix/discovery-loop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/discovery-loop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/discovery-loop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/discovery-loop&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T13:43:09.241Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T13:43:07.357Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->