### PR TITLE
chore(suite): bump beta version to 26.10.0

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite",
-    "suiteVersion": "26.9.0",
+    "suiteVersion": "26.10.0",
     "version": "1.0.0",
     "private": true,
     "exports": {


### PR DESCRIPTION
## Description

Automatically generated PR to bump beta Suite version

## Notes for QA

Regular procedure of bumping the Suite version, just check it is updated accordingly in the app settings.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Changing packages/suite/package.json is most likely a version bump, dependency update, or build configuration change. The highest-risk, directly observable regressions would be in version display and analytics version reporting, so a small targeted run of version-related tests is the best first line of validation. If those pass, broader functional smoke tests can be considered only if the dependency changed is known to affect a specific feature.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/package.json`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics event asserts on suiteVersion, which is typically sourced from the suite package version in package.json. A version bump or build metadata change here would directly alter that event payload.
- `suite/e2e/tests/settings/general.test.ts` — This test verifies the Suite version element is visible on the general settings page; the displayed version is derived from package.json, so any change to version or build config could affect this assertion.
- `suite/e2e/tests/suite/version-page.test.ts` — The version page explicitly checks the semantic version string and commit hash injected at build time, both of which are tied to package.json/build metadata.

</details>

_Updated: 2026-09-01T13:45:48.422Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bump-suite-version-26.10.0/web/](https://dev.suite.sldev.cz/suite-web/chore/bump-suite-version-26.10.0/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-suite-version-26.10.0&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-suite-version-26.10.0&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T13:48:51.623Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T13:48:24.451Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->