### PR TITLE
chore(suite-native): stabilize Android emulator configuration

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   run_android_e2e_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -153,8 +153,9 @@ jobs:
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           emulator-port: 5554
-          emulator-options: -no-window -gpu swiftshader -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -memory 4096
+          emulator-options: -no-window -gpu swiftshader -accel on -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -memory 4096
           disable-spellchecker: true
+          disable-linux-hw-accel: false
           disable-animations: true
           cores: 4
           heap-size: 512M

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -153,7 +153,7 @@ jobs:
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           emulator-port: 5554
-          emulator-options: -no-window -gpu swiftshader -accel on -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none
+          emulator-options: -no-window -gpu lavapipe -accel on -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none
           disable-spellchecker: true
           disable-linux-hw-accel: false
           disable-animations: true

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -153,7 +153,7 @@ jobs:
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           emulator-port: 5554
-          emulator-options: -no-window -gpu swiftshader -accel on -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -memory 4096
+          emulator-options: -no-window -gpu swiftshader -accel on -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim
           disable-spellchecker: true
           disable-linux-hw-accel: false
           disable-animations: true

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -152,7 +152,7 @@ jobs:
           ram-size: 4096M
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -grpc 8554 -memory 4096
+          emulator-options: -no-window -gpu swiftshader -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -grpc 8554 -memory 4096
           disable-animations: true
           cores: 4
           heap-size: 512M

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -153,7 +153,7 @@ jobs:
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           emulator-port: 5554
-          emulator-options: -no-window -gpu swiftshader -accel on -no-snapshot -noaudio -no-boot-anim
+          emulator-options: -no-window -gpu swiftshader -accel on -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none
           disable-spellchecker: true
           disable-linux-hw-accel: false
           disable-animations: true

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -152,7 +152,7 @@ jobs:
           ram-size: 4096M
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
-          emulator-options: -no-window -gpu swiftshader -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -grpc 8554 -memory 4096
+          emulator-options: -no-window -gpu swiftshader -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -memory 4096
           disable-animations: true
           cores: 4
           heap-size: 512M

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -154,6 +154,7 @@ jobs:
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           emulator-port: 5554
           emulator-options: -no-window -gpu swiftshader -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -memory 4096
+          disable-spellchecker: true
           disable-animations: true
           cores: 4
           heap-size: 512M

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -152,6 +152,7 @@ jobs:
           ram-size: 4096M
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
+          emulator-port: 5554
           emulator-options: -no-window -gpu swiftshader -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim -memory 4096
           disable-animations: true
           cores: 4

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -153,7 +153,7 @@ jobs:
           force-avd-creation: true
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           emulator-port: 5554
-          emulator-options: -no-window -gpu swiftshader -accel on -no-snapshot-load -no-snapshot-save -noaudio -no-boot-anim
+          emulator-options: -no-window -gpu swiftshader -accel on -no-snapshot -noaudio -no-boot-anim
           disable-spellchecker: true
           disable-linux-hw-accel: false
           disable-animations: true


### PR DESCRIPTION
## Description

Makes the Android E2E emulator setup explicit and removes redundant or unused options:

- Uses the supported SwiftShader renderer instead of the deprecated indirect mode.
- Removes the unused gRPC port.
- Pins emulator port 5554 to match recovery diagnostics.
- Disables the spellchecker to reduce text-field flakiness.
- Requires Linux hardware acceleration so missing KVM fails fast.
- Pins the runner image to Ubuntu 24.04.
- Keeps ram-size as the single source of truth for emulator memory.
- Replaces separate snapshot load/save flags with no-snapshot.
- Disables both cameras because automated E2E tests do not use camera or QR scanning.

## Notes for QA

CI-only change. Validate with the suite-native Android E2E workflow; no manual app QA is needed.

## Related Issue

Related to #31864.

## Screenshots:



<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/matejkriz/chore/android-emulator-config/web/](https://dev.suite.sldev.cz/suite-web/matejkriz/chore/android-emulator-config/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=matejkriz/chore/android-emulator-config&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=matejkriz/chore/android-emulator-config&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/chore/android-emulator-config&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T12:45:25.692Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T12:45:06.777Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->