### PR TITLE
fix(suite): don't report yield cancels as errors, store pending tx fee

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts
@@ -172,7 +172,7 @@ describe('claimMerklRewardsThunk', () => {
         expect(TrezorConnect.pushTransaction).not.toHaveBeenCalled();
     });
 
-    it('stores the pending claim', async () => {
+    it('stores the pending claim with its fee and submission time', async () => {
         const { store, result } = await dispatchClaim(jest.fn());
 
         expect(result).toEqual({ txid: '0xclaim' });
@@ -188,6 +188,8 @@ describe('claimMerklRewardsThunk', () => {
                 type: 'claim',
                 txid: '0xclaim',
                 amount: '',
+                fee: '777000000000',
+                submittedAt: expect.any(Number),
             },
         });
     });

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts
@@ -1,0 +1,194 @@
+import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { asGetter } from '@suite-common/dependency-injection';
+import { USER_CANCELLED_ERROR_CODES } from '@suite-common/earn-stablecoin';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { createTestStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { yieldActions } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
+import TrezorConnect from '@trezor/connect';
+
+import { claimMerklRewardsThunk } from './claimMerklRewardsThunk';
+import { type SendYieldTransactionDeps } from './signingHelpers';
+
+const mockOpenDeferredModal = jest.fn();
+const mockEstimateYieldFeeLevel = jest.fn();
+const mockDevice = mockSuiteDevice({
+    connected: true,
+    available: true,
+    state: { staticSessionId: 'wallet@device:0' },
+});
+
+type ClaimMerklRewardsThunkDeps = SendYieldTransactionDeps & { services: DesktopAnalyticsDep };
+
+const createExtra = (report: jest.Mock = jest.fn()): ClaimMerklRewardsThunkDeps => ({
+    services: {
+        analytics: mockAnalytics(report),
+        getIsWindowVisible: asGetter(() => true),
+        getTradedAccountKeys: asGetter(() => []),
+    },
+});
+
+jest.mock('@suite/modal', () => ({
+    preserveModal: () => ({ type: 'mock/preserveModal' }),
+    closeModal: () => ({ type: 'mock/closeModal' }),
+    openDeferredModal: (payload: unknown) => mockOpenDeferredModal(payload),
+}));
+
+jest.mock('@suite-common/earn-stablecoin', () => ({
+    ...jest.requireActual('@suite-common/earn-stablecoin'),
+    buildClaimCalldata: () => '0xclaimdata',
+    buildUnsignedClaimTransaction: () => '{}',
+    buildClaimTransactionReview: () => ({
+        formState: {},
+        precomposedTransaction: { fee: '777000000000' },
+        availableRewards: [],
+        transactionForSigning: {
+            to: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
+            value: '0x0',
+            data: '0xclaimdata',
+            chainId: 1,
+            nonce: '0x5',
+            gasLimit: '0x5208',
+            gasPrice: '0x1',
+        },
+    }),
+}));
+
+jest.mock('@suite-common/device', () => ({
+    ...jest.requireActual('@suite-common/device'),
+    selectSelectedDevice: () => mockDevice,
+}));
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    estimateYieldFeeLevel: (payload: unknown) => mockEstimateYieldFeeLevel(payload),
+    getYieldClaimRewardsSnapshot: () => [],
+    selectAddressDisplayType: () => 'original',
+    selectIsMevProtectionEnabled: () => false,
+    synchronizeSentTransactionThunk: (payload: unknown) => () => Promise.resolve(payload),
+}));
+
+jest.mock('@suite-common/wallet-core/src/send/sendFormEthereumThunks', () => ({
+    ethereumGetCurrentNonceThunk: jest.fn(() => () => {
+        const result = { nonce: '5', confirmedNonce: '5' };
+
+        return Object.assign(Promise.resolve(result), {
+            unwrap: () => Promise.resolve(result),
+        });
+    }),
+}));
+
+jest.mock('@suite-common/mev', () => ({
+    selectIsMevProtectionFeatureEnabled: () => false,
+}));
+
+const account = mockWalletAccount({
+    symbol: asNetworkSymbol('eth'),
+    deviceState: 'mock@device:0',
+}) as Account;
+
+const rewards = [{}] as Parameters<typeof claimMerklRewardsThunk>[0]['rewards'];
+
+const dispatchClaim = (report: jest.Mock) => {
+    const store = createTestStore({ extra: createExtra(report), preloadedState: {} });
+
+    return store
+        .dispatch(claimMerklRewardsThunk({ account, flowKey: 'flow-1', rewards }))
+        .unwrap()
+        .then(result => ({ store, result }));
+};
+
+describe('claimMerklRewardsThunk', () => {
+    beforeAll(() => {
+        // The thunk logs every caught failure; the expected ones would clutter the test output.
+        jest.spyOn(console, 'error').mockImplementation();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockEstimateYieldFeeLevel.mockResolvedValue({
+            success: true,
+            payload: { feeLimit: '21000', feePerUnit: '1' },
+        });
+        mockOpenDeferredModal.mockImplementation(
+            (payload: { type: string }) => () =>
+                payload.type === 'review-transaction'
+                    ? Promise.resolve(true)
+                    : Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+        );
+        jest.spyOn(TrezorConnect, 'ethereumSignTransaction').mockResolvedValue({
+            success: true,
+            payload: { v: '0x1', r: '0x2', s: '0x3', serializedTx: '0xsigned' },
+        });
+        jest.spyOn(TrezorConnect, 'pushTransaction').mockResolvedValue({
+            success: true,
+            payload: { txid: '0xclaim' },
+        });
+    });
+
+    it.each([...USER_CANCELLED_ERROR_CODES])(
+        'returns null without an error report when signing fails with %s',
+        async code => {
+            const report = jest.fn();
+            jest.spyOn(TrezorConnect, 'ethereumSignTransaction').mockResolvedValue({
+                success: false,
+                error: { code, message: 'cancelled by user' },
+            });
+
+            const { store, result } = await dispatchClaim(report);
+
+            expect(result).toBeNull();
+            expect(report).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    payload: expect.objectContaining({ type: 'error' }),
+                }),
+            );
+            expect(
+                store.getActions().filter(action => action.type === yieldActions.setError.type),
+            ).toHaveLength(0);
+        },
+    );
+
+    it('returns null without an error report when the review modal is declined', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(
+            (payload: { type: string }) => () =>
+                payload.type === 'review-transaction'
+                    ? Promise.resolve(false)
+                    : Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+        );
+
+        const { result } = await dispatchClaim(report);
+
+        expect(result).toBeNull();
+        expect(report).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({ type: 'error' }),
+            }),
+        );
+        expect(TrezorConnect.pushTransaction).not.toHaveBeenCalled();
+    });
+
+    it('stores the pending claim', async () => {
+        const { store, result } = await dispatchClaim(jest.fn());
+
+        expect(result).toEqual({ txid: '0xclaim' });
+
+        const pendingTxAction = store
+            .getActions()
+            .find(action => action.type === yieldActions.setPendingTx.type);
+
+        expect(pendingTxAction?.payload).toMatchObject({
+            flowType: 'claim',
+            flowKey: 'flow-1',
+            tx: {
+                type: 'claim',
+                txid: '0xclaim',
+                amount: '',
+            },
+        });
+    });
+});

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -331,6 +331,8 @@ export const claimMerklRewardsThunk = createThunk<
                             type: 'claim',
                             txid: pushResponse.payload.txid,
                             amount: '',
+                            fee: precomposedTransaction.fee,
+                            submittedAt: Date.now(),
                         },
                     }),
                 );

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -7,6 +7,7 @@ import {
     buildClaimCalldata,
     buildClaimTransactionReview,
     buildUnsignedClaimTransaction,
+    isUserCancelledSignErrorCode,
 } from '@suite-common/earn-stablecoin';
 import { type YieldAccountsRewards } from '@suite-common/earn-stablecoin-api';
 import { type MessageSystemRootState } from '@suite-common/message-system';
@@ -256,7 +257,7 @@ export const claimMerklRewardsThunk = createThunk<
                     dispatch(closeModal());
 
                     const { code } = signingResponse.error;
-                    if (code === 'Failure_ActionCancelled' || code === 'Method_Cancel') {
+                    if (isUserCancelledSignErrorCode(code)) {
                         return null;
                     }
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.test.ts
@@ -141,7 +141,11 @@ describe('sendYieldTransaction', () => {
         });
     });
 
-    it('returns sent with the txid after broadcast', async () => {
-        await expect(sendTransaction()).resolves.toEqual({ status: 'sent', txid: '0xtxid' });
+    it('returns sent with the txid and the precomposed fee after broadcast', async () => {
+        await expect(sendTransaction()).resolves.toEqual({
+            status: 'sent',
+            txid: '0xtxid',
+            fee: '31500000000',
+        });
     });
 });

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.test.ts
@@ -1,0 +1,147 @@
+import { USER_CANCELLED_ERROR_CODES } from '@suite-common/earn-stablecoin';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import TrezorConnect from '@trezor/connect';
+
+import {
+    type SendYieldTransactionParams,
+    type SendYieldTransactionState,
+    sendYieldTransaction,
+} from './signingHelpers';
+
+const mockBuildStablecoinYieldTransactionReview = jest.fn();
+const mockDevice = mockSuiteDevice({
+    connected: true,
+    available: true,
+    state: { staticSessionId: 'wallet@device:0' },
+});
+const OPEN_DEFERRED_MODAL_ACTION_TYPE = 'mock/openDeferredModal';
+
+jest.mock('@suite/modal', () => ({
+    preserveModal: () => ({ type: 'mock/preserveModal' }),
+    closeModal: () => ({ type: 'mock/closeModal' }),
+    openDeferredModal: (payload: unknown) => ({
+        type: 'mock/openDeferredModal',
+        payload,
+    }),
+}));
+
+jest.mock('@suite-common/earn-stablecoin', () => ({
+    ...jest.requireActual('@suite-common/earn-stablecoin'),
+    buildStablecoinYieldTransactionReview: (payload: unknown) =>
+        mockBuildStablecoinYieldTransactionReview(payload),
+}));
+
+jest.mock('@suite-common/device', () => ({
+    ...jest.requireActual('@suite-common/device'),
+    selectSelectedDevice: () => mockDevice,
+}));
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    selectAddressDisplayType: () => 'original',
+    selectIsMevProtectionEnabled: () => false,
+}));
+
+jest.mock('@suite-common/mev', () => ({
+    selectIsMevProtectionFeatureEnabled: () => false,
+}));
+
+const account = mockWalletAccount({ symbol: asNetworkSymbol('eth') }) as Account;
+
+// Only openDeferredModal needs a real return value; every other dispatched action is recorded
+// and ignored (thunks are intentionally not executed).
+const createDispatch = (isReviewModalConfirmed: boolean) =>
+    jest.fn((action: { type?: string }) => {
+        if (action?.type === OPEN_DEFERRED_MODAL_ACTION_TYPE) {
+            return Promise.resolve(isReviewModalConfirmed);
+        }
+
+        return action;
+    }) as unknown as SendYieldTransactionParams['dispatch'];
+
+const sendTransaction = ({ isReviewModalConfirmed = true } = {}) =>
+    sendYieldTransaction({
+        account,
+        amount: '100',
+        token: {
+            networkSymbol: asNetworkSymbol('eth'),
+            symbol: 'usdc',
+            decimals: 6,
+            contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        },
+        unsignedTransaction: '{}',
+        flowKey: 'flow-1',
+        flowType: 'deposit',
+        dispatch: createDispatch(isReviewModalConfirmed),
+        getState: () => ({}) as unknown as SendYieldTransactionState,
+        selectedFee: null,
+    });
+
+describe('sendYieldTransaction', () => {
+    beforeAll(() => {
+        // The helper logs every failure it rethrows; the expected ones would clutter the output.
+        jest.spyOn(console, 'error').mockImplementation();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockBuildStablecoinYieldTransactionReview.mockReturnValue({
+            transactionForSigning: {
+                to: '0xd63070114470f685b75B74D60EEc7c1113d33a3D',
+                value: '0x0',
+                data: '0x',
+                chainId: 1,
+                nonce: '0x1',
+                gasLimit: '0x5208',
+                gasPrice: '0x1',
+            },
+            formState: {},
+            precomposedTransaction: { fee: '31500000000' },
+        });
+        jest.spyOn(TrezorConnect, 'ethereumSignTransaction').mockResolvedValue({
+            success: true,
+            payload: { v: '0x1', r: '0x2', s: '0x3', serializedTx: '0xsigned' },
+        });
+        jest.spyOn(TrezorConnect, 'pushTransaction').mockResolvedValue({
+            success: true,
+            payload: { txid: '0xtxid' },
+        });
+    });
+
+    it.each([...USER_CANCELLED_ERROR_CODES])(
+        'returns cancelled when signing fails with %s',
+        async code => {
+            jest.spyOn(TrezorConnect, 'ethereumSignTransaction').mockResolvedValue({
+                success: false,
+                error: { code, message: 'cancelled by user' },
+            });
+
+            await expect(sendTransaction()).resolves.toEqual({ status: 'cancelled' });
+        },
+    );
+
+    it('returns cancelled when the review modal is declined before broadcast', async () => {
+        await expect(sendTransaction({ isReviewModalConfirmed: false })).resolves.toEqual({
+            status: 'cancelled',
+        });
+        expect(TrezorConnect.pushTransaction).not.toHaveBeenCalled();
+    });
+
+    it('throws with the connect code as cause for other signing failures', async () => {
+        jest.spyOn(TrezorConnect, 'ethereumSignTransaction').mockResolvedValue({
+            success: false,
+            error: { code: 'Failure_FirmwareError', message: 'firmware error' },
+        });
+
+        await expect(sendTransaction()).rejects.toMatchObject({
+            cause: 'Failure_FirmwareError',
+        });
+    });
+
+    it('returns sent with the txid after broadcast', async () => {
+        await expect(sendTransaction()).resolves.toEqual({ status: 'sent', txid: '0xtxid' });
+    });
+});

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -2,7 +2,10 @@ import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
 
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
-import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin';
+import {
+    buildStablecoinYieldTransactionReview,
+    isUserCancelledSignErrorCode,
+} from '@suite-common/earn-stablecoin';
 import { type MessageSystemRootState } from '@suite-common/message-system';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import {
@@ -64,6 +67,9 @@ type SendYieldTransactionDispatch = ThunkDispatch<
     UnknownAction
 >;
 
+// Genuine failures are thrown — a returned `cancelled` is always the user backing out on purpose.
+export type SendYieldTransactionResult = { status: 'sent'; txid: string } | { status: 'cancelled' };
+
 export type SendYieldTransactionParams = {
     account: Account;
     amount: string;
@@ -86,7 +92,7 @@ export const sendYieldTransaction = async ({
     dispatch,
     getState,
     selectedFee,
-}: SendYieldTransactionParams): Promise<{ txid: string } | undefined> => {
+}: SendYieldTransactionParams): Promise<SendYieldTransactionResult> => {
     const device = selectSelectedDevice(getState());
     const addressDisplayType = selectAddressDisplayType(getState());
 
@@ -142,8 +148,8 @@ export const sendYieldTransaction = async ({
             dispatch(closeModal());
 
             const { code } = signingResponse.error;
-            if (code === 'Failure_ActionCancelled' || code === 'Method_Cancel') {
-                return;
+            if (isUserCancelledSignErrorCode(code)) {
+                return { status: 'cancelled' };
             }
 
             throw new Error(`${code}: ${signingResponse.error.message}`, { cause: code });
@@ -161,7 +167,7 @@ export const sendYieldTransaction = async ({
         const isPushConfirmed = await dispatch(openDeferredModal({ type: 'review-transaction' }));
 
         if (!isPushConfirmed) {
-            return;
+            return { status: 'cancelled' };
         }
 
         const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
@@ -196,7 +202,7 @@ export const sendYieldTransaction = async ({
             }),
         );
 
-        return pushResponse.payload;
+        return { status: 'sent', txid: pushResponse.payload.txid };
     } catch (error) {
         console.error(error);
         throw error;

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -68,7 +68,8 @@ type SendYieldTransactionDispatch = ThunkDispatch<
 >;
 
 // Genuine failures are thrown — a returned `cancelled` is always the user backing out on purpose.
-export type SendYieldTransactionResult = { status: 'sent'; txid: string } | { status: 'cancelled' };
+export type SendYieldTransactionResult =
+    { status: 'sent'; txid: string; fee: string } | { status: 'cancelled' };
 
 export type SendYieldTransactionParams = {
     account: Account;
@@ -202,7 +203,11 @@ export const sendYieldTransaction = async ({
             }),
         );
 
-        return { status: 'sent', txid: pushResponse.payload.txid };
+        return {
+            status: 'sent',
+            txid: pushResponse.payload.txid,
+            fee: precomposedTransaction.fee,
+        };
     } catch (error) {
         console.error(error);
         throw error;

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts
@@ -1,0 +1,161 @@
+import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { events } from '@suite-common/analytics';
+import { asGetter } from '@suite-common/dependency-injection';
+import { createTestStore } from '@suite-common/test-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type YieldFlowResolvedData, yieldActions } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
+
+import { type SendYieldTransactionDeps } from './signingHelpers';
+import { submitYieldDepositThunk } from './submitYieldDepositThunk';
+
+const mockComposeYieldDepositTransactionThunk = jest.fn();
+const mockOpenDeferredModal = jest.fn();
+const mockSendYieldTransaction = jest.fn();
+
+const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid });
+const mockCancelledResult = { status: 'cancelled' as const };
+
+type SubmitYieldDepositThunkDeps = SendYieldTransactionDeps & { services: DesktopAnalyticsDep };
+
+const createExtra = (report: jest.Mock = jest.fn()): SubmitYieldDepositThunkDeps => ({
+    services: {
+        analytics: mockAnalytics(report),
+        getIsWindowVisible: asGetter(() => true),
+        getTradedAccountKeys: asGetter(() => []),
+    },
+});
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    composeYieldDepositTransactionThunk: (payload: unknown) =>
+        mockComposeYieldDepositTransactionThunk(payload),
+}));
+
+jest.mock('@suite/modal', () => ({
+    openDeferredModal: (payload: unknown) => mockOpenDeferredModal(payload),
+}));
+
+jest.mock('./signingHelpers', () => ({
+    ...jest.requireActual('./signingHelpers'),
+    sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
+}));
+
+const account = mockWalletAccount({ symbol: asNetworkSymbol('eth') }) as Account;
+
+const flowData = {
+    account,
+    vault: { id: 'vault-1' },
+    token: {
+        networkSymbol: 'eth',
+        symbol: 'usdc',
+        decimals: 6,
+        contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        balance: '100',
+    },
+    receiptToken: {
+        networkSymbol: 'eth',
+        symbol: 'musdc',
+        decimals: 18,
+        contractAddress: '0xd63070114470f685b75B74D60EEc7c1113d33a3D',
+    },
+} as unknown as YieldFlowResolvedData;
+
+const dispatchDeposit = (report: jest.Mock) => {
+    const store = createTestStore({ extra: createExtra(report), preloadedState: {} });
+
+    return store
+        .dispatch(submitYieldDepositThunk({ flowKey: 'flow-1', flowData, amount: '100' }))
+        .unwrap()
+        .then(() => store);
+};
+
+describe('submitYieldDepositThunk', () => {
+    beforeAll(() => {
+        // The thunk logs every caught failure; the expected ones would clutter the test output.
+        jest.spyOn(console, 'error').mockImplementation();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockComposeYieldDepositTransactionThunk.mockImplementation(() => () => ({
+            unwrap: () =>
+                Promise.resolve({
+                    type: 'action-ready',
+                    unsignedTransaction: '{}',
+                    receiptAmount: '99',
+                }),
+        }));
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+        );
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xdeposit'));
+    });
+
+    it('does not report an error when the user cancels the signing', async () => {
+        const report = jest.fn();
+        mockSendYieldTransaction.mockResolvedValue(mockCancelledResult);
+
+        const store = await dispatchDeposit(report);
+
+        expect(report).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({ type: 'error' }),
+            }),
+        );
+        expect(
+            store.getActions().filter(action => action.type === yieldActions.setError.type),
+        ).toHaveLength(0);
+        expect(
+            store.getActions().filter(action => action.type === yieldActions.setPendingTx.type),
+        ).toHaveLength(0);
+    });
+
+    it('stores the broadcast transaction as pending', async () => {
+        const store = await dispatchDeposit(jest.fn());
+
+        const pendingTxAction = store
+            .getActions()
+            .find(action => action.type === yieldActions.setPendingTx.type);
+
+        expect(pendingTxAction?.payload).toMatchObject({
+            flowType: 'deposit',
+            flowKey: 'flow-1',
+            receiptAmount: '99',
+            tx: {
+                type: 'deposit',
+                txid: '0xdeposit',
+                amount: '100',
+            },
+        });
+
+        const toast = store
+            .getActions()
+            .filter(notificationsActions.addToast.match)
+            .find(action => action.payload.type === 'tx-yield-deposit');
+        expect(toast?.payload).toMatchObject({ txid: '0xdeposit' });
+    });
+
+    it('still reports submit-failed when the signing throws', async () => {
+        const report = jest.fn();
+        mockSendYieldTransaction.mockRejectedValue(new Error('boom'));
+
+        const store = await dispatchDeposit(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldDepositEvent.name,
+                payload: expect.objectContaining({
+                    type: 'error',
+                    errorMessage: 'submit-failed',
+                }),
+            }),
+        );
+        expect(
+            store.getActions().find(action => action.type === yieldActions.setError.type)?.payload,
+        ).toMatchObject({ error: 'TR_EARN_YIELD_ERROR_GENERIC' });
+    });
+});

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts
@@ -16,7 +16,7 @@ const mockComposeYieldDepositTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
 const mockSendYieldTransaction = jest.fn();
 
-const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid });
+const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid, fee: '31500000000' });
 const mockCancelledResult = { status: 'cancelled' as const };
 
 type SubmitYieldDepositThunkDeps = SendYieldTransactionDeps & { services: DesktopAnalyticsDep };
@@ -114,7 +114,7 @@ describe('submitYieldDepositThunk', () => {
         ).toHaveLength(0);
     });
 
-    it('stores the broadcast transaction as pending', async () => {
+    it('stores the broadcast transaction with its fee and submission time', async () => {
         const store = await dispatchDeposit(jest.fn());
 
         const pendingTxAction = store
@@ -129,6 +129,8 @@ describe('submitYieldDepositThunk', () => {
                 type: 'deposit',
                 txid: '0xdeposit',
                 amount: '100',
+                fee: '31500000000',
+                submittedAt: expect.any(Number),
             },
         });
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -149,6 +149,8 @@ export const submitYieldDepositThunk = createThunk<
                         type: flowType,
                         txid: sendResult.txid,
                         amount,
+                        fee: sendResult.fee,
+                        submittedAt: Date.now(),
                     },
                     receiptAmount: result.receiptAmount,
                 }),

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -127,18 +127,8 @@ export const submitYieldDepositThunk = createThunk<
 
             userAcceptedTxSimulation?.resolve();
 
-            if (!sendResult) {
-                extra.services.analytics.report({
-                    type: events.yieldDepositEvent.name,
-                    payload: {
-                        type: 'error',
-                        action: 'continue',
-                        networkSymbol: flowData.account.symbol,
-                        vaultId: flowData.vault.id,
-                        errorMessage: 'submit-failed',
-                    },
-                });
-
+            // A deliberate user cancel — not reported as a failure.
+            if (sendResult.status === 'cancelled') {
                 return;
             }
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts
@@ -1,0 +1,166 @@
+import { type DesktopAnalyticsDep } from '@suite/analytics';
+import { events } from '@suite-common/analytics';
+import { asGetter } from '@suite-common/dependency-injection';
+import { createTestStore } from '@suite-common/test-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type YieldFlowResolvedData, yieldActions } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
+
+import { type SendYieldTransactionDeps } from './signingHelpers';
+import { submitYieldWithdrawThunk } from './submitYieldWithdrawThunk';
+
+const mockComposeYieldWithdrawTransactionThunk = jest.fn();
+const mockOpenDeferredModal = jest.fn();
+const mockSendYieldTransaction = jest.fn();
+
+const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid });
+const mockCancelledResult = { status: 'cancelled' as const };
+
+type SubmitYieldWithdrawThunkDeps = SendYieldTransactionDeps & { services: DesktopAnalyticsDep };
+
+const createExtra = (report: jest.Mock = jest.fn()): SubmitYieldWithdrawThunkDeps => ({
+    services: {
+        analytics: mockAnalytics(report),
+        getIsWindowVisible: asGetter(() => true),
+        getTradedAccountKeys: asGetter(() => []),
+    },
+});
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    composeYieldWithdrawTransactionThunk: (payload: unknown) =>
+        mockComposeYieldWithdrawTransactionThunk(payload),
+}));
+
+jest.mock('@suite/modal', () => ({
+    openDeferredModal: (payload: unknown) => mockOpenDeferredModal(payload),
+}));
+
+jest.mock('./signingHelpers', () => ({
+    ...jest.requireActual('./signingHelpers'),
+    sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
+}));
+
+const account = mockWalletAccount({ symbol: asNetworkSymbol('eth') }) as Account;
+
+const flowData = {
+    account,
+    vault: { id: 'vault-1' },
+    token: {
+        networkSymbol: 'eth',
+        symbol: 'usdc',
+        decimals: 6,
+        contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        balance: '100',
+    },
+    receiptToken: {
+        networkSymbol: 'eth',
+        symbol: 'musdc',
+        decimals: 18,
+        contractAddress: '0xd63070114470f685b75B74D60EEc7c1113d33a3D',
+    },
+} as unknown as YieldFlowResolvedData;
+
+const dispatchWithdraw = (report: jest.Mock) => {
+    const store = createTestStore({ extra: createExtra(report), preloadedState: {} });
+
+    return store
+        .dispatch(
+            submitYieldWithdrawThunk({
+                flowKey: 'flow-1',
+                flowData,
+                amount: '100',
+                flowType: 'withdraw',
+            }),
+        )
+        .unwrap()
+        .then(() => store);
+};
+
+describe('submitYieldWithdrawThunk', () => {
+    beforeAll(() => {
+        // The thunk logs every caught failure; the expected ones would clutter the test output.
+        jest.spyOn(console, 'error').mockImplementation();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockComposeYieldWithdrawTransactionThunk.mockImplementation(() => () => ({
+            unwrap: () =>
+                Promise.resolve({
+                    type: 'action-ready',
+                    unsignedTransaction: '{}',
+                }),
+        }));
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+        );
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xwithdraw'));
+    });
+
+    it('does not report an error when the user cancels the signing', async () => {
+        const report = jest.fn();
+        mockSendYieldTransaction.mockResolvedValue(mockCancelledResult);
+
+        const store = await dispatchWithdraw(report);
+
+        expect(report).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({ type: 'error' }),
+            }),
+        );
+        expect(
+            store.getActions().filter(action => action.type === yieldActions.setError.type),
+        ).toHaveLength(0);
+        expect(
+            store.getActions().filter(action => action.type === yieldActions.setPendingTx.type),
+        ).toHaveLength(0);
+    });
+
+    it('stores the broadcast transaction as pending', async () => {
+        const store = await dispatchWithdraw(jest.fn());
+
+        const pendingTxAction = store
+            .getActions()
+            .find(action => action.type === yieldActions.setPendingTx.type);
+
+        expect(pendingTxAction?.payload).toMatchObject({
+            flowType: 'withdraw',
+            flowKey: 'flow-1',
+            tx: {
+                type: 'withdraw',
+                txid: '0xwithdraw',
+                amount: '100',
+            },
+        });
+
+        const toast = store
+            .getActions()
+            .filter(notificationsActions.addToast.match)
+            .find(action => action.payload.type === 'tx-yield-withdraw');
+        expect(toast?.payload).toMatchObject({ txid: '0xwithdraw' });
+    });
+
+    it('still reports submit-failed when the signing throws', async () => {
+        const report = jest.fn();
+        mockSendYieldTransaction.mockRejectedValue(new Error('boom'));
+
+        const store = await dispatchWithdraw(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWithdrawEvent.name,
+                payload: expect.objectContaining({
+                    type: 'error',
+                    errorMessage: 'submit-failed',
+                }),
+            }),
+        );
+        expect(
+            store.getActions().find(action => action.type === yieldActions.setError.type)?.payload,
+        ).toMatchObject({ error: 'TR_EARN_YIELD_ERROR_GENERIC' });
+    });
+});

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts
@@ -16,7 +16,7 @@ const mockComposeYieldWithdrawTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
 const mockSendYieldTransaction = jest.fn();
 
-const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid });
+const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid, fee: '31500000000' });
 const mockCancelledResult = { status: 'cancelled' as const };
 
 type SubmitYieldWithdrawThunkDeps = SendYieldTransactionDeps & { services: DesktopAnalyticsDep };
@@ -120,7 +120,7 @@ describe('submitYieldWithdrawThunk', () => {
         ).toHaveLength(0);
     });
 
-    it('stores the broadcast transaction as pending', async () => {
+    it('stores the broadcast transaction with its fee and submission time', async () => {
         const store = await dispatchWithdraw(jest.fn());
 
         const pendingTxAction = store
@@ -134,6 +134,8 @@ describe('submitYieldWithdrawThunk', () => {
                 type: 'withdraw',
                 txid: '0xwithdraw',
                 amount: '100',
+                fee: '31500000000',
+                submittedAt: expect.any(Number),
             },
         });
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -153,6 +153,8 @@ export const submitYieldWithdrawThunk = createThunk<
                         type: flowType,
                         txid: result.txid,
                         amount,
+                        fee: result.fee,
+                        submittedAt: Date.now(),
                     },
                 }),
             );

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -131,19 +131,8 @@ export const submitYieldWithdrawThunk = createThunk<
 
             userAcceptedTxSimulation?.resolve();
 
-            if (!result) {
-                extra.services.analytics.report({
-                    type: events.yieldWithdrawEvent.name,
-                    payload: {
-                        type: 'error',
-                        operation: flowType,
-                        action: 'continue',
-                        networkSymbol: account.symbol,
-                        vaultId: flowData.vault.id,
-                        errorMessage: 'submit-failed',
-                    },
-                });
-
+            // A deliberate user cancel — not reported as a failure.
+            if (result.status === 'cancelled') {
                 return;
             }
 

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
@@ -16,6 +16,9 @@ const mockComposeYieldUnwrapTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
 const mockSendYieldTransaction = jest.fn();
 
+const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid });
+const mockCancelledResult = { status: 'cancelled' as const };
+
 type UnwrapNativeTokenThunkDeps = SendYieldTransactionDeps & WithServices<AnalyticsDep>;
 
 const createExtra = (report: jest.Mock = jest.fn()): UnwrapNativeTokenThunkDeps => ({
@@ -78,7 +81,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
                 }),
         }));
         mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve({ value: false }));
-        mockSendYieldTransaction.mockResolvedValue(undefined);
+        mockSendYieldTransaction.mockResolvedValue(mockCancelledResult);
     });
 
     it('uses the shared unwrap composition from wallet-core', async () => {
@@ -102,7 +105,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xunwrap'));
 
         await store
             .dispatch(
@@ -131,7 +134,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xunwrap'));
 
         await store
             .dispatch(submitUnwrapNativeTokenThunk({ account, token, unwrapAmount: '1.5' }))
@@ -166,7 +169,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xunwrap'));
 
         await buildStore(report)
             .dispatch(
@@ -236,7 +239,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
             mockOpenDeferredModal.mockImplementation(
                 () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
             );
-            mockSendYieldTransaction.mockResolvedValue(undefined);
+            mockSendYieldTransaction.mockResolvedValue(mockCancelledResult);
 
             await dispatchInFlowUnwrap(report);
 
@@ -260,7 +263,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
             mockOpenDeferredModal.mockImplementation(
                 () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
             );
-            mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
+            mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xunwrap'));
 
             await dispatchInFlowUnwrap(report);
 
@@ -339,7 +342,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
         );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xabc' });
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xabc'));
 
         await dispatchUnwrap(report);
 

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
@@ -16,7 +16,7 @@ const mockComposeYieldUnwrapTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
 const mockSendYieldTransaction = jest.fn();
 
-const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid });
+const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid, fee: '31500000000' });
 const mockCancelledResult = { status: 'cancelled' as const };
 
 type UnwrapNativeTokenThunkDeps = SendYieldTransactionDeps & WithServices<AnalyticsDep>;

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -40,7 +40,7 @@ type SubmitUnwrapNativeTokenThunkDeps = SendYieldTransactionDeps & {
 };
 
 export const submitUnwrapNativeTokenThunk = createThunk<
-    { txid: string } | undefined,
+    { txid: string; fee: string } | undefined,
     UnwrapNativeTokenPayload,
     { state: SubmitUnwrapNativeTokenThunkState; extra: SubmitUnwrapNativeTokenThunkDeps }
 >(
@@ -180,7 +180,7 @@ export const submitUnwrapNativeTokenThunk = createThunk<
                 }),
             );
 
-            return { txid: sendResult.txid };
+            return { txid: sendResult.txid, fee: sendResult.fee };
         } catch (error) {
             console.error(error);
             reportError(getYieldSubmitErrorAnalyticsMessage(error));

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -136,7 +136,9 @@ export const submitUnwrapNativeTokenThunk = createThunk<
 
             userAcceptedTxSimulation?.resolve();
 
-            if (!sendResult) {
+            // Unlike the main yield transactions, a cancelled unwrap is reported: the unwrap-step
+            // failure values documented on the withdraw event include user rejections.
+            if (sendResult.status === 'cancelled') {
                 reportError('submit-failed');
 
                 return undefined;
@@ -178,7 +180,7 @@ export const submitUnwrapNativeTokenThunk = createThunk<
                 }),
             );
 
-            return sendResult;
+            return { txid: sendResult.txid };
         } catch (error) {
             console.error(error);
             reportError(getYieldSubmitErrorAnalyticsMessage(error));

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -25,7 +25,7 @@ const mockComposeYieldWrapTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
 const mockSendYieldTransaction = jest.fn();
 
-const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid });
+const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid, fee: '31500000000' });
 const mockCancelledResult = { status: 'cancelled' as const };
 
 type WrapNativeTokenThunkDeps = SendYieldTransactionDeps & WithServices<AnalyticsDep>;

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -25,6 +25,9 @@ const mockComposeYieldWrapTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
 const mockSendYieldTransaction = jest.fn();
 
+const mockSentResult = (txid: string) => ({ status: 'sent' as const, txid });
+const mockCancelledResult = { status: 'cancelled' as const };
+
 type WrapNativeTokenThunkDeps = SendYieldTransactionDeps & WithServices<AnalyticsDep>;
 
 const createExtra = (report: jest.Mock = jest.fn()): WrapNativeTokenThunkDeps => ({
@@ -87,7 +90,7 @@ describe('submitWrapNativeTokenThunk', () => {
                 }),
         }));
         mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve({ value: false }));
-        mockSendYieldTransaction.mockResolvedValue(undefined);
+        mockSendYieldTransaction.mockResolvedValue(mockCancelledResult);
     });
 
     it('uses the shared wrap composition from wallet-core', async () => {
@@ -111,7 +114,7 @@ describe('submitWrapNativeTokenThunk', () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xwrap' });
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xwrap'));
 
         await store
             .dispatch(
@@ -150,7 +153,7 @@ describe('submitWrapNativeTokenThunk', () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xwrap' });
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xwrap'));
     };
 
     it('shows a wrap toast displaying both the native and wrapped assets', async () => {
@@ -230,7 +233,7 @@ describe('submitWrapNativeTokenThunk', () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
-        mockSendYieldTransaction.mockResolvedValue(undefined);
+        mockSendYieldTransaction.mockResolvedValue(mockCancelledResult);
         const store = buildStore(jest.fn());
 
         await store
@@ -398,7 +401,7 @@ describe('submitWrapNativeTokenThunk', () => {
             mockOpenDeferredModal.mockImplementation(
                 () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
             );
-            mockSendYieldTransaction.mockResolvedValue(undefined);
+            mockSendYieldTransaction.mockResolvedValue(mockCancelledResult);
 
             await dispatchInFlowWrap(report);
 
@@ -498,7 +501,7 @@ describe('submitWrapNativeTokenThunk', () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
         );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xabc' });
+        mockSendYieldTransaction.mockResolvedValue(mockSentResult('0xabc'));
 
         await dispatchWrap(report);
 

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -151,7 +151,9 @@ export const submitWrapNativeTokenThunk = createThunk<
 
             userAcceptedTxSimulation?.resolve();
 
-            if (!sendResult) {
+            // Unlike the main yield transactions, a cancelled wrap is reported: the wrap-step
+            // failure values documented on the deposit event include user rejections.
+            if (sendResult.status === 'cancelled') {
                 reportError('submit-failed');
 
                 return undefined;
@@ -214,7 +216,7 @@ export const submitWrapNativeTokenThunk = createThunk<
                 }),
             );
 
-            return sendResult;
+            return { txid: sendResult.txid };
         } catch (error) {
             console.error(error);
             reportError(getYieldSubmitErrorAnalyticsMessage(error));

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -43,7 +43,7 @@ type SubmitWrapNativeTokenThunkDeps = SendYieldTransactionDeps & {
 };
 
 export const submitWrapNativeTokenThunk = createThunk<
-    { txid: string } | undefined,
+    { txid: string; fee: string } | undefined,
     WrapNativeTokenPayload,
     { state: SubmitWrapNativeTokenThunkState; extra: SubmitWrapNativeTokenThunkDeps }
 >(
@@ -216,7 +216,7 @@ export const submitWrapNativeTokenThunk = createThunk<
                 }),
             );
 
-            return { txid: sendResult.txid };
+            return { txid: sendResult.txid, fee: sendResult.fee };
         } catch (error) {
             console.error(error);
             reportError(getYieldSubmitErrorAnalyticsMessage(error));

--- a/packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.test.ts
@@ -37,6 +37,18 @@ describe('ensureDeviceSession', () => {
         });
     });
 
+    it('treats a cancelled PIN entry as a silent cancel, not an error', async () => {
+        jest.spyOn(TrezorConnect, 'getDeviceState').mockResolvedValue({
+            success: false,
+            error: {
+                code: 'Failure_PinCancelled',
+                message: 'PIN entry cancelled',
+            },
+        });
+
+        await expect(ensureDeviceSession(device)).resolves.toEqual({ success: false });
+    });
+
     it('maps a device-state failure to a yield error', async () => {
         jest.spyOn(TrezorConnect, 'getDeviceState').mockResolvedValue({
             success: false,

--- a/packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.ts
+++ b/packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.ts
@@ -1,3 +1,4 @@
+import { isUserCancelledSignErrorCode } from '@suite-common/earn-stablecoin';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type YieldTranslationKey } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
@@ -29,7 +30,7 @@ export const ensureDeviceSession = async (
 
     const { code } = response.error;
 
-    if (code === 'Failure_ActionCancelled' || code === 'Method_Cancel') {
+    if (isUserCancelledSignErrorCode(code)) {
         return { success: false };
     }
 

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -388,10 +388,10 @@ export const useYieldFlow = ({
 
             dispatch(yieldActions.startSubmittingWrappedNative({ flowType, flowKey }));
             try {
-                let txid: string | undefined;
+                let broadcastTx: { txid: string; fee: string } | undefined;
 
                 if (step === 'wrap') {
-                    const result = await dispatch(
+                    broadcastTx = await dispatch(
                         submitWrapNativeTokenThunk({
                             account,
                             token: wrappedToken,
@@ -399,9 +399,8 @@ export const useYieldFlow = ({
                             yieldFlow: { flowType: 'deposit', flowKey, vaultId: vault.id },
                         }),
                     ).unwrap();
-                    txid = result?.txid;
                 } else if (isYieldWithdrawFlow(flowType)) {
-                    const result = await dispatch(
+                    broadcastTx = await dispatch(
                         submitUnwrapNativeTokenThunk({
                             account,
                             token: wrappedToken,
@@ -409,18 +408,19 @@ export const useYieldFlow = ({
                             yieldFlow: { flowType, flowKey, vaultId: vault.id },
                         }),
                     ).unwrap();
-                    txid = result?.txid;
                 }
 
-                if (txid) {
+                if (broadcastTx) {
                     dispatch(
                         yieldActions.setPendingTx({
                             flowType,
                             flowKey,
                             tx: {
                                 type: step,
-                                txid,
+                                txid: broadcastTx.txid,
                                 amount,
+                                fee: broadcastTx.fee,
+                                submittedAt: Date.now(),
                             },
                         }),
                     );

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.test.ts
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react';
+
+import { events } from '@suite-common/analytics';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type YieldPendingTransactionState } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { useYieldPendingTransactionTracking } from './useYieldPendingTransactionTracking';
+
+const mockReport = jest.fn();
+const mockDispatch = jest.fn();
+const mockGetPendingTransaction = jest.fn<YieldPendingTransactionState | null, []>();
+const mockGetPendingTxStatus = jest.fn<string | null, []>();
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useDispatch: () => mockDispatch,
+}));
+
+jest.mock('src/hooks/suite', () => ({
+    useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock('@suite-common/dependency-injection', () => {
+    const analytics = { report: (...args: unknown[]) => mockReport(...args) };
+
+    return { useServices: () => ({ analytics }) };
+});
+
+jest.mock('@suite/analytics', () => ({ selectDesktopAnalyticsDep: () => ({}) }));
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    selectYieldSession: () => ({
+        action: { pendingTransaction: mockGetPendingTransaction() },
+    }),
+    useYieldPendingTxStatus: () => mockGetPendingTxStatus(),
+}));
+
+const account = mockWalletAccount({ symbol: asNetworkSymbol('eth') }) as Account;
+
+const SUBMITTED_AGO_MS = 60_000;
+
+const pendingDeposit = (): YieldPendingTransactionState => ({
+    type: 'deposit',
+    txid: '0xdeposit',
+    amount: '100',
+    fee: '31500000000',
+    submittedAt: Date.now() - SUBMITTED_AGO_MS,
+});
+
+const renderTracking = () =>
+    renderHook(() =>
+        useYieldPendingTransactionTracking({ account, flowType: 'deposit', flowKey: 'flow-1' }),
+    );
+
+const getReportedDurationMs = (type: string) =>
+    mockReport.mock.calls.find(
+        ([event]) => event.type === events.yieldDepositEvent.name && event.payload.type === type,
+    )?.[0].payload.durationMs;
+
+describe('useYieldPendingTransactionTracking', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('measures durationMs from the stored submittedAt, not from the mount time', () => {
+        // The tx resolves right on mount — the mount-scoped ref would measure ~0 ms here, only the
+        // stored submittedAt gives the real time since broadcast (it survives leaving the page).
+        mockGetPendingTransaction.mockReturnValue(pendingDeposit());
+        mockGetPendingTxStatus.mockReturnValue('confirmed');
+
+        renderTracking();
+
+        const durationMs = getReportedDurationMs('success');
+        expect(durationMs).toBeGreaterThanOrEqual(SUBMITTED_AGO_MS);
+        expect(durationMs).toBeLessThan(SUBMITTED_AGO_MS + 10_000);
+    });
+
+    it('measures the leftPending durationMs from the stored submittedAt on unmount', () => {
+        mockGetPendingTransaction.mockReturnValue(pendingDeposit());
+        mockGetPendingTxStatus.mockReturnValue('pending');
+
+        const { unmount } = renderTracking();
+        unmount();
+
+        const durationMs = getReportedDurationMs('leftPending');
+        expect(durationMs).toBeGreaterThanOrEqual(SUBMITTED_AGO_MS);
+        expect(durationMs).toBeLessThan(SUBMITTED_AGO_MS + 10_000);
+    });
+});

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -69,6 +69,23 @@ type ReportContext = {
     wrappedNative?: boolean;
 };
 
+// The stored submittedAt survives leaving and reopening the page, unlike the mount-scoped ref
+// fallback, which restarts the measurement on every remount.
+const getPendingDurationMs = (
+    pendingTransaction: YieldPendingTransactionState,
+    pendingStart: { txid: string; startedAt: number } | null,
+) => {
+    if (pendingTransaction.submittedAt) {
+        return Date.now() - pendingTransaction.submittedAt;
+    }
+
+    if (pendingStart) {
+        return Date.now() - pendingStart.startedAt;
+    }
+
+    return undefined;
+};
+
 const resolveReportedType = <T extends string>(
     outcome: 'success' | 'error' | 'leftPending',
     successType: T,
@@ -178,7 +195,7 @@ export const useYieldPendingTransactionTracking = ({
 
     const isCurrentlyPending = pendingTxStatus === 'pending';
 
-    // Track start time per pending txid so we can compute durationMs on resolution.
+    // Fallback start time per pending txid for pending transactions stored without submittedAt.
     const pendingStartRef = useRef<{ txid: string; startedAt: number } | null>(null);
     const pendingTxid = pendingTransaction?.txid;
 
@@ -203,9 +220,7 @@ export const useYieldPendingTransactionTracking = ({
         }
 
         const resolution = getResolutionEventType(pendingTransaction.type, flowType);
-        const durationMs = pendingStartRef.current
-            ? Date.now() - pendingStartRef.current.startedAt
-            : undefined;
+        const durationMs = getPendingDurationMs(pendingTransaction, pendingStartRef.current);
         const context: ReportContext = {
             networkSymbol: account.symbol,
             vault,
@@ -318,9 +333,10 @@ export const useYieldPendingTransactionTracking = ({
             );
             if (!resolution) return;
 
-            const durationMs = pendingStartRef.current
-                ? Date.now() - pendingStartRef.current.startedAt
-                : undefined;
+            const durationMs = getPendingDurationMs(
+                snapshot.pendingTransaction,
+                pendingStartRef.current,
+            );
 
             reportResolution(analytics, resolution, 'leftPending', {
                 networkSymbol: snapshot.networkSymbol,

--- a/suite-common/analytics/src/events/yieldClaimEvent.ts
+++ b/suite-common/analytics/src/events/yieldClaimEvent.ts
@@ -46,7 +46,13 @@ export const yieldClaimEvent: EventDef<Attributes, EventType.YieldClaim> = {
             changelog: [{ version: '26.5.2', notes: 'added' }],
         },
         errorMessage: {
-            changelog: [{ version: '26.5.0', notes: 'added' }],
+            changelog: [
+                { version: '26.5.0', notes: 'added' },
+                {
+                    version: '26.9.0',
+                    notes: 'desktop no longer reports a cancelled PIN entry as `submit-failed`',
+                },
+            ],
         },
     },
 };

--- a/suite-common/analytics/src/events/yieldDepositEvent.ts
+++ b/suite-common/analytics/src/events/yieldDepositEvent.ts
@@ -83,6 +83,10 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 { version: '26.9.0', notes: 'added `wrap-` prefixed values' },
+                {
+                    version: '26.9.0',
+                    notes: 'desktop no longer reports user cancellations of the deposit transaction (device button, PIN entry, review modal) as `submit-failed`',
+                },
             ],
         },
         apyBreakdown: {

--- a/suite-common/analytics/src/events/yieldWithdrawEvent.ts
+++ b/suite-common/analytics/src/events/yieldWithdrawEvent.ts
@@ -73,6 +73,10 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 { version: '26.9.0', notes: 'added `unwrap-` prefixed values' },
+                {
+                    version: '26.9.0',
+                    notes: 'desktop no longer reports user cancellations of the withdraw transaction (device button, PIN entry, review modal) as `submit-failed`',
+                },
             ],
         },
         apyBreakdown: {

--- a/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts
+++ b/suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts
@@ -15,6 +15,17 @@ import {
 import { type EthereumSignTransaction, type TokenInfo } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils';
 
+// Codes TrezorConnect returns when the user backs out of signing on purpose (device button, PIN
+// entry, connect popup) — not failures.
+export const USER_CANCELLED_ERROR_CODES = [
+    'Failure_ActionCancelled',
+    'Failure_PinCancelled',
+    'Method_Cancel',
+] as const;
+
+export const isUserCancelledSignErrorCode = (code: string | undefined) =>
+    USER_CANCELLED_ERROR_CODES.some(cancelledCode => cancelledCode === code);
+
 export type StablecoinYieldParsedTransactionForSigning = NonNullable<
     ReturnType<typeof parseUnsignedEvmTransactionForSigning>
 >;

--- a/suite-native/module-earn/src/constants.ts
+++ b/suite-native/module-earn/src/constants.ts
@@ -13,9 +13,3 @@ export const AMOUNT_INPUT_WRAPPER_HEIGHT = 128;
 // Mirrors the desktop YieldAmountCard input length caps.
 export const AMOUNT_INPUT_MAX_LENGTH = 30;
 export const FIAT_INPUT_MAX_LENGTH = 18;
-
-export const USER_CANCELLED_ERROR_CODES = [
-    'Failure_PinCancelled',
-    'Method_Cancel',
-    'Failure_ActionCancelled',
-] as const;

--- a/suite-native/module-earn/src/utils/earn/utils.ts
+++ b/suite-native/module-earn/src/utils/earn/utils.ts
@@ -1,6 +1,5 @@
+import { isUserCancelledSignErrorCode } from '@suite-common/earn-stablecoin';
 import { type FormState } from '@suite-common/wallet-types';
-
-import { USER_CANCELLED_ERROR_CODES } from '../../constants';
 
 export const buildEarnComposeFormState = (
     contractAddress: string,
@@ -31,7 +30,7 @@ export const isUserCancelledSignError = (
     payload: { errorCode?: string; message?: string } | undefined,
 ) =>
     payload?.message === 'tx-cancelled' ||
-    (!!payload?.errorCode && USER_CANCELLED_ERROR_CODES.some(code => code === payload.errorCode));
+    (!!payload?.errorCode && isUserCancelledSignErrorCode(payload.errorCode));
 
 export type EarnReviewErrorPayload =
     { error?: string; errorCode?: string; message?: string } | undefined;
@@ -64,7 +63,7 @@ export const getEarnReviewErrorReaction = (
 
     const errorCode = payload?.errorCode;
 
-    if (USER_CANCELLED_ERROR_CODES.some(code => code === errorCode)) {
+    if (isUserCancelledSignErrorCode(errorCode)) {
         return 'popScreen';
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `sendYieldTransaction` now returns `{ status: 'sent' | 'cancelled' }`, so user cancellations (device, PIN, review modal) are no longer reported as `submit-failed` analytics errors. `Failure_PinCancelled` is newly treated as a cancel; the cancel codes are shared via `USER_CANCELLED_ERROR_CODES` in `@suite-common/earn-stablecoin` (desktop + native).
- Desktop `setPendingTx` now stores `fee` and `submittedAt` (parity with native), and `durationMs` analytics is measured from `submittedAt` instead of a mount-scoped ref, so it survives leaving and reopening the page.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #29541

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are concentrated in the stablecoin yield/earn feature: deposit/withdraw/claim thunks, signing helpers, yield flow hooks, pending-transaction tracking, and yield analytics events. The most targeted E2E coverage is the two yield tests (redeem and withdrawal), which exercise the withdraw/redeem paths and their signing, device-session, and flow infrastructure. Deposit, Merkl reward claim, and native token wrap/unwrap flows lack direct E2E coverage and rely on the included unit test files; native mobile earn files are outside the web E2E scope.

<details><summary><b>Changed files (23)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`
- `packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.test.ts`
- `packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.test.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts`
- `suite-common/analytics/src/events/yieldClaimEvent.ts`
- `suite-common/analytics/src/events/yieldDepositEvent.ts`
- `suite-common/analytics/src/events/yieldWithdrawEvent.ts`
- `suite-common/earn-stablecoin/src/signing/stablecoinYieldSigningUtils.ts`
- `suite-native/module-earn/src/constants.ts`
- `suite-native/module-earn/src/utils/earn/utils.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — This test directly exercises the yield vault redeem/withdraw flow, which relies on submitYieldWithdrawThunk, stablecoin yield signing helpers/utils, ensureDeviceSession, and useYieldFlow — all files changed in this PR. Regression here would be immediately user-visible for the earn/yield feature.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test covers the yield vault withdrawal flow end-to-end, including transaction simulation, device confirmation, and completion toasts. It exercises the same changed signing, session, flow, and withdraw thunk code paths as the redeem test.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/module-earn/src/constants.ts`
- `suite-native/module-earn/src/utils/earn/utils.ts`

_Updated: 2026-09-02T17:37:00.736Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-cancel-reporting/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-cancel-reporting/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-cancel-reporting&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-cancel-reporting&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-cancel-reporting&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T17:38:40.911Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T17:39:37.658Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->