### PR TITLE
WIP: attempt fix

### DIFF
--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -87,6 +87,20 @@ export const handleDeviceDisconnect = createThunk<
 
     const devices = selectDevices(getState());
 
+    // @ts-expect-error - router is not in DeviceRootState but we know it's there
+    // eslint-disable-next-line no-restricted-syntax
+    const routerApp = getState().router.app;
+
+    /**
+     * Under normal circumstances, after device is disconnected we want suite to select another existing device (either remembered or physically connected)
+     * This is not the case in firmware update and onboarding; In this case we simply wan't suite.device to be empty until user reconnects a device again
+     */
+    if (['onboarding', 'firmware', 'firmware-type'].includes(routerApp)) {
+        dispatch(selectDeviceThunk({ device: undefined }));
+
+        return;
+    }
+
     // selected device is disconnected, decide what to do next
     // device is still present in reducer (remembered or candidate to remember)
     const devicePresent = getSelectedDevice(selectedDevice, devices);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a broad device Redux-thunk module referenced by 138 tests, so most mappings are indirect. The real risk is in device lifecycle, session management, passphrase wallet handling, and forget/disconnect flows. Running the targeted high-priority tests above gives strong coverage of the most likely regression surfaces without running the full suite.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-core/src/device/deviceThunks.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This test exercises forgetting, disconnecting, and Bluetooth unpairing of devices through the device settings UI. deviceThunks is the canonical place where forget-device actions and device state transitions live, so a regression here would directly break these flows.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session acquisition, session stealing, reclaiming via 'Use Here', and device status transitions across tabs and reloads. Those lifecycle operations are exactly the responsibility of deviceThunks.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test verifies that hidden wallets, passphrase cache, and device reconnection state persist correctly after power cycling. deviceThunks handles passphrase-protected wallet creation and device reconnect bookkeeping.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test ejects a wallet and re-adds a standard wallet, then performs discovery. deviceThunks controls wallet/device lifecycle actions such as ejecting and adding standard wallets.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test checks disconnected-device UI behavior and the connection modal during send when no device is present. deviceThunks drives the disconnected/connected device status and the prompt for reconnection.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/safety-checks.test.ts` — This test applies a safety-check level change to the device and confirms it on the device. deviceThunks likely handles applying device settings and dispatching the resulting device update, so it is adjacent infrastructure worth verifying.
- `suite/e2e/tests/recovery/dry-run.test.ts` — This test covers recovery dry-run reinitialization after simulated device disconnect/reconnect and page reload. deviceThunks manages device reconnect state and recovery/session reacquisition, which this flow depends on.

</details>

_Updated: 2026-09-01T15:31:52.090Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/try-to-fix-connected-device/web/](https://dev.suite.sldev.cz/suite-web/try-to-fix-connected-device/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=try-to-fix-connected-device&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=try-to-fix-connected-device&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=try-to-fix-connected-device&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-01T15:34:54.055Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > Set a custom BTC backend before enabling the network | 🤖 auto |
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-01T15:34:51.464Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->