### PR TITLE
fix(blockchain-link): read XRP payment amount from delivered_amount, not DeliverMax

### DIFF
--- a/packages/blockchain-link-utils/src/ripple.ts
+++ b/packages/blockchain-link-utils/src/ripple.ts
@@ -30,7 +30,26 @@ export const transformTransaction = (
         const deliverMax = (tx_json as { DeliverMax?: string }).DeliverMax ?? undefined;
         const isTokenTransaction = typeof deliverMax !== 'string';
 
-        amount = !isTokenTransaction ? deliverMax : undefined;
+        // DeliverMax (formerly Amount) is only the MAXIMUM the sender authorised.
+        // On a partial payment (Flags & tfPartialPayment) the amount actually delivered
+        // can be anything up to DeliverMax, chosen by the sender - the XRPL docs are
+        // explicit that DeliverMax/Amount must never be used to determine what was
+        // delivered. meta.delivered_amount is the authoritative value; it's absent only
+        // on legacy pre-delivered_amount ledgers, and reported as the string sentinel
+        // 'unavailable' on some very old validated ledgers where it can't be determined.
+        // https://xrpl.org/docs/references/protocol/transactions/metadata#delivered_amount
+        const deliveredAmount =
+            meta != null && typeof meta !== 'string' ? meta.delivered_amount : undefined;
+        // delivered_amount is a string for a native XRP (drops) delivery, an object for
+        // an issued-currency/MPT delivery, or the literal string 'unavailable' when the
+        // server can't determine it - only the drops case is usable here, and it must be
+        // told apart from the 'unavailable' sentinel, which is also typeof 'string'.
+        const resolvedAmount =
+            typeof deliveredAmount === 'string' && deliveredAmount !== 'unavailable'
+                ? deliveredAmount
+                : deliverMax;
+
+        amount = !isTokenTransaction ? resolvedAmount : undefined;
 
         // https://xrpl.org/docs/references/protocol/transactions/transaction-results
         // Success - tes - (Not an error) The transaction succeeded. This result only final in a validated ledger.

--- a/packages/blockchain-link/src/__fixtures__/getAccountInfo-ripple.ts
+++ b/packages/blockchain-link/src/__fixtures__/getAccountInfo-ripple.ts
@@ -344,4 +344,209 @@ export default [
             marker: undefined,
         },
     },
+    {
+        // DeliverMax is only the maximum the sender authorised - on a partial payment
+        // (Flags & tfPartialPayment) the sender chooses how much of that is actually
+        // delivered, and only meta.delivered_amount reports it. This transaction
+        // authorises 25718124 drops but only delivers 4200000; a wallet reading
+        // DeliverMax as the received amount would overstate a real receive by ~6.1x.
+        description: 'With partial payment',
+        params: {
+            descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
+            details: 'txs',
+        },
+        serverFixtures: [
+            {
+                method: 'account_info',
+                response: xrpAccount.account_info.validated,
+            },
+            {
+                method: 'account_info',
+                response: xrpAccount.account_info.current,
+            },
+            {
+                method: 'account_tx',
+                response: {
+                    status: 'success',
+                    type: 'response',
+                    result: {
+                        account: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
+                        transactions: [
+                            {
+                                hash: '73C90DEB024FDBFCEC80DAB423CD98B4E77D3D34C9E85B4E3EE1DAB43F49F9DE',
+                                meta: {
+                                    TransactionIndex: 7,
+                                    TransactionResult: 'tesSUCCESS',
+                                    delivered_amount: '4200000',
+                                },
+                                tx_json: {
+                                    Account: 'r4eEbLKZGbVSBHnSUBZW8i5XaMjGLdqT4a',
+                                    DeliverMax: '25718124',
+                                    Destination: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
+                                    Fee: '6000',
+                                    Flags: 2147483648 + 131072, // tfFullyCanonicalSig | tfPartialPayment
+                                    LastLedgerSequence: 47457602,
+                                    Sequence: 157331,
+                                    SigningPubKey:
+                                        '038CF47114672A12B269AEE015BF7A8438609B994B0640E4B28B2F56E93D948B15',
+                                    TransactionType: 'Payment',
+                                    TxnSignature:
+                                        '30440220665BEB140619A36C737929487519B862D1592225568CBEBC248972AD8453D8EE0220020852427CE83EC4BD8A5BFB48B7DA573FFC042A1E3BE9A513FC04F3C3D45B12',
+                                    date: 611932692,
+                                    hash: '',
+                                    inLedger: 47455208,
+                                    ledger_index: 47455208,
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        ],
+        response: {
+            descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
+            balance: '20000000',
+            availableBalance: '10000000',
+            empty: false,
+            history: {
+                total: -1,
+                unconfirmed: 0,
+                transactions: [
+                    {
+                        type: 'recv',
+                        txid: '73C90DEB024FDBFCEC80DAB423CD98B4E77D3D34C9E85B4E3EE1DAB43F49F9DE',
+                        amount: '4200000',
+                        fee: '6000',
+                        blockTime: 1558617492,
+                        blockHeight: 47455208,
+                        blockHash:
+                            '73C90DEB024FDBFCEC80DAB423CD98B4E77D3D34C9E85B4E3EE1DAB43F49F9DE',
+                        targets: [
+                            {
+                                addresses: ['rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj'],
+                                isAddress: true,
+                                amount: '4200000',
+                                n: 0,
+                            },
+                        ],
+                        tokens: [],
+                        internalTransfers: [],
+                        feeRate: undefined,
+                        details: {
+                            vin: [],
+                            vout: [],
+                            size: 0,
+                            totalInput: '0',
+                            totalOutput: '0',
+                        },
+                        rippleSpecific: { destinationTag: undefined },
+                    },
+                ],
+            },
+            misc: { sequence: 2, reserve: '10000000' },
+            marker: undefined,
+        },
+    },
+    {
+        // delivered_amount can be the literal string 'unavailable' when the server can't
+        // determine it (some old validated ledgers). That sentinel is still typeof
+        // 'string' and must not be mistaken for a real drops amount - it must fall back
+        // to DeliverMax, same as when delivered_amount is absent entirely.
+        description: "With delivered_amount: 'unavailable' sentinel",
+        params: {
+            descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
+            details: 'txs',
+        },
+        serverFixtures: [
+            {
+                method: 'account_info',
+                response: xrpAccount.account_info.validated,
+            },
+            {
+                method: 'account_info',
+                response: xrpAccount.account_info.current,
+            },
+            {
+                method: 'account_tx',
+                response: {
+                    status: 'success',
+                    type: 'response',
+                    result: {
+                        account: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
+                        transactions: [
+                            {
+                                hash: '8F7B96A6CF38B9DE9CB6F82594452FDB4EE8C31D014AF0FB959FABA8871C74C8',
+                                meta: {
+                                    TransactionIndex: 9,
+                                    TransactionResult: 'tesSUCCESS',
+                                    delivered_amount: 'unavailable',
+                                },
+                                tx_json: {
+                                    Account: 'r4eEbLKZGbVSBHnSUBZW8i5XaMjGLdqT4a',
+                                    DeliverMax: '25718124',
+                                    Destination: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
+                                    Fee: '6000',
+                                    Flags: 2147483648,
+                                    LastLedgerSequence: 47457602,
+                                    Sequence: 157331,
+                                    SigningPubKey:
+                                        '038CF47114672A12B269AEE015BF7A8438609B994B0640E4B28B2F56E93D948B15',
+                                    TransactionType: 'Payment',
+                                    TxnSignature:
+                                        '30440220665BEB140619A36C737929487519B862D1592225568CBEBC248972AD8453D8EE0220020852427CE83EC4BD8A5BFB48B7DA573FFC042A1E3BE9A513FC04F3C3D45B12',
+                                    date: 611932692,
+                                    hash: '',
+                                    inLedger: 47455208,
+                                    ledger_index: 47455208,
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        ],
+        response: {
+            descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
+            balance: '20000000',
+            availableBalance: '10000000',
+            empty: false,
+            history: {
+                total: -1,
+                unconfirmed: 0,
+                transactions: [
+                    {
+                        type: 'recv',
+                        txid: '8F7B96A6CF38B9DE9CB6F82594452FDB4EE8C31D014AF0FB959FABA8871C74C8',
+                        amount: '25718124',
+                        fee: '6000',
+                        blockTime: 1558617492,
+                        blockHeight: 47455208,
+                        blockHash:
+                            '8F7B96A6CF38B9DE9CB6F82594452FDB4EE8C31D014AF0FB959FABA8871C74C8',
+                        targets: [
+                            {
+                                addresses: ['rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj'],
+                                isAddress: true,
+                                amount: '25718124',
+                                n: 0,
+                            },
+                        ],
+                        tokens: [],
+                        internalTransfers: [],
+                        feeRate: undefined,
+                        details: {
+                            vin: [],
+                            vout: [],
+                            size: 0,
+                            totalInput: '0',
+                            totalOutput: '0',
+                        },
+                        rippleSpecific: { destinationTag: undefined },
+                    },
+                ],
+            },
+            misc: { sequence: 2, reserve: '10000000' },
+            marker: undefined,
+        },
+    },
 ];

--- a/packages/blockchain-link/src/__fixtures__/getTransaction.ts
+++ b/packages/blockchain-link/src/__fixtures__/getTransaction.ts
@@ -99,13 +99,22 @@ const xrpFixture = {
     validated: true,
     inLedger: 21230990,
     ledger_index: 21230990,
+    // A real partial payment: DeliverMax (what the sender authorised at most) is
+    // 10000000 drops, but meta.delivered_amount (what was actually delivered, per
+    // https://xrpl.org/docs/references/protocol/transactions/metadata#delivered_amount)
+    // is only 4200000 drops. DeliverMax must never be read as the delivered amount.
+    meta: {
+        TransactionIndex: 3,
+        TransactionResult: 'tesSUCCESS',
+        delivered_amount: '4200000',
+    },
     tx_json: {
         Account: 'rB8Ai21NLgz85T9js2fKAVTVEDZnbTn8Eu',
         DeliverMax: '10000000',
         Destination: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
         DestinationTag: 1000000999,
         Fee: '10',
-        Flags: 2147483648,
+        Flags: 2147483648 + 131072, // tfFullyCanonicalSig | tfPartialPayment
         Sequence: 176,
         SigningPubKey: '02EEFCFCDC10B7ADAD61C9DF80AEF746A7D2439B52AA5155E6D21B4008CDB6AC43',
         TransactionType: 'Payment',
@@ -122,7 +131,7 @@ const xrpTx = {
     blockHeight: xrpFixture.ledger_index,
     blockHash: xrpFixture.hash,
     blockTime: xrpFixture.tx_json.date + 946684800,
-    amount: xrpFixture.tx_json.DeliverMax,
+    amount: xrpFixture.meta.delivered_amount,
     fee: xrpFixture.tx_json.Fee,
 
     targets: [],

--- a/packages/blockchain-link/src/__fixtures__/notifications-ripple.ts
+++ b/packages/blockchain-link/src/__fixtures__/notifications-ripple.ts
@@ -245,6 +245,104 @@ const notifyAddresses = [
             },
         },
     },
+    {
+        // DeliverMax is only the maximum the sender authorised - on a partial payment
+        // (tfPartialPayment) the amount actually delivered can be less, and is only
+        // known from meta.delivered_amount. A live "received" notification must report
+        // what was actually delivered, not the sender's authorised maximum.
+        description: 'address tx notification (recv, partial payment)',
+        method: 'subscribe',
+        params: {
+            type: 'addresses',
+            addresses: ['A'],
+        },
+        notifications: {
+            hash: 'abcd',
+            tx_json: {
+                Account: 'B',
+                Destination: 'A',
+                TransactionType: 'Payment',
+                DeliverMax: '100',
+                DestinationTag: '123',
+                Flags: 131072, // tfPartialPayment
+            },
+            meta: {
+                TransactionIndex: 1,
+                TransactionResult: 'tesSUCCESS',
+                delivered_amount: '42',
+            },
+            Account: 'A',
+            type: 'transaction',
+            validated: true,
+        },
+        result: {
+            descriptor: 'A',
+            tx: {
+                ...tx,
+                amount: '42',
+                type: 'recv',
+                targets: [
+                    {
+                        addresses: ['A'],
+                        isAddress: true,
+                        n: 0,
+                        amount: '42',
+                    },
+                ],
+                rippleSpecific: {
+                    destinationTag: '123',
+                },
+            },
+        },
+    },
+    {
+        // A tec*-failed payment is still validated into a ledger (and charges a fee),
+        // but delivers nothing. It must be classified 'failed', not 'recv' - relying on
+        // meta being plumbed through to the live notification path, not just historical
+        // getAccountInfo/getTransaction reads.
+        description: 'address tx notification (tec-failed payment is not reported as received)',
+        method: 'subscribe',
+        params: {
+            type: 'addresses',
+            addresses: ['A'],
+        },
+        notifications: {
+            hash: 'abcd',
+            tx_json: {
+                Account: 'B',
+                Destination: 'A',
+                TransactionType: 'Payment',
+                DeliverMax: '100',
+                DestinationTag: '123',
+            },
+            meta: {
+                TransactionIndex: 2,
+                TransactionResult: 'tecDST_TAG_NEEDED',
+            },
+            Account: 'A',
+            type: 'transaction',
+            validated: true,
+        },
+        result: {
+            descriptor: 'A',
+            tx: {
+                ...tx,
+                amount: '100',
+                type: 'failed',
+                targets: [
+                    {
+                        addresses: ['A'],
+                        isAddress: true,
+                        n: 0,
+                        amount: '100',
+                    },
+                ],
+                rippleSpecific: {
+                    destinationTag: '123',
+                },
+            },
+        },
+    },
 ] as const;
 
 export default {

--- a/packages/blockchain-link/src/workers/ripple/subscriptions/notifications.ts
+++ b/packages/blockchain-link/src/workers/ripple/subscriptions/notifications.ts
@@ -23,7 +23,7 @@ export const onTransaction = ({ state, post }: Context, event: TransactionStream
     // ignore transactions other than Payment
     if (event.tx_json?.TransactionType !== 'Payment') return;
 
-    const { tx_json, hash } = event;
+    const { tx_json, hash, meta } = event;
 
     const notify = (descriptor: string) => {
         if (!tx_json || !hash) return;
@@ -35,7 +35,7 @@ export const onTransaction = ({ state, post }: Context, event: TransactionStream
                 type: 'notification',
                 payload: {
                     descriptor,
-                    tx: transformTransaction(hash, tx_json, undefined, descriptor),
+                    tx: transformTransaction(hash, tx_json, meta, descriptor),
                 },
             },
         });


### PR DESCRIPTION
## What

XRP `Payment` amounts are read from `DeliverMax` (the sender's authorised **maximum**) instead of `meta.delivered_amount` (what was **actually delivered**). On a partial payment (`Flags & tfPartialPayment`), the sender chooses how much of `DeliverMax` actually gets delivered — anything up to that maximum. The [XRPL docs are explicit](https://xrpl.org/docs/references/protocol/transactions/metadata#delivered_amount) that `Amount`/`DeliverMax` must never be used to determine what was delivered.

`transformTransaction()` already receives `meta` as a parameter (used for `TransactionResult`) but never consults it for the amount.

```ts
// packages/blockchain-link-utils/src/ripple.ts:30-33 (before)
const deliverMax = (tx_json as { DeliverMax?: string }).DeliverMax ?? undefined;
const isTokenTransaction = typeof deliverMax !== 'string';
amount = !isTokenTransaction ? deliverMax : undefined;
```

## Real mainnet evidence

Independently fetched and verified against `xrplcluster.com` (live, not cached):

```
tx 8F7B96A6CF38B9DE9CB6F82594452FDB4EE8C31D014AF0FB959FABA8871C74C8 (tesSUCCESS)
Flags               : 131072 (tfPartialPayment)
DeliverMax          : 100000000000000000 drops = 100,000,000,000 XRP
meta.delivered_amount: 147413155 drops         = 147.413155 XRP

BUGGY  (current code) reports amount: 100,000,000,000 XRP
FIXED  (this PR)      reports amount: 147.413155 XRP
Overstatement factor: 678,365,509.5x
```

## Why it matters

`xrp` is in `LOCAL_BALANCE_HISTORY_COINS`, so Suite's balance graph is rebuilt client-side from `tx.amount` (`suite-common/graph/src/balanceHistoryUtils.ts` → `graphDataFetching.ts`). A standalone replica of that reconstruction logic, fed one honest 500 XRP receive plus one attacker-crafted partial payment (`DeliverMax` 100,000 XRP, 1 drop actually delivered):

```
HONEST graph (fixed):     day1: 500.000000 XRP   day2: 500.000001 XRP
CORRUPTED graph (buggy):  day1: -99499.999999 XRP  day2: 500.000001 XRP
```

One transaction, costing the sender ~12 drops, drives the entire preceding balance history arbitrarily negative — the attacker picks the magnitude. This is the textbook partial-payment exploit aimed at a wallet UI.

**Honest scoping:** no key material, no signing path, no fund loss — the account-header balance still comes from `account_info` and stays correct. What's affected: per-transaction row/detail amounts, live "received" notifications, and the reconstructed balance graph. I did **not** drive a real partial payment through a running Suite build, so exactly how the UI renders a resulting negative graph point (clamp / NaN / crash) is unobserved — this PR fixes the data at its source rather than papering over a specific rendering symptom.

## Fix

- `ripple.ts`: prefer `meta.delivered_amount` (a string) over `DeliverMax`, falling back to `DeliverMax` only when `delivered_amount` is absent **or** is the XRPL `'unavailable'` sentinel — both are `typeof 'string'`, so they need an explicit check to tell apart (caught by Codex review, see below).
- `notifications.ts`: plumb `event.meta` through to the live notification path (previously hardcoded to `undefined`). Bonus fix: this also means a `tec*`-failed payment is no longer reported as a live "received" notification, since failure status lives in the same `meta` object.

## Test fix (the bug was invisible by construction)

The existing `getTransaction` fixture computed its expected value as `xrpFixture.tx_json.DeliverMax` — the test oracle was derived from the *same field* the implementation read, so it passed for any implementation that returned `DeliverMax`. There is also no dedicated `ripple.test.ts` — the only transform module in `blockchain-link-utils` without direct unit coverage.

Fixed the vacuous fixture and added non-vacuous cases:
- `getTransaction.ts`: partial payment where `delivered_amount` genuinely differs from `DeliverMax`.
- `getAccountInfo-ripple.ts`: partial payment via `account_tx`, plus a dedicated `delivered_amount: 'unavailable'` sentinel case.
- `notifications-ripple.ts`: live partial-payment notification, plus the tec-failed-not-reported-as-received case.

Verified genuine red-before/green-after by `git stash`-ing the fix and re-running: exactly 4 tests fail against unfixed code (the ones targeting this bug), all others pass; restoring the fix brings the suite back to green.

## receipts

```
$ yarn test:unit   (packages/blockchain-link)
Test Suites: 23 passed, 23 total
Tests:       300 passed, 300 total

$ yarn test:unit   (packages/blockchain-link-utils)
Test Suites: 5 passed, 5 total
Tests:       157 passed, 157 total

$ yarn type-check   (both packages) -- clean
$ yarn lint:js       (both packages) -- clean
```

Adversarial review with Codex caught a real bug in my first pass: `typeof deliveredAmount === 'string'` doesn't exclude the `'unavailable'` sentinel, which is also a string — so a genuinely-undeterminable delivery would have leaked the literal string `"unavailable"` into `amount`. Fixed to explicitly exclude the sentinel, added a dedicated regression test, and confirmed (by temporarily reintroducing the narrower bug) that the new test catches it.

## Adjacent PRs, disclosed

- #17417 (merged) introduced the `DeliverMax`-only read during the ripple-lib → xrpl.js migration — not a fix for this.
- #31778 (open draft) touches a different file (`workers/ripple/index.ts`), no overlap.
- #30782 (umbrella) contains two other `ripple.ts` null-safety guards unrelated to amount/delivery logic — confirmed via diff, no conflict expected.

## risk

Low blast radius of the *fix itself* — it reuses the value the XRPL protocol already documents as authoritative, and only changes behavior when `delivered_amount` is present and differs from `DeliverMax` (the partial-payment case). Full payments (the overwhelming majority) are unaffected since `delivered_amount` equals `DeliverMax` when nothing was partial.
