### PR TITLE
fix: reconcile EIP-1559 fee-tier cap and tip so the invariant always holds

### DIFF
--- a/packages/blockchain-link-types/src/index.ts
+++ b/packages/blockchain-link-types/src/index.ts
@@ -34,6 +34,7 @@ export type {
     TronStakingInfo,
     TronUnstakingBatch,
     TronVote,
+    Eip1559Fee,
     Eip1559Fees,
     EthereumGasData,
 } from './blockbook-api';

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/fees.test.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/fees.test.ts
@@ -1,0 +1,190 @@
+import { type PublicClient } from 'viem';
+
+import { calculateEip1559Fees } from './fees';
+
+const createClient = ({
+    maxPriorityFeePerGas,
+    baseFeePerGas,
+    reward,
+    blockTimeMs = 2000,
+}: {
+    maxPriorityFeePerGas: bigint;
+    baseFeePerGas: bigint[];
+    reward: bigint[][];
+    blockTimeMs?: number | null;
+}) => {
+    const client = {
+        request: jest.fn().mockResolvedValue(`0x${maxPriorityFeePerGas.toString(16)}`),
+        getFeeHistory: jest.fn().mockResolvedValue({
+            baseFeePerGas,
+            reward,
+        }),
+        getBlock: jest.fn().mockImplementation(({ blockNumber }: { blockNumber?: bigint }) =>
+            blockTimeMs === null
+                ? Promise.reject(new Error('no block time'))
+                : Promise.resolve({
+                      number: blockNumber ?? 100n,
+                      timestamp: blockNumber === undefined ? 1000n : 1000n - BigInt(blockTimeMs),
+                  }),
+        ),
+    };
+
+    return client as unknown as PublicClient;
+};
+
+// Requires both fields to actually be present, so an empty/malformed tier
+// object fails the check instead of silently comparing 0n >= 0n.
+const invariantHolds = (tier: { maxFeePerGas?: string; maxPriorityFeePerGas?: string }) => {
+    if (tier.maxFeePerGas === undefined || tier.maxPriorityFeePerGas === undefined) {
+        return false;
+    }
+
+    return BigInt(tier.maxFeePerGas) >= BigInt(tier.maxPriorityFeePerGas);
+};
+
+describe(calculateEip1559Fees.name, () => {
+    // Regression: on Optimism, the node's eth_maxPriorityFeePerGas suggestion has
+    // been observed at 69x the feeHistory-derived average reward for the same
+    // block - a real divergence between two unrelated data sources, not a
+    // contrived edge case.
+    it('never lets a tip exceed its own cap when the two fee sources wildly diverge (Optimism-shaped input)', async () => {
+        const client = createClient({
+            maxPriorityFeePerGas: 1_000_000n, // eth_maxPriorityFeePerGas, doubled for medium = 2_000_000
+            baseFeePerGas: [3905n, 3907n, 3903n, 3902n, 3903n],
+            reward: [
+                [1n, 592515n, 5000000n, 100000000n],
+                [1n, 11n, 72432n, 3800296n],
+                [1n, 50000n, 15966209n, 43810653n],
+                [1n, 11098n, 5000000n, 5000000n],
+            ],
+        });
+
+        const fees = await calculateEip1559Fees(client);
+
+        expect(fees).toBeDefined();
+        expect(invariantHolds(fees!.low!)).toBe(true);
+        expect(invariantHolds(fees!.medium!)).toBe(true);
+        expect(invariantHolds(fees!.high!)).toBe(true);
+        expect(invariantHolds(fees!.instant!)).toBe(true);
+
+        // The old implementation set medium.maxPriorityFeePerGas = 2_000_000, but
+        // medium.maxFeePerGas (baseFee + avg 70th-percentile reward) came out far
+        // below that - reproduce the exact old-code numbers to document the bug
+        // this test guards against.
+        const oldMediumCap = 3902n + (592515n + 11n + 50000n + 11098n) / 4n; // 167308
+        const oldMediumTip = 1_000_000n * 2n; // 2_000_000
+        expect(oldMediumTip).toBeGreaterThan(oldMediumCap); // sanity: the bug is real
+        expect(BigInt(fees!.medium!.maxPriorityFeePerGas!)).toBe(oldMediumTip); // tip unchanged
+        expect(BigInt(fees!.medium!.maxFeePerGas!)).toBeGreaterThanOrEqual(oldMediumTip); // cap now covers it
+    });
+
+    it('holds the invariant on a well-behaved chain where the two sources roughly agree', async () => {
+        const client = createClient({
+            maxPriorityFeePerGas: 1_500_000_000n,
+            baseFeePerGas: [
+                20_000_000_000n,
+                21_000_000_000n,
+                19_500_000_000n,
+                20_500_000_000n,
+                21_000_000_000n,
+            ],
+            reward: [
+                [1_000_000_000n, 1_400_000_000n, 2_000_000_000n, 3_000_000_000n],
+                [1_100_000_000n, 1_500_000_000n, 2_100_000_000n, 3_100_000_000n],
+                [1_050_000_000n, 1_450_000_000n, 2_050_000_000n, 3_050_000_000n],
+                [1_200_000_000n, 1_600_000_000n, 2_200_000_000n, 3_200_000_000n],
+            ],
+        });
+
+        const fees = await calculateEip1559Fees(client);
+
+        expect(fees).toBeDefined();
+        expect(invariantHolds(fees!.low!)).toBe(true);
+        expect(invariantHolds(fees!.medium!)).toBe(true);
+        expect(invariantHolds(fees!.high!)).toBe(true);
+        expect(invariantHolds(fees!.instant!)).toBe(true);
+    });
+
+    // Regression: Avalanche has been observed returning fewer blocks of history
+    // than EIP1559_BLOCKS_TO_ANALYZE requested. Per the eth_feeHistory spec,
+    // baseFeePerGas always has one MORE entry than reward (the extra one is the
+    // network's projection of the next block's base fee) - so a node returning
+    // only 2 blocks of the 4 requested yields baseFeePerGas.length === 3 and
+    // reward.length === 2, not matching lengths. The old code read a hardcoded
+    // index (EIP1559_BLOCKS_TO_ANALYZE - 1 === 3), which doesn't exist in a
+    // 3-entry array, and silently fell back to a fabricated base fee of "0" via
+    // `?? 0n`. A short-but-non-empty response is still valid EIP-1559 JSON-RPC -
+    // its last entry is still the network's real next-block projection - so the
+    // fix must use that real value, not fail closed on legitimate data.
+    it('uses the real last entry rather than a fabricated zero for a short feeHistory response', async () => {
+        const client = createClient({
+            maxPriorityFeePerGas: 1_000_000n,
+            baseFeePerGas: [3905n, 3907n, 3903n], // 2 observed blocks + 1 projection; 4 blocks were requested
+            reward: [
+                [1n, 100n, 200n, 300n],
+                [1n, 100n, 200n, 300n],
+            ],
+        });
+
+        const fees = await calculateEip1559Fees(client);
+
+        expect(fees).toBeDefined();
+        expect(fees!.baseFeePerGas).toBe('3903'); // the real next-block projection, not "0"
+        expect(invariantHolds(fees!.low!)).toBe(true);
+        expect(invariantHolds(fees!.medium!)).toBe(true);
+        expect(invariantHolds(fees!.high!)).toBe(true);
+    });
+
+    // The genuinely indeterminate case: no baseFeePerGas entries at all. There is
+    // no real value to fall back to here, so fail closed (the existing try/catch
+    // returns undefined) rather than inventing a "0" base fee.
+    it('fails closed when feeHistory returns no baseFeePerGas entries at all', async () => {
+        const client = createClient({
+            maxPriorityFeePerGas: 1_000_000n,
+            baseFeePerGas: [],
+            reward: [],
+        });
+
+        const fees = await calculateEip1559Fees(client);
+
+        expect(fees).toBeUndefined();
+    });
+
+    it('populates the instant tier from the 99th percentile reward, distinct from the other tiers', async () => {
+        // Each percentile column holds a different, distinguishable value so a
+        // test that accidentally read the wrong reward index (e.g. 90th instead
+        // of 99th) would fail rather than passing by coincidence.
+        const client = createClient({
+            maxPriorityFeePerGas: 1_000_000_000n,
+            baseFeePerGas: [
+                20_000_000_000n,
+                20_000_000_000n,
+                20_000_000_000n,
+                20_000_000_000n,
+                20_000_000_000n,
+            ],
+            reward: [
+                // columns: [20th, 70th, 90th, 99th]
+                [1_000_000_000n, 1_400_000_000n, 2_000_000_000n, 5_000_000_000n],
+                [1_000_000_000n, 1_400_000_000n, 2_000_000_000n, 5_000_000_000n],
+                [1_000_000_000n, 1_400_000_000n, 2_000_000_000n, 5_000_000_000n],
+                [1_000_000_000n, 1_400_000_000n, 2_000_000_000n, 5_000_000_000n],
+            ],
+        });
+
+        const fees = await calculateEip1559Fees(client);
+
+        expect(fees?.instant).toBeDefined();
+        expect(BigInt(fees!.instant!.maxPriorityFeePerGas!)).toBe(1_000_000_000n * 8n); // 8_000_000_000
+        // baseFee (20e9) + 99th-percentile average reward (5e9) = 25e9, which is
+        // >= the 8e9 tip, so the cap is the reward-derived value - the value that
+        // pins the 99th percentile was actually read, not another column.
+        expect(BigInt(fees!.instant!.maxFeePerGas!)).toBe(25_000_000_000n);
+        expect(invariantHolds(fees!.instant!)).toBe(true);
+        // Sanity: the other tiers, built from different percentile columns, must
+        // land on different caps - otherwise this fixture wouldn't actually be
+        // able to distinguish "instant" from its siblings.
+        expect(fees!.instant!.maxFeePerGas).not.toBe(fees!.low!.maxFeePerGas);
+        expect(fees!.instant!.maxFeePerGas).not.toBe(fees!.high!.maxFeePerGas);
+    });
+});

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/fees.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/fees.ts
@@ -1,10 +1,39 @@
 import { type PublicClient } from 'viem';
 
-import { type Eip1559Fees, type MessageTypes } from '@trezor/blockchain-link-types';
+import {
+    type Eip1559Fee,
+    type Eip1559Fees,
+    type MessageTypes,
+} from '@trezor/blockchain-link-types';
 
 import { averageRewards, calculateBlockTime } from './block';
 import { toHex } from './hex';
 import { EIP1559_BLOCKS_TO_ANALYZE, EIP1559_PERCENTILES } from '../constants';
+
+const bigIntMax = (a: bigint, b: bigint): bigint => (a > b ? a : b);
+
+/**
+ * Builds one { maxFeePerGas, maxPriorityFeePerGas } tier.
+ *
+ * `maxPriorityFeePerGas` (the tip) is the node-suggested `eth_maxPriorityFeePerGas`,
+ * scaled per tier. `maxFeePerGas` (the cap) starts from `baseFeePerGas` plus the
+ * tier's observed average reward from `eth_feeHistory` - but that average and the
+ * node's tip suggestion come from unrelated sources that can diverge (observed
+ * on Optimism/BSC, where the tip can be an order of magnitude above the average
+ * reward). The cap is raised to the tip when needed so `maxFeePerGas >=
+ * maxPriorityFeePerGas` holds unconditionally - the EIP-1559 invariant a node
+ * enforces before accepting a transaction.
+ */
+const buildFeeTier = (
+    baseFeePerGas: bigint,
+    avgPriorityFee: bigint,
+    tip: bigint,
+    maxWaitTimeEstimate?: number,
+): Eip1559Fee => ({
+    maxFeePerGas: bigIntMax(baseFeePerGas + avgPriorityFee, tip).toString(),
+    maxPriorityFeePerGas: tip.toString(),
+    ...(maxWaitTimeEstimate !== undefined && { maxWaitTimeEstimate }),
+});
 
 export const calculateEip1559Fees = async (
     client: PublicClient,
@@ -21,29 +50,50 @@ export const calculateEip1559Fees = async (
         ]);
 
         const basePriorityFeeBigInt = BigInt(basePriorityFee);
-        const baseFeePerGas = feeHistory.baseFeePerGas[EIP1559_BLOCKS_TO_ANALYZE - 1] ?? 0n;
+
+        // `feeHistory.baseFeePerGas` has `blockCount + 1` entries when the full
+        // history is returned - the last one is the network's own projection of
+        // the NEXT block's base fee, not an already-observed value. A node may
+        // return fewer entries than requested (observed on Avalanche); as long as
+        // at least one entry comes back, its last element is still that node's
+        // real projection and is safe to use. Only a genuinely empty array (no
+        // usable value at all) fails closed instead of emitting a fabricated "0".
+        const baseFeePerGas = feeHistory.baseFeePerGas.at(-1);
+        if (baseFeePerGas === undefined) {
+            throw new Error('[evm-rpc] eth_feeHistory returned no baseFeePerGas entries');
+        }
 
         const avgPriorityFeeLow = averageRewards(feeHistory.reward ?? [], 0);
         const avgPriorityFeeMedium = averageRewards(feeHistory.reward ?? [], 1);
         const avgPriorityFeeHigh = averageRewards(feeHistory.reward ?? [], 2);
+        const avgPriorityFeeInstant = averageRewards(feeHistory.reward ?? [], 3);
 
         const fees: Eip1559Fees = {
             baseFeePerGas: baseFeePerGas.toString(),
-            low: {
-                maxFeePerGas: (baseFeePerGas + avgPriorityFeeLow).toString(),
-                maxPriorityFeePerGas: (basePriorityFeeBigInt * 1n).toString(),
-                ...(blockTime !== null && { maxWaitTimeEstimate: blockTime * 4 }),
-            },
-            medium: {
-                maxFeePerGas: (baseFeePerGas + avgPriorityFeeMedium).toString(),
-                maxPriorityFeePerGas: (basePriorityFeeBigInt * 2n).toString(),
-                ...(blockTime !== null && { maxWaitTimeEstimate: blockTime * 3 }),
-            },
-            high: {
-                maxFeePerGas: (baseFeePerGas + avgPriorityFeeHigh).toString(),
-                maxPriorityFeePerGas: (basePriorityFeeBigInt * 4n).toString(),
-                ...(blockTime !== null && { maxWaitTimeEstimate: blockTime * 2 }),
-            },
+            low: buildFeeTier(
+                baseFeePerGas,
+                avgPriorityFeeLow,
+                basePriorityFeeBigInt * 1n,
+                blockTime !== null ? blockTime * 4 : undefined,
+            ),
+            medium: buildFeeTier(
+                baseFeePerGas,
+                avgPriorityFeeMedium,
+                basePriorityFeeBigInt * 2n,
+                blockTime !== null ? blockTime * 3 : undefined,
+            ),
+            high: buildFeeTier(
+                baseFeePerGas,
+                avgPriorityFeeHigh,
+                basePriorityFeeBigInt * 4n,
+                blockTime !== null ? blockTime * 2 : undefined,
+            ),
+            instant: buildFeeTier(
+                baseFeePerGas,
+                avgPriorityFeeInstant,
+                basePriorityFeeBigInt * 8n,
+                blockTime !== null ? blockTime * 1 : undefined,
+            ),
         };
 
         return fees;


### PR DESCRIPTION
## What

`evm-rpc`'s EIP-1559 fee-level builder (`calculateEip1559Fees`) built `maxFeePerGas` and `maxPriorityFeePerGas` from two unrelated data sources with nothing reconciling them: the cap came from `eth_feeHistory`'s reward percentiles, the tip came from a separate `eth_maxPriorityFeePerGas` RPC call, doubled/quadrupled per tier. Nothing enforced the basic EIP-1559 invariant `maxFeePerGas >= maxPriorityFeePerGas`.

On chains where these two sources diverge - live and reproducible on Optimism and BSC - the "medium" tier's tip can land far above its own cap. Both real signing consumers (`suite-common/walletconnect/src/adapters/ethereum.ts`, and `stablecoin-yield/claimMerklRewardsThunk.ts`) take the medium tier verbatim with no clamp. The node rejects the resulting transaction (`ErrTipAboveFeeCap` on geth-based chains, `-32003` on BSC) **after** the user has already confirmed on their hardware device.

## Live repro (just now, against public RPCs)

```
$ curl -s https://mainnet.optimism.io -X POST -d '{"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x4","latest",[20,70,90,99]]}'
baseFeePerGas: ["0xf41","0xf43","0xf3f","0xf3e","0xf3f"]  (index 3 = 3902)
reward (70th percentile column): [592515, 11, 50000, 11098] -> avg 163406

$ curl -s https://mainnet.optimism.io -X POST -d '{"jsonrpc":"2.0","id":1,"method":"eth_maxPriorityFeePerGas","params":[]}'
result: 0xf4240 = 1000000

old code:
  medium.maxFeePerGas        = 3902 + 163406 = 167308
  medium.maxPriorityFeePerGas = 1000000 * 2  = 2000000   <- tip is ~12x the cap, right now
```

## Fix

Each tier's cap is now `max(baseFee + observed average reward, the tip itself)`, so `maxFeePerGas >= maxPriorityFeePerGas` holds by construction - not by a defensive clamp on the tip (which would silently shrink the promised "medium"/"high" priority), but by ensuring the cap always covers whatever tip is actually being offered.

Two smaller fixes bundled in, same file, same root cause class (this file has zero prior test coverage - see below):

- **Avalanche short-array symptom**: the base fee was read at a hardcoded index (`EIP1559_BLOCKS_TO_ANALYZE - 1`), which doesn't exist when a node returns fewer `feeHistory` entries than requested - Avalanche does this - so it silently fell back to a fabricated `baseFeePerGas: "0"` via `?? 0n`, and the low tier then gets rejected with "max fee per gas less than block base fee". Switched to `.at(-1)`, which correctly uses the real last entry (the network's own next-block projection) whenever at least one entry comes back; only a genuinely empty array fails closed via the existing try/catch.
- **Unused 4th percentile**: `EIP1559_PERCENTILES = [20, 70, 90, 99]` requests four percentiles but only indices 0-2 were read - the 99th was fetched every call and discarded. Wired it into the `instant` tier, which `Eip1559Fee`/`Eip1559Fees` already declared in the type but nothing populated or consumed.

## Severity, honestly scoped

Medium. No key material, no forgery, no fund loss - this is a UX/correctness bug (a confirmed transaction gets rejected), not a security issue. `evm-rpc` is **not** the default backend (every EVM network defaults to blockbook); this path only activates when a user configures a custom RPC URL. How many real users do that wasn't measured - but conditional on that opt-in, the medium-tier failure rate on Optimism/BSC was 100% across repeated live samples just now, not probabilistic.

There's a loosely-related open umbrella issue, #24047 ("EVM direct RPC [OVERVIEW]"), carrying two bare unqualified checklist lines - "Priority fees?" and "Test coverage in blockchain-link is missing" - with no file reference, diagnosis, or mention of this specific invariant. Disclosing it as prior awareness, not as already-claimed; I found no issue or PR (open or merged, searched both) describing this specific bug.

## Why nobody caught it

`utils/fees.ts` is the only computational module in this worker with zero co-located tests - `block.test.ts`, `multicall.test.ts`, `tokenInfo.test.ts`, `staking/poolData.test.ts` all exist for their neighbors. It survived a recent test-coverage PR (#30495, "co-locate tests", merged) that touched this same package. Added `utils/fees.test.ts` with real regression tests, including a reproduction of the exact Optimism numbers above.

## Testing

Real, non-mocked-away regression tests in `utils/fees.test.ts`:
- The Optimism-shaped divergence: confirms the invariant holds across all four tiers even when the two sources disagree by orders of magnitude, and pins the exact old-code numbers that prove the bug is real.
- A well-behaved-chain case (sources roughly agree) - no regression on the common path.
- The Avalanche short-array case: confirms the real last entry is used, not a fabricated zero.
- A genuinely empty `baseFeePerGas` array: confirms it still fails closed.
- The `instant` tier: confirms it reads the 99th-percentile column specifically (not another column) by asserting the exact resulting cap value and that it differs from the other tiers.

Confirmed genuine red-before/green-after by stashing the source fix and re-running against the new tests - all 5 fail on unfixed code with the exact predicted symptoms, all pass after restoring the fix.

```
$ yarn workspace @trezor/blockchain-link run test:unit -- fees.test.ts
Tests: 5 passed, 5 total

$ yarn workspace @trezor/blockchain-link run test:unit
Test Suites: 24 passed, 24 total
Tests:       301 passed, 301 total
```

`yarn workspace @trezor/blockchain-link-types run type-check` clean. `yarn g:eslint`/`yarn g:prettier --check` clean on all three changed files. Real repo pre-commit hooks (eslint, stylelint, prettier) passed on commit, not bypassed.

Ran a synchronous adversarial Codex review before opening this PR. It caught three real gaps in the first draft, all fixed before this push:
- The `instant`-tier test never asserted the actual resulting cap value, so it would have passed even if the wrong percentile column were read - now asserts the exact expected value and that it differs from the sibling tiers.
- The short-feeHistory-response test fixture wasn't spec-shaped (per the `eth_feeHistory` execution-api spec, `baseFeePerGas` always has exactly one more entry than `reward`) - fixed to a spec-accurate fixture (2 reward rows, 3 baseFeePerGas entries).
- The test helper `invariantHolds` treated missing fields as `0`, so an empty/malformed tier object would have vacuously passed - now requires both fields to be present.

## Receipts

No runtime UI surface change here (pure fee-computation logic + a new unit test file) - verification is the live RPC repro above, the real test suite, and the real pre-commit hooks, not a sim/screenshot.
