### PR TITLE
fix(blockchain-link): close subscribeBlock race in ripple/solana/stellar workers

### DIFF
--- a/packages/blockchain-link/src/workers/ripple/subscriptions/block.ts
+++ b/packages/blockchain-link/src/workers/ripple/subscriptions/block.ts
@@ -3,9 +3,13 @@ import { onNewBlock } from './notifications';
 
 export const subscribeBlock = async (ctx: Context) => {
     if (!ctx.state.getSubscription('ledger')) {
+        // Claim the subscription synchronously before the awaited connect() so a
+        // concurrent subscribeBlock() call sees the guard already set and bails
+        // out, instead of both calls racing past the guard and connecting/
+        // registering a listener twice (see e566cc8823 for the same fix in blockbook).
+        ctx.state.addSubscription('ledger');
         const api = await ctx.connect();
         api.on('ledgerClosed', ev => onNewBlock(ctx, ev));
-        ctx.state.addSubscription('ledger');
     }
 
     return { subscribed: true };

--- a/packages/blockchain-link/src/workers/solana/subscriptions/block.ts
+++ b/packages/blockchain-link/src/workers/solana/subscriptions/block.ts
@@ -8,6 +8,13 @@ const BLOCK_SUBSCRIBE_INTERVAL_MS = 50000;
 
 export const subscribeBlock = async ({ state, connect, post }: Context) => {
     if (state.getSubscription('block')) return { subscribed: true };
+    // Claim the subscription synchronously before the awaited connect() so a
+    // concurrent subscribeBlock() call sees the guard already set and bails
+    // out, instead of both calls racing past the guard and each creating its
+    // own interval - the second addSubscription('block', interval) call below
+    // would otherwise silently overwrite the first, orphaning it forever
+    // (see e566cc8823 for the same fix in blockbook).
+    state.addSubscription('block');
     const api = await connect();
 
     const fetchBlock = async () => {

--- a/packages/blockchain-link/src/workers/stellar/subscriptions/block.ts
+++ b/packages/blockchain-link/src/workers/stellar/subscriptions/block.ts
@@ -10,6 +10,13 @@ const BLOCK_SUBSCRIBE_INTERVAL_MS = 1000 * 15;
 
 export const subscribeBlock = async ({ state, connect, post }: Context) => {
     if (state.getSubscription('block')) return { subscribed: true };
+    // Claim the subscription synchronously before the awaited connect() so a
+    // concurrent subscribeBlock() call sees the guard already set and bails
+    // out, instead of both calls racing past the guard and each creating its
+    // own interval - the second addSubscription('block', interval) call below
+    // would otherwise silently overwrite the first, orphaning it forever
+    // (see e566cc8823 for the same fix in blockbook).
+    state.addSubscription('block');
     const api = await connect();
 
     const fetchBlock = async () => {

--- a/packages/blockchain-link/src/workers/subscribeBlockRace.test.ts
+++ b/packages/blockchain-link/src/workers/subscribeBlockRace.test.ts
@@ -1,0 +1,207 @@
+import {
+    subscribeBlock as blockbookSubscribeBlock,
+    unsubscribeBlock as blockbookUnsubscribeBlock,
+} from './blockbook/subscriptions/block';
+import {
+    subscribeBlock as rippleSubscribeBlock,
+    unsubscribeBlock as rippleUnsubscribeBlock,
+} from './ripple/subscriptions/block';
+import {
+    subscribeBlock as solanaSubscribeBlock,
+    unsubscribeBlock as solanaUnsubscribeBlock,
+} from './solana/subscriptions/block';
+import { WorkerState } from './state';
+import {
+    subscribeBlock as stellarSubscribeBlock,
+    unsubscribeBlock as stellarUnsubscribeBlock,
+} from './stellar/subscriptions/block';
+
+// Regression coverage for the race condition originally fixed in blockbook
+// (commit e566cc8823, "fix(blockchain-link): fix race condition in block
+// subscription"). That fix moved the subscription guard to before the
+// awaited connect() call so a second concurrent subscribeBlock() call sees
+// the guard is already set and bails out. ripple, solana and stellar never
+// received the equivalent fix: their guard is only fully established after
+// an await, so two concurrent subscribeBlock() calls both pass the guard
+// check and both proceed to create a subscription/interval. Since
+// WorkerState.addSubscription() is a last-write-wins overwrite, the second
+// call's handle clobbers the first's, orphaning the first subscription /
+// interval, which then survives unsubscribeBlock() + disconnect().
+
+describe('subscribeBlock concurrency (blockbook / ripple / solana / stellar)', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('blockbook: two concurrent subscribeBlock calls only ever connect once (already fixed)', async () => {
+        const state = new WorkerState();
+        let connectCalls = 0;
+        const listeners: Record<string, (() => void)[]> = {};
+        const api = {
+            on: (event: string, cb: () => void) => {
+                listeners[event] = (listeners[event] ?? []).concat(cb);
+            },
+            removeAllListeners: (event: string) => {
+                listeners[event] = [];
+            },
+            subscribeBlock: () => Promise.resolve({ subscribed: true }),
+            unsubscribeBlock: () => Promise.resolve({ subscribed: false }),
+        };
+        const connect = () => {
+            connectCalls += 1;
+
+            return Promise.resolve(api as any);
+        };
+        const ctx = { state, connect, post: jest.fn() } as any;
+
+        await Promise.all([blockbookSubscribeBlock(ctx), blockbookSubscribeBlock(ctx)]);
+
+        expect(connectCalls).toBe(1);
+        expect(listeners.block).toHaveLength(1);
+
+        await blockbookUnsubscribeBlock(ctx);
+        expect(state.getSubscription('block')).toBeUndefined();
+    });
+
+    it('ripple: a concurrent subscribeBlock call self-heals (no orphaned handle, but connects twice)', async () => {
+        const state = new WorkerState();
+        let connectCalls = 0;
+        let listenerCount = 0;
+        const client = {
+            on: () => {
+                listenerCount += 1;
+            },
+            removeAllListeners: () => {
+                listenerCount = 0;
+            },
+        };
+        const connect = () => {
+            connectCalls += 1;
+
+            return Promise.resolve(client as any);
+        };
+        const ctx = { state, connect, post: jest.fn() } as any;
+
+        await Promise.all([rippleSubscribeBlock(ctx), rippleSubscribeBlock(ctx)]);
+
+        // Pre-fix: the guard is only set after the awaited connect(), so both
+        // concurrent calls race past it and connect/register a listener twice.
+        expect(connectCalls).toBe(1);
+        expect(listenerCount).toBe(1);
+
+        await rippleUnsubscribeBlock(ctx);
+        expect(listenerCount).toBe(0);
+        expect(state.getSubscription('ledger')).toBeUndefined();
+    });
+
+    it('solana: a concurrent subscribeBlock call orphans the first interval, which survives unsubscribe', async () => {
+        const state = new WorkerState();
+        let connectCalls = 0;
+        let intervalsCreated = 0;
+        const clearedIntervals: unknown[] = [];
+        const realSetInterval = global.setInterval;
+        const realClearInterval = global.clearInterval;
+        const createdIntervalIds: unknown[] = [];
+
+        jest.spyOn(global, 'setInterval').mockImplementation(((fn: any, ms: any) => {
+            intervalsCreated += 1;
+            const id = realSetInterval(fn, ms);
+            createdIntervalIds.push(id);
+
+            return id;
+        }) as any);
+        jest.spyOn(global, 'clearInterval').mockImplementation(((id: any) => {
+            clearedIntervals.push(id);
+
+            return realClearInterval(id);
+        }) as any);
+
+        const api = {
+            rpc: {
+                getLatestBlockhash: () => ({
+                    send: () =>
+                        Promise.resolve({
+                            value: { blockhash: '0x0', lastValidBlockHeight: 1 },
+                        }),
+                }),
+            },
+        };
+        const connect = () => {
+            connectCalls += 1;
+
+            return Promise.resolve(api as any);
+        };
+        const ctx = { state, connect, post: jest.fn() } as any;
+
+        await Promise.all([solanaSubscribeBlock(ctx), solanaSubscribeBlock(ctx)]);
+
+        // Pre-fix: two concurrent calls both pass the guard (only set after
+        // the awaited connect()), so two intervals get created; the second
+        // addSubscription('block', interval) overwrites the first's handle.
+        expect(connectCalls).toBe(1);
+        expect(intervalsCreated).toBe(1);
+        expect(createdIntervalIds).toHaveLength(1);
+
+        solanaUnsubscribeBlock(ctx as any);
+
+        // Every interval that was actually created must have been cleared -
+        // none should be left running after unsubscribe.
+        expect(clearedIntervals.sort()).toEqual(
+            [...createdIntervalIds].sort() as unknown as never[],
+        );
+    });
+
+    it('stellar: a concurrent subscribeBlock call orphans the first interval, which survives unsubscribe', async () => {
+        const state = new WorkerState();
+        let connectCalls = 0;
+        let intervalsCreated = 0;
+        const clearedIntervals: unknown[] = [];
+        const realSetInterval = global.setInterval;
+        const realClearInterval = global.clearInterval;
+        const createdIntervalIds: unknown[] = [];
+
+        jest.spyOn(global, 'setInterval').mockImplementation(((fn: any, ms: any) => {
+            intervalsCreated += 1;
+            const id = realSetInterval(fn, ms);
+            createdIntervalIds.push(id);
+
+            return id;
+        }) as any);
+        jest.spyOn(global, 'clearInterval').mockImplementation(((id: any) => {
+            clearedIntervals.push(id);
+
+            return realClearInterval(id);
+        }) as any);
+
+        const api = {
+            ledgers: () => ({
+                order: () => ({
+                    limit: () => ({
+                        call: () =>
+                            Promise.resolve({
+                                records: [{ sequence: 1, hash: '0x0' }],
+                            }),
+                    }),
+                }),
+            }),
+        };
+        const connect = () => {
+            connectCalls += 1;
+
+            return Promise.resolve(api as any);
+        };
+        const ctx = { state, connect, post: jest.fn() } as any;
+
+        await Promise.all([stellarSubscribeBlock(ctx), stellarSubscribeBlock(ctx)]);
+
+        expect(connectCalls).toBe(1);
+        expect(intervalsCreated).toBe(1);
+        expect(createdIntervalIds).toHaveLength(1);
+
+        stellarUnsubscribeBlock(ctx as any);
+
+        expect(clearedIntervals.sort()).toEqual(
+            [...createdIntervalIds].sort() as unknown as never[],
+        );
+    });
+});


### PR DESCRIPTION
## what it says on the box

`subscribeBlock()` registers its subscription guard AFTER the awaited `connect()` call in 3 of 4 blockchain-link workers (ripple, solana, stellar) — the same race condition that was already fixed in the 4th worker, blockbook, back in `e566cc8823` (2025-05-12, *"fix(blockchain-link): fix race condition in block subscription"*). The fix was never propagated to the siblings.

## the bug

Two concurrent `subscribeBlock()` calls on the same worker (both invoked before either one's `connect()` resolves) both see the subscription guard as unset and both proceed:

- **solana / stellar** — both create a `setInterval` poll. `WorkerState.addSubscription()` is a last-write-wins overwrite, so the second call's interval id clobbers the first's in state. The first interval is now unreferenced anywhere and **survives both `unsubscribeBlock()` and `disconnect()`** — it keeps firing forever, still issuing backend RPC calls and posting block notifications after the caller believed it had unsubscribed.
- **ripple** — both calls register a `'ledgerClosed'` listener. This self-heals on unsubscribe (`removeAllListeners` clears every listener regardless of count), but still double-connects and double-registers needlessly.

## reachability

`BackendManager.test.ts` documents, from a captured HAR, that Suite issues roughly 9 `blockchainSubscribe` calls per second in real usage, and `BlockchainSubscribe` runs with `useDevice = false` so these aren't serialized behind a device queue — concurrent calls are a normal occurrence, not a contrived edge case. The race window reopens on every reconnect, so a flapping backend connection accumulates orphaned intervals over time. Solana polls every ~50s, stellar every ~15s.

**Open dependency, not claimed as proven:** whether each phantom post-unsubscribe block notification actually triggers a real account re-sync in the Suite app layer above this worker wasn't traced end-to-end. There's a suggestively-related closed PR (#27922, "throttle block-mined-triggered account sync") worth citing as context, but this PR is scoped to the proven leak itself.

## fix

Mirror blockbook's existing pattern in all three workers: claim the subscription synchronously **before** the awaited `connect()` call, so a second concurrent call sees the guard already set and bails out immediately.

```diff
 export const subscribeBlock = async ({ state, connect, post }: Context) => {
     if (state.getSubscription('block')) return { subscribed: true };
+    state.addSubscription('block');
     const api = await connect();
     ...
-    state.addSubscription('block', interval);
+    state.addSubscription('block', interval); // now updates the already-claimed guard with the real handle
```

## receipts

New regression test (`subscribeBlockRace.test.ts`) imports `subscribeBlock`/`unsubscribeBlock` directly from all four workers and drives two concurrent calls through each with a real `connect`/`state` context (no worker-message-bus mocking needed — this targets the actual functions under test).

**Before the fix**, run against the real unfixed source:
```
FAIL src/workers/subscribeBlockRace.test.ts
    ✓ blockbook: two concurrent subscribeBlock calls only ever connect once (already fixed)
    ✕ ripple: a concurrent subscribeBlock call self-heals (no orphaned handle, but connects twice)
    ✕ solana: a concurrent subscribeBlock call orphans the first interval, which survives unsubscribe
    ✕ stellar: a concurrent subscribeBlock call orphans the first interval, which survives unsubscribe

Tests:       3 failed, 1 passed, 4 total
```
All three failures were `connectCalls: 2` instead of `1` — both concurrent calls raced past the guard.

Independent confirmation beyond the assertions: running the unfixed test **without** `--forceExit`, the Jest process itself hangs indefinitely (had to be killed manually) because the leaked solana/stellar intervals keep the event loop alive. This is the bug demonstrating itself at the process level, not just via assertions.

**After the fix:**
```
PASS src/workers/subscribeBlockRace.test.ts
    ✓ blockbook: two concurrent subscribeBlock calls only ever connect once (already fixed)
    ✓ ripple: a concurrent subscribeBlock call self-heals (no orphaned handle, but connects twice)
    ✓ solana: a concurrent subscribeBlock call orphans the first interval, which survives unsubscribe
    ✓ stellar: a concurrent subscribeBlock call orphans the first interval, which survives unsubscribe

Tests:       4 passed, 4 total
```
And confirmed the process now exits cleanly on its own (no `--forceExit` needed) — the leak is genuinely gone, not just the assertions passing.

Full package suite: **24 test suites, 300 tests, all passing** (baseline was 23/296 — +4 new, zero regressions). `yarn type-check` clean. Real pre-commit hooks (eslint, stylelint, prettier) ran and passed on commit, not bypassed.

## known limitation, not introduced by this change

Calling `unsubscribeBlock()` in the narrow window between the synchronous guard claim and the subscription actually being established (the `await connect()` still in flight) can still race back to a live subscription, since the original `subscribeBlock()` call resumes afterward and re-establishes it regardless. **This exact same trade-off already exists in blockbook's fixed implementation** (the reference this PR mirrors) — it's not a new risk this change introduces, and closing it would require a larger refactor than this bug warrants. Flagging for visibility, not proposing to fix here.

## risk

Low. Three one-line reorders, each mirroring an already-shipped, already-proven-correct pattern in the sibling blockbook worker. No behavior change on the non-concurrent (single subscribe call) path.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
