### PR TITLE
fix(blockchain-link): default electrum estimateFee blocks, exclude blockfrost collateral misuse

### DIFF
--- a/packages/blockchain-link-utils/src/blockfrost.test.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.test.ts
@@ -62,4 +62,125 @@ describe('blockfrost/utils', () => {
             });
         });
     });
+
+    // trezor-suite backlog: a script-failure transaction's collateral input was unconditionally
+    // summed together with the account's regular (non-collateral) input for the same address,
+    // inflating totalInput and able to flip a receive into a false "sent" with a wrong amount.
+    describe('transformTransaction — collateral handling (valid_contract)', () => {
+        const myAddress =
+            'addr1q9f9jr6e48u63ym65esmrwgle84zspnrsew37gwe88e0zfy9ckxhkvuc5xj49rw6zrp443wlygmhv8gwcu38jk6ms6usxwwdwc';
+        const otherAddress =
+            'addr1q8u5ktsj5zsmhvwv0ep9zuhfu39x3wyt9wxjnsn3cagsyy59ckxhkvuc5xj49rw6zrp443wlygmhv8gwcu38jk6ms6usrmcafl';
+
+        const baseTxData = {
+            hash: 'deadbeef',
+            block: 'deadbeef',
+            block_height: 1,
+            block_time: 1,
+            slot: 1,
+            index: 0,
+            output_amount: [{ unit: 'lovelace', quantity: '10000000' }],
+            fees: '200000',
+            deposit: '0',
+            size: 100,
+            invalid_before: null,
+            invalid_hereafter: null,
+            utxo_count: 2,
+            withdrawal_count: 0,
+            mir_cert_count: 0,
+            delegation_count: 0,
+            stake_cert_count: 0,
+            pool_update_count: 0,
+            pool_retire_count: 0,
+            asset_mint_or_burn_count: 0,
+            redeemer_count: 1,
+        };
+
+        it("does not double-count a script-failure tx's collateral alongside its regular declared input for the same address", () => {
+            const result = transformTransaction(
+                {
+                    address: myAddress,
+                    txData: { ...baseTxData, valid_contract: false },
+                    txUtxos: {
+                        hash: 'deadbeef',
+                        inputs: [
+                            {
+                                address: myAddress,
+                                amount: [{ unit: 'lovelace', quantity: '5000000' }],
+                                tx_hash: 'a',
+                                output_index: 0,
+                                data_hash: null,
+                                collateral: false,
+                            },
+                            {
+                                address: myAddress,
+                                amount: [{ unit: 'lovelace', quantity: '2000000' }],
+                                tx_hash: 'b',
+                                output_index: 0,
+                                data_hash: null,
+                                collateral: true,
+                            },
+                        ],
+                        outputs: [
+                            {
+                                address: otherAddress,
+                                amount: [{ unit: 'lovelace', quantity: '1800000' }],
+                                output_index: 0,
+                            },
+                        ],
+                    },
+                    // @ts-expect-error incorrect params
+                },
+                { change: [], used: [{ address: myAddress, path: '', transfers: 0 }], unused: [] },
+            );
+
+            // only the collateral input (2,000,000) was actually spent on script-validation
+            // failure — the 5,000,000 regular declared input never took effect and must not
+            // be summed in.
+            expect(result.details.totalInput).toBe('2000000');
+        });
+
+        it("excludes a successful tx's collateral input entirely, since it was never spent", () => {
+            const result = transformTransaction(
+                {
+                    address: myAddress,
+                    txData: { ...baseTxData, valid_contract: true },
+                    txUtxos: {
+                        hash: 'deadbeef',
+                        inputs: [
+                            {
+                                address: myAddress,
+                                amount: [{ unit: 'lovelace', quantity: '5000000' }],
+                                tx_hash: 'a',
+                                output_index: 0,
+                                data_hash: null,
+                                collateral: false,
+                            },
+                            {
+                                address: myAddress,
+                                amount: [{ unit: 'lovelace', quantity: '2000000' }],
+                                tx_hash: 'b',
+                                output_index: 0,
+                                data_hash: null,
+                                collateral: true,
+                            },
+                        ],
+                        outputs: [
+                            {
+                                address: otherAddress,
+                                amount: [{ unit: 'lovelace', quantity: '4800000' }],
+                                output_index: 0,
+                            },
+                        ],
+                    },
+                    // @ts-expect-error incorrect params
+                },
+                { change: [], used: [{ address: myAddress, path: '', transfers: 0 }], unused: [] },
+            );
+
+            // the collateral input (2,000,000) was never spent on success — only the regular
+            // 5,000,000 input represents a real spend.
+            expect(result.details.totalInput).toBe('5000000');
+        });
+    });
 });

--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -244,7 +244,21 @@ export const transformTransaction = (
     // refundable fee for registering staking address (sent to self tx with stake registration cert)
     let deposit: string | undefined;
 
-    const inputs = fullData ? transformInputOutput(blockfrostTxData.txUtxos.inputs) : [];
+    // Blockfrost's `txUtxos.inputs` unconditionally includes collateral inputs alongside regular
+    // ones (its own txs_hash_utxos SQL UNION ALLs them together with no distinguishing flag beyond
+    // `collateral`). Collateral is only actually consumed when script validation fails
+    // (`valid_contract === false`); on a successful transaction it is never spent and must be
+    // excluded here, or it inflates totalInput and can flip a receive into a false "sent".
+    // On a failed transaction, only the collateral inputs represent a real spend — the regular
+    // (non-collateral) inputs/outputs the contract declared never took effect.
+    const scriptValidationFailed = fullData && blockfrostTxData.txData.valid_contract === false;
+    let rawInputs: BlockfrostTransaction['txUtxos']['inputs'] = [];
+    if (fullData) {
+        rawInputs = scriptValidationFailed
+            ? blockfrostTxData.txUtxos.inputs.filter(i => i.collateral)
+            : blockfrostTxData.txUtxos.inputs.filter(i => !i.collateral);
+    }
+    const inputs = transformInputOutput(rawInputs);
     const outputs = fullData ? transformInputOutput(blockfrostTxData.txUtxos.outputs) : [];
     const vinLength = Array.isArray(inputs) ? inputs.length : 0;
     const voutLength = Array.isArray(outputs) ? outputs.length : 0;

--- a/packages/blockchain-link/src/workers/electrum/methods/estimateFee.test.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/estimateFee.test.ts
@@ -1,0 +1,39 @@
+import estimateFee from './estimateFee';
+
+const makeClient = (feeByBlocks: Record<number, string>) => ({
+    request: jest.fn((method: string, num: number) => {
+        expect(method).toBe('blockchain.estimatefee');
+
+        return Promise.resolve(feeByBlocks[num]);
+    }),
+});
+
+describe('electrum estimateFee', () => {
+    it('estimates fee for each explicitly requested block target', async () => {
+        const client = makeClient({ 1: '0.00001000', 6: '0.00000500' });
+        const result = await estimateFee({ client } as any, { blocks: [1, 6] });
+
+        expect(client.request).toHaveBeenCalledTimes(2);
+        expect(result).toEqual([{ feePerUnit: '1000' }, { feePerUnit: '500' }]);
+    });
+
+    // blockchainEstimateFee (packages/connect/src/api/blockchainEstimateFee.ts) allows a caller to omit
+    // `request.blocks` entirely (`backend.estimateFee(request || {})`), bypassing the "smart" fee-levels
+    // loader that always supplies an explicit `blocks` array. Before this fix, an absent/empty `blocks`
+    // silently produced `[]` (no fee data, no error) instead of a usable fallback.
+    it('falls back to a single default block target when blocks is absent', async () => {
+        const client = makeClient({ 2: '0.00000800' });
+        const result = await estimateFee({ client } as any, {});
+
+        expect(client.request).toHaveBeenCalledTimes(1);
+        expect(result).toEqual([{ feePerUnit: '800' }]);
+    });
+
+    it('falls back to the default block target when blocks is an empty array', async () => {
+        const client = makeClient({ 2: '0.00000800' });
+        const result = await estimateFee({ client } as any, { blocks: [] });
+
+        expect(client.request).toHaveBeenCalledTimes(1);
+        expect(result).toEqual([{ feePerUnit: '800' }]);
+    });
+});

--- a/packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts
@@ -5,9 +5,17 @@ import { type Api, btcToSat } from '../utils';
 type Req = MessageTypes.EstimateFee;
 type Res = ResponseTypes.EstimateFee;
 
+// `blockchainEstimateFee` (packages/connect/src/api/blockchainEstimateFee.ts) allows a caller to omit
+// `request.blocks` entirely and calls `backend.estimateFee(request || {})` directly — bypassing the
+// "smart" fee-levels loader, which always supplies an explicit `blocks` array. Without a fallback here,
+// an absent `blocks` silently produced an empty result (no fee data, no error), unlike the ripple handler's
+// equivalent path, which falls back to a single sensible entry. 2 blocks (~20 min confirmation target) is
+// used as that same single-entry fallback.
+const DEFAULT_BLOCKS = [2];
+
 const estimateFee: Api<Req, Res> = ({ client }, payload) =>
     Promise.all(
-        (payload.blocks || []).map(num =>
+        (payload.blocks && payload.blocks.length > 0 ? payload.blocks : DEFAULT_BLOCKS).map(num =>
             client
                 .request('blockchain.estimatefee', num)
                 .then(btc => ({ feePerUnit: btcToSat(btc) })),


### PR DESCRIPTION
Two independent, small fixes bundled in one PR since they're both trezor-suite backlog items promoted this round after resolving their "no observed caller"/"needs API key" park reasons — happy to split into two if preferred.

## 1. electrum `estimateFee` silently returns no fee data when `blocks` is omitted

`packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts:10` did `(payload.blocks || []).map(...)`, so an absent/empty `blocks` produced an empty array with no error.

This is reachable from the public API, not just internal callers: `packages/connect/src/api/blockchainEstimateFee.ts:98` calls `backend.estimateFee(request || {})`, and `request.blocks` is optional in the `validateParams` schema — a direct `blockchainEstimateFee` call (bypassing the "smart" fee-levels loader, which always supplies an explicit `blocks` array) with no `request.blocks` reaches this path.

The ripple handler already has the correct pattern for this exact situation — when `payload.blocks` isn't a usable array, it falls back to a single sensible entry rather than returning nothing:
```ts
const payload =
    request.payload && Array.isArray(request.payload.blocks)
        ? request.payload.blocks.map(() => ({ feePerUnit: drops }))
        : [{ feePerUnit: drops }];
```

Fix mirrors that shape for electrum, falling back to a single default block target (`2`, ~20 min confirmation window) instead of an empty array.

## 2. blockfrost includes collateral inputs in the sent/received calculation, which can flip the transaction sign

`packages/blockchain-link-utils/src/blockfrost.ts`'s `transformTransaction` used `blockfrostTxData.txUtxos.inputs` directly for `totalInput`/`outgoing`, with no reference to the `collateral` flag each input carries or the transaction-level `valid_contract` flag.

Blockfrost's `inputs` field unconditionally includes collateral inputs alongside regular ones (its own open-source `txs_hash_utxos` SQL `UNION ALL`s them together with no separate field — `collateral: boolean` on each input is the only distinguishing marker). Collateral has fundamentally different spend semantics depending on script outcome:
- **Script validation succeeds** (`valid_contract: true`, the common case): collateral is never spent. Including it in `totalInput` inflates the spent amount and can flip a receive into a false "sent".
- **Script validation fails** (`valid_contract: false`): only the collateral is actually spent (as the penalty) — the regular declared inputs/outputs never took effect.

Fix filters `inputs` by `collateral` and `valid_contract` before computing `totalInput`/`outgoing`: non-collateral inputs on success, collateral-only inputs on failure.

## Testing

Both fixes have real regression tests, verified genuine red-before/green-after (stashed each source fix independently, confirmed the new tests fail with the exact predicted symptoms, restored and confirmed green):

```
electrum estimateFee: 3/3 passing (1 pre-existing + 2 new)
blockfrost transformTransaction: 15/15 passing (13 pre-existing unchanged + 2 new)
```

All 13 pre-existing `blockfrost.test.ts` fixtures are byte-unchanged and still pass — none of them exercise a collateral input (`collateral: false` throughout), so this is a pure additive fix with zero behavior change for the existing test population.

`yarn g:tsc --build` and `yarn g:eslint` both clean on all four changed files (real project-references build mode, not the noisier direct `tsc --noEmit` invocation which reports unrelated pre-existing errors repo-wide).

Codex adversarial review timed out with no output; did a thorough self-review covering fix semantics, the `valid_contract: undefined` edge case (pre-Alonzo/non-script transactions — correctly falls through to the non-collateral-filter branch, a no-op since such transactions have no collateral inputs anyway), and test-narrowness (assertions deliberately scoped to `totalInput` to isolate exactly the fixed mechanism).

## Risk

Low. Both are additive/defensive — the electrum fix only changes behavior for a previously-broken (empty) case; the blockfrost fix only changes behavior for transactions containing a `collateral: true` input, which no existing fixture has.
