### PR TITLE
fix(suite-common): fix solana token trades

### DIFF
--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.test.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.test.ts
@@ -1,0 +1,135 @@
+import { tokenProgramsInfo } from '@trezor/network-solana/constants';
+import solana from '@trezor/network-solana/runtime';
+
+import SolanaComposeTransaction from './solanaComposeTransaction';
+import { assertBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
+import { getCoinInfoOrThrow } from '../../../data/coinInfo';
+
+jest.mock('@trezor/schema-utils', () => {
+    const actual = jest.requireActual('@trezor/schema-utils');
+
+    return {
+        ...actual,
+        Assert: jest.fn(),
+    };
+});
+
+jest.mock('@trezor/network-solana/runtime', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+jest.mock('../../../backend/BlockchainLink', () => ({
+    initBlockchain: jest.fn(),
+    assertBackendSupported: jest.fn(),
+}));
+
+jest.mock('../../../data/coinInfo', () => ({
+    getCoinInfoOrThrow: jest.fn(),
+}));
+
+const VALID_PAYLOAD = {
+    method: 'solanaComposeTransaction',
+    coin: 'sol',
+    serializedTx: '00aa',
+    toAddress: 'recipient-base-address',
+    token: {
+        mint: 'fallback-token-mint',
+        program: 'spl-token',
+        decimals: 6,
+        accounts: [
+            {
+                publicKey: 'source-token-account',
+                balance: '1',
+            },
+        ],
+    },
+};
+
+const createMethod = (payload: Record<string, unknown> = VALID_PAYLOAD) =>
+    new SolanaComposeTransaction({ payload } as any);
+
+describe('solanaComposeTransaction', () => {
+    beforeEach(() => {
+        jest.mocked(getCoinInfoOrThrow).mockReturnValue({ type: 'solana' } as any);
+        jest.mocked(assertBackendSupported).mockImplementation(() => undefined);
+        jest.mocked(initBlockchain).mockResolvedValue({} as any);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('uses transfer-checked instruction data when serializedTx can be decompiled', async () => {
+        jest.mocked(solana).mockResolvedValue({
+            getDecompiledMessage: jest.fn().mockReturnValue({
+                instructions: [
+                    {
+                        type: 'transfer-checked',
+                        parsed: {
+                            accounts: {
+                                mint: { address: 'instruction-token-mint' },
+                                destination: { address: 'instruction-destination-account' },
+                            },
+                        },
+                    },
+                ],
+            }),
+        } as any);
+
+        expect(await createMethod().run({ sendCoreMessage: undefined } as any)).toEqual({
+            serializedTx: VALID_PAYLOAD.serializedTx,
+            additionalInfo: {
+                newAccountProgramName: 'spl-token',
+                tokenAccountInfo: {
+                    baseAddress: 'recipient-base-address',
+                    tokenProgram: tokenProgramsInfo['spl-token'].publicKey,
+                    tokenMint: 'instruction-token-mint',
+                    tokenAccount: 'instruction-destination-account',
+                },
+            },
+        });
+    });
+
+    it('falls back to payload token data when transfer-checked instruction is missing', async () => {
+        jest.mocked(solana).mockResolvedValue({
+            getDecompiledMessage: jest.fn().mockReturnValue({
+                instructions: [{ type: 'memo' }],
+            }),
+        } as any);
+
+        expect(await createMethod().run({ sendCoreMessage: undefined } as any)).toEqual({
+            serializedTx: VALID_PAYLOAD.serializedTx,
+            additionalInfo: {
+                newAccountProgramName: 'spl-token',
+                tokenAccountInfo: {
+                    baseAddress: 'recipient-base-address',
+                    tokenProgram: tokenProgramsInfo['spl-token'].publicKey,
+                    tokenMint: 'fallback-token-mint',
+                    tokenAccount: 'recipient-base-address',
+                },
+            },
+        });
+    });
+
+    it('falls back to payload token data when decompilation throws', async () => {
+        jest.mocked(solana).mockResolvedValue({
+            getDecompiledMessage: jest.fn(() => {
+                throw new Error('decode failed');
+            }),
+        } as any);
+
+        expect(await createMethod().run({ sendCoreMessage: undefined } as any)).toEqual({
+            serializedTx: VALID_PAYLOAD.serializedTx,
+            additionalInfo: {
+                newAccountProgramName: 'spl-token',
+                tokenAccountInfo: {
+                    baseAddress: 'recipient-base-address',
+                    tokenProgram: tokenProgramsInfo['spl-token'].publicKey,
+                    tokenMint: 'fallback-token-mint',
+                    tokenAccount: 'recipient-base-address',
+                },
+            },
+        });
+    });
+});

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -1,7 +1,7 @@
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import { SolanaComposeTransaction as SolanaComposeTransactionSchema } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { SYSTEM_PROGRAM_PUBLIC_KEY } from '@trezor/network-solana/constants';
+import { SYSTEM_PROGRAM_PUBLIC_KEY, tokenProgramsInfo } from '@trezor/network-solana/constants';
 import solana from '@trezor/network-solana/runtime';
 import { Assert } from '@trezor/schema-utils';
 
@@ -50,11 +50,49 @@ export default class SolanaComposeTransaction extends AbstractMethod<
             this.params.identity,
         );
 
-        // if the serializedTx is set, there is nothing to compose
+        // If serializedTx is provided, preserve token metadata for the signing step so
+        // firmware can resolve known SPL tokens instead of displaying a raw address.
         if (this.params.serializedTx) {
+            const { token, toAddress } = this.params;
+            let newAccountProgramName;
+            let tokenAccountInfo;
+
+            if (token && toAddress) {
+                newAccountProgramName = token.program;
+                const fallbackTokenAccountInfo = {
+                    baseAddress: toAddress,
+                    tokenProgram: tokenProgramsInfo[token.program].publicKey,
+                    tokenMint: token.mint,
+                    tokenAccount: toAddress,
+                };
+
+                try {
+                    const { getDecompiledMessage } = await solana();
+                    const decompiledMessage = getDecompiledMessage(this.params.serializedTx, true);
+                    const tokenTransferInstruction = decompiledMessage?.instructions.find(
+                        instruction => instruction.type === 'transfer-checked',
+                    );
+
+                    tokenAccountInfo = tokenTransferInstruction
+                        ? {
+                              baseAddress: toAddress,
+                              tokenProgram: tokenProgramsInfo[token.program].publicKey,
+                              tokenMint: tokenTransferInstruction.parsed.accounts.mint.address,
+                              tokenAccount:
+                                  tokenTransferInstruction.parsed.accounts.destination.address,
+                          }
+                        : fallbackTokenAccountInfo;
+                } catch {
+                    tokenAccountInfo = fallbackTokenAccountInfo;
+                }
+            }
+
             return {
                 serializedTx: this.params.serializedTx,
-                additionalInfo: {},
+                additionalInfo: {
+                    newAccountProgramName,
+                    tokenAccountInfo,
+                },
             };
         }
 

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -55,6 +55,7 @@ const tradingReducer = prepareTradingReducer({
 });
 const trxSymbol = asNetworkSymbol('trx');
 const ethSymbol = asNetworkSymbol('eth');
+const solSymbol = asNetworkSymbol('sol');
 const btcFeeData = {
     blockHeight: 890366,
     blockTime: 10,
@@ -86,6 +87,10 @@ const fees: FeesState = {
         data: btcFeeData,
     },
     [trxSymbol]: {
+        status: 'loaded',
+        data: btcFeeData,
+    },
+    [solSymbol]: {
         status: 'loaded',
         data: btcFeeData,
     },
@@ -588,6 +593,67 @@ describe('recomposeAndSignTxThunk', () => {
             },
         });
         expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep token in form output for Solana when transactionData is provided', async () => {
+        const { store, tradingFormState } = getMocks({
+            composedTransactionInfo: {
+                ...mockComposedTransactionInfo,
+                composed: {
+                    ...mockComposedTransactionInfo.composed,
+                    token: {
+                        contract: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                    } as TokenInfo,
+                },
+            },
+        });
+
+        const solanaAccount = {
+            ...accountBtc,
+            symbol: solSymbol,
+            networkType: 'solana',
+            descriptor: 'solanaAccountDescriptor',
+        } as Account;
+
+        const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce({
+            success: true,
+            payload: {
+                txid: 'txid',
+            },
+        });
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            outputs: [
+                                {
+                                    amount: '10000000',
+                                },
+                            ],
+                        },
+                    }),
+            ),
+        );
+
+        await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account: solanaAccount,
+                address: 'recipient',
+                amount: '1.25',
+                transactionData: 'abcd',
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(
+            (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mock.calls[0][0]
+                .formState.outputs[0].token,
+        ).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
     });
 
     it('should reject as cancelled when the signing flow returns no result', async () => {

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -132,9 +132,11 @@ export const recomposeAndSignTxThunk = createThunk<
 
         // Token is being used for approval transactions unless on firmware < 2.9.0.
         // Otherwise if transactionData is present, token is not used as details are in the transactionData.
+        // The exception is Solana, where token is needed for fee compose to correctly treat the transfer as token-based (fee-only in native SOL).
         const shouldIncludeToken =
             !transactionData ||
-            (isApprovalFlowSupported(device) && isEvmApprovalTx(transactionData));
+            (isApprovalFlowSupported(device) && isEvmApprovalTx(transactionData)) ||
+            network.networkType === 'solana';
 
         // prepare the fee levels, set custom values from composed
         // WORKAROUND: sendFormEthereumActions and sendFormRippleActions use form outputs instead of composed transaction data

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -83,19 +83,21 @@ export const sendDexTransactionThunk = createThunk<
             receiveAccountKey,
         });
 
-        let serializedTx: string;
-        try {
-            serializedTx = normalizeDexTransactionData({
-                data: selectedQuote.dexTx.data,
-                networkType: account.networkType,
-            });
-        } catch (error) {
-            console.error(error);
+        let serializedTx: string | undefined;
+        if (selectedQuote.dexTx.data) {
+            try {
+                serializedTx = normalizeDexTransactionData({
+                    data: selectedQuote.dexTx.data,
+                    networkType: account.networkType,
+                });
+            } catch (error) {
+                console.error(error);
 
-            return rejectWithValue({
-                type: 'error',
-                error: { id: 'TR_TRADING_INCORRECT_SERIALIZED_DATA' },
-            });
+                return rejectWithValue({
+                    type: 'error',
+                    error: { id: 'TR_TRADING_INCORRECT_SERIALIZED_DATA' },
+                });
+            }
         }
 
         const recomposeInputs = buildRecomposeInputsFromTrade({

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -532,6 +532,31 @@ describe('constructTransactionReviewOutputs', () => {
         );
     });
 
+    it('treats plain 0x calldata as a regular transfer', () => {
+        const recipient = '0x000000000000000000000000000000000000abcd';
+        const outputs = constructTransactionReviewOutputs({
+            account,
+            device,
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({ transactionData: '0x' }),
+            precomposedTx: buildPrecomposedTransaction({ to: recipient }),
+        });
+
+        expect(outputs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: 'address', value: recipient }),
+            ]),
+        );
+        expect(outputs).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: 'contract', value: recipient }),
+            ]),
+        );
+        expect(outputs).not.toEqual(
+            expect.arrayContaining([expect.objectContaining({ type: 'data', value: '0x' })]),
+        );
+    });
+
     it('keeps the raw data row for a wrapped native the firmware does not clear-sign (WBNB on BSC)', () => {
         const outputs = constructTransactionReviewOutputs({
             account: buildEthereumAccount({ symbol: bscSymbol }),

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -713,7 +713,7 @@ const constructNewFlow = ({
                     outputs.push(tokenOutput);
                     outputs.push({ type: 'address', value: o.address });
                 } else if (
-                    !isTron &&
+                    networkType === 'ethereum' &&
                     ((precomposedForm.transactionData && !isEvmApproval) ||
                         (isEvmApproval && !isApprovalFlowSupported))
                 ) {

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -89,6 +89,16 @@ const getIsUpdatedStellarSendFlow = (device: TrezorDevice, network: Account['net
     return versionUtils.isNewer(firmwareVersion, '2.9.0');
 };
 
+const isValidTxData = (transactionData?: string): transactionData is string => {
+    if (typeof transactionData !== 'string') {
+        return false;
+    }
+
+    const normalizedTransactionData = transactionData.trim().toLowerCase();
+
+    return normalizedTransactionData !== '' && normalizedTransactionData !== '0x';
+};
+
 const getCardanoTokenBundle = (account: Account, output: CardanoOutput) => {
     // Transforms cardano's tokenBundle into outputs, 1 output per one token
     // since suite supports only 1 token per output it will return just one item
@@ -392,7 +402,7 @@ const constructOldFlow = ({
     if (networkType === 'tron' && precomposedForm.destinationTag) {
         outputs.push({ type: 'note', value: precomposedForm.destinationTag });
     } else if (
-        precomposedForm.transactionData &&
+        isValidTxData(precomposedForm.transactionData) &&
         (!precomposedTx.token || isYieldOperation) &&
         !isClearSignedTradingSwap
     ) {
@@ -586,16 +596,19 @@ const constructNewFlow = ({
         });
     }
 
+    const isValidTx = isValidTxData(precomposedForm.transactionData);
+
     if (isTron && precomposedForm.destinationTag) {
         outputs.push({ type: 'note', value: precomposedForm.destinationTag });
     } else if (
-        ((precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
-            (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
-            (precomposedForm.transactionData && isYieldOp && !isUpdatedEthereumSendFlow) ||
-            (precomposedForm.transactionData && isClaimOp && !isEvmClaimClearSign)) &&
+        isValidTx &&
+        ((!precomposedTx.token && !isEvmApproval) ||
+            (isEvmApproval && !isApprovalFlowSupported) ||
+            (isYieldOp && !isUpdatedEthereumSendFlow) ||
+            (isClaimOp && !isEvmClaimClearSign)) &&
         !isClearSignedTradingSwap
     ) {
-        outputs.push({ type: 'data', value: precomposedForm.transactionData });
+        outputs.push({ type: 'data', value: precomposedForm.transactionData! });
     }
 
     const isRbf = isRbfBumpFeeTransaction(precomposedTx);
@@ -714,8 +727,8 @@ const constructNewFlow = ({
                     outputs.push({ type: 'address', value: o.address });
                 } else if (
                     networkType === 'ethereum' &&
-                    ((precomposedForm.transactionData && !isEvmApproval) ||
-                        (isEvmApproval && !isApprovalFlowSupported))
+                    isValidTx &&
+                    (!isEvmApproval || !isApprovalFlowSupported)
                 ) {
                     // EVM contract call
                     outputs.push({ type: 'contract', value: o.address });


### PR DESCRIPTION
## Description

Enables trading of Solana tokens and Ripple in Suite:
- adjusts `recomposeAndSignTxThunk` to include Solana token so the transfer is treated as token-based
- includes `tokenAccountInfo` in `solanaComposeTransaction` so firmware can resolve known SPL tokens
- ensures `targetAddress` is not classified as a token address in the confirm trade form by adjusting condition in `reviewTransactionUtils` so `type` `contract` only applies to EVM networks
- ensured `0x` is treated as empty tx data in `reviewTransactionUtils`
- skips serialization when dex tx data is not provided

## Notes for QA

Should be tested together with [SwapKit integration](https://github.com/trezor/trezor-trade-api/pull/733) and [enabled SwapKit Solana support](https://github.com/trezor/trezor-trade-api/pull/764) by trying various Solana trades.

## Related Issue

Resolve [TTA-739](https://github.com/trezor/trezor-trade-api/issues/739)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-token-trading/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-token-trading/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-token-trading&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-token-trading&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/solana-token-trading&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T15:28:21.732Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T15:27:16.608Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect Solana transaction composition, trading transaction recomposition/signing (including DEX swaps), and transaction review formatting. Risk is concentrated on signed transaction flows and device prompt details. A focused set of high-priority tests across Solana send/sell/swap, a Bitcoin sell, a DEX LI.FI swap, and an Ethereum send provides strong coverage without running the entire suite.

<details><summary><b>Changed files (7)</b></summary>

- `packages/connect/src/api/solana/api/solanaComposeTransaction.test.ts`
- `packages/connect/src/api/solana/api/solanaComposeTransaction.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the full Bitcoin sell flow including signing the sell transaction, broadcasting, and verifying amounts/fees on the device prompt. It directly covers recomposeAndSignTxThunk and reviewTransactionUtils for a non-Solana trading send.
- `suite/e2e/tests/trading/sell-solana.test.ts` — The test sends SOL as part of the sell flow and verifies device prompt details and transaction status. It directly exercises packages/connect/src/api/solana/api/solanaComposeTransaction.ts and the trading recompose/sign thunk for Solana.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This is a full DEX swap (ETH→USDC via LI.FI) that reaches the device confirmation and broadcast steps, making it the most direct E2E coverage for sendDexTransactionThunk changes.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — The test swaps native SOL for BTC and signs the Solana send transaction on the device. It directly hits solanaComposeTransaction.ts and recomposeAndSignTxThunk for a Solana swap.
- `suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts` — This test sends a Solana SPL token (USDT) as part of a cross-chain swap, which is the key Solana token transaction path affected by solanaComposeTransaction.ts and the trading signing thunk.
- `suite/e2e/tests/wallet/send-eth.test.ts` — It validates custom Ethereum fee fields and amount/fee display on the device prompt, directly testing reviewTransactionUtils rounding and formatting behavior for EVM transactions.
- `suite/e2e/tests/wallet/send-sol.test.ts` — The test covers native Solana send max calculation, reserve handling, and review/device prompt amounts, directly exercising solanaComposeTransaction.ts and reviewTransactionUtils for Solana.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect/src/api/solana/api/solanaComposeTransaction.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`

_Updated: 2026-09-09T15:26:31.309Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->