### PR TITLE
fix(suite): update fees when cardano stored delegation changes

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
@@ -7,14 +7,17 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
-import { selectVotingDelegationOption, stakeActions } from '@suite-common/wallet-core';
+import {
+    DEFAULT_VOTING_OPTION,
+    selectVotingDelegationOption,
+    stakeActions,
+} from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { getCardanoAccountDrepId, validateCardanoDrep } from '@suite-common/wallet-utils';
 import { Card, Column, Modal, Tooltip } from '@trezor/components';
 
 import { VotingDelegationsOptions } from 'src/components/earn';
 import { Fees } from 'src/components/wallet/Fees/Fees';
-import { useSeededCardanoVotingDelegation } from 'src/hooks/earn/useCardanoAccountVotingDelegation';
 import { useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import {
@@ -52,7 +55,18 @@ export const StakeChangeDelegateModalLoaded = ({
     const currentDrepId = getCardanoAccountDrepId(account);
     const isEverstake = currentDrepId === CARDANO_EVERSTAKE_DREP.bech32;
 
-    const drepIdOptionValue = useSeededCardanoVotingDelegation(account);
+    // we don't want to show current delegation option in this modal
+    // if it was pre-selected, select the default option instead
+    useEffect(() => {
+        if (selectedVotingDelegation.type !== 'current') return;
+
+        dispatch(
+            stakeActions.setAccountVotingDelegation({
+                accountKey: account.key,
+                option: DEFAULT_VOTING_OPTION,
+            }),
+        );
+    }, [dispatch, selectedVotingDelegation, account.key]);
 
     const handleCancel = () => {
         dispatch(stakeActions.clearAccountVotingDelegation());
@@ -145,11 +159,7 @@ export const StakeChangeDelegateModalLoaded = ({
                     <Card>
                         <Column gap={20} hasDivider>
                             <CurrentDelegate account={account} />
-                            <VotingDelegationsOptions
-                                account={account}
-                                hasTitle
-                                hasKeepCurrentOption={!!drepIdOptionValue}
-                            />
+                            <VotingDelegationsOptions account={account} hasTitle />
 
                             <Fees
                                 feeInfo={feeInfo}

--- a/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
+++ b/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
@@ -3,12 +3,17 @@ import { useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
 import { getStakeFormsDefaultValues, getStakingContractAddress } from '@suite-common/staking';
-import { selectBaseCurrency, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
+import {
+    selectBaseCurrency,
+    selectRawNetworkFeeInfo,
+    selectVotingDelegationOption,
+} from '@suite-common/wallet-core';
 import {
     type ChangeDelegateFormState,
     type SelectedAccountLoaded,
 } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import { useCurrentRef } from '@trezor/react-utils';
 import { throwError } from '@trezor/utils';
 
 import { signTransaction } from 'src/actions/wallet/stakeActions';
@@ -35,6 +40,9 @@ export const useChangeDelegateForm = ({
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
+    const selectedVotingDelegation = useSelector(state =>
+        selectVotingDelegationOption(state, account.key),
+    );
 
     const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account.networkType,
@@ -85,6 +93,12 @@ export const useChangeDelegateForm = ({
         ...methods,
         state,
     });
+
+    const composeRequestRef = useCurrentRef(composeRequest);
+
+    useEffect(() => {
+        composeRequestRef.current();
+    }, [composeRequestRef, selectedVotingDelegation]);
 
     const { changeFeeLevel, selectedFee: _selectedFee } = useFees({
         defaultValue: 'normal',


### PR DESCRIPTION
## Description

This PR fixes the following two bugs:
- fee didn't load in change delegation modal
- change delegation modal showed `Keep current delegation` option

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31983
Resolve https://github.com/trezor/trezor-suite/issues/31984

## Screenshots:

https://github.com/user-attachments/assets/022f2f6b-693c-4f7c-a580-5af1eeff6ce9

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/cardano-change-delegate-modal-fees/web/](https://dev.suite.sldev.cz/suite-web/fix/cardano-change-delegate-modal-fees/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-change-delegate-modal-fees&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-change-delegate-modal-fees&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T07:29:38.933Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |

</details>

_Updated: 2026-09-02T07:29:30.056Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are narrowly scoped to the staking delegate-change modal and its form hook. The static coverage mapping points to nearly every test, which is a strong signal that these files are pulled in through a global modal provider rather than being directly exercised by most tests. No analyzed test specifically covers changing a delegate, so the best available proxy is a small set of core staking flow tests (ADA, ETH, SOL) that load the staking UI and modal stack. If a dedicated change-delegate E2E test exists, it should be added and run instead.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx`
- `packages/suite/src/hooks/wallet/useChangeDelegateForm.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test exercises the full Cardano staking flow, loading the staking section and interacting with staking modals. The changed delegate-change modal and form hook live in the same staking feature area, so a regression there could affect staking page rendering or modal behavior.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The ETH initial-stake test navigates through the staking dashboard and confirmation modals. Although it does not explicitly change delegate, it relies on the staking modal/component tree that includes the changed delegate-change code, making it a useful smoke test for staking UI health.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This Solana staking test covers another staking coin path and confirms the staking form and device prompts work end-to-end. Running it helps catch any cross-coin impact from changes to shared staking form/modal infrastructure.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx`
- `packages/suite/src/hooks/wallet/useChangeDelegateForm.ts`

_Updated: 2026-09-02T07:30:01.021Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->