### PR TITLE
fix(suite-native-31681): normalize Solana DEX transaction data

### DIFF
--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -52,6 +52,7 @@ export * from './utils/exchange/composeDexTxSimulationAction';
 export * from './utils/exchange/exchangeUtils';
 export * from './utils/exchange/getExchangeIssue';
 export * from './utils/exchange/getSimulatedReceiveAmount';
+export * from './utils/exchange/normalizeDexTransactionData';
 export * from './utils/exchange/receiveAddressCoherence';
 export * from './utils/exchange/resolveExchangeTradeError';
 export * from './utils/exchange/signDataUtils';

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -16,6 +16,7 @@ import {
 } from '../../selectors/tradingSelectors';
 import { type TradingSendRejectedProps } from '../../types';
 import { getTradingFormState } from '../../utils';
+import { normalizeDexTransactionData } from '../../utils/exchange/normalizeDexTransactionData';
 import { tradingThunks } from '../common';
 import { buildRecomposeInputsFromTrade } from '../common/buildRecomposeInputsFromTrade';
 import { type RecomposeAndSignTxThunkProps } from '../common/recomposeAndSignTxThunk';
@@ -82,21 +83,19 @@ export const sendDexTransactionThunk = createThunk<
             receiveAccountKey,
         });
 
-        let serializedTx = selectedQuote.dexTx.data;
-        if (account.networkType === 'solana' && serializedTx) {
-            // let's assume data obtained from trading api are always base64
-            // convert from base64 to hex (base16)
-            try {
-                const transactionBuffer = Buffer.from(serializedTx, 'base64');
-                serializedTx = transactionBuffer.toString('hex');
-            } catch (error) {
-                console.error(error);
+        let serializedTx: string;
+        try {
+            serializedTx = normalizeDexTransactionData({
+                data: selectedQuote.dexTx.data,
+                networkType: account.networkType,
+            });
+        } catch (error) {
+            console.error(error);
 
-                return rejectWithValue({
-                    type: 'error',
-                    error: { id: 'TR_TRADING_INCORRECT_SERIALIZED_DATA' },
-                });
-            }
+            return rejectWithValue({
+                type: 'error',
+                error: { id: 'TR_TRADING_INCORRECT_SERIALIZED_DATA' },
+            });
         }
 
         const recomposeInputs = buildRecomposeInputsFromTrade({

--- a/suite-common/trading/src/utils/exchange/normalizeDexTransactionData.test.ts
+++ b/suite-common/trading/src/utils/exchange/normalizeDexTransactionData.test.ts
@@ -1,0 +1,21 @@
+import { normalizeDexTransactionData } from './normalizeDexTransactionData';
+
+describe(normalizeDexTransactionData.name, () => {
+    it('converts Solana transaction data from base64 to hex', () => {
+        expect(
+            normalizeDexTransactionData({
+                data: 'AQID/w==',
+                networkType: 'solana',
+            }),
+        ).toBe('010203ff');
+    });
+
+    it('keeps EVM transaction data unchanged', () => {
+        expect(
+            normalizeDexTransactionData({
+                data: '0xabcdef',
+                networkType: 'ethereum',
+            }),
+        ).toBe('0xabcdef');
+    });
+});

--- a/suite-common/trading/src/utils/exchange/normalizeDexTransactionData.ts
+++ b/suite-common/trading/src/utils/exchange/normalizeDexTransactionData.ts
@@ -1,0 +1,12 @@
+import { type NetworkType } from '@suite-common/wallet-config';
+
+type NormalizeDexTransactionDataParams = {
+    data: string;
+    networkType: NetworkType;
+};
+
+export const normalizeDexTransactionData = ({
+    data,
+    networkType,
+}: NormalizeDexTransactionDataParams): string =>
+    networkType === 'solana' ? Buffer.from(data, 'base64').toString('hex') : data;

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -209,6 +209,7 @@ export const composeTradingTransactionThunk = createThunk<
                     maxPriorityFeePerGas: maxPriorityFeePerGas ?? '',
                 },
                 isSlip24Active,
+                networkType: account.networkType,
                 sendAccountKey: account.key,
                 receiveAccountKey,
             });

--- a/suite-native/module-trading/src/utils/tradingFormUtils.test.ts
+++ b/suite-native/module-trading/src/utils/tradingFormUtils.test.ts
@@ -31,6 +31,7 @@ describe('createFormStateForSendForm', () => {
             const formState = createFormStateForSendForm({
                 quote: exchangeQuote,
                 feeLevel,
+                networkType: 'solana',
                 providers,
                 sendAccountKey,
             });
@@ -76,6 +77,7 @@ describe('createFormStateForSendForm', () => {
             const providers = { invity: sellInvity };
             const formState = createFormStateForSendForm({
                 quote: sellQuote,
+                networkType: 'bitcoin',
                 providers,
                 sendAccountKey,
             });
@@ -108,6 +110,7 @@ describe('createFormStateForSendForm', () => {
             const providers = { invity: exchangeInvity };
             const formState = createFormStateForSendForm({
                 quote: tokenQuote,
+                networkType: 'ethereum',
                 providers,
                 sendAccountKey,
             });
@@ -136,6 +139,7 @@ describe('createFormStateForSendForm', () => {
             const providers = { changelly: exchangeInvity };
             const formState = createFormStateForSendForm({
                 quote: xrpQuote,
+                networkType: 'ripple',
                 providers,
                 sendAccountKey,
             });
@@ -170,6 +174,7 @@ describe('createFormStateForSendForm', () => {
             const formState = createFormStateForSendForm({
                 quote,
                 extraField: customExtraField,
+                networkType: 'bitcoin',
                 providers,
                 sendAccountKey,
             });
@@ -190,6 +195,7 @@ describe('createFormStateForSendForm', () => {
             expect(() =>
                 createFormStateForSendForm({
                     quote: invalidQuote as any,
+                    networkType: 'bitcoin',
                     providers,
                     sendAccountKey,
                 }),
@@ -219,6 +225,7 @@ describe('createFormStateForSendForm', () => {
             const providers = { '1inch': exchangeInvity };
             const formState = createFormStateForSendForm({
                 quote: dexQuote,
+                networkType: 'ethereum',
                 providers,
                 sendAccountKey,
             });
@@ -227,6 +234,37 @@ describe('createFormStateForSendForm', () => {
             expect(formState.outputs[0]?.address).toBe('0xDexRouterAddress');
             expect(formState.transactionData).toBe('0xabcdef1234567890');
             expect(formState.ethereumAdjustGasLimit).toBe('1.25');
+        });
+
+        it('should convert Solana DEX transaction data from base64 to hex', () => {
+            const dexQuote: ExchangeTrade = {
+                exchange: 'jupiter',
+                send: 'solana' as any,
+                sendStringAmount: '1.0',
+                sendAddress: 'sender',
+                receive: 'solana' as any,
+                receiveStringAmount: '1.0',
+                receiveAddress: 'receiver',
+                status: 'CONFIRM',
+                orderId: 'dex-order-123',
+                quoteId: 'dex-quote-456',
+                isDex: true,
+                dexTx: {
+                    from: 'sender',
+                    to: 'receiver',
+                    data: 'AQID/w==',
+                    value: '1000000000',
+                },
+            };
+
+            const formState = createFormStateForSendForm({
+                quote: dexQuote,
+                networkType: 'solana',
+                providers: { jupiter: exchangeInvity },
+                sendAccountKey,
+            });
+
+            expect(formState.transactionData).toBe('010203ff');
         });
 
         it('should apply gas limit adjustment for DEX approval transactions', () => {
@@ -252,6 +290,7 @@ describe('createFormStateForSendForm', () => {
             const providers = { '1inch': exchangeInvity };
             const formState = createFormStateForSendForm({
                 quote: dexApprovalQuote,
+                networkType: 'ethereum',
                 providers,
                 sendAccountKey,
             });
@@ -279,6 +318,7 @@ describe('createFormStateForSendForm', () => {
             const providers = { changelly: exchangeInvity };
             const formState = createFormStateForSendForm({
                 quote: cexQuote,
+                networkType: 'ethereum',
                 providers,
                 sendAccountKey,
             });
@@ -302,7 +342,12 @@ describe('createFormStateForSendForm', () => {
             };
 
             const providers = { test: exchangeInvity };
-            const formState = createFormStateForSendForm({ quote, providers, sendAccountKey });
+            const formState = createFormStateForSendForm({
+                quote,
+                networkType: 'bitcoin',
+                providers,
+                sendAccountKey,
+            });
 
             expect(formState.selectedFee).toBe('normal');
             expect(formState.feePerUnit).toBe('');

--- a/suite-native/module-trading/src/utils/tradingFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradingFormUtils.ts
@@ -10,7 +10,9 @@ import {
     getTradingFormState,
     isExchangeTrade,
     isSellFiatTrade,
+    normalizeDexTransactionData,
 } from '@suite-common/trading';
+import { type NetworkType } from '@suite-common/wallet-config';
 import { ETHEREUM_ADJUST_GAS_LIMIT } from '@suite-common/wallet-core';
 import { type AccountKey, type FormState, type FormStateTrading } from '@suite-common/wallet-types';
 import { QuoteError } from '@suite-native/trading-quote-utils';
@@ -25,6 +27,7 @@ interface CreateFormStateForSendFormParams {
     >;
     extraField?: string;
     isSlip24Active?: boolean;
+    networkType: NetworkType;
     sendAccountKey: AccountKey | undefined;
     receiveAccountKey?: AccountKey | undefined;
 }
@@ -38,6 +41,7 @@ export const createFormStateForSendForm = ({
     feeLevel = { label: 'normal', feePerUnit: '' },
     extraField,
     isSlip24Active = false,
+    networkType,
     sendAccountKey,
     receiveAccountKey,
 }: CreateFormStateForSendFormParams): FormState => {
@@ -69,7 +73,10 @@ export const createFormStateForSendForm = ({
         // DEX quotes carry transaction data for correct fee estimation
         if (exchangeQuote.isDex && exchangeQuote.dexTx) {
             outputAddress = exchangeQuote.dexTx.to;
-            transactionData = exchangeQuote.dexTx.data;
+            transactionData = normalizeDexTransactionData({
+                data: exchangeQuote.dexTx.data,
+                networkType,
+            });
             ethereumAdjustGasLimit = ETHEREUM_ADJUST_GAS_LIMIT;
         }
 


### PR DESCRIPTION
## Description

- Normalize Solana DEX transaction data from base64 to hex for mobile transaction composition and sending.
- Preserve EVM transaction data unchanged.
- Add shared normalization utility and coverage for Solana and EVM transaction formats.

## Notes for QA
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

- Verify Solana DEX swaps compose and send successfully.
- Confirm EVM DEX transaction data remains unaffected.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31681

## Screenshots:
<!--- Keep just title, empty for later add -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated on the DEX swap transaction path (sendDexTransactionThunk and normalizeDexTransactionData) plus some suite-native/mobile trading utilities. The highest-risk user-facing path is LI.FI DEX swaps, so run the two DEX-specific E2E tests unconditionally. The remaining changed files are either broad re-exports, unit test files, or suite-native code not exercised by suite-web E2E tests; rely on unit/native tests for those.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/trading/src/index.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/trading/src/utils/exchange/normalizeDexTransactionData.test.ts`
- `suite-common/trading/src/utils/exchange/normalizeDexTransactionData.ts`
- `suite-native/module-trading/src/thunks.ts`
- `suite-native/module-trading/src/utils/tradingFormUtils.test.ts`
- `suite-native/module-trading/src/utils/tradingFormUtils.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — This test exercises the LI.FI DEX token approval flow, which sits directly on the DEX swap code path and is likely to invoke the changed DEX transaction thunk and normalizer utilities. A regression here would break ERC-20 DEX swaps.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — End-to-end DEX swap ETH to USDC via LI.FI; it composes, reviews, signs, and broadcasts a DEX transaction, exercising sendDexTransactionThunk and normalizeDexTransactionData in the full user flow. Regression would be immediately user-visible.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — Validates swap form inputs, percentages, max amount, and error states. Changes to shared trading utilities or form helpers could affect input validation and pre-submission state, though it does not exercise the DEX broadcast path.

</details>

⚠️ **Changes with no test coverage (5)**
- `suite-common/trading/src/index.ts`
- `suite-common/trading/src/utils/exchange/normalizeDexTransactionData.test.ts`
- `suite-native/module-trading/src/thunks.ts`
- `suite-native/module-trading/src/utils/tradingFormUtils.test.ts`
- `suite-native/module-trading/src/utils/tradingFormUtils.ts`

_Updated: 2026-09-02T08:24:42.028Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31681-sol-dex-mobile-issues/web/](https://dev.suite.sldev.cz/suite-web/fix/31681-sol-dex-mobile-issues/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31681-sol-dex-mobile-issues&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31681-sol-dex-mobile-issues&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31681-sol-dex-mobile-issues&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T08:26:01.887Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T08:25:07.995Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->