### PR TITLE
docs(suite-sync): clarify Evolu abstraction

### DIFF
--- a/suite-common/suite-sync-evolu/README.md
+++ b/suite-common/suite-sync-evolu/README.md
@@ -1,12 +1,24 @@
 ## Suite Sync Evolu
 
-This package is the concrete storage implementation for Evolu library.
-This is the ONLY package that shall depend on the `@evolu/common`.
-Do not import Evolu anywhere else.
+This package provides the Evolu-backed transport layer for Suite Sync. It connects
+the shared storage contract from `@suite-common/suite-sync-storage` to Evolu and
+contains the Evolu-specific setup, schema, data mapping, relay connection, and
+lifecycle management.
+
+Keeping the integration in one package gives Suite Sync a clear, modular boundary.
+The rest of Suite Sync can work with shared abstractions instead of depending on
+Evolu-specific APIs. Evolu is the current implementation, but another sync solution
+could be introduced by implementing the same storage contract without requiring
+changes throughout Suite Sync.
+
+To preserve this boundary, Evolu-specific code and direct dependencies on
+`@evolu/common` belong in this package. This keeps the integration cohesive and
+makes it easier to maintain or replace independently.
 
 ### Data
 
-In the `data` directory there is an implementation (and type-mapping)
-of abstract Suite Sync types from `suite-sync-storage` onto Evolu types.
+The `src/data` directory contains the adapters that map the abstract Suite Sync
+table types from `@suite-common/suite-sync-storage` to Evolu schemas and types.
 
-Every table has `update` and `subcribe` method for bidirectional data flow.
+Each table supports updates and subscriptions, enabling bidirectional data flow
+between Suite Sync and Evolu.


### PR DESCRIPTION
## Description

Clarify that suite-sync-evolu is the Evolu-backed transport layer behind the shared Suite Sync storage contract. Explain how this boundary keeps the integration modular and allows another sync implementation to be introduced without framing Evolu as unwanted.