### PR TITLE
Bump required FW to 1.12.1/2.5.3

### DIFF
--- a/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [1, 12, 1],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],

--- a/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json
+++ b/packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [1, 12, 1],
     "min_bootloader_version": [1, 12, 0],
     "min_firmware_version": [1, 12, 0],

--- a/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json
+++ b/packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [2, 5, 3],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],

--- a/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.3-universal.json
+++ b/packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.3-universal.json
@@ -1,5 +1,5 @@
 {
-    "required": false,
+    "required": true,
     "version": [2, 5, 3],
     "min_bootloader_version": [2, 0, 0],
     "min_firmware_version": [2, 0, 8],


### PR DESCRIPTION
## Description

By bumping minimum required firmware from 1.9.0/2.3.0 (March 2020) to 1.12.1/2.5.3 (~March 2023) we would be able to remove some legacy code branches from our codebase.

There are no strong reasons apart from cleaning things a little and maybe shrinking attack surface, but I believe there are no negative consequences either, and supporting more than 3 years old firmwares sounds enough.

## Notes for QA

**Warning:** Updating from 1.9.0 to 1.12.1 goes over two intermediary firmwares, so proper testing is needed.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bump-fw-require/web/](https://dev.suite.sldev.cz/suite-web/chore/bump-fw-require/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-fw-require&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-fw-require&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set updates firmware release metadata JSONs for T1B1 and T2T1. These files are consumed by onboarding firmware checks and the firmware update modal, so the highest-value coverage is the firmware readiness test and the T2T1 device-settings firmware-update flow. Running one T1B1 and one T2T1 onboarding create-wallet test adds confidence that the metadata does not break model-specific onboarding firmware steps. The bitcoinonly firmware variants are not expected to be exercised by the existing Suite-web E2E paths.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t1b1/universal/t1b1-1.12.1-universal.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/universal/t2t1-2.5.3-universal.json`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test directly validates firmware readiness detection during onboarding, which consumes connect-data firmware metadata to determine if the connected device firmware is current. The changed t1b1-1.12.1 and t2t1-2.5.3 JSONs are the exact release records that could alter that readiness evaluation.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — The test opens the firmware update modal on a T2T1 device, which loads the available firmware release metadata for that model. The t2t1-2.5.3 JSON changes can therefore directly affect whether the modal renders correctly or reports the expected version.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This T1B1 onboarding flow passes through the firmware step, which consults the model's firmware metadata to decide if the device is ready or needs an update. Changes to t1b1-1.12.1 firmware data could affect that decision path.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — The T2T1 onboarding create-wallet flow traverses the firmware installation/ready check step, which uses the t2t1-2.5.3 firmware release metadata. A regression in firmware parsing would likely surface here.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — The test exercises T1B1 device settings including homescreen background selection and PIN changes; available homescreen options and feature gating can depend on the model's firmware version metadata defined in t1b1-1.12.1 JSONs.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-data/files/firmware/t1b1/bitcoinonly/t1b1-1.12.1-bitcoinonly.json`
- `packages/connect-data/files/firmware/t2t1/bitcoinonly/t2t1-2.5.3-bitcoinonly.json`

_Updated: 2026-09-02T08:45:18.647Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T08:46:00.368Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T08:45:20.304Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->