### PR TITLE
[DO NOT MERGE] test(e2e): try lavapipe renderer

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -49,7 +49,7 @@ jobs:
       # `-no-metrics` keeps the emulator non-interactive (the metrics-collection
       # prompt is planned to become blocking in a future release).
       EMULATOR_OPTIONS: >-
-        -no-window -gpu swiftshader -no-snapshot-load -no-snapshot-save
+        -no-window -gpu lavapipe -no-snapshot-load -no-snapshot-save
         -noaudio -no-boot-anim -no-metrics -grpc 8554 -memory 4096
       DIAGNOSTICS_DIR: /tmp/e2e-diagnostics
       RESOURCE_MONITOR_INTERVAL_SECONDS: "2"


### PR DESCRIPTION
⚠️ DO NOT MERGE — diagnostic experiment only.

## Description

This draft PR is an isolated A/B experiment based on #31864. It changes only the Android Emulator renderer from swiftshader to lavapipe to test whether avoiding the suspected SwiftShader execution path reduces or eliminates the native QEMU SIGSEGV crashes.

Keep the existing crash collector and resource monitoring enabled. Interpret the Android E2E run only as diagnostic evidence; this branch is not a proposed production CI configuration.

## Notes for QA

No manual QA. Let the Android E2E workflow run and compare emulator SIGSEGV frequency and signatures with #31864.

## Related Issue

Diagnostic follow-up to #31864.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/e2e-android-lavapipe&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->