### PR TITLE
[DO NOT MERGE] test(e2e): disable Detox video

### DIFF
--- a/suite-native/app/.detoxrc.js
+++ b/suite-native/app/.detoxrc.js
@@ -83,7 +83,7 @@ module.exports = {
                 keepOnlyFailedTestsArtifacts: false,
             },
             video: {
-                enabled: true,
+                enabled: false,
                 keepOnlyFailedTestsArtifacts: false,
             },
             uiHierarchy: {


### PR DESCRIPTION
⚠️ DO NOT MERGE — diagnostic experiment only.

## Description

This draft PR is an isolated A/B experiment based on #31864. It disables only the Detox video artifact plugin while keeping screenshots, UI hierarchy, the swiftshader renderer, crash collection, and the normal Android E2E workload unchanged.

The goal is to determine whether continuous adb screenrecord and the additional SurfaceFlinger/codec workload increase the probability of the native QEMU SIGSEGV crashes. Changing artifact retention alone would still record every test, so this experiment disables recording itself.

## Notes for QA

No manual QA. Let the Android E2E workflow run and compare emulator SIGSEGV frequency with #31864.

## Related Issue

Diagnostic follow-up to #31864.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/e2e-android-no-video&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->