### PR TITLE
[DO NOT MERGE] test(e2e): stress NetworkIcon lifecycle

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -53,6 +53,7 @@ jobs:
         -noaudio -no-boot-anim -no-metrics -grpc 8554 -memory 4096
       DIAGNOSTICS_DIR: /tmp/e2e-diagnostics
       RESOURCE_MONITOR_INTERVAL_SECONDS: "2"
+      TDR_SKIP_TREZOR_USER_ENV: "true"
 
     steps:
       - name: Checkout project

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TEST_GROUP: [0, 1, 2, 3, 4]
+        TEST_GROUP: [0]
     env:
       # Single source of truth for the emulator options: the Detox runner reuses
       # them verbatim when it has to relaunch an emulator that died mid-run.
@@ -102,29 +102,9 @@ jobs:
         working-directory: ./suite-common/message-system
         run: yarn sign-config
 
-      - name: Generate GitHub App token
-        id: trezor-bot-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          client-id: ${{ secrets.TREZOR_BOT_APP_ID }}
-          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
-
-      - name: Extract Release Build
-        id: extract_branch
-        shell: bash
-        run: |
-          echo "release_build=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-
       - name: Get device name from detox config file
         id: device
         run: node -e "console.log('AVD_NAME=' + require('./suite-native/app/.detoxrc').devices.emulator.device.avdName)" >> $GITHUB_OUTPUT
-
-      - name: Run trezor-user-env
-        env:
-          COMPOSE_FILE: ./docker/docker-compose.suite-native-ci.yml
-        run: |
-          docker compose pull trezor-user-env-unix trezor-user-env-regtest quota-db suite-sync
-          docker compose up --detach trezor-user-env-unix trezor-user-env-regtest quota-db suite-sync
 
       - name: Download Android build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -188,17 +168,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
         env:
           RUNNER_TEMP: /tmp
-          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
-          RELEASE_BUILD: ${{ env.release_build }}
-          PUBLISH_RESULTS_TO_GITHUB: ${{ inputs.publish_results_to_github == true }}
-          TRADING_ACADEMIC_SEED_WALLET_PASSPHRASE: ${{ secrets.E2E_TEST_PASSPHRASE }}
           GITHUB_ACTION: true
-          CURRENTS_PROJECT_ID: iUe1Y4
-          CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
-          CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
-          CURRENTS_CI_BUILD_ID: ${{ inputs.currents_ci_build_id }}
-          CURRENTS_TAG: ${{ inputs.currents_tags }}
-          COMMIT_INFO_BRANCH: ${{ github.head_ref }}
         with:
           api-level: 34
           profile: pixel_6
@@ -212,30 +182,14 @@ jobs:
           cores: 4
           heap-size: 512M
           script: |
-            yarn test:e2e --config=${{ inputs.runner_config }} --shard=${{ matrix.TEST_GROUP }} --totalShards=5 --headless --quarantine
+            yarn test:e2e --config=${{ inputs.runner_config }} --project=no_device --headless e2e/tests/networkIconStress.test.ts
 
-      - name: Post Currents link
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        uses: ./.github/actions/post-currents-link
-        with:
-          github_token: ${{ steps.trezor-bot-token.outputs.token }}
-          project: "native android"
-          currents-project-id: "iUe1Y4"
-
-      - name: Extract Trezor-user-env and Regtest logs
+      - name: Collect Android tombstones
         if: ${{ !cancelled() }}
         shell: bash
         run: |
           set -euo pipefail
           LOG_DIR="suite-native/app/artifacts"
-          docker cp trezor-user-env.unix:/trezor-user-env/logs/debugging.log "$LOG_DIR/trezor-user-env-debugging.log" || true
-          docker cp trezor-user-env.unix:/trezor-user-env/logs/emulator_bridge.log "$LOG_DIR/tenv-emulator-bridge-debugging.log" || true
-          docker cp trezor-user-env.unix:/trezor-user-env/logs/tropic_model.log "$LOG_DIR/trezor-user-env-tropic_model.log" || true
-          docker cp trezor-user-env.unix:/trezor-user-env/docker/version.txt "$LOG_DIR/trezor-user-env-version.txt" || true
-          docker logs trezor-user-env-regtest > "$LOG_DIR/electrum-regtest.txt" || true
-          docker logs docker-quota-db-1 > "$LOG_DIR/quota-db.log" 2>&1 || true
-          docker logs docker-suite-sync-1 > "$LOG_DIR/suite-sync.log" 2>&1 || true
-          # Android tombstones (only available if the emulator is still reachable via ADB)
           mkdir -p "$LOG_DIR/tombstones"
           adb shell ls /data/tombstones/ 2>/dev/null \
             && adb pull /data/tombstones/. "$LOG_DIR/tombstones" \
@@ -361,6 +315,6 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: android-tests-${{ matrix.TEST_GROUP }}
+          name: android-network-icon-stress
           path: suite-native/app/artifacts
           retention-days: 14

--- a/suite-native/app/e2e/jest.perTestFile.teardown.ts
+++ b/suite-native/app/e2e/jest.perTestFile.teardown.ts
@@ -6,11 +6,13 @@ const TEARDOWN_TIMEOUT = 30_000;
 // 1) afterAll - to cover normal test run teardowns
 // 2) beforeEach - to cover cases where previous tests hang and afterAll is not called
 const stopTrezorUserEnv = async () => {
-    if (device.getPlatform() === 'android') {
-        await TrezorUserEnvLink.stopEmu();
-        await TrezorUserEnvLink.stopBridge();
-        await TrezorUserEnvLink.disconnect();
+    if (device.getPlatform() !== 'android' || process.env.TDR_SKIP_TREZOR_USER_ENV === 'true') {
+        return;
     }
+
+    await TrezorUserEnvLink.stopEmu();
+    await TrezorUserEnvLink.stopBridge();
+    await TrezorUserEnvLink.disconnect();
 };
 
 const teardownPromises = async () => {

--- a/suite-native/app/e2e/tests/networkIconStress.test.ts
+++ b/suite-native/app/e2e/tests/networkIconStress.test.ts
@@ -1,0 +1,29 @@
+import { expect as detoxExpect } from 'detox';
+
+import { openApp } from '../support/setup';
+import { wait, waitForVisible } from '../support/utils';
+
+const STRESS_DURATION_MS = 15 * 60 * 1000;
+const TEST_TIMEOUT_MS = STRESS_DURATION_MS + 2 * 60 * 1000;
+
+describe('NetworkIcon surface lifecycle stress [@noDevice]', () => {
+    it(
+        'repeatedly mounts and unmounts batches of NetworkIcon canvases',
+        async () => {
+            await openApp({});
+            await waitForVisible(by.id('@screen/NetworkIconStress'));
+
+            await device.disableSynchronization();
+            await element(by.id('@networkIconStress/start')).tap();
+            await waitForVisible(by.id('@networkIconStress/icons'));
+
+            await wait(STRESS_DURATION_MS);
+
+            await element(by.id('@networkIconStress/stop')).tap();
+            await device.enableSynchronization();
+
+            await detoxExpect(element(by.id('@screen/NetworkIconStress'))).toBeVisible();
+        },
+        TEST_TIMEOUT_MS,
+    );
+});

--- a/suite-native/app/e2e/tests/networkIconStress.test.ts
+++ b/suite-native/app/e2e/tests/networkIconStress.test.ts
@@ -1,7 +1,7 @@
 import { expect as detoxExpect } from 'detox';
 
 import { openApp } from '../support/setup';
-import { wait, waitForVisible } from '../support/utils';
+import { wait, waitForVisible, waitToHaveRegex, waitToHaveText } from '../support/utils';
 
 const STRESS_DURATION_MS = 15 * 60 * 1000;
 const TEST_TIMEOUT_MS = STRESS_DURATION_MS + 2 * 60 * 1000;
@@ -12,10 +12,15 @@ describe('NetworkIcon surface lifecycle stress [@noDevice]', () => {
         async () => {
             await openApp({});
             await waitForVisible(by.id('@screen/NetworkIconStress'));
+            await waitToHaveText(by.id('@networkIconStress/status'), 'Idle');
 
             await device.disableSynchronization();
             await element(by.id('@networkIconStress/start')).tap();
             await waitForVisible(by.id('@networkIconStress/icons'));
+            await waitToHaveRegex(
+                by.id('@networkIconStress/status'),
+                /^Running cycle [1-9]\d* with 112 icons per mount$/,
+            );
 
             await wait(STRESS_DURATION_MS);
 

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -60,6 +60,7 @@
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-native/alerts": "workspace:*",

--- a/suite-native/app/src/App.e2e.tsx
+++ b/suite-native/app/src/App.e2e.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import { networkSymbolCollection } from '@suite-common/wallet-config';
+import { NetworkIcon } from '@suite-native/icons';
+import { IntlProvider } from '@suite-native/intl';
+import { StoreProvider, initStore } from '@suite-native/state';
+
+import { StylesProvider } from './StylesProvider';
+
+const ICON_BATCH_COUNT = 4;
+const ICON_MOUNT_TOGGLE_INTERVAL_MS = 500;
+
+const stressIcons = Array.from({ length: ICON_BATCH_COUNT }).flatMap((_, batchIndex) =>
+    networkSymbolCollection.map(symbol => ({
+        key: `${batchIndex}-${symbol}`,
+        symbol,
+    })),
+);
+
+const styles = StyleSheet.create({
+    screen: {
+        flex: 1,
+        padding: 16,
+        backgroundColor: '#ffffff',
+    },
+    title: {
+        marginBottom: 8,
+        color: '#000000',
+        fontSize: 18,
+        fontWeight: '600',
+    },
+    status: {
+        marginBottom: 12,
+        color: '#000000',
+    },
+    controls: {
+        flexDirection: 'row',
+        gap: 12,
+        marginBottom: 16,
+    },
+    button: {
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+        borderRadius: 8,
+        backgroundColor: '#00854d',
+    },
+    buttonText: {
+        color: '#ffffff',
+        fontWeight: '600',
+    },
+    iconGrid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        alignContent: 'flex-start',
+        gap: 4,
+    },
+});
+
+const NetworkIconStressScreen = () => {
+    const [isRunning, setIsRunning] = useState(false);
+    const [areIconsMounted, setAreIconsMounted] = useState(false);
+    const [cycle, setCycle] = useState(0);
+
+    useEffect(() => {
+        if (!isRunning) {
+            return undefined;
+        }
+
+        const intervalId = setInterval(() => {
+            setAreIconsMounted(iconsMounted => !iconsMounted);
+            setCycle(currentCycle => currentCycle + 1);
+        }, ICON_MOUNT_TOGGLE_INTERVAL_MS);
+
+        return () => clearInterval(intervalId);
+    }, [isRunning]);
+
+    const startStressTest = () => {
+        setCycle(0);
+        setAreIconsMounted(true);
+        setIsRunning(true);
+    };
+
+    const stopStressTest = () => {
+        setIsRunning(false);
+        setAreIconsMounted(false);
+    };
+
+    return (
+        <View style={styles.screen} testID="@screen/NetworkIconStress">
+            <Text style={styles.title}>NetworkIcon surface lifecycle stress test</Text>
+            <Text style={styles.status} testID="@networkIconStress/status">
+                {isRunning
+                    ? `Running cycle ${cycle} with ${stressIcons.length} icons per mount`
+                    : 'Idle'}
+            </Text>
+            <View style={styles.controls}>
+                <Pressable
+                    accessibilityRole="button"
+                    disabled={isRunning}
+                    onPress={startStressTest}
+                    style={styles.button}
+                    testID="@networkIconStress/start"
+                >
+                    <Text style={styles.buttonText}>Start</Text>
+                </Pressable>
+                <Pressable
+                    accessibilityRole="button"
+                    disabled={!isRunning}
+                    onPress={stopStressTest}
+                    style={styles.button}
+                    testID="@networkIconStress/stop"
+                >
+                    <Text style={styles.buttonText}>Stop</Text>
+                </Pressable>
+            </View>
+            {areIconsMounted && (
+                <View style={styles.iconGrid} testID="@networkIconStress/icons">
+                    {stressIcons.map(({ key, symbol }) => (
+                        <NetworkIcon key={key} symbol={symbol} size="extraLarge" />
+                    ))}
+                </View>
+            )}
+        </View>
+    );
+};
+
+const store = initStore();
+
+export const App = () => (
+    <StoreProvider store={store}>
+        <IntlProvider>
+            <SafeAreaProvider>
+                <StylesProvider>
+                    <NetworkIconStressScreen />
+                </StylesProvider>
+            </SafeAreaProvider>
+        </IntlProvider>
+    </StoreProvider>
+);

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -28,6 +28,9 @@
             "path": "../../suite-common/suite-types"
         },
         {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11949,6 +11949,7 @@ __metadata:
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-native/alerts": "workspace:*"


### PR DESCRIPTION
⚠️ DO NOT MERGE — destructive diagnostic experiment only.

## Description

This draft PR is a focused reproducer based on #31864. The E2E-only app entry point renders no normal Suite navigation. Instead, it repeatedly mounts and unmounts four copies of every configured NetworkIcon (currently 112 Skia canvases per mount) every 500 ms for 15 minutes.

The Android workflow runs one job, one no_device project, and only e2e/tests/networkIconStress.test.ts. Trezor-user-env, Currents reporting, all normal E2E files, and unrelated runtime variables are disabled. The baseline swiftshader renderer and Detox video recording remain enabled so the experiment tests the suspected NetworkIcon/Skia SurfaceTexture lifecycle under the same graphics path as #31864.

The host resource monitor, Android tombstone collection, QEMU coredumps, and GDB backtraces remain enabled. A dead emulator is still recovered and the project is retried once, providing another reproduction attempt.

## Notes for QA

No manual QA. Let the Android E2E workflow run. Success means the emulator survived the complete 15-minute mount/unmount loop; failure should be evaluated through the QEMU backtrace and device log artifacts.

## Related Issue

Diagnostic follow-up to #31864.