### PR TITLE
chore(suite): remove dead capability type fields left after legacy check removal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
@@ -11,7 +11,6 @@ import { RequestEnableTorResponse } from '@suite-common/suite-config';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { type Network, type NetworkAccount, type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectAccounts } from '@suite-common/wallet-core';
-import { type UnavailableCapabilities } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 import { resolveAfter } from '@trezor/utils';
 
@@ -23,7 +22,6 @@ import { AddButton } from './AddButton';
 interface VerifyAvailabilityProps {
     coinjoinAccounts: Account[];
     symbol: NetworkSymbol;
-    unavailableCapabilities?: UnavailableCapabilities;
 }
 
 const verifyAvailability = ({ coinjoinAccounts, symbol }: VerifyAvailabilityProps) => {

--- a/suite-common/wallet-core/src/fees/feesUtils.ts
+++ b/suite-common/wallet-core/src/fees/feesUtils.ts
@@ -1,4 +1,3 @@
-import { type TrezorDevice } from '@suite-common/suite-types';
 import { type Network, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { isEip1559 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type FeeLevel } from '@trezor/connect';
@@ -30,7 +29,6 @@ export const sortLevels = (levelA: FeeLevel, levelB: FeeLevel) =>
 type GetEip1559AvailabilityProps = {
     symbol: NetworkSymbol;
     feeLevel: FeeLevel;
-    device?: TrezorDevice;
 };
 const getEip1559Availability = ({ symbol, feeLevel }: GetEip1559AvailabilityProps) =>
     getNetwork(symbol).features.includes('eip1559') && isEip1559(feeLevel);


### PR DESCRIPTION
## Description

Small follow-up cleanup stacked on top of #31862.

That PR removed the device capability checks for `eip1559` and `coinjoin`, but left two now-unused optional type members behind together with the imports that only existed to type them. This removes the dead code:

- **`suite-common/wallet-core/src/fees/feesUtils.ts`** — `GetEip1559AvailabilityProps.device?: TrezorDevice` is no longer destructured/read by `getEip1559Availability` and no caller passes it; the `TrezorDevice` import survived only via that field.
- **`packages/suite/.../AddAccountButton/AddCoinjoinAccountButton.tsx`** — `VerifyAvailabilityProps.unavailableCapabilities?: UnavailableCapabilities` is no longer destructured by `verifyAvailability` and the call site no longer passes it; the `UnavailableCapabilities` import survived only via that field.

Both are behavior-preserving removals — no runtime, type-check, or lint impact (unused optional type members and their type-only imports don't fail CI, they're just dead references).

## Related

- Base branch / parent PR: #31862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/remove-legacy-signing-dead-code&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->