### PR TITLE
chore(e2e): enforce test stream annotation via typing and lint

### DIFF
--- a/eslint-local-rules/enforce-e2e-test-stream/rule.test.ts
+++ b/eslint-local-rules/enforce-e2e-test-stream/rule.test.ts
@@ -1,0 +1,66 @@
+import { RuleTester } from 'eslint';
+import { parser } from 'typescript-eslint';
+
+import { enforceE2eTestStreamRule } from './rule';
+
+const typescriptRuleTester = new RuleTester({
+    languageOptions: {
+        parser,
+        parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+    },
+});
+
+typescriptRuleTester.run('enforce-e2e-test-stream', enforceE2eTestStreamRule, {
+    valid: [
+        {
+            code: "test('a', { annotation: createTestAnnotation({ stream: TestStream.Wallet }) }, async () => {});",
+        },
+        {
+            code: "test('a', { ...tagOptions, annotation: createTestAnnotation({ stream: TestStream.Earn }) }, async () => {});",
+        },
+        {
+            code: "test.skip('a', { annotation: createTestAnnotation({ stream: TestStream.Growth }) }, async () => {});",
+        },
+        // The metadata is typed by TestMetadataInput, so the rule does not inspect its contents.
+        {
+            code: "test('a', { annotation: createTestAnnotation(sharedMetadata) }, async () => {});",
+        },
+        // Tests are declared by test(), test.skip(), test.fixme() and test.only() only.
+        { code: "test.describe('group', () => {});" },
+        { code: "test.describe.skip('group', () => {});" },
+        { code: 'test.use({ deviceSetup: {} });' },
+        { code: 'test.beforeEach(async () => {});' },
+        { code: "test.step('a step', async () => {});" },
+        { code: "it('a jest test', async () => {});" },
+    ],
+    invalid: [
+        {
+            code: "test('a', async () => {});",
+            errors: [{ messageId: 'missingOptions' }],
+        },
+        {
+            code: "test.fixme('a', async () => {});",
+            errors: [{ messageId: 'missingOptions' }],
+        },
+        {
+            code: "test('a', { tag: ['@webOnly'] }, async () => {});",
+            errors: [{ messageId: 'missingAnnotation' }],
+        },
+        {
+            code: "test('a', { ...tagOptions }, async () => {});",
+            errors: [{ messageId: 'missingAnnotation' }],
+        },
+        {
+            code: "test('a', tagOptions, async () => {});",
+            errors: [{ messageId: 'optionsNotObject', data: { name: 'tagOptions' } }],
+        },
+        {
+            code: "test('a', { annotation: sharedAnnotation }, async () => {});",
+            errors: [{ messageId: 'annotationShape' }],
+        },
+        {
+            code: "test('a', { annotation: [{ type: 'stream', description: 'Wallet' }] }, async () => {});",
+            errors: [{ messageId: 'annotationShape' }],
+        },
+    ],
+} as Parameters<typeof typescriptRuleTester.run>[2]);

--- a/eslint-local-rules/enforce-e2e-test-stream/rule.ts
+++ b/eslint-local-rules/enforce-e2e-test-stream/rule.ts
@@ -1,0 +1,101 @@
+import type { Rule } from 'eslint';
+import type { CallExpression, Expression, ObjectExpression, Property, SpreadElement } from 'estree';
+
+const TEST_MODIFIERS = new Set(['skip', 'fixme', 'only']);
+const ANNOTATION_HELPER = 'createTestAnnotation';
+const STREAM_ENUM = 'TestStream';
+
+const isTestCall = (node: CallExpression) => {
+    const { callee } = node;
+    if (callee.type === 'Identifier') {
+        return callee.name === 'test';
+    }
+
+    // test.skip / test.fixme / test.only declare tests; test.describe, test.use and the hooks do not.
+    return (
+        callee.type === 'MemberExpression' &&
+        callee.object.type === 'Identifier' &&
+        callee.object.name === 'test' &&
+        callee.property.type === 'Identifier' &&
+        TEST_MODIFIERS.has(callee.property.name)
+    );
+};
+
+const isTestBody = (node: Expression | SpreadElement | undefined) =>
+    node?.type === 'ArrowFunctionExpression' || node?.type === 'FunctionExpression';
+
+const findAnnotation = (options: ObjectExpression): Property | undefined =>
+    options.properties.find(
+        (property): property is Property =>
+            property.type === 'Property' &&
+            ((property.key.type === 'Identifier' && property.key.name === 'annotation') ||
+                (property.key.type === 'Literal' && property.key.value === 'annotation')),
+    );
+
+const isAnnotationHelperCall = (annotation: Property['value']) =>
+    annotation.type === 'CallExpression' &&
+    annotation.callee.type === 'Identifier' &&
+    annotation.callee.name === ANNOTATION_HELPER;
+
+/**
+ * Guards the one thing types cannot: a test that carries no annotation at all, so
+ * `TestMetadataInput` never applies and the reporter falls back to an unassigned stream.
+ */
+export const enforceE2eTestStreamRule: Rule.RuleModule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Enforces that every e2e test declares its owning team through a createTestAnnotation call.',
+            recommended: false,
+        },
+        messages: {
+            annotationShape: `Build the annotation with ${ANNOTATION_HELPER}({ ... }) so its metadata is type-checked.`,
+            missingAnnotation: `This test's options have no annotation. Add annotation: ${ANNOTATION_HELPER}({ stream: ${STREAM_ENUM}.Wallet }) next to the options that are already there.`,
+            missingOptions: `This test has no options object. Insert { annotation: ${ANNOTATION_HELPER}({ stream: ${STREAM_ENUM}.Wallet }) } between the title and the test body.`,
+            optionsNotObject: `Spread the options into an object literal so the annotation stays visible: { ...{{name}}, annotation: ${ANNOTATION_HELPER}({ stream: ${STREAM_ENUM}.Wallet }) }.`,
+        },
+        schema: [],
+    },
+    create(context) {
+        return {
+            CallExpression(node) {
+                const call = node as unknown as CallExpression;
+                if (!isTestCall(call)) {
+                    return;
+                }
+
+                const [, options] = call.arguments;
+                if (!options || isTestBody(options)) {
+                    context.report({ node, messageId: 'missingOptions' });
+
+                    return;
+                }
+
+                if (options.type !== 'ObjectExpression') {
+                    context.report({
+                        node: options as Rule.Node,
+                        messageId: 'optionsNotObject',
+                        data: { name: options.type === 'Identifier' ? options.name : 'options' },
+                    });
+
+                    return;
+                }
+
+                const annotation = findAnnotation(options);
+                if (!annotation) {
+                    context.report({ node: options as Rule.Node, messageId: 'missingAnnotation' });
+
+                    return;
+                }
+
+                if (!isAnnotationHelperCall(annotation.value)) {
+                    context.report({
+                        node: annotation.value as Rule.Node,
+                        messageId: 'annotationShape',
+                    });
+                }
+            },
+        };
+    },
+};

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -6,6 +6,7 @@ require('ts-node').register({
 });
 
 const { analyticsEventNameRule } = require('./analytics-event-name/rule');
+const { enforceE2eTestStreamRule } = require('./enforce-e2e-test-stream/rule');
 const { enforceDiFactoryContractsRule } = require('./named-contracts/di/rule');
 const { enforceThunkContractsRule } = require('./named-contracts/thunks/rule');
 const { noOverrideDsComponentRule } = require('./no-override-ds-component/rule');
@@ -16,6 +17,7 @@ const { noUnusedIntersectionMembersRule } = require('./no-unused-intersection-me
 module.exports = {
     'analytics-event-name': analyticsEventNameRule,
     'enforce-di-factory-contracts': enforceDiFactoryContractsRule,
+    'enforce-e2e-test-stream': enforceE2eTestStreamRule,
     'enforce-thunk-contracts': enforceThunkContractsRule,
     'no-override-ds-component': noOverrideDsComponentRule,
     'no-package-deep-imports': noPackageDeepImportsRule,

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
         "@swc/core": "^1.15.47",
         "@swc/jest": "^0.2.39",
         "@trezor/eslint": "workspace:*",
+        "@types/estree": "^1.0.8",
         "@types/jest": "30.0.0",
         "@types/node": "22.13.10",
         "@typescript/native-preview": "npm:typescript@^7.0.2",

--- a/packages/e2e-utils/src/githubReporter/types.ts
+++ b/packages/e2e-utils/src/githubReporter/types.ts
@@ -1,3 +1,11 @@
+import type {
+    DeviceModel,
+    TestCategory,
+    TestOsMatrix,
+    TestPriority,
+    TestStream,
+} from '../enums/testAnnotations';
+
 export interface LoggingFunctions {
     log: (...args: any[]) => void;
     logError: (...args: any[]) => void;
@@ -110,13 +118,16 @@ export interface TestDetailsAnnotation {
     description?: string | undefined;
 }
 
+// NotDefined is the reporter's fallback for tests that carry no annotation, never an assignment.
+export type AssignedTestStream = Exclude<TestStream, TestStream.NotDefined>;
+
 export interface TestMetadataInput {
     testCase?: string;
     prerequisites?: string[];
     steps?: string[];
-    category?: string;
-    priority?: string;
-    stream?: string;
-    deviceModel?: string;
-    osMatrix?: string[];
+    category?: TestCategory;
+    priority?: TestPriority;
+    stream: AssignedTestStream;
+    deviceModel?: DeviceModel;
+    osMatrix?: TestOsMatrix[];
 }

--- a/packages/e2e-utils/src/githubReporter/watchdog/samples.ts
+++ b/packages/e2e-utils/src/githubReporter/watchdog/samples.ts
@@ -6,6 +6,7 @@ import {
     TestStatus,
     TestStream,
 } from '../../enums/testAnnotations';
+import type { AssignedTestStream } from '../types';
 
 interface ReporterWatchdogManualSample {
     testCase: string;
@@ -13,7 +14,7 @@ interface ReporterWatchdogManualSample {
     steps: string[];
     category: TestCategory;
     priority: TestPriority;
-    stream: TestStream;
+    stream: AssignedTestStream;
     deviceModel: DeviceModel;
     osMatrix: TestOsMatrix[];
 }

--- a/packages/e2e-utils/src/index.ts
+++ b/packages/e2e-utils/src/index.ts
@@ -19,7 +19,11 @@ export {
     REPORTER_WATCHDOG_NATIVE_MANUAL_SAMPLES,
 } from './githubReporter/watchdog/samples';
 export { TestReportProviderBase, createTestAnnotation } from './githubReporter/annotationBase';
-export type { TestDetailsAnnotation, TestMetadataInput } from './githubReporter/types';
+export type {
+    AssignedTestStream,
+    TestDetailsAnnotation,
+    TestMetadataInput,
+} from './githubReporter/types';
 export type * from './githubReporter/types';
 export { resolvePullRequestNumber, resolveRunUrl, upsertStickyPrComment } from './gitHub/prComment';
 export type { StickyPrCommentResult } from './gitHub/prComment';

--- a/suite/e2e/docs/e2e-github-reporter.md
+++ b/suite/e2e/docs/e2e-github-reporter.md
@@ -32,18 +32,23 @@ The framework consists of three main components:
 
 ## Annotation Types
 
-Test annotations are defined in `testAnnotations.ts`, all of them are optional and include:
+Test annotations are defined in `testAnnotations.ts`. Every annotation is optional except `stream`,
+which `TestMetadataInput` requires. The `local-rules/enforce-e2e-test-stream` lint rule covers what
+typing cannot: a test in `suite/e2e/tests` that carries no annotation at all.
 
-| Annotation Type | Description                                            |
-| --------------- | ------------------------------------------------------ |
-| `testCase`      | The title of the test                                  |
-| `prerequisites` | List of requirements before running the test           |
-| `steps`         | List of steps to execute the test                      |
-| `category`      | Test category (e.g., Onboarding, Security, Wallets)    |
-| `priority`      | Test priority (Critical, High, Medium, Low)            |
-| `stream`        | Team assignment (Trends, Foundation, Engagement, etc.) |
-| `deviceModel`   | Target device model (T1B1, T2T1, etc.)                 |
-| `osMatrix`      | Operating systems to test on                           |
+| Annotation Type | Description                                                           |
+| --------------- | --------------------------------------------------------------------- |
+| `testCase`      | The title of the test                                                 |
+| `prerequisites` | List of requirements before running the test                          |
+| `steps`         | List of steps to execute the test                                     |
+| `category`      | Test category (e.g., Onboarding, Security, Wallets)                   |
+| `priority`      | Test priority (Critical, High, Medium, Low)                           |
+| `stream`        | Owning team (Connect, Earn, Firmware, Growth, Network, Trade, Wallet) |
+| `deviceModel`   | Target device model (T1B1, T2T1, etc.)                                |
+| `osMatrix`      | Operating systems to test on                                          |
+
+`TestStream.NotDefined` is the reporter's fallback for tests without an annotation and is excluded
+from `AssignedTestStream`, so it cannot be assigned in a test.
 
 ## Project Fields
 

--- a/suite/e2e/eslint.config.mjs
+++ b/suite/e2e/eslint.config.mjs
@@ -28,6 +28,12 @@ export default [
         },
     },
     {
+        files: ['**/tests/**/*.test.ts'],
+        rules: {
+            'local-rules/enforce-e2e-test-stream': 'error',
+        },
+    },
+    {
         files: ['**/tests/manual/**'],
         rules: {
             'playwright/no-skipped-test': 'off',

--- a/yarn.lock
+++ b/yarn.lock
@@ -45559,6 +45559,7 @@ __metadata:
     "@swc/core": "npm:^1.15.47"
     "@swc/jest": "npm:^0.2.39"
     "@trezor/eslint": "workspace:*"
+    "@types/estree": "npm:^1.0.8"
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:22.13.10"
     "@typescript/native-preview": "npm:typescript@^7.0.2"


### PR DESCRIPTION
## Description

Makes the `stream` annotation impossible to omit, split across the two mechanisms that can each enforce part of it.

Typing (`packages/e2e-utils`):

- `TestMetadataInput.stream` is now required and typed `AssignedTestStream` (`Exclude<TestStream, TestStream.NotDefined>`), so a missing stream, a typo, a bare string, or the reporter's fallback value are all compile errors. Previously every metadata field was `string`, so `stream: 'Fondation'` type-checked and reached the project board as-is.
- `NotDefined` stays in `TestStream` because the reporter still needs a fallback for tests without an annotation. It now lives only in the reporter's defaults and cannot be assigned from a test.
- `category`, `priority`, `deviceModel` and `osMatrix` are typed to their enums for the same reason.

Lint (`eslint-local-rules/enforce-e2e-test-stream`, enabled for `suite/e2e/tests/**/*.test.ts`):

- Catches the one case types cannot see — a test with no annotation, where `createTestAnnotation` is never called. That was 121 of the 197 tests fixed in the base branch.
- Four messages: no options object, options without an annotation, an annotation that bypasses `createTestAnnotation`, and options passed as a variable rather than an object literal. It deliberately does not inspect the metadata contents; typing does that.

Targets #31987 — review that one first.

## Notes for QA

No runtime change; this only affects compilation and linting. Test behaviour, tagging and the GitHub reporter output are untouched. Nothing to verify manually.

## Related Issue

Resolve <!--- link the issue here -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
