### PR TITLE
fix(connect): firmware rollout bucketing excludes ~1% of devices at any rollout percentage, including 100

### DIFF
--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -390,8 +390,13 @@ const calculateShouldOfferRelease = (
         // unless rolloutProbability is 0, in that case we should never offer it.
         return rolloutProbability > 0;
     } else {
-        // If deviceId is provided, use the deterministic approach.
-        const deterministicValueToCompare = getIntegerInRangeFromString(deviceId, 101);
+        // If deviceId is provided, use the deterministic approach. `rolloutProbability` is a
+        // 0..100 percentage compared with `<`, so the bucket count must be 100 (values 0..99) -
+        // passing 101 here would bucket one extra value (100) that can never satisfy `< 100`,
+        // permanently excluding ~1% of devices from being offered a release at ANY rollout
+        // percentage including 100. See the sibling usage in
+        // suite-common/message-system/src/experimentUtils.ts for the same pattern done right.
+        const deterministicValueToCompare = getIntegerInRangeFromString(deviceId, 100);
 
         return deterministicValueToCompare < rolloutProbability;
     }

--- a/packages/connect/src/data/getReleaseInfo.firmware.test.ts
+++ b/packages/connect/src/data/getReleaseInfo.firmware.test.ts
@@ -42,6 +42,44 @@ const fixtures = [
         },
     },
     {
+        // Regression test: `calculateShouldOfferRelease` used to bucket device ids into 101
+        // buckets (0..100 via `getIntegerInRangeFromString(deviceId, 101)`) but compared the
+        // result against a 0..100 rollout_probability with `<`, so bucket 100 could never
+        // satisfy `< 100` at ANY rollout percentage, including 100. This device_id was found by
+        // brute-forcing the real project hash function for one that lands in bucket 100 under
+        // the buggy max=101 - verified independently outside this test suite. Every other
+        // fixture in this file uses the default mocked device_id ('device-id'), which happens
+        // not to land in the excluded bucket, which is exactly why this bug went unnoticed.
+        desc: 'A device id that hashes into the excluded bucket is still offered at rollout_probability 100',
+        releasesOfDevice: releasesT2T1,
+        features: getDeviceFeatures({
+            bootloader_mode: null,
+            major_version: 2,
+            minor_version: 8,
+            patch_version: 7,
+            device_id: '36647600C9CEB95187D31BC5',
+        }),
+        release: latestT2T1,
+        conditions: {
+            environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
+            rollout_probability: 100,
+        },
+        isBitcoinOnlyAvailable: true,
+        firmwareType: FirmwareType.Universal,
+        result: {
+            releaseConditions: {
+                environment: { min_suite_version: '25.2.1', min_suite_native_version: '25.2.1' },
+                rollout_probability: 100,
+                shouldBeOffered: true,
+            },
+            release: latestT2T1,
+            intermediary: undefined,
+            isRequired: false,
+            isNewer: true,
+            translations: latestT2T1.translations,
+        },
+    },
+    {
         desc: 'Having newer version makes release `isNewer` and probability 0 `shouldBeOffered` false',
         releasesOfDevice: releasesT2T1,
         features: getDeviceFeatures({


### PR DESCRIPTION
## Description

Internal branch for #31966, see details there

## Notes for QA

Not easily testable

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches firmware release-info logic in @trezor/connect, which is a broad dependency referenced by many suites. Risk is concentrated in onboarding firmware checks, device authenticity/revision checks, and firmware update/install flows. The recommended tests target these specific flows rather than the full transitive dependency list.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/data/firmwareInfo.ts`
- `packages/connect/src/data/getReleaseInfo.firmware.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test directly exercises the custom firmware installation flow in Settings > Device. Changes to firmwareInfo.ts (which supplies firmware release metadata) could alter how custom firmware binaries are validated or how the post-install reconnect state is determined.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — The test explicitly toggles firmware hash check and firmware revision check settings during onboarding and must pass the authenticity check. These checks depend on firmware release info from firmwareInfo.ts, so a regression here would be immediately visible.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test is narrowly focused on detecting that device firmware is ready during onboarding. It directly relies on the firmware readiness detection logic that firmwareInfo.ts feeds into.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — The test runs onboarding firmware setup and revision checks while the app is offline. If firmwareInfo.ts changes offline release-info resolution or revision-check behavior, this flow could fail.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Opens the firmware update modal from device settings. Changes to firmwareInfo.ts could affect whether the modal loads available release info or errors on load.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Opens the firmware update modal from device settings. Changes to firmwareInfo.ts could affect whether the modal loads available release info or errors on load.
- `suite/e2e/tests/suite/initial-run.test.ts` — Optionally dismisses a firmware hash check error modal during initial onboarding. If firmwareInfo.ts changes how firmware hashes/revisions are resolved, this modal path may be triggered differently.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/data/getReleaseInfo.firmware.test.ts`

_Updated: 2026-09-03T08:42:12.395Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gomesalexandre/fix_firmware_rollout_bucket_off_by_one/web/](https://dev.suite.sldev.cz/suite-web/gomesalexandre/fix_firmware_rollout_bucket_off_by_one/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=gomesalexandre/fix_firmware_rollout_bucket_off_by_one&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=gomesalexandre/fix_firmware_rollout_bucket_off_by_one&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=gomesalexandre/fix_firmware_rollout_bucket_off_by_one&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T08:44:09.644Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T08:43:34.817Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->