### PR TITLE
refactor(suite-desktop): remove dead bridge rollout settings

### DIFF
--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -113,7 +113,6 @@ export type Status = {
 // todo: duplicate, see prev comment
 export type BridgeSettings = {
     doNotStartOnStartup: boolean;
-    legacy?: boolean;
 };
 
 export type BioAuthSettings = {

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -114,7 +114,6 @@ export type Status = {
 export type BridgeSettings = {
     doNotStartOnStartup: boolean;
     legacy?: boolean;
-    newBridgeRollout?: number;
 };
 
 export type BioAuthSettings = {

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -121,10 +121,6 @@ declare type BridgeSettings = {
      * Force suite not to start bridge on application startup
      */
     doNotStartOnStartup: boolean;
-    /**
-     * Should run trezord-go
-     */
-    legacy?: boolean;
 };
 
 declare type TraySettings = {

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -125,10 +125,6 @@ declare type BridgeSettings = {
      * Should run trezord-go
      */
     legacy?: boolean;
-    /**
-     * Should run the new bridge?
-     */
-    newBridgeRollout?: number;
 };
 
 declare type TraySettings = {

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -91,7 +91,6 @@ export class Store {
     public getBridgeSettings() {
         return this.store.get('bridgeSettings', {
             doNotStartOnStartup: false,
-            legacy: false,
         });
     }
 


### PR DESCRIPTION
## Description

Removes two dead fields from the desktop `BridgeSettings` type, both leftovers of the old trezord-go-vs-node-bridge rollout:

- **`newBridgeRollout?: number`** — never read or written anywhere. Only existed in the two `BridgeSettings` type declarations.
- **`legacy?: boolean`** — no longer read as a decision input. The bridge module now always runs the bundled node bridge (`TrezordNode` from `@trezor/transport-bridge`) unconditionally and never branches on this flag.

The last reader of both was removed in `8a74cb2a65` ("feat(suite-desktop): remove node-bridge rollout"). Since then the fields have been pure vestiges.

## Why

Dead code. `git grep newBridgeRollout` returns exactly two hits (both type declarations, zero property accesses); `legacy` on `BridgeSettings` has no remaining readers. Keeping them around is misleading — they suggest a rollout/legacy branch that no longer exists.

## Changes (2 commits)

1. `refactor(suite-desktop): remove dead newBridgeRollout bridge setting` — drop the field from `packages/suite-desktop-api/src/messages.ts` and the hand-maintained ambient duplicate in `packages/suite-desktop-core/src/index.d.ts`.
2. `refactor(suite-desktop): remove dead legacy bridge setting` — drop `legacy` from both declarations plus its `false` default in the electron-store getter (`store.ts`).

## Notes for QA

- The two `BridgeSettings` declarations are a deliberate, un-codegen'd duplication (see the `// todo: duplicate` comment in `messages.ts`; `suite-desktop-api` can't depend on `suite-desktop`), so both copies are updated together.
- Backwards compatible: `electron-store` has no schema/migrations, so a value persisted by an older Suite simply lingers on disk unread — no runtime path ever consumed it.
- Both fields were optional and never read, so removal is type-safe; the only object literal typed as `BridgeSettings` (the store default) had `legacy: false` removed to avoid an excess-property error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
