### PR TITLE
test(native): enable quarantine bot for ios

### DIFF
--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -195,8 +195,9 @@ jobs:
           GITHUB_ACTION: true
           CURRENTS_PROJECT_ID: LjEjiV
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
+          CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
           CURRENTS_CI_BUILD_ID: pr-run-${{ github.run_id }}-${{ github.run_attempt }}
-        run: yarn test:e2e --config=e2e/trezorDetoxRunner/config/runner-ios-release.config.js --shard=${{ matrix.TEST_GROUP }} --totalShards=2 --headless
+        run: yarn test:e2e --config=e2e/trezorDetoxRunner/config/runner-ios-release.config.js --shard=${{ matrix.TEST_GROUP }} --totalShards=2 --headless --quarantine
 
       - name: "Store test artifacts"
         if: ${{ !cancelled() }}

--- a/packages/e2e-utils/src/quarantineBot/config.ts
+++ b/packages/e2e-utils/src/quarantineBot/config.ts
@@ -23,5 +23,6 @@ export const PROJECTS: Array<{ id: string; name: string; label: string }> = [
     { id: 'Og0NOQ', name: 'web', label: 'Trezor Suite (web)' },
     { id: '4ytF0E', name: 'desktop', label: 'Trezor Suite (desktop)' },
     { id: 'iUe1Y4', name: 'android', label: 'Trezor Suite Native (Android)' },
+    { id: 'LjEjiV', name: 'ios', label: 'Trezor Suite Native (iOS)' },
     //{ id: 'iBEsWE', name: 'playground', label: 'Experimental Playground' },
 ];


### PR DESCRIPTION
## What

Brings iOS into the quarantine bot. Three things were missing, and all of them were needed together:

- `PROJECTS` had no entry for the iOS Currents project (`LjEjiV`), so the bot never inspected, quarantined or restored iOS tests.
- The iOS job never passed `CURRENTS_API_KEY`, so the runner's action fetch returned an empty list.
- The iOS job never passed `--quarantine`, so the fetch never ran in the first place.

Android already had all three — this just brings iOS in line.

## Validation

Verified with two deliberately failing tests in `appSettings.test.ts`, one of them quarantined:

https://github.com/trezor/trezor-suite/actions/runs/33599369883

The quarantined test was reported as skipped and the control still failed the job. The sabotage commit has been removed from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ios-quarantine&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ios-quarantine&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T10:52:25.665Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T10:51:48.454Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ios-quarantine/web/](https://dev.suite.sldev.cz/suite-web/ios-quarantine/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->