### PR TITLE
fix(suite): restrict selectDevice in onboarding and fwupdate apps

### DIFF
--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -4,9 +4,14 @@ import { type FlagsRootState } from '@suite/flags';
 import { METADATA } from '@suite/metadata';
 import { type ModalRootState } from '@suite/modal';
 import { recoveryActions } from '@suite/recovery';
-import { type RouterRootState, goto, routerAppChanged } from '@suite/router';
+import { type RouterRootState, goto, routerAppChanged, selectCanSwitchDevice } from '@suite/router';
 import { updateOnlineStatus } from '@suite/suite-lifecycle';
-import { deviceActions, isTrezorDeviceWithState } from '@suite-common/device';
+import {
+    type DeviceRootState,
+    deviceActions,
+    isTrezorDeviceWithState,
+    selectDevicePath,
+} from '@suite-common/device';
 import { type WithServices, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
@@ -17,6 +22,7 @@ import {
     forgetDisconnectedDevices,
     handleDeviceDisconnect,
     observeSelectedDevice,
+    selectDeviceThunk,
     selectIsDeviceAutoEjectEnabled,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
@@ -25,10 +31,11 @@ import { handleProtocolRequest } from 'src/actions/suite/protocolActions';
 import { desktopHandshake, setRecentlyDisconnectedDevice } from 'src/actions/suite/suiteActions';
 
 type SuiteMiddlewareState = AccountsRootState &
+    DeviceRootState &
+    RouterRootState &
     WalletSettingsRootState & {
         flags: Pick<FlagsRootState['flags'], 'hasSeenDisconnectTooltip'>;
         modal: Pick<ModalRootState['modal'], 'context'>;
-        router: Pick<RouterRootState['router'], 'route'>;
     };
 
 const isActionDeviceRelated = (action: UnknownAction): boolean => {
@@ -141,7 +148,13 @@ export const prepareSuiteMiddleware = createSuiteMiddleware(
                 );
             }
         } else if (deviceActions.deviceDisconnect.match(action)) {
-            dispatch(handleDeviceDisconnect(action.payload));
+            const selectedDevicePath = selectDevicePath(getState());
+            const canSwitchDevice = selectCanSwitchDevice(getState());
+            if (selectedDevicePath === action.payload.path && !canSwitchDevice) {
+                dispatch(selectDeviceThunk({ device: undefined }));
+            } else {
+                dispatch(handleDeviceDisconnect(action.payload));
+            }
         } else if (updateOnlineStatus.match(action) && action.payload) {
             // Restart discovery to reconnect to backends when user goes offline -> online.
             dispatch(startOrRestartDiscoveryThunk());

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -119,6 +119,20 @@ export const selectForegroundAppParams = (state: RouterRootState) =>
 export const selectCanNavigate = (state: LocksRootState & ModalRootState) =>
     !selectIsRouterOrUiLocked(state) && !selectHasActiveModal(state);
 
+/**
+ * Under normal circumstances, after device is disconnected we want suite to select another existing device (either remembered or physically connected)
+ * This is not the case in firmware update and onboarding; In this case we simply wan't suite.device to be empty until user reconnects a device again
+ */
+export const selectCanSwitchDevice = (state: RouterRootState) =>
+    !(
+        [
+            'onboarding',
+            'firmware',
+            'firmware-type',
+            'firmware-custom',
+        ] satisfies RouterAppWithParams['app'][]
+    ).some(app => app === state.router.app);
+
 export type RouterAction =
     | {
           type: typeof routerLocationChange.type;


### PR DESCRIPTION
revert 1331302f952cf591ef8915da92c6cd08aa4199e3

<!--- Provide a general summary of your changes in the Title above -->

## Description
I've mistakenly removed it as misleading code here: https://github.com/trezor/trezor-suite/pull/30771/changes/df7a89783650c959f216f89db0350144f5dfd5fc

Bringing it back but closer to the source.

### Why suiteMiddleware you may ask?
- the code is suite-web/desktop related, there is no router in `@suite-native` and suite-native supports only one connected device. Thats why it does not belong to suite-common.
- `deviceActions.deviceDisconnect` handler in the middleware dispatch explicit thunk depending on the route. Either deselect the device (in fw/oboarding) or select using `handleDeviceDisconnect` heuristics. No need for router logic inside of the thunk.



## Notes for QA

Should fix: https://github.com/trezor/trezor-suite/issues/31911
Testing scenarios:

- do fresh onboarding without any other remembered device
- do fresh onboarding with one or more remembered device
- do FW update from the settings with both scenarios (remembered/not-remembered)
- do FW type switch  (to/from bitcoin-only) from the settings, again with both scenarios

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/select-device-onboarding&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/select-device-onboarding&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T12:45:02.168Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T12:46:08.076Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch the core suite middleware and router reducer, both high-impact global pieces. The recommended set focuses on route coverage (all routes, trading navigation, specific routes like /bridge and /version) and lifecycle smoke tests (onboarding, reload, session handling, wallet discovery) rather than the full 139-test static mapping. This gives strong confidence that route resolution, navigation-driven state, and suite initialization still work while keeping CI runtime short.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/middlewares/suite/suiteMiddleware.ts`
- `suite/router/src/routerReducer.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — The test explicitly asserts that opening the device switcher fires a 'router/location-change' analytics event and verifies session/instance ID behavior across reloads, directly exercising router location tracking and suiteMiddleware lifecycle logic.
- `suite/e2e/tests/general/check-links.test.ts` — It navigates to every application route defined in router-config and verifies each page renders. A regression in routerReducer would likely surface here as missing or broken routes.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation into Buy/Sell/Swap forms from dashboard, account, header, sidebar, and token pages, asserting the correct asset is pre-selected based on routing context. This directly validates route-driven state.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Verifies the order and contents of analytics events including routerLocationChangeEvent after settings changes, so it covers both routing middleware and suite-level event dispatch.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Exercises the full onboarding-to-dashboard flow, wallet ejection, and standard wallet discovery, which depends on suiteMiddleware for device and discovery state orchestration.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Navigates directly to /accounts during onboarding and asserts the app reaches the dashboard layout, covering route handling and initial-run middleware behavior.
- `suite/e2e/tests/suite/bridge.test.ts` — Transitions from the /bridge route to wallet-index and checks the connect-device prompt, directly testing route navigation and post-route UI state.
- `suite/e2e/tests/suite/initial-run.test.ts` — Reloads the page at various onboarding stages and verifies initial-run persistence and final dashboard state, which relies on suiteMiddleware initialization and routing.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests reload and new-tab session reclamation flows and asserts device connection status, covering middleware-level bridge/session handling.
- `suite/e2e/tests/suite/version-page.test.ts` — Navigates to the hidden /version route and verifies route-specific content, serving as a focused regression check for route rendering.

</details>

_Updated: 2026-09-02T12:43:41.101Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/select-device-onboarding/web/](https://dev.suite.sldev.cz/suite-web/fix/select-device-onboarding/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->