### PR TITLE
refactor(suite-native): simplify layout of MayBeStuckBottomSheet

### DIFF
--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -21,7 +21,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { setTemporaryRememberedDeviceThunk } from '../firmwareThunks';
 import { DoNotCloseAppBottomSheetTrigger } from './DoNotCloseAppBottomSheetTrigger';
 import { FirmwareInstallationProgressTitles } from './FirmwareInstallationProgressTitles';
-import { MayBeStuckedBottomSheet } from './MayBeStuckedBottomSheet';
+import { MayBeStuckBottomSheet } from './MayBeStuckBottomSheet';
 import { TrezorFacts } from './TrezorFacts';
 import {
     UpdateProgressIndicator,
@@ -78,13 +78,13 @@ export const FirmwareInstallationScreenContent = ({
         status,
         resetReducer,
         translatedText,
-        mayBeStucked,
+        mayBeStuck,
         originalDevice,
         targetFirmwareType,
     } = useFirmware({ navigationLocation });
     const {
         handleAnalyticsReportFinished,
-        handleAnalyticsReportStucked,
+        handleAnalyticsReportStuck,
         handleAnalyticsReportCancelled,
         handleAnalyticsReportStarted,
     } = useFirmwareAnalytics({
@@ -101,7 +101,7 @@ export const FirmwareInstallationScreenContent = ({
     const deviceFirmwareVendor = originalDevice?.features?.fw_vendor;
 
     const openMayBeStuckBottomSheet = () => {
-        handleAnalyticsReportStucked('modalPart1');
+        handleAnalyticsReportStuck('modalPart1');
         openModal();
     };
 
@@ -264,7 +264,7 @@ export const FirmwareInstallationScreenContent = ({
     );
 
     const isDontCloseAppAlertDisplayed =
-        indicatorStatus === 'inProgress' && !isSheetOpen && !mayBeStucked && !isDone;
+        indicatorStatus === 'inProgress' && !isSheetOpen && !mayBeStuck && !isDone;
 
     return (
         <ConfirmOnTrezorWrapper
@@ -306,7 +306,7 @@ export const FirmwareInstallationScreenContent = ({
                         </Button>
                     </VStack>
                 )}
-                {mayBeStucked && (
+                {mayBeStuck && (
                     <Animated.View
                         entering={FadeInDown}
                         exiting={FadeOutDown}
@@ -338,11 +338,10 @@ export const FirmwareInstallationScreenContent = ({
                     isTriggerDisplayed={isDontCloseAppAlertDisplayed}
                 />
             </Box>
-
-            <MayBeStuckedBottomSheet
+            <MayBeStuckBottomSheet
                 ref={bottomSheetRef}
                 onClose={closeMayBeStuckBottomSheet}
-                onAnalyticsReportStucked={handleAnalyticsReportStucked}
+                onAnalyticsReportStuck={handleAnalyticsReportStuck}
             />
         </ConfirmOnTrezorWrapper>
     );

--- a/suite-native/firmware/src/components/MayBeStuckBottomSheet.tsx
+++ b/suite-native/firmware/src/components/MayBeStuckBottomSheet.tsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
-import Animated, { FadeIn } from 'react-native-reanimated';
+import { FadeIn } from 'react-native-reanimated';
 
 import { type FirmwareUpdateStuckedState } from '@suite-native/analytics';
 import {
+    AnimatedVStack,
     BottomSheetModal,
     type BottomSheetModalRef,
-    Box,
     Button,
     NumberedListItem,
-    Text,
+    TitleHeader,
     VStack,
 } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -37,61 +37,46 @@ export const MayBeStuckBottomSheet = ({
     };
 
     return (
-        <BottomSheetModal ref={ref} paddingHorizontal="sp24">
+        <BottomSheetModal ref={ref}>
             {visiblePart === 1 && (
-                <Animated.View>
-                    <VStack spacing="sp24">
-                        <VStack alignItems="center" spacing="sp8">
-                            <Text textAlign="center" variant="headline-sm">
-                                <Translation id="firmware.stuckedBottomSheet.part1.title" />
-                            </Text>
-                            <Text textAlign="center" color="contentSecondary">
-                                <Translation id="firmware.stuckedBottomSheet.part1.description" />
-                            </Text>
-                        </VStack>
-
-                        <VStack spacing="sp16">
-                            <Button onPress={handleContinue} intent="warning" priority="primary">
-                                <Translation id="firmware.stuckedBottomSheet.part1.continueButton" />
-                            </Button>
-                            <Button onPress={handleClose} intent="warning" priority="secondary">
-                                <Translation id="firmware.stuckedBottomSheet.part1.closeButton" />
-                            </Button>
-                        </VStack>
+                <AnimatedVStack spacing="sp24">
+                    <TitleHeader
+                        title={<Translation id="firmware.stuckedBottomSheet.part1.title" />}
+                        subtitle={
+                            <Translation id="firmware.stuckedBottomSheet.part1.description" />
+                        }
+                    />
+                    <VStack spacing="sp12">
+                        <Button onPress={handleContinue} intent="warning" priority="primary">
+                            <Translation id="firmware.stuckedBottomSheet.part1.continueButton" />
+                        </Button>
+                        <Button onPress={handleClose} intent="warning" priority="secondary">
+                            <Translation id="firmware.stuckedBottomSheet.part1.closeButton" />
+                        </Button>
                     </VStack>
-                </Animated.View>
+                </AnimatedVStack>
             )}
             {visiblePart === 2 && (
-                <Animated.View entering={FadeIn}>
-                    <VStack spacing="sp24">
-                        <VStack spacing="sp8">
-                            <Text variant="headline-sm">
-                                <Translation id="firmware.stuckedBottomSheet.part2.title" />
-                            </Text>
-                            <Text color="contentSecondary">
-                                <Translation id="firmware.stuckedBottomSheet.part2.subtitle" />
-                            </Text>
-                        </VStack>
-
-                        <VStack spacing="sp2">
-                            <NumberedListItem number={1}>
-                                <Translation id="firmware.stuckedBottomSheet.part2.tip1" />
-                            </NumberedListItem>
-                            <NumberedListItem number={2}>
-                                <Translation id="firmware.stuckedBottomSheet.part2.tip2" />
-                            </NumberedListItem>
-                            <NumberedListItem number={3}>
-                                <Translation id="firmware.stuckedBottomSheet.part2.tip3" />
-                            </NumberedListItem>
-                        </VStack>
-
-                        <Box flex={1}>
-                            <Button onPress={handleClose} intent="brand" priority="primary">
-                                <Translation id="firmware.stuckedBottomSheet.part2.gotItButton" />
-                            </Button>
-                        </Box>
+                <AnimatedVStack entering={FadeIn} spacing="sp24">
+                    <TitleHeader
+                        title={<Translation id="firmware.stuckedBottomSheet.part2.title" />}
+                        subtitle={<Translation id="firmware.stuckedBottomSheet.part2.subtitle" />}
+                    />
+                    <VStack spacing="sp2">
+                        <NumberedListItem number={1}>
+                            <Translation id="firmware.stuckedBottomSheet.part2.tip1" />
+                        </NumberedListItem>
+                        <NumberedListItem number={2}>
+                            <Translation id="firmware.stuckedBottomSheet.part2.tip2" />
+                        </NumberedListItem>
+                        <NumberedListItem number={3}>
+                            <Translation id="firmware.stuckedBottomSheet.part2.tip3" />
+                        </NumberedListItem>
                     </VStack>
-                </Animated.View>
+                    <Button onPress={handleClose} intent="brand" priority="primary">
+                        <Translation id="firmware.stuckedBottomSheet.part2.gotItButton" />
+                    </Button>
+                </AnimatedVStack>
             )}
         </BottomSheetModal>
     );

--- a/suite-native/firmware/src/components/MayBeStuckBottomSheet.tsx
+++ b/suite-native/firmware/src/components/MayBeStuckBottomSheet.tsx
@@ -13,17 +13,17 @@ import {
 } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
-type MayBeStuckedBottomSheetProps = {
+type MayBeStuckBottomSheetProps = {
     onClose: () => void;
-    onAnalyticsReportStucked: (state: FirmwareUpdateStuckedState) => void;
+    onAnalyticsReportStuck: (state: FirmwareUpdateStuckedState) => void;
     ref: BottomSheetModalRef;
 };
 
-export const MayBeStuckedBottomSheet = ({
+export const MayBeStuckBottomSheet = ({
     onClose,
-    onAnalyticsReportStucked,
+    onAnalyticsReportStuck,
     ref,
-}: MayBeStuckedBottomSheetProps) => {
+}: MayBeStuckBottomSheetProps) => {
     const [visiblePart, setVisiblePart] = useState<1 | 2>(1);
 
     const handleClose = () => {
@@ -33,7 +33,7 @@ export const MayBeStuckedBottomSheet = ({
 
     const handleContinue = () => {
         setVisiblePart(2);
-        onAnalyticsReportStucked('modalPart2');
+        onAnalyticsReportStuck('modalPart2');
     };
 
     return (

--- a/suite-native/firmware/src/hooks/useFirmware.tsx
+++ b/suite-native/firmware/src/hooks/useFirmware.tsx
@@ -10,7 +10,7 @@ import { nativeFirmwareActions } from '../nativeFirmwareSlice';
 import { useFirmwareAnalytics } from './useFirmwareAnalytics';
 
 // If progress doesn't change for 1 minute
-const MAYBE_STUCKED_TIMEOUT = 1 * 60 * 1000; // 1 minute
+const MAYBE_STUCK_TIMEOUT = 1 * 60 * 1000; // 1 minute
 
 export const useFirmware = (params?: { navigationLocation: 'settings' | 'onboarding' }) => {
     const dispatch = useDispatch();
@@ -25,9 +25,9 @@ export const useFirmware = (params?: { navigationLocation: 'settings' | 'onboard
         ...firmwareInstallation
     } = useFirmwareInstallation();
     const { translate } = useTranslate();
-    const [mayBeStucked, setMayBeStucked] = useState(false);
-    const mayBeStuckedTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const { handleAnalyticsReportStucked } = useFirmwareAnalytics({
+    const [mayBeStuck, setMayBeStuck] = useState(false);
+    const mayBeStuckTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const { handleAnalyticsReportStuck } = useFirmwareAnalytics({
         device: firmwareInstallation.originalDevice,
         targetFirmwareType: firmwareInstallation.targetFirmwareType,
         navigationLocation: params?.navigationLocation,
@@ -46,20 +46,20 @@ export const useFirmware = (params?: { navigationLocation: 'settings' | 'onboard
         [dispatch],
     );
 
-    const resetMayBeStuckedTimeout = useCallback(() => {
-        if (mayBeStuckedTimeout.current) {
-            clearTimeout(mayBeStuckedTimeout.current);
+    const resetMayBeStuckTimeout = useCallback(() => {
+        if (mayBeStuckTimeout.current) {
+            clearTimeout(mayBeStuckTimeout.current);
         }
-        setMayBeStucked(false);
+        setMayBeStuck(false);
     }, []);
 
     const setMayBeStuckedTimeout = useCallback(() => {
-        resetMayBeStuckedTimeout();
-        mayBeStuckedTimeout.current = setTimeout(() => {
-            handleAnalyticsReportStucked('buttonVisible');
-            setMayBeStucked(true);
-        }, MAYBE_STUCKED_TIMEOUT);
-    }, [resetMayBeStuckedTimeout, handleAnalyticsReportStucked]);
+        resetMayBeStuckTimeout();
+        mayBeStuckTimeout.current = setTimeout(() => {
+            handleAnalyticsReportStuck('buttonVisible');
+            setMayBeStuck(true);
+        }, MAYBE_STUCK_TIMEOUT);
+    }, [resetMayBeStuckTimeout, handleAnalyticsReportStuck]);
 
     useEffect(() => {
         if (status === 'started' && progress < 100) {
@@ -67,9 +67,9 @@ export const useFirmware = (params?: { navigationLocation: 'settings' | 'onboard
         }
 
         return () => {
-            resetMayBeStuckedTimeout();
+            resetMayBeStuckTimeout();
         };
-    }, [progress, status, setMayBeStuckedTimeout, resetMayBeStuckedTimeout]);
+    }, [progress, status, setMayBeStuckedTimeout, resetMayBeStuckTimeout]);
 
     const firmwareUpdate = useCallback(async () => {
         if (!isDeviceConnectedViaBluetoothRef.current) {
@@ -89,11 +89,11 @@ export const useFirmware = (params?: { navigationLocation: 'settings' | 'onboard
                 if (!isDeviceConnectedViaBluetoothRef.current) {
                     setPriorityMode(false);
                 }
-                resetMayBeStuckedTimeout();
+                resetMayBeStuckTimeout();
             });
 
         return result;
-    }, [firmwareUpdateCommon, resetMayBeStuckedTimeout]);
+    }, [firmwareUpdateCommon, resetMayBeStuckTimeout]);
 
     const confirmOnDevice =
         confirmOnDeviceCommon ||
@@ -149,7 +149,7 @@ export const useFirmware = (params?: { navigationLocation: 'settings' | 'onboard
         operation,
         status,
         error,
-        mayBeStucked,
+        mayBeStuck,
         progress,
         setStatus,
     };

--- a/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareAnalytics.ts
@@ -77,7 +77,7 @@ export const useFirmwareAnalytics = ({
         [getAnalyticsPayload, analytics, resetTimeStarted],
     );
 
-    const handleAnalyticsReportStucked = useCallback(
+    const handleAnalyticsReportStuck = useCallback(
         (state: 'modalPart1' | 'modalPart2' | 'buttonVisible') => {
             analytics.report({
                 type: events.firmwareFirmwareUpdateStuckedEvent.name,
@@ -116,9 +116,9 @@ export const useFirmwareAnalytics = ({
         getElapsedTimeInSeconds,
         getAnalyticsPayload,
         resetTimeStarted,
-        handleAnalyticsReportStucked,
+        handleAnalyticsReportStarted,
+        handleAnalyticsReportStuck,
         handleAnalyticsReportFinished,
         handleAnalyticsReportCancelled,
-        handleAnalyticsReportStarted,
     };
 };


### PR DESCRIPTION
## Description

- Typo in mayBeStuck identifiers corrected.
- Layout of `MayBeStuckBottomSheet` simplified.

## Screenshots:
| Part 1 | Part 2 |
| --- | --- |
| <img width="1179" height="1042" alt="image" src="https://github.com/user-attachments/assets/04ec8767-8145-418f-8298-49c9d42dc814" /> | <img width="1179" height="1051" alt="image" src="https://github.com/user-attachments/assets/3f423874-5f24-4d19-9797-1224f2cd0fb8" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/firmware-may-be-stuck&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->