### PR TITLE
fix(connect): retry features read when handshake hits a stale Cancel response

### DIFF
--- a/packages/connect/src/device/Device.test.ts
+++ b/packages/connect/src/device/Device.test.ts
@@ -1,0 +1,139 @@
+import { parseConnectSettings } from '@trezor/connect-common/src/data/connectSettings';
+import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
+
+import { Device } from './Device';
+import { initializeFirmwareConfig } from '../data/firmwareInfo';
+import * as firmwareReleaseStore from '../data/firmwareReleaseStore';
+import { loadProtobufModules } from '../data/protobufLoader';
+import * as settingsStore from '../data/settingsStore';
+
+const { createTestTransport } = global.JestMocks;
+
+// trezor protocol v1 frames: magic 3f2323 | type (2B) | length (4B) | payload
+const FAILURE_ACTION_CANCELLED = Buffer.from('3f23230003000000020804', 'hex');
+const FEATURES = Buffer.from('3f232300110000000c1002180020006000aa010154', 'hex');
+
+const getAcquiredDevice = async (apiMethods: any = {}) => {
+    let emitTransportEvent: (d: any[]) => void = () => {};
+    const transport = createTestTransport({
+        openDevice: () => {
+            setTimeout(() => emitTransportEvent([{ path: '1', session: '1' }]), 100);
+
+            return { success: true, payload: true };
+        },
+        on: (name: string, fn: typeof emitTransportEvent) => {
+            if (name === 'transport-interface-change') {
+                fn([{ path: '1', session: null }]);
+                emitTransportEvent = fn;
+            }
+        },
+        ...apiMethods,
+    });
+
+    await transport.init();
+    await transport.enumerate();
+    await transport.listen();
+
+    const device = new Device({
+        id: 'ABCD' as any, // any = DeviceUniquePath
+        transport,
+        descriptor: { path: '1' as any, type: 1, session: null, apiType: 'usb' }, // any = PathPublic
+        createLogger: noopCreateLogger,
+    });
+    await device.acquire();
+
+    return { transport, device };
+};
+
+// Serves scripted frames in order, then falls back to Features for any further read
+const createScriptedRead = (frames: Buffer[]) => {
+    let readCount = 0;
+
+    return jest.fn(() => {
+        const frame = frames[readCount] ?? FEATURES;
+        readCount++;
+
+        return Promise.resolve({ success: true, payload: frame });
+    });
+};
+
+const runOptions = { skipFirmwareChecks: true, skipLanguageChecks: true };
+
+describe('Device.run stale Cancel response recovery', () => {
+    beforeAll(async () => {
+        const settings = { ...parseConnectSettings({}) };
+        settingsStore.set(settings);
+        await firmwareReleaseStore.init(settings.firmwareChannel, true, initializeFirmwareConfig);
+        await loadProtobufModules();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('recovers when GetFeatures reads a stale Failure(ActionCancelled)', async () => {
+        // read 1: consumed by handshakeCancel; read 2: stale Failure hits GetFeatures;
+        // read 3 (retry): Features
+        const readMock = createScriptedRead([FAILURE_ACTION_CANCELLED, FAILURE_ACTION_CANCELLED]);
+        const { device } = await getAcquiredDevice({ read: readMock });
+
+        await device.run(undefined, runOptions);
+
+        expect(device.features).toBeDefined();
+        expect(readMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('recovers from two stale Failures on the last allowed attempt', async () => {
+        const readMock = createScriptedRead([
+            FAILURE_ACTION_CANCELLED,
+            FAILURE_ACTION_CANCELLED,
+            FAILURE_ACTION_CANCELLED,
+        ]);
+        const { device } = await getAcquiredDevice({ read: readMock });
+
+        await device.run(undefined, runOptions);
+
+        expect(device.features).toBeDefined();
+        expect(readMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('rejects with Failure_ActionCancelled once the retry limit is exhausted', async () => {
+        const readMock = jest.fn(() =>
+            Promise.resolve({ success: true, payload: FAILURE_ACTION_CANCELLED }),
+        );
+        const { device } = await getAcquiredDevice({ read: readMock });
+
+        await expect(device.run(undefined, runOptions)).rejects.toMatchObject({
+            code: 'Failure_ActionCancelled',
+        });
+        // 1 read consumed by handshakeCancel + 3 GetFeatures attempts
+        expect(readMock).toHaveBeenCalledTimes(4);
+        expect(device.features).toBeUndefined();
+    });
+
+    it('does not retry when the run is interrupted', async () => {
+        let readCount = 0;
+        let interruptRun = () => {};
+        const readMock = jest.fn(() => {
+            readCount++;
+            if (readCount === 1) {
+                // consumed by handshakeCancel
+                return Promise.resolve({ success: true, payload: FAILURE_ACTION_CANCELLED });
+            }
+
+            // interrupt the run while the GetFeatures response is a stale Failure
+            interruptRun();
+
+            return Promise.resolve({ success: true, payload: FAILURE_ACTION_CANCELLED });
+        });
+        const { device } = await getAcquiredDevice({ read: readMock });
+        interruptRun = () => device.interrupt(new Error('user interrupt'));
+
+        await expect(device.run(undefined, runOptions)).rejects.toThrow();
+
+        // let any zombie retry surface before asserting
+        await new Promise(resolve => setTimeout(resolve, 50));
+        expect(readMock).toHaveBeenCalledTimes(2);
+        expect(device.features).toBeUndefined();
+    });
+});

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -549,9 +549,12 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                         await this.getFeatures();
                     }
                 } else if (fn) {
-                    await this.initialize(!!options.useCardanoDerivation);
+                    await this.retryOnStaleCancelResponse(
+                        () => this.initialize(!!options.useCardanoDerivation),
+                        abortSignal,
+                    );
                 } else {
-                    await this.getFeatures();
+                    await this.retryOnStaleCancelResponse(() => this.getFeatures(), abortSignal);
                 }
             } catch (error) {
                 this.logger.warn('Device._runInner error: ', error.message);
@@ -704,6 +707,30 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
         const { message } = await this.getCurrentSession().typedCall('GetFeatures', 'Features', {});
         this._updateFeatures(message);
         await this._updateCurrentRelease(message);
+    }
+
+    // Initialize/GetFeatures have no on-device UI, so Failure(ActionCancelled) can only be
+    // a stale response left in the device buffer by an interrupted previous session
+    // (e.g. page reload sent Cancel and never read the reply). Each failed attempt drains
+    // one stale message, so a bounded retry recovers the handshake.
+    private async retryOnStaleCancelResponse(call: () => Promise<void>, abortSignal: AbortSignal) {
+        const attemptsLimit = 3;
+        for (let attempt = 1; ; ++attempt) {
+            try {
+                return await call();
+            } catch (error) {
+                if (
+                    error.code !== 'Failure_ActionCancelled' ||
+                    abortSignal.aborted ||
+                    attempt >= attemptsLimit
+                ) {
+                    throw error;
+                }
+                this.logger.warn(
+                    `handshake received stale Failure(ActionCancelled), retrying (attempt ${attempt})`,
+                );
+            }
+        }
     }
 
     getAuthenticityChecks() {

--- a/suite/e2e/tests/recovery/repro-poisoned-buffer.test.ts
+++ b/suite/e2e/tests/recovery/repro-poisoned-buffer.test.ts
@@ -1,0 +1,115 @@
+/**
+ * THROWAWAY REPRO — DO NOT MERGE
+ *
+ * Deterministic reproduction of the "Recovery after partial recovery" web flakiness.
+ *
+ * The natural failure is a race on page.reload(): the unloading page's teardown fires
+ * abort → post(Cancel) → release?beacon=1, and when the Cancel lands while the session
+ * is still alive, the device's Failure("Cancelled") response is never read and stays
+ * queued in the device buffer. After reload, connect acquires, sends its own Cancel,
+ * reads one Failure — and then GetFeatures consumes the stale second Failure instead
+ * of Features. Connect gives up, suite ends with an unacquired device, the recovery
+ * modal never reappears.
+ *
+ * This test forces the losing side of the race by replaying the exact teardown
+ * sequence (abort + orphaned Cancel) via the bridge HTTP API just before the reload,
+ * so the failure reproduces on every run instead of ~10% of them.
+ */
+import { MNEMONICS } from '@trezor/trezor-user-env-link';
+
+import { BRIDGE_URL } from '../../support/bridge';
+import { expect, test } from '../../support/fixtures';
+
+const pin = '1';
+
+// trezor protocol v1: magic 3f2323, message type 20 (Cancel), zero-length payload
+const CANCEL_MESSAGE = JSON.stringify({ protocol: 'v1', data: '3f2323001400000000' });
+const BRIDGE_HEADERS = {
+    Origin: 'https://wallet.trezor.io',
+    'Content-Type': 'text/plain;charset=UTF-8',
+};
+
+test.describe('REPRO Recovery T2T1 - poisoned device buffer', { tag: ['@T2T1'] }, () => {
+    test.use({
+        deviceSetup: { mnemonic: 'mnemonic_all', pin },
+    });
+
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('device');
+    });
+
+    test('Recovery after partial recovery with forced teardown race', async ({
+        page,
+        request,
+        device,
+        settingsPage,
+        recoveryModal,
+        trezorInput,
+    }) => {
+        await test.step('Initiate recovery dry run in settings', async () => {
+            await settingsPage.checkSeedButton.click();
+            await recoveryModal.userUnderstandsCheckbox.click();
+            await recoveryModal.startButton.click();
+            await recoveryModal.verifyDryCheckPrompt();
+        });
+
+        await test.step('Partially complete the dry run on emulator', async () => {
+            await device.pressYes();
+            await device.type('1');
+            await device.selectNumberOfWords(12);
+            await device.pressYes();
+            await device.type('all');
+        });
+
+        await test.step('Plant an orphaned Failure in the device buffer', async () => {
+            const enumerateResponse = await request.post(`${BRIDGE_URL}/enumerate`, {
+                headers: BRIDGE_HEADERS,
+            });
+            expect(enumerateResponse.ok()).toBe(true);
+            const devices = await enumerateResponse.json();
+            const session = devices[0]?.session;
+            expect(session, 'suite should hold an active bridge session').toBeTruthy();
+
+            // 1. Kill suite's in-flight RecoveryDevice call — same as the unload abort.
+            const abortResponse = await request.post(`${BRIDGE_URL}/abort/${session}`, {
+                headers: BRIDGE_HEADERS,
+            });
+            expect(abortResponse.ok()).toBe(true);
+
+            // 2. Post Cancel on the still-live session and never read the reply.
+            //    The device answers Failure("Cancelled") into a buffer nobody drains —
+            //    the exact poisoned state the lost unload race leaves behind.
+            const postResponse = await request.post(`${BRIDGE_URL}/post/${session}`, {
+                headers: BRIDGE_HEADERS,
+                data: CANCEL_MESSAGE,
+            });
+            expect(postResponse.ok()).toBe(true);
+        });
+
+        await test.step('Reload suite and check recovery dry run is reinitialized', async () => {
+            await page.reload();
+            // EXPECTED REPRO FAILURE: connect's post-reload GetFeatures reads the stale
+            // Failure, the device stays unacquired, and this prompt never appears.
+            await expect(
+                recoveryModal.header,
+                'REPRO CONFIRMED — this failure is the expected reproduction of the flaky ' +
+                    '"Recovery after partial recovery" web run: the orphaned Cancel response ' +
+                    'poisoned the device buffer, post-reload GetFeatures consumed the stale ' +
+                    'Failure("Cancelled") instead of Features, connect gave up and the device ' +
+                    'stayed unacquired, so the recovery modal never reappeared.',
+            ).toHaveText('Check wallet backup', { timeout: 30_000 });
+            await recoveryModal.verifyDryCheckPrompt();
+        });
+
+        await test.step('Complete the dry run on emulator', async () => {
+            await device.selectNumberOfWords(12);
+            await device.pressYes();
+            await trezorInput.inputMnemonicT2T1(MNEMONICS.mnemonic_all);
+            await device.pressYes();
+            await expect(recoveryModal.successTitle).toHaveText(
+                'Wallet backup checked successfully',
+            );
+        });
+    });
+});


### PR DESCRIPTION
## ⚠️ Contains a temporary test — how to see the bug yourself

The first commit (`TMP: DO NOT MERGE …`) adds `suite/e2e/tests/recovery/repro-poisoned-buffer.test.ts`, a throwaway e2e test that reproduces the bug **deterministically** (the natural failure rate is ~10%). It will be rebased out before merge; the intentionally non-conventional commit prefix keeps the commit-format check red so this PR cannot be merged by accident until then.

To see the original problem:

1. Revert the `fix(connect): …` commit (or check out the TMP commit directly — it sits below the fix)
2. Run the repro against a web build:
   ```
   cd suite/e2e && yarn playwright test --config=./playwright-config/playwright-web.config.ts repro-poisoned-buffer --project=T2T1 --retries=0
   ```
3. It fails every time with a self-explaining `REPRO CONFIRMED — …` assertion message. With the fix in place, the same test passes.

The test forces the losing side of a race instead of gambling on it: mid dry-run it replays the exact unload teardown sequence over the bridge HTTP API (`/abort` + `/post` a Cancel whose reply nobody reads) before `page.reload()`.

## Problem

The web e2e test `Recovery T2T1 - dry run › Recovery after partial recovery` is flaky (6 failures on develop/PR branches in August), while the identical desktop test is 100% stable. Trace analysis of passing vs failing runs showed a race in the bridge session teardown on `page.reload()`:

1. The unloading page's teardown fires `abort` → `post`(Cancel) → `release?beacon=1` concurrently. When the Cancel lands **before** the release, the device answers `Failure(ActionCancelled)` into a buffer nobody ever reads — an orphaned message.
2. After reload, connect acquires a new session and runs `handshakeCancel`, which drains only **one** queued message. With two Failures queued (the orphan + the reply to its own Cancel), one is left over.
3. `GetFeatures` then consumes the stale `Failure` instead of `Features`, the handshake rejects with `Failure_ActionCancelled`, and the device is stranded `unacquired` with no retry. Suite never learns the device is mid-recovery, so the dry-run flow is never resumed.

Desktop is immune because the renderer reload doesn't tear down the transport session, so the race doesn't exist there. This is not test-only: a real user reloading the web app mid dry-run hits the same dead end. `handshakeCancel`'s own comment (note 3) anticipated this fix: *"it might be better to catch this call and repeat it."*

## Solution

`Device._runInner`: wrap the protocol-v1 features update (`initialize`/`GetFeatures`) in `retryOnStaleCancelResponse()` — retry on `Failure_ActionCancelled`, bounded to 3 attempts (each attempt drains exactly one stale message), and never retry when the run's abort signal has fired.

Why this is safe by construction:

- `Initialize`/`GetFeatures` have no on-device UI, so a user cannot legitimately cancel them — an `ActionCancelled` response to them can only be a stale leftover.
- Any genuine host-side interruption goes through `runAbort.abort()`, which the retry checks — a real cancellation is never swallowed.
- The v2/THP path is untouched; the `Failure_ActionCancelled` pass-through added for THP pairing (01f77c2622) keeps its exact behavior.

## Potential impact

- `@trezor/connect` core — ships to Suite web/desktop/mobile and third-party integrators. However, the changed branch only executes when the features read got a `Failure` — today that is always a terminal handshake failure, so the happy path is untouched and there is no added latency.
- Behavior change: a handshake that previously died (stranding the device unacquired) now recovers. If retries exhaust, it rejects exactly as before.

## Verification

- New unit tests (`Device.test.ts`, mocked transport): recovery from one and two stale Failures, rejection when the retry limit is exhausted, and no retry after interruption. Mutation-checked — the recovery tests fail on the unpatched code.
- Connect unit suite: 557/557.
- E2E against a patched web build: the deterministic repro passes (trace confirms one retry consuming the stale Failure, then real Features), plus 11/11 T2T1 recovery + onboarding recovery specs and 4/4 T1B1 onboarding recovery specs (covering the `initialize` branch and cancel/disconnect paths).
- Repo-wide affected type-check and lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-t1b1-web-recovery-reload/web/](https://dev.suite.sldev.cz/suite-web/fix-t1b1-web-recovery-reload/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is tightly focused on connect's core Device class and its poisoned-buffer handling, plus a new regression test. Device.ts is a global dependency, so the 132 static mappings are mostly transitive; the highest-confidence coverage comes from the new repro test and a couple of recovery dry-run tests that stress device message exchange. The unit-test change to Device.test.ts has no E2E coverage and should be validated by the unit suite instead.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect/src/device/Device.test.ts`
- `packages/connect/src/device/Device.ts`
- `suite/e2e/tests/recovery/repro-poisoned-buffer.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/recovery/repro-poisoned-buffer.test.ts` — This is the newly added/modified regression test that directly reproduces the poisoned-buffer scenario against the connect Device class, so it must be run to validate the fix.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/recovery/dry-run.test.ts` — Recovery dry-run exercises repeated device message round-trips, reconnects, and reloads; a poisoned-buffer issue in Device.ts could corrupt these device exchanges and is in the same recovery feature area as the regression test.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — The T2T1 dry-run path uses the same recovery/seed-check device communication flow and shares the connect device-message handling surface where the buffer fix applies.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/device/Device.test.ts`

_Updated: 2026-09-04T07:21:38.231Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-t1b1-web-recovery-reload&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-t1b1-web-recovery-reload&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-t1b1-web-recovery-reload&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T07:22:36.584Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T07:22:52.681Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->