### PR TITLE
fix(suite): add `ConnectionGlobalModalManager` to Firmware modal

### DIFF
--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -13,6 +13,7 @@ import { acquireDevice } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
+import { ConnectionGlobalModalManager } from 'src/components/connection/ConnectionGlobalModalManager';
 import { FirmwareInstallationProgressCheck } from 'src/components/firmware/ProgressCheck/FirmwareInstallationProgressCheck';
 import { useSelector } from 'src/hooks/suite';
 
@@ -123,6 +124,7 @@ export const FirmwareModal = ({
 
     return (
         <Modal.Backdrop onClick={isCancelable ? handleClose : undefined}>
+            <ConnectionGlobalModalManager />
             {getContent()}
         </Modal.Backdrop>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 Firmware update modal doesnt show `ConnectionGlobalModalManager`
 
 depends on https://github.com/trezor/trezor-suite/pull/32007

## Notes for QA

- go to settings/device update FW (or switch FW type)
- disconnect the device before installation
- Connect your device view should be visible, the button should open ConnectionModal

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="1338" height="819" alt="Screenshot from 2026-09-02 13-16-00" src="https://github.com/user-attachments/assets/0db96dd8-e548-456c-923e-fed4d738a996" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** FirmwareModal.tsx is a shared firmware UI component that statically maps to many tests, so we apply the broad-utility heuristic and select only tests that concretely exercise firmware modals. The highest-confidence tests are custom firmware installation and device-settings firmware update modals. Onboarding firmware readiness and authenticity checks share related infrastructure and are included at medium priority. All other mapped tests only transitively depend on this file and are omitted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/firmware/FirmwareModal.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test directly exercises the custom firmware installation modal flow and its source hints explicitly reference the 'Custom firmware modal component'. Changes to FirmwareModal.tsx are highly likely to affect this flow.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — The test explicitly opens and closes the firmware update modal from device settings on a T2T1. Since FirmwareModal.tsx is the firmware modal component, this test directly covers the changed UI.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — The test explicitly opens and closes the firmware update modal from device settings on a T3B1, making it a direct coverage target for FirmwareModal.tsx changes.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This onboarding test disables firmware hash/revision checks and proceeds through firmware-related onboarding steps. It shares the firmware onboarding infrastructure with FirmwareModal.tsx and could be affected by modal behavior changes.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test specifically validates firmware readiness detection during onboarding and uses the onboarding firmware page object. Changes to the firmware modal could influence how readiness is presented or confirmed.

</details>

_Updated: 2026-09-02T13:19:04.360Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-fw-update-connection-modal/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-fw-update-connection-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-fw-update-connection-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-fw-update-connection-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T13:21:47.373Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T13:22:14.257Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->