### PR TITLE
test(suite): refactor toHaveLoadedImage to built-in assertions

### DIFF
--- a/suite/e2e/support/pageObjects/guidePanel.ts
+++ b/suite/e2e/support/pageObjects/guidePanel.ts
@@ -1,9 +1,10 @@
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 import type { FeedbackCategory } from '@suite-common/feedback';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
 import { step } from '../common';
+import { expect } from '../testExtends/customMatchers';
 
 const anyTestIdEndingWithClose = '[data-testid$="close"]';
 
@@ -127,8 +128,7 @@ export class GuidePanel {
 
     @step()
     async openArticleImageModal(locator: Locator) {
-        await expect(locator).toHaveJSProperty('complete', true);
-        await expect(locator).not.toHaveJSProperty('naturalWidth', 0);
+        await expect(locator).toHaveLoadedImage();
         await locator.click();
         await expect(this.articleImageModal).toBeVisible();
     }

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -361,22 +361,15 @@ export const expect = baseExpect.extend({
 
     async toHaveLoadedImage(locator: Locator, options?: { timeout?: number }) {
         await baseExpect(locator).toBeVisible({ timeout: options?.timeout });
-        await baseExpect
-            .poll(
-                async () =>
-                    await locator.evaluate(
-                        (img: HTMLImageElement) => img.complete && img.naturalWidth > 0,
-                    ),
-                {
-                    timeout: options?.timeout,
-                    message:
-                        'expected locator to have image loaded but naturalWidth is 0 or complete is false',
-                },
-            )
-            .toBe(true);
+        await baseExpect(locator).toHaveJSProperty('complete', true, {
+            timeout: options?.timeout,
+        });
+        await baseExpect(locator).not.toHaveJSProperty('naturalWidth', 0, {
+            timeout: options?.timeout,
+        });
 
         return {
-            message: () => 'passed',
+            message: () => 'errors are handled in expects above',
             pass: true,
         };
     },


### PR DESCRIPTION
## Description

Replaces the hand-rolled `expect.poll` + `locator.evaluate` inside the `toHaveLoadedImage`
custom matcher with Playwright's built-in auto-retrying `toHaveJSProperty` assertions —
the same style `GuidePanel.openArticleImageModal` already used inline. That inline check
now calls the matcher, so there is one canonical way to assert an image is loaded.

## Notes for QA

No test behavior change intended — same conditions checked (`complete === true`,
`naturalWidth > 0`). Affects the device-background e2e test (`settingsPage.changeDeviceBackground`)
and the guide article image test.

## Related Issue

Resolve

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/to-have-loaded-image/web/](https://dev.suite.sldev.cz/suite-web/refactor/to-have-loaded-image/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/to-have-loaded-image&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/to-have-loaded-image&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T11:30:05.451Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T11:29:27.009Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->