### PR TITLE
feat(scripts): accept PR reference for Slack message

### DIFF
--- a/scripts/generate-slack-pr-message.sh
+++ b/scripts/generate-slack-pr-message.sh
@@ -2,12 +2,13 @@
 
 show_help() {
     cat << EOF
-Usage: $(basename "$0") PR [PLATFORM]
+Usage: $(basename "$0") [PR] [PLATFORM]
+       $(basename "$0") [PLATFORM]
 
 Generate a Slack-formatted PR message with stats and copy it to clipboard.
 
 PR:
-    GitHub pull request number or URL
+    GitHub pull request number or URL. Uses the current branch when omitted.
 
 PLATFORM options:
     mobile, m       Use mobile icon (:iphone:)
@@ -20,6 +21,8 @@ Environment variables:
     DEFAULT_SLACK_PR_ICON    Override the default icon (e.g., ":rocket:")
 
 Examples:
+    $(basename "$0")
+    $(basename "$0") mobile
     $(basename "$0") 12345
     $(basename "$0") 12345 mobile
     $(basename "$0") https://github.com/trezor/trezor-suite/pull/12345 m
@@ -28,6 +31,7 @@ Examples:
 Requirements:
     - GitHub CLI (gh) must be installed and authenticated
     - A PR number must be used from within its GitHub repository
+    - When PR is omitted, the current branch must have a pull request
 
 EOF
 }
@@ -125,20 +129,41 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     exit 0
 fi
 
-if [[ -z "$1" ]]; then
-    echo -e "\033[0;31mError: A PR number or URL is required.\033[0m
-Use -h option for more info." >&2
-    exit 1
-fi
-
 # Input and environment checks
 check_dependencies
 check_gh_available
 
 PR_REFERENCE="$1"
+PLATFORM="$2"
+
+case "$1" in
+    mobile | m | common | c | desktop | d | yanas | y)
+        PR_REFERENCE=""
+        PLATFORM="$1"
+        ;;
+esac
+
+if [[ -z "$PR_REFERENCE" ]]; then
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+
+    if [[ -z "$CURRENT_BRANCH" ]]; then
+        echo -e "\033[0;31mError: A PR number or URL is required when no branch is checked out.\033[0m
+Use -h option for more info." >&2
+        exit 1
+    fi
+
+    if [[ "$CURRENT_BRANCH" == "develop" || "$CURRENT_BRANCH" == "main" ]]; then
+        echo -e "\033[0;31mError: You are on the '$CURRENT_BRANCH' branch.
+Provide a PR number or URL, or switch to a feature/PR branch.\033[0m
+Use -h option for more info." >&2
+        exit 1
+    fi
+
+    PR_REFERENCE="$CURRENT_BRANCH"
+fi
 
 # Determine platform icon
-ICON=$(get_platform_icon "$2")
+ICON=$(get_platform_icon "$PLATFORM")
 
 if ! PR_JSON=$(gh pr view "$PR_REFERENCE" --json title,changedFiles,additions,deletions,url 2>&1); then
     echo -e "\033[0;31mError: Failed to fetch PR information.

--- a/scripts/generate-slack-pr-message.sh
+++ b/scripts/generate-slack-pr-message.sh
@@ -36,12 +36,158 @@ Requirements:
 EOF
 }
 
-check_dependencies() {
+check_jq_available() {
     if ! command -v jq &> /dev/null; then
         echo -e "\033[0;31mError: Missing required dependency: jq\033[0m" >&2
         echo -e "Please install it before running this script." >&2
+        return 1
+    fi
+}
+
+install_gh_with_homebrew() {
+    echo -e "\033[0;33mHomebrew detected. Would you like to install GitHub CLI now? (y/n)\033[0m"
+    read -r response
+
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        echo -e "Please install it manually: https://cli.github.com/" >&2
         exit 1
     fi
+
+    echo "Installing GitHub CLI..."
+    if ! brew install gh; then
+        echo -e "\033[0;31mInstallation failed.\033[0m" >&2
+        exit 1
+    fi
+
+    echo -e "\033[0;32m✓ GitHub CLI installed successfully!\033[0m"
+    echo -e "\033[0;33mAuthentication required. Running 'gh auth login'...\033[0m"
+
+    if ! gh auth login; then
+        echo -e "\033[0;31mAuthentication failed. Please run 'gh auth login' manually.\033[0m" >&2
+        exit 1
+    fi
+
+    echo -e "\033[0;32m✓ Authentication successful! Please re-run the script.\033[0m"
+    exit 0
+}
+
+check_gh_available() {
+    if command -v gh &> /dev/null; then
+        return 0
+    fi
+
+    echo -e "\033[0;31mError: GitHub CLI (gh) is not installed or not in PATH.\033[0m" >&2
+
+    if command -v brew &> /dev/null; then
+        install_gh_with_homebrew
+    fi
+
+    echo -e "Please install it: https://cli.github.com/" >&2
+    return 1
+}
+
+is_platform() {
+    case "$1" in
+        mobile | m | common | c | desktop | d | yanas | y) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+get_pr_reference_argument() {
+    if is_platform "$1"; then
+        return
+    fi
+
+    echo "$1"
+}
+
+get_platform_argument() {
+    if is_platform "$1"; then
+        echo "$1"
+    else
+        echo "$2"
+    fi
+}
+
+resolve_pr_reference() {
+    local pr_reference="$1"
+
+    if [[ -n "$pr_reference" ]]; then
+        echo "$pr_reference"
+        return 0
+    fi
+
+    local current_branch
+    current_branch=$(git branch --show-current 2>/dev/null)
+
+    if [[ -z "$current_branch" ]]; then
+        echo -e "\033[0;31mError: A PR number or URL is required when no branch is checked out.\033[0m
+Use -h option for more info." >&2
+        return 1
+    fi
+
+    if [[ "$current_branch" == "develop" || "$current_branch" == "main" ]]; then
+        echo -e "\033[0;31mError: You are on the '$current_branch' branch.
+Provide a PR number or URL, or switch to a feature/PR branch.\033[0m
+Use -h option for more info." >&2
+        return 1
+    fi
+
+    echo "$current_branch"
+}
+
+get_platform_icon() {
+    local platform="$1"
+    local icon=":desktop_computer:"
+
+    if [[ -n "$DEFAULT_SLACK_PR_ICON" ]]; then
+        icon="$DEFAULT_SLACK_PR_ICON"
+    fi
+
+    case "$platform" in
+        mobile | m) icon=":iphone:" ;;
+        common | c) icon=":commie:" ;;
+        desktop | d) icon=":desktop_computer:" ;;
+        yanas | y) icon=":typical-yanas:" ;;
+    esac
+
+    echo "$icon"
+}
+
+fetch_pr_json() {
+    local pr_reference="$1"
+    local pr_json
+
+    if ! pr_json=$(gh pr view "$pr_reference" --json title,changedFiles,additions,deletions,url 2>&1); then
+        echo -e "\033[0;31mError: Failed to fetch PR information.
+$pr_json
+Make sure the PR number or URL is valid.\033[0m
+Use -h option for more info" >&2
+        return 1
+    fi
+
+    echo "$pr_json"
+}
+
+build_slack_message() {
+    local pr_json="$1"
+    local icon="$2"
+    local title url deletions additions changed_files small_pr_emoji
+
+    title=$(echo "$pr_json" | jq -r ".title")
+    url=$(echo "$pr_json" | jq -r ".url")
+    deletions=$(echo "$pr_json" | jq -r ".deletions")
+    additions=$(echo "$pr_json" | jq -r ".additions")
+    changed_files=$(echo "$pr_json" | jq -r ".changedFiles")
+
+    small_pr_emoji=""
+    if [[ $((additions + deletions)) -lt 20 ]]; then
+        small_pr_emoji=":pinching_hand: "
+    fi
+
+    echo ":new-pull-request: $icon ${small_pr_emoji}${title}
+$url
+:heavy_plus_sign: $additions :heavy_minus_sign: $deletions :file_folder: $changed_files"
 }
 
 copy_to_clipboard() {
@@ -49,16 +195,12 @@ copy_to_clipboard() {
 
     if command -v pbcopy &> /dev/null; then
         echo -e "$content" | pbcopy
-        return 0
     elif command -v wl-copy &> /dev/null; then
         echo -e "$content" | wl-copy
-        return 0
     elif command -v xsel &> /dev/null; then
         echo -e "$content" | xsel --clipboard --input
-        return 0
     elif command -v xclip &> /dev/null; then
         echo -e "$content" | xclip -selection clipboard
-        return 0
     else
         echo -e "\033[0;33mWarning: No clipboard utility found (pbcopy, wl-copy, xsel, or xclip).\033[0m" >&2
         echo -e "\033[0;33mSkipping clipboard copy. Please copy the message manually.\033[0m" >&2
@@ -66,139 +208,46 @@ copy_to_clipboard() {
     fi
 }
 
-check_gh_available() {
-    if ! command -v gh &> /dev/null; then
-        echo -e "\033[0;31mError: GitHub CLI (gh) is not installed or not in PATH.\033[0m" >&2
+print_result() {
+    local result="$1"
 
-        # Offer to install via Homebrew if available
-        if command -v brew &> /dev/null; then
-            echo -e "\033[0;33mHomebrew detected. Would you like to install GitHub CLI now? (y/n)\033[0m"
-            read -r response
-            if [[ "$response" =~ ^[Yy]$ ]]; then
-                echo "Installing GitHub CLI..."
-                if brew install gh; then
-                    echo -e "\033[0;32m✓ GitHub CLI installed successfully!\033[0m"
-                    echo -e "\033[0;33mAuthentication required. Running 'gh auth login'...\033[0m"
-                    if gh auth login; then
-                        echo -e "\033[0;32m✓ Authentication successful! Please re-run the script.\033[0m"
-                        exit 0
-                    else
-                        echo -e "\033[0;31mAuthentication failed. Please run 'gh auth login' manually.\033[0m" >&2
-                        exit 1
-                    fi
-                else
-                    echo -e "\033[0;31mInstallation failed.\033[0m" >&2
-                    exit 1
-                fi
-            else
-                echo -e "Please install it manually: https://cli.github.com/" >&2
-                exit 1
-            fi
-        else
-            echo -e "Please install it: https://cli.github.com/" >&2
-            exit 1
-        fi
-    fi
-}
-
-get_platform_icon() {
-    local platform="$1"
-    local icon=":desktop_computer:"
-
-    # Allow override via environment variable
-    if [[ -n "$DEFAULT_SLACK_PR_ICON" ]]; then
-        icon="$DEFAULT_SLACK_PR_ICON"
-    fi
-
-    if [[ "$platform" == "mobile" || "$platform" == "m" ]]; then
-        icon=":iphone:"
-    elif [[ "$platform" == "common" || "$platform" == "c" ]]; then
-        icon=":commie:"
-    elif [[ "$platform" == "desktop" || "$platform" == "d" ]]; then
-        icon=":desktop_computer:"
-    elif [[ "$platform" == "yanas" || "$platform" == "y" ]]; then
-        icon=":typical-yanas:"
-    fi
-
-    echo "$icon"
-}
-
-# Handle help flag
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-    show_help
-    exit 0
-fi
-
-# Input and environment checks
-check_dependencies
-check_gh_available
-
-PR_REFERENCE="$1"
-PLATFORM="$2"
-
-case "$1" in
-    mobile | m | common | c | desktop | d | yanas | y)
-        PR_REFERENCE=""
-        PLATFORM="$1"
-        ;;
-esac
-
-if [[ -z "$PR_REFERENCE" ]]; then
-    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
-
-    if [[ -z "$CURRENT_BRANCH" ]]; then
-        echo -e "\033[0;31mError: A PR number or URL is required when no branch is checked out.\033[0m
-Use -h option for more info." >&2
-        exit 1
-    fi
-
-    if [[ "$CURRENT_BRANCH" == "develop" || "$CURRENT_BRANCH" == "main" ]]; then
-        echo -e "\033[0;31mError: You are on the '$CURRENT_BRANCH' branch.
-Provide a PR number or URL, or switch to a feature/PR branch.\033[0m
-Use -h option for more info." >&2
-        exit 1
-    fi
-
-    PR_REFERENCE="$CURRENT_BRANCH"
-fi
-
-# Determine platform icon
-ICON=$(get_platform_icon "$PLATFORM")
-
-if ! PR_JSON=$(gh pr view "$PR_REFERENCE" --json title,changedFiles,additions,deletions,url 2>&1); then
-    echo -e "\033[0;31mError: Failed to fetch PR information.
-$PR_JSON
-Make sure the PR number or URL is valid.\033[0m
-Use -h option for more info" >&2
-    exit 1
-fi
-
-NAME=$(echo "$PR_JSON" | jq -r ".title")
-URL=$(echo "$PR_JSON" | jq -r ".url")
-MINUS=$(echo "$PR_JSON" | jq -r ".deletions")
-PLUS=$(echo "$PR_JSON" | jq -r ".additions")
-FILES=$(echo "$PR_JSON" | jq -r ".changedFiles")
-
-# Add small PR indicator if total changes < 20
-SMALL_PR_EMOJI=""
-TOTAL_CHANGES=$((PLUS + MINUS))
-if [[ $TOTAL_CHANGES -lt 20 ]]; then
-    SMALL_PR_EMOJI=":pinching_hand: "
-fi
-
-# Construct the final Slack message
-RESULT=":new-pull-request: $ICON ${SMALL_PR_EMOJI}${NAME}
-$URL
-:heavy_plus_sign: $PLUS :heavy_minus_sign: $MINUS :file_folder: $FILES"
-
-# Output to terminal and copy to clipboard
-echo -e "
+    echo -e "
 -------------- Generated message -----------------
-$RESULT
+$result
 --------------------------------------------------"
+}
 
-if copy_to_clipboard "$RESULT"; then
-    echo -e "\n\033[0;32m✓ Copied to clipboard!\033[0m"
-else
-    echo -e "\n\033[0;33m✓ Message generated (not copied to clipboard)\033[0m"
-fi
+main() {
+    if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+        show_help
+        return 0
+    fi
+
+    check_jq_available || return 1
+    check_gh_available || return 1
+
+    local pr_reference platform icon pr_json result
+    pr_reference=$(get_pr_reference_argument "$1")
+    platform=$(get_platform_argument "$1" "$2")
+
+    if ! pr_reference=$(resolve_pr_reference "$pr_reference"); then
+        return 1
+    fi
+
+    icon=$(get_platform_icon "$platform")
+
+    if ! pr_json=$(fetch_pr_json "$pr_reference"); then
+        return 1
+    fi
+
+    result=$(build_slack_message "$pr_json" "$icon")
+    print_result "$result"
+
+    if copy_to_clipboard "$result"; then
+        echo -e "\n\033[0;32m✓ Copied to clipboard!\033[0m"
+    else
+        echo -e "\n\033[0;33m✓ Message generated (not copied to clipboard)\033[0m"
+    fi
+}
+
+main "$@"

--- a/scripts/generate-slack-pr-message.sh
+++ b/scripts/generate-slack-pr-message.sh
@@ -2,9 +2,12 @@
 
 show_help() {
     cat << EOF
-Usage: $(basename "$0") [PLATFORM]
+Usage: $(basename "$0") PR [PLATFORM]
 
 Generate a Slack-formatted PR message with stats and copy it to clipboard.
+
+PR:
+    GitHub pull request number or URL
 
 PLATFORM options:
     mobile, m       Use mobile icon (:iphone:)
@@ -17,15 +20,14 @@ Environment variables:
     DEFAULT_SLACK_PR_ICON    Override the default icon (e.g., ":rocket:")
 
 Examples:
-    $(basename "$0")              # Uses desktop icon
-    $(basename "$0") mobile       # Uses mobile icon
-    $(basename "$0") m            # Uses mobile icon (short form)
-    DEFAULT_SLACK_PR_ICON=":bug:" $(basename "$0")  # Custom icon
+    $(basename "$0") 12345
+    $(basename "$0") 12345 mobile
+    $(basename "$0") https://github.com/trezor/trezor-suite/pull/12345 m
+    DEFAULT_SLACK_PR_ICON=":bug:" $(basename "$0") 12345
 
 Requirements:
     - GitHub CLI (gh) must be installed and authenticated
-    - Must be run from a feature/PR branch (not develop or main)
-    - A pull request must exist for the current branch
+    - A PR number must be used from within its GitHub repository
 
 EOF
 }
@@ -95,16 +97,6 @@ check_gh_available() {
     fi
 }
 
-check_branch() {
-    CURRENT_BRANCH=$(git branch --show-current)
-    if [[ "$CURRENT_BRANCH" == "develop" || "$CURRENT_BRANCH" == "main" ]]; then
-        echo -e "\033[0;31mError: You are on the '$CURRENT_BRANCH' branch.
-This script should only be run from a feature/PR branch.\033[0m
-Use -h option for more info." >&2
-        exit 1
-    fi
-}
-
 get_platform_icon() {
     local platform="$1"
     local icon=":desktop_computer:"
@@ -133,21 +125,25 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     exit 0
 fi
 
+if [[ -z "$1" ]]; then
+    echo -e "\033[0;31mError: A PR number or URL is required.\033[0m
+Use -h option for more info." >&2
+    exit 1
+fi
+
 # Input and environment checks
 check_dependencies
 check_gh_available
-check_branch
+
+PR_REFERENCE="$1"
 
 # Determine platform icon
-ICON=$(get_platform_icon "$1")
+ICON=$(get_platform_icon "$2")
 
-# Pass the branch name explicitly. Without it, gh searches for a PR opened from
-# the branch's upstream instead, which is develop for branches created from
-# origin/develop, so no PR is found.
-if ! PR_JSON=$(gh pr view "$CURRENT_BRANCH" --json title,changedFiles,additions,deletions,url 2>&1); then
+if ! PR_JSON=$(gh pr view "$PR_REFERENCE" --json title,changedFiles,additions,deletions,url 2>&1); then
     echo -e "\033[0;31mError: Failed to fetch PR information.
 $PR_JSON
-Make sure you have a PR open for the current branch.\033[0m
+Make sure the PR number or URL is valid.\033[0m
 Use -h option for more info" >&2
     exit 1
 fi


### PR DESCRIPTION
## Description

The Slack PR message generator previously required its pull request to match the checked-out branch. It now accepts a PR number or URL while preserving branch-based invocation, and splits the workflow into focused helpers for readability.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-09-02T12:03:41.395Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/slack-pr-message-reference/web/](https://dev.suite.sldev.cz/suite-web/feat/slack-pr-message-reference/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/slack-pr-message-reference&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/slack-pr-message-reference&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T12:07:31.632Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T12:07:24.423Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->