### PR TITLE
chore(redux): enforce Thunk suffix

### DIFF
--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -12,11 +12,13 @@ const { noOverrideDsComponentRule } = require('./no-override-ds-component/rule')
 const { noPackageDeepImportsRule } = require('./no-package-deep-imports/rule');
 const { noSuiteImportsInSuiteCommonRule } = require('./no-suite-imports-in-suite-common/rule');
 const { noUnusedIntersectionMembersRule } = require('./no-unused-intersection-members/rule');
+const { enforceThunkNamesRule } = require('./thunk-names/rule');
 
 module.exports = {
     'analytics-event-name': analyticsEventNameRule,
     'enforce-di-factory-contracts': enforceDiFactoryContractsRule,
     'enforce-thunk-contracts': enforceThunkContractsRule,
+    'enforce-thunk-names': enforceThunkNamesRule,
     'no-override-ds-component': noOverrideDsComponentRule,
     'no-package-deep-imports': noPackageDeepImportsRule,
     'no-suite-imports-in-suite-common': noSuiteImportsInSuiteCommonRule,

--- a/eslint-local-rules/named-contracts/thunks/rule.test.ts
+++ b/eslint-local-rules/named-contracts/thunks/rule.test.ts
@@ -48,32 +48,6 @@ namedContractsRuleTester.run('enforce-thunk-contracts', enforceThunkContractsRul
         {
             filename: namedContractsFilename,
             code: `
-                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
-
-                type SaveThunkState = { value: string };
-
-                const saveThunks = createThunk<void, void, { state: SaveThunkState }>(
-                    'save',
-                    () => undefined,
-                );
-            `,
-        },
-        {
-            filename: namedContractsFilename,
-            code: `
-                declare const createThunk: <Result, Payload, Config>(name: string, callback: unknown) => unknown;
-
-                type SaveThunkState = { value: string };
-
-                const saveThunkInner = createThunk<void, void, { state: SaveThunkState }>(
-                    'save',
-                    () => undefined,
-                );
-            `,
-        },
-        {
-            filename: namedContractsFilename,
-            code: `
                 type SaveThunkState = { value: string };
 
                 type SaveThunkDeps = { save: () => void };

--- a/eslint-local-rules/named-contracts/thunks/rule.ts
+++ b/eslint-local-rules/named-contracts/thunks/rule.ts
@@ -2,11 +2,11 @@ import type { Rule } from 'eslint';
 import ts from 'typescript';
 
 import {
-    getFunctionExpression,
-    getTypeReferenceName,
-    getVariableFunction,
-    unwrapExpression,
-} from '../../utils';
+    getRtkThunkCallExpression,
+    getThunkImplementation,
+    getThunkImplementationFromFunction,
+} from '../../thunks/utils';
+import { getTypeReferenceName } from '../../utils';
 import { createNamedContractRuleListener } from '../utils';
 
 type RequiredContract = {
@@ -14,53 +14,12 @@ type RequiredContract = {
     node: ts.TypeNode;
 };
 
-const thunkCreators = new Set(['createSingleInstanceThunk', 'createThunk']);
-
 const capitalize = (name: string) => `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
 
 const getThunkContractBaseName = (name: string) => {
     const capitalizedName = capitalize(name);
 
-    if (capitalizedName.endsWith('Thunks')) {
-        return capitalizedName.slice(0, -1);
-    }
-
-    if (capitalizedName.endsWith('ThunkInner')) {
-        return capitalizedName.slice(0, -'Inner'.length);
-    }
-
     return capitalizedName.endsWith('Thunk') ? capitalizedName : `${capitalizedName}Thunk`;
-};
-
-const getReturnedFunction = (functionNode: ts.FunctionLikeDeclaration) => {
-    if (functionNode.body === undefined) {
-        return undefined;
-    }
-
-    if (!ts.isBlock(functionNode.body)) {
-        return getFunctionExpression(functionNode.body);
-    }
-
-    const returnStatements = functionNode.body.statements.filter(ts.isReturnStatement);
-    const [returnStatement] = returnStatements;
-
-    if (returnStatements.length !== 1 || returnStatement?.expression === undefined) {
-        return undefined;
-    }
-
-    return getFunctionExpression(returnStatement.expression);
-};
-
-const getInnermostReturnedFunction = (functionNode: ts.FunctionLikeDeclaration) => {
-    let currentFunction = functionNode;
-    let returnedFunction = getReturnedFunction(currentFunction);
-
-    while (returnedFunction !== undefined) {
-        currentFunction = returnedFunction;
-        returnedFunction = getReturnedFunction(currentFunction);
-    }
-
-    return currentFunction;
 };
 
 const getPropertyName = (node: ts.TypeElement) => {
@@ -89,27 +48,6 @@ const isEmptyContractType = (node: ts.TypeNode | undefined) => {
         node.typeName.text === 'Record' &&
         node.typeArguments?.[0]?.kind === ts.SyntaxKind.NeverKeyword
     );
-};
-
-const getThunkImplementationFromFunction = (outerFunction: ts.FunctionLikeDeclaration) => {
-    const implementation = getInnermostReturnedFunction(outerFunction);
-    const rawParameterNames = implementation.parameters.map(parameter =>
-        ts.isIdentifier(parameter.name) ? parameter.name.text : '',
-    );
-    const parameterNames = rawParameterNames.map(name => name.replace(/^_/, ''));
-
-    return (parameterNames[0] === 'dispatch' || rawParameterNames[0] === '_') &&
-        (parameterNames[1] === 'getState' || parameterNames[2] === 'extra')
-        ? implementation
-        : undefined;
-};
-
-const getThunkImplementation = (declaration: ts.VariableDeclaration) => {
-    const outerFunction = getVariableFunction(declaration);
-
-    return outerFunction === undefined
-        ? undefined
-        : getThunkImplementationFromFunction(outerFunction);
 };
 
 const getGetStateReturnType = (parameter: ts.ParameterDeclaration | undefined) => {
@@ -419,14 +357,10 @@ export const enforceThunkContractsRule: Rule.RuleModule = {
                         }
 
                         const declarationName = declaration.name.text;
-                        const unwrappedInitializer = unwrapExpression(declaration.initializer);
+                        const rtkThunk = getRtkThunkCallExpression(declaration.initializer);
 
-                        if (
-                            ts.isCallExpression(unwrappedInitializer) &&
-                            ts.isIdentifier(unwrappedInitializer.expression) &&
-                            thunkCreators.has(unwrappedInitializer.expression.text)
-                        ) {
-                            validateRtkThunk(declarationName, unwrappedInitializer, statementIndex);
+                        if (rtkThunk !== undefined) {
+                            validateRtkThunk(declarationName, rtkThunk, statementIndex);
                             continue;
                         }
 

--- a/eslint-local-rules/thunk-names/rule.test.ts
+++ b/eslint-local-rules/thunk-names/rule.test.ts
@@ -1,0 +1,198 @@
+import { RuleTester } from 'eslint';
+import { parser } from 'typescript-eslint';
+
+import { enforceThunkNamesRule } from './rule';
+
+const typescriptRuleTester = new RuleTester({
+    languageOptions: {
+        parser,
+        parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+    },
+});
+
+typescriptRuleTester.run('enforce-thunk-names', enforceThunkNamesRule, {
+    valid: [
+        {
+            code: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const saveThunk = createThunk('save', () => undefined);
+            `,
+        },
+        {
+            code: `
+                declare const createSingleInstanceThunk: (...args: unknown[]) => unknown;
+                const saveThunk = createSingleInstanceThunk('save', () => undefined);
+            `,
+        },
+        {
+            code: `
+                const saveThunk = () => (dispatch: unknown, getState: () => unknown) => {
+                    void dispatch;
+                    void getState;
+                };
+            `,
+        },
+        {
+            code: `
+                function saveThunk() {
+                    return (dispatch: unknown, getState: () => unknown, extra: unknown) => {
+                        void dispatch;
+                        void getState;
+                        void extra;
+                    };
+                }
+            `,
+        },
+        {
+            code: `
+                const save = () => (value: unknown) => value;
+                const createThunk = () => undefined;
+            `,
+        },
+    ],
+    invalid: [
+        {
+            code: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const save = createThunk('save', () => undefined);
+            `,
+            output: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const saveThunk = createThunk('save', () => undefined);
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'save' } }],
+        },
+        {
+            code: `
+                declare const createSingleInstanceThunk: (...args: unknown[]) => unknown;
+                const save = createSingleInstanceThunk('save', () => undefined);
+            `,
+            output: `
+                declare const createSingleInstanceThunk: (...args: unknown[]) => unknown;
+                const saveThunk = createSingleInstanceThunk('save', () => undefined);
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'save' } }],
+        },
+        {
+            code: `
+                const save = () => (dispatch: unknown, getState: () => unknown) => {
+                    void dispatch;
+                    void getState;
+                };
+            `,
+            output: `
+                const saveThunk = () => (dispatch: unknown, getState: () => unknown) => {
+                    void dispatch;
+                    void getState;
+                };
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'save' } }],
+        },
+        {
+            code: `
+                const save = () => {
+                    return (_: unknown, _getState: () => unknown, extra: unknown) => {
+                        void extra;
+                    };
+                };
+            `,
+            output: `
+                const saveThunk = () => {
+                    return (_: unknown, _getState: () => unknown, extra: unknown) => {
+                        void extra;
+                    };
+                };
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'save' } }],
+        },
+        {
+            code: `
+                function save() {
+                    return (dispatch: unknown, getState: () => unknown) => {
+                        void dispatch;
+                        void getState;
+                    };
+                }
+            `,
+            output: `
+                function saveThunk() {
+                    return (dispatch: unknown, getState: () => unknown) => {
+                        void dispatch;
+                        void getState;
+                    };
+                }
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'save' } }],
+        },
+        {
+            code: `
+                function run() {
+                    const save = () => (dispatch: unknown, getState: () => unknown) => {
+                        void dispatch;
+                        void getState;
+                    };
+
+                    return save;
+                }
+            `,
+            output: `
+                function run() {
+                    const saveThunk = () => (dispatch: unknown, getState: () => unknown) => {
+                        void dispatch;
+                        void getState;
+                    };
+
+                    return saveThunk;
+                }
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'save' } }],
+        },
+        {
+            code: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const save = createThunk('save', () => undefined);
+                const actions = { save };
+                void actions;
+            `,
+            output: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const saveThunk = createThunk('save', () => undefined);
+                const actions = { save: saveThunk };
+                void actions;
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'save' } }],
+        },
+        {
+            code: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const saveThunks = createThunk('save', () => undefined);
+            `,
+            output: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const saveThunk = createThunk('save', () => undefined);
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'saveThunks' } }],
+        },
+        {
+            code: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const saveThunkInner = createThunk('save', () => undefined);
+            `,
+            output: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const saveThunk = createThunk('save', () => undefined);
+            `,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'saveThunkInner' } }],
+        },
+        {
+            code: `
+                declare const createThunk: (...args: unknown[]) => unknown;
+                const saveThunk = createThunk('existing', () => undefined);
+                const save = createThunk('save', () => undefined);
+                void save;
+            `,
+            output: null,
+            errors: [{ messageId: 'missingThunkSuffix', data: { thunkName: 'save' } }],
+        },
+    ],
+} as Parameters<typeof typescriptRuleTester.run>[2]);

--- a/eslint-local-rules/thunk-names/rule.ts
+++ b/eslint-local-rules/thunk-names/rule.ts
@@ -1,0 +1,148 @@
+import type { Rule } from 'eslint';
+import ts from 'typescript';
+
+import { getRtkThunkCallExpression, getThunkImplementationFromFunction } from '../thunks/utils';
+import {
+    createTypeScriptNodeReporter,
+    getTypeScriptParserServices,
+    getVariableFunction,
+} from '../utils';
+
+/** Enforces the Thunk suffix for RTK and vanilla Redux thunk declarations. */
+export const enforceThunkNamesRule: Rule.RuleModule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Enforces the Thunk suffix for Redux thunk declarations.',
+            category: 'Best Practices',
+            recommended: false,
+        },
+        fixable: 'code',
+        messages: {
+            missingThunkSuffix: "Redux thunk name '{{thunkName}}' must end with 'Thunk'.",
+        },
+        schema: [],
+    },
+    create: context => {
+        const parserServices = getTypeScriptParserServices(context);
+
+        if (parserServices === undefined) {
+            return {};
+        }
+
+        const report = createTypeScriptNodeReporter(context, parserServices);
+
+        const getFixedName = (name: string) => {
+            if (name.endsWith('Thunks')) {
+                return name.slice(0, -1);
+            }
+
+            if (name.endsWith('ThunkInner')) {
+                return name.slice(0, -'Inner'.length);
+            }
+
+            return `${name}Thunk`;
+        };
+
+        const createRenameFix = (name: ts.Identifier): Rule.ReportFixer | undefined => {
+            const estreeName = parserServices.getESTreeNode(name);
+
+            if (estreeName === undefined) {
+                return undefined;
+            }
+
+            const fixedName = getFixedName(name.text);
+            const hasNameConflict = context.sourceCode.scopeManager?.scopes.some(scope =>
+                scope.set.has(fixedName),
+            );
+
+            if (hasNameConflict === true) {
+                return undefined;
+            }
+
+            let scope = context.sourceCode.getScope(estreeName);
+            let variable;
+
+            while (scope !== null) {
+                const candidate = scope.set.get(name.text);
+
+                if (candidate?.identifiers.includes(estreeName as never) === true) {
+                    variable = candidate;
+                    break;
+                }
+
+                if (scope.upper === null) {
+                    break;
+                }
+
+                scope = scope.upper;
+            }
+
+            if (variable === undefined) {
+                return undefined;
+            }
+
+            const references = new Set<Rule.Node>([
+                ...(variable.identifiers as Rule.Node[]),
+                ...variable.references.map(reference => reference.identifier as Rule.Node),
+            ]);
+
+            return fixer =>
+                [...references].map(reference => {
+                    const typescriptReference = parserServices.getTypeScriptNode(reference);
+                    const isShorthandProperty =
+                        typescriptReference !== undefined &&
+                        ts.isIdentifier(typescriptReference) &&
+                        ts.isShorthandPropertyAssignment(typescriptReference.parent);
+
+                    return fixer.replaceText(
+                        reference,
+                        isShorthandProperty ? `${name.text}: ${fixedName}` : fixedName,
+                    );
+                });
+        };
+
+        const validateName = (name: ts.Identifier) => {
+            if (!name.text.endsWith('Thunk')) {
+                report(name, 'missingThunkSuffix', { thunkName: name.text }, createRenameFix(name));
+            }
+        };
+
+        const visitNode = (node: ts.Node) => {
+            if (
+                ts.isFunctionDeclaration(node) &&
+                node.name !== undefined &&
+                getThunkImplementationFromFunction(node) !== undefined
+            ) {
+                validateName(node.name);
+            }
+
+            if (
+                ts.isVariableDeclaration(node) &&
+                ts.isIdentifier(node.name) &&
+                node.initializer !== undefined
+            ) {
+                const variableFunction = getVariableFunction(node);
+                const isVanillaThunk =
+                    variableFunction !== undefined &&
+                    getThunkImplementationFromFunction(variableFunction) !== undefined;
+
+                if (getRtkThunkCallExpression(node.initializer) !== undefined || isVanillaThunk) {
+                    validateName(node.name);
+                }
+            }
+
+            ts.forEachChild(node, visitNode);
+        };
+
+        return {
+            'Program:exit': programNode => {
+                const sourceFile = parserServices.getTypeScriptNode(programNode as Rule.Node);
+
+                if (sourceFile !== undefined) {
+                    visitNode(sourceFile);
+                }
+            },
+        };
+    },
+};

--- a/eslint-local-rules/thunks/utils.ts
+++ b/eslint-local-rules/thunks/utils.ts
@@ -1,0 +1,67 @@
+import ts from 'typescript';
+
+import { getFunctionExpression, getVariableFunction, unwrapExpression } from '../utils';
+
+const thunkCreators = new Set(['createSingleInstanceThunk', 'createThunk']);
+
+const getReturnedFunction = (functionNode: ts.FunctionLikeDeclaration) => {
+    if (functionNode.body === undefined) {
+        return undefined;
+    }
+
+    if (!ts.isBlock(functionNode.body)) {
+        return getFunctionExpression(functionNode.body);
+    }
+
+    const returnStatements = functionNode.body.statements.filter(ts.isReturnStatement);
+    const [returnStatement] = returnStatements;
+
+    if (returnStatements.length !== 1 || returnStatement?.expression === undefined) {
+        return undefined;
+    }
+
+    return getFunctionExpression(returnStatement.expression);
+};
+
+const getInnermostReturnedFunction = (functionNode: ts.FunctionLikeDeclaration) => {
+    let currentFunction = functionNode;
+    let returnedFunction = getReturnedFunction(currentFunction);
+
+    while (returnedFunction !== undefined) {
+        currentFunction = returnedFunction;
+        returnedFunction = getReturnedFunction(currentFunction);
+    }
+
+    return currentFunction;
+};
+
+export const getThunkImplementationFromFunction = (outerFunction: ts.FunctionLikeDeclaration) => {
+    const implementation = getInnermostReturnedFunction(outerFunction);
+    const rawParameterNames = implementation.parameters.map(parameter =>
+        ts.isIdentifier(parameter.name) ? parameter.name.text : '',
+    );
+    const parameterNames = rawParameterNames.map(name => name.replace(/^_/, ''));
+
+    return (parameterNames[0] === 'dispatch' || rawParameterNames[0] === '_') &&
+        (parameterNames[1] === 'getState' || parameterNames[2] === 'extra')
+        ? implementation
+        : undefined;
+};
+
+export const getThunkImplementation = (declaration: ts.VariableDeclaration) => {
+    const outerFunction = getVariableFunction(declaration);
+
+    return outerFunction === undefined
+        ? undefined
+        : getThunkImplementationFromFunction(outerFunction);
+};
+
+export const getRtkThunkCallExpression = (initializer: ts.Expression) => {
+    const unwrappedInitializer = unwrapExpression(initializer);
+
+    return ts.isCallExpression(unwrappedInitializer) &&
+        ts.isIdentifier(unwrappedInitializer.expression) &&
+        thunkCreators.has(unwrappedInitializer.expression.text)
+        ? unwrappedInitializer
+        : undefined;
+};

--- a/packages/connect-explorer/src/actions/methodActions.ts
+++ b/packages/connect-explorer/src/actions/methodActions.ts
@@ -67,35 +67,36 @@ export const onSetManualMode = (manualMode: boolean) => ({
 
 type OnSubmitThunkState = ConnectRootState & MethodRootState;
 
-export const onSubmit = () => async (dispatch: Dispatch, getState: () => OnSubmitThunkState) => {
-    const method = selectMethod(getState());
-    const connect = selectConnect(getState());
-    if (!method?.name) throw new Error('method name not specified');
-    dispatch({ type: SET_METHOD_PROCESSING, payload: true });
-    const trezorConnectImpl =
-        connect.options?.coreMode === 'deeplink' ? TrezorConnectMobile : TrezorConnect;
-    const connectMethod = trezorConnectImpl[method.name];
-    if (typeof connectMethod !== 'function') {
-        dispatch(
-            onResponse({
-                error: `Method "${method.name}" not found in TrezorConnect`,
-            }),
-        );
+export const onSubmitThunk =
+    () => async (dispatch: Dispatch, getState: () => OnSubmitThunkState) => {
+        const method = selectMethod(getState());
+        const connect = selectConnect(getState());
+        if (!method?.name) throw new Error('method name not specified');
+        dispatch({ type: SET_METHOD_PROCESSING, payload: true });
+        const trezorConnectImpl =
+            connect.options?.coreMode === 'deeplink' ? TrezorConnectMobile : TrezorConnect;
+        const connectMethod = trezorConnectImpl[method.name];
+        if (typeof connectMethod !== 'function') {
+            dispatch(
+                onResponse({
+                    error: `Method "${method.name}" not found in TrezorConnect`,
+                }),
+            );
 
-        return;
-    }
+            return;
+        }
 
-    // @ts-expect-error params type is unknown
-    const response = await connectMethod({
-        ...method.params,
-    });
-    dispatch({ type: SET_METHOD_PROCESSING, payload: false });
-    dispatch(onResponse(response));
-};
+        // @ts-expect-error params type is unknown
+        const response = await connectMethod({
+            ...method.params,
+        });
+        dispatch({ type: SET_METHOD_PROCESSING, payload: false });
+        dispatch(onResponse(response));
+    };
 
 type OnCodeChangeThunkState = MethodRootState;
 
-export const onCodeChange =
+export const onCodeChangeThunk =
     (value: string) => (dispatch: Dispatch, getState: () => OnCodeChangeThunkState) => {
         try {
             const { fields } = selectMethod(getState());

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -83,8 +83,9 @@ export const initWithOptions = (options: ConnectOptions) => (dispatch: Dispatch)
 
 type OnSubmitInitThunkState = ConnectRootState;
 
-export const onSubmitInit = () => (dispatch: Dispatch, getState: () => OnSubmitInitThunkState) => {
-    const connect = selectConnect(getState());
+export const onSubmitInitThunk =
+    () => (dispatch: Dispatch, getState: () => OnSubmitInitThunkState) => {
+        const connect = selectConnect(getState());
 
-    return dispatch(initWithOptions(connect.options ?? {}));
-};
+        return dispatch(initWithOptions(connect.options ?? {}));
+    };

--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -34,7 +34,7 @@ import { selectMethod } from '../reducers/methodReducer';
 
 interface Props {
     actions: {
-        onSubmit: typeof methodActions.onSubmit;
+        onSubmit: typeof methodActions.onSubmitThunk;
         onBatchAdd: typeof methodActions.onBatchAdd;
         onBatchRemove: typeof methodActions.onBatchRemove;
         onFieldChange: typeof methodActions.onFieldChange;
@@ -231,13 +231,13 @@ export const Method = () => {
     const theme = useTheme();
     const method = useSelector(selectMethod);
     const actions = useActions({
-        onSubmit: methodActions.onSubmit,
+        onSubmit: methodActions.onSubmitThunk,
         onCancelCall: methodActions.onCancelCall,
         onBatchAdd: methodActions.onBatchAdd,
         onBatchRemove: methodActions.onBatchRemove,
         onFieldChange: methodActions.onFieldChange,
         onSetUnion: methodActions.onSetUnion,
-        onCodeChange: methodActions.onCodeChange,
+        onCodeChange: methodActions.onCodeChangeThunk,
     });
 
     const { onSubmit } = actions;

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -101,6 +101,7 @@ export const localRulesConfig = [
         rules: {
             'local-rules/enforce-di-factory-contracts': 'error',
             'local-rules/enforce-thunk-contracts': 'error',
+            'local-rules/enforce-thunk-names': 'error',
         },
     },
     ...(areExpensiveChecksEnabled

--- a/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
@@ -1,4 +1,4 @@
-import { firmwareActions, firmwareUpdate } from '@suite-common/firmware';
+import { firmwareActions, firmwareUpdateThunk } from '@suite-common/firmware';
 import { mockGetFirmwareReleaseConfigInfo, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { FirmwareType, UI_EVENTS } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
@@ -42,7 +42,7 @@ const firmwareUpdateResponsePayload = {
 export const actions = [
     {
         description: 'Success T2T1',
-        action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
+        action: () => firmwareUpdateThunk({ firmwareType: FirmwareType.Universal }),
         mocks: {
             connect: {
                 success: true,
@@ -68,7 +68,7 @@ export const actions = [
     },
     {
         description: 'Success T2T1 - install Bitcoin-only firmware',
-        action: () => firmwareUpdate({ firmwareType: FirmwareType.BitcoinOnly }),
+        action: () => firmwareUpdateThunk({ firmwareType: FirmwareType.BitcoinOnly }),
         mocks: {
             connect: {
                 success: true,
@@ -94,7 +94,7 @@ export const actions = [
     },
     {
         description: 'Success T1B1 (with intermediary)',
-        action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
+        action: () => firmwareUpdateThunk({ firmwareType: FirmwareType.Universal }),
         mocks: {
             connect: {
                 success: true,
@@ -123,7 +123,7 @@ export const actions = [
     },
     {
         description: 'Success T1B1 (without intermediary)',
-        action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
+        action: () => firmwareUpdateThunk({ firmwareType: FirmwareType.Universal }),
         mocks: {
             connect: {
                 success: true,
@@ -152,7 +152,7 @@ export const actions = [
     },
     {
         description: 'Errors for missing device',
-        action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
+        action: () => firmwareUpdateThunk({ firmwareType: FirmwareType.Universal }),
         initialState: {
             device: {
                 selectedDevice: undefined,
@@ -165,7 +165,7 @@ export const actions = [
     },
     {
         description: 'FirmwareUpdate call to connect errors',
-        action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
+        action: () => firmwareUpdateThunk({ firmwareType: FirmwareType.Universal }),
         initialState: {
             device: {
                 selectedDevice: bootloaderDevice,
@@ -189,7 +189,7 @@ export const actions = [
                 { type: firmwareActions.setStatus.type, payload: 'error' },
                 { type: firmwareActions.setFirmwareUpdateError.type, payload: 'foo' },
                 {
-                    type: firmwareUpdate.rejected.type,
+                    type: firmwareUpdateThunk.rejected.type,
                     payload: {
                         device: bootloaderDevice,
                         error: 'foo',
@@ -202,7 +202,7 @@ export const actions = [
     },
     {
         description: 'FirmwareUpdate call to connect errors due to cancelling on device',
-        action: () => firmwareUpdate({ firmwareType: FirmwareType.Universal }),
+        action: () => firmwareUpdateThunk({ firmwareType: FirmwareType.Universal }),
         initialState: {
             device: {
                 selectedDevice: bootloaderDevice,
@@ -229,7 +229,7 @@ export const actions = [
                     payload: 'Firmware install failed',
                 },
                 {
-                    type: firmwareUpdate.rejected.type,
+                    type: firmwareUpdateThunk.rejected.type,
                     payload: {
                         device: bootloaderDevice,
                         error: 'Firmware install failed',

--- a/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
+++ b/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
@@ -8,7 +8,7 @@ import { sanitizeFilename } from '@trezor/utils';
 
 type ExportMetadataToBip329FileThunkDeps = WithServices<Bip329Dep>;
 
-export const exportMetadataToBip329File = createThunk<
+export const exportMetadataToBip329FileThunk = createThunk<
     void,
     {
         account: Account;

--- a/packages/suite/src/actions/onboarding/__fixtures__/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/__fixtures__/onboardingActions.ts
@@ -6,33 +6,33 @@ import onboardingReducer from 'src/reducers/onboarding/onboardingReducer';
 
 export default [
     {
-        description: 'goToNextStep (without param)',
+        description: 'goToNextStepThunk (without param)',
         initialState: {
             device: mockSuiteDevice(),
         },
-        action: () => onboardingActions.goToNextStep(),
+        action: () => onboardingActions.goToNextStepThunk(),
         expect: {
             toMatchObject: { activeStepId: STEP.ID_AUTHENTICATE_DEVICE_STEP },
         },
     },
     {
-        description: 'goToNextStep (with param)',
+        description: 'goToNextStepThunk (with param)',
         initialState: {
             device: mockSuiteDevice(),
         },
-        action: () => onboardingActions.goToNextStep('firmware'),
+        action: () => onboardingActions.goToNextStepThunk('firmware'),
         expect: {
             toMatchObject: { activeStepId: STEP.ID_FIRMWARE_STEP },
         },
     },
     {
-        description: 'goToPreviousStep',
+        description: 'goToPreviousStepThunk',
         initialState: {
             onboarding: {
                 activeStepId: STEP.ID_RECOVERY_STEP,
             },
         },
-        action: () => onboardingActions.goToPreviousStep(),
+        action: () => onboardingActions.goToPreviousStepThunk(),
         expect: {
             toMatchObject: { activeStepId: STEP.ID_BACKUP_TYPE_STEP },
         },

--- a/packages/suite/src/actions/onboarding/goToSuite.test.ts
+++ b/packages/suite/src/actions/onboarding/goToSuite.test.ts
@@ -8,7 +8,7 @@ import { createTestStore } from '@suite-common/test-utils';
 import { type StartDiscoveryThunkDeps } from '@suite-common/wallet-core';
 import { type DeepPartial } from '@trezor/type-utils';
 
-import { goToSuite } from 'src/actions/onboarding/onboardingActions';
+import { goToSuiteThunk } from 'src/actions/onboarding/onboardingActions';
 import { type AppState } from 'src/types/suite';
 
 const device = mockSuiteDevice();
@@ -51,11 +51,11 @@ const setup = () => {
     return { store, report };
 };
 
-describe('goToSuite', () => {
+describe('goToSuiteThunk', () => {
     it('reports device-setup-completed by default', () => {
         const { store, report } = setup();
 
-        store.dispatch(goToSuite());
+        store.dispatch(goToSuiteThunk());
 
         expect(report).toHaveBeenCalledTimes(1);
         expect(report.mock.calls[0][0].type).toBe('device-setup-completed');
@@ -64,7 +64,7 @@ describe('goToSuite', () => {
     it('does not report device-setup-completed when the event is skipped', () => {
         const { store, report } = setup();
 
-        store.dispatch(goToSuite({ skipDeviceSetupCompletedEvent: true }));
+        store.dispatch(goToSuiteThunk({ skipDeviceSetupCompletedEvent: true }));
 
         expect(report).not.toHaveBeenCalled();
     });

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -2,14 +2,14 @@ import { type Dispatch, type UnknownAction, createAction } from '@reduxjs/toolki
 import { type ThunkDispatch } from 'redux-thunk';
 
 import { type DesktopAnalyticsDep, type OnboardingAnalytics, events } from '@suite/analytics';
-import { initialRunCompleted } from '@suite/flags';
+import { initialRunCompletedThunk } from '@suite/flags';
 import { closeModal } from '@suite/modal';
 import { type RecoveryState, recoveryRerunThunk } from '@suite/recovery';
 import {
     type GotoThunkState,
     type SuiteRouterHistoryDep,
-    closeModalApp,
-    goto,
+    closeModalAppThunk,
+    gotoThunk,
     selectRouterApp,
 } from '@suite/router';
 import { type SuiteSettingsRootState } from '@suite/settings';
@@ -28,7 +28,7 @@ import {
     type StartDiscoveryThunkDeps,
     type StartDiscoveryThunkState,
     type WalletSettingsRootState,
-    changeCoinVisibility,
+    changeCoinVisibilityThunk,
     selectEnabledNetworks,
     startDiscoveryThunk,
 } from '@suite-common/wallet-core';
@@ -74,7 +74,7 @@ const getAllStepsInPath = (getState: () => GetAllStepsInPathState) => {
 
 type GoToPreviousStepThunkState = DeviceRootState & OnboardingRootState & SuiteSettingsRootState;
 
-const goToPreviousStep =
+const goToPreviousStepThunk =
     (stepId?: AnyStepId) =>
     (dispatch: Dispatch<UnknownAction>, getState: () => GoToPreviousStepThunkState) => {
         if (stepId) {
@@ -115,7 +115,7 @@ export type GoToSuiteOptions = {
     skipDeviceSetupCompletedEvent?: boolean;
 };
 
-const goToSuite =
+const goToSuiteThunk =
     ({ skipDeviceSetupCompletedEvent }: GoToSuiteOptions = {}) =>
     (
         dispatch: ThunkDispatch<GoToSuiteThunkState, GoToSuiteThunkDeps, UnknownAction>,
@@ -134,9 +134,9 @@ const goToSuite =
         // a device from scratch. Pairing an already set up device leaves the path empty.
         const isFreshDeviceSetup = selectOnboardingPath(getState()).length > 0;
 
-        dispatch(initialRunCompleted({ isFreshDeviceSetup }));
+        dispatch(initialRunCompletedThunk({ isFreshDeviceSetup }));
         dispatch(resetOnboarding());
-        dispatch(closeModalApp(true));
+        dispatch(closeModalAppThunk(true));
 
         // For Bitcoin-only firmware, pre-activate BTC so the user lands on a populated dashboard
         // instead of the empty "activate assets" state. Only do this on initial setup, when no
@@ -144,7 +144,7 @@ const goToSuite =
         const isBitcoinOnlyFirmware = selectHasBitcoinOnlyFirmware(getState());
         const enabledNetworks = selectEnabledNetworks(getState());
         if (isBitcoinOnlyFirmware && enabledNetworks.length === 0) {
-            dispatch(changeCoinVisibility({ symbol: 'btc', shouldBeVisible: true }));
+            dispatch(changeCoinVisibilityThunk({ symbol: 'btc', shouldBeVisible: true }));
         }
 
         // there must be a device to progress with onboarding
@@ -197,7 +197,7 @@ type GoToNextStepThunkDeps = {
     services: DesktopAnalyticsDep & SuiteRouterHistoryDep;
 } & StartDiscoveryThunkDeps;
 
-const goToNextStep =
+const goToNextStepThunk =
     (nextStepId?: AnyStepId) =>
     (
         dispatch: ThunkDispatch<GoToNextStepThunkState, GoToNextStepThunkDeps, UnknownAction>,
@@ -215,7 +215,7 @@ const goToNextStep =
         );
         // we are at last step, so go to Suite
         if (nextStep === null) {
-            dispatch(goToSuite());
+            dispatch(goToSuiteThunk());
 
             return;
         }
@@ -241,7 +241,7 @@ type BeginOnboardingTutorialThunkDeps = {
     services: DesktopAnalyticsDep & SuiteRouterHistoryDep;
 } & StartDiscoveryThunkDeps;
 
-const beginOnboardingTutorial =
+const beginOnboardingTutorialThunk =
     () =>
     async (
         dispatch: ThunkDispatch<
@@ -255,14 +255,14 @@ const beginOnboardingTutorial =
         if (!device) return;
 
         await TrezorConnect.showDeviceTutorial({ device });
-        dispatch(goToNextStep());
+        dispatch(goToNextStepThunk());
     };
 
 type ResolveNextAfterSkippedThunkState = DeviceRootState &
     OnboardingRootState &
     SuiteSettingsRootState;
 
-const resolveNextAfterSkipped =
+const resolveNextAfterSkippedThunk =
     (skippedToStepId: AnyStepId) =>
     (_dispatch: Dispatch<UnknownAction>, getState: () => ResolveNextAfterSkippedThunkState) => {
         const device = selectSelectedDevice(getState());
@@ -276,15 +276,15 @@ const resolveNextAfterSkipped =
         return resolvedNextStep?.id;
     };
 
-type RecoveryRerunThunkState = DeviceRootState & GotoThunkState & { recovery: RecoveryState };
+type RerunRecoveryThunkState = DeviceRootState & GotoThunkState & { recovery: RecoveryState };
 
-type RecoveryRerunThunkDeps = { services: DesktopAnalyticsDep & SuiteRouterHistoryDep };
+type RerunRecoveryThunkDeps = { services: DesktopAnalyticsDep & SuiteRouterHistoryDep };
 
-const recoveryRerun =
+const rerunRecoveryThunk =
     () =>
     async (
-        dispatch: ThunkDispatch<RecoveryRerunThunkState, RecoveryRerunThunkDeps, UnknownAction>,
-        getState: () => RecoveryRerunThunkState,
+        dispatch: ThunkDispatch<RerunRecoveryThunkState, RerunRecoveryThunkDeps, UnknownAction>,
+        getState: () => RerunRecoveryThunkState,
     ) => {
         const result = await dispatch(recoveryRerunThunk());
 
@@ -294,10 +294,10 @@ const recoveryRerun =
 
         const { initialized } = result.payload;
         if (initialized) {
-            dispatch(goto({ routeName: 'recovery-index' }));
+            dispatch(gotoThunk({ routeName: 'recovery-index' }));
         } else {
             if (selectRouterApp(getState()) !== 'onboarding') {
-                dispatch(goto({ routeName: 'onboarding-index' }));
+                dispatch(gotoThunk({ routeName: 'onboarding-index' }));
             }
             dispatch(goToStep('recovery'));
             dispatch(addPath('recovery'));
@@ -306,17 +306,17 @@ const recoveryRerun =
 
 export {
     enableOnboardingReducer,
-    goToNextStep,
+    goToNextStepThunk,
     goToStep,
-    goToPreviousStep,
+    goToPreviousStepThunk,
     addPath,
     removePath,
     resetOnboarding,
-    goToSuite,
+    goToSuiteThunk,
     updateAnalytics,
-    beginOnboardingTutorial,
+    beginOnboardingTutorialThunk,
     updateBackupType,
     updateBackupMedium,
-    resolveNextAfterSkipped,
-    recoveryRerun,
+    resolveNextAfterSkippedThunk,
+    rerunRecoveryThunk,
 };

--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettingsActions.ts
@@ -264,7 +264,7 @@ const fixture: Fixture[] = [
     },
     {
         description: 'Apply settings',
-        action: () => deviceSettingsActions.applySettings({ label: 'foo' }),
+        action: () => deviceSettingsActions.applySettingsThunk({ label: 'foo' }),
         mocks: { success: true, payload: { message: 'huraa' } },
         result: {
             actions: [
@@ -278,7 +278,7 @@ const fixture: Fixture[] = [
     },
     {
         description: 'Apply settings - connect error',
-        action: () => deviceSettingsActions.applySettings({ label: 'foo' }),
+        action: () => deviceSettingsActions.applySettingsThunk({ label: 'foo' }),
         mocks: { success: false, error: { message: 'eeeh', code: 'Failure_UnknownCode' } },
         result: {
             actions: [
@@ -297,7 +297,7 @@ const fixture: Fixture[] = [
     },
     {
         description: 'Change pin',
-        action: () => deviceSettingsActions.changePin({}),
+        action: () => deviceSettingsActions.changePinThunk({}),
         mocks: { success: true, payload: { message: 'huraa' } },
         result: {
             actions: [
@@ -311,7 +311,7 @@ const fixture: Fixture[] = [
     },
     {
         description: 'Change pin - connect error',
-        action: () => deviceSettingsActions.changePin({}),
+        action: () => deviceSettingsActions.changePinThunk({}),
         mocks: { success: false, error: { message: 'eeeh', code: 'Failure_UnknownCode' } },
         result: {
             actions: [
@@ -330,7 +330,7 @@ const fixture: Fixture[] = [
     },
     {
         description: 'Reset device - Cancel - Entropy check not triggered',
-        action: () => deviceSettingsActions.resetDevice(),
+        action: () => deviceSettingsActions.resetDeviceThunk(),
         mocks: { success: false, error: { message: 'Canceled', code: 'Method_Cancel' } },
         result: {
             actions: [
@@ -356,7 +356,7 @@ const fixture: Fixture[] = [
     },
     {
         description: 'Reset device - Entropy check success',
-        action: () => deviceSettingsActions.resetDevice(),
+        action: () => deviceSettingsActions.resetDeviceThunk(),
         mocks: { success: true, payload: { message: 'whatever' } },
         result: {
             actions: [
@@ -375,7 +375,7 @@ const fixture: Fixture[] = [
     },
     {
         description: 'Reset device - Entropy check errored - show Device compromised',
-        action: () => deviceSettingsActions.resetDevice(),
+        action: () => deviceSettingsActions.resetDeviceThunk(),
         mocks: {
             success: false,
             error: { message: 'Entropy check failed', code: 'Failure_EntropyCheck' },

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -29,7 +29,7 @@ import {
 
 type ApplySettingsThunkState = DeviceRootState;
 
-export const applySettings =
+export const applySettingsThunk =
     (params: Parameters<typeof TrezorConnect.applySettings>[0]) =>
     async (dispatch: Dispatch<UnknownAction>, getState: () => ApplySettingsThunkState) => {
         const device = selectSelectedDevice(getState());
@@ -51,7 +51,7 @@ export const applySettings =
 
 type ChangePinThunkState = DeviceRootState;
 
-export const changePin =
+export const changePinThunk =
     (params: Parameters<typeof TrezorConnect.changePin>[0] = {}, skipSuccessToast?: boolean) =>
     async (dispatch: Dispatch<UnknownAction>, getState: () => ChangePinThunkState) => {
         const device = selectSelectedDevice(getState());
@@ -86,7 +86,7 @@ export const changePin =
 
 type ChangeWipeCodeThunkState = DeviceRootState;
 
-export const changeWipeCode =
+export const changeWipeCodeThunk =
     ({ remove }: Parameters<typeof TrezorConnect.changeWipeCode>[0] = {}) =>
     async (dispatch: Dispatch<UnknownAction>, getState: () => ChangeWipeCodeThunkState) => {
         const device = selectSelectedDevice(getState());
@@ -116,7 +116,7 @@ type ResetDeviceThunkState = DeviceRootState & SuiteSettingsRootState & MessageS
 
 type ResetDeviceThunkDeps = { services: ReportSecurityCheckDep };
 
-export const resetDevice =
+export const resetDeviceThunk =
     (params: Parameters<typeof TrezorConnect.resetDevice>[0] = {}) =>
     async (
         dispatch: ThunkDispatch<ResetDeviceThunkState, ResetDeviceThunkDeps, UnknownAction>,
@@ -201,7 +201,7 @@ export const resetDevice =
 
 type ChangeLanguageThunkState = DeviceRootState;
 
-export const changeLanguage = createThunk<
+export const changeLanguageThunk = createThunk<
     Awaited<ReturnType<typeof TrezorConnect.changeLanguage>> | undefined,
     Parameters<typeof TrezorConnect.changeLanguage>[0],
     { state: ChangeLanguageThunkState }

--- a/packages/suite/src/actions/suite/analyticsActions.test.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.test.ts
@@ -9,7 +9,7 @@ import {
 import { type WithServices } from '@suite-common/redux-utils';
 import { createTestStore } from '@suite-common/test-utils';
 
-import { init } from 'src/actions/suite/analyticsActions';
+import { initThunk } from 'src/actions/suite/analyticsActions';
 
 const extra: WithServices<DesktopAnalyticsDep> = {
     services: { analytics: mockDesktopAnalytics() },
@@ -32,7 +32,7 @@ const mockStore = (preloadedState: AnalyticsRootState) =>
         preloadedState,
     });
 
-describe('analytics init thunks ', () => {
+describe('analytics initThunk', () => {
     beforeAll(() => {
         jest.spyOn(console, 'error').mockImplementation();
     });
@@ -40,7 +40,7 @@ describe('analytics init thunks ', () => {
         jest.clearAllMocks();
     });
 
-    it('analytics init with unconfirmed', () => {
+    it('analytics initThunk with unconfirmed', () => {
         const state = getInitialState({
             analytics: {
                 enabled: undefined,
@@ -50,7 +50,7 @@ describe('analytics init thunks ', () => {
         });
         const store = mockStore(state);
 
-        store.dispatch(init());
+        store.dispatch(initThunk());
         expect(store.getActions()).toMatchObject([
             {
                 type: analyticsActions.initAnalytics.type,
@@ -63,7 +63,7 @@ describe('analytics init thunks ', () => {
         ]);
     });
 
-    it('analytics init with confirmed', () => {
+    it('analytics initThunk with confirmed', () => {
         const state = getInitialState({
             analytics: {
                 enabled: undefined,
@@ -73,7 +73,7 @@ describe('analytics init thunks ', () => {
         });
         const store = mockStore(state);
 
-        store.dispatch(init());
+        store.dispatch(initThunk());
         expect(store.getActions()).toMatchObject([
             {
                 type: analyticsActions.initAnalytics.type,
@@ -86,7 +86,7 @@ describe('analytics init thunks ', () => {
         ]);
     });
 
-    it('analytics init with confirmed but not enabled', () => {
+    it('analytics initThunk with confirmed but not enabled', () => {
         const state = getInitialState({
             analytics: {
                 enabled: false,
@@ -96,7 +96,7 @@ describe('analytics init thunks ', () => {
         });
         const store = mockStore(state);
 
-        store.dispatch(init());
+        store.dispatch(initThunk());
         expect(store.getActions()).toMatchObject([
             {
                 type: analyticsActions.initAnalytics.type,

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -77,7 +77,7 @@ type InitThunkDeps = WithServices<DesktopAnalyticsDep>;
  * - set sentry user id
  * @param state - tracking state loaded from storage
  */
-export const init =
+export const initThunk =
     () =>
     (
         dispatch: ThunkDispatch<InitThunkState, InitThunkDeps, UnknownAction>,

--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -1,4 +1,4 @@
-import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
+import { type GotoThunkDeps, type GotoThunkState, gotoThunk } from '@suite/router';
 import { selectDevices } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import {
@@ -32,13 +32,13 @@ export const setAutoEjectEnabledThunk = createThunk<
     // which means connected device are preserved in local redux.
     const allDevices = selectDevices(getState());
     allDevices.forEach(device => {
-        dispatch(storageActions.forgetDevice(device));
+        dispatch(storageActions.forgetDeviceThunk(device));
     });
 
     const currentDevices = selectDevices(getState());
     const connectedDevices = currentDevices.filter(device => device.connected && device.state);
 
     if (connectedDevices.length === 0) {
-        dispatch(goto({ routeName: 'suite-index' }));
+        dispatch(gotoThunk({ routeName: 'suite-index' }));
     }
 });

--- a/packages/suite/src/actions/suite/bioAuthThunks.ts
+++ b/packages/suite/src/actions/suite/bioAuthThunks.ts
@@ -23,7 +23,7 @@ const handleError = (error: string, dispatch: Dispatch<UnknownAction>, message: 
     );
 };
 
-export const init = createThunk<void, void, void>(
+export const initBioAuthThunk = createThunk<void, void, void>(
     `${BIO_AUTH_PREFIX}/init`,
     (_args, { dispatch }) => {
         // only fetches settings from electron-store, not dependent on BioAuthModule, see bio-auth/get-bio-auth-settings

--- a/packages/suite/src/actions/suite/guideActions.ts
+++ b/packages/suite/src/actions/suite/guideActions.ts
@@ -28,7 +28,7 @@ export const setView = (payload: ActiveView) => (dispatch: Dispatch<UnknownActio
 // a keyboard-shortcut handler's render closure, so the toggle can't act on a stale open/view.
 type ToggleViewThunkState = { guide: GuideState };
 
-export const toggleView =
+export const toggleViewThunk =
     (payload: ActiveView) =>
     (
         dispatch: ThunkDispatch<ToggleViewThunkState, unknown, UnknownAction>,

--- a/packages/suite/src/actions/suite/initAction.test.ts
+++ b/packages/suite/src/actions/suite/initAction.test.ts
@@ -9,11 +9,11 @@ import { modalReducer } from '@suite/modal';
 import type { PathString } from '@suite/router';
 import {
     createSuiteRouterHistory,
-    goto,
-    initialRedirection,
-    onLocationChange,
+    gotoThunk,
+    initialRedirectionThunk,
+    onLocationChangeThunk,
     routerAppChanged,
-    routerInit,
+    routerInitThunk,
     routerLocationChange,
     routerMiddleware,
     routerReducer,
@@ -54,7 +54,7 @@ import {
     feesActions,
     fetchFiatRatesThunk,
     initBlockchainThunk,
-    initDevices,
+    initDevicesThunk,
     initStakeDataThunk,
     periodicCheckStakeDataThunk,
     periodicFetchFiatRatesThunk,
@@ -68,7 +68,7 @@ import { noopCreateLogger } from '@trezor/connect-common';
 import { initialBreakpointFlags } from '@trezor/theme';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { init } from 'src/actions/suite/initAction';
+import { initThunk } from 'src/actions/suite/initAction';
 import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import windowReducer from 'src/reducers/suite/windowReducer';
@@ -156,24 +156,24 @@ const fixtures: Fixture[] = [
         },
         actions: [
             onSuiteInit.type,
-            initDevices.pending.type,
-            initDevices.fulfilled.type,
+            initDevicesThunk.pending.type,
+            initDevicesThunk.fulfilled.type,
             suiteSettingsActions.setLanguage.type,
             initMessageSystemThunk.pending.type,
             fetchConfigThunk.pending.type,
             messageSystemActions.fetchSuccessUpdate.type,
             fetchConfigThunk.fulfilled.type,
             initMessageSystemThunk.fulfilled.type,
-            initialRedirection.pending.type,
-            goto.pending.type,
-            onLocationChange.pending.type,
+            initialRedirectionThunk.pending.type,
+            gotoThunk.pending.type,
+            onLocationChangeThunk.pending.type,
             routerLocationChange.type,
             routerAppChanged.type,
             lockRouter.type,
             connectInitThunk.pending.type,
-            onLocationChange.fulfilled.type,
-            goto.fulfilled.type,
-            initialRedirection.fulfilled.type,
+            onLocationChangeThunk.fulfilled.type,
+            gotoThunk.fulfilled.type,
+            initialRedirectionThunk.fulfilled.type,
             connectInitThunk.fulfilled.type,
             initBlockchainThunk.pending.type,
             preloadFeeInfoThunk.pending.type,
@@ -194,7 +194,7 @@ const fixtures: Fixture[] = [
             periodicFetchFiatRatesThunk.fulfilled.type,
             updateMissingTxFiatRatesThunk.pending.type,
             updateMissingTxFiatRatesThunk.fulfilled.type,
-            routerInit.pending.type,
+            routerInitThunk.pending.type,
             periodicCheckStakeDataThunk.pending.type,
             initStakeDataThunk.pending.type,
             stakeDataActions.fetchStakeDataRequest.type,
@@ -212,17 +212,17 @@ const fixtures: Fixture[] = [
         },
         actions: [
             onSuiteInit.type,
-            initDevices.pending.type,
-            initDevices.fulfilled.type,
+            initDevicesThunk.pending.type,
+            initDevicesThunk.fulfilled.type,
             suiteSettingsActions.setLanguage.type,
             initMessageSystemThunk.pending.type,
             fetchConfigThunk.pending.type,
             messageSystemActions.fetchSuccessUpdate.type,
             fetchConfigThunk.fulfilled.type,
             initMessageSystemThunk.fulfilled.type,
-            initialRedirection.pending.type,
+            initialRedirectionThunk.pending.type,
             connectInitThunk.pending.type,
-            initialRedirection.fulfilled.type,
+            initialRedirectionThunk.fulfilled.type,
             connectInitThunk.fulfilled.type,
             initBlockchainThunk.pending.type,
             preloadFeeInfoThunk.pending.type,
@@ -243,8 +243,8 @@ const fixtures: Fixture[] = [
             periodicFetchFiatRatesThunk.fulfilled.type,
             updateMissingTxFiatRatesThunk.pending.type,
             updateMissingTxFiatRatesThunk.fulfilled.type,
-            routerInit.pending.type,
-            onLocationChange.pending.type,
+            routerInitThunk.pending.type,
+            onLocationChangeThunk.pending.type,
             routerLocationChange.type,
             routerAppChanged.type,
             periodicCheckStakeDataThunk.pending.type,
@@ -263,17 +263,17 @@ const fixtures: Fixture[] = [
         },
         actions: [
             onSuiteInit.type,
-            initDevices.pending.type,
-            initDevices.fulfilled.type,
+            initDevicesThunk.pending.type,
+            initDevicesThunk.fulfilled.type,
             suiteSettingsActions.setLanguage.type,
             initMessageSystemThunk.pending.type,
             fetchConfigThunk.pending.type,
             messageSystemActions.fetchSuccessUpdate.type,
             fetchConfigThunk.fulfilled.type,
             initMessageSystemThunk.fulfilled.type,
-            initialRedirection.pending.type,
+            initialRedirectionThunk.pending.type,
             connectInitThunk.pending.type,
-            initialRedirection.fulfilled.type,
+            initialRedirectionThunk.fulfilled.type,
             connectInitThunk.fulfilled.type,
             initBlockchainThunk.pending.type,
             preloadFeeInfoThunk.pending.type,
@@ -294,8 +294,8 @@ const fixtures: Fixture[] = [
             periodicFetchFiatRatesThunk.fulfilled.type,
             updateMissingTxFiatRatesThunk.pending.type,
             updateMissingTxFiatRatesThunk.fulfilled.type,
-            routerInit.pending.type,
-            onLocationChange.pending.type,
+            routerInitThunk.pending.type,
+            onLocationChangeThunk.pending.type,
             routerLocationChange.type,
             periodicCheckStakeDataThunk.pending.type,
             initStakeDataThunk.pending.type,
@@ -314,24 +314,24 @@ const fixtures: Fixture[] = [
         },
         actions: [
             onSuiteInit.type,
-            initDevices.pending.type,
-            initDevices.fulfilled.type,
+            initDevicesThunk.pending.type,
+            initDevicesThunk.fulfilled.type,
             suiteSettingsActions.setLanguage.type,
             initMessageSystemThunk.pending.type,
             fetchConfigThunk.pending.type,
             messageSystemActions.fetchSuccessUpdate.type,
             fetchConfigThunk.fulfilled.type,
             initMessageSystemThunk.fulfilled.type,
-            initialRedirection.pending.type,
-            goto.pending.type,
-            onLocationChange.pending.type,
+            initialRedirectionThunk.pending.type,
+            gotoThunk.pending.type,
+            onLocationChangeThunk.pending.type,
             routerLocationChange.type,
             routerAppChanged.type,
             lockRouter.type,
             connectInitThunk.pending.type,
-            onLocationChange.fulfilled.type,
-            goto.fulfilled.type,
-            initialRedirection.fulfilled.type,
+            onLocationChangeThunk.fulfilled.type,
+            gotoThunk.fulfilled.type,
+            initialRedirectionThunk.fulfilled.type,
             connectInitThunk.rejected.type,
             SUITE.ERROR,
         ],
@@ -383,7 +383,7 @@ const initStore = (state: State) => {
     };
 };
 
-describe('Suite init action', () => {
+describe('Suite init thunk', () => {
     fixtures.forEach(({ description, options, actions }) => {
         it(description, async () => {
             const { store, suiteRouterHistory } = initStore(getInitialState(options.initialRun));
@@ -398,12 +398,12 @@ describe('Suite init action', () => {
                 });
 
                 try {
-                    await store.dispatch(init());
+                    await store.dispatch(initThunk());
                 } catch (err) {
                     expect(err.message).toEqual(options.trezorConnectError);
                 }
             } else {
-                await expect(store.dispatch(init())).resolves.not.toThrow();
+                await expect(store.dispatch(initThunk())).resolves.not.toThrow();
             }
 
             expect(store.getActions().map(({ type }) => type)).toEqual(actions);

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -6,8 +6,8 @@ import { type MetadataRootState, metadataLabelingActions } from '@suite/metadata
 import {
     type GotoThunkDeps,
     type GotoThunkState,
-    initialRedirection,
-    routerInit,
+    initialRedirectionThunk,
+    routerInitThunk,
 } from '@suite/router';
 import {
     type SuiteSettingsRootState,
@@ -40,7 +40,7 @@ import {
     type UpdateMissingTxFiatRatesThunkState,
     type WalletSettingsRootState,
     initBlockchainThunk,
-    initDevices,
+    initDevicesThunk,
     periodicCheckStakeDataThunk,
     periodicFetchFiatRatesThunk,
     selectBaseCurrency,
@@ -83,7 +83,7 @@ type InitThunkDeps = ConnectInitThunkDeps &
     PeriodicFetchFiatRatesThunkDeps &
     WalletConnectInitThunkDeps;
 
-export const init =
+export const initThunk =
     () =>
     async (
         dispatch: ThunkDispatch<InitThunkState, InitThunkDeps, UnknownAction>,
@@ -101,7 +101,7 @@ export const init =
         // apply the earn yield worker base url from debug settings (or the default for this build)
         earnYieldWorkerBaseUrl.set(selectEarnYieldWorkerBaseUrl(getState()));
 
-        await dispatch(initDevices());
+        await dispatch(initDevicesThunk());
 
         /**
          * ----------------------------------------------
@@ -127,7 +127,7 @@ export const init =
         }
 
         // 5. redirecting user into welcome screen (if needed)
-        dispatch(initialRedirection({ isInitialRun: selectFlags(getState()).initialRun }));
+        dispatch(initialRedirectionThunk({ isInitialRun: selectFlags(getState()).initialRun }));
 
         // Do not initialize Connect or anything else related to it, if there is an app-wide killswitch via message-system.
         const activeKillswitchMessage = selectActiveKillswitchMessage(getState());
@@ -170,12 +170,12 @@ export const init =
         await dispatch(updateMissingTxFiatRatesThunk({ localCurrency }));
 
         // 11. dispatch initial location change
-        dispatch(routerInit());
+        dispatch(routerInitThunk());
 
         // 12. fetch metadata. metadata is not saved together with other data in storage.
         // historically it was saved in indexedDB together with devices and accounts and we did not need to load them
         // immediately after suite start.
-        dispatch(metadataLabelingActions.fetchAndSaveMetadataForAllDevices());
+        dispatch(metadataLabelingActions.fetchAndSaveMetadataForAllDevicesThunk());
 
         // 13. start fetching staking data if needed, does need to be waited
         dispatch(periodicCheckStakeDataThunk());
@@ -184,7 +184,7 @@ export const init =
         dispatch(walletConnectActions.walletConnectInitThunk());
         // 15. bio auth
         if (isDesktop()) {
-            dispatch(bioAuthThunks.init());
+            dispatch(bioAuthThunks.initBioAuthThunk());
         }
         // 16. backend connected, suite is ready to use
         dispatch(onSuiteReady());

--- a/packages/suite/src/actions/suite/protocolActions.test.ts
+++ b/packages/suite/src/actions/suite/protocolActions.test.ts
@@ -47,7 +47,7 @@ describe('Protocol actions', () => {
     it('saves address, amount and label from Bitcoin URI protocol', () => {
         const { actions, dispatch, getState, extra } = createHandleProtocolRequestDeps();
 
-        protocolActions.handleProtocolRequest('bitcoin:12345abcde?amount=1.02&label=Alice')(
+        protocolActions.handleProtocolRequestThunk('bitcoin:12345abcde?amount=1.02&label=Alice')(
             dispatch,
             getState,
             extra,
@@ -70,7 +70,7 @@ describe('Protocol actions', () => {
     it('saves address from Bitcoin URI protocol', () => {
         const { actions, dispatch, getState, extra } = createHandleProtocolRequestDeps();
 
-        protocolActions.handleProtocolRequest('bitcoin:12345abcde')(dispatch, getState, extra);
+        protocolActions.handleProtocolRequestThunk('bitcoin:12345abcde')(dispatch, getState, extra);
 
         expect(actions).toHaveLength(2);
         expect(actions).toContainEqual(

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -7,11 +7,11 @@ import {
     type GotoThunkState,
     SettingsAnchor,
     type SuiteRouterHistoryDep,
-    goto,
+    gotoThunk,
     mapAnchorToRoute,
-    onLocationChange,
+    onLocationChangeThunk,
 } from '@suite/router';
-import { handleCoinProtocolUri } from '@suite/transfer-uri';
+import { handleCoinProtocolUriThunk } from '@suite/transfer-uri';
 import type { FindNetworkSymbolForProtocolDep } from '@suite-common/networks';
 import { type WithServices } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -50,7 +50,7 @@ export type HandleProtocolRequestThunkDeps = WithServices<
 export type HandleProtocolRequestDispatchDeps = HandleProtocolRequestThunkDeps &
     WalletConnectInitThunkDeps;
 
-export const handleProtocolRequest =
+export const handleProtocolRequestThunk =
     (uri: string) =>
     (
         dispatch: ThunkDispatch<
@@ -61,10 +61,12 @@ export const handleProtocolRequest =
         _getState: () => HandleProtocolRequestThunkState,
         extra: HandleProtocolRequestThunkDeps,
     ) => {
-        dispatch(handleCoinProtocolUri(uri, saveCoinProtocol));
+        dispatch(handleCoinProtocolUriThunk(uri, saveCoinProtocol));
 
         if (uri?.startsWith(SUITE_BRIDGE_DEEPLINK)) {
-            dispatch(goto({ routeName: 'suite-bridge-requested', params: { cancelable: true } }));
+            dispatch(
+                gotoThunk({ routeName: 'suite-bridge-requested', params: { cancelable: true } }),
+            );
         } else if (uri?.startsWith(SUITE_WALLETCONNECT_DEEPLINK)) {
             const parsedUri = safeParseUrl(uri);
             const wcUri = parsedUri?.searchParams?.get('uri');
@@ -88,7 +90,7 @@ export const handleProtocolRequest =
 
                 const targetRoute =
                     mapAnchorToRoute[domain?.replace(/^@/, '') as AnchorSettingSection];
-                dispatch(goto({ routeName: targetRoute, anchor }));
+                dispatch(gotoThunk({ routeName: targetRoute, anchor }));
             }
         } else if (SUITE_TRADING_REDIRECT_DEEPLINKS.some(deeplink => uri?.startsWith(deeplink))) {
             const parsedUri = safeParseUrl(decodeURIComponent(uri));
@@ -100,7 +102,7 @@ export const handleProtocolRequest =
                 if (hash) {
                     const path = { pathname: '/coinmarket-redirect', hash: `#${hash}` } as const;
                     extra.services.suiteRouterHistory.navigate(path);
-                    dispatch(onLocationChange(path));
+                    dispatch(onLocationChangeThunk(path));
                 }
             }
         }

--- a/packages/suite/src/actions/suite/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/storageActions.test.ts
@@ -4,7 +4,7 @@ import { coinjoinReducer } from '@suite/coinjoin';
 import { prepareDesktopDeviceReducer } from '@suite/device';
 import {
     NewContentIndicatorId,
-    initialRunCompleted,
+    initialRunCompletedThunk,
     markNewContentIndicatorAsSeen,
     prepareFlagsReducer,
     setNewContentIndicatorSeen,
@@ -21,7 +21,7 @@ import { type SuiteSyncOwnerSerialized } from '@suite-common/suite-sync-storage'
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { createTestStore, testMocks, wireEnabledNetworksMock } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { changeCoinVisibility, transactionsActions } from '@suite-common/wallet-core';
+import { changeCoinVisibilityThunk, transactionsActions } from '@suite-common/wallet-core';
 import * as discoveryActions from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountKey, mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -241,7 +241,7 @@ describe('Storage actions', () => {
         const store = mockStore(getInitialState());
 
         // save wallet settings to the db
-        await store.dispatch(storageActions.saveWalletSettings());
+        await store.dispatch(storageActions.saveWalletSettingsThunk());
         // change local currency in the reducer, changes should be synced to the db via storageMiddleware
         await store.dispatch(discoveryActions.setBaseCurrency('czk'));
         const { settings } = store.getState().wallet;
@@ -258,8 +258,8 @@ describe('Storage actions', () => {
         const store = mockStore(getInitialState());
         const f = global.fetch;
         global.fetch = mockFetch({ TR_ID: 'Message' });
-        await store.dispatch(storageActions.saveSuiteSettings());
-        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
+        await store.dispatch(storageActions.saveSuiteSettingsThunk());
+        await store.dispatch(initialRunCompletedThunk({ isFreshDeviceSetup: true }));
         await store.dispatch(markNewContentIndicatorAsSeen(NewContentIndicatorId.Activity26_8));
         await store.dispatch(
             setNewContentIndicatorSeen({
@@ -324,9 +324,9 @@ describe('Storage actions', () => {
         store.dispatch(transactionsActions.addTransaction({ transactions: [tx2], account: acc2 }));
 
         // remember devices
-        await store.dispatch(storageActions.rememberDevice(dev1));
-        await store.dispatch(storageActions.rememberDevice(dev2));
-        await store.dispatch(storageActions.rememberDevice(dev2Instance1));
+        await store.dispatch(storageActions.rememberDeviceThunk(dev1));
+        await store.dispatch(storageActions.rememberDeviceThunk(dev2));
+        await store.dispatch(storageActions.rememberDeviceThunk(dev2Instance1));
 
         store.dispatch((await preloadStore())!);
 
@@ -361,7 +361,7 @@ describe('Storage actions', () => {
         expect(load1.wallet.accounts[1]).toEqual(acc2);
 
         // forget dev1
-        await store.dispatch(storageActions.forgetDevice(dev1));
+        await store.dispatch(storageActions.forgetDeviceThunk(dev1));
         store = mockStore(getInitialState());
         store.dispatch((await preloadStore())!);
 
@@ -383,8 +383,8 @@ describe('Storage actions', () => {
         expect(load2.wallet.accounts.length).toEqual(1);
         expect(load2.wallet.accounts[0]?.deviceState).toEqual(dev2.state?.staticSessionId);
         // forget device dev1 along with its instances
-        await store.dispatch(storageActions.forgetDevice(dev2));
-        await store.dispatch(storageActions.forgetDevice(dev2Instance1));
+        await store.dispatch(storageActions.forgetDeviceThunk(dev2));
+        await store.dispatch(storageActions.forgetDeviceThunk(dev2Instance1));
         store.dispatch((await preloadStore())!);
         expect(selectDevicesCount(store.getState())).toEqual(0);
     });
@@ -409,8 +409,8 @@ describe('Storage actions', () => {
         store.dispatch(transactionsActions.addTransaction({ transactions: [tx2], account: acc2 }));
 
         // store in db
-        await store.dispatch(storageActions.rememberDevice(dev1));
-        await store.dispatch(storageActions.rememberDevice(dev2));
+        await store.dispatch(storageActions.rememberDeviceThunk(dev1));
+        await store.dispatch(storageActions.rememberDeviceThunk(dev2));
 
         // remove txs for acc 1
         await storageActions.removeAccountTransactions(acc1);
@@ -426,8 +426,8 @@ describe('Storage actions', () => {
         // acc2 txs are still there
         const acc2Txs = getAccountTransactions(acc2.key, state.wallet.transactions.transactions);
         expect(acc2Txs.length).toEqual(1);
-        await store.dispatch(storageActions.forgetDevice(dev1));
-        await store.dispatch(storageActions.forgetDevice(dev2));
+        await store.dispatch(storageActions.forgetDeviceThunk(dev1));
+        await store.dispatch(storageActions.forgetDeviceThunk(dev2));
     });
 
     it('should update device settings in the db', async () => {
@@ -448,7 +448,7 @@ describe('Storage actions', () => {
         );
 
         // store device in db
-        await store.dispatch(storageActions.rememberDevice(dev1));
+        await store.dispatch(storageActions.rememberDeviceThunk(dev1));
 
         // Change device label inside a reducer. This is a plain action, and storageMiddleware updates the db.
         await store.dispatch(
@@ -504,7 +504,7 @@ describe('Storage actions', () => {
             }),
         );
         // store device in db
-        await store.dispatch(storageActions.rememberDevice(dev1));
+        await store.dispatch(storageActions.rememberDeviceThunk(dev1));
 
         // verify that graph data are stored
         store.dispatch((await preloadStore())!);
@@ -513,8 +513,12 @@ describe('Storage actions', () => {
         // changeCoinVisibility awaits updateConnectSettings; mock it as a no-op success.
         wireEnabledNetworksMock();
         // disable btc network, enable ltc, triggering ACCOUNT.REMOVE
-        await store.dispatch(changeCoinVisibility({ symbol: ltcSymbol, shouldBeVisible: true }));
-        await store.dispatch(changeCoinVisibility({ symbol: btcSymbol, shouldBeVisible: false }));
+        await store.dispatch(
+            changeCoinVisibilityThunk({ symbol: ltcSymbol, shouldBeVisible: true }),
+        );
+        await store.dispatch(
+            changeCoinVisibilityThunk({ symbol: btcSymbol, shouldBeVisible: false }),
+        );
 
         // verify that graph data for acc1 were removed
         store.dispatch((await preloadStore())!);
@@ -538,7 +542,7 @@ describe('Storage actions', () => {
 
         expect(await db.getItemByPK('suiteSyncOwners', deviceStaticId)).toEqual('owner-key');
 
-        await store.dispatch(storageActions.forgetDevice(dev1));
+        await store.dispatch(storageActions.forgetDeviceThunk(dev1));
 
         expect(await db.getItemByPK('suiteSyncOwners', deviceStaticId)).toBeUndefined();
     });
@@ -569,8 +573,8 @@ describe('Storage actions', () => {
             }),
         );
 
-        await store.dispatch(storageActions.saveMetadataSettings());
-        await store.dispatch(storageActions.forgetDevice(forgottenDevice));
+        await store.dispatch(storageActions.saveMetadataSettingsThunk());
+        await store.dispatch(storageActions.forgetDeviceThunk(forgottenDevice));
 
         store = mockStore(getInitialState());
         store.dispatch((await preloadStore())!);

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -143,7 +143,7 @@ export const removeDraft = (accountKey: AccountKey) => {
 
 type SaveAccountDraftThunkState = SendRootState;
 
-export const saveAccountDraft =
+export const saveAccountDraftThunk =
     (account: Account) =>
     (_: Dispatch<UnknownAction>, getState: () => SaveAccountDraftThunkState) => {
         if (!db.isAccessible()) return;
@@ -156,7 +156,7 @@ export const saveAccountDraft =
 
 type SaveAccountReceiveThunkState = ReceiveRootState;
 
-export const saveAccountReceive =
+export const saveAccountReceiveThunk =
     (accountKey: AccountKey) =>
     (_: Dispatch<UnknownAction>, getState: () => SaveAccountReceiveThunkState) => {
         if (!db.isAccessible()) return;
@@ -174,7 +174,7 @@ const removeAccountDraft = (account: Account) => {
 
 type SaveCoinjoinAccountThunkState = CoinjoinRootState;
 
-export const saveCoinjoinAccount =
+export const saveCoinjoinAccountThunk =
     (accountKey: AccountKey) =>
     (_: Dispatch<UnknownAction>, getState: () => SaveCoinjoinAccountThunkState) => {
         const coinjoinAccount = selectCoinjoinAccountByKey(getState(), accountKey);
@@ -229,7 +229,7 @@ export const removeCoinjoinAccount = async (
 
 type SaveCoinjoinDebugSettingsThunkState = CoinjoinRootState;
 
-export const saveCoinjoinDebugSettings =
+export const saveCoinjoinDebugSettingsThunk =
     () =>
     (_dispatch: Dispatch<UnknownAction>, getState: () => SaveCoinjoinDebugSettingsThunkState) => {
         if (!db.isAccessible()) return;
@@ -239,18 +239,19 @@ export const saveCoinjoinDebugSettings =
 
 type SaveThpCredentialsThunkState = ThpRootState;
 
-export const saveThpCredentials = createThunk<void, void, { state: SaveThpCredentialsThunkState }>(
-    `${STORAGE.MODULE_PREFIX}/saveThpCredentials`,
-    async (_, { getState }) => {
-        if (!db.isAccessible()) return;
-        const { credentials } = selectThp(getState());
-        await db.addItem('thp', { credentials }, 'value', true);
-    },
-);
+export const saveThpCredentialsThunk = createThunk<
+    void,
+    void,
+    { state: SaveThpCredentialsThunkState }
+>(`${STORAGE.MODULE_PREFIX}/saveThpCredentials`, async (_, { getState }) => {
+    if (!db.isAccessible()) return;
+    const { credentials } = selectThp(getState());
+    await db.addItem('thp', { credentials }, 'value', true);
+});
 
 type SaveKnownDevicesThunkState = WithBluetoothState<DesktopBluetoothDevice>;
 
-export const saveKnownDevices = createThunk<void, void, { state: SaveKnownDevicesThunkState }>(
+export const saveKnownDevicesThunk = createThunk<void, void, { state: SaveKnownDevicesThunkState }>(
     `${STORAGE.MODULE_PREFIX}/saveKnownDevices`,
     async (_, { getState }) => {
         if (!db.isAccessible()) return;
@@ -281,7 +282,7 @@ export const saveKnownDevices = createThunk<void, void, { state: SaveKnownDevice
 
 type SaveAccountFormDraftThunkState = FormDraftRootState;
 
-export const saveAccountFormDraft =
+export const saveAccountFormDraftThunk =
     (prefix: FormDraftKeyPrefix, accountKey: string) =>
     (_: Dispatch<UnknownAction>, getState: () => SaveAccountFormDraftThunkState) => {
         if (!db.isAccessible()) return;
@@ -364,7 +365,7 @@ export const removeAccountWithDependencies =
 type ForgetDeviceThunkState = AccountsRootState &
     RemoveAccountWithDependenciesState & { metadata: MetadataState };
 
-export const forgetDevice =
+export const forgetDeviceThunk =
     (device: TrezorDevice) =>
     (_: Dispatch<UnknownAction>, getState: () => ForgetDeviceThunkState) => {
         if (!db.isAccessible()) return;
@@ -440,7 +441,7 @@ export const saveGraph = (graphData: GraphData[]) => {
 
 type SaveAccountHistoricRatesThunkState = TransactionsRootState;
 
-export const saveAccountHistoricRates =
+export const saveAccountHistoricRatesThunk =
     (accountKey: AccountKey, historicRates: RatesByTimestamps) =>
     (_dispatch: Dispatch<UnknownAction>, getState: () => SaveAccountHistoricRatesThunkState) => {
         if (!db.isAccessible()) return Promise.resolve();
@@ -454,7 +455,7 @@ export const saveAccountHistoricRates =
 
 type SaveAccountTransactionsThunkState = TransactionsRootState;
 
-export const saveAccountTransactions =
+export const saveAccountTransactionsThunk =
     (account: Account) =>
     (_dispatch: Dispatch<UnknownAction>, getState: () => SaveAccountTransactionsThunkState) => {
         if (!db.isAccessible()) return Promise.resolve();
@@ -477,7 +478,7 @@ export const saveAccountTransactions =
 
 type SavePhishingMetadataThunkState = PhishingRootState;
 
-export const savePhishingMetadata =
+export const savePhishingMetadataThunk =
     (phishingMetadata: Partial<PhishingState>) =>
     (_dispatch: Dispatch<UnknownAction>, getState: () => SavePhishingMetadataThunkState) => {
         if (!db.isAccessible()) return;
@@ -498,7 +499,7 @@ type RememberDeviceThunkState = AccountsRootState &
         wallet: { graph: GraphState };
     };
 
-export const rememberDevice =
+export const rememberDeviceThunk =
     (device: TrezorDevice) =>
     async (
         dispatch: ThunkDispatch<RememberDeviceThunkState, unknown, UnknownAction>,
@@ -520,14 +521,14 @@ export const rememberDevice =
             (promises, account) =>
                 promises.concat(
                     [
-                        dispatch(saveAccountReceive(account.key)),
-                        dispatch(saveAccountTransactions(account)),
-                        dispatch(saveAccountDraft(account)),
-                        dispatch(saveCoinjoinAccount(account.key)),
-                        dispatch(saveAccountHistoricRates(account.key, historicRates)),
+                        dispatch(saveAccountReceiveThunk(account.key)),
+                        dispatch(saveAccountTransactionsThunk(account)),
+                        dispatch(saveAccountDraftThunk(account)),
+                        dispatch(saveCoinjoinAccountThunk(account.key)),
+                        dispatch(saveAccountHistoricRatesThunk(account.key, historicRates)),
                     ],
                     FormDraftPrefixKeyValues.map(prefix =>
-                        dispatch(saveAccountFormDraft(prefix, account.key)),
+                        dispatch(saveAccountFormDraftThunk(prefix, account.key)),
                     ),
                 ),
             [],
@@ -539,7 +540,7 @@ export const rememberDevice =
                 saveAccounts(accounts),
                 saveGraph(graphData),
                 // eslint-disable-next-line  @typescript-eslint/no-use-before-define
-                dispatch(saveDeviceMetadataError(device)),
+                dispatch(saveDeviceMetadataErrorThunk(device)),
                 ...accountPromises,
             ]);
         } catch (error) {
@@ -549,7 +550,7 @@ export const rememberDevice =
 
 type SaveWalletSettingsThunkState = WalletSettingsRootState;
 
-export const saveWalletSettings =
+export const saveWalletSettingsThunk =
     () =>
     async (_dispatch: Dispatch<UnknownAction>, getState: () => SaveWalletSettingsThunkState) => {
         if (!db.isAccessible()) return;
@@ -565,7 +566,7 @@ export const saveWalletSettings =
 
 type SaveDiscreetModeThunkState = DiscreetModeRootState;
 
-export const saveDiscreetMode =
+export const saveDiscreetModeThunk =
     () =>
     async (_dispatch: Dispatch<UnknownAction>, getState: () => SaveDiscreetModeThunkState) => {
         if (!db.isAccessible()) return;
@@ -574,7 +575,7 @@ export const saveDiscreetMode =
 
 type SaveBackendThunkState = BlockchainRootState;
 
-export const saveBackend =
+export const saveBackendThunk =
     (symbol: NetworkSymbol) =>
     async (_dispatch: Dispatch<UnknownAction>, getState: () => SaveBackendThunkState) => {
         if (!db.isAccessible()) return;
@@ -591,7 +592,7 @@ type SaveSuiteSettingsThunkState = FlagsRootState &
         suite: Pick<SuiteState, 'evmSettings' | 'seenDisconnectNotificationForDeviceIds'>;
     };
 
-export const saveSuiteSettings =
+export const saveSuiteSettingsThunk =
     () =>
     (
         _dispatch: Dispatch<UnknownAction>,
@@ -625,7 +626,7 @@ export const saveSuiteSettings =
 
 type SaveDebugSettingsThunkState = DebugRootState;
 
-export const saveDebugSettings =
+export const saveDebugSettingsThunk =
     () =>
     async (_dispatch: Dispatch<UnknownAction>, getState: () => SaveDebugSettingsThunkState) => {
         if (!db.isAccessible()) return;
@@ -634,7 +635,7 @@ export const saveDebugSettings =
 
 type SaveTokenManagementThunkState = TokenDefinitionsRootState;
 
-export const saveTokenManagement =
+export const saveTokenManagementThunk =
     (symbol: NetworkSymbol, type: DefinitionType, status: TokenManagementAction) =>
     async (_dispatch: Dispatch<UnknownAction>, getState: () => SaveTokenManagementThunkState) => {
         if (!db.isAccessible()) return;
@@ -651,7 +652,7 @@ export const saveTokenManagement =
 
 type SaveAnalyticsThunkState = AnalyticsRootState;
 
-export const saveAnalytics =
+export const saveAnalyticsThunk =
     () => (_dispatch: Dispatch<UnknownAction>, getState: () => SaveAnalyticsThunkState) => {
         if (!db.isAccessible()) return;
 
@@ -697,7 +698,7 @@ const saveMetadata = async (metadata: Partial<Pick<MetadataState, MetadataPersis
  */
 type SaveMetadataSettingsThunkState = { metadata: MetadataState };
 
-export const saveMetadataSettings =
+export const saveMetadataSettingsThunk =
     () =>
     async (_dispatch: Dispatch<UnknownAction>, getState: () => SaveMetadataSettingsThunkState) => {
         // for some strage race-condition reason it has to be awaited, so that the getState runs async
@@ -715,7 +716,7 @@ export const saveMetadataSettings =
 
 type SaveSuiteSyncSettingsThunkState = DesktopSuiteSyncRootState;
 
-export const saveSuiteSyncSettings =
+export const saveSuiteSyncSettingsThunk =
     () => (_dispatch: Dispatch<UnknownAction>, getState: () => SaveSuiteSyncSettingsThunkState) => {
         if (!db.isAccessible()) return;
 
@@ -753,7 +754,7 @@ export const saveSuiteSyncOwner =
 
 type SaveSuiteSyncQuotaManagerThunkState = WithSuiteSyncQuotaManagerState;
 
-export const saveSuiteSyncQuotaManager =
+export const saveSuiteSyncQuotaManagerThunk =
     () =>
     (_dispatch: Dispatch<UnknownAction>, getState: () => SaveSuiteSyncQuotaManagerThunkState) => {
         if (!db.isAccessible()) return;
@@ -775,7 +776,7 @@ export const saveSuiteSyncQuotaManager =
 
 type SaveDeviceMetadataErrorThunkState = { metadata: MetadataState };
 
-export const saveDeviceMetadataError =
+export const saveDeviceMetadataErrorThunk =
     (device: TrezorDevice) =>
     async (
         _dispatch: Dispatch<UnknownAction>,
@@ -791,7 +792,7 @@ export const saveDeviceMetadataError =
 
 type SaveMessageSystemThunkState = MessageSystemRootState;
 
-export const saveMessageSystem =
+export const saveMessageSystemThunk =
     () => (_dispatch: Dispatch<UnknownAction>, getState: () => SaveMessageSystemThunkState) => {
         if (!db.isAccessible()) return;
 
@@ -821,7 +822,7 @@ export const saveMessageSystem =
 
 type SavePersistentDeviceDataThunkState = DeviceRootState;
 
-export const savePersistentDeviceData =
+export const savePersistentDeviceDataThunk =
     () =>
     async (
         _dispatch: Dispatch<UnknownAction>,
@@ -835,7 +836,7 @@ export const savePersistentDeviceData =
 
 type SaveConnectSettingsThunkState = ConnectPopupStateRootState & WalletConnectStateRootState;
 
-export const saveConnectSettings =
+export const saveConnectSettingsThunk =
     () => (_dispatch: Dispatch<UnknownAction>, getState: () => SaveConnectSettingsThunkState) => {
         if (!db.isAccessible()) return;
         const permissions = selectConnectAppPermissions(getState());
@@ -854,7 +855,7 @@ export const saveConnectSettings =
 
 type SaveFirmwareSettingsThunkState = FirmwareRootState;
 
-export const saveFirmwareSettings =
+export const saveFirmwareSettingsThunk =
     () => (_dispatch: Dispatch<UnknownAction>, getState: () => SaveFirmwareSettingsThunkState) => {
         if (!db.isAccessible()) return;
         const firmwareChannel = selectFirmwareChannel(getState());
@@ -871,7 +872,7 @@ export const saveFirmwareSettings =
 
 type SaveFeatureFeedbackThunkState = FeatureFeedbackRootState<FeedbackFeatureName>;
 
-export const saveFeatureFeedback =
+export const saveFeatureFeedbackThunk =
     () => (_dispatch: Dispatch<UnknownAction>, getState: () => SaveFeatureFeedbackThunkState) => {
         if (!db.isAccessible()) return;
         const featureFeedback = selectFeatureFeedback(getState());
@@ -881,7 +882,7 @@ export const saveFeatureFeedback =
 
 type RemoveDatabaseThunkState = DeviceRootState;
 
-export const removeDatabase =
+export const removeDatabaseThunk =
     () => async (dispatch: Dispatch<UnknownAction>, getState: () => RemoveDatabaseThunkState) => {
         if (!db.isAccessible()) return;
 

--- a/packages/suite/src/actions/suite/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/suiteActions.test.ts
@@ -35,9 +35,9 @@ import {
 } from '@suite-common/suite-types/mocks';
 import { createTestStore, filterThunkActionTypes, testMocks } from '@suite-common/test-utils';
 import {
-    acquireDevice,
-    forgetDisconnectedDevices,
-    observeSelectedDevice,
+    acquireDeviceThunk,
+    forgetDisconnectedDevicesThunk,
+    observeSelectedDeviceThunk,
 } from '@suite-common/wallet-core';
 import { type GetTradedAccountKeysDep } from '@suite-common/wallet-types';
 import { mockGetTradedAccountKeys } from '@suite-common/wallet-types/mocks';
@@ -205,7 +205,7 @@ describe('Suite Actions', () => {
         it(`forgetDisconnectedDevices: ${f.description}`, () => {
             const state = getInitialState(f.state.suite, f.state.device);
             const store = mockStore(state);
-            store.dispatch(forgetDisconnectedDevices({ device: f.device }));
+            store.dispatch(forgetDisconnectedDevicesThunk({ device: f.device }));
             const actions = filterThunkActionTypes(store.getActions());
             expect(actions.length).toEqual(f.result.length);
             actions.forEach((a, i) => {
@@ -223,7 +223,7 @@ describe('Suite Actions', () => {
         it(`observeSelectedDevice: ${f.description}`, async () => {
             const state = getInitialState(f.state.suite, f.state.device);
             const store = mockStore(state);
-            const observeResult = await store.dispatch(observeSelectedDevice()).unwrap();
+            const observeResult = await store.dispatch(observeSelectedDeviceThunk()).unwrap();
             expect(observeResult).toEqual(f.observeResult);
 
             const actionTypes = filterThunkActionTypes(store.getActions()).map(
@@ -240,7 +240,7 @@ describe('Suite Actions', () => {
             const state = getInitialState(undefined, f.state.device);
             const store = mockStore(state);
             store.dispatch(connectInitThunk()); // trezorConnectActions.connectInitThunk needs to be called in order to wrap "getFeatures" with lockUi action
-            await store.dispatch(acquireDevice({ requestedDevice: f.requestedDevice }));
+            await store.dispatch(acquireDeviceThunk({ requestedDevice: f.requestedDevice }));
             // we are not interested in thunk state here
             const expectedActions = filterThunkActionTypes(
                 discardMockedConnectInitActions(store.getActions()),

--- a/packages/suite/src/actions/suite/suiteForgetDeviceThunk.ts
+++ b/packages/suite/src/actions/suite/suiteForgetDeviceThunk.ts
@@ -49,9 +49,9 @@ export const suiteForgetDeviceThunk = createThunk<
             }),
         ).unwrap();
 
-        await dispatch(storageActions.savePersistentDeviceData());
+        await dispatch(storageActions.savePersistentDeviceDataThunk());
         if (device?.state) {
-            await dispatch(storageActions.forgetDevice(device));
+            await dispatch(storageActions.forgetDeviceThunk(device));
         }
     },
 );

--- a/packages/suite/src/actions/suite/suiteThunks.ts
+++ b/packages/suite/src/actions/suite/suiteThunks.ts
@@ -1,9 +1,9 @@
-import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
+import { type GotoThunkDeps, type GotoThunkState, gotoThunk } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
 import { type ReloadAppDep } from '@suite-common/suite-types';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
-import { removeDatabase } from './storageActions';
+import { removeDatabaseThunk } from './storageActions';
 
 type ResetSuiteAppThunkState = GotoThunkState;
 
@@ -17,7 +17,7 @@ export const resetSuiteAppThunk = createThunk<
     { state: ResetSuiteAppThunkState; extra: ResetSuiteAppThunkDeps }
 >('@suite/reset-app', async (_, { dispatch, extra }) => {
     localStorage.clear();
-    dispatch(removeDatabase());
+    dispatch(removeDatabaseThunk());
 
     if (desktopApi.available) {
         // Reset the desktop-specific store.
@@ -25,7 +25,7 @@ export const resetSuiteAppThunk = createThunk<
         desktopApi.appAutoStart(false);
     } else {
         // redirect to / and reload the web
-        await dispatch(goto({ routeName: 'suite-index' }));
+        await dispatch(gotoThunk({ routeName: 'suite-index' }));
     }
 
     extra.services.reloadApp();

--- a/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
@@ -25,7 +25,7 @@ export default [
         description: 'Show public key success (bitcoin)',
         initialState: undefined,
         mocks: {},
-        action: publicKeyActions.showXpub,
+        action: publicKeyActions.showXpubThunk,
         result: {
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },
@@ -45,7 +45,7 @@ export default [
             networkType: 'cardano',
         },
         mocks: {},
-        action: publicKeyActions.showXpub,
+        action: publicKeyActions.showXpubThunk,
         result: {
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },
@@ -64,7 +64,7 @@ export default [
             networkType: 'ethereum',
         },
         mocks: {},
-        action: publicKeyActions.showXpub,
+        action: publicKeyActions.showXpubThunk,
         result: {
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },
@@ -90,7 +90,7 @@ export default [
             },
         },
         mocks: {},
-        action: publicKeyActions.showXpub,
+        action: publicKeyActions.showXpubThunk,
         result: {
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },
@@ -110,7 +110,7 @@ export default [
             },
         },
         mocks: {},
-        action: publicKeyActions.showXpub,
+        action: publicKeyActions.showXpubThunk,
         result: {
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },
@@ -124,7 +124,7 @@ export default [
         mocks: {
             getPublicKey: { success: false, error: { message: 'Runtime error' } },
         },
-        action: publicKeyActions.showXpub,
+        action: publicKeyActions.showXpubThunk,
         result: {
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },
@@ -151,7 +151,7 @@ export default [
                 error: { message: 'Runtime error', code: 'Method_PermissionsNotGranted' },
             },
         },
-        action: publicKeyActions.showXpub,
+        action: publicKeyActions.showXpubThunk,
         result: {
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },

--- a/packages/suite/src/actions/wallet/addWalletThunk.ts
+++ b/packages/suite/src/actions/wallet/addWalletThunk.ts
@@ -1,4 +1,4 @@
-import { type GotoThunkDeps, type GotoThunkState, findRoute, goto } from '@suite/router';
+import { type GotoThunkDeps, type GotoThunkState, findRoute, gotoThunk } from '@suite/router';
 import { DEVICE_MODULE_PREFIX } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 
@@ -20,7 +20,7 @@ export const redirectAfterWalletSelectedThunk = createThunk<
         // when you switch to other device (wallet), there might not be /btc/4, but just /btc/1
         // this causes Account not found error, so we allow this option
         if (options?.forceDeviceDashboard) {
-            dispatch(goto({ routeName: 'suite-index' }));
+            dispatch(gotoThunk({ routeName: 'suite-index' }));
 
             return;
         }
@@ -28,14 +28,14 @@ export const redirectAfterWalletSelectedThunk = createThunk<
         const isWalletOrDashboardContext =
             backgroundRoute && ['wallet', 'dashboard'].includes(backgroundRoute.app);
         if (!isWalletOrDashboardContext) {
-            await dispatch(goto({ routeName: 'suite-index' }));
+            await dispatch(gotoThunk({ routeName: 'suite-index' }));
         }
 
         // Subpaths of wallet are not available to all account types (e.g. Tokens tab not available to BTC accounts).
         const isWalletSubpath =
             backgroundRoute?.app === 'wallet' && backgroundRoute?.name !== 'wallet-index';
         if (isWalletSubpath) {
-            await dispatch(goto({ routeName: 'wallet-index' }));
+            await dispatch(gotoThunk({ routeName: 'wallet-index' }));
         }
     },
 );
@@ -44,10 +44,10 @@ type OpenSwitchDeviceDialogThunkState = GotoThunkState;
 
 type OpenSwitchDeviceDialogThunkDeps = GotoThunkDeps;
 
-export const openSwitchDeviceDialog = createThunk<
+export const openSwitchDeviceDialogThunk = createThunk<
     void,
     void,
     { state: OpenSwitchDeviceDialogThunkState; extra: OpenSwitchDeviceDialogThunkDeps }
 >(`${DEVICE_MODULE_PREFIX}/openSwitchDeviceDialog`, (_, { dispatch }) => {
-    dispatch(goto({ routeName: 'suite-switch-device', params: { cancelable: true } }));
+    dispatch(gotoThunk({ routeName: 'suite-switch-device', params: { cancelable: true } }));
 });

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -68,7 +68,7 @@ type FetchAccountGraphDataThunkState = BlockchainRootState &
  * @param {Account} account
  * @returns
  */
-export const fetchAccountGraphData =
+export const fetchAccountGraphDataThunk =
     (account: Account, options: { abortSignal?: AbortSignal }) =>
     async (dispatch: Dispatch, getState: () => FetchAccountGraphDataThunkState) => {
         dispatch(
@@ -165,7 +165,7 @@ export const fetchAccountGraphData =
 
 type UpdateGraphDataThunkState = FetchAccountGraphDataThunkState;
 
-export const updateGraphData = createThunk<
+export const updateGraphDataThunk = createThunk<
     void,
     { accounts: Account[]; abortSignal?: AbortSignal },
     { state: UpdateGraphDataThunkState }
@@ -211,7 +211,7 @@ export const updateGraphData = createThunk<
         dispatch(aggregatedGraphStart());
         const promises = accountsToFetch.map(a =>
             dispatch(
-                fetchAccountGraphData(a, {
+                fetchAccountGraphDataThunk(a, {
                     abortSignal,
                 }),
             ),

--- a/packages/suite/src/actions/wallet/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/publicKeyActions.ts
@@ -16,7 +16,7 @@ export const openXpubModal =
 
 export type ShowXpubThunkState = DeviceRootState & SelectedAccountRootState;
 
-export const showXpub =
+export const showXpubThunk =
     () =>
     async (
         dispatch: ThunkDispatch<ShowXpubThunkState, unknown, UnknownAction>,

--- a/packages/suite/src/actions/wallet/selectedAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.test.ts
@@ -2,7 +2,7 @@ import { selectedAccountReducer } from '@suite/account';
 import { createTestStore } from '@suite-common/test-utils';
 
 import fixtures from './__fixtures__/selectedAccountActions';
-import { syncSelectedAccount } from './selectedAccountActions';
+import { syncSelectedAccountThunk } from './selectedAccountActions';
 
 const getInitialState = (initialState: any = {}) => ({
     suite: {},
@@ -47,7 +47,7 @@ describe('selectedAccount Actions', () => {
         it(f.description, () => {
             const state = getInitialState(f.initialState);
             const store = mockStore(state);
-            store.dispatch(syncSelectedAccount(f.action as any));
+            store.dispatch(syncSelectedAccountThunk(f.action as any));
             expect(store.getState().wallet.selectedAccount).toMatchObject(f.result as any);
         });
     });

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -200,7 +200,7 @@ const actions = new Set<UnknownAction['type']>([
  */
 type SyncSelectedAccountThunkState = SelectedAccountState;
 
-export const syncSelectedAccount =
+export const syncSelectedAccountThunk =
     (action: UnknownAction) =>
     (dispatch: Dispatch<UnknownAction>, getState: () => SyncSelectedAccountThunkState) => {
         // ignore not listed actions

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -227,7 +227,7 @@ const applySendFormMetadataLabelsThunk = createThunk<
                         );
                     } else {
                         return dispatch(
-                            metadataLabelingActions.addAccountMetadata({
+                            metadataLabelingActions.addAccountMetadataThunk({
                                 ...output,
                                 skipSave: !isLast,
                             }),

--- a/packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts
@@ -5,15 +5,16 @@ import TrezorConnect from '@trezor/connect';
 
 type CancelSignYieldTxThunkState = YieldRootState;
 
-export const cancelSignYieldTx = createThunk<void, void, { state: CancelSignYieldTxThunkState }>(
-    `${YIELD_PREFIX}/thunk/cancelSignYieldTx`,
-    (_params, { dispatch, getState }) => {
-        const { serializedTx } = selectYieldTxReview(getState());
+export const cancelSignYieldTxThunk = createThunk<
+    void,
+    void,
+    { state: CancelSignYieldTxThunkState }
+>(`${YIELD_PREFIX}/thunk/cancelSignYieldTx`, (_params, { dispatch, getState }) => {
+    const { serializedTx } = selectYieldTxReview(getState());
 
-        if (!serializedTx) {
-            TrezorConnect.cancel({ reason: 'tx-cancelled' });
-        }
+    if (!serializedTx) {
+        TrezorConnect.cancel({ reason: 'tx-cancelled' });
+    }
 
-        dispatch(closeModal());
-    },
-);
+    dispatch(closeModal());
+});

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -291,7 +291,7 @@ export const calculateOutputAmount = (
 
 type ComposeTransactionThunkState = SelectedAccountRootState & StakeRootState;
 
-export const composeTransaction =
+export const composeTransactionThunk =
     (formValues: StakeFormState, formState: ComposeActionContext) =>
     async (_: Dispatch<UnknownAction>, getState: () => ComposeTransactionThunkState) => {
         const selectedAccount = selectFullSelectedAccount(getState());
@@ -387,7 +387,7 @@ type SignTransactionThunkState = DeviceRootState & SelectedAccountRootState & St
 
 type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
-export const signTransaction =
+export const signTransactionThunk =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
     async (
         dispatch: Dispatch<UnknownAction>,

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -127,7 +127,7 @@ type SignTransactionThunkState = DeviceRootState &
 
 type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
-export const signTransaction =
+export const signTransactionThunk =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
     async (
         dispatch: ThunkDispatch<SignTransactionThunkState, SignTransactionThunkDeps, UnknownAction>,

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -27,7 +27,7 @@ const getSolanaUserAgent = () => `Trezor Suite ${getSuiteVersion()}`;
 
 type ComposeTransactionThunkState = BlockchainRootState & SelectedAccountRootState;
 
-export const composeTransaction =
+export const composeTransactionThunk =
     (formValues: StakeFormState, formState: ComposeActionContext) =>
     async (_: Dispatch<UnknownAction>, getState: () => ComposeTransactionThunkState) => {
         const selectedAccount = selectFullSelectedAccount(getState());
@@ -56,7 +56,7 @@ type SignTransactionThunkState = BlockchainRootState &
 
 type SignTransactionThunkDeps = WithServices<DesktopAnalyticsDep>;
 
-export const signTransaction =
+export const signTransactionThunk =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
     async (
         dispatch: Dispatch<UnknownAction>,

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -70,11 +70,11 @@ export const composeTransaction =
         }
 
         if (isSupportedSolStakingNetworkSymbol(account.symbol)) {
-            return dispatch(stakeFormSolanaActions.composeTransaction(formValues, formState));
+            return dispatch(stakeFormSolanaActions.composeTransactionThunk(formValues, formState));
         }
 
         if (isSupportedAdaStakingNetworkSymbol(account.symbol)) {
-            return dispatch(stakeFormCardanoActions.composeTransaction(formValues, formState));
+            return dispatch(stakeFormCardanoActions.composeTransactionThunk(formValues, formState));
         }
 
         return Promise.resolve(undefined);
@@ -83,7 +83,7 @@ export const composeTransaction =
 // this could be called at any time during signTransaction or pushTransaction process (from TransactionReviewModal)
 type CancelSignTxThunkState = StakeRootState;
 
-export const cancelSignTx =
+export const cancelSignTxThunk =
     (isSuccessTx?: boolean, account?: Account) =>
     (dispatch: Dispatch<UnknownAction>, getState: () => CancelSignTxThunkState) => {
         const { serializedTx, precomposedForm } = selectStake(getState());
@@ -123,7 +123,7 @@ type PushTransactionThunkDeps = WithServices<DesktopAnalyticsDep> &
     SyncAccountsWithBlockchainThunkDeps;
 
 // private, called from signTransaction only
-const pushTransaction =
+const pushTransactionThunk =
     (stakeType: StakeType, cardanoPoolDelegation?: StakingCardanoPoolDelegationPayload) =>
     async (
         dispatch: ThunkDispatch<PushTransactionThunkState, PushTransactionThunkDeps, UnknownAction>,
@@ -273,7 +273,7 @@ const pushTransaction =
             });
         }
 
-        dispatch(cancelSignTx(sentTx.success, account));
+        dispatch(cancelSignTxThunk(sentTx.success, account));
 
         // resolve sign process
         return sentTx;
@@ -290,7 +290,7 @@ type SignTransactionThunkState = DeviceRootState &
 
 type SignTransactionThunkDeps = PushTransactionThunkDeps;
 
-export const signTransaction =
+export const signTransactionThunk =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
     async (
         dispatch: ThunkDispatch<SignTransactionThunkState, SignTransactionThunkDeps, UnknownAction>,
@@ -322,20 +322,20 @@ export const signTransaction =
         let serializedTx: undefined | string | Err<SerializedError>;
         if (isSupportedEthStakingNetworkSymbol(account.symbol)) {
             serializedTx = await dispatch(
-                stakeFormEthereumActions.signTransaction(formValues, enhancedTxInfo),
+                stakeFormEthereumActions.signTransactionThunk(formValues, enhancedTxInfo),
             );
         }
 
         if (isSupportedSolStakingNetworkSymbol(account.symbol)) {
             serializedTx = await dispatch(
-                stakeFormSolanaActions.signTransaction(formValues, enhancedTxInfo),
+                stakeFormSolanaActions.signTransactionThunk(formValues, enhancedTxInfo),
             );
         }
 
         let cardanoPoolDelegation: StakingCardanoPoolDelegationPayload | undefined;
         if (isSupportedAdaStakingNetworkSymbol(account.symbol)) {
             const signResult = await dispatch(
-                stakeFormCardanoActions.signTransaction(formValues, enhancedTxInfo),
+                stakeFormCardanoActions.signTransactionThunk(formValues, enhancedTxInfo),
             );
 
             if (signResult && 'serializedTx' in signResult) {
@@ -377,13 +377,13 @@ export const signTransaction =
         );
 
         if (account?.networkType === 'cardano') {
-            return dispatch(pushTransaction(formValues.stakeType, cardanoPoolDelegation));
+            return dispatch(pushTransactionThunk(formValues.stakeType, cardanoPoolDelegation));
         }
 
         // Open a deferred modal and get the decision
         const decision = await dispatch(openDeferredModal({ type: 'review-transaction' }));
         if (decision) {
             // push tx to the network
-            return dispatch(pushTransaction(formValues.stakeType));
+            return dispatch(pushTransactionThunk(formValues.stakeType));
         }
     };

--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -1,7 +1,7 @@
 import { type BuyTrade } from 'invity-api';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
-import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
+import { type GotoThunkDeps, type GotoThunkState, gotoThunk } from '@suite/router';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type TradingFormAccountRootState,
@@ -76,7 +76,7 @@ export const selectBuyQuoteThunk = createThunk<
                 dispatch(submitRequestForm(form));
             },
             nextStep: () => {
-                dispatch(goto({ routeName: 'wallet-trading-buy-confirm' }));
+                dispatch(gotoThunk({ routeName: 'wallet-trading-buy-confirm' }));
             },
         }),
     );

--- a/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
@@ -1,7 +1,7 @@
 import { type ExchangeTrade } from 'invity-api';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
-import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
+import { type GotoThunkDeps, type GotoThunkState, gotoThunk } from '@suite/router';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type TradingRootState,
@@ -76,7 +76,7 @@ export const selectExchangeQuoteThunk = createThunk<
             exchangeThunks.selectQuoteThunk({
                 quote,
                 nextStep: () => {
-                    dispatch(goto({ routeName: 'wallet-trading-exchange-confirm' }));
+                    dispatch(gotoThunk({ routeName: 'wallet-trading-exchange-confirm' }));
                 },
             }),
         );

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.test.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.test.ts
@@ -15,7 +15,7 @@ import { selectSellQuoteThunk } from './selectSellQuoteThunk';
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
+    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
 }));
 
 const mockRequestSellTradeThunk = jest.fn((args: unknown) =>

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
@@ -1,7 +1,7 @@
 import { type SellFiatTrade } from 'invity-api';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
-import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
+import { type GotoThunkDeps, type GotoThunkState, gotoThunk } from '@suite/router';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     cryptoIdToNetworkSymbolAndContractAddress,
@@ -63,7 +63,7 @@ export const selectSellQuoteThunk = createThunk<
         });
 
         const nextStep = () => {
-            dispatch(goto({ routeName: 'wallet-trading-sell-confirm' }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-sell-confirm' }));
 
             // Empty quoteId means the partner requests login first; keep the UI moving
             // to confirm while the partner request continues in the background.

--- a/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
+++ b/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
@@ -49,7 +49,7 @@ export const submitRequestForm =
 
 type ConvertDraftsThunkState = AccountsRootState & FormDraftRootState & WalletSettingsRootState;
 
-export const convertDrafts =
+export const convertDraftsThunk =
     () => (dispatch: Dispatch<UnknownAction>, getState: () => ConvertDraftsThunkState) => {
         const accounts = selectAccounts(getState());
         const formDraftKeys = selectFormDraftKeys(getState());

--- a/packages/suite/src/actions/wallet/tron-stake/cancelSignTronFreezeTx.ts
+++ b/packages/suite/src/actions/wallet/tron-stake/cancelSignTronFreezeTx.ts
@@ -9,7 +9,7 @@ import TrezorConnect from '@trezor/connect';
 
 type CancelSignTronFreezeTxThunkState = TronStakeRootState;
 
-export const cancelSignTronFreezeTx = createThunk<
+export const cancelSignTronFreezeTxThunk = createThunk<
     void,
     void,
     { state: CancelSignTronFreezeTxThunkState }

--- a/packages/suite/src/components/earn/YieldBadge/YieldBadge.tsx
+++ b/packages/suite/src/components/earn/YieldBadge/YieldBadge.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey } from '@suite/intl';
-import { EarnAnchor, goto } from '@suite/router';
+import { EarnAnchor, gotoThunk } from '@suite/router';
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -80,7 +80,7 @@ export const YieldBadge = ({ apy, variant, account, vaultId, analyticsFrom }: Yi
             ? (getYieldOpportunityAnchor({ account, vaultId }) ?? EarnAnchor.Yield)
             : undefined;
 
-        dispatch(goto({ routeName: 'suite-earn', anchor }));
+        dispatch(gotoThunk({ routeName: 'suite-earn', anchor }));
 
         analytics.report({
             type: sharedEvents.yieldNavigateEvent.name,

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -1,7 +1,7 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -93,7 +93,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
                 getTradingPrefilledFromAccountData(account),
             ),
         );
-        dispatch(goto({ routeName: 'wallet-trading-buy' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-buy' }));
 
         analytics.report({
             type: events.tradeNavigateEvent.name,
@@ -110,7 +110,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
         event?.stopPropagation();
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-staking',
                 params: {
                     symbol: account.symbol,
@@ -138,7 +138,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-staking',
                 params: {
                     symbol: account.symbol,
@@ -167,7 +167,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-staking',
                 params: {
                     symbol: account.symbol,
@@ -247,7 +247,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
         event.stopPropagation();
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-tron-stake',
                 params: {
                     symbol: account.symbol,
@@ -275,7 +275,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
         event.stopPropagation();
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-tron-vote',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -2,7 +2,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
@@ -135,7 +135,7 @@ export const EarnYieldAccountOpportunity = ({
         });
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-trading-buy',
                 params: {
                     symbol: networkSymbol,
@@ -225,7 +225,7 @@ export const EarnYieldAccountOpportunity = ({
         });
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-yield-deposit',
                 params: getEarnRouteParams({
                     account: opportunity.account,
@@ -267,7 +267,7 @@ export const EarnYieldAccountOpportunity = ({
         });
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-yield-withdraw',
                 params: getEarnRouteParams({
                     account: opportunity.account,

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -5,7 +5,7 @@ import { Translation } from '@suite/intl';
 import { ContextMessage } from '@suite/message-system';
 import {
     EarnAnchor,
-    goto,
+    gotoThunk,
     isEarnYieldRowAnchor,
     selectRouterAnchor,
     useAnchor,
@@ -158,7 +158,7 @@ export const EarnYieldTable = () => {
 
     const handleClaimableAccountSelect = ({ account }: YieldAccountRewards) => {
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-yield-claim',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
@@ -1,6 +1,6 @@
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
@@ -63,7 +63,7 @@ export const useEarnProviderConsentActions = ({
             case EarnFlow.Yield:
                 if (yieldContext?.vaultAddress) {
                     dispatch(
-                        goto({
+                        gotoThunk({
                             routeName: 'earn-yield-deposit',
                             params: getEarnRouteParams({
                                 account,

--- a/packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronStakePageHeader.tsx
@@ -2,7 +2,7 @@ import { AccountLabel } from '@suite/account';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto, selectRouteName, selectSettingsBackRoute } from '@suite/router';
+import { gotoThunk, selectRouteName, selectSettingsBackRoute } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectTronStakeSession } from '@suite-common/wallet-core';
@@ -79,7 +79,7 @@ export const TronStakePageHeader = ({ account }: TronStakePageHeaderProps) => {
 
     const onBackClick = () => {
         reportFlowClose();
-        dispatch(goto({ routeName: previousRoute.name, params: previousRoute.params }));
+        dispatch(gotoThunk({ routeName: previousRoute.name, params: previousRoute.params }));
     };
 
     const onHowItWorksClick = () => {

--- a/packages/suite/src/components/earn/staking/tron/complete/TronStakeComplete.tsx
+++ b/packages/suite/src/components/earn/staking/tron/complete/TronStakeComplete.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
 import { Button, Column, IconCircle, Text } from '@trezor/components';
@@ -27,7 +27,7 @@ export const TronStakeComplete = ({
 
     const handleBackToOverview = () =>
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-staking',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
@@ -1,7 +1,7 @@
 import { AccountLabel } from '@suite/account';
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -34,7 +34,7 @@ export const YieldClaimPageHeader = ({ account }: YieldClaimPageHeaderProps) => 
             },
         });
 
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(gotoThunk({ routeName: 'suite-earn' }));
     };
 
     return (

--- a/packages/suite/src/components/earn/yield/common/EarnException.tsx
+++ b/packages/suite/src/components/earn/yield/common/EarnException.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type IconCircleIntent, type IconComponent } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
@@ -31,7 +31,7 @@ export const EarnException = ({
                     key: 'back-to-earn-dashboard',
                     intent: 'neutral',
                     priority: 'secondary',
-                    onClick: () => dispatch(goto({ routeName: 'suite-earn' })),
+                    onClick: () => dispatch(gotoThunk({ routeName: 'suite-earn' })),
                     children: <Translation id="TR_EARN_YIELD_BACK_TO_OVERVIEW" />,
                 },
             ]}

--- a/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
@@ -6,10 +6,10 @@ import {
     selectDesktopAnalyticsDep,
 } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { type Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
+import { type Rating, buildUserFeedbackData, sendFeedbackThunk } from '@suite-common/feedback';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Button, Card, Column, Divider, Icon, IconCircle, Row, Text } from '@trezor/components';
 import { CheckCircleFilledIcon, CheckIcon } from '@trezor/icons';
@@ -50,7 +50,7 @@ export const YieldFlowComplete = ({
             },
         });
 
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(gotoThunk({ routeName: 'suite-earn' }));
     };
 
     const handleRatingSelect = (rating: Rating) => {
@@ -71,7 +71,7 @@ export const YieldFlowComplete = ({
         });
 
         dispatch(
-            sendFeedbackAction({
+            sendFeedbackThunk({
                 type: 'SUGGESTION',
                 payload: {
                     category: 'experimental',

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -4,7 +4,7 @@ import { AccountLabel } from '@suite/account';
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { type EarnParams, goto } from '@suite/router';
+import { type EarnParams, gotoThunk } from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
@@ -134,7 +134,7 @@ export const YieldPageHeader = ({
             },
         });
 
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(gotoThunk({ routeName: 'suite-earn' }));
     };
 
     const onHowItWorksClick = () => {

--- a/packages/suite/src/components/earn/yield/common/useNavigateToAccountRoute.ts
+++ b/packages/suite/src/components/earn/yield/common/useNavigateToAccountRoute.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
 
@@ -18,7 +18,7 @@ export const useNavigateToAccountRoute = (
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName,
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/components/guide/Feedback.tsx
+++ b/packages/suite/src/components/guide/Feedback.tsx
@@ -12,7 +12,7 @@ import {
     type FeedbackType,
     type Rating,
     buildUserFeedbackData,
-    sendFeedbackAction,
+    sendFeedbackThunk,
 } from '@suite-common/feedback';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Box, Button, CollapsibleBox, Select, Textarea } from '@trezor/components';
@@ -108,7 +108,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
 
         if (type === 'BUG') {
             dispatch(
-                sendFeedbackAction({
+                sendFeedbackThunk({
                     type: 'BUG',
                     payload: {
                         description,
@@ -121,7 +121,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
             );
         } else {
             dispatch(
-                sendFeedbackAction({
+                sendFeedbackThunk({
                     type: 'SUGGESTION',
                     payload: {
                         description,

--- a/packages/suite/src/components/settings/SettingsLayout.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 
 import { selectIsDebugModeActive } from '@suite/debug';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Box, Column, motionEasing } from '@trezor/components';
 
@@ -36,7 +36,7 @@ const SettingsHeader = () => {
                 position: 'primary',
                 'data-testid': '@settings/menu/general',
                 callback: () =>
-                    dispatch(goto({ routeName: 'settings-index', preserveParams: true })),
+                    dispatch(gotoThunk({ routeName: 'settings-index', preserveParams: true })),
             },
             {
                 id: 'settings-device',
@@ -44,7 +44,7 @@ const SettingsHeader = () => {
                 position: 'primary',
                 'data-testid': '@settings/menu/device',
                 callback: () =>
-                    dispatch(goto({ routeName: 'settings-device', preserveParams: true })),
+                    dispatch(gotoThunk({ routeName: 'settings-device', preserveParams: true })),
             },
             {
                 id: 'settings-coins',
@@ -52,7 +52,7 @@ const SettingsHeader = () => {
                 position: 'primary',
                 'data-testid': '@settings/menu/wallet',
                 callback: () =>
-                    dispatch(goto({ routeName: 'settings-coins', preserveParams: true })),
+                    dispatch(gotoThunk({ routeName: 'settings-coins', preserveParams: true })),
             },
             {
                 id: 'settings-connected-apps',
@@ -60,7 +60,9 @@ const SettingsHeader = () => {
                 position: 'primary',
                 'data-testid': '@settings/menu/connected-apps',
                 callback: () =>
-                    dispatch(goto({ routeName: 'settings-connected-apps', preserveParams: true })),
+                    dispatch(
+                        gotoThunk({ routeName: 'settings-connected-apps', preserveParams: true }),
+                    ),
             },
             {
                 id: 'settings-debug',
@@ -69,7 +71,7 @@ const SettingsHeader = () => {
                 isHidden: !isDebugModeActive,
                 'data-testid': '@settings/menu/debug',
                 callback: () =>
-                    dispatch(goto({ routeName: 'settings-debug', preserveParams: true })),
+                    dispatch(gotoThunk({ routeName: 'settings-debug', preserveParams: true })),
             },
         ],
         [dispatch, isDebugModeActive],

--- a/packages/suite/src/components/suite/AcquireDeviceButton.tsx
+++ b/packages/suite/src/components/suite/AcquireDeviceButton.tsx
@@ -3,7 +3,7 @@ import { type MouseEventHandler } from 'react';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
 type AcquireButtonProps = {
@@ -18,7 +18,7 @@ export const AcquireDeviceButton = ({ onClick }: AcquireButtonProps) => {
 
     const handleClick: MouseEventHandler = e => {
         onClick?.(e);
-        dispatch(acquireDevice({}));
+        dispatch(acquireDeviceThunk({}));
     };
 
     return (

--- a/packages/suite/src/components/suite/HomescreenGallery.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery.tsx
@@ -12,7 +12,7 @@ import { resolveStaticPath } from '@trezor/env-utils';
 import { exhaustive } from '@trezor/type-utils';
 import { versionUtils } from '@trezor/utils';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 import { getDefaultHomeScreenImage, getHomescreens } from 'src/constants/suite/homescreens';
 import { imagePathToHex } from 'src/utils/suite/homescreen';
 
@@ -72,13 +72,13 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
                 fwVersion !== null && versionUtils.isNewerOrEqual(fwVersion, '2.9.0');
 
             dispatch(
-                applySettings(
+                applySettingsThunk(
                     supportsHomescreenLength ? { homescreen_length: 0 } : { homescreen: '' },
                 ),
             );
         } else {
             const hex = await imagePathToHex(imagePath, deviceModelInternal);
-            dispatch(applySettings({ homescreen: hex }));
+            dispatch(applySettingsThunk({ homescreen: hex }));
         }
 
         onConfirm?.();

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -20,7 +20,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { Card } from '@trezor/components';
 
 import * as analyticsActions from 'src/actions/suite/analyticsActions';
-import { init } from 'src/actions/suite/initAction';
+import { initThunk } from 'src/actions/suite/initAction';
 import { useGuideDesktopMenu, useGuideKeyboard } from 'src/hooks/guide';
 import { useAppShortcuts, useSelector } from 'src/hooks/suite';
 import { useWindowVisibility } from 'src/hooks/suite/useWindowVisibility';
@@ -81,14 +81,14 @@ export const Preloader = memo(function Preloader({ children }: PropsWithChildren
 
     useEffect(() => {
         // Analytics needs to be resolved before we show anything to the user. Until this is solved,
-        // we do not init anything. Especially nothing related to the devices/connect. With THP,
+        // we do not initialize anything. Especially nothing related to the devices/connect. With THP,
         // the autoconnect flow may be automatically triggered, resulting in Suite vs. Device Screen inconsistency.
-        dispatch(analyticsActions.init());
+        dispatch(analyticsActions.initThunk());
     }, [dispatch]);
 
     useEffect(() => {
         if (isAnalyticsConsentConfirmed) {
-            dispatch(init());
+            dispatch(initThunk());
         }
     }, [dispatch, isAnalyticsConsentConfirmed]);
 

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -3,7 +3,7 @@ import { type MouseEventHandler } from 'react';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
@@ -20,7 +20,7 @@ export const DeviceAcquire = () => {
 
     const handleClick: MouseEventHandler = e => {
         e.stopPropagation();
-        dispatch(acquireDevice({}));
+        dispatch(acquireDeviceThunk({}));
     };
 
     const ctaButton = (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceFirmwareCorrupted.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceFirmwareCorrupted.tsx
@@ -1,7 +1,7 @@
 import { type MouseEventHandler } from 'react';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 import { CpuIcon } from '@trezor/icons';
@@ -13,7 +13,7 @@ export const DeviceFirmwareCorrupted = () => {
 
     const handleClick: MouseEventHandler = e => {
         e.stopPropagation();
-        dispatch(goto({ routeName: 'firmware-index' }));
+        dispatch(gotoThunk({ routeName: 'firmware-index' }));
     };
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -2,7 +2,7 @@ import { type MouseEvent } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -43,7 +43,7 @@ export const DeviceInitialize = () => {
             },
             { force: true },
         );
-        dispatch(goto({ routeName: 'onboarding-index' }));
+        dispatch(gotoThunk({ routeName: 'onboarding-index' }));
     };
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
@@ -2,7 +2,7 @@ import { type MouseEventHandler } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -31,7 +31,7 @@ export const DeviceNoFirmware = () => {
             },
             { force: true },
         );
-        dispatch(goto({ routeName: 'onboarding-index' }));
+        dispatch(gotoThunk({ routeName: 'onboarding-index' }));
     };
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceRecoveryMode.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceRecoveryMode.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 import { TrezorBodyIcon } from '@trezor/icons';
 
-import { recoveryRerun } from 'src/actions/onboarding/onboardingActions';
+import { rerunRecoveryThunk } from 'src/actions/onboarding/onboardingActions';
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useSelector } from 'src/hooks/suite';
 
@@ -23,7 +23,7 @@ export const DeviceRecoveryMode = () => {
 
     const handleClick: MouseEventHandler = e => {
         e.stopPropagation();
-        dispatch(recoveryRerun());
+        dispatch(rerunRecoveryThunk());
     };
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
@@ -3,7 +3,7 @@ import { type MouseEventHandler } from 'react';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
@@ -15,7 +15,7 @@ export const DeviceTrezorHostProtocolPair = () => {
     const isDeviceLocked = isLocked();
 
     const handleStartPairing: MouseEventHandler = () => {
-        dispatch(acquireDevice({ requestedDevice: device }));
+        dispatch(acquireDeviceThunk({ requestedDevice: device }));
     };
 
     const ctaButton = (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUpdateRequired.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceUpdateRequired.tsx
@@ -1,7 +1,7 @@
 import { type MouseEventHandler } from 'react';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 import { ArrowsClockwiseIcon } from '@trezor/icons';
@@ -13,7 +13,7 @@ export const DeviceUpdateRequired = () => {
 
     const handleClick: MouseEventHandler = e => {
         e.stopPropagation();
-        dispatch(goto({ routeName: 'firmware-index' }));
+        dispatch(gotoThunk({ routeName: 'firmware-index' }));
     };
 
     return (

--- a/packages/suite/src/components/suite/StakeAmountWrapper.tsx
+++ b/packages/suite/src/components/suite/StakeAmountWrapper.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { TOOLTIP_DELAY_NONE, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
 import { mediaQueries } from '@trezor/styles';
@@ -32,7 +32,7 @@ interface StakeAmountWrapperProps {
 export const StakeAmountWrapper = ({ children }: StakeAmountWrapperProps) => {
     const dispatch = useDispatch();
     const goToStakingTab = () =>
-        dispatch(goto({ routeName: 'wallet-staking', preserveParams: true }));
+        dispatch(gotoThunk({ routeName: 'wallet-staking', preserveParams: true }));
 
     return (
         <Tooltip

--- a/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.test.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.test.tsx
@@ -9,7 +9,7 @@ jest.mock('@suite/intl', () => ({
 }));
 
 jest.mock('@suite/router', () => ({
-    goto: () => ({ type: 'goto' }),
+    gotoThunk: () => ({ type: 'goto' }),
 }));
 
 jest.mock('@trezor/env-utils', () => ({

--- a/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 import { isWeb } from '@trezor/env-utils';
@@ -72,7 +72,7 @@ export const BridgeDeprecated = () => {
             intent="info"
             rightContent={
                 <Banner.Button
-                    onClick={() => dispatch(goto({ routeName: 'suite-bridge-deprecated' }))}
+                    onClick={() => dispatch(gotoThunk({ routeName: 'suite-bridge-deprecated' }))}
                     data-testid="@notification/bridge-deprecated/button"
                 >
                     <Translation id="TR_LEARN_MORE" />

--- a/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/CardanoOutdatedStakingBanner.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectPoolStatsApy } from '@suite-common/wallet-core';
@@ -25,7 +25,7 @@ export const CardanoOutdatedStakingBanner = () => {
             icon
             intent="warning"
             rightContent={
-                <Banner.Button onClick={() => dispatch(goto({ routeName: 'suite-earn' }))}>
+                <Banner.Button onClick={() => dispatch(gotoThunk({ routeName: 'suite-earn' }))}>
                     <Translation id="TR_STAKING_MODAL_OUTDATED_BUTTON" />
                 </Banner.Button>
             }

--- a/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/NoBackupBanner.tsx
@@ -1,5 +1,5 @@
 import { Translation, useTranslation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 
@@ -17,7 +17,7 @@ export const NoBackup = () => {
             intent="critical"
             rightContent={
                 <Banner.Button
-                    onClick={() => dispatch(goto({ routeName: 'backup-index' }))}
+                    onClick={() => dispatch(gotoThunk({ routeName: 'backup-index' }))}
                     data-testid="@notification/no-backup/button"
                 >
                     <Translation id="TR_CREATE_BACKUP" />

--- a/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SafetyChecksBanner.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 import { XIcon } from '@trezor/icons';
@@ -21,7 +21,7 @@ export const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
                     <Banner.Button
                         onClick={() =>
                             dispatch(
-                                goto({
+                                gotoThunk({
                                     routeName: 'settings-device',
                                     preserveParams: true,
                                     anchor: SettingsAnchor.SafetyChecks,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { selectRoundsDurationInHours, selectSessionProgressByAccountKey } from '@suite/coinjoin';
 import { type CoinjoinSession } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
-import { goto, selectRouterParams } from '@suite/router';
+import { gotoThunk, selectRouterParams } from '@suite/router';
 import { selectDeviceThunk, selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectAccountByKey } from '@suite-common/wallet-core';
@@ -100,7 +100,7 @@ export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinSta
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-index',
                 params: {
                     symbol,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -11,7 +11,7 @@ import { CaretCircleDownIcon } from '@trezor/icons';
 import { zIndices } from '@trezor/theme';
 
 import { setRecentlyConnectedDevicePath } from 'src/actions/suite/suiteActions';
-import { openSwitchDeviceDialog } from 'src/actions/wallet/addWalletThunk';
+import { openSwitchDeviceDialogThunk } from 'src/actions/wallet/addWalletThunk';
 import { useSelector } from 'src/hooks/suite';
 import { selectRecentlyConnectedDevice } from 'src/selectors/suite/suiteSelectors';
 import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
@@ -73,7 +73,7 @@ const RecentlyConnectedDeviceTooltipContent = () => {
     if (deviceNameRef.current === undefined) return null;
 
     const handleClick = () => {
-        dispatch(openSwitchDeviceDialog());
+        dispatch(openSwitchDeviceDialogThunk());
         dispatch(setRecentlyConnectedDevicePath(null));
     };
 
@@ -90,7 +90,7 @@ export const DeviceSelector = () => {
     const dispatch = useDispatch();
 
     const handleSwitchDeviceClick = () => {
-        dispatch(openSwitchDeviceDialog());
+        dispatch(openSwitchDeviceDialogThunk());
         dispatch(setRecentlyConnectedDevicePath(null));
     };
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useNetworkFilter.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/hooks/useNetworkFilter.ts
@@ -1,6 +1,6 @@
 import { type RefObject, useEffect, useMemo, useState } from 'react';
 
-import { goto, parseDashboardParams, selectRouterParams } from '@suite/router';
+import { gotoThunk, parseDashboardParams, selectRouterParams } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
@@ -53,7 +53,7 @@ export function useNetworkFilter({ listRef, resetSearch, modal }: UseNetworkFilt
         dispatch(globalSendReceiveFiltersActions.setNetworkSymbol(networkFilter));
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'suite-index',
                 params: {
                     modal,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { goto, selectRouterParams } from '@suite/router';
+import { gotoThunk, selectRouterParams } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { yup } from '@suite-common/validators';
 import { type Account, type GlobalSendReceiveType } from '@suite-common/wallet-types';
@@ -51,7 +51,7 @@ export function useGlobalSendReceiveModal() {
 
     const openModal = (modal: NonNullable<GlobalSendReceiveType>) => {
         setActiveModal(modal);
-        dispatch(goto({ routeName: 'suite-index', params: { modal } }));
+        dispatch(gotoThunk({ routeName: 'suite-index', params: { modal } }));
     };
 
     const closeModal = (routeName?: Route['name'], account?: Account) => {
@@ -67,7 +67,7 @@ export function useGlobalSendReceiveModal() {
                 },
             });
         } else {
-            dispatch(goto({ routeName: 'suite-index' }));
+            dispatch(gotoThunk({ routeName: 'suite-index' }));
         }
     };
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountSubpageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/AccountName/AccountSubpageName.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { goto, selectSettingsBackRoute } from '@suite/router';
+import { gotoThunk, selectSettingsBackRoute } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
 import { IconButton, Row } from '@trezor/components';
@@ -18,7 +18,7 @@ export const AccountSubpageName = ({ selectedAccount }: AccountSubpageNameProps)
     const previousRoute = useSelector(selectSettingsBackRoute);
 
     const handleBackClick = () =>
-        dispatch(goto({ routeName: previousRoute.name, params: previousRoute.params }));
+        dispatch(gotoThunk({ routeName: previousRoute.name, params: previousRoute.params }));
 
     return (
         <Row alignItems="center" gap={16}>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -1,6 +1,6 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto, selectIsAccountTabPage, selectRouteName } from '@suite/router';
+import { gotoThunk, selectIsAccountTabPage, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
@@ -23,7 +23,7 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
     const isAccountTabPage = useSelector(selectIsAccountTabPage);
     const currentRouteName = useSelector(selectRouteName);
 
-    const goToWithAnalytics = (...[payload]: Parameters<typeof goto>) => {
+    const goToWithAnalytics = (...[payload]: Parameters<typeof gotoThunk>) => {
         if (currentRouteName === 'suite-index') {
             analytics.report({
                 type: events.dashboardActionsEvent.name,
@@ -38,7 +38,7 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
             });
         }
 
-        dispatch(goto(payload));
+        dispatch(gotoThunk(payload));
     };
 
     const navigateToTrading = (type: 'buy' | 'sell') => {

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
@@ -1,6 +1,6 @@
 import { selectSelectedAccountSymbol } from '@suite/account';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
@@ -13,13 +13,13 @@ export const useGoToWithAnalytics = (account?: Account) => {
     const symbol = account?.symbol ?? selectedAccountSymbol;
     const dispatch = useDispatch();
 
-    return (...[payload]: Parameters<typeof goto>) => {
+    return (...[payload]: Parameters<typeof gotoThunk>) => {
         if (symbol) {
             analytics.report({
                 type: events.accountsActionsEvent.name,
                 payload: { symbol, action: payload.routeName },
             });
         }
-        dispatch(goto(payload));
+        dispatch(gotoThunk(payload));
     };
 };

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -3,7 +3,7 @@ import { type MouseEvent } from 'react';
 import styled, { css } from 'styled-components';
 
 import { type ExtendedMessageDescriptor, Translation, type TranslationKey } from '@suite/intl';
-import { type Route, goto, selectRouteName } from '@suite/router';
+import { type Route, gotoThunk, selectRouteName } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     Badge,
@@ -103,7 +103,7 @@ const NavItem = ({
 
         if (goToRoute !== undefined) {
             dispatch(
-                goto({
+                gotoThunk({
                     routeName: goToRoute,
                     ...(preserveParams === true ? { preserveParams } : undefined),
                 }),

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/CustomBackend.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/CustomBackend.tsx
@@ -1,4 +1,4 @@
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { CheckIcon, DatabaseIcon } from '@trezor/icons';
 import { QuickActionButton } from '@trezor/product-components';
@@ -12,7 +12,7 @@ export const CustomBackend = () => {
     const isCustomBackendIconVisible = enabledBackends.length > 0;
 
     const handleClick = () => {
-        dispatch(goto({ routeName: 'settings-coins' }));
+        dispatch(gotoThunk({ routeName: 'settings-coins' }));
     };
 
     return (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx
@@ -1,7 +1,7 @@
 import { selectIsDebugModeActive } from '@suite/debug';
 import { selectDesktopUpdateAllowPrerelease } from '@suite/desktop-update';
 import { Translation } from '@suite/intl';
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { selectIsExperimentalEnabled } from '@suite/settings';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Box, Column, Icon } from '@trezor/components';
@@ -64,7 +64,7 @@ export const DebugAndExperimental = () => {
     const position = { type: 'absolute', top: 0, left: 0 } as const;
 
     const handleEapClick = () => {
-        dispatch(goto({ routeName: 'settings-index', anchor: SettingsAnchor.EarlyAccess }));
+        dispatch(gotoThunk({ routeName: 'settings-index', anchor: SettingsAnchor.EarlyAccess }));
     };
 
     if (!isEapEnabled && !isExperimental && !isDebug) return null;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Tor.tsx
@@ -1,5 +1,5 @@
 import { Translation, type TranslationKey } from '@suite/intl';
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { TorStatus, selectIsTorDisabled, selectTorStatus } from '@suite/tor';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Column, Icon, type IconComponent, type UIIntent } from '@trezor/components';
@@ -70,7 +70,7 @@ export const Tor = () => {
                     ),
                 }}
                 onClick={() =>
-                    dispatch(goto({ routeName: 'settings-index', anchor: SettingsAnchor.Tor }))
+                    dispatch(gotoThunk({ routeName: 'settings-index', anchor: SettingsAnchor.Tor }))
                 }
                 icon={TorBrowserIcon}
                 subIconIntent={torIntentMap[torStatus]}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/SwitchDeviceLayer.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/SwitchDeviceLayer.tsx
@@ -1,4 +1,4 @@
-import { closeModalApp } from '@suite/router';
+import { closeModalAppThunk } from '@suite/router';
 import {
     TurnOnSuiteSyncModals,
     selectShowEnableSuiteSyncModal,
@@ -21,7 +21,7 @@ export const SwitchDeviceLayer = () => {
         <>
             <SwitchDevice
                 cancelable={modal.payload.cancelable}
-                onCancel={() => dispatch(closeModalApp())}
+                onCancel={() => dispatch(closeModalAppThunk())}
             />
             <TurnOnSuiteSyncModals
                 deviceStaticSessionId={deviceStaticSessionId}

--- a/packages/suite/src/components/suite/layouts/WelcomeLayout/NavSettings.tsx
+++ b/packages/suite/src/components/suite/layouts/WelcomeLayout/NavSettings.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { IconButton } from '@trezor/components';
 import { GearIcon } from '@trezor/icons';
@@ -7,7 +7,7 @@ import { GearIcon } from '@trezor/icons';
 export const NavSettings = () => {
     const dispatch = useDispatch();
 
-    const handleClick = () => dispatch(goto({ routeName: 'settings-index' }));
+    const handleClick = () => dispatch(gotoThunk({ routeName: 'settings-index' }));
 
     return (
         <IconButton

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ForegroundAppModal.tsx
@@ -1,7 +1,7 @@
 import { type FunctionComponent } from 'react';
 
 import { CreateWalletBackupModal } from '@suite/backup';
-import { closeModalApp } from '@suite/router';
+import { closeModalAppThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 
 import type { ForegroundAppRoute } from 'src/types/suite';
@@ -49,7 +49,7 @@ type ForegroundAppModalProps = {
 export const ForegroundAppModal = ({ app, cancelable }: ForegroundAppModalProps) => {
     const dispatch = useDispatch();
 
-    const onCancel = () => dispatch(closeModalApp());
+    const onCancel = () => dispatch(closeModalAppThunk());
 
     // check if current route is a "foreground application" marked as isForegroundApp in router config
     // display it above requested physical route (route in url) or as fullscreen app

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -4,7 +4,7 @@ import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { selectSelectedDevice } from '@suite-common/device';
 import { convertTaprootXpub } from '@trezor/utils';
 
-import { showXpub } from 'src/actions/wallet/publicKeyActions';
+import { showXpubThunk } from 'src/actions/wallet/publicKeyActions';
 import { useSelector } from 'src/hooks/suite';
 
 import {
@@ -47,7 +47,7 @@ export const ConfirmXpubModal = (
         <ConfirmValueModal
             account={account}
             heading={<Translation id="TR_XPUB" />}
-            validateOnDevice={showXpub}
+            validateOnDevice={showXpubThunk}
             value={xpubWithReplacedApostropheWithH ?? xpub}
             isValueChunked={false}
             data-testid="@metadata/copy-xpub-button"

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/NoBackupModal.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
-import { onReceiveConfirmation } from '@suite/modal';
-import { SettingsAnchor, goto } from '@suite/router';
+import { onReceiveConfirmationThunk } from '@suite/modal';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { H2, Modal, Paragraph } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
@@ -8,11 +8,13 @@ import { WarningIcon } from '@trezor/icons';
 export const NoBackupModal = () => {
     const dispatch = useDispatch();
 
-    const confirm = () => dispatch(onReceiveConfirmation(true));
-    const close = () => dispatch(onReceiveConfirmation(false));
+    const confirm = () => dispatch(onReceiveConfirmationThunk(true));
+    const close = () => dispatch(onReceiveConfirmationThunk(false));
     const goToSettings = () => {
         close();
-        dispatch(goto({ routeName: 'settings-device', anchor: SettingsAnchor.BackupRecoverySeed }));
+        dispatch(
+            gotoThunk({ routeName: 'settings-device', anchor: SettingsAnchor.BackupRecoverySeed }),
+        );
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { selectIsDeviceInteractionModalActive, selectModalRequestId } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectHasDevicePassphraseEntryCapability } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
@@ -9,7 +9,7 @@ import {
     cancelDiscoveryThunk,
     selectDiscoveryByDevicePath,
     selectIsDiscoveryStatusConfirmEmptyPassphrase,
-    submitPassphrase,
+    submitPassphraseThunk,
 } from '@suite-common/wallet-core';
 import { UI_EVENTS } from '@trezor/connect';
 
@@ -31,7 +31,7 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
             if (!discovery) return;
 
             dispatch(
-                submitPassphrase({
+                submitPassphraseThunk({
                     device,
                     passphrase: value,
                     passphraseOnDevice,
@@ -49,7 +49,7 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
     const onBackToInitial = () => {
         dispatch(cancelDiscoveryThunk(device));
         dispatch({ type: UI_EVENTS.CLOSE_UI_WINDOW });
-        dispatch(goto({ routeName: 'suite-switch-device', params: { cancelable: true } }));
+        dispatch(gotoThunk({ routeName: 'suite-switch-device', params: { cancelable: true } }));
     };
 
     const onCancel = () => {
@@ -68,7 +68,7 @@ export const PassphraseModal = ({ device }: { device: TrezorDevice }) => {
             }
 
             dispatch(
-                submitPassphrase({
+                submitPassphraseThunk({
                     device,
                     passphrase: value,
                     passphraseOnDevice,

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsEmpty.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsEmpty.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { closeModal as closeModalAction } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
@@ -103,7 +103,7 @@ const PassphraseWalletIsEmptyContent = ({
                                     onClick={() => {
                                         onCancel();
                                         dispatch(closeModalAction());
-                                        dispatch(goto({ routeName: 'settings-coins' }));
+                                        dispatch(gotoThunk({ routeName: 'settings-coins' }));
                                     }}
                                 >
                                     <Translation id="TR_ADD" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -1,5 +1,5 @@
 import { selectFullSelectedAccount } from '@suite/account';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     cancelSignSendFormTransactionThunk,
@@ -18,12 +18,12 @@ import {
     removeSendFormDraftThunk,
     signAndPushSendFormTransactionThunk,
 } from 'src/actions/wallet/send/sendFormThunks';
-import { cancelSignYieldTx } from 'src/actions/wallet/stablecoin-yield';
+import { cancelSignYieldTxThunk } from 'src/actions/wallet/stablecoin-yield';
 import {
-    cancelSignTx as cancelSignStakingTx,
-    signTransaction,
+    cancelSignTxThunk as cancelSignStakingTx,
+    signTransactionThunk,
 } from 'src/actions/wallet/stakeActions';
-import { cancelSignTronFreezeTx } from 'src/actions/wallet/tron-stake/cancelSignTronFreezeTx';
+import { cancelSignTronFreezeTxThunk } from 'src/actions/wallet/tron-stake/cancelSignTronFreezeTx';
 import { useSelector } from 'src/hooks/suite';
 
 import { TransactionReviewModalBody } from './TransactionReviewModalBody';
@@ -53,14 +53,14 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
             return {
                 txInfoState: tronStakeTxReview,
                 precomposedForm: tronStakeTxReview.precomposedForm,
-                cancelSignTx: () => dispatch(cancelSignTronFreezeTx()),
+                cancelSignTx: () => dispatch(cancelSignTronFreezeTxThunk()),
             };
         }
         if (yieldTxReview.precomposedTx) {
             return {
                 txInfoState: yieldTxReview,
                 precomposedForm: yieldTxReview.precomposedForm,
-                cancelSignTx: () => dispatch(cancelSignYieldTx()),
+                cancelSignTx: () => dispatch(cancelSignYieldTxThunk()),
             };
         }
         if (send?.precomposedTx) {
@@ -96,7 +96,7 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
 
             if (result?.success) {
                 dispatch(removeSendFormDraftThunk());
-                dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+                dispatch(gotoThunk({ routeName: 'wallet-index', preserveParams: true }));
             }
         } catch {
             // Error state is handled by signAndPushSendFormTransactionThunk.
@@ -106,7 +106,7 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
     const handleStakeTx = async () => {
         dispatch(stakeActions.dispose());
         await dispatch(
-            signTransaction(
+            signTransactionThunk(
                 stake.precomposedForm!,
                 stake.precomposedTx as PrecomposedTransactionFinal,
             ),

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ActivateAssetsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ActivateAssetsModal.tsx
@@ -8,7 +8,7 @@ import { preserveModal, removePreserveModal } from '@suite/modal';
 import { useDispatch } from '@suite-common/redux-utils';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import {
-    changeCoinVisibility,
+    changeCoinVisibilityThunk,
     selectEnabledNetworks,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
@@ -91,10 +91,10 @@ export const ActivateAssetsModal = ({ onCancel }: ActivateAssetsModalProps) => {
         const toDisable = enabledNetworks.filter(symbol => !pendingNetworks.includes(symbol));
 
         toEnable.forEach(symbol =>
-            dispatch(changeCoinVisibility({ symbol, shouldBeVisible: true })),
+            dispatch(changeCoinVisibilityThunk({ symbol, shouldBeVisible: true })),
         );
         toDisable.forEach(symbol =>
-            dispatch(changeCoinVisibility({ symbol, shouldBeVisible: false })),
+            dispatch(changeCoinVisibilityThunk({ symbol, shouldBeVisible: false })),
         );
 
         if (toEnable.length > 0) {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountButton/AddCoinjoinAccountButton.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
-import { createCoinjoinAccount } from '@suite/coinjoin';
+import { createCoinjoinAccountThunk } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { openDeferredModal, openModal } from '@suite/modal';
 import { selectIsTorEnabled } from '@suite/tor';
-import { toggleTor } from '@suite/tor-desktop';
+import { toggleTorThunk } from '@suite/tor-desktop';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { RequestEnableTorResponse } from '@suite-common/suite-config';
@@ -79,7 +79,7 @@ export const AddCoinjoinAccountButton = ({ network, selectedAccount }: AddCoinjo
 
     const onCreateCoinjoinAccountClick = async () => {
         const createAccount = async () => {
-            await dispatch(createCoinjoinAccount(network, selectedAccount));
+            await dispatch(createCoinjoinAccountThunk(network, selectedAccount));
             setIsLoading(false);
         };
 
@@ -108,7 +108,7 @@ export const AddCoinjoinAccountButton = ({ network, selectedAccount }: AddCoinjo
             }
 
             // Triggering Tor process and displaying Tor loading to give user feedback of Tor progress.
-            dispatch(toggleTor(true));
+            dispatch(toggleTorThunk(true));
             const isTorLoaded = await dispatch(openDeferredModal({ type: 'tor-loading' }));
             // When Tor was not loaded it means there was an error or user canceled it, stop the coinjoin account activation.
             if (!isTorLoaded) return;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -18,7 +18,7 @@ import {
 } from '@suite-common/wallet-config';
 import {
     accountsActions,
-    changeCoinVisibility,
+    changeCoinVisibilityThunk,
     reportWalletBalanceThunk,
     selectAccounts,
     selectEnabledNetworks,
@@ -290,7 +290,7 @@ export const AddAccountModal = ({
     );
 
     function enablePinnedNetwork(network: Network) {
-        dispatch(changeCoinVisibility({ symbol: network.symbol, shouldBeVisible: true }));
+        dispatch(changeCoinVisibilityThunk({ symbol: network.symbol, shouldBeVisible: true }));
         closeModalAndNotifyCompletion();
     }
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/useNetworkActivationQueue.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/useNetworkActivationQueue.ts
@@ -7,7 +7,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import {
     accountsActions,
-    changeCoinVisibility,
+    changeCoinVisibilityThunk,
     discoveryActions,
     runAdditionalDiscoveryThunk,
     selectAccounts,
@@ -82,13 +82,13 @@ export const useNetworkActivationQueue = (device: TrezorDevice) => {
         );
 
         void dispatch(
-            changeCoinVisibility({
+            changeCoinVisibilityThunk({
                 symbol: nextNetworkSymbol,
                 shouldBeVisible: true,
             }),
         )
             .then(result => {
-                if (changeCoinVisibility.rejected.match(result)) {
+                if (changeCoinVisibilityThunk.rejected.match(result)) {
                     dispatch(
                         discoveryActions.updateDiscovery(
                             {
@@ -180,7 +180,7 @@ export const useNetworkActivationQueue = (device: TrezorDevice) => {
         );
 
         void dispatch(
-            changeCoinVisibility({
+            changeCoinVisibilityThunk({
                 symbol: networkSymbol,
                 shouldBeVisible: false,
             }),

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Translation } from '@suite/intl';
 import { selectHasExperimentalFeature } from '@suite/settings';
 import { selectIsTorEnabled } from '@suite/tor';
-import { TorModal, type TorResult, toggleTor } from '@suite/tor-desktop';
+import { TorModal, type TorResult, toggleTorThunk } from '@suite/tor-desktop';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { selectNetworkExplorers } from '@suite-common/wallet-core';
@@ -77,7 +77,7 @@ export const AdvancedCoinSettingsModal = ({
     const onTorResult = async (result: TorResult) => {
         switch (result) {
             case 'enable-tor':
-                await dispatch(toggleTor(true));
+                await dispatch(toggleTorThunk(true));
 
                 setTorModalOpen(false);
                 backendsForm.save().then(success => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CancelCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CancelCoinjoinModal.tsx
@@ -1,5 +1,5 @@
 import { selectSelectedAccount } from '@suite/account';
-import { stopCoinjoinSession } from '@suite/coinjoin';
+import { stopCoinjoinSessionThunk } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
@@ -30,7 +30,7 @@ export const CancelCoinjoinModal = ({ onClose }: CancelCoinjoinModalProps) => {
                 <>
                     <Modal.Button
                         onClick={() => {
-                            dispatch(stopCoinjoinSession(account.key));
+                            dispatch(stopCoinjoinSessionThunk(account.key));
                             onClose();
                         }}
                     >

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinjoinSuccessModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CoinjoinSuccessModal.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
-import { goto, selectRouterParams } from '@suite/router';
+import { gotoThunk, selectRouterParams } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey, type WalletParams } from '@suite-common/wallet-types';
@@ -29,7 +29,7 @@ export const CoinjoinSuccessModal = ({ relatedAccountKey }: CoinjoinSuccessModal
     const navigateToRelatedAccount = () => {
         dispatch(closeModal());
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-index',
                 params: {
                     symbol,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -11,7 +11,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { H3, Modal, Paragraph, Tooltip } from '@trezor/components';
 import { ShieldWarningIcon } from '@trezor/icons';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 import { type ShowXpubThunkState } from 'src/actions/wallet/publicKeyActions';
 import { useSelector } from 'src/hooks/suite';
 
@@ -58,7 +58,7 @@ export const ConfirmUnverifiedModal = ({
 
     const enablePassphraseAndContinue = async () => {
         if (!device?.available) {
-            await dispatch(applySettings({ use_passphrase: true }));
+            await dispatch(applySettingsThunk({ use_passphrase: true }));
         }
     };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedXpubModal.tsx
@@ -1,12 +1,12 @@
 import { useCallback } from 'react';
 
-import { openXpubModal, showXpub } from 'src/actions/wallet/publicKeyActions';
+import { openXpubModal, showXpubThunk } from 'src/actions/wallet/publicKeyActions';
 
 import { ConfirmUnverifiedModal } from './ConfirmUnverifiedModal';
 
 export const ConfirmUnverifiedXpubModal = () => {
     const event = useCallback(() => openXpubModal(), []);
-    const verifyProcess = useCallback(() => showXpub(), []);
+    const verifyProcess = useCallback(() => showXpubThunk(), []);
 
     return (
         <ConfirmUnverifiedModal

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectErrorModal.tsx
@@ -1,7 +1,7 @@
 import { Translation } from '@suite/intl';
 import {
     connectPopupActions,
-    connectPopupCallThunkInner,
+    connectPopupCallInnerThunk,
     selectConnectPopupCall,
 } from '@suite-common/connect-popup';
 import { selectDevices, selectSelectedDevice } from '@suite-common/device';
@@ -33,7 +33,7 @@ export const ConnectSelectDeviceModal = () => {
     const onResume = () => {
         if (popupCall?.state === 'call-error')
             dispatch(
-                connectPopupCallThunkInner({
+                connectPopupCallInnerThunk({
                     ...popupCall,
                     payload: {
                         ...popupCall.payload,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
@@ -1,4 +1,4 @@
-import { selectIsSessionAutostopped, toggleAutostopCoinjoin } from '@suite/coinjoin';
+import { selectIsSessionAutostopped, toggleAutostopCoinjoinThunk } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -15,7 +15,7 @@ export const AutoStopButton = ({ relatedAccountKey }: AutoStopButtonProps) => {
     const dispatch = useDispatch();
 
     const handleClick = () => {
-        dispatch(toggleAutostopCoinjoin(relatedAccountKey));
+        dispatch(toggleAutostopCoinjoinThunk(relatedAccountKey));
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PassphraseDuplicateModal.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import {
     cancelDiscoveryThunk,
     startAddWalletDiscoveryThunk,
-    switchToDuplicatedWallet,
+    switchToDuplicatedWalletThunk,
 } from '@suite-common/wallet-core';
 import { type DiscoveryStatus } from '@suite-common/wallet-types';
 import { Button, Column, H3, Text, Tooltip } from '@trezor/components';
@@ -28,7 +28,7 @@ export const PassphraseDuplicateModal = ({
     const isDeviceLocked = isLocked();
 
     const handleDuplicateDevicePassphrase = () => {
-        dispatch(switchToDuplicatedWallet());
+        dispatch(switchToDuplicatedWalletThunk());
     };
 
     const onTryDifferentPassphrase = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/PinMismatchModal.tsx
@@ -3,13 +3,13 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { H3, Modal } from '@trezor/components';
 import { PasswordIcon } from '@trezor/icons';
 
-import { changePin } from 'src/actions/settings/deviceSettingsActions';
+import { changePinThunk } from 'src/actions/settings/deviceSettingsActions';
 
 export const PinMismatchModal = () => {
     const dispatch = useDispatch();
 
     const onTryAgain = () => {
-        dispatch(changePin({}));
+        dispatch(changePinThunk({}));
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
@@ -14,7 +14,7 @@ import {
     Text,
 } from '@trezor/components';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 
 /**
  * A Modal that allows user to set the `safety_checks` feature of connected Trezor.
@@ -27,7 +27,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
     const [level, setLevel] = useState(device?.features?.safety_checks || undefined);
     const dispatch = useDispatch();
 
-    const confirm = () => dispatch(applySettings({ safety_checks: level }));
+    const confirm = () => dispatch(applySettingsThunk({ safety_checks: level }));
 
     return (
         <Modal

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
@@ -2,7 +2,7 @@ import { selectSelectedAccount } from '@suite/account';
 import { UNECONOMICAL_COINJOIN_THRESHOLD } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { convertAmountSubunitsToUnits, getAccountDecimals } from '@suite-common/wallet-utils';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
@@ -24,7 +24,7 @@ export const UnecoCoinjoinModal = () => {
 
     const handleContinue = () => {
         dispatch(closeModal());
-        dispatch(goto({ routeName: 'wallet-anonymize', preserveParams: true }));
+        dispatch(gotoThunk({ routeName: 'wallet-anonymize', preserveParams: true }));
     };
 
     const handleCancel = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { TxSimulationBanner } from '@suite/tx-simulation/src/common';
 import { useDispatch } from '@suite-common/redux-utils';
 import { useDappScan } from '@suite-common/tx-simulation';
@@ -100,7 +100,7 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
     };
     const handleGoToCoinSettings = async () => {
         await dispatch(closeModal());
-        dispatch(goto({ routeName: 'settings-coins' }));
+        dispatch(gotoThunk({ routeName: 'settings-coins' }));
     };
 
     const getTooltipContent = (network: PendingConnectionProposalNetwork) => {

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx
@@ -1,6 +1,6 @@
 import { selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
 import type { NotificationRendererProps } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';
@@ -24,7 +24,7 @@ export const ActionRenderer = ({ render: View, ...props }: ActionRendererProps) 
         case DEVICE.CONNECT_UNACQUIRED:
             action = {
                 label: 'TR_SOLVE_ISSUE',
-                onClick: () => dispatch(acquireDevice({ requestedDevice: device })),
+                onClick: () => dispatch(acquireDeviceThunk({ requestedDevice: device })),
             };
             break;
         // no default

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/AutoEjectRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/AutoEjectRenderer.tsx
@@ -1,4 +1,4 @@
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 
 import { resetProtocol } from 'src/actions/suite/protocolActions';
@@ -10,7 +10,7 @@ export const AutoEjectRenderer = ({ render: View, notification }: NotificationRe
     const onCancel = () => dispatch(resetProtocol());
 
     const handleActionClick = () => {
-        dispatch(goto({ routeName: 'settings-index', anchor: SettingsAnchor.AutoEject }));
+        dispatch(gotoThunk({ routeName: 'settings-index', anchor: SettingsAnchor.AutoEject }));
     };
 
     return (

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
-import { goto, selectRouteName } from '@suite/router';
+import { gotoThunk, selectRouteName } from '@suite/router';
 import { isBech32AddressUppercase } from '@suite-common/address';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectFindNetworkSymbolForProtocolDep } from '@suite-common/networks';
@@ -65,7 +65,7 @@ export const CoinProtocolRenderer = ({
                 const firstAccount = networkAccounts[0];
                 if (networkAccounts.length === 1 && firstAccount) {
                     dispatch(
-                        goto({
+                        gotoThunk({
                             routeName: 'wallet-send',
                             params: {
                                 symbol: firstAccount.symbol,
@@ -77,7 +77,7 @@ export const CoinProtocolRenderer = ({
                 } else {
                     dispatch(globalSendReceiveFiltersActions.setNetworkSymbol(networkSymbol));
                     dispatch(
-                        goto({
+                        gotoThunk({
                             routeName: 'suite-index',
                             params: {
                                 modal: 'send',

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -1,7 +1,7 @@
 import { HiddenPlaceholder } from '@suite/discreet-mode';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { getTxAnchor, goto, selectRouteName, selectRouterApp } from '@suite/router';
+import { getTxAnchor, gotoThunk, selectRouteName, selectRouterApp } from '@suite/router';
 import { selectDeviceThunk, selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
@@ -71,7 +71,7 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
 
         const txAnchor = getTxAnchor(tx?.txid);
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: destinationRoute,
                 params: {
                     accountIndex: account.index,

--- a/packages/suite/src/components/suite/troubleshooting/tips/UdevDescription.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/UdevDescription.tsx
@@ -1,12 +1,12 @@
 import { TrezorLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 
 export const UdevDescription = () => {
     const dispatch = useDispatch();
 
-    const handleClick = () => dispatch(goto({ routeName: 'suite-udev' }));
+    const handleClick = () => dispatch(gotoThunk({ routeName: 'suite-udev' }));
 
     return (
         <div data-testid="@connect-device-prompt/unreadable-udev">

--- a/packages/suite/src/components/suite/troubleshooting/tips/UpdateGoToSettingsDescription.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/tips/UpdateGoToSettingsDescription.tsx
@@ -1,12 +1,12 @@
 import { TrezorLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 
 export const UpdateGoToSettingsDescription = () => {
     const dispatch = useDispatch();
 
-    const gotToDeviceSettings = () => dispatch(goto({ routeName: 'settings-device' }));
+    const gotToDeviceSettings = () => dispatch(gotoThunk({ routeName: 'settings-device' }));
 
     return (
         <Translation

--- a/packages/suite/src/components/tx-simulation/common/components/TxSimulationErrorBoundary.tsx
+++ b/packages/suite/src/components/tx-simulation/common/components/TxSimulationErrorBoundary.tsx
@@ -4,7 +4,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { TxSimulationBanner } from '@suite/tx-simulation/src/common';
 import { useDispatch } from '@suite-common/redux-utils';
 
-import { reportToSentry } from 'src/utils/suite/sentry';
+import { reportToSentryThunk } from 'src/utils/suite/sentry';
 
 export interface TxSimulationErrorBoundaryProps {
     children: ReactNode;
@@ -42,7 +42,7 @@ export function TxSimulationErrorBoundary({
                 onError(true);
                 // The error itself only ever carries a React message; the scan payload behind it
                 // holds addresses and balances and must never be reported.
-                dispatch(reportToSentry(error));
+                dispatch(reportToSentryThunk(error));
             }}
             // A later refetch can still deliver a renderable result.
             resetKeys={[resetKey]}

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/DeviceUnavailable.tsx
@@ -3,7 +3,7 @@ import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 
 export const DeviceUnavailable = () => {
     const dispatch = useDispatch();
@@ -14,7 +14,7 @@ export const DeviceUnavailable = () => {
         return null;
     }
 
-    const handleButtonClick = () => dispatch(applySettings({ use_passphrase: true }));
+    const handleButtonClick = () => dispatch(applySettingsThunk({ use_passphrase: true }));
 
     return (
         <Banner

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EarnEthBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EarnEthBanner.tsx
@@ -1,7 +1,7 @@
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -39,7 +39,7 @@ export const EarnEthBanner = ({ networkSymbol, apy }: EarnEthBannerProps) => {
     };
 
     const goToEarnDashboard = () => {
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(gotoThunk({ routeName: 'suite-earn' }));
 
         analytics.report({
             type: sharedEvents.yieldNavigateEvent.name,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { goto, selectRouter } from '@suite/router';
+import { gotoThunk, selectRouter } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -104,7 +104,7 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     };
 
     const goToStakingTab = () => {
-        dispatch(goto({ routeName: 'wallet-staking', preserveParams: true }));
+        dispatch(gotoThunk({ routeName: 'wallet-staking', preserveParams: true }));
 
         analytics.report({
             type: events.stakingNavigateEvent.name,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TorDisconnected.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TorDisconnected.tsx
@@ -1,7 +1,7 @@
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { selectIsTorEnabled, selectIsTorLoading } from '@suite/tor';
-import { toggleTor } from '@suite/tor-desktop';
+import { toggleTorThunk } from '@suite/tor-desktop';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 
@@ -15,7 +15,7 @@ export const TorDisconnected = () => {
 
     if (account?.accountType !== 'coinjoin' || isTorEnabled) return null;
 
-    const handleButtonClick = () => dispatch(toggleTor(true));
+    const handleButtonClick = () => dispatch(toggleTorThunk(true));
 
     return (
         <Banner

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotEnabled.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/AccountNotEnabled.tsx
@@ -2,7 +2,7 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Network } from '@suite-common/wallet-config';
-import { changeCoinVisibility } from '@suite-common/wallet-core';
+import { changeCoinVisibilityThunk } from '@suite-common/wallet-core';
 import { PlusIcon, WarningIcon } from '@trezor/icons';
 
 import { AccountExceptionLayout } from 'src/components/wallet';
@@ -20,7 +20,7 @@ export const AccountNotEnabled = ({ network }: AccountNotEnabledProps) => {
     const { isLocked } = useDevice();
 
     const handleClick = () =>
-        dispatch(changeCoinVisibility({ symbol: network.symbol, shouldBeVisible: true }));
+        dispatch(changeCoinVisibilityThunk({ symbol: network.symbol, shouldBeVisible: true }));
 
     return (
         <AccountExceptionLayout

--- a/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryEmpty.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountException/DiscoveryEmpty.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { CloudIcon, GearIcon } from '@trezor/icons';
 
@@ -12,7 +12,7 @@ import { AccountExceptionLayout } from 'src/components/wallet';
 export const DiscoveryEmpty = () => {
     const dispatch = useDispatch();
 
-    const goToCoinsSettings = () => dispatch(goto({ routeName: 'settings-coins' }));
+    const goToCoinsSettings = () => dispatch(gotoThunk({ routeName: 'settings-coins' }));
 
     return (
         <AccountExceptionLayout

--- a/packages/suite/src/hooks/earn/useClaimForm.ts
+++ b/packages/suite/src/hooks/earn/useClaimForm.ts
@@ -9,7 +9,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { throwError } from '@trezor/utils';
 
-import { signTransaction } from 'src/actions/wallet/stakeActions';
+import { signTransactionThunk } from 'src/actions/wallet/stakeActions';
 import { useSelector } from 'src/hooks/suite';
 import { type ClaimContextValues, type ClaimFormState } from 'src/types/earn/claimForm';
 import { CRYPTO_INPUT, OUTPUT_AMOUNT } from 'src/types/earn/earnFormFields';
@@ -126,7 +126,7 @@ export const useClaimForm = ({ account }: UseClaimFormsProps): ClaimContextValue
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
             try {
-                const result = await dispatch(signTransaction(values, composedTx));
+                const result = await dispatch(signTransactionThunk(values, composedTx));
 
                 if (result?.success) {
                     clearForm();

--- a/packages/suite/src/hooks/earn/useStakeForm.ts
+++ b/packages/suite/src/hooks/earn/useStakeForm.ts
@@ -25,7 +25,7 @@ import {
 import { isChanged, throwError } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
-import { signTransaction } from 'src/actions/wallet/stakeActions';
+import { signTransactionThunk } from 'src/actions/wallet/stakeActions';
 import { useSelector } from 'src/hooks/suite';
 import { CRYPTO_INPUT, FIAT_INPUT, OUTPUT_AMOUNT } from 'src/types/earn/earnFormFields';
 import type { AmountLimitProps } from 'src/utils/suite/validation';
@@ -353,7 +353,7 @@ export const useStakeForm = ({ account }: UseStakeFormProps): StakeContextValues
         if (composedTx?.type === 'final') {
             setIsLoading(true);
             try {
-                const result = await dispatch(signTransaction(values, composedTx));
+                const result = await dispatch(signTransactionThunk(values, composedTx));
 
                 if (result?.success) {
                     clearForm();

--- a/packages/suite/src/hooks/earn/useWithdrawalForm.ts
+++ b/packages/suite/src/hooks/earn/useWithdrawalForm.ts
@@ -26,7 +26,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { BigNumber, isChanged, throwError } from '@trezor/utils';
 
-import { signTransaction } from 'src/actions/wallet/stakeActions';
+import { signTransactionThunk } from 'src/actions/wallet/stakeActions';
 import { useSelector } from 'src/hooks/suite';
 import { CRYPTO_INPUT, FIAT_INPUT, OUTPUT_AMOUNT } from 'src/types/earn/earnFormFields';
 import type { AmountLimitProps } from 'src/utils/suite/validation';
@@ -276,7 +276,7 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
             try {
-                const result = await dispatch(signTransaction(values, composedTx));
+                const result = await dispatch(signTransactionThunk(values, composedTx));
 
                 if (result?.success) {
                     clearForm();

--- a/packages/suite/src/hooks/suite/useAppShortcuts.tsx
+++ b/packages/suite/src/hooks/suite/useAppShortcuts.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 import { selectSelectedAccount } from '@suite/account';
 import { useToggleDebugMode } from '@suite/debug';
 import { openModal } from '@suite/modal';
-import { SettingsAnchor, closeModalApp, goto } from '@suite/router';
+import { SettingsAnchor, closeModalAppThunk, gotoThunk } from '@suite/router';
 import { selectAutodetectTheme, selectTheme, suiteSettingsActions } from '@suite/settings';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDiscreetMode } from '@suite-common/discreet-mode';
@@ -14,7 +14,7 @@ import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { bioAuthActions } from 'src/actions/suite/bioAuthActions';
-import { toggleView as toggleGuideView } from 'src/actions/suite/guideActions';
+import { toggleViewThunk as toggleGuideView } from 'src/actions/suite/guideActions';
 import { useSelector } from 'src/hooks/suite';
 import { selectIsBioAuthEnabled } from 'src/reducers/bioAuth';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
@@ -56,7 +56,7 @@ export const useAppShortcuts = () => {
 
         const gotoAccount = (account: ListedAccount | undefined) =>
             dispatch(
-                goto({
+                gotoThunk({
                     routeName: 'wallet-index',
                     params: {
                         symbol: account?.symbol,
@@ -75,13 +75,13 @@ export const useAppShortcuts = () => {
             isDeviceSelected
         ) {
             e.preventDefault();
-            dispatch(goto({ routeName: 'settings-index' }));
+            dispatch(gotoThunk({ routeName: 'settings-index' }));
         }
 
         // press ALT + P to open a passphrase (hidden) wallet
         if (altOnly && e.code === KEYBOARD_CODE.KEY_P && selectedDevice?.connected) {
             e.preventDefault();
-            dispatch(closeModalApp());
+            dispatch(closeModalAppThunk());
             dispatch(
                 startDiscoveryThunk({
                     device: selectedDevice,
@@ -95,7 +95,9 @@ export const useAppShortcuts = () => {
         if (altOnly && e.code === KEYBOARD_CODE.KEY_W && isDeviceSelected) {
             e.preventDefault();
             if (!discoveryInProgress) {
-                dispatch(goto({ routeName: 'suite-switch-device', params: { cancelable: true } }));
+                dispatch(
+                    gotoThunk({ routeName: 'suite-switch-device', params: { cancelable: true } }),
+                );
             }
         }
 
@@ -142,7 +144,9 @@ export const useAppShortcuts = () => {
             if (!isBioAuthEnabled) {
                 // Biometric lock isn't set up yet, so there's nothing to lock with.
                 // Take the user to the setting and highlight it instead.
-                dispatch(goto({ routeName: 'settings-index', anchor: SettingsAnchor.BioAuth }));
+                dispatch(
+                    gotoThunk({ routeName: 'settings-index', anchor: SettingsAnchor.BioAuth }),
+                );
             } else {
                 dispatch(bioAuthActions.setCancelled(false));
                 dispatch(bioAuthActions.setIsBioAuthValidationRequired(true));
@@ -152,43 +156,43 @@ export const useAppShortcuts = () => {
         // press ALT + S to open the send flow
         if (altOnly && e.code === KEYBOARD_CODE.KEY_S && isDeviceSelected) {
             e.preventDefault();
-            dispatch(goto({ routeName: 'suite-index', params: { modal: 'send' } }));
+            dispatch(gotoThunk({ routeName: 'suite-index', params: { modal: 'send' } }));
         }
 
         // press ALT + R to open the receive flow
         if (altOnly && e.code === KEYBOARD_CODE.KEY_R && isDeviceSelected) {
             e.preventDefault();
-            dispatch(goto({ routeName: 'suite-index', params: { modal: 'receive' } }));
+            dispatch(gotoThunk({ routeName: 'suite-index', params: { modal: 'receive' } }));
         }
 
         // press ALT + X to open Swap (exchange)
         if (altOnly && e.code === KEYBOARD_CODE.KEY_X && isDeviceSelected) {
             e.preventDefault();
-            dispatch(goto({ routeName: 'wallet-trading-exchange', preserveParams: false }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-exchange', preserveParams: false }));
         }
 
         // press ALT + B to open Buy
         if (altOnly && e.code === KEYBOARD_CODE.KEY_B && isDeviceSelected) {
             e.preventDefault();
-            dispatch(goto({ routeName: 'wallet-trading-buy', preserveParams: false }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-buy', preserveParams: false }));
         }
 
         // press ALT + C to open Sell
         if (altOnly && e.code === KEYBOARD_CODE.KEY_C && isDeviceSelected) {
             e.preventDefault();
-            dispatch(goto({ routeName: 'wallet-trading-sell', preserveParams: false }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-sell', preserveParams: false }));
         }
 
         // press ALT + E to open Earn
         if (altOnly && e.code === KEYBOARD_CODE.KEY_E && isDeviceSelected) {
             e.preventDefault();
-            dispatch(goto({ routeName: 'suite-earn' }));
+            dispatch(gotoThunk({ routeName: 'suite-earn' }));
         }
 
         // press ALT + N to open Networks (coin settings)
         if (altOnly && e.code === KEYBOARD_CODE.KEY_N && isDeviceSelected) {
             e.preventDefault();
-            dispatch(goto({ routeName: 'settings-coins' }));
+            dispatch(gotoThunk({ routeName: 'settings-coins' }));
         }
 
         // press ALT + I to toggle the notifications (activity) dropdown in the sidebar
@@ -203,7 +207,7 @@ export const useAppShortcuts = () => {
         if (cmdOrCtrlAndAlt && isDeviceSelected) {
             if (e.code === KEYBOARD_CODE.DIGIT_ZERO) {
                 e.preventDefault();
-                dispatch(goto({ routeName: 'suite-index' }));
+                dispatch(gotoThunk({ routeName: 'suite-index' }));
             }
 
             const digitCodes: string[] = [

--- a/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
+++ b/packages/suite/src/hooks/suite/useChangeDeviceLabel.ts
@@ -11,7 +11,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { yup } from '@suite-common/validators';
 import { isAscii } from '@trezor/utils';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 import { MAX_LABEL_LENGTH } from 'src/constants/suite/device';
 import { useSelector } from 'src/hooks/suite';
 
@@ -61,7 +61,7 @@ export const useChangeDeviceLabel = (): {
     const currentLabel = useWatch({ control, name: 'deviceLabel' });
 
     const onSubmit = form.handleSubmit(({ deviceLabel }) => {
-        dispatch(applySettings({ label: deviceLabel }));
+        dispatch(applySettingsThunk({ label: deviceLabel }));
         analytics.report({
             type: events.settingsDeviceChangeLabelEvent.name,
         });

--- a/packages/suite/src/hooks/suite/useFirmwareUpgradeModal.ts
+++ b/packages/suite/src/hooks/suite/useFirmwareUpgradeModal.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { selectIsConnectionModalOpen, setConnectionModal, setConnectionMode } from '@suite/device';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 
@@ -19,7 +19,7 @@ export const useFirmwareUpgradeModal = () => {
             setIsAwaitingConnectionForFwUpdate(false);
             if (device?.connected) {
                 setIsFirmwareModalOpen(false);
-                dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+                dispatch(gotoThunk({ routeName: 'firmware-index', params: { cancelable: true } }));
             }
         }
     }, [isAwaitingConnectionForFwUpdate, isConnectionModalOpen, device?.connected, dispatch]);
@@ -43,7 +43,7 @@ export const useFirmwareUpgradeModal = () => {
         }
 
         setIsFirmwareModalOpen(false);
-        dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+        dispatch(gotoThunk({ routeName: 'firmware-index', params: { cancelable: true } }));
     };
 
     return { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware };

--- a/packages/suite/src/hooks/suite/useGraph.ts
+++ b/packages/suite/src/hooks/suite/useGraph.ts
@@ -17,7 +17,7 @@ export const useGraph = () => {
         () => ({
             setSelectedRange: (range: GraphRange) => dispatch(graphActions.setSelectedRange(range)),
             updateGraphData: (accounts: Account[]) =>
-                dispatch(graphActions.updateGraphData({ accounts })),
+                dispatch(graphActions.updateGraphDataThunk({ accounts })),
         }),
         [dispatch],
     );

--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -26,12 +26,13 @@ export const useOnboarding = () => {
     const actions = useMemo(
         () => ({
             goToStep: (stepId: AnyStepId) => dispatch(onboardingActions.goToStep(stepId)),
-            goToNextStep: (stepId?: AnyStepId) => dispatch(onboardingActions.goToNextStep(stepId)),
-            goToPreviousStep: () => dispatch(onboardingActions.goToPreviousStep()),
+            goToNextStep: (stepId?: AnyStepId) =>
+                dispatch(onboardingActions.goToNextStepThunk(stepId)),
+            goToPreviousStep: () => dispatch(onboardingActions.goToPreviousStepThunk()),
             resetOnboarding: () => dispatch(onboardingActions.resetOnboarding()),
             enableOnboardingReducer: (enabled: boolean) =>
                 dispatch(onboardingActions.enableOnboardingReducer(enabled)),
-            rerun: () => dispatch(onboardingActions.recoveryRerun()),
+            rerun: () => dispatch(onboardingActions.rerunRecoveryThunk()),
             updateAnalytics: (payload: Partial<OnboardingAnalytics>) =>
                 dispatch(onboardingActions.updateAnalytics(payload)),
             addPath: (payload: AnyPath) => dispatch(onboardingActions.addPath(payload)),
@@ -40,9 +41,9 @@ export const useOnboarding = () => {
             updateBackupMedium: (payload: BackupMedium) =>
                 dispatch(onboardingActions.updateBackupMedium(payload)),
             goToSuite: (options?: GoToSuiteOptions) =>
-                dispatch(onboardingActions.goToSuite(options)),
+                dispatch(onboardingActions.goToSuiteThunk(options)),
             resolveNextAfterSkipped: (requestedStepId: AnyStepId) =>
-                dispatch(onboardingActions.resolveNextAfterSkipped(requestedStepId)),
+                dispatch(onboardingActions.resolveNextAfterSkippedThunk(requestedStepId)),
         }),
         [dispatch],
     );

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyFlow.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyFlow.test.tsx
@@ -4,7 +4,7 @@ import { useBuyFlow } from './useBuyFlow';
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
+    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
 }));
 
 jest.mock('@suite-common/trading', () => {

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyFlow.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyFlow.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type selectTradingBuyQuotesRequest, tradingThunks } from '@suite-common/trading';
 
@@ -23,7 +23,7 @@ export const useBuyFlow = ({ isFromRedirect, quotesRequest, isAmountEmpty }: Use
 
     useEffect(() => {
         if (isFromRedirect && quotesRequest) {
-            dispatch(goto({ routeName: 'wallet-trading-buy-confirm' }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-buy-confirm' }));
         }
     }, [isFromRedirect, quotesRequest, dispatch]);
 };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeTradeRequest.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeTradeRequest.ts
@@ -1,7 +1,7 @@
 import type { ExchangeTrade } from 'invity-api';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
@@ -48,7 +48,7 @@ export const useTradingExchangeTradeRequest = (account: Account | undefined) => 
         };
 
         const nextStep = () => {
-            dispatch(goto({ routeName: 'wallet-trading-exchange-detail' }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-exchange-detail' }));
         };
 
         return {

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
@@ -10,7 +10,7 @@ import { useTradingBuyConfirm } from './useTradingBuyConfirm';
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
+    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
 }));
 
 const mockConfirmTradeThunk = jest.fn((args: unknown) => {

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import type { BuyTrade, BuyTradeResponse } from 'invity-api';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
@@ -38,7 +38,7 @@ export const useTradingBuyConfirm = () => {
 
     useEffect(() => {
         if (!isReady) {
-            dispatch(goto({ routeName: 'wallet-trading-buy' }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-buy' }));
         }
     }, [isReady, dispatch]);
 
@@ -56,7 +56,7 @@ export const useTradingBuyConfirm = () => {
                 if (response.trade.paymentId) {
                     dispatch(tradingBuyActions.saveTransactionId(response.trade.paymentId));
                 }
-                dispatch(goto({ routeName: 'wallet-trading-buy-detail' }));
+                dispatch(gotoThunk({ routeName: 'wallet-trading-buy-detail' }));
             }
         };
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeConfirm.test.tsx
@@ -10,7 +10,7 @@ import { useTradingExchangeConfirm } from './useTradingExchangeConfirm';
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
+    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
 }));
 
 const mockLoadInitialDataThunk = jest.fn((args: unknown) =>

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeConfirm.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeConfirm.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     selectTradingExchangeActiveTrade,
@@ -27,7 +27,7 @@ export const useTradingExchangeConfirm = () => {
 
     useEffect(() => {
         if (!quotesRequest) {
-            dispatch(goto({ routeName: 'wallet-trading-exchange' }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-exchange' }));
         }
     }, [quotesRequest, dispatch]);
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.test.tsx
@@ -10,7 +10,7 @@ import { useTradingSellConfirm } from './useTradingSellConfirm';
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
+    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
 }));
 
 jest.mock('src/hooks/wallet/trading/useServerEnviroment', () => ({

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     selectTradingSellActiveTrade,
@@ -30,7 +30,7 @@ export const useTradingSellConfirm = () => {
 
     useEffect(() => {
         if (!quotesRequest) {
-            dispatch(goto({ routeName: 'wallet-trading-sell' }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-sell' }));
         }
     }, [quotesRequest, dispatch]);
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.test.tsx
@@ -10,7 +10,7 @@ import { useTradingSellTradeActions } from './useTradingSellTradeActions';
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
+    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
 }));
 
 const mockLoadInitialDataThunk = jest.fn((args: unknown) =>

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts
@@ -2,7 +2,7 @@ import type { BankAccount } from 'invity-api';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { type TranslationKey, useTranslation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectHasExperimentalFeature } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
@@ -112,7 +112,7 @@ export const useTradingSellTradeActions = () => {
         if (!account) return false;
 
         const nextStep = () => {
-            dispatch(goto({ routeName: 'wallet-trading-sell-detail' }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-sell-detail' }));
         };
 
         const signAndPushSendFormTransaction = async ({

--- a/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
+++ b/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
@@ -4,7 +4,7 @@ import { type NetworkSymbol, getNetworkOptional } from '@suite-common/wallet-con
 import {
     selectBitcoinAmountUnit,
     setBitcoinAmountUnits,
-    toggleBitcoinAmountUnits,
+    toggleBitcoinAmountUnitsThunk,
 } from '@suite-common/wallet-core';
 import { PROTO } from '@trezor/connect';
 
@@ -16,7 +16,7 @@ export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
     const dispatch = useDispatch();
 
     const toggleBitcoinAmountUnitsAction = () => {
-        dispatch(toggleBitcoinAmountUnits());
+        dispatch(toggleBitcoinAmountUnitsThunk());
     };
 
     const setBitcoinAmountUnitsAction = (unit: PROTO.AmountUnit) => {

--- a/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
+++ b/packages/suite/src/hooks/wallet/useChangeDelegateForm.ts
@@ -16,7 +16,7 @@ import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
 import { throwError } from '@trezor/utils';
 
-import { signTransaction } from 'src/actions/wallet/stakeActions';
+import { signTransactionThunk } from 'src/actions/wallet/stakeActions';
 import { useSelector } from 'src/hooks/suite';
 import { CRYPTO_INPUT } from 'src/types/earn/earnFormFields';
 
@@ -119,7 +119,7 @@ export const useChangeDelegateForm = ({
         const values = getValues();
         const composedTx = composedLevels ? composedLevels[selectedFee] : undefined;
         if (composedTx?.type === 'final') {
-            const result = await dispatch(signTransaction(values, composedTx));
+            const result = await dispatch(signTransactionThunk(values, composedTx));
 
             if (result?.success) {
                 clearForm();

--- a/packages/suite/src/hooks/wallet/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/useRbfForm.test.tsx
@@ -31,7 +31,7 @@ jest.unmock('@trezor/connect');
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: () => ({ type: 'mock-redirect' }),
+    gotoThunk: () => ({ type: 'mock-redirect' }),
 }));
 
 // !!! Must be a stable reference, else it will break some hooks / memoization and causes inf. re-renders

--- a/packages/suite/src/hooks/wallet/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/useSendForm.test.tsx
@@ -72,7 +72,7 @@ jest.mock('cross-fetch', () => ({
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: () => ({ type: 'mock-redirect' }),
+    gotoThunk: () => ({ type: 'mock-redirect' }),
 }));
 
 // !!! Must be a stable reference, else it will break some hooks / memoization and causes inf. re-renders

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectFindNetworkSymbolForProtocolDep } from '@suite-common/networks';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -289,7 +289,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             setLoading(false);
             if (result?.success) {
                 resetContext();
-                dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+                dispatch(gotoThunk({ routeName: 'wallet-index', preserveParams: true }));
             }
         }
     }, [getValues, composedLevels, dispatch, resetContext, selectedAccount.account]);

--- a/packages/suite/src/hooks/wallet/useTradingRedirect.ts
+++ b/packages/suite/src/hooks/wallet/useTradingRedirect.ts
@@ -7,7 +7,7 @@ import {
     type SellFiatTradeQuoteRequest,
 } from 'invity-api';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     parseCryptoId,
@@ -134,7 +134,7 @@ export const useTradingRedirect = () => {
         prefilledAccountFromRedirect(params);
         dispatch(tradingBuyActions.saveQuoteRequest(request));
         dispatch(tradingBuyActions.setIsFromRedirect(true));
-        dispatch(goto({ routeName: 'wallet-trading-buy' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-buy' }));
     };
 
     const redirectToSellOffers = (params: SellOfferRedirectParams) => {
@@ -188,7 +188,7 @@ export const useTradingRedirect = () => {
         );
         dispatch(tradingSellActions.saveTransactionId(orderId));
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: orderId ? 'wallet-trading-sell-confirm' : 'wallet-trading-sell',
             }),
         );
@@ -232,7 +232,7 @@ export const useTradingRedirect = () => {
             }),
         );
         dispatch(tradingExchangeActions.saveTransactionId(orderId));
-        dispatch(goto({ routeName: 'wallet-trading-exchange-confirm' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-exchange-confirm' }));
     };
 
     const redirectToBuyDetail = (params: DetailRedirectParams) => {
@@ -240,7 +240,7 @@ export const useTradingRedirect = () => {
 
         prefilledAccountFromRedirect(params);
         dispatch(tradingBuyActions.saveTransactionId(transactionId));
-        dispatch(goto({ routeName: 'wallet-trading-buy-detail' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-buy-detail' }));
     };
 
     return {

--- a/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
+++ b/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
@@ -6,7 +6,7 @@ import { routerAppChanged } from '@suite/router';
 import { deviceActions } from '@suite-common/device';
 import { firmwareActions } from '@suite-common/firmware';
 import { type Dispatch } from '@suite-common/redux-utils';
-import { forgetDisconnectedDevices } from '@suite-common/wallet-core';
+import { forgetDisconnectedDevicesThunk } from '@suite-common/wallet-core';
 import { UI_EVENTS, isUiEventOfType } from '@trezor/connect';
 
 import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
@@ -25,7 +25,7 @@ const onboardingMiddleware =
             // After the THP pairing is finished we want to jump to the next step automatically.
             // User already drifted away from the installation flow and is not aware that THP is actually in the middle
             // of the Firmware installation.
-            api.dispatch(onboardingActions.goToNextStep());
+            api.dispatch(onboardingActions.goToNextStepThunk());
             api.dispatch(firmwareActions.resetReducer());
         } else {
             // pass action
@@ -35,7 +35,7 @@ const onboardingMiddleware =
         // seed is wiped when switching firmware type so we need to forget all device instances as well
         if (isUiEventOfType(action, UI_EVENTS.FIRMWARE_TYPE_CHANGED)) {
             api.dispatch(
-                forgetDisconnectedDevices({
+                forgetDisconnectedDevicesThunk({
                     device: firmware.cachedDevice || action.payload.device,
                     forceForget: true,
                 }),
@@ -66,7 +66,7 @@ const onboardingMiddleware =
                 // If you connect T2T1 in recovery mode to fresh Suite, you should see analytics opt-out option first.
                 api.dispatch(recoveryActions.setStatus('in-progress'));
             } else {
-                api.dispatch(onboardingActions.recoveryRerun());
+                api.dispatch(onboardingActions.rerunRecoveryThunk());
             }
         }
 

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -19,7 +19,7 @@ import {
 } from '@suite/router';
 import { onSuiteReady } from '@suite/suite-lifecycle';
 import { deviceActions, selectDevices, selectDevicesCount } from '@suite-common/device';
-import { firmwareUpdate } from '@suite-common/firmware';
+import { firmwareUpdateThunk } from '@suite-common/firmware';
 import { type WithServices, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
 import {
@@ -93,7 +93,7 @@ export const prepareAnalyticsMiddleware = createAnalyticsMiddleware(
         const state = getState();
         const { analytics } = extra.services;
 
-        if (isAnyOf(firmwareUpdate.fulfilled, firmwareUpdate.rejected)(action)) {
+        if (isAnyOf(firmwareUpdateThunk.fulfilled, firmwareUpdateThunk.rejected)(action)) {
             const { device, toBtcOnly, toFwVersion, error = '' } = action.payload ?? {};
 
             if (device?.features) {

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts
@@ -20,7 +20,10 @@ import {
     mockSuiteDevice,
 } from '@suite-common/suite-types/mocks';
 import { createTestStore, testMocks } from '@suite-common/test-utils';
-import { defaultTrezorUIEventHandlerThunk, observeSelectedDevice } from '@suite-common/wallet-core';
+import {
+    defaultTrezorUIEventHandlerThunk,
+    observeSelectedDeviceThunk,
+} from '@suite-common/wallet-core';
 import { UI_EVENT, UI_EVENTS, UI_REQUEST, UI_REQUESTS } from '@trezor/connect';
 import { noopCreateLogger } from '@trezor/connect-common';
 
@@ -89,7 +92,7 @@ describe('buttonRequest middleware', () => {
         const store = initStore(getInitialState());
         const { dispatch } = store;
         await dispatch(connectInitThunk());
-        const call = dispatch(deviceSettingsActions.changePin({ remove: false }));
+        const call = dispatch(deviceSettingsActions.changePinThunk({ remove: false }));
         const { emitTestEvent } = testMocks.getTrezorConnectMock();
         // fake few ui events, just like when user is changing PIN
         emitTestEvent(UI_EVENT, {
@@ -105,14 +108,14 @@ describe('buttonRequest middleware', () => {
 
         // Not interested in noisy lifecycle actions from reduxJS toolkit
         const unrelatedActionTypes = [
-            observeSelectedDevice.pending.type,
-            observeSelectedDevice.fulfilled.type,
+            observeSelectedDeviceThunk.pending.type,
+            observeSelectedDeviceThunk.fulfilled.type,
         ];
         const actions = store
             .getActions()
             .filter(action => !unrelatedActionTypes.includes(action.type));
 
-        // not interested in the last action (its from changePin mock);
+        // not interested in the last action (its from changePinThunk mock);
         actions.pop();
 
         expect(actions).toMatchObject([

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.test.ts
@@ -2,7 +2,7 @@ import { type UnknownAction } from '@reduxjs/toolkit';
 
 import { locksInitialState, locksReducer } from '@suite/locks';
 import { modalReducer } from '@suite/modal';
-import { goto, routerReducer } from '@suite/router';
+import { gotoThunk, routerReducer } from '@suite/router';
 import { type RouterStateOverrides, createRouterStateMock } from '@suite/router/mocks';
 import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
 import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
@@ -18,7 +18,7 @@ import suiteReducer from 'src/reducers/suite/suiteReducer';
 jest.mock('src/actions/suite/storageActions', () => ({ __esModule: true }));
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: jest.fn(() => ({ type: '@router/goto/mocked' })),
+    gotoThunk: jest.fn(() => ({ type: '@router/goto/mocked' })),
 }));
 
 const deviceReducer = prepareDeviceReducer({
@@ -90,7 +90,7 @@ const initStore = (state: State) => {
 
 describe('redirectMiddleware', () => {
     describe('redirects on DEVICE.CONNECT event', () => {
-        const gotoMock = jest.mocked(goto);
+        const gotoMock = jest.mocked(gotoThunk);
 
         afterEach(() => {
             gotoMock.mockClear();

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -3,8 +3,8 @@ import { type MiddlewareAPI, type Dispatch as ReduxDispatch } from 'redux';
 
 import { selectIsRouterLocked } from '@suite/locks';
 import {
-    closeModalApp,
-    goto,
+    closeModalAppThunk,
+    gotoThunk,
     selectRouteName,
     selectRouterApp,
     selectRouterParams,
@@ -30,15 +30,15 @@ const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: Trez
 
     // device is not initialized, redirect to onboarding
     if (device.mode === 'initialize') {
-        dispatch(goto({ routeName: 'suite-start' }));
+        dispatch(gotoThunk({ routeName: 'suite-start' }));
     }
     // firmware none (T2T1) or unknown (T1B1) indicates freshly unpacked device
     if (device.mode === 'bootloader' && device.features?.firmware_present === false) {
-        dispatch(goto({ routeName: 'suite-start' }));
+        dispatch(gotoThunk({ routeName: 'suite-start' }));
     }
     // device firmware update required, redirect to "firmware update"
     else if (device.firmware === 'required') {
-        dispatch(goto({ routeName: 'firmware-index' }));
+        dispatch(gotoThunk({ routeName: 'firmware-index' }));
     }
 
     const selected = selectSelectedDevice(state);
@@ -52,7 +52,7 @@ const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: Trez
     ) {
         const routeName = selectRouteName(state);
         if (routeName) {
-            dispatch(goto({ routeName }));
+            dispatch(gotoThunk({ routeName }));
         }
     }
 };
@@ -73,7 +73,7 @@ const redirect =
                 !action.payload &&
                 selectRouterApp(api.getState()) === 'switch-device'
             ) {
-                api.dispatch(closeModalApp());
+                api.dispatch(closeModalAppThunk());
             }
 
             return action;

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -122,7 +122,7 @@ const sentryMiddleware =
             const { result } = action.payload;
             if (!result) return action;
 
-            const reportToSentry = (error: string, errorDetails?: string) => {
+            const reportToSentryThunk = (error: string, errorDetails?: string) => {
                 withSentryScope(scope => {
                     scope.setLevel('error');
                     scope.setTag('deviceAuthenticityError', error);
@@ -136,20 +136,20 @@ const sentryMiddleware =
 
             // report error from the TrezorConnect call itself
             if ('error' in result) {
-                reportToSentry(result.error);
+                reportToSentryThunk(result.error);
             }
             // report errors from either one of the secure elements (or both)
             if ('optigaResult' in result && result.optigaResult.error) {
                 const { error, errorDetails } = result.optigaResult;
-                reportToSentry(error, errorDetails);
+                reportToSentryThunk(error, errorDetails);
             }
             if ('tropicResult' in result && result.tropicResult?.error) {
                 const { error, errorDetails } = result.tropicResult;
-                reportToSentry(error, errorDetails);
+                reportToSentryThunk(error, errorDetails);
             }
             if ('mcuResult' in result && result.mcuResult?.error) {
                 const { error, errorDetails } = result.mcuResult;
-                reportToSentry(error, errorDetails);
+                reportToSentryThunk(error, errorDetails);
             }
         }
 

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -4,7 +4,12 @@ import { type FlagsRootState } from '@suite/flags';
 import { METADATA } from '@suite/metadata';
 import { type ModalRootState } from '@suite/modal';
 import { recoveryActions } from '@suite/recovery';
-import { type RouterRootState, goto, routerAppChanged, selectCanSwitchDevice } from '@suite/router';
+import {
+    type RouterRootState,
+    gotoThunk,
+    routerAppChanged,
+    selectCanSwitchDevice,
+} from '@suite/router';
 import { updateOnlineStatus } from '@suite/suite-lifecycle';
 import {
     type DeviceRootState,
@@ -20,14 +25,14 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type AccountsRootState,
     type WalletSettingsRootState,
-    forgetDisconnectedDevices,
-    handleDeviceDisconnect,
-    observeSelectedDevice,
+    forgetDisconnectedDevicesThunk,
+    handleDeviceDisconnectThunk,
+    observeSelectedDeviceThunk,
     selectIsDeviceAutoEjectEnabled,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 
-import { handleProtocolRequest } from 'src/actions/suite/protocolActions';
+import { handleProtocolRequestThunk } from 'src/actions/suite/protocolActions';
 import { desktopHandshake, setRecentlyDisconnectedDevice } from 'src/actions/suite/suiteActions';
 
 type SuiteMiddlewareState = AccountsRootState &
@@ -87,7 +92,7 @@ export const prepareSuiteMiddleware = createSuiteMiddleware(
             const state = getState();
             const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(state);
             dispatch(
-                forgetDisconnectedDevices({
+                forgetDisconnectedDevicesThunk({
                     device: action.payload,
                     forceForget: isAutoEjectEnabled,
                 }),
@@ -110,7 +115,7 @@ export const prepareSuiteMiddleware = createSuiteMiddleware(
                         !isModalActive
                     ) {
                         dispatch(
-                            goto({
+                            gotoThunk({
                                 routeName: 'suite-switch-device',
                                 params: { cancelable: true },
                             }),
@@ -132,12 +137,12 @@ export const prepareSuiteMiddleware = createSuiteMiddleware(
                 });
             }
 
-            dispatch(handleDeviceDisconnect(device));
+            dispatch(handleDeviceDisconnectThunk(device));
         }
 
         if (desktopHandshake.match(action)) {
             if (action.payload.protocol) {
-                dispatch(handleProtocolRequest(action.payload.protocol));
+                dispatch(handleProtocolRequestThunk(action.payload.protocol));
             }
             if (action.payload.desktopUpdate?.firstRun) {
                 dispatch(
@@ -153,7 +158,7 @@ export const prepareSuiteMiddleware = createSuiteMiddleware(
             if (selectedDevicePath === action.payload.path && !canSwitchDevice) {
                 dispatch(selectDeviceThunk({ device: undefined }));
             } else {
-                dispatch(handleDeviceDisconnect(action.payload));
+                dispatch(handleDeviceDisconnectThunk(action.payload));
             }
         } else if (updateOnlineStatus.match(action) && action.payload) {
             // Restart discovery to reconnect to backends when user goes offline -> online.
@@ -161,7 +166,7 @@ export const prepareSuiteMiddleware = createSuiteMiddleware(
         }
         if (isActionDeviceRelated(action)) {
             // keep suite reducer synchronized with other reducers (selected device)
-            dispatch(observeSelectedDevice());
+            dispatch(observeSelectedDeviceThunk());
         }
 
         return action;

--- a/packages/suite/src/middlewares/wallet/graphMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/graphMiddleware.ts
@@ -18,7 +18,7 @@ const graphMiddleware =
             // fetch graph data for selected account and range if needed
             if (action.payload.account) {
                 api.dispatch(
-                    graphActions.updateGraphData({
+                    graphActions.updateGraphDataThunk({
                         accounts: [action.payload.account],
                     }),
                 );
@@ -30,7 +30,7 @@ const graphMiddleware =
             action.payload.status.status === 'complete'
         ) {
             api.dispatch(
-                graphActions.updateGraphData({
+                graphActions.updateGraphDataThunk({
                     accounts: currentAccounts,
                 }),
             );

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -151,7 +151,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
             }
 
             storageActions.saveAccounts([account]);
-            dispatch(storageActions.saveCoinjoinAccount(account.key));
+            dispatch(storageActions.saveCoinjoinAccountThunk(account.key));
         },
     }),
     defineRememberedDeviceHandler({
@@ -192,7 +192,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
         ],
         getDevice: (action, state) => getDeviceByAccountKey(action.payload.accountKey, state),
         save: ({ action }, { dispatch }) => {
-            dispatch(storageActions.saveAccountReceive(action.payload.accountKey));
+            dispatch(storageActions.saveAccountReceiveThunk(action.payload.accountKey));
         },
     }),
     defineRememberedDeviceHandler({
@@ -206,7 +206,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
             const { account } = action.payload;
 
             storageActions.removeAccountTransactions(account);
-            dispatch(storageActions.saveAccountTransactions(account));
+            dispatch(storageActions.saveAccountTransactionsThunk(account));
         },
     }),
     defineRememberedDeviceHandler({
@@ -216,7 +216,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
             const account = selectAccountByKey(getState(), action.payload.key);
 
             if (account) {
-                dispatch(storageActions.saveAccountTransactions(account));
+                dispatch(storageActions.saveAccountTransactionsThunk(account));
             }
         },
     }),
@@ -241,7 +241,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
 
             const historicRates = selectHistoricFiatRates(getState());
             if (historicRates) {
-                dispatch(storageActions.saveAccountHistoricRates(account.key, historicRates));
+                dispatch(storageActions.saveAccountHistoricRatesThunk(account.key, historicRates));
             }
         },
     }),
@@ -265,7 +265,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
         match: [suiteSettingsActions.setCoinjoinReceiveWarningHidden.match],
         getDevice: (_action, state) => selectSelectedDevice(state),
         save: (_params, { dispatch }) => {
-            dispatch(storageActions.saveSuiteSettings());
+            dispatch(storageActions.saveSuiteSettingsThunk());
         },
     }),
     defineRememberedDeviceHandler({
@@ -292,7 +292,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
         getDevice: (action, state) =>
             selectDeviceByStaticSessionId(state, action.payload.deviceState),
         save: ({ device }, { dispatch }) => {
-            dispatch(storageActions.saveDeviceMetadataError(device));
+            dispatch(storageActions.saveDeviceMetadataErrorThunk(device));
         },
     }),
     defineRememberedDeviceHandler({
@@ -313,7 +313,9 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
         getDevice: (action, state) =>
             getDeviceByAccountKey(action.payload.accountKey as AccountKey, state),
         save: ({ action }, { dispatch }) => {
-            dispatch(storageActions.saveCoinjoinAccount(action.payload.accountKey as AccountKey));
+            dispatch(
+                storageActions.saveCoinjoinAccountThunk(action.payload.accountKey as AccountKey),
+            );
         },
     }),
 ];
@@ -346,7 +348,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
             }
 
             if (changeNetworks.match(action)) {
-                api.dispatch(storageActions.saveWalletSettings());
+                api.dispatch(storageActions.saveWalletSettingsThunk());
             }
 
             if (transactionsActions.resetTransaction.match(action)) {
@@ -359,18 +361,18 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
 
             if (phishingActions.setDustPhishing.match(action)) {
                 api.dispatch(
-                    storageActions.savePhishingMetadata({
+                    storageActions.savePhishingMetadataThunk({
                         dustPhishing: action.payload,
                     }),
                 );
             }
 
             if (blockchainActions.setBackend.match(action)) {
-                api.dispatch(storageActions.saveBackend(action.payload.symbol));
+                api.dispatch(storageActions.saveBackendThunk(action.payload.symbol));
             }
 
             if (blockchainActions.setBackendGapLimit.match(action)) {
-                api.dispatch(storageActions.saveBackend(action.payload.symbol));
+                api.dispatch(storageActions.saveBackendThunk(action.payload.symbol));
             }
 
             if (explorerActions.setExplorer.match(action)) {
@@ -384,7 +386,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     messageSystemActions.setConfigSource,
                 )(action)
             ) {
-                api.dispatch(storageActions.saveMessageSystem());
+                api.dispatch(storageActions.saveMessageSystemThunk());
             }
 
             if (
@@ -396,7 +398,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     analyticsActions.setLoggerEnabled,
                 )(action)
             ) {
-                api.dispatch(storageActions.saveAnalytics());
+                api.dispatch(storageActions.saveAnalyticsThunk());
             }
 
             if (
@@ -407,7 +409,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     setSuiteSyncRelayUrl,
                 )(action)
             ) {
-                api.dispatch(storageActions.saveSuiteSyncSettings());
+                api.dispatch(storageActions.saveSuiteSyncSettingsThunk());
             }
 
             if (setSuiteSyncOwner.match(action)) {
@@ -422,33 +424,33 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     suiteSyncQuotaManagerActions.eraseFetchedData,
                 )(action)
             ) {
-                api.dispatch(storageActions.saveSuiteSyncQuotaManager());
+                api.dispatch(storageActions.saveSuiteSyncQuotaManagerThunk());
             }
 
             if (deviceActions.setRememberDevice.match(action)) {
                 const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(api.getState());
 
                 if (action.payload.remember && !isAutoEjectEnabled) {
-                    api.dispatch(storageActions.rememberDevice(action.payload.device));
+                    api.dispatch(storageActions.rememberDeviceThunk(action.payload.device));
                 } else {
-                    api.dispatch(storageActions.forgetDevice(action.payload.device));
+                    api.dispatch(storageActions.forgetDeviceThunk(action.payload.device));
                 }
             }
 
             if (deviceActions.forgetDevice.match(action)) {
-                api.dispatch(storageActions.forgetDevice(action.payload.device));
+                api.dispatch(storageActions.forgetDeviceThunk(action.payload.device));
             }
 
             if (tokenDefinitionsActions.setTokenStatus.match(action)) {
                 api.dispatch(
-                    storageActions.saveTokenManagement(
+                    storageActions.saveTokenManagementThunk(
                         action.payload.symbol,
                         action.payload.type,
                         TokenManagementAction.HIDE,
                     ),
                 );
                 api.dispatch(
-                    storageActions.saveTokenManagement(
+                    storageActions.saveTokenManagementThunk(
                         action.payload.symbol,
                         action.payload.type,
                         TokenManagementAction.SHOW,
@@ -465,7 +467,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     bluetoothActions.deviceUpdateAction, // Known devices may be updated
                 )(action)
             ) {
-                api.dispatch(storageActions.saveKnownDevices());
+                api.dispatch(storageActions.saveKnownDevicesThunk());
             }
 
             if (
@@ -478,15 +480,15 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     walletConnectActions.removeSession,
                 )(action)
             ) {
-                api.dispatch(storageActions.saveConnectSettings());
+                api.dispatch(storageActions.saveConnectSettingsThunk());
             }
 
             if (firmwareActions.setFirmwareChannel.match(action)) {
-                api.dispatch(storageActions.saveFirmwareSettings());
+                api.dispatch(storageActions.saveFirmwareSettingsThunk());
             }
 
             if (isAnyOf(featureUsed, feedbackRequested, feedbackDismissed)(action)) {
-                api.dispatch(storageActions.saveFeatureFeedback());
+                api.dispatch(storageActions.saveFeatureFeedbackThunk());
             }
 
             if (
@@ -495,7 +497,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                 (isDeviceEventOfType(action, DEVICE.THP_PAIRING_STATUS_CHANGED) &&
                     action.payload.status === 'finished')
             ) {
-                api.dispatch(storageActions.saveThpCredentials());
+                api.dispatch(storageActions.saveThpCredentialsThunk());
             }
 
             if (
@@ -509,11 +511,11 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     deviceActions.forgetDevicePersistentData,
                 )(action)
             ) {
-                api.dispatch(storageActions.savePersistentDeviceData());
+                api.dispatch(storageActions.savePersistentDeviceDataThunk());
             }
 
             if (discreetModeActions.setDiscreetMode.match(action)) {
-                api.dispatch(storageActions.saveDiscreetMode());
+                api.dispatch(storageActions.saveDiscreetModeThunk());
             }
 
             if (
@@ -527,7 +529,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     setSuspiciousTransactionsFilter,
                 )(action)
             ) {
-                api.dispatch(storageActions.saveWalletSettings());
+                api.dispatch(storageActions.saveWalletSettingsThunk());
             } else if (
                 isAnyOf(
                     suiteSettingsActions.setLanguage,
@@ -549,9 +551,9 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                     confirmEvmExplanationModal,
                 )(action)
             ) {
-                api.dispatch(storageActions.saveSuiteSettings());
+                api.dispatch(storageActions.saveSuiteSettingsThunk());
             } else if (debugActions.setShowDebugMenu.match(action)) {
-                api.dispatch(storageActions.saveDebugSettings());
+                api.dispatch(storageActions.saveDebugSettingsThunk());
             } else if (tradingActions.saveTrade.match(action)) {
                 storageActions.saveTradingTrade(action.payload);
             } else if (
@@ -560,9 +562,9 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                 metadataActions.addMetadataProvider.match(action) ||
                 metadataActions.removeMetadataProvider.match(action)
             ) {
-                api.dispatch(storageActions.saveMetadataSettings());
+                api.dispatch(storageActions.saveMetadataSettingsThunk());
             } else if (setDebugSettings.match(action)) {
-                api.dispatch(storageActions.saveCoinjoinDebugSettings());
+                api.dispatch(storageActions.saveCoinjoinDebugSettingsThunk());
             } else if (clientOnPrisonEvent.match(action)) {
                 // Not a rememberedDeviceHandlers entry: unlike those handlers (one action ->
                 // one device), this one action affects multiple accounts on potentially
@@ -574,7 +576,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, StorageMiddleware
                 affectedAccounts.forEach(key => {
                     const device = getDeviceByAccountKey(key, state);
                     if (device && getIsDeviceRemembered(device)) {
-                        api.dispatch(storageActions.saveCoinjoinAccount(key));
+                        api.dispatch(storageActions.saveCoinjoinAccountThunk(key));
                     }
                 });
             }

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -128,10 +128,10 @@ const walletMiddleware =
                     isOnSendPage: suiteRouteName === 'wallet-send',
                 }),
             );
-            api.dispatch(tradingCommonActions.convertDrafts());
+            api.dispatch(tradingCommonActions.convertDraftsThunk());
         }
 
-        api.dispatch(selectedAccountActions.syncSelectedAccount(action));
+        api.dispatch(selectedAccountActions.syncSelectedAccountThunk(action));
 
         return action;
     };

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -43,9 +43,9 @@ export type ExtraDependenciesSuite = ExtraDependenciesStatic &
 
 export const extraDependencies: ExtraDependenciesStatic & TokenDefinitionsMiddlewareDeps = {
     thunks: {
-        initMetadata: metadataLabelingActions.init,
-        fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadata,
-        addAccountMetadata: metadataLabelingActions.addAccountMetadata,
+        initMetadata: metadataLabelingActions.initThunk,
+        fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadataThunk,
+        addAccountMetadata: metadataLabelingActions.addAccountMetadataThunk,
         forgetBluetoothDevice: forgetBluetoothDeviceThunk,
     },
     actions: {

--- a/packages/suite/src/support/suite/ErrorBoundary.tsx
+++ b/packages/suite/src/support/suite/ErrorBoundary.tsx
@@ -3,7 +3,7 @@ import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
 import { useDispatch } from '@suite-common/redux-utils';
 
 import { Error } from 'src/components/suite/Error';
-import { reportToSentry } from 'src/utils/suite/sentry';
+import { reportToSentryThunk } from 'src/utils/suite/sentry';
 
 const Fallback = ({ error }: { error: Error }) => <Error error={error.message} />;
 
@@ -14,7 +14,7 @@ export const ErrorBoundary = ({ children }: { children: React.ReactNode }) => {
         <ReactErrorBoundary
             FallbackComponent={Fallback}
             onError={error => {
-                dispatch(reportToSentry(error));
+                dispatch(reportToSentryThunk(error));
             }}
         >
             {children}

--- a/packages/suite/src/support/suite/Protocol.tsx
+++ b/packages/suite/src/support/suite/Protocol.tsx
@@ -11,9 +11,9 @@ import { useSelector } from 'src/hooks/suite';
 const Protocol = () => {
     const dispatch = useDispatch();
 
-    const handleProtocolRequest = useCallback(
+    const handleProtocolRequestThunk = useCallback(
         (uri: string) => {
-            dispatch(protocolActions.handleProtocolRequest(uri));
+            dispatch(protocolActions.handleProtocolRequestThunk(uri));
         },
         [dispatch],
     );
@@ -24,10 +24,10 @@ const Protocol = () => {
         if (searchParams) {
             const uri = searchParams.get('uri');
             if (uri) {
-                handleProtocolRequest(uri);
+                handleProtocolRequestThunk(uri);
             }
         }
-    }, [handleProtocolRequest, searchParams]);
+    }, [handleProtocolRequestThunk, searchParams]);
 
     useEffect(() => {
         processSearch();
@@ -45,11 +45,11 @@ const Protocol = () => {
         }
 
         if (isDesktop()) {
-            desktopApi.on('protocol/open', handleProtocolRequest);
+            desktopApi.on('protocol/open', handleProtocolRequestThunk);
 
             return () => desktopApi.removeAllListeners('protocol/open');
         }
-    }, [handleProtocolRequest]);
+    }, [handleProtocolRequestThunk]);
 
     return null;
 };

--- a/packages/suite/src/support/suite/RouterHandler.tsx
+++ b/packages/suite/src/support/suite/RouterHandler.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { Action } from 'history';
 
 import {
-    onLocationChange,
+    onLocationChangeThunk,
     selectCanNavigate,
     selectRouterLoaded,
     selectSuiteRouterHistoryDep,
@@ -23,7 +23,7 @@ export const RouterHandler = () => {
         const emitLocation = () => {
             if (routerLoaded) {
                 const location = suiteRouterHistory.getLocation();
-                dispatch(onLocationChange(location));
+                dispatch(onLocationChangeThunk(location));
             }
         };
 

--- a/packages/suite/src/support/suite/useConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupModals.tsx
@@ -13,10 +13,10 @@ import {
     selectModalContext,
     selectModalType,
 } from '@suite/modal';
-import { goto, selectRouteName } from '@suite/router';
+import { gotoThunk, selectRouteName } from '@suite/router';
 import {
     connectPopupActions,
-    connectPopupCallThunkInner,
+    connectPopupCallInnerThunk,
     selectConnectPopupCall,
 } from '@suite-common/connect-popup';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -133,7 +133,7 @@ export const useConnectPopupModals = () => {
                     dispatch(removePreserveModal());
                     dispatch(cancelModal());
                     dispatch(
-                        goto({
+                        gotoThunk({
                             routeName: 'suite-switch-device',
                             params: {
                                 cancelable: true,
@@ -185,7 +185,7 @@ export const useConnectPopupModals = () => {
             !isConnectionModalOpen
         ) {
             dispatch(
-                connectPopupCallThunkInner({
+                connectPopupCallInnerThunk({
                     ...popupCall,
                 }),
             );

--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -50,7 +50,7 @@ type ReportToSentryThunkState = AnalyticsRootState &
     LogsSliceRootState &
     WalletSettingsRootState;
 
-export const reportToSentry =
+export const reportToSentryThunk =
     (error: any) => (_: Dispatch<UnknownAction>, getState: () => ReportToSentryThunkState) => {
         const instanceId = selectAnalyticsInstanceId(getState());
         const enabledNetworks = selectEnabledNetworks(getState());

--- a/packages/suite/src/views/dashboard/AssetsView/AssetActionButton.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetActionButton.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent, type ReactNode } from 'react';
 
-import { type Route, goto } from '@suite/router';
+import { type Route, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -41,7 +41,7 @@ export const AssetActionButton = ({
         switch (routeName) {
             case 'wallet-staking':
                 dispatch(
-                    goto({
+                    gotoThunk({
                         routeName,
                         params: {
                             symbol,
@@ -59,7 +59,7 @@ export const AssetActionButton = ({
                         ),
                     );
                 }
-                dispatch(goto({ routeName }));
+                dispatch(gotoThunk({ routeName }));
                 break;
             default:
                 exhaustive(routeName);

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -1,6 +1,6 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectShouldAnimateLoadingSkeleton } from '@suite/ui-animations';
 import { type AssetFiatBalance } from '@suite-common/assets';
 import { useServices } from '@suite-common/dependency-injection';
@@ -94,7 +94,7 @@ export const AssetCard = ({
 
     const handleCardClick = () => {
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-index',
                 params: {
                     symbol,

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { type AssetFiatBalance } from '@suite-common/assets';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -66,7 +66,7 @@ export const AssetRow = memo(
 
         const handleRowClick = () => {
             dispatch(
-                goto({
+                gotoThunk({
                     routeName: 'wallet-index',
                     params: {
                         symbol,

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DefiYieldBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DefiYieldBanner.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Image } from '@trezor/components';
 
@@ -17,7 +17,7 @@ export const DefiYieldBanner = ({ onClose, onCTAClick }: DefiYieldBannerProps) =
 
     const handleCTAClick = () => {
         onCTAClick();
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(gotoThunk({ routeName: 'suite-earn' }));
     };
 
     return (

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/ETHVaultBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/ETHVaultBanner.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Box, Image } from '@trezor/components';
 
@@ -15,7 +15,7 @@ export const ETHVaultBanner = ({ onClose, onCTAClick }: ETHVaultBannerProps) => 
 
     const handleCTAClick = () => {
         onCTAClick();
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(gotoThunk({ routeName: 'suite-earn' }));
     };
 
     return (

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/StablecoinYieldBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/StablecoinYieldBanner.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Image } from '@trezor/components';
 
@@ -17,7 +17,7 @@ export const StablecoinYieldBanner = ({ onClose, onCTAClick }: StablecoinYieldBa
 
     const handleCTAClick = () => {
         onCTAClick();
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(gotoThunk({ routeName: 'suite-earn' }));
     };
 
     return (

--- a/packages/suite/src/views/dashboard/PortfolioCard/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/DashboardGraph.tsx
@@ -13,7 +13,7 @@ import { Box, Button } from '@trezor/components';
 import { RepeatIcon } from '@trezor/icons';
 import { typography } from '@trezor/theme';
 
-import { updateGraphData } from 'src/actions/wallet/graphActions';
+import { updateGraphDataThunk } from 'src/actions/wallet/graphActions';
 import { HiddenPlaceholder, TransactionsGraph } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectGraph } from 'src/reducers/wallet/graphReducer';
@@ -66,7 +66,7 @@ export const DashboardGraph = memo(({ accounts }: DashboardGraphProps) => {
         accounts.every(a => failedAccounts.some(fa => fa.descriptor === a.descriptor));
 
     const onRefresh = useCallback(
-        () => dispatch(updateGraphData({ accounts })).unwrap(),
+        () => dispatch(updateGraphDataThunk({ accounts })).unwrap(),
         [accounts, dispatch],
     );
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsOnboardingFeedbackBannerShown, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -39,7 +39,7 @@ export const EmptyWallet = () => {
             type: events.dashboardReceiveModalEvent.name,
             payload: { source: 'empty-wallet' },
         });
-        dispatch(goto({ routeName: 'suite-index', params: { modal: 'receive' } }));
+        dispatch(gotoThunk({ routeName: 'suite-index', params: { modal: 'receive' } }));
     };
 
     const handleBuy = () => {
@@ -52,7 +52,7 @@ export const EmptyWallet = () => {
                 from: 'dashboard/empty-wallet',
             },
         });
-        dispatch(goto({ routeName: 'wallet-trading-buy' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-buy' }));
     };
 
     return (

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -26,7 +26,7 @@ import {
 import { CaretDownIcon, CaretUpIcon, InfoIcon } from '@trezor/icons';
 import { breakpoints } from '@trezor/theme';
 
-import { updateGraphData } from 'src/actions/wallet/graphActions';
+import { updateGraphDataThunk } from 'src/actions/wallet/graphActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { GraphRangeSelector, GraphSkeleton } from 'src/components/suite';
 import { useDiscovery, useSelector } from 'src/hooks/suite';
@@ -128,7 +128,7 @@ export const PortfolioCard = memo(() => {
 
     const onSelectedRange = () =>
         dispatch(
-            updateGraphData({
+            updateGraphDataThunk({
                 accounts,
             }),
         );

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -21,7 +21,7 @@ import {
 } from '@trezor/components';
 import { PlusIcon, RepeatIcon, WarningIcon } from '@trezor/icons';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 import { type DiscoveryStatusType } from 'src/types/wallet';
 
 interface CTA {
@@ -197,7 +197,9 @@ export const PortfolioCardException = ({
                     cta={{
                         action: async () => {
                             // enable passphrase
-                            const result = await dispatch(applySettings({ use_passphrase: true }));
+                            const result = await dispatch(
+                                applySettingsThunk({ use_passphrase: true }),
+                            );
                             if (!result?.success) return;
                             // restart discovery
                             dispatch(startOrRestartDiscoveryThunk());

--- a/packages/suite/src/views/earn/tron/EarnTronRedirect.tsx
+++ b/packages/suite/src/views/earn/tron/EarnTronRedirect.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 
 export const EarnTronRedirect = () => {
     const dispatch = useDispatch();
 
     useEffect(() => {
-        dispatch(goto({ routeName: 'suite-earn' }));
+        dispatch(gotoThunk({ routeName: 'suite-earn' }));
     }, [dispatch]);
 
     return null;

--- a/packages/suite/src/views/earn/yield/unwrap/index.tsx
+++ b/packages/suite/src/views/earn/yield/unwrap/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { getWrappedNativeToken, isWrappedNativeToken } from '@trezor/network-ethereum-suite-common';
 
@@ -20,7 +20,7 @@ export const EarnUnwrap = () => {
 
     useEffect(() => {
         if (!routeParams) {
-            dispatch(goto({ routeName: 'suite-earn' }));
+            dispatch(gotoThunk({ routeName: 'suite-earn' }));
         }
     }, [dispatch, routeParams]);
 

--- a/packages/suite/src/views/earn/yield/useEarnLayout.tsx
+++ b/packages/suite/src/views/earn/yield/useEarnLayout.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { type TranslationKey } from '@suite/intl';
-import { type EarnParams, goto } from '@suite/router';
+import { type EarnParams, gotoThunk } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type YieldDtoV2, useGetVaultByAddress } from '@suite-common/earn-stablecoin-api';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -168,7 +168,7 @@ export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): E
 
     useEffect(() => {
         if (!routeParams) {
-            dispatch(goto({ routeName: 'suite-earn' }));
+            dispatch(gotoThunk({ routeName: 'suite-earn' }));
         }
     }, [dispatch, routeParams]);
 
@@ -188,7 +188,7 @@ export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): E
 
     useEffect(() => {
         if (isFirmwareNotSupported) {
-            dispatch(goto({ routeName: 'suite-earn' }));
+            dispatch(gotoThunk({ routeName: 'suite-earn' }));
         }
     }, [dispatch, isFirmwareNotSupported]);
 

--- a/packages/suite/src/views/earn/yield/wrap/index.tsx
+++ b/packages/suite/src/views/earn/yield/wrap/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { getWrappedNativeToken } from '@trezor/network-ethereum-suite-common';
 
@@ -20,7 +20,7 @@ export const EarnWrap = () => {
 
     useEffect(() => {
         if (!routeParams) {
-            dispatch(goto({ routeName: 'suite-earn' }));
+            dispatch(gotoThunk({ routeName: 'suite-earn' }));
         }
     }, [dispatch, routeParams]);
 

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -5,11 +5,11 @@ import {
     useFirmwareInstallationProgressCheck,
 } from '@suite/firmware-upgrade';
 import { closeModal } from '@suite/modal';
-import { closeModalApp } from '@suite/router';
+import { closeModalAppThunk } from '@suite/router';
 import { ThpPairingStep } from '@suite/thp';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -50,10 +50,10 @@ export const FirmwareModal = ({
 
     const handleClose = () => {
         if (device?.status !== 'available') {
-            dispatch(acquireDevice({ requestedDevice: device }));
+            dispatch(acquireDeviceThunk({ requestedDevice: device }));
         }
         dispatch(closeModal());
-        dispatch(closeModalApp());
+        dispatch(closeModalAppThunk());
         resetReducer();
     };
 

--- a/packages/suite/src/views/firmware/Steps/StepCheckSeed.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepCheckSeed.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import {
     selectIsDeviceBackedUp,
     selectSelectedDevice,
@@ -125,7 +125,7 @@ export const StepCheckSeed = ({
                         onClick={() => {
                             resetReducer();
                             dispatch(
-                                goto({
+                                gotoThunk({
                                     routeName: isDeviceBackedUp ? 'recovery-index' : 'backup-index',
                                 }),
                             );

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
@@ -37,7 +37,7 @@ export const Onboarding = () => {
     // we redirect user to the dashboard where onboarding starts over and picks up where it ended.
     useEffect(() => {
         if (activeStepId !== STEP.ID_FIRMWARE_STEP && thpStep === 'ConfirmOnlyConnection') {
-            dispatch(goto({ routeName: 'suite-index' }));
+            dispatch(gotoThunk({ routeName: 'suite-index' }));
         }
     }, [device, thpStep, activeStepId, dispatch]);
 

--- a/packages/suite/src/views/onboarding/steps/BackupStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/BackupStep.tsx
@@ -10,13 +10,13 @@ import {
 import { Translation } from '@suite/intl';
 import { selectIsDeviceLocked } from '@suite/locks';
 import { OnboardingCard } from '@suite/onboarding-components';
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { CheckIcon, TrezorBackupIcon } from '@trezor/icons';
 import { exhaustive } from '@trezor/type-utils';
 
-import { goToNextStep, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
+import { goToNextStepThunk, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
 import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
 import { BackupSeedCards } from 'src/components/backup';
 import { SkipStepConfirmation } from 'src/components/onboarding/SkipStepConfirmation';
@@ -53,7 +53,7 @@ export const BackupStep = () => {
 
     const handleResetOnboarding = () => {
         dispatch(onboardingActions.resetOnboarding());
-        dispatch(goto({ routeName: 'settings-device', anchor: SettingsAnchor.WipeDevice }));
+        dispatch(gotoThunk({ routeName: 'settings-device', anchor: SettingsAnchor.WipeDevice }));
     };
 
     const getContent = () => {
@@ -105,7 +105,7 @@ export const BackupStep = () => {
                         innerActions={
                             <OnboardingCard.Button
                                 data-testid="@backup/close-button"
-                                onClick={() => dispatch(goToNextStep())}
+                                onClick={() => dispatch(goToNextStepThunk())}
                                 isDisabled={!canContinue(backup.userConfirmed)}
                             >
                                 <Translation id="TR_BACKUP_FINISHED_BUTTON" />

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -5,7 +5,7 @@ import { TrezorLink } from '@suite/external-links';
 import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { selectRecoveryStatus } from '@suite/recovery';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import {
     selectIsDeviceAuthenticityCheckEnabled,
     selectIsUnlockedBootloaderAllowed,
@@ -176,9 +176,9 @@ const SecurityCheckContent = ({
         } else if (isOnboardingActive) {
             goToNextStep('firmware');
             // ensure that we are not stuck in the 'start' FullscreenApp
-            dispatch(goto({ routeName: 'onboarding-index' }));
+            dispatch(gotoThunk({ routeName: 'onboarding-index' }));
         } else {
-            dispatch(goto({ routeName: 'onboarding-index' }));
+            dispatch(gotoThunk({ routeName: 'onboarding-index' }));
         }
     };
 

--- a/packages/suite/src/views/onboarding/steps/DeviceTutorialStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceTutorialStep.tsx
@@ -9,7 +9,7 @@ import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import TrezorConnect from '@trezor/connect';
 import { mapTrezorModelToFilledIcon } from '@trezor/product-components';
 
-import { beginOnboardingTutorial } from 'src/actions/onboarding/onboardingActions';
+import { beginOnboardingTutorialThunk } from 'src/actions/onboarding/onboardingActions';
 import { useSelector } from 'src/hooks/suite';
 
 export const DeviceTutorialStep = () => {
@@ -18,7 +18,7 @@ export const DeviceTutorialStep = () => {
     const intl = useIntl();
 
     useEffect(() => {
-        dispatch(beginOnboardingTutorial());
+        dispatch(beginOnboardingTutorialThunk());
     }, [dispatch]);
 
     // Cancelling before the `showDeviceTutorial` call reaches the device (and registers in Connect

--- a/packages/suite/src/views/onboarding/steps/PinStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/PinStep.tsx
@@ -9,7 +9,7 @@ import { Button, Column } from '@trezor/components';
 import TrezorConnect, { UI_RESPONSE } from '@trezor/connect';
 import { LockKeyIcon } from '@trezor/icons';
 
-import { changePin } from 'src/actions/settings/deviceSettingsActions';
+import { changePinThunk } from 'src/actions/settings/deviceSettingsActions';
 import { SkipStepConfirmation } from 'src/components/onboarding/SkipStepConfirmation';
 import { PinMatrix } from 'src/components/suite';
 import { useOnboarding, useSelector } from 'src/hooks/suite';
@@ -27,7 +27,7 @@ export const PinStep = () => {
 
     const { goToNextStep, showPinMatrix, updateAnalytics } = useOnboarding();
 
-    const setPinAndSkipSuccessToast = () => dispatch(changePin({}, true));
+    const setPinAndSkipSuccessToast = () => dispatch(changePinThunk({}, true));
     const onTryAgain = () => {
         setStatus('initial');
         setPinAndSkipSuccessToast();

--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/RecoveryStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/RecoveryStepBox.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { TrezorBackupIcon } from '@trezor/icons';
 
-import { goToPreviousStep } from 'src/actions/onboarding/onboardingActions';
+import { goToPreviousStepThunk } from 'src/actions/onboarding/onboardingActions';
 import { useSelector } from 'src/hooks/suite';
 
 const RecoveryStepBox = (props: OnboardingCardProps) => {
@@ -35,7 +35,7 @@ const RecoveryStepBox = (props: OnboardingCardProps) => {
             return dispatch(recoveryActions.setStatus('initial'));
         }
 
-        return dispatch(goToPreviousStep());
+        return dispatch(goToPreviousStepThunk());
     };
 
     const isBackButtonVisible = () => {

--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -18,7 +18,7 @@ import { Badge, Banner, Column } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
 
-import { goToNextStep, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
+import { goToNextStepThunk, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
 import { SelectRecoveryType, SelectRecoveryWord, SelectWordCount } from 'src/components/recovery';
 import { useSelector } from 'src/hooks/suite';
 
@@ -223,7 +223,7 @@ export const RecoveryStep = () => {
 
     if (device?.mode === 'normal') {
         // Ready to continue to the next step
-        const handleClick = () => dispatch(goToNextStep('set-pin'));
+        const handleClick = () => dispatch(goToNextStepThunk('set-pin'));
 
         return (
             <RecoveryStepBox

--- a/packages/suite/src/views/onboarding/steps/SecurityStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityStep.tsx
@@ -5,14 +5,14 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { CreateNfcBackup, NoNfcTags } from '@suite/nfc';
 import { OnboardingCard } from '@suite/onboarding-components';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectIsDeviceBackupRequired, selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Badge, Column } from '@trezor/components';
 import { CheckIcon, TrezorBackupIcon, WalletIcon, WarningIcon } from '@trezor/icons';
 import { exhaustive } from '@trezor/type-utils';
 
-import { resetDevice } from 'src/actions/settings/deviceSettingsActions';
+import { resetDeviceThunk } from 'src/actions/settings/deviceSettingsActions';
 import { BackupSeedCards } from 'src/components/backup';
 import { SkipStepConfirmation } from 'src/components/onboarding/SkipStepConfirmation';
 import { ConfirmActionModal } from 'src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal';
@@ -20,7 +20,7 @@ import { useOnboarding, useSelector } from 'src/hooks/suite';
 
 type SecurityStepStatus = 'initial' | 'in-progress' | 'skipping-backup' | 'finished';
 
-type ResetDeviceParams = NonNullable<Parameters<typeof resetDevice>[0]>;
+type ResetDeviceParams = NonNullable<Parameters<typeof resetDeviceThunk>[0]>;
 
 export const SecurityStep = () => {
     const [status, setStatus] = useState<SecurityStepStatus>('initial');
@@ -82,13 +82,13 @@ export const SecurityStep = () => {
 
         // Wallet creation + backup in one atomic call, same as native device onboarding.
         // If backup fails, the device wipes itself (skip_backup: false).
-        const result = await dispatch(resetDevice(getResetDeviceParams()));
+        const result = await dispatch(resetDeviceThunk(getResetDeviceParams()));
 
         if (result?.success) {
             setStatus('finished');
         } else {
             // TODO: why should we go to the default dashboard when there is an error??
-            dispatch(goto({ routeName: 'suite-index' }));
+            dispatch(gotoThunk({ routeName: 'suite-index' }));
         }
     }, [dispatch, getResetDeviceParams, updateAnalytics]);
 
@@ -97,7 +97,7 @@ export const SecurityStep = () => {
             updateAnalytics({ backup: 'skip' });
             setShowSkipConfirmation(false);
             setStatus('skipping-backup');
-            const result = await dispatch(resetDevice(getResetDeviceParams(true)));
+            const result = await dispatch(resetDeviceThunk(getResetDeviceParams(true)));
             if (result?.success) {
                 if (showFinishedScreen) {
                     setStatus('finished');
@@ -105,7 +105,7 @@ export const SecurityStep = () => {
                     goToNextStep('set-pin');
                 }
             } else {
-                dispatch(goto({ routeName: 'suite-index' }));
+                dispatch(gotoThunk({ routeName: 'suite-index' }));
             }
         },
         [dispatch, getResetDeviceParams, goToNextStep, updateAnalytics],

--- a/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
@@ -1,7 +1,7 @@
 import { useDevice } from '@suite/device';
 import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Banner, Paragraph } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
@@ -18,7 +18,7 @@ export const FirmwareTypeSuggestion = () => {
     const handleClose = () => dispatch(setFlag({ key: 'firmwareTypeBannerClosed', value: true }));
 
     const goToFirmwareType = () =>
-        dispatch(goto({ routeName: 'settings-device', anchor: SettingsAnchor.FirmwareType }));
+        dispatch(gotoThunk({ routeName: 'settings-device', anchor: SettingsAnchor.FirmwareType }));
 
     return (
         <Banner

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -15,7 +15,7 @@ import { Context } from '@suite-common/message-system';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
 import {
-    changeCoinVisibility,
+    changeCoinVisibilityThunk,
     selectDeviceSupportedNetworks,
     selectEnabledNetworks,
     selectShowRediscoverButton,
@@ -140,7 +140,7 @@ export const SettingsCoins = () => {
 
     const onToggle = (symbol: NetworkSymbol, isEnabled?: boolean) => {
         dispatch(
-            changeCoinVisibility({
+            changeCoinVisibilityThunk({
                 symbol,
                 shouldBeVisible: isEnabled ?? true,
             }),

--- a/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Column, Icon, Row, SubTabs } from '@trezor/components';
 import { TrezorLogoIcon, WalletConnectIcon } from '@trezor/icons';
@@ -35,7 +35,7 @@ export const SettingsConnectedApps = () => {
 
     useEffect(() => {
         if (tabs.length === 0) {
-            dispatch(goto({ routeName: 'settings-index' }));
+            dispatch(gotoThunk({ routeName: 'settings-index' }));
         }
     }, [tabs.length, dispatch]);
 

--- a/packages/suite/src/views/settings/SettingsDebug/Metadata.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Metadata.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { exportMetadataToLocalFile } from '@suite/metadata';
+import { exportMetadataToLocalFileThunk } from '@suite/metadata';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Button } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
@@ -11,7 +11,7 @@ export const Metadata = () => {
 
     const onClick = () => {
         setExporting(true);
-        dispatch(exportMetadataToLocalFile()).finally(() => {
+        dispatch(exportMetadataToLocalFileThunk()).finally(() => {
             setExporting(false);
         });
     };

--- a/packages/suite/src/views/settings/SettingsDebug/Tor.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Tor.tsx
@@ -1,4 +1,4 @@
-import { toggleTor } from '@suite/tor-desktop';
+import { toggleTorThunk } from '@suite/tor-desktop';
 import { useDispatch } from '@suite-common/redux-utils';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
@@ -16,7 +16,7 @@ export const Tor = () => {
                     <ActionButton
                         intent="critical"
                         onClick={() => {
-                            dispatch(toggleTor(false));
+                            dispatch(toggleTorThunk(false));
                         }}
                     >
                         Stop Tor

--- a/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
@@ -1,4 +1,4 @@
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
@@ -16,7 +16,10 @@ export const TriggerHighlight = () => {
                     intent="brand"
                     onClick={() =>
                         dispatch(
-                            goto({ routeName: 'settings-index', anchor: SettingsAnchor.Labeling }),
+                            gotoThunk({
+                                routeName: 'settings-index',
+                                anchor: SettingsAnchor.Labeling,
+                            }),
                         )
                     }
                 >

--- a/packages/suite/src/views/settings/SettingsDevice/AutoLock.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/AutoLock.tsx
@@ -9,7 +9,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { formatDurationStrict } from '@suite-common/suite-utils';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 import { useLocales } from 'src/hooks/suite';
 
 // auto lock times in seconds; allowed lock times by device: <1 minute, 6 days>
@@ -49,7 +49,7 @@ export const AutoLock = ({ isDeviceLocked }: AutoLockProps) => {
     const handleChange = (option: { value: number; label: string }) => {
         const value = option.value * 1000;
 
-        dispatch(applySettings({ auto_lock_delay_ms: value }));
+        dispatch(applySettingsThunk({ auto_lock_delay_ms: value }));
         analytics.report({
             type: events.settingsDeviceUpdateAutoLockEvent.name,
             payload: {

--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -8,7 +8,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { type Locale } from '@suite-common/suite-types';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { changeLanguage } from 'src/actions/settings/deviceSettingsActions';
+import { changeLanguageThunk } from 'src/actions/settings/deviceSettingsActions';
 import { useSelector } from 'src/hooks/suite';
 
 interface ChangeLanguageProps {
@@ -22,7 +22,7 @@ export const ChangeLanguage = ({ isDeviceLocked }: ChangeLanguageProps) => {
     const supportedDeviceLanguages = useSelector(selectSupportedDeviceLanguages);
 
     const onChange = ({ value }: { value: Locale }) => {
-        dispatch(changeLanguage({ device, language: value }));
+        dispatch(changeLanguageThunk({ device, language: value }));
     };
 
     const languageOptions = useMemo(

--- a/packages/suite/src/views/settings/SettingsDevice/ChangePin.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangePin.tsx
@@ -5,7 +5,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { changePin } from 'src/actions/settings/deviceSettingsActions';
+import { changePinThunk } from 'src/actions/settings/deviceSettingsActions';
 
 interface ChangePinProps {
     isDeviceLocked: boolean;
@@ -15,7 +15,7 @@ export const ChangePin = ({ isDeviceLocked }: ChangePinProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const handleClick = () => {
-        dispatch(changePin({ remove: false }));
+        dispatch(changePinThunk({ remove: false }));
         analytics.report({
             type: events.settingsDeviceChangePinEvent.name,
         });

--- a/packages/suite/src/views/settings/SettingsDevice/CheckRecoverySeed.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/CheckRecoverySeed.tsx
@@ -1,7 +1,7 @@
 import { useDevice } from '@suite/device';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { Anchor, SettingsAnchor, goto } from '@suite/router';
+import { Anchor, SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { getCheckBackupUrl } from '@suite-common/suite-utils';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
@@ -18,7 +18,7 @@ export const CheckRecoverySeed = ({ isDeviceLocked }: CheckRecoverySeedProps) =>
     const learnMoreUrl = getCheckBackupUrl(device);
 
     const handleClick = () =>
-        dispatch(goto({ routeName: 'recovery-index', params: { cancelable: true } }));
+        dispatch(gotoThunk({ routeName: 'recovery-index', params: { cancelable: true } }));
 
     if (needsBackup) return null;
 

--- a/packages/suite/src/views/settings/SettingsDevice/CustomFirmware.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/CustomFirmware.tsx
@@ -1,7 +1,7 @@
 import { useDevice } from '@suite/device';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { Anchor, SettingsAnchor, goto } from '@suite/router';
+import { Anchor, SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { getFirmwareDowngradeUrl } from '@suite-common/suite-utils';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
@@ -14,7 +14,7 @@ export const CustomFirmware = () => {
     const firmwareDowngradeUrl = getFirmwareDowngradeUrl(device);
 
     const openModal = () =>
-        dispatch(goto({ routeName: 'firmware-custom', params: { cancelable: true } }));
+        dispatch(gotoThunk({ routeName: 'firmware-custom', params: { cancelable: true } }));
 
     return (
         <Anchor anchorId={SettingsAnchor.CustomFirmware}>

--- a/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/DisplayRotation.tsx
@@ -12,7 +12,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import { ArrowDownIcon, ArrowLeftIcon, ArrowRightIcon, ArrowUpIcon } from '@trezor/icons';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 
 type Rotation = { label: JSX.Element; value: DisplayRotationType };
 
@@ -95,7 +95,7 @@ export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
                                 options={DISPLAY_ROTATIONS}
                                 size="small"
                                 onChange={(value: DisplayRotationType) => {
-                                    dispatch(applySettings({ display_rotation: value }));
+                                    dispatch(applySettingsThunk({ display_rotation: value }));
                                     analytics.report({
                                         type: events.settingsDeviceChangeOrientationEvent.name,
                                         payload: {

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareTypeChange.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareTypeChange.tsx
@@ -1,7 +1,7 @@
 import { useDevice } from '@suite/device';
 import { getSuiteFirmwareTypeString } from '@suite/firmware-upgrade';
 import { Translation } from '@suite/intl';
-import { Anchor, SettingsAnchor, goto } from '@suite/router';
+import { Anchor, SettingsAnchor, gotoThunk } from '@suite/router';
 import { firmwareActions } from '@suite-common/firmware';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Button } from '@trezor/components';
@@ -33,7 +33,7 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
         : 'TR_SWITCH_TO_BITCOIN_ONLY';
 
     const handleAction = () => {
-        dispatch(goto({ routeName: 'firmware-type', params: { cancelable: true } }));
+        dispatch(gotoThunk({ routeName: 'firmware-type', params: { cancelable: true } }));
         dispatch(firmwareActions.setSwitchFirmwareType(true));
     };
 

--- a/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/FirmwareVersion.tsx
@@ -1,6 +1,6 @@
 import { useDevice } from '@suite/device';
 import { Translation, useTranslation } from '@suite/intl';
-import { Anchor, SettingsAnchor, goto } from '@suite/router';
+import { Anchor, SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { getChangelogUrl } from '@suite-common/suite-utils';
 import { Button, Tooltip } from '@trezor/components';
@@ -43,7 +43,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
     const changelogUrl = getChangelogUrl(device, revision);
 
     const handleUpdate = () => {
-        dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+        dispatch(gotoThunk({ routeName: 'firmware-index', params: { cancelable: true } }));
     };
 
     return (

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ForgetDeviceFlows.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ForgetDeviceFlows.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 
 import { unpairCurrentBondThunk } from 'src/actions/bluetooth/bluetoothEraseBondsThunk';
 
@@ -25,7 +25,7 @@ export const ImmediateForgetFlow = ({ onCancel }: ForgetFlowProps) => {
         <ConfirmationModal
             onConfirm={() => {
                 forgetDevice();
-                dispatch(goto({ routeName: 'suite-index' }));
+                dispatch(gotoThunk({ routeName: 'suite-index' }));
                 onCancel();
             }}
             onCancel={onCancel}
@@ -59,7 +59,7 @@ export const ConnectedCableForgetFlow = ({
                         deviceId,
                         toastType: 'device-forgotten',
                     });
-                    dispatch(goto({ routeName: 'suite-index' }));
+                    dispatch(gotoThunk({ routeName: 'suite-index' }));
                     onCancel();
                 }}
             />
@@ -110,7 +110,7 @@ export const ThpBtConnectedForgetFlow = ({ onCancel }: ForgetFlowProps) => {
                         skipDisconnect: true,
                         isOsUnpairingFinished: true,
                     });
-                    dispatch(goto({ routeName: 'suite-index' }));
+                    dispatch(gotoThunk({ routeName: 'suite-index' }));
                     onCancel();
                 }}
             />
@@ -166,7 +166,7 @@ export const ThpCableConnectedForgetFlow = ({ onCancel }: ForgetFlowProps) => {
                     isOsUnpairingFinished: true,
                     skipDisconnect: true,
                 });
-                dispatch(goto({ routeName: 'suite-index' }));
+                dispatch(gotoThunk({ routeName: 'suite-index' }));
                 onCancel();
             }}
         />
@@ -201,7 +201,7 @@ export const ThpBtKnownForgetFlow = ({ onCancel }: ForgetFlowProps) => {
                     toastType: 'device-forgotten',
                     isOsUnpairingFinished: true,
                 });
-                dispatch(goto({ routeName: 'suite-index' }));
+                dispatch(gotoThunk({ routeName: 'suite-index' }));
                 onCancel();
             }}
         />

--- a/packages/suite/src/views/settings/SettingsDevice/HapticFeedback.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/HapticFeedback.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { Switch, Tooltip } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 
 interface DeviceLabelProps {
     isDeviceLocked: boolean;
@@ -26,7 +26,7 @@ export const HapticFeedback = ({ isDeviceLocked }: DeviceLabelProps) => {
     const hapticEnabled = device?.features?.haptic_feedback ?? false;
 
     const handleChange = async () => {
-        const result = await dispatch(applySettings({ haptic_feedback: !hapticEnabled }));
+        const result = await dispatch(applySettingsThunk({ haptic_feedback: !hapticEnabled }));
 
         if (result?.success) {
             analytics.report({

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -9,7 +9,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { Paragraph, Tooltip } from '@trezor/components';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 import {
     ImageValidationError,
     convertImage,
@@ -82,7 +82,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
     const onChangeHomescreen = async () => {
         const hex = await imagePathToHex(customHomescreen, deviceModelInternal);
 
-        await dispatch(applySettings({ homescreen: hex }));
+        await dispatch(applySettingsThunk({ homescreen: hex }));
         resetUpload();
     };
 

--- a/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Passphrase.tsx
@@ -9,7 +9,7 @@ import { Switch, Tooltip } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 import { HELP_CENTER_PASSPHRASE_URL } from '@trezor/urls';
 
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { applySettingsThunk } from 'src/actions/settings/deviceSettingsActions';
 
 interface PassphraseProps {
     isDeviceLocked: boolean;
@@ -22,7 +22,7 @@ export const Passphrase = ({ isDeviceLocked }: PassphraseProps) => {
     const passphraseProtection = !!device?.features?.passphrase_protection;
 
     const handleChange = () => {
-        dispatch(applySettings({ use_passphrase: !passphraseProtection }));
+        dispatch(applySettingsThunk({ use_passphrase: !passphraseProtection }));
         analytics.report({
             type: events.settingsDeviceChangePassphraseProtectionEvent.name,
             payload: {

--- a/packages/suite/src/views/settings/SettingsDevice/PinProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/PinProtection.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { Switch, Tooltip } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { changePin } from 'src/actions/settings/deviceSettingsActions';
+import { changePinThunk } from 'src/actions/settings/deviceSettingsActions';
 
 interface PinProtectionProps {
     isDeviceLocked: boolean;
@@ -21,7 +21,7 @@ export const PinProtection = ({ isDeviceLocked }: PinProtectionProps) => {
     const pinProtection = device?.features?.pin_protection ?? null;
 
     const handleChange = () => {
-        dispatch(changePin({ remove: !!pinProtection }));
+        dispatch(changePinThunk({ remove: !!pinProtection }));
         analytics.report({
             type: events.settingsDeviceChangePinProtectionEvent.name,
             payload: {

--- a/packages/suite/src/views/settings/SettingsDevice/WipeCode.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/WipeCode.tsx
@@ -8,7 +8,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 import { HELP_CENTER_WIPE_CODE_URL } from '@trezor/urls';
 
-import { changeWipeCode } from 'src/actions/settings/deviceSettingsActions';
+import { changeWipeCodeThunk } from 'src/actions/settings/deviceSettingsActions';
 import { useSelector } from 'src/hooks/suite';
 
 interface Props {
@@ -21,7 +21,7 @@ export const WipeCode = ({ isDeviceLocked }: Props) => {
     const isDeviceProtectedByWipeCode = useSelector(selectIsDeviceProtectedByWipeCode);
 
     const enableWipeCode = () => {
-        dispatch(changeWipeCode({ remove: false }));
+        dispatch(changeWipeCodeThunk({ remove: false }));
         analytics.report({
             type: isDeviceProtectedByWipeCode
                 ? events.settingsDeviceChangeWipeCodeEvent.name
@@ -30,7 +30,7 @@ export const WipeCode = ({ isDeviceLocked }: Props) => {
     };
 
     const disableWipeCode = () => {
-        dispatch(changeWipeCode({ remove: true }));
+        dispatch(changeWipeCodeThunk({ remove: true }));
         analytics.report({
             type: events.settingsDeviceDisableWipeCodeEvent.name,
         });

--- a/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/ConnectLabelingProvider.tsx
@@ -10,7 +10,7 @@ export const ConnectLabelingProvider = () => {
     const dispatch = useDispatch();
     const { device } = useDevice();
     const isDeviceConnected = device?.connected && device?.available;
-    const handleClick = () => dispatch(metadataLabelingActions.init(true));
+    const handleClick = () => dispatch(metadataLabelingActions.initThunk(true));
 
     return (
         <Anchor anchorId={SettingsAnchor.LabelingConnect}>

--- a/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DisconnectLabelingProvider.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import {
-    disconnectProvider,
+    disconnectProviderThunk,
     selectMetadata,
     selectSelectedProviderForLabels,
 } from '@suite/metadata';
@@ -21,7 +21,7 @@ export const DisconnectLabelingProvider = () => {
 
     const handleClick = () =>
         dispatch(
-            disconnectProvider({
+            disconnectProviderThunk({
                 clientId: metadata.selectedProvider.labels,
                 dataType: 'labels',
             }),

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -7,7 +7,7 @@ import { type ExperimentalFeature } from '@suite/experimental';
 import { LearnMoreButton } from '@suite/external-links';
 import { feedbackRequested } from '@suite/feature-feedback';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectExperimentalFeatures, suiteSettingsActions } from '@suite/settings';
 import { useImperativeServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -57,7 +57,7 @@ const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
 
     const handleClick = () => {
         if (!config.routeName) return;
-        dispatch(goto({ routeName: config.routeName }));
+        dispatch(gotoThunk({ routeName: config.routeName }));
     };
 
     return (

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { selectIsDeviceOrUiLocked } from '@suite/locks';
-import { closeModalApp, goto } from '@suite/router';
+import { closeModalAppThunk, gotoThunk } from '@suite/router';
 import { selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectIsAnyNetworkEnabled, startAddWalletDiscoveryThunk } from '@suite-common/wallet-core';
@@ -37,8 +37,8 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
 
     const goToCoinsSettings = () => {
         onCancel?.(false);
-        dispatch(closeModalApp());
-        dispatch(goto({ routeName: 'settings-coins' }));
+        dispatch(closeModalAppThunk());
+        dispatch(gotoThunk({ routeName: 'settings-coins' }));
     };
 
     const noNetworksTooltipContent = (
@@ -69,7 +69,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
     }) => {
         onCancel?.(false);
         dispatch(selectDeviceThunk({ device }));
-        dispatch(closeModalApp());
+        dispatch(closeModalAppThunk());
         // TODO: when creating a new hidden wallet, we should not start discovery yet, but only after going through the best practices flow
         dispatch(
             startAddWalletDiscoveryThunk({
@@ -78,7 +78,7 @@ export const AddWalletButton = ({ device, instances, onCancel }: AddWalletButton
                 isAddingExistingWallet: isExisting,
             }),
         );
-        dispatch(goto({ routeName: 'suite-index' }));
+        dispatch(gotoThunk({ routeName: 'suite-index' }));
     };
 
     const ExpandedPassphraseContainer = () => (

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useEffect, useState } from 'react';
 
 import { selectHasSeenDisconnectTooltip, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
@@ -142,7 +142,7 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
                                                 onClick={() => {
                                                     onTooltipClose();
                                                     dispatch(
-                                                        goto({
+                                                        gotoThunk({
                                                             routeName: 'settings-index',
                                                             anchor: SettingsAnchor.AutoEject,
                                                         }),

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -1,13 +1,13 @@
 import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     type DeviceStatus as ConnectedDeviceStatus,
     type getStatus,
 } from '@suite-common/suite-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Banner, type BannerIntent } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -110,7 +110,7 @@ export const NeedsAttentionBanner = ({
                 return () => {
                     onCancel?.(false);
                     dispatch(selectDeviceThunk({ device }));
-                    dispatch(goto({ routeName: 'firmware-index' }));
+                    dispatch(gotoThunk({ routeName: 'firmware-index' }));
                 };
             // If onboarding is pending, then it should pass through Manual Device Check.
             case 'initialize': // Wiped device with firmware present.
@@ -118,7 +118,7 @@ export const NeedsAttentionBanner = ({
                 // but we cannot tell (device.features.initialized is null)
                 return () => {
                     selectDevice();
-                    dispatch(goto({ routeName: 'suite-start' }));
+                    dispatch(gotoThunk({ routeName: 'suite-start' }));
                 };
 
             case 'seedless':
@@ -134,11 +134,11 @@ export const NeedsAttentionBanner = ({
             case 'used-in-other-window':
             case 'was-used-in-other-window':
             case 'unacquired':
-                return () => dispatch(acquireDevice({ requestedDevice: device }));
+                return () => dispatch(acquireDeviceThunk({ requestedDevice: device }));
             case 'device-thp-locked':
                 return () => {
                     onCancel?.(false);
-                    dispatch(acquireDevice({ requestedDevice: device }));
+                    dispatch(acquireDeviceThunk({ requestedDevice: device }));
                 };
 
             case 'device-busy':

--- a/packages/suite/src/views/suite/bridge-deprecated/index.tsx
+++ b/packages/suite/src/views/suite/bridge-deprecated/index.tsx
@@ -1,6 +1,6 @@
 import { useExternalLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Column, H3, Link, Modal, Paragraph } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
@@ -19,7 +19,7 @@ export const BridgeDeprecated = () => {
     useLayout('Bridge');
 
     const onClose = () => {
-        dispatch(goto({ routeName: 'wallet-index' }));
+        dispatch(gotoThunk({ routeName: 'wallet-index' }));
     };
 
     return (

--- a/packages/suite/src/views/suite/bridge-requested/index.tsx
+++ b/packages/suite/src/views/suite/bridge-requested/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Card, Column, H3, H4, Modal, Paragraph } from '@trezor/components';
@@ -24,7 +24,10 @@ export const BridgeRequested = () => {
 
     const dispatch = useDispatch();
 
-    const goToWallet = useCallback(() => dispatch(goto({ routeName: 'wallet-index' })), [dispatch]);
+    const goToWallet = useCallback(
+        () => dispatch(gotoThunk({ routeName: 'wallet-index' })),
+        [dispatch],
+    );
 
     useEffect(() => {
         // Popup flow started, exit the bridge requested foreground app

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { AppWindowIcon, CaretLeftIcon } from '@trezor/icons';
@@ -22,7 +22,7 @@ export const BridgeUnavailable = () => {
 
     const handleOpenSuite = useOpenSuiteDesktop();
 
-    const goToWallet = () => dispatch(goto({ routeName: 'wallet-index' }));
+    const goToWallet = () => dispatch(gotoThunk({ routeName: 'wallet-index' }));
 
     // if bridge is running, user will never be directed to this page, but since this page is accessible directly over /bridge url
     // it makes sense to show some meaningful information here

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import {
     selectCoinjoinClient,
     selectStartCoinjoinSessionArguments,
-    startCoinjoinSession,
+    startCoinjoinSessionThunk,
 } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -109,7 +109,7 @@ export const CoinjoinConfirmation = ({ account }: CoinjoinConfirmationProps) => 
     };
     const anonymize = async () => {
         setIsLoading(true);
-        await dispatch(startCoinjoinSession(...startCoinjoinArgs));
+        await dispatch(startCoinjoinSessionThunk(...startCoinjoinArgs));
         setIsLoading(false);
     };
 

--- a/packages/suite/src/views/wallet/details/RescanAccount.tsx
+++ b/packages/suite/src/views/wallet/details/RescanAccount.tsx
@@ -1,4 +1,4 @@
-import { rescanCoinjoinAccount } from '@suite/coinjoin';
+import { rescanCoinjoinAccountThunk } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Row } from '@trezor/components';
@@ -22,7 +22,7 @@ export const RescanAccount = ({ account }: RescanAccountProps) => {
             <ActionColumn>
                 <ActionButton
                     isDisabled={account.status === 'initial' || account.syncing}
-                    onClick={() => dispatch(rescanCoinjoinAccount(account.key, true))}
+                    onClick={() => dispatch(rescanCoinjoinAccountThunk(account.key, true))}
                 >
                     <Translation id="TR_COINJOIN_ACCOUNT_RESCAN_ACTION" />
                 </ActionButton>

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -13,7 +13,7 @@ import { Button, Card, Column, InfoItem, Paragraph } from '@trezor/components';
 import { typography } from '@trezor/theme';
 import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL, type Url } from '@trezor/urls';
 
-import { showXpub } from 'src/actions/wallet/publicKeyActions';
+import { showXpubThunk } from 'src/actions/wallet/publicKeyActions';
 import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription';
 import { WalletLayout } from 'src/components/wallet';
 import { useSelector } from 'src/hooks/suite';
@@ -94,7 +94,7 @@ const Details = () => {
     const shouldDisplayXpubSection =
         account.networkType === 'bitcoin' || account.networkType === 'cardano';
 
-    const handleXpubClick = () => dispatch(showXpub());
+    const handleXpubClick = () => dispatch(showXpubThunk());
 
     return (
         <WalletLayout title="TR_ACCOUNT_DETAILS_HEADER" account={selectedAccount}>

--- a/packages/suite/src/views/wallet/labels/Bip329Labels.tsx
+++ b/packages/suite/src/views/wallet/labels/Bip329Labels.tsx
@@ -27,7 +27,7 @@ import {
 } from '@trezor/product-components';
 import { HELP_CENTER_BIP329_URL } from '@trezor/urls';
 
-import { exportMetadataToBip329File } from 'src/actions/labels/exportMetadataToBip329File';
+import { exportMetadataToBip329FileThunk } from 'src/actions/labels/exportMetadataToBip329File';
 import { useSelector } from 'src/hooks/suite';
 import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
@@ -58,7 +58,7 @@ export const Bip329Labels = ({ account, isLoading }: Bip329LabelsProps) => {
     }
 
     const handleExportBip329 = () =>
-        dispatch(exportMetadataToBip329File({ account, defaultAccountLabel: defaultLabel }));
+        dispatch(exportMetadataToBip329FileThunk({ account, defaultAccountLabel: defaultLabel }));
 
     const handleImportBip329 = async (bip329Labels: Bip329Label[]) => {
         const result = await bip329.import({

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -4,7 +4,7 @@ import { Address, copyAddressToClipboard, showCopyAddressModal } from '@suite/ad
 import { RedactNumericalValue } from '@suite/discreet-mode';
 import { selectIsCopyAddressModalShown } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     DefinitionType,
@@ -163,7 +163,7 @@ const NftsRow = ({
                                         dispatch(setTransactionHistoryPrefill(nft.contract || ''));
                                         if (account) {
                                             dispatch(
-                                                goto({
+                                                gotoThunk({
                                                     routeName: 'wallet-index',
                                                     params: {
                                                         symbol: account.symbol,

--- a/packages/suite/src/views/wallet/nfts/index.tsx
+++ b/packages/suite/src/views/wallet/nfts/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { selectFullSelectedAccount } from '@suite/account';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Column } from '@trezor/components';
 
@@ -24,7 +24,7 @@ export const Nfts = () => {
             selectedAccount.status === 'loaded' &&
             !selectedAccount.network?.features.includes('nfts')
         ) {
-            dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+            dispatch(gotoThunk({ routeName: 'wallet-index', preserveParams: true }));
         }
     }, [selectedAccount, dispatch]);
 

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardContent.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardContent.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from 'react';
 import { type DesktopAnalyticsDep, events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { type Dispatch, useDispatch } from '@suite-common/redux-utils';
 import { EarnFlow, EarnProvider } from '@suite-common/suite-types/src/staking';
@@ -92,7 +92,7 @@ const getTronContent = ({
         if (!account || isStartStakingDisabled) return;
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-tron-stake',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
@@ -1,6 +1,6 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
@@ -91,7 +91,7 @@ export const TronResourceModal = ({ account, resourceType, onClose }: TronResour
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-tron-stake',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourcesCard/TronResourcesCard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
@@ -40,7 +40,7 @@ export const TronResourcesCard = ({ account }: TronResourcesCardProps) => {
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-tron-stake',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { getTronVotedApr, useTronStakingStats } from '@suite-common/earn-staking-api';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -74,7 +74,7 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName,
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVoteAllocationModal/TronVoteAllocationModal.tsx
@@ -1,6 +1,6 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useTronStakingStats } from '@suite-common/earn-staking-api';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -53,7 +53,7 @@ export const TronVoteAllocationModal = ({ account, onClose }: TronVoteAllocation
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-tron-vote',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
@@ -2,7 +2,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
@@ -63,7 +63,7 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
         }
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-tron-claim',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
@@ -1,6 +1,6 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
@@ -30,7 +30,7 @@ export const TronWithdrawReadyBanner = ({ account }: TronWithdrawReadyBannerProp
 
     const goToWithdraw = () => {
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-tron-withdraw',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
@@ -4,7 +4,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsDebugModeActive } from '@suite/debug';
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { type Route, goto, selectRouteName } from '@suite/router';
+import { type Route, gotoThunk, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectCoinDefinitions, selectNftDefinitions } from '@suite-common/token-definitions';
@@ -144,7 +144,7 @@ export const TokensNavigation = ({
     };
 
     const goToRoute = (route: Route['name']) => () => {
-        dispatch(goto({ routeName: route, preserveParams: true }));
+        dispatch(gotoThunk({ routeName: route, preserveParams: true }));
     };
 
     useEffect(() => {

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -9,7 +9,7 @@ import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { selectIsCopyAddressModalShown, selectIsUnhideTokenModalShown } from '@suite/flags';
 import { Translation, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
@@ -157,14 +157,14 @@ const TokenRowBasicActions = ({
 
     if (!unusedAddress || !device) return null;
 
-    const goToWithAnalytics = (...[payload]: Parameters<typeof goto>) => {
+    const goToWithAnalytics = (...[payload]: Parameters<typeof gotoThunk>) => {
         if (network.networkType) {
             analytics.report({
                 type: events.accountsActionsEvent.name,
                 payload: { symbol: network.symbol, action: payload.routeName },
             });
         }
-        dispatch(goto(payload));
+        dispatch(gotoThunk(payload));
     };
 
     // This table renders on both the Tokens and the DeFi tab, so the reported origin has to follow
@@ -186,7 +186,7 @@ const TokenRowBasicActions = ({
         });
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-yield-deposit',
                 params: getEarnRouteParams({
                     account,
@@ -211,7 +211,7 @@ const TokenRowBasicActions = ({
         });
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-yield-withdraw',
                 params: getEarnRouteParams({
                     account,
@@ -221,7 +221,7 @@ const TokenRowBasicActions = ({
         );
     };
 
-    const onTradeButtonClick = (type: TradingType, ...[payload]: Parameters<typeof goto>) => {
+    const onTradeButtonClick = (type: TradingType, ...[payload]: Parameters<typeof gotoThunk>) => {
         dispatch(
             tradingActions.setTradingFromPrefilledAccount(
                 getTradingPrefilledFromAccountData(account, tokenCryptoId),
@@ -328,7 +328,7 @@ const TokenRowBasicActions = ({
         });
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-yield-unwrap',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/tokens/index.tsx
+++ b/packages/suite/src/views/wallet/tokens/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { selectFullSelectedAccount } from '@suite/account';
-import { goto, selectRouteName } from '@suite/router';
+import { gotoThunk, selectRouteName } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
@@ -33,7 +33,7 @@ export const Tokens = () => {
             !hasNetworkFeatures(selectedAccount.account, 'tokens') &&
             routeName !== 'wallet-index'
         ) {
-            dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+            dispatch(gotoThunk({ routeName: 'wallet-index', preserveParams: true }));
         }
     }, [selectedAccount, dispatch, routeName]);
 

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type TradingBuyType, selectTradingComposedTransactionInfo } from '@suite-common/trading';
@@ -97,7 +97,7 @@ export const TradingBuyDetailContent = () => {
     // if trade not found, it is because user refreshed the page and stored transactionId got removed
     // go to the default trading page, the trade is shown there in the previous trades
     if (!trade) {
-        dispatch(goto({ routeName: 'wallet-trading-buy' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-buy' }));
 
         return null;
     }

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailPaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailPaymentFailed.tsx
@@ -1,7 +1,7 @@
 import { type BuyProviderInfo, type BuyTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Button, Card, Column, H3, IconCircle, Paragraph } from '@trezor/components';
 import { XIcon } from '@trezor/icons';
@@ -20,7 +20,7 @@ export const TradingBuyDetailPaymentFailed = ({
 }: TradingBuyDetailPaymentFailedProps) => {
     const dispatch = useDispatch();
 
-    const handleClick = () => dispatch(goto({ routeName: 'wallet-trading-buy' }));
+    const handleClick = () => dispatch(gotoThunk({ routeName: 'wallet-trading-buy' }));
 
     return (
         <Column gap={24} padding={{ top: 12, bottom: 4 }}>

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailPaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailPaymentSuccessful.tsx
@@ -1,7 +1,7 @@
 import { type BuyProviderInfo, type BuyTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Button, Card, Column, H3, IconCircle, Paragraph } from '@trezor/components';
 import { CheckIcon } from '@trezor/icons';
@@ -19,7 +19,7 @@ export const TradingBuyDetailPaymentSuccessful = ({
 }: TradingBuyDetailPaymentSuccessfulProps) => {
     const dispatch = useDispatch();
 
-    const handleClick = () => dispatch(goto({ routeName: 'wallet-trading-buy' }));
+    const handleClick = () => dispatch(gotoThunk({ routeName: 'wallet-trading-buy' }));
 
     return (
         <Column gap={24} padding={{ top: 12, bottom: 4 }}>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailFeedback.tsx
@@ -9,7 +9,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
-import { type Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
+import { type Rating, buildUserFeedbackData, sendFeedbackThunk } from '@suite-common/feedback';
 import { selectCountryCode } from '@suite-common/geolocation';
 import {
     formatExperimentVariantsForAnalytics,
@@ -56,7 +56,7 @@ export const TradingDetailFeedback = ({
         const userData = buildUserFeedbackData(device);
 
         dispatch(
-            sendFeedbackAction({
+            sendFeedbackThunk({
                 type: 'SUGGESTION',
                 payload: {
                     category: 'trade',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
@@ -2,7 +2,7 @@ import { type FiatCurrencyCode } from 'invity-api';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectLanguage } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -101,7 +101,7 @@ export const TradingFormOfferOTC = () => {
     const isBuy = context.type === 'buy';
 
     const handleConciergeClick = () => {
-        dispatch(goto({ routeName: 'wallet-trading-concierge' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-concierge' }));
 
         analytics.report({
             type: events.tradeNavigateEvent.name,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
@@ -1,5 +1,5 @@
 import { Translation } from '@suite/intl';
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
@@ -22,7 +22,7 @@ export const TradingNetworkReserveBanner = ({
 
     const onManageClick = () => {
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'settings-index',
                 preserveParams: true,
                 anchor: SettingsAnchor.NetworkReserve,

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx
@@ -1,6 +1,6 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey } from '@suite/intl';
-import { type Route, goto } from '@suite/router';
+import { type Route, gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type IconComponent, SubTabs } from '@trezor/components';
@@ -43,7 +43,7 @@ export const TradingLayoutNavigation = ({ route }: TradingLayoutNavigationProps)
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const goToRoute = (route: Route['name']) => () => {
-        dispatch(goto({ routeName: route }));
+        dispatch(gotoThunk({ routeName: route }));
 
         switch (route) {
             case 'wallet-trading-buy':

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
@@ -1,5 +1,5 @@
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
-import { type Route, goto, selectRouteName, selectSettingsBackRoute } from '@suite/router';
+import { type Route, gotoThunk, selectRouteName, selectSettingsBackRoute } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectTradingActiveSection } from '@suite-common/trading';
 import { Box, Button, IconButton, Row } from '@trezor/components';
@@ -28,7 +28,7 @@ const TradingPageHeader = ({ title }: TradingPageHeaderProps) => {
     const isTopLevelRoute = isTradingTopLevelRoute(currentRouteName);
 
     const goToRoute = (route: Route['name']) => () => {
-        dispatch(goto({ routeName: route, preserveParams: true }));
+        dispatch(gotoThunk({ routeName: route, preserveParams: true }));
     };
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
@@ -41,7 +41,7 @@ jest.mock('@suite/intl', () => ({
 
 jest.mock('@suite/router', () => ({
     ...jest.requireActual('@suite/router'),
-    goto: (payload: unknown) => mockGoto(payload),
+    gotoThunk: (payload: unknown) => mockGoto(payload),
 }));
 
 jest.mock('@suite-common/trading', () => ({

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -1,7 +1,7 @@
 import { type TradeExchangeAction, events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -116,7 +116,7 @@ export const TradingOfferExchange = () => {
 
     const onBackToTradeFormClick = () => {
         reportConfirmAndSendStep('cancel');
-        dispatch(goto({ routeName: 'wallet-trading-exchange', preserveParams: true }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-exchange', preserveParams: true }));
     };
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange.tsx
@@ -1,7 +1,7 @@
 import { type ExchangeProviderInfo } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import type { TradingTransactionExchange as TradingTxExchange } from '@suite-common/trading';
 import { tradingExchangeActions } from '@suite-common/trading';
@@ -32,7 +32,7 @@ export const TradingTransactionExchange = ({
 
     const viewDetail = () => {
         dispatch(tradingExchangeActions.saveTransactionId(trade.key || ''));
-        dispatch(goto({ routeName: 'wallet-trading-exchange-detail' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-exchange-detail' }));
     };
 
     useTradingWatchTrade({ account, trade });

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsBuy.tsx
@@ -1,7 +1,7 @@
 import { type BuyProviderInfo } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     type TradingTransactionBuy as TradingTxBuy,
@@ -36,7 +36,7 @@ export const TradingTransactionBuy = ({
 
     const handleViewDetailsButtonClick = () => {
         dispatch(tradingBuyActions.saveTransactionId(trade.key ?? ''));
-        dispatch(goto({ routeName: 'wallet-trading-buy-detail' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-buy-detail' }));
     };
 
     useTradingWatchTrade({

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsSell.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsSell.tsx
@@ -1,7 +1,7 @@
 import { type SellProviderInfo } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     type TradingTransactionSell as TradingTxSell,
@@ -68,12 +68,12 @@ export const TradingTransactionSell = ({
                     },
                 }),
             );
-            dispatch(goto({ routeName: 'wallet-trading-sell-confirm' }));
+            dispatch(gotoThunk({ routeName: 'wallet-trading-sell-confirm' }));
 
             return;
         }
 
-        dispatch(goto({ routeName: 'wallet-trading-sell-detail' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-sell-detail' }));
     };
 
     useTradingWatchTrade({ account, trade });

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsTorWarning.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsTorWarning.tsx
@@ -1,5 +1,5 @@
 import { Translation, type TranslationKey } from '@suite/intl';
-import { SettingsAnchor, goto } from '@suite/router';
+import { SettingsAnchor, gotoThunk } from '@suite/router';
 import { selectIsTorEnabled } from '@suite/tor';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type TradingType } from '@suite-common/trading';
@@ -40,7 +40,7 @@ export const TradingUtilsTorWarning = ({
     if (!isTorEnabled) return null;
 
     const handleGoToSettings = () => {
-        dispatch(goto({ routeName: 'settings-index', anchor: SettingsAnchor.Tor }));
+        dispatch(gotoThunk({ routeName: 'settings-index', anchor: SettingsAnchor.Tor }));
     };
 
     const translationId = getTorWarningTranslationId(tradingType, noOffer);

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailContent.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
@@ -101,7 +101,7 @@ export const TradingExchangeDetailContent = () => {
     // if trade not found, it is because user refreshed the page and stored transactionId got removed
     // go to the default trading page, the trade is shown there in the previous trades
     if (!trade) {
-        dispatch(goto({ routeName: 'wallet-trading-exchange' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-exchange' }));
 
         return null;
     }

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentFailed.tsx
@@ -1,7 +1,7 @@
 import { type ExchangeProviderInfo, type ExchangeTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Button, Card, Column, H3, IconCircle, Paragraph } from '@trezor/components';
@@ -26,7 +26,7 @@ export const TradingExchangeDetailPaymentFailed = ({
 }: TradingExchangeDetailPaymentFailedProps) => {
     const dispatch = useDispatch();
 
-    const handleClick = () => dispatch(goto({ routeName: 'wallet-trading-exchange' }));
+    const handleClick = () => dispatch(gotoThunk({ routeName: 'wallet-trading-exchange' }));
 
     return (
         <Column gap={24} padding={{ top: 12, bottom: 4 }}>

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSuccessful.tsx
@@ -1,7 +1,7 @@
 import { type ExchangeProviderInfo, type ExchangeTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Button, Card, Column, H3, IconCircle, Paragraph } from '@trezor/components';
@@ -25,7 +25,7 @@ export const TradingExchangeDetailPaymentSuccessful = ({
 }: TradingExchangeDetailPaymentSuccessfulProps) => {
     const dispatch = useDispatch();
 
-    const handleClick = () => dispatch(goto({ routeName: 'wallet-trading-exchange' }));
+    const handleClick = () => dispatch(gotoThunk({ routeName: 'wallet-trading-exchange' }));
 
     return (
         <Column gap={24} padding={{ top: 12, bottom: 4 }}>

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/TradingSellDetailContent.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/TradingSellDetailContent.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useTranslation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type TradingSellType, selectTradingComposedTransactionInfo } from '@suite-common/trading';
@@ -89,7 +89,7 @@ export const TradingSellDetailContent = () => {
     // if trade not found, it is because user refreshed the page and stored transactionId got removed
     // go to the default trading page, the trade is shown there in the previous trades
     if (!trade) {
-        dispatch(goto({ routeName: 'wallet-trading-sell' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-sell' }));
 
         return null;
     }

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/TradingSellDetailPaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/TradingSellDetailPaymentFailed.tsx
@@ -1,7 +1,7 @@
 import { type SellFiatTrade, type SellProviderInfo } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Button, Card, Column, H3, IconCircle, Paragraph } from '@trezor/components';
 import { XIcon } from '@trezor/icons';
@@ -23,7 +23,7 @@ export const TradingSellDetailPaymentFailed = ({
 }: TradingSellDetailPaymentFailedProps) => {
     const dispatch = useDispatch();
 
-    const handleClick = () => dispatch(goto({ routeName: 'wallet-trading-sell' }));
+    const handleClick = () => dispatch(gotoThunk({ routeName: 'wallet-trading-sell' }));
 
     return (
         <Column gap={24} padding={{ top: 12, bottom: 4 }}>

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinProgressWheel.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinProgressWheel.tsx
@@ -8,12 +8,12 @@ import {
     selectCurrentCoinjoinWheelStates,
     selectSessionProgressByAccountKey,
     selectStartCoinjoinSessionArguments,
-    startCoinjoinSession,
-    stopCoinjoinSession,
+    startCoinjoinSessionThunk,
+    stopCoinjoinSessionThunk,
 } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Tooltip } from '@trezor/components';
@@ -199,7 +199,7 @@ export const CoinjoinProgressWheel = ({ accountKey }: CoinjoinProgressWheelProps
             if (isCriticalPhase) {
                 dispatch(coinjoinSessionAutostop(accountKey, !isAutoStopEnabled));
             } else if (!isAutoStopEnabled) {
-                dispatch(stopCoinjoinSession(accountKey));
+                dispatch(stopCoinjoinSessionThunk(accountKey));
             }
 
             return;
@@ -212,12 +212,12 @@ export const CoinjoinProgressWheel = ({ accountKey }: CoinjoinProgressWheelProps
         }
 
         if (isLegalDocumentConfirmed && startCoinjoinArgs) {
-            dispatch(startCoinjoinSession(...startCoinjoinArgs));
+            dispatch(startCoinjoinSessionThunk(...startCoinjoinArgs));
 
             return;
         }
 
-        dispatch(goto({ routeName: 'wallet-anonymize', preserveParams: true }));
+        dispatch(gotoThunk({ routeName: 'wallet-anonymize', preserveParams: true }));
     }, [
         isCoinjoinSessionBlocked,
         isAllPrivate,

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusWheel.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinStatusWheel/CoinjoinStatusWheel.tsx
@@ -1,4 +1,4 @@
-import { selectCurrentCoinjoinWheelStates, stopCoinjoinSession } from '@suite/coinjoin';
+import { selectCurrentCoinjoinWheelStates, stopCoinjoinSessionThunk } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -39,7 +39,7 @@ export const CoinjoinStatusWheel = ({ accountKey }: CoinjoinStatusWheelProps) =>
                         intent="neutral"
                         priority="secondary"
                         iconRight={StopIcon}
-                        onClick={() => dispatch(stopCoinjoinSession(accountKey))}
+                        onClick={() => dispatch(stopCoinjoinSessionThunk(accountKey))}
                         size="small"
                         margin={{ top: 8 }}
                     >

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxActionButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxActionButton.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { type Route, goto } from '@suite/router';
+import { type Route, gotoThunk } from '@suite/router';
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -49,7 +49,7 @@ export const TradeBoxActionButton = ({
                     ),
                 );
 
-                dispatch(goto({ routeName: gotoRouteName }));
+                dispatch(gotoThunk({ routeName: gotoRouteName }));
 
                 analytics.report({
                     type: events.tradeNavigateEvent.name,
@@ -64,7 +64,7 @@ export const TradeBoxActionButton = ({
                 break;
             }
             case 'earn': {
-                dispatch(goto({ routeName: 'suite-earn' }));
+                dispatch(gotoThunk({ routeName: 'suite-earn' }));
 
                 analytics.report({
                     type: sharedEvents.yieldNavigateEvent.name,

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
@@ -4,7 +4,7 @@ import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsDebugModeActive } from '@suite/debug';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
@@ -76,7 +76,7 @@ export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) =
         });
 
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'earn-yield-wrap',
                 params: {
                     symbol: account.symbol,

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -1,6 +1,6 @@
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
@@ -27,7 +27,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
     const networkName = getNetwork(account.symbol).name;
 
     const handleNavigateToReceivePage = () => {
-        dispatch(goto({ routeName: 'wallet-receive', preserveParams: true }));
+        dispatch(gotoThunk({ routeName: 'wallet-receive', preserveParams: true }));
         analytics.report({
             type: events.accountsEmptyAccountReceiveEvent.name,
             payload: {
@@ -41,7 +41,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
                 getTradingPrefilledFromAccountData(account),
             ),
         );
-        dispatch(goto({ routeName: 'wallet-trading-buy' }));
+        dispatch(gotoThunk({ routeName: 'wallet-trading-buy' }));
 
         analytics.report({
             type: events.tradeNavigateEvent.name,

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -10,7 +10,7 @@ import { RepeatIcon } from '@trezor/icons';
 import { typography } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
-import { updateGraphData } from 'src/actions/wallet/graphActions';
+import { updateGraphDataThunk } from 'src/actions/wallet/graphActions';
 import { GraphRangeSelector, HiddenPlaceholder, TransactionsGraph } from 'src/components/suite';
 import { useSelector } from 'src/hooks/suite';
 import { selectGraph, selectGraphSelectedRange } from 'src/reducers/wallet/graphReducer';
@@ -83,14 +83,14 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
 
     const onRefresh = (abortSignal?: AbortSignal) =>
         dispatch(
-            updateGraphData({
+            updateGraphDataThunk({
                 accounts: [account],
                 abortSignal,
             }),
         ).unwrap();
     const onSelectedRange = () =>
         dispatch(
-            updateGraphData({
+            updateGraphDataThunk({
                 accounts: [account],
             }),
         );

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -26,7 +26,7 @@ import { type GetThpSettingsDep, type ThpHostNameDep } from '@suite-common/thp';
 import {
     type WalletSettingsRootState,
     defaultTrezorUIEventHandlerThunk,
-    deviceConnectThunks,
+    deviceConnectThunk,
     isScopedCallId,
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
@@ -109,7 +109,7 @@ export const connectInitThunk = createThunk<
             // This special case here allows us to "inject" extra data into action's payload
             // and change the type of the action (in this case DeviceEvent type !== Redux Action type)
             const connectedDevices = selectDevices(getState());
-            dispatch(deviceConnectThunks({ type: eventData.type, device: eventData.payload }));
+            dispatch(deviceConnectThunk({ type: eventData.type, device: eventData.payload }));
 
             connectInitHooks.deviceEvent[eventData.type]?.(eventData.payload, connectedDevices);
         } else {

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -70,17 +70,21 @@ type ConnectPopupCallThunkParams<M extends CallMethodKeys> = {
     source: ConnectCallSource;
 };
 
-export type ConnectPopupCallThunkState = DeviceRootState & ConnectPopupStateRootState;
+export type ConnectPopupCallInnerThunkState = DeviceRootState & ConnectPopupStateRootState;
 
-export type ConnectPopupCallThunkDeps = {
+export type ConnectPopupCallInnerThunkDeps = {
     actions: LockDeviceDep;
     services: AnalyticsDep;
 };
 
-export const connectPopupCallThunkInner = createThunk<
+export type ConnectPopupCallThunkState = ConnectPopupCallInnerThunkState;
+
+export type ConnectPopupCallThunkDeps = ConnectPopupCallInnerThunkDeps;
+
+export const connectPopupCallInnerThunk = createThunk<
     void,
     ConnectPopupCallThunkParams<CallMethodKeys>,
-    { state: ConnectPopupCallThunkState; extra: ConnectPopupCallThunkDeps }
+    { state: ConnectPopupCallInnerThunkState; extra: ConnectPopupCallInnerThunkDeps }
 >(
     `${CONNECT_POPUP_MODULE}/callThunk`,
     async ({ source, ...params }, { dispatch, getState, extra }) => {
@@ -305,7 +309,7 @@ export const connectPopupCallThunk = <M extends CallMethodKeys>(
     void,
     ConnectPopupCallThunkParams<M>,
     { state: ConnectPopupCallThunkState; extra: ConnectPopupCallThunkDeps }
-> => connectPopupCallThunkInner(params) as any;
+> => connectPopupCallInnerThunk(params) as any;
 
 type ConnectPopupDeeplinkThunkState = DeviceRootState & ConnectPopupStateRootState;
 
@@ -1106,7 +1110,7 @@ export const connectPopupCancelThunk = createThunk<void, { error?: string; callI
         // reaches the caller immediately.  Without this, the response
         // depends on TrezorConnect.cancel() propagating through the
         // internal core, interrupting the device, and eventually causing
-        // the catch block in connectPopupCallThunkInner to resolve the
+        // the catch block in connectPopupCallInnerThunk to resolve the
         // deferred — which may not happen reliably (e.g. the device
         // interrupt doesn't complete, or the Suite popup tab closes
         // before RESPONSE_EVENT is sent).

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -37,7 +37,7 @@ export type ConnectProcessInfo = {
 export type ConnectCallSource = {
     origin: string;
     // Permissions the host declared up front (via ConnectSettings.requestedPermissions), carried on
-    // the handshake. Sanitized in connectPopupCallThunkInner so the first consent covers the set.
+    // the handshake. Sanitized in connectPopupCallInnerThunk so the first consent covers the set.
     requestedPermissions?: PermissionRequest[];
 } & (
     | {

--- a/suite-common/feedback/src/sendFeedbackAction.ts
+++ b/suite-common/feedback/src/sendFeedbackAction.ts
@@ -6,7 +6,7 @@ import { getFeedbackUrl } from './getFeedbackUrl';
 
 const FEEDBACK_MODULE_PREFIX = '@suite/feedback';
 
-export const sendFeedbackAction = createThunk<void, Feedback, void>(
+export const sendFeedbackThunk = createThunk<void, Feedback, void>(
     `${FEEDBACK_MODULE_PREFIX}/sendFeedback`,
     async ({ type, payload }, { dispatch, rejectWithValue }) => {
         const url = getFeedbackUrl(type);

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -33,7 +33,7 @@ export type FirmwareUpdateThunkDeps = WithServices<
     GetBinFilesBaseUrlDep & GetLanguageDep & ReportSecurityCheckDep
 >;
 
-export const firmwareUpdate = createThunk<
+export const firmwareUpdateThunk = createThunk<
     FirmwareUpdateResult,
     FirmwareUpdateProps,
     {

--- a/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
+++ b/suite-common/firmware/src/hooks/useFirmwareInstallation.ts
@@ -26,7 +26,7 @@ import { isArrayMember } from '@trezor/utils';
 
 import { firmwareActions } from '../firmwareActions';
 import { selectFirmware, selectSwitchFirmwareType } from '../firmwareReducer';
-import { type FirmwareUpdateProps, firmwareUpdate as firmwareUpdateThunk } from '../firmwareThunks';
+import { type FirmwareUpdateProps, firmwareUpdateThunk } from '../firmwareThunks';
 
 /*
 There are three firmware update flows, depending on current firmware version:

--- a/suite-common/graph/src/graphBalanceEvents.ts
+++ b/suite-common/graph/src/graphBalanceEvents.ts
@@ -3,7 +3,7 @@ import { fromUnixTime, getUnixTime } from 'date-fns';
 
 import { type Dispatch } from '@suite-common/redux-utils';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
-import { fetchTransactionsFromNowUntilTimestamp } from '@suite-common/wallet-core';
+import { fetchTransactionsFromNowUntilTimestampThunk } from '@suite-common/wallet-core';
 import type { AccountKey, Timestamp, TokenAddress } from '@suite-common/wallet-types';
 import { type AccountBalanceHistory as AccountMovementHistory } from '@trezor/blockchain-link';
 import TrezorConnect from '@trezor/connect';
@@ -143,7 +143,7 @@ export const getAccountMovementEvents = async ({
         }
         if (isLocalBalanceHistoryCoin(symbol)) {
             const allTransactions = await dispatch(
-                fetchTransactionsFromNowUntilTimestamp({
+                fetchTransactionsFromNowUntilTimestampThunk({
                     accountKey: account.accountKey,
                     timestamp: startOfTimeFrameDate
                         ? (getUnixTime(startOfTimeFrameDate) as Timestamp)

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -4,7 +4,7 @@ import { fromUnixTime, getUnixTime } from 'date-fns';
 import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
 import { type Dispatch } from '@suite-common/redux-utils';
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
-import { fetchTransactionsFromNowUntilTimestamp } from '@suite-common/wallet-core';
+import { fetchTransactionsFromNowUntilTimestampThunk } from '@suite-common/wallet-core';
 import { type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { type AccountBalanceHistory as AccountMovementHistory } from '@trezor/blockchain-link';
@@ -173,7 +173,7 @@ const getAccountBalanceHistory = async ({
         }
         if (isLocalBalanceHistoryCoin(symbol)) {
             const allTransactions = await dispatch(
-                fetchTransactionsFromNowUntilTimestamp({
+                fetchTransactionsFromNowUntilTimestampThunk({
                     accountKey,
                     timestamp: startOfTimeFrameDateTimestamp,
                 }),

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -239,7 +239,7 @@ export const findInstanceIndex = (draft: TrezorDevice[], device: AcquiredDevice)
 
 /**
  * Utility for retrieving fresh data from the "devices" reducer
- * It's used for keep "suite" reducer synchronized via `suiteMiddleware > suiteActions.observeSelectedDevice`
+ * It's used for keep "suite" reducer synchronized via `suiteMiddleware > suiteActions.observeSelectedDeviceThunk`
  * @param {(TrezorDevice)} device
  * @param {TrezorDevice[]} devices
  * @returns {TrezorDevice | undefined }

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.test.ts
@@ -11,9 +11,9 @@ import TrezorConnect, { type Address, type PROTO } from '@trezor/connect';
 import { validatePath } from '@trezor/connect-common';
 
 import { createPaymentRequestsThunk } from './createPaymentRequestsThunk';
-import { getNonce } from './getNonce';
-import { getPurchaseAddress } from './getPurchaseAddress';
-import { getRefundAddress } from './getRefundAddress';
+import { getNonceThunk } from './getNonce';
+import { getPurchaseAddressThunk } from './getPurchaseAddress';
+import { getRefundAddressThunk } from './getRefundAddress';
 import { initialState } from '../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../reducers/tradingReducer';
 import { tradeApi } from '../../tradeApi';
@@ -24,15 +24,15 @@ const tradingReducer = prepareTradingReducer({
 
 // Mock internal thunks - this is the key change from the previous approach
 jest.mock('./getNonce', () => ({
-    getNonce: jest.fn(),
+    getNonceThunk: jest.fn(),
 }));
 
 jest.mock('./getRefundAddress', () => ({
-    getRefundAddress: jest.fn(),
+    getRefundAddressThunk: jest.fn(),
 }));
 
 jest.mock('./getPurchaseAddress', () => ({
-    getPurchaseAddress: jest.fn(),
+    getPurchaseAddressThunk: jest.fn(),
 }));
 
 jest.mock('../../utils/signature/signatureUtils', () => {
@@ -181,14 +181,14 @@ describe('createPaymentRequestsThunk', () => {
     beforeEach(() => {
         jest.clearAllMocks();
 
-        (getNonce as unknown as jest.Mock).mockImplementation(
-            createThunk(getNonce.typePrefix, (_, { fulfillWithValue }) =>
+        (getNonceThunk as unknown as jest.Mock).mockImplementation(
+            createThunk(getNonceThunk.typePrefix, (_, { fulfillWithValue }) =>
                 fulfillWithValue(mockNonce),
             ),
         );
 
-        (getRefundAddress as unknown as jest.Mock).mockImplementation(
-            createThunk(getRefundAddress.typePrefix, (_, { fulfillWithValue }) =>
+        (getRefundAddressThunk as unknown as jest.Mock).mockImplementation(
+            createThunk(getRefundAddressThunk.typePrefix, (_, { fulfillWithValue }) =>
                 fulfillWithValue({
                     mac: mockMac,
                     path: "m/44'/0'/0'",
@@ -196,8 +196,8 @@ describe('createPaymentRequestsThunk', () => {
             ),
         );
 
-        (getPurchaseAddress as unknown as jest.Mock).mockImplementation(
-            createThunk(getPurchaseAddress.typePrefix, (_, { fulfillWithValue }) =>
+        (getPurchaseAddressThunk as unknown as jest.Mock).mockImplementation(
+            createThunk(getPurchaseAddressThunk.typePrefix, (_, { fulfillWithValue }) =>
                 fulfillWithValue({
                     mac: mockMac,
                     path: "m/84'/2'/0'",

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -12,10 +12,10 @@ import { type PROTO } from '@trezor/connect';
 import { getSlip44ByPath, validatePath } from '@trezor/connect-common';
 import { exhaustive } from '@trezor/type-utils';
 
-import { type GetNonceThunkState, getNonce } from './getNonce';
-import { getPaymentRequestOutputs } from './getPaymentRequestOutputs';
-import { type GetPurchaseAddressThunkState, getPurchaseAddress } from './getPurchaseAddress';
-import { type GetRefundAddressThunkState, getRefundAddress } from './getRefundAddress';
+import { type GetNonceThunkState, getNonceThunk } from './getNonce';
+import { getPaymentRequestOutputsThunk } from './getPaymentRequestOutputs';
+import { type GetPurchaseAddressThunkState, getPurchaseAddressThunk } from './getPurchaseAddress';
+import { type GetRefundAddressThunkState, getRefundAddressThunk } from './getRefundAddress';
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { type TradingRootState } from '../../reducers/tradingCommonReducer';
 import {
@@ -65,9 +65,9 @@ export const createPaymentRequestsThunk = createThunk<
         { dispatch, getState, fulfillWithValue, rejectWithValue },
     ) => {
         const { mac: macRefund, path: pathRefund } = await dispatch(
-            getRefundAddress({ account }),
+            getRefundAddressThunk({ account }),
         ).unwrap();
-        const nonce = await dispatch(getNonce()).unwrap();
+        const nonce = await dispatch(getNonceThunk()).unwrap();
 
         if (!('outputs' in composedLevels)) {
             return rejectWithValue({
@@ -108,11 +108,11 @@ export const createPaymentRequestsThunk = createThunk<
                 }
 
                 const { mac: macPurchase, path: pathPurchase } = await dispatch(
-                    getPurchaseAddress({ account: receiveAccount, address: receiveAddress }),
+                    getPurchaseAddressThunk({ account: receiveAccount, address: receiveAddress }),
                 ).unwrap();
 
                 const outputs = await dispatch(
-                    getPaymentRequestOutputs({
+                    getPaymentRequestOutputsThunk({
                         network: sendNetwork,
                         composedLevels,
                         destinationTag,
@@ -213,7 +213,7 @@ export const createPaymentRequestsThunk = createThunk<
                 const memoText = `Selling ${quote.cryptoStringAmount} ${cryptoSymbol?.symbol} for ${quote.fiatStringAmount} ${quote.fiatCurrency}`;
 
                 const outputs = await dispatch(
-                    getPaymentRequestOutputs({
+                    getPaymentRequestOutputsThunk({
                         network: sendNetwork,
                         composedLevels,
                         destinationTag,

--- a/suite-common/trading/src/thunks/common/getNonce.test.ts
+++ b/suite-common/trading/src/thunks/common/getNonce.test.ts
@@ -4,7 +4,7 @@ import { deviceInitialState, selectSelectedDevice } from '@suite-common/device';
 import { createTestStore } from '@suite-common/test-utils';
 import TrezorConnect from '@trezor/connect';
 
-import { getNonce } from './getNonce';
+import { getNonceThunk } from './getNonce';
 
 jest.mock('@suite-common/device', () => ({
     ...jest.requireActual('@suite-common/device'),
@@ -52,9 +52,9 @@ describe('getNonce thunk', () => {
             });
 
             const store = createMockStore();
-            const result = await store.dispatch(getNonce());
+            const result = await store.dispatch(getNonceThunk());
 
-            expect(result.type).toBe(getNonce.fulfilled.type);
+            expect(result.type).toBe(getNonceThunk.fulfilled.type);
             expect(result.payload).toBe(expectedNonce);
 
             // Verify TrezorConnect.getNonce was called with correct parameters
@@ -84,8 +84,8 @@ describe('getNonce thunk', () => {
 
             const store = createMockStore();
 
-            const result1 = await store.dispatch(getNonce());
-            const result2 = await store.dispatch(getNonce());
+            const result1 = await store.dispatch(getNonceThunk());
+            const result2 = await store.dispatch(getNonceThunk());
 
             expect(result1.payload).toBe(expectedNonce1);
             expect(result2.payload).toBe(expectedNonce2);
@@ -98,9 +98,9 @@ describe('getNonce thunk', () => {
             (selectSelectedDevice as jest.Mock).mockReturnValue(null);
 
             const store = createMockStore();
-            const result = await store.dispatch(getNonce());
+            const result = await store.dispatch(getNonceThunk());
 
-            expect(result.type).toBe(getNonce.rejected.type);
+            expect(result.type).toBe(getNonceThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -116,9 +116,9 @@ describe('getNonce thunk', () => {
             (selectSelectedDevice as jest.Mock).mockReturnValue(undefined);
 
             const store = createMockStore();
-            const result = await store.dispatch(getNonce());
+            const result = await store.dispatch(getNonceThunk());
 
-            expect(result.type).toBe(getNonce.rejected.type);
+            expect(result.type).toBe(getNonceThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -135,9 +135,9 @@ describe('getNonce thunk', () => {
             });
 
             const store = createMockStore();
-            const result = await store.dispatch(getNonce());
+            const result = await store.dispatch(getNonceThunk());
 
-            expect(result.type).toBe(getNonce.rejected.type);
+            expect(result.type).toBe(getNonceThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -159,9 +159,9 @@ describe('getNonce thunk', () => {
             );
 
             const store = createMockStore();
-            const result = await store.dispatch(getNonce());
+            const result = await store.dispatch(getNonceThunk());
 
-            expect(result.type).toBe(getNonce.rejected.type);
+            expect(result.type).toBe(getNonceThunk.rejected.type);
             // When an async thunk throws an error, it gets rejected
             expect(result.meta.requestStatus).toBe('rejected');
         });
@@ -176,9 +176,9 @@ describe('getNonce thunk', () => {
             });
 
             const store = createMockStore();
-            const result = await store.dispatch(getNonce());
+            const result = await store.dispatch(getNonceThunk());
 
-            expect(result.type).toBe(getNonce.fulfilled.type);
+            expect(result.type).toBe(getNonceThunk.fulfilled.type);
             expect(result.payload).toBe('');
         });
 
@@ -195,9 +195,9 @@ describe('getNonce thunk', () => {
             });
 
             const store = createMockStore();
-            const result = await store.dispatch(getNonce());
+            const result = await store.dispatch(getNonceThunk());
 
-            expect(result.type).toBe(getNonce.fulfilled.type);
+            expect(result.type).toBe(getNonceThunk.fulfilled.type);
             expect(result.payload).toBe('minimal-nonce');
 
             expect(TrezorConnect.getNonce).toHaveBeenCalledWith({
@@ -226,9 +226,9 @@ describe('getNonce thunk', () => {
             });
 
             const store = createMockStore();
-            const result = await store.dispatch(getNonce());
+            const result = await store.dispatch(getNonceThunk());
 
-            expect(result.type).toBe(getNonce.fulfilled.type);
+            expect(result.type).toBe(getNonceThunk.fulfilled.type);
             expect(result.payload).toBe('trezor-one-nonce');
 
             expect(TrezorConnect.getNonce).toHaveBeenCalledWith({
@@ -240,7 +240,7 @@ describe('getNonce thunk', () => {
 
     describe('thunk metadata', () => {
         it('should have correct thunk type prefix', () => {
-            expect(getNonce.typePrefix).toBe('@trading/thunk/getNonce');
+            expect(getNonceThunk.typePrefix).toBe('@trading/thunk/getNonce');
         });
 
         it('should handle pending state correctly', async () => {
@@ -260,16 +260,16 @@ describe('getNonce thunk', () => {
             );
 
             const store = createMockStore();
-            const promise = store.dispatch(getNonce());
+            const promise = store.dispatch(getNonceThunk());
 
             // Check if the action is in pending state
             const actions = store.getActions();
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const firstAction: (typeof actions)[number] = actions[0];
-            expect(firstAction.type).toBe(getNonce.pending.type);
+            expect(firstAction.type).toBe(getNonceThunk.pending.type);
 
             const result = await promise;
-            expect(result.type).toBe(getNonce.fulfilled.type);
+            expect(result.type).toBe(getNonceThunk.fulfilled.type);
         });
     });
 });

--- a/suite-common/trading/src/thunks/common/getNonce.ts
+++ b/suite-common/trading/src/thunks/common/getNonce.ts
@@ -7,7 +7,7 @@ import { type TradingSendRejectedProps } from '../../types';
 
 export type GetNonceThunkState = DeviceRootState;
 
-export const getNonce = createThunk<
+export const getNonceThunk = createThunk<
     string,
     void,
     { rejectValue: TradingSendRejectedProps; state: GetNonceThunkState }

--- a/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
+++ b/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
@@ -13,7 +13,7 @@ import {
     formatSlip24SendAmountByNetwork,
 } from '../../utils/signature/signatureUtils';
 
-export const getPaymentRequestOutputs = createThunk<
+export const getPaymentRequestOutputsThunk = createThunk<
     PaymentRequestOutput[],
     {
         network: Network;

--- a/suite-common/trading/src/thunks/common/getPurchaseAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/getPurchaseAddress.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 
-import { getPurchaseAddress } from './getPurchaseAddress';
+import { getPurchaseAddressThunk } from './getPurchaseAddress';
 import { accounts } from '../../reducers/__fixtures__/account';
 import { initialState } from '../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../reducers/tradingReducer';
@@ -92,10 +92,10 @@ describe('getPurchaseAddress thunk', () => {
 
             const store = createMockStore();
             const result = await store.dispatch(
-                getPurchaseAddress({ account: mockAccount, address: mockAddress }),
+                getPurchaseAddressThunk({ account: mockAccount, address: mockAddress }),
             );
 
-            expect(result.type).toBe(getPurchaseAddress.fulfilled.type);
+            expect(result.type).toBe(getPurchaseAddressThunk.fulfilled.type);
             expect(result.payload).toEqual({
                 address: mockAddress,
                 mac: mockMac,
@@ -142,10 +142,10 @@ describe('getPurchaseAddress thunk', () => {
             });
 
             const result = await storeWithNonChunked.dispatch(
-                getPurchaseAddress({ account: mockAccount, address: mockAddress }),
+                getPurchaseAddressThunk({ account: mockAccount, address: mockAddress }),
             );
 
-            expect(result.type).toBe(getPurchaseAddress.fulfilled.type);
+            expect(result.type).toBe(getPurchaseAddressThunk.fulfilled.type);
             expect(confirmAddressOnDeviceThunk).toHaveBeenCalledWith({
                 accountKey: mockAccount.key,
                 addressPath: mockPath,
@@ -159,10 +159,10 @@ describe('getPurchaseAddress thunk', () => {
         it('should reject when address is not in account', async () => {
             const store = createMockStore();
             const result = await store.dispatch(
-                getPurchaseAddress({ account: mockAccount, address: 'non-existent-address' }),
+                getPurchaseAddressThunk({ account: mockAccount, address: 'non-existent-address' }),
             );
 
-            expect(result.type).toBe(getPurchaseAddress.rejected.type);
+            expect(result.type).toBe(getPurchaseAddressThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -184,10 +184,10 @@ describe('getPurchaseAddress thunk', () => {
 
             const store = createMockStore();
             const result = await store.dispatch(
-                getPurchaseAddress({ account: mockAccount, address: mockAddress }),
+                getPurchaseAddressThunk({ account: mockAccount, address: mockAddress }),
             );
 
-            expect(result.type).toBe(getPurchaseAddress.rejected.type);
+            expect(result.type).toBe(getPurchaseAddressThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -209,10 +209,10 @@ describe('getPurchaseAddress thunk', () => {
 
             const store = createMockStore();
             const result = await store.dispatch(
-                getPurchaseAddress({ account: mockAccount, address: mockAddress }),
+                getPurchaseAddressThunk({ account: mockAccount, address: mockAddress }),
             );
 
-            expect(result.type).toBe(getPurchaseAddress.rejected.type);
+            expect(result.type).toBe(getPurchaseAddressThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -224,7 +224,7 @@ describe('getPurchaseAddress thunk', () => {
 
     describe('thunk metadata', () => {
         it('should have correct thunk type prefix', () => {
-            expect(getPurchaseAddress.typePrefix).toBe('@trading/thunk/getPurchaseAddress');
+            expect(getPurchaseAddressThunk.typePrefix).toBe('@trading/thunk/getPurchaseAddress');
         });
     });
 });

--- a/suite-common/trading/src/thunks/common/getPurchaseAddress.ts
+++ b/suite-common/trading/src/thunks/common/getPurchaseAddress.ts
@@ -24,7 +24,7 @@ type GetPurchaseAddressFulfillValue = {
 export type GetPurchaseAddressThunkState = ConfirmAddressOnDeviceThunkState &
     WalletSettingsRootState;
 
-export const getPurchaseAddress = createThunk<
+export const getPurchaseAddressThunk = createThunk<
     GetPurchaseAddressFulfillValue,
     GetPurchaseAddressProps,
     {

--- a/suite-common/trading/src/thunks/common/getRefundAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/getRefundAddress.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 
-import { getRefundAddress } from './getRefundAddress';
+import { getRefundAddressThunk } from './getRefundAddress';
 import { accounts } from '../../reducers/__fixtures__/account';
 import { initialState } from '../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../reducers/tradingReducer';
@@ -88,9 +88,9 @@ describe('getRefundAddress thunk', () => {
             );
 
             const store = createMockStore();
-            const result = await store.dispatch(getRefundAddress({ account: mockAccount }));
+            const result = await store.dispatch(getRefundAddressThunk({ account: mockAccount }));
 
-            expect(result.type).toBe(getRefundAddress.fulfilled.type);
+            expect(result.type).toBe(getRefundAddressThunk.fulfilled.type);
             expect(result.payload).toEqual({
                 address: mockAddress,
                 mac: mockMac,
@@ -137,10 +137,10 @@ describe('getRefundAddress thunk', () => {
             });
 
             const result = await storeWithNonChunked.dispatch(
-                getRefundAddress({ account: mockAccount }),
+                getRefundAddressThunk({ account: mockAccount }),
             );
 
-            expect(result.type).toBe(getRefundAddress.fulfilled.type);
+            expect(result.type).toBe(getRefundAddressThunk.fulfilled.type);
             expect(confirmAddressOnDeviceThunk).toHaveBeenCalledWith({
                 accountKey: mockAccount.key,
                 addressPath: mockPath,
@@ -158,9 +158,9 @@ describe('getRefundAddress thunk', () => {
             });
 
             const store = createMockStore();
-            const result = await store.dispatch(getRefundAddress({ account: mockAccount }));
+            const result = await store.dispatch(getRefundAddressThunk({ account: mockAccount }));
 
-            expect(result.type).toBe(getRefundAddress.rejected.type);
+            expect(result.type).toBe(getRefundAddressThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -179,9 +179,9 @@ describe('getRefundAddress thunk', () => {
             });
 
             const store = createMockStore();
-            const result = await store.dispatch(getRefundAddress({ account: mockAccount }));
+            const result = await store.dispatch(getRefundAddressThunk({ account: mockAccount }));
 
-            expect(result.type).toBe(getRefundAddress.rejected.type);
+            expect(result.type).toBe(getRefundAddressThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -199,9 +199,9 @@ describe('getRefundAddress thunk', () => {
             );
 
             const store = createMockStore();
-            const result = await store.dispatch(getRefundAddress({ account: mockAccount }));
+            const result = await store.dispatch(getRefundAddressThunk({ account: mockAccount }));
 
-            expect(result.type).toBe(getRefundAddress.rejected.type);
+            expect(result.type).toBe(getRefundAddressThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -222,9 +222,9 @@ describe('getRefundAddress thunk', () => {
             );
 
             const store = createMockStore();
-            const result = await store.dispatch(getRefundAddress({ account: mockAccount }));
+            const result = await store.dispatch(getRefundAddressThunk({ account: mockAccount }));
 
-            expect(result.type).toBe(getRefundAddress.rejected.type);
+            expect(result.type).toBe(getRefundAddressThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -245,9 +245,9 @@ describe('getRefundAddress thunk', () => {
             );
 
             const store = createMockStore();
-            const result = await store.dispatch(getRefundAddress({ account: mockAccount }));
+            const result = await store.dispatch(getRefundAddressThunk({ account: mockAccount }));
 
-            expect(result.type).toBe(getRefundAddress.rejected.type);
+            expect(result.type).toBe(getRefundAddressThunk.rejected.type);
             expect(result.payload).toEqual({
                 type: 'sign-tx-error',
                 error: {
@@ -275,9 +275,9 @@ describe('getRefundAddress thunk', () => {
             );
 
             const store = createMockStore();
-            const result = await store.dispatch(getRefundAddress({ account: segwitAccount }));
+            const result = await store.dispatch(getRefundAddressThunk({ account: segwitAccount }));
 
-            expect(result.type).toBe(getRefundAddress.fulfilled.type);
+            expect(result.type).toBe(getRefundAddressThunk.fulfilled.type);
             expect(result.payload).toEqual({
                 address: mockAddress,
                 mac: mockMac,
@@ -304,9 +304,9 @@ describe('getRefundAddress thunk', () => {
             );
 
             const store = createMockStore();
-            const result = await store.dispatch(getRefundAddress({ account: mockAccount }));
+            const result = await store.dispatch(getRefundAddressThunk({ account: mockAccount }));
 
-            expect(result.type).toBe(getRefundAddress.fulfilled.type);
+            expect(result.type).toBe(getRefundAddressThunk.fulfilled.type);
             expect(confirmAddressOnDeviceThunk).toHaveBeenCalledWith({
                 accountKey: mockAccount.key,
                 addressPath: tapRootPath,
@@ -318,7 +318,7 @@ describe('getRefundAddress thunk', () => {
 
     describe('thunk metadata', () => {
         it('should have correct thunk type prefix', () => {
-            expect(getRefundAddress.typePrefix).toBe('@trading/thunk/getRefundAddress');
+            expect(getRefundAddressThunk.typePrefix).toBe('@trading/thunk/getRefundAddress');
         });
 
         it('should handle pending state correctly', async () => {
@@ -333,16 +333,16 @@ describe('getRefundAddress thunk', () => {
             );
 
             const store = createMockStore();
-            const promise = store.dispatch(getRefundAddress({ account: mockAccount }));
+            const promise = store.dispatch(getRefundAddressThunk({ account: mockAccount }));
 
             // Check if the action is in pending state
             const actions = store.getActions();
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const firstAction: (typeof actions)[number] = actions[0];
-            expect(firstAction.type).toBe(getRefundAddress.pending.type);
+            expect(firstAction.type).toBe(getRefundAddressThunk.pending.type);
 
             const result = await promise;
-            expect(result.type).toBe(getRefundAddress.fulfilled.type);
+            expect(result.type).toBe(getRefundAddressThunk.fulfilled.type);
         });
     });
 });

--- a/suite-common/trading/src/thunks/common/getRefundAddress.ts
+++ b/suite-common/trading/src/thunks/common/getRefundAddress.ts
@@ -23,7 +23,7 @@ type GetRefundAddressFulfillValue = {
 
 export type GetRefundAddressThunkState = ConfirmAddressOnDeviceThunkState & WalletSettingsRootState;
 
-export const getRefundAddress = createThunk<
+export const getRefundAddressThunk = createThunk<
     GetRefundAddressFulfillValue,
     GetRefundAddressProps,
     {

--- a/suite-common/trading/src/thunks/common/index.ts
+++ b/suite-common/trading/src/thunks/common/index.ts
@@ -2,7 +2,7 @@ import { clearQuotesAndParamsByTradingTypeThunk } from './clearQuotesAndParamsBy
 import { createPaymentRequestsThunk } from './createPaymentRequestsThunk';
 import { loadInitialDataThunk } from './loadInitialDataThunk';
 import { recomposeAndSignTxThunk } from './recomposeAndSignTxThunk';
-import { setLastErrorMessageByTradingType } from './setLastErrorMessageByTradingType';
+import { setLastErrorMessageByTradingTypeThunk } from './setLastErrorMessageByTradingType';
 import { verifyAddressThunk } from './verifyAddressThunk';
 import { watchTradeThunk } from './watchTradeThunk';
 
@@ -12,6 +12,6 @@ export const tradingThunks = {
     recomposeAndSignTxThunk,
     watchTradeThunk,
     createPaymentRequestsThunk,
-    setLastErrorMessageByTradingType,
+    setLastErrorMessageByTradingTypeThunk,
     clearQuotesAndParamsByTradingTypeThunk,
 };

--- a/suite-common/trading/src/thunks/common/logErrorThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/logErrorThunk.test.ts
@@ -22,7 +22,7 @@ jest.mock('./setLastErrorMessageByTradingType', () => {
 
     return {
         ...originalModule,
-        setLastErrorMessageByTradingType: jest
+        setLastErrorMessageByTradingTypeThunk: jest
             .fn()
             .mockImplementation(({ tradingType, errorMessage }) => ({
                 type: 'mockedSetLastErrorMessageByTradingTypeAction',

--- a/suite-common/trading/src/thunks/common/logErrorThunk.ts
+++ b/suite-common/trading/src/thunks/common/logErrorThunk.ts
@@ -7,7 +7,7 @@ import {
     type ResolvedTradeError,
     isResolvedTradeError,
 } from '../../utils/exchange/resolveExchangeTradeError';
-import { setLastErrorMessageByTradingType } from '../common/setLastErrorMessageByTradingType';
+import { setLastErrorMessageByTradingTypeThunk } from '../common/setLastErrorMessageByTradingType';
 
 export type LogErrorThunkProps = {
     errorMessage: string | ResolvedTradeError;
@@ -28,7 +28,7 @@ export const logErrorThunk = createThunk<void, LogErrorThunkProps, void>(
                 }),
             );
             dispatch(
-                setLastErrorMessageByTradingType({
+                setLastErrorMessageByTradingTypeThunk({
                     tradingType,
                     errorMessage: errorMessage.message ?? '',
                 }),
@@ -38,6 +38,6 @@ export const logErrorThunk = createThunk<void, LogErrorThunkProps, void>(
         }
 
         dispatch(notificationsActions.addToast({ type: toastType, error: errorMessage }));
-        dispatch(setLastErrorMessageByTradingType({ tradingType, errorMessage }));
+        dispatch(setLastErrorMessageByTradingTypeThunk({ tradingType, errorMessage }));
     },
 );

--- a/suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.test.ts
+++ b/suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.test.ts
@@ -1,6 +1,6 @@
 import { type ActionCreator } from '@reduxjs/toolkit';
 
-import { setLastErrorMessageByTradingType } from './setLastErrorMessageByTradingType';
+import { setLastErrorMessageByTradingTypeThunk } from './setLastErrorMessageByTradingType';
 import { tradingBuyActions } from '../../reducers/buyReducer';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingSellActions } from '../../reducers/sellReducer';
@@ -22,7 +22,7 @@ describe('setLastErrorMessageByTradingType', () => {
     ])('should set last error message for %s', async (tradingType, expectedAction) => {
         const errorMessage = 'Test error message';
 
-        const thunk = setLastErrorMessageByTradingType({
+        const thunk = setLastErrorMessageByTradingTypeThunk({
             errorMessage,
             tradingType,
         });

--- a/suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.ts
+++ b/suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.ts
@@ -12,7 +12,7 @@ export type SetLastErrorMessageByTradingTypeProps = {
     errorMessage: string | undefined;
 };
 
-export const setLastErrorMessageByTradingType = createThunk<
+export const setLastErrorMessageByTradingTypeThunk = createThunk<
     void,
     SetLastErrorMessageByTradingTypeProps,
     void

--- a/suite-common/wallet-core/src/device/deviceThunks.test.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.test.ts
@@ -15,7 +15,7 @@ import { handleDeviceDisconnectFixture } from './__fixtures__/handleDeviceDiscon
 import {
     type ForgetDevicePersistentDataThunkDeps,
     forgetDevicePersistentDataThunk,
-    handleDeviceDisconnect,
+    handleDeviceDisconnectThunk,
 } from './deviceThunks';
 
 const deviceReducer = prepareDeviceReducer({
@@ -126,7 +126,7 @@ const initDisconnectStore = (state: DisconnectState) =>
         preloadedState: state,
     });
 
-describe(handleDeviceDisconnect.name, () => {
+describe(handleDeviceDisconnectThunk.name, () => {
     handleDeviceDisconnectFixture.forEach(fixture => {
         it(`handleDeviceDisconnect: ${fixture.description}`, async () => {
             const state = getDisconnectInitialState(fixture.state);
@@ -136,7 +136,7 @@ describe(handleDeviceDisconnect.name, () => {
                 type: DEVICE.DISCONNECT,
                 payload: fixture.device,
             });
-            await store.dispatch(handleDeviceDisconnect(fixture.device));
+            await store.dispatch(handleDeviceDisconnectThunk(fixture.device));
 
             const actions = filterThunkActionTypes(store.getActions());
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -77,7 +77,7 @@ type HandleDeviceDisconnectThunkState = DeviceRootState;
  * Triggered by `@trezor/connect DEVICE_EVENT`
  * @param {Device} device
  */
-export const handleDeviceDisconnect = createThunk<
+export const handleDeviceDisconnectThunk = createThunk<
     void,
     Device | TrezorDevice,
     { state: HandleDeviceDisconnectThunkState }
@@ -117,7 +117,7 @@ type ForgetDisconnectedDevicesThunkState = DeviceRootState;
  * Remove all data related to all instances of disconnected device if they are not remembered
  * @param {Device} device
  */
-export const forgetDisconnectedDevices = createThunk<
+export const forgetDisconnectedDevicesThunk = createThunk<
     void,
     ForgetDisconnectedDevicesThunkParams,
     { state: ForgetDisconnectedDevicesThunkState }
@@ -154,7 +154,7 @@ type ObserveSelectedDeviceThunkState = DeviceRootState;
  * of one of the `devices` (and those are updated via DEVICE.CHANGED. etc.).
  * Called from `suiteMiddleware` (Desktop) or `deviceMiddleware` (Mobile).
  */
-export const observeSelectedDevice = createThunk<
+export const observeSelectedDeviceThunk = createThunk<
     ObserveSelectedDeviceResult,
     void,
     { state: ObserveSelectedDeviceThunkState }
@@ -216,7 +216,7 @@ type AcquireDeviceThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDe
     thunks: FetchAndSaveMetadataDep;
 };
 
-export const acquireDevice = createThunk<
+export const acquireDeviceThunk = createThunk<
     void,
     AcquireDeviceThunkParams,
     { state: AcquireDeviceThunkState; extra: AcquireDeviceThunkDeps }
@@ -251,7 +251,7 @@ export const acquireDevice = createThunk<
 
 type InitDevicesThunkState = DeviceRootState;
 
-export const initDevices = createThunk<void, void, { state: InitDevicesThunkState }>(
+export const initDevicesThunk = createThunk<void, void, { state: InitDevicesThunkState }>(
     `${DEVICE_MODULE_PREFIX}/initDevices`,
     (_, { dispatch, getState }) => {
         const devices = selectDevices(getState());
@@ -342,7 +342,7 @@ export const confirmAddressOnDeviceThunk = createThunk<
 
 type DeviceConnectThunkEventType = typeof DEVICE.CONNECT | typeof DEVICE.CONNECT_UNACQUIRED;
 
-type DeviceConnectThunksParams = {
+type DeviceConnectThunkParams = {
     type: DeviceConnectThunkEventType;
     device: Device;
 };
@@ -353,9 +353,9 @@ export type DeviceConnectThunkDeps = WithServices<AnalyticsDep & GetTradedAccoun
     thunks: FetchAndSaveMetadataDep;
 };
 
-export const deviceConnectThunks = createThunk<
+export const deviceConnectThunk = createThunk<
     void,
-    DeviceConnectThunksParams,
+    DeviceConnectThunkParams,
     { state: DeviceConnectThunkState; extra: DeviceConnectThunkDeps }
 >(`${DEVICE_MODULE_PREFIX}/deviceConnectThunk`, ({ type, device }, { dispatch, getState }) => {
     // TODO (THP phase): Using selectIsFirmwareInstallationRunning = (hidden) circular dependency.
@@ -370,7 +370,7 @@ export const deviceConnectThunks = createThunk<
             if (getIsThpDevice(device) && !isFwInstallation) {
                 // This needs to be re-selected to convert Device to TrezorDevice.
                 const requestedDevice = selectDevices(getState()).find(d => d.path === device.path);
-                dispatch(acquireDevice({ requestedDevice }));
+                dispatch(acquireDeviceThunk({ requestedDevice }));
             }
             dispatch(selectNewlyConnectedDeviceThunk({ device }));
             break;
@@ -417,7 +417,7 @@ export const setDeviceAutoEjectThunk = createThunk<
         );
 
         if (shouldEnable && !wallet.connected) {
-            dispatch(forgetDisconnectedDevices({ device: wallet, forceForget: true }));
+            dispatch(forgetDisconnectedDevicesThunk({ device: wallet, forceForget: true }));
         }
     });
 });

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -809,7 +809,7 @@ type SubmitPassphraseThunkParams = {
 
 type SubmitPassphraseThunkState = DiscoveryRootState;
 
-export const submitPassphrase = createThunk<
+export const submitPassphraseThunk = createThunk<
     void,
     SubmitPassphraseThunkParams,
     { state: SubmitPassphraseThunkState }
@@ -879,7 +879,7 @@ export const startOrRestartDiscoveryThunk = createThunk<
 
 type SwitchToDuplicatedWalletThunkState = DeviceRootState & DiscoveryRootState;
 
-export const switchToDuplicatedWallet = createThunk<
+export const switchToDuplicatedWalletThunk = createThunk<
     void,
     void,
     { state: SwitchToDuplicatedWalletThunkState }

--- a/suite-common/wallet-core/src/send/composeCancelTransaction/composeCancelTransactionThunk.ts
+++ b/suite-common/wallet-core/src/send/composeCancelTransaction/composeCancelTransactionThunk.ts
@@ -66,7 +66,7 @@ type CalculateNewTransactionSizeParams = {
     account: ComposeCancelTransactionPartialAccount;
 };
 
-const calculateNewTransactionSize = createThunk<
+const calculateNewTransactionSizeThunk = createThunk<
     number,
     CalculateNewTransactionSizeParams,
     { rejectValue: string }
@@ -112,7 +112,7 @@ export const composeCancelTransactionThunk = createThunk<
             return rejectWithValue('Transaction vsize is not loaded');
         }
 
-        const response = await dispatch(calculateNewTransactionSize({ account, tx }));
+        const response = await dispatch(calculateNewTransactionSizeThunk({ account, tx }));
 
         if (isRejected(response)) {
             return rejectWithValue(response.error.message ?? 'unknown');

--- a/suite-common/wallet-core/src/settings/__fixtures__/walletSettingsActions.fixtures.ts
+++ b/suite-common/wallet-core/src/settings/__fixtures__/walletSettingsActions.fixtures.ts
@@ -1,11 +1,11 @@
 import * as walletSettingsActions from '../walletSettingsActions';
-import { changeCoinVisibility } from '../walletSettingsThunks';
+import { changeCoinVisibilityThunk } from '../walletSettingsThunks';
 
 export const walletSettingsFixtures = [
     {
         description: 'No networks enabled by default if no initial state provided',
         initialState: undefined,
-        action: () => changeCoinVisibility({ symbol: 'ltc', shouldBeVisible: true }),
+        action: () => changeCoinVisibilityThunk({ symbol: 'ltc', shouldBeVisible: true }),
         result: {
             enabledNetworks: ['ltc'],
         },
@@ -13,7 +13,7 @@ export const walletSettingsFixtures = [
     {
         description: 'Enable already enabled network',
         initialState: { enabledNetworks: ['btc', 'ltc'] },
-        action: () => changeCoinVisibility({ symbol: 'ltc', shouldBeVisible: true }),
+        action: () => changeCoinVisibilityThunk({ symbol: 'ltc', shouldBeVisible: true }),
         result: {
             enabledNetworks: ['btc', 'ltc'],
         },
@@ -21,7 +21,7 @@ export const walletSettingsFixtures = [
     {
         description: 'Disable already enabled network',
         initialState: { enabledNetworks: ['btc', 'ltc'] },
-        action: () => changeCoinVisibility({ symbol: 'ltc', shouldBeVisible: false }),
+        action: () => changeCoinVisibilityThunk({ symbol: 'ltc', shouldBeVisible: false }),
         result: {
             enabledNetworks: ['btc'],
         },

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.test.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.test.ts
@@ -6,7 +6,7 @@ import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { walletSettingsFixtures } from './__fixtures__/walletSettingsActions.fixtures';
 import { prepareWalletSettingsReducer } from './walletSettingsReducer';
-import { changeCoinVisibility } from './walletSettingsThunks';
+import { changeCoinVisibilityThunk } from './walletSettingsThunks';
 
 const btcSymbol = asNetworkSymbol('btc');
 const adaSymbol = asNetworkSymbol('ada');
@@ -44,7 +44,7 @@ describe('walletSettings Actions', () => {
             const { updateConnectSettings } = wireEnabledNetworksMock();
 
             await store.dispatch(
-                changeCoinVisibility({
+                changeCoinVisibilityThunk({
                     symbol: adaSymbol,
                     shouldBeVisible: true,
                 }) as any,
@@ -61,7 +61,7 @@ describe('walletSettings Actions', () => {
             const { updateConnectSettings } = wireEnabledNetworksMock();
 
             await store.dispatch(
-                changeCoinVisibility({
+                changeCoinVisibilityThunk({
                     symbol: adaSymbol,
                     shouldBeVisible: false,
                 }) as any,
@@ -75,7 +75,7 @@ describe('walletSettings Actions', () => {
             const { updateConnectSettings } = wireEnabledNetworksMock();
 
             await store.dispatch(
-                changeCoinVisibility({
+                changeCoinVisibilityThunk({
                     symbol: adaSymbol,
                     shouldBeVisible: true,
                 }) as any,
@@ -97,7 +97,7 @@ describe('walletSettings Actions', () => {
             );
 
             const dispatched = store.dispatch(
-                changeCoinVisibility({
+                changeCoinVisibilityThunk({
                     symbol: adaSymbol,
                     shouldBeVisible: true,
                 }) as any,

--- a/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
@@ -21,7 +21,7 @@ import { type WalletCoreCompoundRootState, selectAccountsToBeForgotten } from '.
 
 type ChangeCoinVisibilityThunkState = WalletCoreCompoundRootState;
 
-export const changeCoinVisibility = createThunk<
+export const changeCoinVisibilityThunk = createThunk<
     void,
     {
         symbol: NetworkSymbol;
@@ -64,7 +64,7 @@ export const changeCoinVisibility = createThunk<
 
 type ToggleBitcoinAmountUnitsThunkState = WalletSettingsRootState;
 
-export const toggleBitcoinAmountUnits =
+export const toggleBitcoinAmountUnitsThunk =
     () => (dispatch: Dispatch, getState: () => ToggleBitcoinAmountUnitsThunkState) => {
         const currentUnits = selectBitcoinAmountUnit(getState());
 

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -811,7 +811,7 @@ export type FetchTransactionsFromNowUntilTimestampThunkState = AccountsRootState
     FetchAllTransactionsForAccountThunkState &
     FetchTransactionsPageThunkState;
 
-export const fetchTransactionsFromNowUntilTimestamp = createSingleInstanceThunk<
+export const fetchTransactionsFromNowUntilTimestampThunk = createSingleInstanceThunk<
     FetchTransactionsFromNowUntilTimestampParams,
     WalletAccountTransaction[],
     { state: FetchTransactionsFromNowUntilTimestampThunkState }

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -33,7 +33,7 @@ type SolanaSignTransactionThunkState = trezorConnectPopupActions.ConnectPopupCal
 
 type SolanaSignTransactionThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
-const solanaSignTransaction = createThunk<
+const solanaSignTransactionThunk = createThunk<
     { signature: string; transaction: string },
     {
         session: WalletConnectSession;
@@ -142,7 +142,7 @@ const solanaRequestThunk = createThunk<
             const { origin } = event.verifyContext.verified;
 
             const response = await dispatch(
-                solanaSignTransaction({ session, transaction, feePayer, origin, isDevnet }),
+                solanaSignTransactionThunk({ session, transaction, feePayer, origin, isDevnet }),
             ).unwrap();
 
             const signature = base58.encode(Buffer.from(response.signature, 'hex'));
@@ -154,7 +154,7 @@ const solanaRequestThunk = createThunk<
             const { origin } = event.verifyContext.verified;
 
             const signResponse = await dispatch(
-                solanaSignTransaction({ session, transaction, origin, isDevnet }),
+                solanaSignTransactionThunk({ session, transaction, origin, isDevnet }),
             ).unwrap();
 
             const pushResponse = await TrezorConnect.pushTransaction({

--- a/suite-common/walletconnect/src/adapters/stellar.ts
+++ b/suite-common/walletconnect/src/adapters/stellar.ts
@@ -43,7 +43,7 @@ type StellarSignXDRThunkState = trezorConnectPopupActions.ConnectPopupCallThunkS
 
 type StellarSignXDRThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
-const stellarSignXDR = createThunk<
+const stellarSignXDRThunk = createThunk<
     { signedXDR: string },
     {
         session: WalletConnectSession;
@@ -129,7 +129,7 @@ const stellarRequestThunk = createThunk<
             const { origin } = event.verifyContext.verified;
 
             const result = await dispatch(
-                stellarSignXDR({ session, xdrBase64: xdr, origin, event }),
+                stellarSignXDRThunk({ session, xdrBase64: xdr, origin, event }),
             ).unwrap();
 
             return { signedXDR: result.signedXDR };
@@ -140,7 +140,7 @@ const stellarRequestThunk = createThunk<
             const context = resolveStellarRequestContext(event);
 
             const result = await dispatch(
-                stellarSignXDR({ session, xdrBase64: xdr, origin, event }),
+                stellarSignXDRThunk({ session, xdrBase64: xdr, origin, event }),
             ).unwrap();
 
             const pushResponse = await TrezorConnect.pushTransaction({

--- a/suite-native/app-init/src/appInitThunks.ts
+++ b/suite-native/app-init/src/appInitThunks.ts
@@ -28,7 +28,7 @@ import {
     type PeriodicFetchFiatRatesThunkState,
     createImportedDeviceThunk,
     initBlockchainThunk,
-    initDevices,
+    initDevicesThunk,
     initStakeDataThunk,
     periodicFetchFiatRatesThunk,
     selectBaseCurrency,
@@ -66,7 +66,7 @@ type PostOnboardingInitThunkDeps = ConnectInitThunkDeps &
     PeriodicFetchFiatRatesThunkDeps &
     WalletConnectInitThunkDeps;
 
-export const postOnboardingInit = createThunk<
+export const postOnboardingInitThunk = createThunk<
     void,
     void,
     { state: PostOnboardingInitThunkState; extra: PostOnboardingInitThunkDeps }
@@ -111,7 +111,7 @@ type ApplicationInitThunkState = SettingsSliceRootState &
 
 type ApplicationInitThunkDeps = InitAnalyticsThunkDeps & PostOnboardingInitThunkDeps;
 
-export const applicationInit = createThunk<
+export const applicationInitThunk = createThunk<
     void,
     void,
     { state: ApplicationInitThunkState; extra: ApplicationInitThunkDeps }
@@ -127,10 +127,10 @@ export const applicationInit = createThunk<
     dispatch(initMessageSystemThunk());
 
     // Select latest remembered device or Portfolio Tracker device.
-    dispatch(initDevices());
+    dispatch(initDevicesThunk());
 
     if (selectIsOnboardingFinished(getState())) {
-        await dispatch(postOnboardingInit());
+        await dispatch(postOnboardingInitThunk());
     }
 
     // Tell the application to render

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -12,7 +12,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { FormatterProvider } from '@suite-common/formatters';
 import { ReactNativeQueryProvider } from '@suite-common/react-query/src/components/ReactNativeQueryProvider';
 import { useDispatch } from '@suite-common/redux-utils';
-import { applicationInit } from '@suite-native/app-init';
+import { applicationInitThunk } from '@suite-native/app-init';
 import { selectShouldUserBeAuthenticated } from '@suite-native/biometrics';
 import { launchArguments } from '@suite-native/config';
 import { configureNetInfo } from '@suite-native/connection-status';
@@ -74,7 +74,7 @@ const AppComponent = () => {
 
     useEffect(() => {
         if (!isApplicationInitDispatchedRef.current) {
-            dispatch(applicationInit());
+            dispatch(applicationInitThunk());
             isApplicationInitDispatchedRef.current = true;
         }
     }, [dispatch]);

--- a/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
+++ b/suite-native/coin-enabling/src/components/CoinEnablingForm.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { networkSymbolCollection } from '@suite-common/wallet-config';
-import { changeCoinVisibility } from '@suite-common/wallet-core';
+import { changeCoinVisibilityThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { selectDeviceEnabledDiscoveryNetworkSymbols } from '@suite-native/discovery';
@@ -63,7 +63,7 @@ export const CoinEnablingForm = ({ searchQuery }: CoinEnablingFormProps) => {
 
         changedCoins.forEach(symbol => {
             const isEnabled = enabledCoins.includes(symbol);
-            dispatch(changeCoinVisibility({ symbol, shouldBeVisible: isEnabled }));
+            dispatch(changeCoinVisibilityThunk({ symbol, shouldBeVisible: isEnabled }));
 
             analytics.report({
                 type: events.settingsChangeCoinEnabledEvent.name,

--- a/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
+++ b/suite-native/coin-enabling/src/screens/CoinEnablingInitScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { events as commonEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
-import { changeCoinVisibility } from '@suite-common/wallet-core';
+import { changeCoinVisibilityThunk } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { AnimatedBox } from '@suite-native/atoms';
 import { Form, useForm } from '@suite-native/forms';
@@ -71,7 +71,7 @@ export const CoinEnablingInitScreen = () => {
         const enabledCoins = getNetworkSymbolsFromEnabledCoins(values.enabledCoins);
 
         enabledCoins.forEach(symbol => {
-            dispatch(changeCoinVisibility({ symbol, shouldBeVisible: true }));
+            dispatch(changeCoinVisibilityThunk({ symbol, shouldBeVisible: true }));
         });
 
         analytics.report({

--- a/suite-native/device-authorization/src/hooks/useDeviceConnectionGuard.ts
+++ b/suite-native/device-authorization/src/hooks/useDeviceConnectionGuard.ts
@@ -11,8 +11,8 @@ export const useDeviceConnectionGuard = () => {
     // There are two situations we need to distinguish because of THP devices:
     // 1) Device is already connected => we don't need to show the connection guard.
     // 2) Device is not yet connected => we have to wait for it to be connected and THP unlocked.
-    // If we don't do that, TrezorConnect calls get queued behind acquireDevice() triggered from
-    // deviceConnectThunks upon device connection, and that causes UX issues.
+    // If we don't do that, TrezorConnect calls get queued behind acquireDeviceThunk() triggered from
+    // deviceConnectThunk upon device connection, and that causes UX issues.
     const isDeviceConnectionGuardVisible =
         !wasDeviceInitiallyConnected && !isDeviceConnectedAndThpUnlocked;
 

--- a/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
+++ b/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
@@ -11,7 +11,7 @@ import {
     selectIsDeviceThpLocked,
 } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import {
     AuthorizeDeviceStackRoutes,
     type HomeStackParamList,
@@ -39,7 +39,7 @@ export const useConnectDeviceHandler = () => {
 
     const onConnectDevicePress = useCallback(() => {
         if (!isDeviceAuthorized || isDeviceThpLocked) {
-            dispatch(acquireDevice({}));
+            dispatch(acquireDeviceThunk({}));
         } else if (isAnyPhysicalDeviceConnectedViaUsb || Platform.OS === 'ios') {
             // Make sure auto-connect is enabled in case some device was manually disconnected.
             dispatch(bluetoothActions.enableAutoConnect());

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -16,7 +16,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
@@ -110,7 +110,7 @@ export const useDetectDeviceError = () => {
                 appendix: <UnacquiredDeviceModalAppendix />,
                 onPressPrimaryButton: () => {
                     dispatch(
-                        acquireDevice({
+                        acquireDeviceThunk({
                             startDiscovery: true,
                         }),
                     );

--- a/suite-native/device/src/middlewares/deviceMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceMiddleware.ts
@@ -8,9 +8,9 @@ import {
     type AccountsRootState,
     type DiscoveryRootState,
     accountsActions,
-    forgetDisconnectedDevices,
-    handleDeviceDisconnect,
-    observeSelectedDevice,
+    forgetDisconnectedDevicesThunk,
+    handleDeviceDisconnectThunk,
+    observeSelectedDeviceThunk,
     selectAccountsByDeviceState,
     selectDiscoveryByDevicePath,
 } from '@suite-common/wallet-core';
@@ -53,7 +53,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps<
 >((action, { dispatch, next, getState, extra }) => {
     if (deviceActions.deviceDisconnect.match(action)) {
         dispatch(
-            forgetDisconnectedDevices({
+            forgetDisconnectedDevicesThunk({
                 device: action.payload,
                 forceForget: selectIsBluetoothDeviceOsUnpairingRequired(getState()),
             }),
@@ -72,7 +72,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps<
     if (deviceActions.forgetDevice.match(action)) {
         const { device } = action.payload;
 
-        dispatch(handleDeviceDisconnect(device));
+        dispatch(handleDeviceDisconnectThunk(device));
 
         if (isTrezorDeviceWithState(device)) {
             const accountsToRemove = selectAccountsByDeviceState(getState(), device.state);
@@ -86,7 +86,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps<
     if (deviceActions.connectDevice.match(action)) {
         reportDeviceConnectionAnalytics(action.payload.device, extra.services.analytics);
     } else if (deviceActions.deviceDisconnect.match(action)) {
-        dispatch(handleDeviceDisconnect(action.payload));
+        dispatch(handleDeviceDisconnectThunk(action.payload));
 
         clearAndUnlockDeviceAccessQueue();
     } else if (isDeviceEventOfType(action, DEVICE.FIRMWARE_VERSION_CHANGED)) {
@@ -106,7 +106,7 @@ export const prepareDeviceMiddleware = createMiddlewareWithExtraDeps<
     }
 
     if (isActionDeviceRelated(action)) {
-        dispatch(observeSelectedDevice());
+        dispatch(observeSelectedDeviceThunk());
     }
 
     return action;

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -7,7 +7,7 @@ import { periodicCheckTokenDefinitionsThunk } from '@suite-common/token-definiti
 import {
     type WalletCoreCompoundRootState,
     accountsActions,
-    changeCoinVisibility,
+    changeCoinVisibilityThunk,
     changeNetworks,
     discoveryActions,
     selectDiscoveryForSelectedDevice,
@@ -71,7 +71,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps<
             const pendingSymbols = selectPendingCoinVisibilitySymbols(getState());
 
             for (const symbol of pendingSymbols) {
-                dispatch(changeCoinVisibility({ symbol, shouldBeVisible: false }));
+                dispatch(changeCoinVisibilityThunk({ symbol, shouldBeVisible: false }));
             }
 
             dispatch(clearPendingCoinVisibility());
@@ -84,7 +84,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps<
         const newDevice = action.payload;
         if (newDevice?.connected && hasBitcoinOnlyFirmware(newDevice)) {
             if (!isBitcoinEnabled) {
-                dispatch(changeCoinVisibility({ symbol: 'btc', shouldBeVisible: true }));
+                dispatch(changeCoinVisibilityThunk({ symbol: 'btc', shouldBeVisible: true }));
             }
         }
     }
@@ -97,7 +97,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps<
     if (
         action.type === DEVICE.CONNECT ||
         deviceActions.selectDevice.match(action) ||
-        changeCoinVisibility.fulfilled.match(action) ||
+        changeCoinVisibilityThunk.fulfilled.match(action) ||
         deviceActions.dismissFirmwareAuthenticityCheck.match(action) || // may no longer be device compromised
         accountsActions.updateAccount.match(action) || // empty account can become nonempty
         accountsActions.changeAccountVisibility.match(action) ||
@@ -112,7 +112,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps<
         ) {
             // Track every enabled coin for revert on passphrase failure
             if (
-                changeCoinVisibility.fulfilled.match(action) &&
+                changeCoinVisibilityThunk.fulfilled.match(action) &&
                 action.meta.arg?.shouldBeVisible === true
             ) {
                 dispatch(addPendingCoinVisibility(action.meta.arg.symbol));
@@ -121,7 +121,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps<
             // Don't restart discovery when reverting after passphrase failure (we dispatch
             // changeCoinVisibility(false) for each pending coin, which would retrigger discovery).
             const isRevertingAfterPassphraseFailure =
-                changeCoinVisibility.fulfilled.match(action) &&
+                changeCoinVisibilityThunk.fulfilled.match(action) &&
                 action.meta.arg?.shouldBeVisible === false &&
                 isPassphraseDiscoveryFailure(selectDiscoveryForSelectedDevice(getState()));
 

--- a/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
@@ -8,7 +8,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
-    changeCoinVisibility,
+    changeCoinVisibilityThunk,
     selectDeviceAccountsByNetworkSymbol,
     selectDiscoveryForSelectedDevice,
     selectHasRunningDiscovery,
@@ -101,7 +101,7 @@ export const AddCoinDiscoveryRunningScreen = ({
             !isBlockedByPassphraseError
         ) {
             dispatch(
-                changeCoinVisibility({
+                changeCoinVisibilityThunk({
                     symbol: networkSymbol,
                     shouldBeVisible: true,
                 }),

--- a/suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts
+++ b/suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts
@@ -5,7 +5,7 @@ import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import {
     type AuthorizeDeviceStackParamList,
     AuthorizeDeviceStackRoutes,
@@ -24,7 +24,7 @@ export const useInitiateThpConnection = () => {
         // do that. In addition to better UX, this also prevents the current screen from multiplying
         // in the navigation stack and the invalidCode alert from reappearing once dismissed.
         navigation.replace(AuthorizeDeviceStackRoutes.ThpConfirmation);
-        dispatch(acquireDevice({ requestedDevice: device }));
+        dispatch(acquireDeviceThunk({ requestedDevice: device }));
     };
 
     return {

--- a/suite-native/module-connect-popup/src/components/ConnectErrorMessage.tsx
+++ b/suite-native/module-connect-popup/src/components/ConnectErrorMessage.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { connectPopupCallThunkInner, selectConnectPopupCall } from '@suite-common/connect-popup';
+import { connectPopupCallInnerThunk, selectConnectPopupCall } from '@suite-common/connect-popup';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Box, Button, Card, PictogramTitleHeader, VStack } from '@suite-native/atoms';
@@ -47,7 +47,7 @@ export const ConnectErrorMessage = () => {
     const onResume = () => {
         if (popupCall?.state === 'call-error')
             dispatch(
-                connectPopupCallThunkInner({
+                connectPopupCallInnerThunk({
                     ...popupCall,
                     payload: {
                         ...popupCall.payload,

--- a/suite-native/module-earn/src/components/earn/EarnCompleteScreenContent.tsx
+++ b/suite-native/module-earn/src/components/earn/EarnCompleteScreenContent.tsx
@@ -7,7 +7,7 @@ import {
     type FeedbackCategory,
     type Rating,
     buildUserFeedbackData,
-    sendFeedbackAction,
+    sendFeedbackThunk,
 } from '@suite-common/feedback';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type WrappedNativeFlowType, type YieldFlowType } from '@suite-common/wallet-core';
@@ -111,7 +111,7 @@ export const EarnCompleteScreenContent = ({
         const userData = buildUserFeedbackData(device);
 
         dispatch(
-            sendFeedbackAction({
+            sendFeedbackThunk({
                 type: 'SUGGESTION',
                 payload: {
                     category: feedbackCategory,

--- a/suite-native/module-home/src/screens/FeatureFeedbackModalScreen.tsx
+++ b/suite-native/module-home/src/screens/FeatureFeedbackModalScreen.tsx
@@ -1,6 +1,6 @@
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
-import { type Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
+import { type Rating, buildUserFeedbackData, sendFeedbackThunk } from '@suite-common/feedback';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Text, VStack } from '@suite-native/atoms';
 import { FEEDBACK_FEATURE_CONFIGS } from '@suite-native/experimental-features';
@@ -33,7 +33,7 @@ export const FeatureFeedbackModalScreen = () => {
         const userData = buildUserFeedbackData();
 
         dispatch(
-            sendFeedbackAction({
+            sendFeedbackThunk({
                 type: 'SUGGESTION',
                 payload: {
                     category: 'experimental',

--- a/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.test.ts
+++ b/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.test.ts
@@ -21,7 +21,7 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('@suite-native/app-init', () => ({
     ...jest.requireActual('@suite-native/app-init'),
-    postOnboardingInit: () => ({
+    postOnboardingInitThunk: () => ({
         type: 'postOnboardingInitMock',
     }),
 }));

--- a/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.ts
+++ b/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.ts
@@ -1,7 +1,7 @@
 import { CommonActions, useNavigation } from '@react-navigation/native';
 
 import { useDispatch } from '@suite-common/redux-utils';
-import { postOnboardingInit } from '@suite-native/app-init';
+import { postOnboardingInitThunk } from '@suite-native/app-init';
 import { HomeStackRoutes, RootStackRoutes } from '@suite-native/navigation';
 import { setIsOnboardingFinished } from '@suite-native/settings';
 
@@ -11,7 +11,7 @@ export const useExitOnboardingFlow = () => {
 
     return () => {
         dispatch(setIsOnboardingFinished());
-        dispatch(postOnboardingInit());
+        dispatch(postOnboardingInitThunk());
 
         // TODO: COSMETIC IMPROVEMENT: redirect to home only if there is no device connected. In case of device connected,
         // the redirect is handled in useHandleDeviceConnection hook. in reaction to the `setIsOnboardingFinished` call.

--- a/suite-native/module-onboarding/src/screens/BiometricsScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/BiometricsScreen.test.tsx
@@ -34,7 +34,7 @@ jest.mock('@react-navigation/native', () => ({
 // because the global Request constructor is not available.
 jest.mock('@suite-native/app-init', () => ({
     ...jest.requireActual('@suite-native/app-init'),
-    postOnboardingInit: () => ({
+    postOnboardingInitThunk: () => ({
         type: 'postOnboardingInitMock',
     }),
 }));

--- a/suite-native/passphrase/src/components/EnterPassphraseOnTrezorButton.tsx
+++ b/suite-native/passphrase/src/components/EnterPassphraseOnTrezorButton.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectDeviceInternalModel, selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { submitPassphrase } from '@suite-common/wallet-core';
+import { submitPassphraseThunk } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button } from '@suite-native/atoms';
 import { selectPassphraseRequestId } from '@suite-native/device-authorization';
@@ -20,7 +20,9 @@ export const EnterPassphraseOnTrezorButton = () => {
     const handleSubmitOnDevice = () => {
         analytics.report({ type: events.passphraseEnterOnTrezorEvent.name });
         if (!device) return;
-        dispatch(submitPassphrase({ device, passphrase: '', passphraseOnDevice: true, requestId }));
+        dispatch(
+            submitPassphraseThunk({ device, passphrase: '', passphraseOnDevice: true, requestId }),
+        );
     };
 
     if (!deviceModel || !device) return null;

--- a/suite-native/passphrase/src/components/PassphraseDuplicateAlert.tsx
+++ b/suite-native/passphrase/src/components/PassphraseDuplicateAlert.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
-import { switchToDuplicatedWallet } from '@suite-common/wallet-core';
+import { switchToDuplicatedWalletThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { useTranslate } from '@suite-native/intl';
@@ -33,7 +33,7 @@ export const PassphraseDuplicateAlert = ({ children }: { children: React.ReactNo
     const { showAlert } = useAlert();
 
     const handleDuplicateDevicePassphrase = useCallback(() => {
-        dispatch(switchToDuplicatedWallet());
+        dispatch(switchToDuplicatedWalletThunk());
 
         navigation.popTo(RootStackRoutes.AppTabs, {
             screen: AppTabsRoutes.HomeStack,

--- a/suite-native/passphrase/src/components/PassphraseForm.tsx
+++ b/suite-native/passphrase/src/components/PassphraseForm.tsx
@@ -14,7 +14,7 @@ import {
     formInputsMaxLength,
     passphraseFormSchema,
 } from '@suite-common/validators';
-import { submitPassphrase } from '@suite-common/wallet-core';
+import { submitPassphraseThunk } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, Card, TextDivider, VStack } from '@suite-native/atoms';
 import { selectPassphraseRequestId } from '@suite-native/device-authorization';
@@ -74,7 +74,9 @@ export const PassphraseForm = ({
 
     const handleCreateHiddenWallet = handleSubmit(({ passphrase }) => {
         if (!device) return;
-        dispatch(submitPassphrase({ device, passphrase, passphraseOnDevice: false, requestId }));
+        dispatch(
+            submitPassphraseThunk({ device, passphrase, passphraseOnDevice: false, requestId }),
+        );
         // Reset values so when user comes back to this screen,
         // it's clean (for example if try again is triggered later in the flow)
         reset();

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.e2e.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.e2e.ts
@@ -23,7 +23,7 @@ export const useBrowserAuth = (tradingType: TradingType | undefined): BrowserAut
         handleBrowserClosed();
 
         dispatch(
-            tradingThunks.setLastErrorMessageByTradingType({
+            tradingThunks.setLastErrorMessageByTradingTypeThunk({
                 // This string is targeted in E2E tests. Be careful when changing it, and update the tests if needed.
                 errorMessage: 'E2E: Browser auth simulated',
                 tradingType,

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
@@ -40,7 +40,7 @@ const useLastErrorMessageDispatcher = (tradingType: TradingType | undefined) => 
             invariant(tradingType, 'tradingType must be defined for browser auth');
 
             dispatch(
-                tradingThunks.setLastErrorMessageByTradingType({
+                tradingThunks.setLastErrorMessageByTradingTypeThunk({
                     errorMessage,
                     tradingType,
                 }),

--- a/suite-native/trading-history/src/components/TradeHistoryListItem/TradingDetailFeedback.test.tsx
+++ b/suite-native/trading-history/src/components/TradeHistoryListItem/TradingDetailFeedback.test.tsx
@@ -1,4 +1,4 @@
-import { sendFeedbackAction } from '@suite-common/feedback';
+import { sendFeedbackThunk } from '@suite-common/feedback';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
@@ -9,10 +9,10 @@ import { renderWithTradingHistoryProvider } from '../../test-utils/tradingHistor
 
 jest.mock('@suite-common/feedback', () => ({
     ...jest.requireActual('@suite-common/feedback'),
-    sendFeedbackAction: jest.fn(() => ({ type: 'mock/sendFeedbackAction' })),
+    sendFeedbackThunk: jest.fn(() => ({ type: 'mock/sendFeedbackAction' })),
 }));
 
-const sendFeedbackActionMock = sendFeedbackAction as unknown as jest.Mock;
+const sendFeedbackActionMock = sendFeedbackThunk as unknown as jest.Mock;
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep = { analytics: mockNativeAnalytics(reportMock) };

--- a/suite-native/trading-history/src/components/TradeHistoryListItem/TradingDetailFeedback.tsx
+++ b/suite-native/trading-history/src/components/TradeHistoryListItem/TradingDetailFeedback.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
+import { type Rating, buildUserFeedbackData, sendFeedbackThunk } from '@suite-common/feedback';
 import { selectCountryCode } from '@suite-common/geolocation';
 import {
     formatExperimentVariantsForAnalytics,
@@ -50,7 +50,7 @@ export const TradingDetailFeedback = ({
         const userData = buildUserFeedbackData(device);
 
         dispatch(
-            sendFeedbackAction({
+            sendFeedbackThunk({
                 type: 'SUGGESTION',
                 payload: {
                     category: 'trade',

--- a/suite/backup/src/BackupRecoverySeed.tsx
+++ b/suite/backup/src/BackupRecoverySeed.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { Anchor, SettingsAnchor, goto } from '@suite/router';
+import { Anchor, SettingsAnchor, gotoThunk } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
@@ -19,7 +19,7 @@ export const BackupRecoverySeed = ({ isDeviceLocked }: BackupRecoverySeedProps) 
     const needsBackup = device?.features?.backup_availability === 'Required';
 
     const handleClick = () =>
-        dispatch(goto({ routeName: 'backup-index', params: { cancelable: true } }));
+        dispatch(gotoThunk({ routeName: 'backup-index', params: { cancelable: true } }));
 
     if (!needsBackup) return null;
 

--- a/suite/backup/src/CreateWalletBackup.tsx
+++ b/suite/backup/src/CreateWalletBackup.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectIsN4w1BackupEnabled } from '@suite/settings';
 import { hasSlip39Backup, isBackupComplete } from '@suite-common/backup';
 import { selectSelectedDevice } from '@suite-common/device';
@@ -36,7 +36,7 @@ export const CreateWalletBackup = ({ isDeviceLocked }: CreateWalletBackupProps) 
     const isActionDisabled = isDeviceLocked || !isBackupDone;
 
     const handleClick = () => {
-        dispatch(goto({ routeName: 'create-wallet-backup' }));
+        dispatch(gotoThunk({ routeName: 'create-wallet-backup' }));
     };
 
     return (

--- a/suite/backup/src/MultiShareBackup.tsx
+++ b/suite/backup/src/MultiShareBackup.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectIsN4w1BackupEnabled } from '@suite/settings';
 import { doesSupportMultiShare } from '@suite-common/backup';
 import { useServices } from '@suite-common/dependency-injection';
@@ -36,7 +36,7 @@ export const MultiShareBackup = ({ isDeviceLocked }: { isDeviceLocked: boolean }
             payload: { action: 'start' },
         });
 
-        dispatch(goto({ routeName: 'create-multi-share-backup' }));
+        dispatch(gotoThunk({ routeName: 'create-multi-share-backup' }));
     };
 
     return (

--- a/suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts
+++ b/suite/coinjoin/src/__fixtures__/coinjoinAccountActions.ts
@@ -1,4 +1,4 @@
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { accountsActions } from '@suite-common/wallet-core';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
@@ -186,10 +186,10 @@ export const createCoinjoinAccount: CreateCoinjoinAccountFixture[] = [
                 accountsActions.createAccount.type,
                 COINJOIN.ACCOUNT_DISCOVERY_RESET,
                 COINJOIN.ACCOUNT_PRELOADING,
-                goto.pending.type,
+                gotoThunk.pending.type,
                 accountsActions.startCoinjoinAccountSync.type,
                 COINJOIN.ACCOUNT_DISCOVERY_PROGRESS,
-                goto.fulfilled.type,
+                gotoThunk.fulfilled.type,
                 COINJOIN.ACCOUNT_SET_LIQUIDITY_CLUE,
                 accountsActions.updateAccount.type,
                 accountsActions.endCoinjoinAccountSync.type,
@@ -256,7 +256,7 @@ export const startCoinjoinSession: StartCoinjoinSessionFixture[] = [
                 COINJOIN.SESSION_STARTING,
                 COINJOIN.ACCOUNT_AUTHORIZE,
                 COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS,
-                goto.pending.type,
+                gotoThunk.pending.type,
                 COINJOIN.SESSION_STARTING,
             ],
         },

--- a/suite/coinjoin/src/coinjoinAccountActions.test.ts
+++ b/suite/coinjoin/src/coinjoinAccountActions.test.ts
@@ -86,7 +86,7 @@ describe('coinjoinAccountActions', () => {
             jest.spyOn(console, 'log').mockImplementation(() => {});
 
             await store.dispatch(
-                coinjoinAccountActions.createCoinjoinAccount(
+                coinjoinAccountActions.createCoinjoinAccountThunk(
                     f.params.network as any,
                     f.params.account as any,
                 ),
@@ -102,7 +102,7 @@ describe('coinjoinAccountActions', () => {
             const store = initStore(f.state as Wallet);
             testMocks.setTrezorConnectFixtures(f.connect);
             // @ts-expect-error params are incomplete
-            await store.dispatch(coinjoinAccountActions.startCoinjoinSession(f.params, {}));
+            await store.dispatch(coinjoinAccountActions.startCoinjoinSessionThunk(f.params, {}));
 
             const actions = store.getActions();
             expect(actions.map(a => a.type)).toEqual(f.result.actions);
@@ -117,7 +117,7 @@ describe('coinjoinAccountActions', () => {
                 await CoinjoinService.createInstance({ symbol: f.client as any });
             }
 
-            await store.dispatch(coinjoinClientActions.stopCoinjoinSession(f.param));
+            await store.dispatch(coinjoinClientActions.stopCoinjoinSessionThunk(f.param));
 
             const actions = store.getActions();
             expect(actions.map(a => a.type)).toEqual(f.result.actions);
@@ -128,7 +128,7 @@ describe('coinjoinAccountActions', () => {
         it(`restoreCoinjoinAccounts: ${f.description}`, async () => {
             const store = initStore(f.state as Wallet);
 
-            await store.dispatch(coinjoinAccountActions.restoreCoinjoinAccounts());
+            await store.dispatch(coinjoinAccountActions.restoreCoinjoinAccountsThunk());
 
             const actions = store.getActions();
             expect(actions.map(a => a.type)).toEqual(f.result.actions);
@@ -143,7 +143,7 @@ describe('coinjoinAccountActions', () => {
                 await CoinjoinService.createInstance({ symbol: f.client as any });
             }
 
-            await store.dispatch(coinjoinAccountActions.restoreCoinjoinSession(f.param));
+            await store.dispatch(coinjoinAccountActions.restoreCoinjoinSessionThunk(f.param));
 
             const actions = store.getActions();
 

--- a/suite/coinjoin/src/coinjoinAccountActions.ts
+++ b/suite/coinjoin/src/coinjoinAccountActions.ts
@@ -3,7 +3,7 @@ import { createAction, isAnyOf } from '@reduxjs/toolkit';
 import { type SelectedAccountRootState } from '@suite/account';
 import { type LocksRootState, selectIsDeviceLocked } from '@suite/locks';
 import { type ModalRootState, openModal } from '@suite/modal';
-import { type RouterRootState, goto, selectRouteName } from '@suite/router';
+import { type RouterRootState, gotoThunk, selectRouteName } from '@suite/router';
 import { type TorRootState } from '@suite/tor';
 import { type DeviceRootState, selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
@@ -226,7 +226,7 @@ const getAccountCache = ({ addresses, path }: Extract<Account, { backendType: 'c
 
 type UpdateClientAccountThunkState = AccountsRootState & CoinjoinRootState & ModalRootState;
 
-export const updateClientAccount =
+export const updateClientAccountThunk =
     (account: Account) => (dispatch: Dispatch, getState: () => UpdateClientAccountThunkState) => {
         if (!isCoinjoinSupportedSymbol(account.symbol)) return;
         const client = coinjoinClientActions.getCoinjoinClient(account.symbol);
@@ -268,7 +268,7 @@ export const updateClientAccount =
 
 type CoinjoinAccountCheckReorgThunkState = CoinjoinRootState & TransactionsRootState;
 
-const coinjoinAccountCheckReorg =
+const coinjoinAccountCheckReorgThunk =
     (account: Account, checkpoint: ScanAccountProgress['checkpoint']) =>
     (dispatch: Dispatch, getState: () => CoinjoinAccountCheckReorgThunkState) => {
         const state = getState();
@@ -314,7 +314,7 @@ type UpdatePendingAccountInfoThunkState = CoinjoinRootState & TransactionsRootSt
  Prepending txs have deadline (blockHeight) when they should be removed from UI.
  In case of adding a coinjoin transaction, log anonymity gain.
  */
-export const updatePendingAccountInfo =
+export const updatePendingAccountInfoThunk =
     (accountKey: AccountKey) =>
     async (dispatch: Dispatch, getState: () => UpdatePendingAccountInfoThunkState) => {
         const state = getState();
@@ -322,7 +322,7 @@ export const updatePendingAccountInfo =
         const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
         if (account?.backendType !== 'coinjoin' || !coinjoinAccount?.checkpoints) return;
 
-        const api = await dispatch(coinjoinClientActions.initCoinjoinService(account.symbol));
+        const api = await dispatch(coinjoinClientActions.initCoinjoinServiceThunk(account.symbol));
         if (!api) return;
 
         const { backend, client } = api;
@@ -366,7 +366,7 @@ type CreatePendingTransactionThunkState = AccountsRootState &
     BlockchainRootState &
     CoinjoinRootState;
 
-export const createPendingTransaction =
+export const createPendingTransactionThunk =
     (accountKey: AccountKey, payload: BroadcastedTransactionDetails) =>
     async (dispatch: Dispatch, getState: () => CreatePendingTransactionThunkState) => {
         const state = getState();
@@ -374,7 +374,7 @@ export const createPendingTransaction =
         const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
         if (account?.backendType !== 'coinjoin' || !coinjoinAccount?.checkpoints) return;
 
-        const api = await dispatch(coinjoinClientActions.initCoinjoinService(account.symbol));
+        const api = await dispatch(coinjoinClientActions.initCoinjoinServiceThunk(account.symbol));
         if (!api) return;
 
         const { backend } = api;
@@ -393,7 +393,7 @@ export const createPendingTransaction =
 type CleanPendingTransactionsThunkState = BlockchainRootState & TransactionsRootState;
 
 /** Remove outdated pending transactions */
-const cleanPendingTransactions =
+const cleanPendingTransactionsThunk =
     (account: Account, pending: { txid: string }[]) =>
     (dispatch: Dispatch, getState: () => CleanPendingTransactionsThunkState) => {
         const {
@@ -421,14 +421,14 @@ type FetchAndUpdateAccountThunkState = CoinjoinRootState &
     SelectedAccountRootState &
     TransactionsRootState;
 
-export const fetchAndUpdateAccount =
+export const fetchAndUpdateAccountThunk =
     ({ key: accountKey, symbol }: Account) =>
     async (dispatch: Dispatch, getState: () => FetchAndUpdateAccountThunkState) => {
         const state = getState();
         // do not sync if any account CoinjoinSession is in critical phase
         if (selectIsAnySessionInCriticalPhase(state)) return;
 
-        const api = await dispatch(coinjoinClientActions.initCoinjoinService(symbol));
+        const api = await dispatch(coinjoinClientActions.initCoinjoinServiceThunk(symbol));
         if (!api) return;
 
         const { backend, client } = api;
@@ -442,7 +442,7 @@ export const fetchAndUpdateAccount =
 
         const onProgress = (progress: ScanAccountProgress) => {
             // removes transactions if current checkpoint precedes latest stored checkpoint
-            dispatch(coinjoinAccountCheckReorg(account, progress.checkpoint));
+            dispatch(coinjoinAccountCheckReorgThunk(account, progress.checkpoint));
             // add discovered transactions (if any)
             dispatch(
                 coinjoinAccountAddTransactions({ account, transactions: progress.transactions }),
@@ -467,7 +467,7 @@ export const fetchAndUpdateAccount =
 
             onProgress({ checkpoint, transactions: pending });
 
-            dispatch(cleanPendingTransactions(account, pending));
+            dispatch(cleanPendingTransactionsThunk(account, pending));
 
             // get fresh state
             const transactions = getState().wallet.transactions.transactions[account.key];
@@ -512,7 +512,7 @@ export const fetchAndUpdateAccount =
                 );
 
                 // update account in CoinjoinClient
-                dispatch(updateClientAccount(account));
+                dispatch(updateClientAccountThunk(account));
             }
 
             dispatch(accountsActions.endCoinjoinAccountSync(account, 'ready'));
@@ -528,7 +528,7 @@ export const fetchAndUpdateAccount =
 
 type ClearCoinjoinInstancesThunkState = CoinjoinRootState;
 
-export const clearCoinjoinInstances =
+export const clearCoinjoinInstancesThunk =
     (symbol: CoinjoinSymbol) =>
     (dispatch: Dispatch, getState: () => ClearCoinjoinInstancesThunkState) => {
         const cjAccount = selectCoinjoinAccounts(getState()).find(a => a.symbol === symbol);
@@ -545,7 +545,7 @@ const handleError = (error: string) => (dispatch: Dispatch) => {
 
 type CreateCoinjoinAccountThunkState = DeviceRootState;
 
-export const createCoinjoinAccount =
+export const createCoinjoinAccountThunk =
     (network: Network, account: NetworkAccount) =>
     async (dispatch: Dispatch, getState: () => CreateCoinjoinAccountThunkState) => {
         if (account.accountType !== 'coinjoin') {
@@ -557,7 +557,7 @@ export const createCoinjoinAccount =
         }
 
         // initialize @trezor/coinjoin client
-        const api = await dispatch(coinjoinClientActions.initCoinjoinService(network.symbol));
+        const api = await dispatch(coinjoinClientActions.initCoinjoinServiceThunk(network.symbol));
         if (!api) {
             return;
         }
@@ -568,7 +568,7 @@ export const createCoinjoinAccount =
         const unlockPath = await TrezorConnect.unlockPath({ path: "m/10025'", device });
         if (!unlockPath.success) {
             dispatch(handleError(unlockPath.error.message));
-            dispatch(clearCoinjoinInstances(network.symbol));
+            dispatch(clearCoinjoinInstancesThunk(network.symbol));
             dispatch(coinjoinAccountPreloading(false));
 
             return;
@@ -586,7 +586,7 @@ export const createCoinjoinAccount =
         });
         if (!publicKey.success) {
             dispatch(handleError(publicKey.error.message));
-            dispatch(clearCoinjoinInstances(network.symbol));
+            dispatch(clearCoinjoinInstancesThunk(network.symbol));
             dispatch(coinjoinAccountPreloading(false));
 
             return;
@@ -624,7 +624,7 @@ export const createCoinjoinAccount =
 
         // switch to account
         dispatch(
-            goto({
+            gotoThunk({
                 routeName: 'wallet-index',
                 params: {
                     symbol: network.symbol,
@@ -635,19 +635,19 @@ export const createCoinjoinAccount =
         );
 
         // start discovery
-        return dispatch(fetchAndUpdateAccount(coinjoinAccount.payload));
+        return dispatch(fetchAndUpdateAccountThunk(coinjoinAccount.payload));
     };
 
 type RescanCoinjoinAccountThunkState = AccountsRootState & CoinjoinRootState;
 
-export const rescanCoinjoinAccount =
+export const rescanCoinjoinAccountThunk =
     (accountKey: AccountKey, fullRescan = false) =>
     async (dispatch: Dispatch, getState: () => RescanCoinjoinAccountThunkState) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
         if (account?.backendType !== 'coinjoin' || account.syncing) return;
         if (selectIsAnySessionInCriticalPhase(state)) return;
-        const api = await dispatch(coinjoinClientActions.initCoinjoinService(account.symbol));
+        const api = await dispatch(coinjoinClientActions.initCoinjoinServiceThunk(account.symbol));
         if (!api) return;
 
         // lock
@@ -671,12 +671,12 @@ export const rescanCoinjoinAccount =
         );
 
         // start discovery
-        return dispatch(fetchAndUpdateAccount(payload));
+        return dispatch(fetchAndUpdateAccountThunk(payload));
     };
 
 type AuthorizeCoinjoinThunkState = DeviceRootState;
 
-const authorizeCoinjoin =
+const authorizeCoinjoinThunk =
     (account: Account, coordinator: string, params: CoinjoinSessionParameters) =>
     async (dispatch: Dispatch, getState: () => AuthorizeCoinjoinThunkState) => {
         const device = selectSelectedDevice(getState());
@@ -713,7 +713,7 @@ const authorizeCoinjoin =
 type StartCoinjoinSessionThunkState = CoinjoinRootState;
 
 // called from coinjoin account UI
-export const startCoinjoinSession =
+export const startCoinjoinSessionThunk =
     (account: Account, params: CoinjoinSessionParameters) =>
     async (dispatch: Dispatch, getState: () => StartCoinjoinSessionThunkState) => {
         if (account.accountType !== 'coinjoin') {
@@ -721,7 +721,7 @@ export const startCoinjoinSession =
         }
 
         // initialize @trezor/coinjoin client
-        const api = await dispatch(coinjoinClientActions.initCoinjoinService(account.symbol));
+        const api = await dispatch(coinjoinClientActions.initCoinjoinServiceThunk(account.symbol));
         const coinjoinAccount = selectCoinjoinAccountByKey(getState(), account.key);
 
         if (!api || !coinjoinAccount) {
@@ -732,7 +732,7 @@ export const startCoinjoinSession =
 
         // authorize CoinjoinSession on Trezor
         const authResult = await dispatch(
-            authorizeCoinjoin(account, api.client.settings.coordinatorName, params),
+            authorizeCoinjoinThunk(account, api.client.settings.coordinatorName, params),
         );
 
         if (authResult) {
@@ -744,7 +744,7 @@ export const startCoinjoinSession =
                 }),
             );
             // switch to account
-            dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));
+            dispatch(gotoThunk({ routeName: 'wallet-index', preserveParams: true }));
         }
 
         dispatch(coinjoinSessionStarting(account.key, false));
@@ -759,7 +759,7 @@ type RestoreCoinjoinSessionThunkState = AccountsRootState &
 // try to restore current paused CoinjoinSession
 // use same parameters as in startCoinjoinSession but recalculate maxRounds value
 // if Trezor is already preauthorized it will not ask for confirmation
-export const restoreCoinjoinSession =
+export const restoreCoinjoinSessionThunk =
     (accountKey: AccountKey) =>
     async (dispatch: Dispatch, getState: () => RestoreCoinjoinSessionThunkState) => {
         // TODO: check if device is connected, passphrase is authorized...
@@ -839,7 +839,7 @@ export const restoreCoinjoinSession =
 
 type PauseAllCoinjoinSessionsThunkState = CoinjoinRootState;
 
-export const pauseAllCoinjoinSessions =
+export const pauseAllCoinjoinSessionsThunk =
     () => (dispatch: Dispatch, getState: () => PauseAllCoinjoinSessionsThunkState) => {
         const state = getState();
         const coinjoinAccounts = selectCoinjoinAccounts(state);
@@ -847,7 +847,7 @@ export const pauseAllCoinjoinSessions =
         coinjoinAccounts.forEach(account => {
             const hasRunningSession = selectIsAccountWithSessionByAccountKey(state, account.key);
             if (hasRunningSession) {
-                dispatch(coinjoinClientActions.pauseCoinjoinSession(account.key));
+                dispatch(coinjoinClientActions.pauseCoinjoinSessionThunk(account.key));
             }
         });
     };
@@ -862,7 +862,7 @@ type RestorePausedCoinjoinSessionsThunkState = CoinjoinRootState &
     TorRootState;
 
 // check for blocking conditions of interrupted sessions and restore those eligible
-export const restorePausedCoinjoinSessions =
+export const restorePausedCoinjoinSessionsThunk =
     () => (dispatch: Dispatch, getState: () => RestorePausedCoinjoinSessionsThunkState) => {
         const state = getState();
         const coinjoinAccounts = selectCoinjoinAccounts(state);
@@ -875,12 +875,12 @@ export const restorePausedCoinjoinSessions =
             return !hasSendFormOpen && !blocker && session?.paused;
         });
 
-        eligibleAccounts.forEach(account => dispatch(restoreCoinjoinSession(account.key)));
+        eligibleAccounts.forEach(account => dispatch(restoreCoinjoinSessionThunk(account.key)));
     };
 
 type StopCoinjoinAccountThunkState = CoinjoinRootState;
 
-export const stopCoinjoinAccount =
+export const stopCoinjoinAccountThunk =
     (account: Account) => (dispatch: Dispatch, getState: () => StopCoinjoinAccountThunkState) => {
         const cjAccount = selectCoinjoinAccountByKey(getState(), account.key);
 
@@ -892,7 +892,7 @@ export const stopCoinjoinAccount =
                     }),
                 );
             }
-            dispatch(coinjoinClientActions.stopCoinjoinSession(cjAccount.key));
+            dispatch(coinjoinClientActions.stopCoinjoinSessionThunk(cjAccount.key));
         }
     };
 
@@ -900,7 +900,7 @@ type StopCoinjoinSessionByDeviceIdThunkState = AccountsRootState &
     CoinjoinRootState &
     DeviceRootState;
 
-export const stopCoinjoinSessionByDeviceId =
+export const stopCoinjoinSessionByDeviceIdThunk =
     (deviceID: string) =>
     (dispatch: Dispatch, getState: () => StopCoinjoinSessionByDeviceIdThunkState) => {
         const state = getState();
@@ -929,14 +929,14 @@ export const stopCoinjoinSessionByDeviceId =
                     );
                 }
 
-                dispatch(coinjoinClientActions.stopCoinjoinSession(account.key));
+                dispatch(coinjoinClientActions.stopCoinjoinSessionThunk(account.key));
             }
         });
     };
 
 type RestoreCoinjoinAccountsThunkState = CoinjoinRootState;
 
-export const restoreCoinjoinAccounts =
+export const restoreCoinjoinAccountsThunk =
     () => (dispatch: Dispatch, getState: () => RestoreCoinjoinAccountsThunkState) => {
         const { coinjoin } = getState().wallet;
 
@@ -952,14 +952,14 @@ export const restoreCoinjoinAccounts =
         // async actions in sequence, initialize CoinjoinCService for each network
         return promiseAllSequence(
             coinjoinSymbols.map(
-                symbol => () => dispatch(coinjoinClientActions.initCoinjoinService(symbol)),
+                symbol => () => dispatch(coinjoinClientActions.initCoinjoinServiceThunk(symbol)),
             ),
         );
     };
 
 type ToggleAutostopCoinjoinThunkState = CoinjoinRootState;
 
-export const toggleAutostopCoinjoin =
+export const toggleAutostopCoinjoinThunk =
     (accountKey: AccountKey) =>
     (dispatch: Dispatch, getState: () => ToggleAutostopCoinjoinThunkState) => {
         const currentAccountState = selectSessionByAccountKey(getState(), accountKey);
@@ -975,7 +975,7 @@ export const toggleAutostopCoinjoin =
 
 type LogCoinjoinAccountsThunkState = CoinjoinRootState & TransactionsRootState;
 
-export const logCoinjoinAccounts =
+export const logCoinjoinAccountsThunk =
     () => (_: Dispatch, getState: () => LogCoinjoinAccountsThunkState) => {
         const {
             accounts,

--- a/suite/coinjoin/src/coinjoinClientActions.test.ts
+++ b/suite/coinjoin/src/coinjoinClientActions.test.ts
@@ -19,12 +19,12 @@ import { promiseAllSequence } from '@trezor/utils';
 import * as fixtures from './__fixtures__/coinjoinClientActions';
 import {
     clientEmitException,
-    initCoinjoinService,
+    initCoinjoinServiceThunk,
     onCoinjoinClientRequest,
-    onCoinjoinRoundChanged,
-    pauseCoinjoinSession,
+    onCoinjoinRoundChangedThunk,
+    pauseCoinjoinSessionThunk,
     setDebugSettings,
-    stopCoinjoinSession,
+    stopCoinjoinSessionThunk,
 } from './coinjoinClientActions';
 import { coinjoinMiddleware } from './coinjoinMiddleware';
 import { coinjoinReducer } from './coinjoinReducer';
@@ -109,7 +109,7 @@ describe('coinjoinClientActions', () => {
         jest.clearAllMocks();
     });
     fixtures.onCoinjoinRoundChanged.forEach(f => {
-        it(`onCoinjoinRoundChanged: ${f.description}`, async () => {
+        it(`onCoinjoinRoundChangedThunk: ${f.description}`, async () => {
             const store = initStore(f.state as Wallet);
             testMocks.setTrezorConnectFixtures(f.connect);
 
@@ -118,13 +118,13 @@ describe('coinjoinClientActions', () => {
                     f.params.map(
                         (round: any) => () =>
                             store.dispatch(
-                                onCoinjoinRoundChanged({ round }), // params are incomplete
+                                onCoinjoinRoundChangedThunk({ round }), // params are incomplete
                             ),
                     ),
                 );
             } else {
                 await store.dispatch(
-                    onCoinjoinRoundChanged({ round: f.params as any }), // params are incomplete
+                    onCoinjoinRoundChangedThunk({ round: f.params as any }), // params are incomplete
                 );
             }
 
@@ -180,7 +180,7 @@ describe('coinjoinClientActions', () => {
         });
     });
 
-    it('initCoinjoinService and restore prison', async () => {
+    it('initCoinjoinServiceThunk and restore prison', async () => {
         const store = initStore({
             accounts: [
                 {
@@ -227,8 +227,8 @@ describe('coinjoinClientActions', () => {
         } as any); // partial required state
 
         const spy = jest.spyOn(CoinjoinService, 'createInstance');
-        const cli1 = await store.dispatch(initCoinjoinService(btcSymbol));
-        const cli2 = await store.dispatch(initCoinjoinService(btcSymbol));
+        const cli1 = await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
+        const cli2 = await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
         expect(cli1).toEqual(cli2);
         expect(spy.mock.calls[0]?.[0]).toMatchObject({
             symbol: 'btc',
@@ -251,20 +251,20 @@ describe('coinjoinClientActions', () => {
 
         // for coverage, init same instance multiple times without waiting
         // eslint-disable-next-line jest/valid-expect-in-promise
-        store.dispatch(initCoinjoinService(testSymbol)).then(cli3 => {
+        store.dispatch(initCoinjoinServiceThunk(testSymbol)).then(cli3 => {
             expect(cli3?.client.settings.network).toEqual('test');
         });
-        const cli3a = await store.dispatch(initCoinjoinService(testSymbol));
+        const cli3a = await store.dispatch(initCoinjoinServiceThunk(testSymbol));
         expect(cli3a).toBe(undefined); // undefined because cli3 is not loaded yet
     });
 
-    it('initCoinjoinService and throw error', async () => {
+    it('initCoinjoinServiceThunk and throw error', async () => {
         const store = initStore();
-        const cli = await store.dispatch(initCoinjoinService(ltcSymbol)); // ltc not supported
+        const cli = await store.dispatch(initCoinjoinServiceThunk(ltcSymbol)); // ltc not supported
         expect(cli).toBe(undefined);
     });
 
-    it('initCoinjoinService and errors to enable', async () => {
+    it('initCoinjoinServiceThunk and errors to enable', async () => {
         const store = initStore();
         const spy = jest.spyOn(CoinjoinService, 'createInstance').mockImplementationOnce(
             () =>
@@ -274,7 +274,7 @@ describe('coinjoinClientActions', () => {
                     },
                 }) as any,
         );
-        const cli = await store.dispatch(initCoinjoinService(btcSymbol));
+        const cli = await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
         expect(cli).toBe(undefined);
         spy.mockClear();
     });
@@ -283,7 +283,7 @@ describe('coinjoinClientActions', () => {
         it(`CoinjoinClient events: ${f.description}`, async () => {
             const store = initStore(f.state as Wallet);
 
-            const cli = await store.dispatch(initCoinjoinService(btcSymbol));
+            const cli = await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
             cli?.client.emit(f.event as any, f.params);
 
             expect(store.getState().wallet.coinjoin).toMatchObject(f.result);
@@ -318,8 +318,8 @@ describe('coinjoinClientActions', () => {
     it('clientEmitException', async () => {
         const store = initStore();
 
-        const cli1 = await store.dispatch(initCoinjoinService(btcSymbol));
-        const cli2 = await store.dispatch(initCoinjoinService(testSymbol));
+        const cli1 = await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
+        const cli2 = await store.dispatch(initCoinjoinServiceThunk(testSymbol));
 
         if (!cli1 || !cli2) throw new Error('Client not initialized');
 
@@ -362,7 +362,7 @@ describe('coinjoinClientActions', () => {
 
         const store = initializeStore();
 
-        const cli = await store.dispatch(initCoinjoinService(btcSymbol));
+        const cli = await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
 
         if (!cli) throw new Error('Client not initialized');
 
@@ -401,12 +401,12 @@ describe('coinjoinClientActions', () => {
     });
 
     // for coverage: edge cases, missing data etc...
-    it('pauseCoinjoinSession without related account', () => {
+    it('pauseCoinjoinSessionThunk without related account', () => {
         const store = initStore();
-        store.dispatch(pauseCoinjoinSession(mockAccountKey({ descriptor: 'accountZ' })));
+        store.dispatch(pauseCoinjoinSessionThunk(mockAccountKey({ descriptor: 'accountZ' })));
     });
 
-    it('stopCoinjoinSession without connected device', async () => {
+    it('stopCoinjoinSessionThunk without connected device', async () => {
         const accountAKey = mockAccountKey({ descriptor: 'accountA' });
         const store = initStore({
             accounts: [{ key: accountAKey, symbol: 'btc' }],
@@ -414,12 +414,12 @@ describe('coinjoinClientActions', () => {
 
         testMocks.setTrezorConnectFixtures([{ success: false }]);
 
-        await store.dispatch(initCoinjoinService(btcSymbol));
+        await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
 
-        store.dispatch(stopCoinjoinSession(accountAKey));
+        store.dispatch(stopCoinjoinSessionThunk(accountAKey));
     });
 
-    it('stopCoinjoinSession with error from Trezor', async () => {
+    it('stopCoinjoinSessionThunk with error from Trezor', async () => {
         const accountAKey = mockAccountKey({ descriptor: 'accountA' });
         const store = initStore({
             accounts: [
@@ -435,14 +435,14 @@ describe('coinjoinClientActions', () => {
             { success: false, error: { message: 'Firmware error' } },
         ]);
 
-        await store.dispatch(initCoinjoinService(btcSymbol));
+        await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
 
-        store.dispatch(stopCoinjoinSession(accountAKey));
+        store.dispatch(stopCoinjoinSessionThunk(accountAKey));
 
         expect(TrezorConnect.cancelCoinjoinAuthorization).toHaveBeenCalledTimes(1);
     });
 
-    it('stopCoinjoinSession but not cancel authorization', async () => {
+    it('stopCoinjoinSessionThunk but not cancel authorization', async () => {
         const deviceBStaticSessionId: StaticSessionId = '1stTestnetAddress@device_b_id:0';
         const accountAKey = mockAccountKey({ descriptor: 'accountA' });
         const accountBKey = mockAccountKey({
@@ -478,16 +478,16 @@ describe('coinjoinClientActions', () => {
             },
         } as any);
 
-        await store.dispatch(initCoinjoinService(btcSymbol));
+        await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
 
-        store.dispatch(stopCoinjoinSession(accountAKey));
+        store.dispatch(stopCoinjoinSessionThunk(accountAKey));
 
         expect(TrezorConnect.cancelCoinjoinAuthorization).toHaveBeenCalledTimes(0);
     });
 
     it('CoinjoinClient events', async () => {
         const store = initStore();
-        const cli = await store.dispatch(initCoinjoinService(btcSymbol));
+        const cli = await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
 
         // other requests are covered by fixtures.getOwnershipProof and fixtures.signCoinjoinTx
         cli?.client.emit('request', [{ type: 'unknown' } as any]);

--- a/suite/coinjoin/src/coinjoinClientActions.ts
+++ b/suite/coinjoin/src/coinjoinClientActions.ts
@@ -172,7 +172,7 @@ export const getCoinjoinClient = (symbol: CoinjoinSymbol) =>
 
 type UnregisterByAccountKeyThunkState = AccountsRootState;
 
-export const unregisterByAccountKey =
+export const unregisterByAccountKeyThunk =
     (accountKey: string) =>
     (_dispatch: Dispatch, getState: () => UnregisterByAccountKeyThunkState) => {
         const accounts = selectAccounts(getState());
@@ -190,7 +190,7 @@ export const unregisterByAccountKey =
 
 export const endCoinjoinSession = (accountKey: string) => (dispatch: Dispatch) => {
     dispatch(coinjoinSessionCompleted(accountKey));
-    dispatch(unregisterByAccountKey(accountKey));
+    dispatch(unregisterByAccountKeyThunk(accountKey));
 };
 
 type SetBusyScreenThunkState = AccountsRootState & DeviceRootState;
@@ -202,7 +202,7 @@ type SetBusyScreenThunkState = AccountsRootState & DeviceRootState;
  * - N accounts on 1 devices (like two passphrases)
  * - N accounts on X devices (like two physical device)
  */
-export const setBusyScreen =
+export const setBusyScreenThunk =
     (accountKeys: string[], expiry?: number) =>
     (_dispatch: Dispatch, getState: () => SetBusyScreenThunkState) => {
         const accounts = selectAccounts(getState());
@@ -247,7 +247,7 @@ export const setBusyScreen =
 
 type HasCriticalPhaseModalThunkState = ModalRootState;
 
-export const hasCriticalPhaseModal =
+export const hasCriticalPhaseModalThunk =
     () => (_: Dispatch, getState: () => HasCriticalPhaseModalThunkState) => {
         const modal = selectModal(getState());
 
@@ -255,7 +255,7 @@ export const hasCriticalPhaseModal =
     };
 
 export const closeCriticalPhaseModal = () => (dispatch: Dispatch) => {
-    if (dispatch(hasCriticalPhaseModal())) {
+    if (dispatch(hasCriticalPhaseModalThunk())) {
         dispatch(closeModal());
     }
 };
@@ -263,7 +263,7 @@ export const closeCriticalPhaseModal = () => (dispatch: Dispatch) => {
 type PauseCoinjoinSessionThunkState = AccountsRootState;
 
 // called from coinjoin account UI or exceptions like device disconnection, forget wallet/account etc.
-export const pauseCoinjoinSession =
+export const pauseCoinjoinSessionThunk =
     (accountKey: AccountKey) =>
     (dispatch: Dispatch, getState: () => PauseCoinjoinSessionThunkState) => {
         const account = selectAccountByKey(getState(), accountKey);
@@ -284,7 +284,7 @@ export const pauseCoinjoinSession =
 type StopCoinjoinSessionThunkState = AccountsRootState & CoinjoinRootState & DeviceRootState;
 
 // called from coinjoin account UI or exceptions like device disconnection, forget wallet/account etc.
-export const stopCoinjoinSession =
+export const stopCoinjoinSessionThunk =
     (accountKey: AccountKey) =>
     async (dispatch: Dispatch, getState: () => StopCoinjoinSessionThunkState) => {
         const account = selectAccountByKey(getState(), accountKey);
@@ -344,7 +344,7 @@ export const stopCoinjoinSession =
 
 type OnCoinjoinRoundChangedThunkState = AccountsRootState & CoinjoinRootState;
 
-export const onCoinjoinRoundChanged =
+export const onCoinjoinRoundChangedThunk =
     ({ round }: CoinjoinRoundEvent) =>
     async (dispatch: Dispatch, getState: () => OnCoinjoinRoundChangedThunkState) => {
         const coinjoinAccounts = selectCoinjoinAccounts(getState());
@@ -392,7 +392,7 @@ export const onCoinjoinRoundChanged =
         // critical actions should be triggered only once
         if (phaseChanged) {
             if (round.phase === RoundPhase.Ended) {
-                await dispatch(setBusyScreen(accountKeys));
+                await dispatch(setBusyScreenThunk(accountKeys));
                 dispatch(closeCriticalPhaseModal());
 
                 if (round.endRoundState === EndRoundState.TransactionBroadcasted) {
@@ -419,13 +419,13 @@ export const onCoinjoinRoundChanged =
                 );
 
                 accountsWithAutostop.forEach(({ account: { key } }) => {
-                    dispatch(stopCoinjoinSession(key));
+                    dispatch(stopCoinjoinSessionThunk(key));
                 });
             } else if (
                 round.phase > RoundPhase.InputRegistration &&
-                !dispatch(hasCriticalPhaseModal())
+                !dispatch(hasCriticalPhaseModalThunk())
             ) {
-                await dispatch(setBusyScreen(accountKeys, round.roundDeadline - Date.now()));
+                await dispatch(setBusyScreenThunk(accountKeys, round.roundDeadline - Date.now()));
 
                 dispatch(
                     openModal({
@@ -446,7 +446,7 @@ type GetOwnershipProofThunkState = AccountsRootState &
     DeviceRootState &
     LocksRootState;
 
-const getOwnershipProof =
+const getOwnershipProofThunk =
     (request: Extract<CoinjoinRequestEvent, { type: 'ownership' }>) =>
     async (_dispatch: Dispatch, getState: () => GetOwnershipProofThunkState) => {
         const coinjoinAccounts = selectCoinjoinAccounts(getState());
@@ -569,7 +569,7 @@ type SignCoinjoinTxThunkState = AccountsRootState &
     DeviceRootState &
     WalletSettingsRootState;
 
-const signCoinjoinTx =
+const signCoinjoinTxThunk =
     (request: Extract<CoinjoinRequestEvent, { type: 'signature' }>) =>
     async (dispatch: Dispatch, getState: () => SignCoinjoinTxThunkState) => {
         const coinjoinAccounts = selectCoinjoinAccounts(getState());
@@ -698,7 +698,7 @@ const signCoinjoinTx =
         );
 
         // disable busy screen
-        await dispatch(setBusyScreen(Object.keys(groupUtxosByAccount)));
+        await dispatch(setBusyScreenThunk(Object.keys(groupUtxosByAccount)));
         // and close 'critical-coinjoin-phase' modal
         dispatch(closeCriticalPhaseModal());
 
@@ -716,10 +716,10 @@ export const onCoinjoinClientRequest = (data: CoinjoinRequestEvent[]) => (dispat
     Promise.all(
         data.map(request => {
             if (request.type === 'ownership') {
-                return dispatch(getOwnershipProof(request));
+                return dispatch(getOwnershipProofThunk(request));
             }
             if (request.type === 'signature') {
-                return dispatch(signCoinjoinTx(request));
+                return dispatch(signCoinjoinTxThunk(request));
             }
 
             return request;
@@ -728,7 +728,7 @@ export const onCoinjoinClientRequest = (data: CoinjoinRequestEvent[]) => (dispat
 
 type InitCoinjoinServiceThunkState = AccountsRootState & CoinjoinRootState & MessageSystemRootState;
 
-export const initCoinjoinService =
+export const initCoinjoinServiceThunk =
     (symbol: Account['symbol']) =>
     async (dispatch: Dispatch, getState: () => InitCoinjoinServiceThunkState) => {
         const clients = selectCoinjoinClients(getState());
@@ -819,7 +819,7 @@ export const initCoinjoinService =
             // handle prison event
             client.on('prison', event => dispatch(clientOnPrisonEvent(event)));
             // handle active round change
-            client.on('round', event => dispatch(onCoinjoinRoundChanged(event)));
+            client.on('round', event => dispatch(onCoinjoinRoundChangedThunk(event)));
             // handle requests (ownership proof, sign transaction)
             client.on('request', async data => {
                 const response = await dispatch(onCoinjoinClientRequest(data));

--- a/suite/coinjoin/src/coinjoinMiddleware.ts
+++ b/suite/coinjoin/src/coinjoinMiddleware.ts
@@ -81,12 +81,12 @@ export const coinjoinMiddleware =
         }
 
         if (onSuiteInit.match(action)) {
-            api.dispatch(coinjoinAccountActions.logCoinjoinAccounts());
+            api.dispatch(coinjoinAccountActions.logCoinjoinAccountsThunk());
         }
 
         if (accountsActions.removeAccount.match(action)) {
             action.payload.forEach(account =>
-                api.dispatch(coinjoinAccountActions.stopCoinjoinAccount(account)),
+                api.dispatch(coinjoinAccountActions.stopCoinjoinAccountThunk(account)),
             );
         }
 
@@ -101,7 +101,7 @@ export const coinjoinMiddleware =
                 .forEach(
                     symbol =>
                         isCoinjoinSupportedSymbol(symbol) &&
-                        api.dispatch(coinjoinAccountActions.clearCoinjoinInstances(symbol)),
+                        api.dispatch(coinjoinAccountActions.clearCoinjoinInstancesThunk(symbol)),
                 );
         }
 
@@ -116,7 +116,7 @@ export const coinjoinMiddleware =
             } = action.payload;
             accountKeys.forEach((accountKey: string) => {
                 api.dispatch(
-                    coinjoinAccountActions.createPendingTransaction(
+                    coinjoinAccountActions.createPendingTransactionThunk(
                         accountKey as AccountKey,
                         broadcastedTxDetails,
                     ),
@@ -131,7 +131,7 @@ export const coinjoinMiddleware =
             action.payload.transactions.some(tx => 'deadline' in tx)
         ) {
             api.dispatch(
-                coinjoinAccountActions.updatePendingAccountInfo(action.payload.account.key),
+                coinjoinAccountActions.updatePendingAccountInfoThunk(action.payload.account.key),
             );
         }
 
@@ -139,7 +139,7 @@ export const coinjoinMiddleware =
             const state = api.getState();
             const isCoinjoinBlockedByTor = !selectIsTorEnabled(state);
             if (!isCoinjoinBlockedByTor) {
-                api.dispatch(coinjoinAccountActions.restoreCoinjoinAccounts());
+                api.dispatch(coinjoinAccountActions.restoreCoinjoinAccountsThunk());
             }
         }
 
@@ -156,7 +156,7 @@ export const coinjoinMiddleware =
                     a => a.accountType === 'coinjoin' && (!symbol || a.symbol === symbol),
                 );
                 coinjoinAccounts.forEach(a =>
-                    api.dispatch(coinjoinAccountActions.fetchAndUpdateAccount(a)),
+                    api.dispatch(coinjoinAccountActions.fetchAndUpdateAccountThunk(a)),
                 );
             }
         }
@@ -164,7 +164,9 @@ export const coinjoinMiddleware =
         // Pause coinjoin session when device disconnects.
         // This is not treated a temporary interruption with automatic restore because the user probably disconnects the device willingly.
         if (deviceActions.deviceDisconnect.match(action) && action.payload.id) {
-            api.dispatch(coinjoinAccountActions.stopCoinjoinSessionByDeviceId(action.payload.id));
+            api.dispatch(
+                coinjoinAccountActions.stopCoinjoinSessionByDeviceIdThunk(action.payload.id),
+            );
         }
 
         // Pause/restore coinjoin session when Suite goes offline/online.
@@ -179,10 +181,10 @@ export const coinjoinMiddleware =
                     );
                 } else {
                     // pause **only** if not in critical phase
-                    api.dispatch(coinjoinAccountActions.pauseAllCoinjoinSessions());
+                    api.dispatch(coinjoinAccountActions.pauseAllCoinjoinSessionsThunk());
                 }
             } else if (action.payload === true) {
-                api.dispatch(coinjoinAccountActions.restorePausedCoinjoinSessions());
+                api.dispatch(coinjoinAccountActions.restorePausedCoinjoinSessionsThunk());
             }
         }
 
@@ -197,9 +199,9 @@ export const coinjoinMiddleware =
                         ),
                     );
                 }
-                api.dispatch(coinjoinAccountActions.pauseAllCoinjoinSessions());
+                api.dispatch(coinjoinAccountActions.pauseAllCoinjoinSessionsThunk());
             } else if (action.payload === 'Enabled') {
-                api.dispatch(coinjoinAccountActions.restorePausedCoinjoinSessions());
+                api.dispatch(coinjoinAccountActions.restorePausedCoinjoinSessionsThunk());
             }
         }
 
@@ -213,14 +215,16 @@ export const coinjoinMiddleware =
                 const isAccountInCriticalPhase =
                     selectIsAccountWithSessionInCriticalPhaseByAccountKey(state, accountKey);
                 if (!isAccountInCriticalPhase) {
-                    api.dispatch(coinjoinClientActions.pauseCoinjoinSession(accountKey));
+                    api.dispatch(coinjoinClientActions.pauseCoinjoinSessionThunk(accountKey));
                 }
             } else if (status === 'ready' && session?.paused) {
                 const account = selectAccountByKey(state, accountKey);
                 if (account) {
                     const blocker = selectCoinjoinSessionBlockerByAccountKey(state, account.key);
                     if (!blocker)
-                        api.dispatch(coinjoinAccountActions.restoreCoinjoinSession(account.key));
+                        api.dispatch(
+                            coinjoinAccountActions.restoreCoinjoinSessionThunk(account.key),
+                        );
                 }
             }
         }
@@ -233,7 +237,7 @@ export const coinjoinMiddleware =
             if (!isDeviceOrUiLocked) {
                 const previousRoute = selectSettingsBackRoute(state).name;
                 if (previousRoute === 'wallet-send') {
-                    api.dispatch(coinjoinAccountActions.restorePausedCoinjoinSessions());
+                    api.dispatch(coinjoinAccountActions.restorePausedCoinjoinSessionsThunk());
                 } else {
                     const accountKey = state.wallet.selectedAccount.account?.key;
                     if (accountKey) {
@@ -243,7 +247,9 @@ export const coinjoinMiddleware =
                             !session?.paused &&
                             !session?.starting
                         ) {
-                            api.dispatch(coinjoinClientActions.pauseCoinjoinSession(accountKey));
+                            api.dispatch(
+                                coinjoinClientActions.pauseCoinjoinSessionThunk(accountKey),
+                            );
                         }
                     }
                 }
@@ -296,7 +302,7 @@ export const coinjoinMiddleware =
                     action.payload.round.phase === RoundPhase.Ended;
 
                 if (!isAnySessionInCriticalPhase || hasCriticalPhaseJustEnded) {
-                    api.dispatch(coinjoinAccountActions.pauseAllCoinjoinSessions());
+                    api.dispatch(coinjoinAccountActions.pauseAllCoinjoinSessionsThunk());
                 }
             }
         }
@@ -310,7 +316,9 @@ export const coinjoinMiddleware =
 
             if (action.payload.phase === SessionPhase.CriticalError && !isAlreadyPaused) {
                 action.payload.accountKeys.forEach((key: string) =>
-                    api.dispatch(coinjoinClientActions.pauseCoinjoinSession(key as AccountKey)),
+                    api.dispatch(
+                        coinjoinClientActions.pauseCoinjoinSessionThunk(key as AccountKey),
+                    ),
                 );
                 api.dispatch(addToast({ type: 'coinjoin-interrupted' }));
             }

--- a/suite/desktop-update/src/quickActions/updateQuickActionTypes.ts
+++ b/suite/desktop-update/src/quickActions/updateQuickActionTypes.ts
@@ -1,4 +1,4 @@
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { type Dispatch } from '@suite-common/redux-utils';
 import { type IconComponent, type UIIntent } from '@trezor/components';
 import { ArrowDownIcon, ArrowsClockwiseFilledIcon, CheckIcon, PlugsIcon } from '@trezor/icons';
@@ -40,7 +40,7 @@ type OnClickCallback = ((params: { dispatch: Dispatch }) => void) | null;
 export const mapDeviceUpdateToClick: Record<UpdateStatusDevice, OnClickCallback> = {
     disconnected: null,
     'up-to-date': null,
-    'update-available': ({ dispatch }) => dispatch(goto({ routeName: 'firmware-index' })),
+    'update-available': ({ dispatch }) => dispatch(gotoThunk({ routeName: 'firmware-index' })),
 };
 
 export const mapSuiteUpdateToClick: Record<UpdateStatusSuite, OnClickCallback> = {

--- a/suite/discovery/src/discoveryMiddleware.test.ts
+++ b/suite/discovery/src/discoveryMiddleware.test.ts
@@ -151,7 +151,7 @@ const createObserveSelectedDeviceFulfilledAction = (payload: {
     isDeviceChanged: boolean;
     isDeviceBecomingAcquired: boolean;
     isDeviceBecomingConnected: boolean;
-}) => walletCore.observeSelectedDevice.fulfilled(payload, 'request-id', undefined);
+}) => walletCore.observeSelectedDeviceThunk.fulfilled(payload, 'request-id', undefined);
 
 const fixtures: Fixture[] = [
     {

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -6,7 +6,7 @@ import {
 } from '@suite/authenticity-checks';
 import { type LocksRootState } from '@suite/locks';
 import { type RouterRootState, routerAppChanged } from '@suite/router';
-import { connectPopupCallThunkInner } from '@suite-common/connect-popup';
+import { connectPopupCallInnerThunk } from '@suite-common/connect-popup';
 import { deviceActions, selectSelectedDevice } from '@suite-common/device';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { type ThpRootState, selectThpAutoconnectStep, thpActions } from '@suite-common/thp';
@@ -14,7 +14,7 @@ import {
     type WalletCoreCompoundRootState,
     accountsActions,
     changeNetworks,
-    observeSelectedDevice,
+    observeSelectedDeviceThunk,
     selectShouldRediscover,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
@@ -42,7 +42,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps<
     const device = selectSelectedDevice(getState());
     if (!device) return action;
 
-    const isObserveSelectedDeviceMatch = observeSelectedDevice.fulfilled.match(action);
+    const isObserveSelectedDeviceMatch = observeSelectedDeviceThunk.fulfilled.match(action);
     const { isDeviceBecomingAcquired, isDeviceBecomingConnected } = isObserveSelectedDeviceMatch
         ? action.payload
         : { isDeviceBecomingAcquired: false, isDeviceBecomingConnected: false };
@@ -76,7 +76,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps<
         isTHPAutoconnectFinished || // now that the THP Autoconnect was finished, resume the delayed discovery
         routerAppChanged.match(action) || // may no longer be one of the apps where discovery is disabled
         deviceActions.dismissFirmwareAuthenticityCheck.match(action) || // may no longer be device compromised
-        connectPopupCallThunkInner.fulfilled.match(action) ||
+        connectPopupCallInnerThunk.fulfilled.match(action) ||
         deviceActions.selectDevice.match(action) ||
         changeNetworks.match(action) ||
         accountsActions.updateAccount.match(action) || // empty account can become nonempty

--- a/suite/feature-feedback/src/components/FeedbackFormModalManager.tsx
+++ b/suite/feature-feedback/src/components/FeedbackFormModalManager.tsx
@@ -12,7 +12,7 @@ import {
     type Rating,
     buildUserFeedbackData,
     selectPendingFeedbackFeature,
-    sendFeedbackAction,
+    sendFeedbackThunk,
 } from '@suite-common/feedback';
 import { useDispatch } from '@suite-common/redux-utils';
 import { SmileyIcon } from '@trezor/icons';
@@ -48,7 +48,7 @@ export const FeedbackFormManager = () => {
         const userData = buildUserFeedbackData();
 
         dispatch(
-            sendFeedbackAction({
+            sendFeedbackThunk({
                 type: 'SUGGESTION',
                 payload: {
                     category: (experimentalFeedbackFeatureSet as ReadonlySet<string>).has(

--- a/suite/firmware-upgrade/src/FirmwareUpgradeNeededModal.tsx
+++ b/suite/firmware-upgrade/src/FirmwareUpgradeNeededModal.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { Card, Modal, Paragraph } from '@trezor/components';
@@ -29,7 +29,7 @@ export const FirmwareUpgradeNeededModal = ({
         // Update will disconnect device in the process and our Firmware Update
         // flow won't allow us to navigate back. So we just redirect the user
         // and close the modal.
-        dispatch(goto({ routeName: 'firmware-index', params: { cancelable: true } }));
+        dispatch(gotoThunk({ routeName: 'firmware-index', params: { cancelable: true } }));
         onClose();
     };
 

--- a/suite/flags/src/flagsThunks.test.ts
+++ b/suite/flags/src/flagsThunks.test.ts
@@ -2,7 +2,7 @@ import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
 import { createTestStore } from '@suite-common/test-utils';
 
 import { type FlagsState, flagsInitialState, prepareFlagsReducer } from './flagsSlice';
-import { initialRunCompleted } from './flagsThunks';
+import { initialRunCompletedThunk } from './flagsThunks';
 
 const flagsReducer = prepareFlagsReducer({
     actionTypes: { storageLoad: mockActionType('storageLoad') },
@@ -19,31 +19,31 @@ const initStore = (flags?: Partial<FlagsState>) =>
 describe('initialRunCompleted', () => {
     it('should set initialRun to false when initialRun is true', async () => {
         const store = initStore();
-        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
+        await store.dispatch(initialRunCompletedThunk({ isFreshDeviceSetup: true }));
         expect(store.getState().flags.initialRun).toBe(false);
     });
 
     it('should set initialRun to false when initialRun is already false', async () => {
         const store = initStore({ initialRun: false });
-        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: false }));
+        await store.dispatch(initialRunCompletedThunk({ isFreshDeviceSetup: false }));
         expect(store.getState().flags.initialRun).toBe(false);
     });
 
     it('should make a freshly set up device eligible for the onboarding feedback banner', async () => {
         const store = initStore({ showOnboardingFeedbackBanner: false });
-        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
+        await store.dispatch(initialRunCompletedThunk({ isFreshDeviceSetup: true }));
         expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(true);
     });
 
     it('should re-enable the onboarding feedback banner when a returning user sets up a device again', async () => {
         const store = initStore({ initialRun: false, showOnboardingFeedbackBanner: false });
-        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
+        await store.dispatch(initialRunCompletedThunk({ isFreshDeviceSetup: true }));
         expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(true);
     });
 
     it('should not enable the onboarding feedback banner when only pairing an already set up device', async () => {
         const store = initStore({ showOnboardingFeedbackBanner: false });
-        await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: false }));
+        await store.dispatch(initialRunCompletedThunk({ isFreshDeviceSetup: false }));
         expect(store.getState().flags.showOnboardingFeedbackBanner).toBe(false);
     });
 });

--- a/suite/flags/src/flagsThunks.ts
+++ b/suite/flags/src/flagsThunks.ts
@@ -9,7 +9,7 @@ type InitialRunCompletedParams = {
     isFreshDeviceSetup: boolean;
 };
 
-export const initialRunCompleted = createThunk<void, InitialRunCompletedParams, void>(
+export const initialRunCompletedThunk = createThunk<void, InitialRunCompletedParams, void>(
     `${FLAGS_MODULE_PREFIX}/initialRunCompleted`,
     ({ isFreshDeviceSetup }, { dispatch }) => {
         dispatch(setFlag({ key: 'initialRun', value: false }));

--- a/suite/labeling/src/Labeling.tsx
+++ b/suite/labeling/src/Labeling.tsx
@@ -110,7 +110,7 @@ export const Labeling = ({
                 }
             } else {
                 return await dispatch(
-                    metadataLabelingActions.init(
+                    metadataLabelingActions.initThunk(
                         // Provide force=true argument (user wants to enable metadata).
                         true,
                         // If this is wallet(device) label, provide unique identifier entityKey which equals to device.state.
@@ -164,7 +164,10 @@ export const Labeling = ({
                 return true;
             } else {
                 return await dispatch(
-                    metadataLabelingActions.addMetadata({ ...payload, value: value || undefined }),
+                    metadataLabelingActions.addMetadataThunk({
+                        ...payload,
+                        value: value || undefined,
+                    }),
                 );
             }
         },

--- a/suite/labeling/src/LabelingSettings.tsx
+++ b/suite/labeling/src/LabelingSettings.tsx
@@ -130,7 +130,7 @@ export const LabelingSettings = () => {
     const handleLegacyOptionSelect = async () => {
         await turnOffSuiteSync();
         if (legacyMetadataState.enabled === false) {
-            dispatch(metadataLabelingActions.init(true));
+            dispatch(metadataLabelingActions.initThunk(true));
         }
     };
 

--- a/suite/message-system/src/ContextMessage.tsx
+++ b/suite/message-system/src/ContextMessage.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { getTorUrlIfAvailable } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { type Route, goto } from '@suite/router';
+import { type Route, gotoThunk } from '@suite/router';
 import { selectLanguage, selectTorOnionLinks } from '@suite/settings';
 import { selectIsTorEnabled } from '@suite/tor';
 import {
@@ -51,7 +51,11 @@ export const ContextMessage = ({ context }: ContextMessageProps) => {
             action === 'internal-link'
                 ? () =>
                       dispatch(
-                          goto({ routeName: link as Route['name'], anchor, preserveParams: true }),
+                          gotoThunk({
+                              routeName: link as Route['name'],
+                              anchor,
+                              preserveParams: true,
+                          }),
                       )
                 : () =>
                       window.open(

--- a/suite/message-system/src/KillswitchMessageScreen.tsx
+++ b/suite/message-system/src/KillswitchMessageScreen.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useExternalLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { type Route, goto } from '@suite/router';
+import { type Route, gotoThunk } from '@suite/router';
 import { selectLanguage } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import {
@@ -32,7 +32,7 @@ export const CtaButton = ({ ctaLabel, ctaLink, isExternalCta }: CtaButtonProps) 
         if (isExternalCta) {
             window.open(externalLink, '_blank');
         } else {
-            dispatch(goto({ routeName: ctaLink as Route['name'], preserveParams: true }));
+            dispatch(gotoThunk({ routeName: ctaLink as Route['name'], preserveParams: true }));
         }
     };
 

--- a/suite/message-system/src/MessageSystemButton.tsx
+++ b/suite/message-system/src/MessageSystemButton.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { getTorUrlIfAvailable } from '@suite/external-links';
-import { type Route, goto } from '@suite/router';
+import { type Route, gotoThunk } from '@suite/router';
 import { selectLanguage, selectTorOnionLinks } from '@suite/settings';
 import { selectIsTorEnabled } from '@suite/tor';
 import { resolveMessageContent } from '@suite-common/message-system';
@@ -27,7 +27,9 @@ export const MessageSystemButton = ({ cta, id, ...props }: MessageSystemButtonPr
     const onClick = () => {
         switch (action) {
             case 'internal-link':
-                dispatch(goto({ routeName: link as Route['name'], anchor, preserveParams: true }));
+                dispatch(
+                    gotoThunk({ routeName: link as Route['name'], anchor, preserveParams: true }),
+                );
                 break;
             case 'external-link':
                 window.open(

--- a/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
+++ b/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { Translation } from '@suite/intl';
 import {
     MetadataProviderSelectionModal,
-    connectProvider,
+    connectProviderThunk,
     metadataActions,
     metadataLabelingActions,
     selectSelectedProviderForLabels,
@@ -59,7 +59,7 @@ export const LegacyLabelingMigrationModal = ({
         const isProviderAlreadyConnected = selectedProvider?.type === providerType;
 
         if (!isProviderAlreadyConnected) {
-            const providerConnected = await dispatch(connectProvider({ type: providerType }));
+            const providerConnected = await dispatch(connectProviderThunk({ type: providerType }));
 
             if (providerConnected === 'window closed') {
                 setProviderLoading(null);
@@ -83,7 +83,7 @@ export const LegacyLabelingMigrationModal = ({
         }
 
         const initialized = await dispatch(
-            metadataLabelingActions.init(true, selectedDevice.state.staticSessionId),
+            metadataLabelingActions.initThunk(true, selectedDevice.state.staticSessionId),
         );
 
         if (!initialized) {

--- a/suite/metadata/src/MetadataProviderModal.tsx
+++ b/suite/metadata/src/MetadataProviderModal.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from '@suite-common/redux-utils';
 import type { Deferred } from '@trezor/utils';
 
 import { MetadataProviderSelectionModal } from './MetadataProviderSelectionModal';
-import { connectProvider } from './metadataProviderThunks';
+import { connectProviderThunk } from './metadataProviderThunks';
 
 type MetadataProviderModalProps = {
     onCancel: () => void;
@@ -26,7 +26,7 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
 
     const connect = async (type: MetadataProviderType) => {
         setIsLoading(type);
-        const result = await dispatch(connectProvider({ type }));
+        const result = await dispatch(connectProviderThunk({ type }));
         // window close indicates user action, user knows what happened, no need to show an error message
         if (result === 'window closed') {
             setIsLoading('');

--- a/suite/metadata/src/__fixtures__/metadataActions.ts
+++ b/suite/metadata/src/__fixtures__/metadataActions.ts
@@ -16,7 +16,9 @@ type Fixture<T extends (...a: any) => any> = {
     result?: any;
 };
 
-const setDeviceMetadataKey: Fixture<(typeof metadataLabelingActions)['setDeviceMetadataKey']>[] = [
+const setDeviceMetadataKey: Fixture<
+    (typeof metadataLabelingActions)['setDeviceMetadataKeyThunk']
+>[] = [
     {
         description: `Metadata not enabled`,
         params: [
@@ -87,42 +89,43 @@ const setDeviceMetadataKey: Fixture<(typeof metadataLabelingActions)['setDeviceM
     },
 ];
 
-const setAccountMetadataKey: Fixture<(typeof metadataLabelingActions)['setAccountMetadataKey']>[] =
-    [
-        {
-            description: `Account m/49'/0'/0'`,
-            initialState: {
-                device: {
-                    state: { staticSessionId: '1stTestnetAddress@device_id:0' },
-                    metadata: {
-                        1: {
-                            key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
-                        },
-                    },
-                },
-            },
-            params: [
-                mockWalletAccount({
-                    symbol: 'btc',
-                    descriptor: asAccountDescriptor('btc1'),
-                    metadata: {
-                        key: 'xpub6CVKsQYXc9awxgV1tWbG4foDvdcnieK2JkbpPEBKB5WwAPKBZ1mstLbKVB4ov7QzxzjaxNK6EfmNY5Jsk2cG26EVcEkycGW4tchT2dyUhrx',
-                    },
-                }),
-            ],
-            result: {
+const setAccountMetadataKey: Fixture<
+    (typeof metadataLabelingActions)['setAccountMetadataKeyThunk']
+>[] = [
+    {
+        description: `Account m/49'/0'/0'`,
+        initialState: {
+            device: {
+                state: { staticSessionId: '1stTestnetAddress@device_id:0' },
                 metadata: {
                     1: {
-                        fileName:
-                            '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85.mtdt',
-                        aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
+                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                     },
                 },
             },
         },
-    ];
+        params: [
+            mockWalletAccount({
+                symbol: 'btc',
+                descriptor: asAccountDescriptor('btc1'),
+                metadata: {
+                    key: 'xpub6CVKsQYXc9awxgV1tWbG4foDvdcnieK2JkbpPEBKB5WwAPKBZ1mstLbKVB4ov7QzxzjaxNK6EfmNY5Jsk2cG26EVcEkycGW4tchT2dyUhrx',
+                },
+            }),
+        ],
+        result: {
+            metadata: {
+                1: {
+                    fileName:
+                        '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85.mtdt',
+                    aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
+                },
+            },
+        },
+    },
+];
 
-const addDeviceMetadata: Fixture<(typeof metadataLabelingActions)['addDeviceMetadata']>[] = [
+const addDeviceMetadata: Fixture<(typeof metadataLabelingActions)['addDeviceMetadataThunk']>[] = [
     {
         description: `Without device`,
         initialState: {
@@ -159,7 +162,7 @@ const addDeviceMetadata: Fixture<(typeof metadataLabelingActions)['addDeviceMeta
     },
 ];
 
-const addAccountMetadata: Fixture<(typeof metadataLabelingActions)['addAccountMetadata']>[] = [
+const addAccountMetadata: Fixture<(typeof metadataLabelingActions)['addAccountMetadataThunk']>[] = [
     {
         description: `Without provider`,
         initialState: {
@@ -331,7 +334,7 @@ const addAccountMetadata: Fixture<(typeof metadataLabelingActions)['addAccountMe
     },
 ];
 
-const connectProvider: Fixture<(typeof metadataProviderActions)['connectProvider']>[] = [
+const connectProvider: Fixture<(typeof metadataProviderActions)['connectProviderThunk']>[] = [
     {
         description: 'Dropbox',
         initialState: {
@@ -363,7 +366,7 @@ const connectProvider: Fixture<(typeof metadataProviderActions)['connectProvider
     // todo: singleton (instance) behavior
 ];
 
-const addMetadata: Fixture<(typeof metadataLabelingActions)['addMetadata']>[] = [
+const addMetadata: Fixture<(typeof metadataLabelingActions)['addMetadataThunk']>[] = [
     {
         description: 'does not need update',
         initialState: {
@@ -463,7 +466,7 @@ export const disableMetadata: Fixture<(typeof metadataThunks)['disableMetadata']
     },
 ];
 
-const init: Fixture<(typeof metadataLabelingActions)['init']>[] = [
+const init: Fixture<(typeof metadataLabelingActions)['initThunk']>[] = [
     {
         description: 'device without state',
         initialState: {
@@ -577,7 +580,7 @@ const init: Fixture<(typeof metadataLabelingActions)['init']>[] = [
     },
 ];
 
-const disposeMetadata: Fixture<(typeof metadataThunks)['disposeMetadata']>[] = [
+const disposeMetadata: Fixture<(typeof metadataThunks)['disposeMetadataThunk']>[] = [
     {
         description: '',
         initialState: {
@@ -619,7 +622,7 @@ const disposeMetadata: Fixture<(typeof metadataThunks)['disposeMetadata']>[] = [
     },
 ];
 
-const disposeMetadataKeys: Fixture<(typeof metadataThunks)['disposeMetadataKeys']>[] = [
+const disposeMetadataKeys: Fixture<(typeof metadataThunks)['disposeMetadataKeysThunk']>[] = [
     {
         description: 'keys',
         initialState: {

--- a/suite/metadata/src/metadataActions.test.ts
+++ b/suite/metadata/src/metadataActions.test.ts
@@ -144,7 +144,7 @@ const initStore = (state: State) => {
             switch (action.payload.type) {
                 case 'metadata-provider':
                     await store.dispatch(
-                        metadataProviderActions.connectProvider({ type: 'dropbox' }),
+                        metadataProviderActions.connectProviderThunk({ type: 'dropbox' }),
                     );
                     action.payload.decision.resolve(true);
                     break;
@@ -208,7 +208,7 @@ describe('Metadata Actions', () => {
     fixtures.setDeviceMetadataKey.forEach(f => {
         it(`setDeviceMetadataKey - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataLabelingActions.setDeviceMetadataKey(...f.params));
+            await store.dispatch(metadataLabelingActions.setDeviceMetadataKeyThunk(...f.params));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
             } else {
@@ -221,7 +221,7 @@ describe('Metadata Actions', () => {
         it(`setAccountMetadataKey - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
             const account = await store.dispatch(
-                metadataLabelingActions.setAccountMetadataKey(...f.params),
+                metadataLabelingActions.setAccountMetadataKeyThunk(...f.params),
             );
             expect(account).toMatchObject(f.result);
         });
@@ -230,7 +230,7 @@ describe('Metadata Actions', () => {
     fixtures.addDeviceMetadata.forEach(f => {
         it(`addDeviceMetadata - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataLabelingActions.addDeviceMetadata(...f.params));
+            await store.dispatch(metadataLabelingActions.addDeviceMetadataThunk(...f.params));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
             }
@@ -240,7 +240,7 @@ describe('Metadata Actions', () => {
     fixtures.addAccountMetadata.forEach(f => {
         it(`addAccountMetadata - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataLabelingActions.addAccountMetadata(...f.params));
+            await store.dispatch(metadataLabelingActions.addAccountMetadataThunk(...f.params));
 
             const result = store.getActions();
             if (!f.result) {
@@ -254,7 +254,7 @@ describe('Metadata Actions', () => {
     fixtures.connectProvider.forEach(f => {
         it(`connectProvider - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataProviderActions.connectProvider(...f.params));
+            await store.dispatch(metadataProviderActions.connectProviderThunk(...f.params));
 
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
@@ -268,7 +268,7 @@ describe('Metadata Actions', () => {
         it(`add metadata - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
 
-            await store.dispatch(metadataLabelingActions.addMetadata(...f.params));
+            await store.dispatch(metadataLabelingActions.addMetadataThunk(...f.params));
 
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
@@ -305,7 +305,7 @@ describe('Metadata Actions', () => {
     fixtures.init.forEach(f => {
         it(`initMetadata - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataLabelingActions.init(...f.params));
+            await store.dispatch(metadataLabelingActions.initThunk(...f.params));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
             } else {
@@ -317,7 +317,7 @@ describe('Metadata Actions', () => {
     fixtures.disposeMetadata.forEach(f => {
         it(`disposeMetadata - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataThunks.disposeMetadata(...f.params));
+            await store.dispatch(metadataThunks.disposeMetadataThunk(...f.params));
             if (f.result) {
                 expect(store.getState()).toMatchObject(f.result);
             }
@@ -327,7 +327,7 @@ describe('Metadata Actions', () => {
     fixtures.disposeMetadataKeys.forEach(f => {
         it(`disposeMetadataKeys - ${f.description}`, async () => {
             const store = initStore(getInitialState(f.initialState));
-            await store.dispatch(metadataThunks.disposeMetadataKeys(...f.params));
+            await store.dispatch(metadataThunks.disposeMetadataKeysThunk(...f.params));
             if (f.result) {
                 expect(store.getState()).toMatchObject(f.result);
             }

--- a/suite/metadata/src/metadataDataThunks.ts
+++ b/suite/metadata/src/metadataDataThunks.ts
@@ -24,7 +24,7 @@ type DisposeMetadataThunkState = MetadataRootState;
 /**
  * dispose metadata from all labelable objects.
  */
-export const disposeMetadata =
+export const disposeMetadataThunk =
     () => (dispatch: Dispatch, getState: () => DisposeMetadataThunkState) => {
         const provider = selectSelectedProviderForLabels(getState());
 
@@ -43,7 +43,7 @@ export const disposeMetadata =
 
 type DisposeMetadataKeysThunkState = MetadataRootState;
 
-export const disposeMetadataKeys =
+export const disposeMetadataKeysThunk =
     () => (dispatch: Dispatch, getState: () => DisposeMetadataKeysThunkState) => {
         const devices = selectDevices(getState());
         const accounts = selectAccounts(getState());
@@ -72,8 +72,8 @@ export const disableMetadata = () => (dispatch: Dispatch) => {
     dispatch(disableMetadataAction());
 
     // dispose metadata values and keys
-    dispatch(disposeMetadata());
-    dispatch(disposeMetadataKeys());
+    dispatch(disposeMetadataThunk());
+    dispatch(disposeMetadataKeysThunk());
 };
 
 type SetMetadataParams = {

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -39,12 +39,12 @@ import * as metadataUtils from './metadataUtils';
 
 type GetLabelableEntitiesThunkState = MetadataRootState;
 
-const getLabelableEntities =
+const getLabelableEntitiesThunk =
     (deviceState: StaticSessionId) =>
     (_dispatch: Dispatch, getState: () => GetLabelableEntitiesThunkState) =>
         selectLabelableEntities(getState(), deviceState);
 
-type LabelableEntity = ReturnType<ReturnType<typeof getLabelableEntities>>[number];
+type LabelableEntity = ReturnType<ReturnType<typeof getLabelableEntitiesThunk>>[number];
 
 const fetchMetadata =
     ({
@@ -60,7 +60,7 @@ const fetchMetadata =
         const dataType = 'labels';
 
         const providerInstance = dispatch(
-            metadataProviderActions.getProviderInstance({
+            metadataProviderActions.getProviderInstanceThunk({
                 clientId: provider.clientId,
                 dataType,
             }),
@@ -110,7 +110,7 @@ const fetchMetadata =
 
 type SetAccountMetadataKeyThunkState = MetadataRootState;
 
-export const setAccountMetadataKey =
+export const setAccountMetadataKeyThunk =
     (account: Account, encryptionVersion = METADATA_LABELING.ENCRYPTION_VERSION) =>
     (dispatch: Dispatch, getState: () => SetAccountMetadataKeyThunkState) => {
         const device = selectDeviceByStaticSessionId(getState(), account.deviceState);
@@ -150,7 +150,7 @@ type SyncMetadataKeysThunkState = MetadataRootState;
 /**
  * Fill any record in reducer that may have metadata with metadata keys (not values).
  */
-const syncMetadataKeys =
+const syncMetadataKeysThunk =
     (device: TrezorDevice, encryptionVersion = METADATA_LABELING.ENCRYPTION_VERSION) =>
     (dispatch: Dispatch, getState: () => SyncMetadataKeysThunkState) => {
         if (!device.metadata[METADATA_LABELING.ENCRYPTION_VERSION]) {
@@ -163,7 +163,9 @@ const syncMetadataKeys =
         );
 
         targetAccounts.forEach(account => {
-            const accountWithMetadata = dispatch(setAccountMetadataKey(account, encryptionVersion));
+            const accountWithMetadata = dispatch(
+                setAccountMetadataKeyThunk(account, encryptionVersion),
+            );
             dispatch(metadataActions.setAccountAdd(accountWithMetadata));
         });
         // note that devices are intentionally omitted here - device receives metadata
@@ -172,7 +174,7 @@ const syncMetadataKeys =
 
 type FetchAndSaveMetadataThunkState = MetadataRootState;
 
-export const fetchAndSaveMetadata =
+export const fetchAndSaveMetadataThunk =
     (deviceStateArg?: StaticSessionId) =>
     async (dispatch: Dispatch, getState: () => FetchAndSaveMetadataThunkState) => {
         const provider = selectSelectedProviderForLabels(getState());
@@ -195,7 +197,7 @@ export const fetchAndSaveMetadata =
         );
 
         const providerInstance = dispatch(
-            metadataProviderActions.getProviderInstance({
+            metadataProviderActions.getProviderInstanceThunk({
                 clientId: provider.clientId,
                 dataType: 'labels',
             }),
@@ -218,7 +220,7 @@ export const fetchAndSaveMetadata =
             )
                 return;
 
-            dispatch(syncMetadataKeys(device));
+            dispatch(syncMetadataKeysThunk(device));
 
             if (!response.success) {
                 dispatch(
@@ -242,7 +244,9 @@ export const fetchAndSaveMetadata =
                 return;
             }
 
-            const labelableEntities = dispatch(getLabelableEntities(device.state.staticSessionId));
+            const labelableEntities = dispatch(
+                getLabelableEntitiesThunk(device.state.staticSessionId),
+            );
             const promises = labelableEntities.map(entity =>
                 dispatch(fetchMetadata({ provider, entity })).then(result => {
                     if (result) {
@@ -259,7 +263,7 @@ export const fetchAndSaveMetadata =
             // already existing label
             if (device?.state && metadataProviderActions.fetchIntervals[fetchIntervalTrackingId]) {
                 return dispatch(
-                    metadataProviderActions.disconnectProvider({
+                    metadataProviderActions.disconnectProviderThunk({
                         removeMetadata: false,
                         dataType: 'labels',
                         clientId: provider.clientId,
@@ -280,7 +284,7 @@ export const fetchAndSaveMetadata =
 
 type FetchAndSaveMetadataForAllDevicesThunkState = MetadataRootState;
 
-export const fetchAndSaveMetadataForAllDevices =
+export const fetchAndSaveMetadataForAllDevicesThunk =
     () => (dispatch: Dispatch, getState: () => FetchAndSaveMetadataForAllDevicesThunkState) => {
         const metadata = selectMetadata(getState());
         if (!metadata.enabled) {
@@ -293,13 +297,13 @@ export const fetchAndSaveMetadataForAllDevices =
                 !device.metadata[METADATA_LABELING.ENCRYPTION_VERSION]
             )
                 return;
-            dispatch(fetchAndSaveMetadata(device.state.staticSessionId));
+            dispatch(fetchAndSaveMetadataThunk(device.state.staticSessionId));
         });
     };
 
 type AddDeviceMetadataThunkState = MetadataRootState;
 
-export const addDeviceMetadata =
+export const addDeviceMetadataThunk =
     (payload: Extract<MetadataAddPayload, { type: 'walletLabel' }>) =>
     (dispatch: Dispatch, getState: () => AddDeviceMetadataThunkState) => {
         const devices = selectDevices(getState());
@@ -343,7 +347,7 @@ export const addDeviceMetadata =
         );
 
         const providerInstance = dispatch(
-            metadataProviderActions.getProviderInstance({
+            metadataProviderActions.getProviderInstanceThunk({
                 clientId: provider.clientId,
                 dataType: 'labels',
             }),
@@ -368,7 +372,7 @@ type AddAccountMetadataThunkState = MetadataRootState;
  * @param save - should metadata be saved into persistent storage? this is useful when you are updating multiple records
  *               in a single account you may want to set "save" param to true only for the last call
  */
-export const addAccountMetadata =
+export const addAccountMetadataThunk =
     (payload: Exclude<MetadataAddPayload, { type: 'walletLabel' }>) =>
     (dispatch: Dispatch, getState: () => AddAccountMetadataThunkState) => {
         const account = selectAccounts(getState()).find(({ key }) => key === payload.entityKey);
@@ -458,7 +462,7 @@ export const addAccountMetadata =
         }
 
         const providerInstance = dispatch(
-            metadataProviderActions.getProviderInstance({
+            metadataProviderActions.getProviderInstanceThunk({
                 clientId: provider.clientId,
                 dataType: 'labels',
             }),
@@ -485,7 +489,7 @@ type SetDeviceMetadataKeyThunkState = MetadataRootState;
 /**
  * Generate device master-key
  * */
-export const setDeviceMetadataKey =
+export const setDeviceMetadataKeyThunk =
     (device: TrezorDevice, encryptionVersion = METADATA_LABELING.ENCRYPTION_VERSION) =>
     async (dispatch: Dispatch, getState: () => SetDeviceMetadataKeyThunkState) => {
         if (!device.state?.staticSessionId || !device.connected) return;
@@ -532,13 +536,13 @@ export const setDeviceMetadataKey =
 
 type AddMetadataThunkState = MetadataRootState;
 
-export const addMetadata =
+export const addMetadataThunk =
     (payload: MetadataAddPayload) =>
     async (dispatch: Dispatch, getState: () => AddMetadataThunkState): Promise<boolean> => {
         const result = await dispatch(
             payload.type === 'walletLabel'
-                ? addDeviceMetadata(payload)
-                : addAccountMetadata(payload),
+                ? addDeviceMetadataThunk(payload)
+                : addAccountMetadataThunk(payload),
         );
 
         if (!result.success) {
@@ -551,7 +555,7 @@ export const addMetadata =
                 // unknown error, need to generate a custom one from the provider instance
                 if (provider !== undefined) {
                     const providerInstance = dispatch(
-                        metadataProviderActions.getProviderInstance({
+                        metadataProviderActions.getProviderInstanceThunk({
                             clientId: provider.clientId,
                             dataType: 'labels',
                         }),
@@ -596,7 +600,7 @@ type InitThunkState = MetadataRootState;
 
 type InitThunkDeps = InitMetadataDeps;
 
-export const init =
+export const initThunk =
     (force: boolean, deviceStateArg?: StaticSessionId) =>
     async (dispatch: Dispatch, getState: () => InitThunkState, extra: InitThunkDeps) => {
         let device = deviceStateArg
@@ -630,7 +634,7 @@ export const init =
 
         if (!device.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION]) {
             const result = await dispatch(
-                setDeviceMetadataKey(device, METADATA_LABELING.ENCRYPTION_VERSION),
+                setDeviceMetadataKeyThunk(device, METADATA_LABELING.ENCRYPTION_VERSION),
             );
             if (!result?.success) {
                 dispatch({ type: METADATA.SET_INITIATING, payload: false });
@@ -653,7 +657,7 @@ export const init =
         }
 
         // 3. we have master key. use it to derive account keys
-        dispatch(syncMetadataKeys(device, METADATA_LABELING.ENCRYPTION_VERSION));
+        dispatch(syncMetadataKeysThunk(device, METADATA_LABELING.ENCRYPTION_VERSION));
 
         device = deviceStateArg
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
@@ -687,7 +691,7 @@ export const init =
         // todo: 5. migration
 
         // 6. fetch metadata
-        await dispatch(fetchAndSaveMetadata(device.state?.staticSessionId));
+        await dispatch(fetchAndSaveMetadataThunk(device.state?.staticSessionId));
 
         // now we may allow user to edit labels. everything is ready, local data is synced with provider
         if (selectMetadataInitiating(getState())) {
@@ -718,7 +722,7 @@ export const init =
                 if (!selectIsSuiteOnline(getState()) || !device?.state?.staticSessionId) {
                     return;
                 }
-                dispatch(fetchAndSaveMetadata(device.state.staticSessionId));
+                dispatch(fetchAndSaveMetadataThunk(device.state.staticSessionId));
             }, METADATA_LABELING.FETCH_INTERVAL);
         }
 

--- a/suite/metadata/src/metadataMiddleware.ts
+++ b/suite/metadata/src/metadataMiddleware.ts
@@ -11,7 +11,9 @@ import { selectIsLegacyLabelingVisible } from './selectIsLegacyLabelingVisible';
 
 export const metadataMiddleware = createMiddleware((action, { dispatch, getState, next }) => {
     if (accountsActions.createAccount.match(action)) {
-        action.payload = dispatch(metadataLabelingActions.setAccountMetadataKey(action.payload));
+        action.payload = dispatch(
+            metadataLabelingActions.setAccountMetadataKeyThunk(action.payload),
+        );
     }
 
     if (

--- a/suite/metadata/src/metadataPasswordsActions.ts
+++ b/suite/metadata/src/metadataPasswordsActions.ts
@@ -21,11 +21,11 @@ import { type FetchIntervalTrackingId } from './metadataUtils';
 
 type FetchPasswordsThunkState = MetadataRootState;
 
-const fetchPasswords =
+const fetchPasswordsThunk =
     (keys: LabelableEntityKeys) =>
     async (dispatch: Dispatch, _getState: () => FetchPasswordsThunkState) => {
         const provider = dispatch(
-            metadataProviderActions.getProviderInstance({
+            metadataProviderActions.getProviderInstanceThunk({
                 clientId: METADATA_PROVIDER.DROPBOX_PASSWORDS_CLIENT_ID,
                 dataType: 'passwords',
             }),
@@ -85,7 +85,7 @@ const selectIsSuiteOnline = (state: MetadataRootState) => state.suite.online;
 
 type InitThunkState = MetadataRootState;
 
-export const init = () => async (dispatch: Dispatch, getState: () => InitThunkState) => {
+export const initThunk = () => async (dispatch: Dispatch, getState: () => InitThunkState) => {
     let device = selectSelectedDevice(getState());
 
     if (!device?.state?.staticSessionId) {
@@ -152,7 +152,7 @@ export const init = () => async (dispatch: Dispatch, getState: () => InitThunkSt
         const selectedProvider = selectSelectedProviderForPasswords(getState());
         if (!selectedProvider) {
             await dispatch(
-                metadataProviderActions.connectProvider({
+                metadataProviderActions.connectProviderThunk({
                     type: 'dropbox',
                     dataType: 'passwords',
                     clientId: METADATA_PROVIDER.DROPBOX_PASSWORDS_CLIENT_ID,
@@ -161,7 +161,7 @@ export const init = () => async (dispatch: Dispatch, getState: () => InitThunkSt
         }
 
         await dispatch(
-            fetchPasswords({
+            fetchPasswordsThunk({
                 fileName: fname,
                 aesKey: encryptionKey,
             }),
@@ -191,7 +191,7 @@ export const init = () => async (dispatch: Dispatch, getState: () => InitThunkSt
                 return;
             }
             dispatch(
-                fetchPasswords({
+                fetchPasswordsThunk({
                     fileName,
                     aesKey,
                 }),
@@ -202,7 +202,7 @@ export const init = () => async (dispatch: Dispatch, getState: () => InitThunkSt
 
 type AddPasswordMetadataThunkState = MetadataRootState;
 
-export const addPasswordMetadata =
+export const addPasswordMetadataThunk =
     (nextId: number, payload: PasswordEntry, fileName: string, aesKey: string) =>
     (dispatch: Dispatch, getState: () => AddPasswordMetadataThunkState) => {
         if (!payload.note) {
@@ -210,7 +210,7 @@ export const addPasswordMetadata =
         }
         const provider = selectSelectedProviderForPasswords(getState());
         const providerInstance = dispatch(
-            metadataProviderActions.getProviderInstance({
+            metadataProviderActions.getProviderInstanceThunk({
                 clientId: METADATA_PROVIDER.DROPBOX_PASSWORDS_CLIENT_ID,
                 dataType: 'passwords',
             }),
@@ -250,12 +250,12 @@ export const addPasswordMetadata =
 
 type RemovePasswordMetadataThunkState = MetadataRootState;
 
-export const removePasswordMetadata =
+export const removePasswordMetadataThunk =
     (index: number, fileName: string, aesKey: string) =>
     (dispatch: Dispatch, getState: () => RemovePasswordMetadataThunkState) => {
         const provider = selectSelectedProviderForPasswords(getState());
         const providerInstance = dispatch(
-            metadataProviderActions.getProviderInstance({
+            metadataProviderActions.getProviderInstanceThunk({
                 clientId: METADATA_PROVIDER.DROPBOX_PASSWORDS_CLIENT_ID,
                 dataType: 'passwords',
             }),

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -17,7 +17,7 @@ import { createDeferred, createZip, typedObjectKeys } from '@trezor/utils';
 
 import * as metadataActions from './metadataActions';
 import * as METADATA from './metadataConstants';
-import { disposeMetadata } from './metadataDataThunks';
+import { disposeMetadataThunk } from './metadataDataThunks';
 import * as METADATA_PROVIDER from './metadataProviderConstants';
 import {
     type MetadataRootState,
@@ -72,7 +72,7 @@ type GetProviderInstanceThunkState = MetadataRootState;
 /**
  * Return already existing instance of AbstractProvider or recreate it from token;
  */
-export const getProviderInstance =
+export const getProviderInstanceThunk =
     ({ clientId, dataType = 'labels' }: GetProviderInstanceParams) =>
     (_dispatch: Dispatch, getState: () => GetProviderInstanceThunkState) => {
         const { providers } = selectMetadata(getState());
@@ -110,7 +110,7 @@ type DisconnectProviderThunkState = MetadataRootState;
 
 type DisconnectProviderThunkDeps = DisconnectProviderDeps;
 
-export const disconnectProvider =
+export const disconnectProviderThunk =
     ({ clientId, dataType, removeMetadata = true }: DisconnectProviderParams) =>
     async (
         dispatch: Dispatch,
@@ -127,10 +127,10 @@ export const disconnectProvider =
 
         // dispose metadata values (not keys)
         if (removeMetadata) {
-            dispatch(disposeMetadata());
+            dispatch(disposeMetadataThunk());
         }
 
-        const provider = dispatch(getProviderInstance({ clientId, dataType }));
+        const provider = dispatch(getProviderInstanceThunk({ clientId, dataType }));
 
         if (provider !== undefined) {
             await provider.disconnect();
@@ -189,9 +189,9 @@ export const handleProviderError =
                 case 'ACCESS_ERROR':
                 case 'BAD_INPUT_ERROR':
                 case 'OTHER_ERROR':
-                    dispatch(disposeMetadata());
+                    dispatch(disposeMetadataThunk());
                     dispatch(
-                        disconnectProvider({
+                        disconnectProviderThunk({
                             clientId,
                             dataType: 'labels',
                         }),
@@ -202,7 +202,7 @@ export const handleProviderError =
                 case 'RATE_LIMIT_ERROR':
                 case 'AUTH_ERROR':
                     dispatch(
-                        disconnectProvider({
+                        disconnectProviderThunk({
                             clientId,
                             dataType: 'labels',
                         }),
@@ -254,7 +254,7 @@ type ConnectProviderThunkState = MetadataRootState;
 
 type ConnectProviderThunkDeps = ConnectProviderDeps;
 
-export const connectProvider =
+export const connectProviderThunk =
     ({ type, dataType = 'labels', clientId }: ConnectProviderParams) =>
     async (
         dispatch: Dispatch,
@@ -310,12 +310,12 @@ export const connectProvider =
 
 type ExportMetadataToLocalFileThunkState = MetadataRootState;
 
-export const exportMetadataToLocalFile =
+export const exportMetadataToLocalFileThunk =
     () => async (dispatch: Dispatch, getState: () => ExportMetadataToLocalFileThunkState) => {
         const provider = selectSelectedProviderForLabels(getState());
         if (!provider) return;
         const providerInstance = dispatch(
-            getProviderInstance({
+            getProviderInstanceThunk({
                 clientId: provider.clientId,
                 dataType: 'labels',
             }),

--- a/suite/metadata/src/metadataThunks.ts
+++ b/suite/metadata/src/metadataThunks.ts
@@ -25,7 +25,7 @@ export const initNewDeviceStateMetadataThunk = createThunk<
         const metadataPresentOnDevice = device?.metadata[METADATA_LABELING.ENCRYPTION_VERSION];
 
         if (!metadataPresentOnDevice) {
-            await dispatch(metadataLabelingActions.init(false));
+            await dispatch(metadataLabelingActions.initThunk(false));
         }
     },
 );

--- a/suite/metadata/src/moveLabelsForRbfOldMetadataThunk.ts
+++ b/suite/metadata/src/moveLabelsForRbfOldMetadataThunk.ts
@@ -29,7 +29,7 @@ const deleteDanglingLabels = async ({
 }: DeleteAllOutputLabelsParams) => {
     for (const outputIndex of typedObjectKeys(labels)) {
         await dispatch(
-            metadataLabelingActions.addMetadata({
+            metadataLabelingActions.addMetadataThunk({
                 type: 'outputLabel',
                 entityKey: accountKey,
                 txid,
@@ -64,7 +64,7 @@ const copyLabelToNewTransaction = async ({
         const value = accountOutputLabels[outputIndex];
 
         await dispatch(
-            metadataLabelingActions.addMetadata({
+            metadataLabelingActions.addMetadataThunk({
                 type: 'outputLabel',
                 entityKey: accountKey,
                 txid: newTxid,

--- a/suite/metadata/src/password-manager/usePasswords.ts
+++ b/suite/metadata/src/password-manager/usePasswords.ts
@@ -32,7 +32,7 @@ export const usePasswords = () => {
 
     const connect = () => {
         setProviderConnecting(true);
-        dispatch(metadataPasswordsActions.init()).finally(() => {
+        dispatch(metadataPasswordsActions.initThunk()).finally(() => {
             setProviderConnecting(false);
         });
     };
@@ -42,7 +42,7 @@ export const usePasswords = () => {
         if (!selectedProvider) return;
 
         dispatch(
-            metadataProviderActions.disconnectProvider({
+            metadataProviderActions.disconnectProviderThunk({
                 clientId: selectedProvider.clientId,
                 dataType: 'passwords',
                 removeMetadata: false,
@@ -53,7 +53,12 @@ export const usePasswords = () => {
     const savePasswords = (nextId: number, passwordEntry: PasswordEntry) => {
         if (!fileName || !aesKey) return;
         dispatch(
-            metadataPasswordsActions.addPasswordMetadata(nextId, passwordEntry, fileName, aesKey),
+            metadataPasswordsActions.addPasswordMetadataThunk(
+                nextId,
+                passwordEntry,
+                fileName,
+                aesKey,
+            ),
         );
     };
 
@@ -62,7 +67,7 @@ export const usePasswords = () => {
             if (!fileName || !aesKey) return;
 
             return dispatch(
-                metadataPasswordsActions.removePasswordMetadata(index, fileName, aesKey),
+                metadataPasswordsActions.removePasswordMetadataThunk(index, fileName, aesKey),
             );
         },
         [fileName, aesKey, dispatch],

--- a/suite/modal/src/modalActions.ts
+++ b/suite/modal/src/modalActions.ts
@@ -41,7 +41,7 @@ type OnReceiveConfirmationThunkState = {
     };
 };
 
-export const onReceiveConfirmation =
+export const onReceiveConfirmationThunk =
     (confirmation: boolean) =>
     (dispatch: Dispatch, getState: () => OnReceiveConfirmationThunkState) => {
         const requestId = selectModalConfirmationRequestId(getState());

--- a/suite/receive/src/verification/showAddressThunk.ts
+++ b/suite/receive/src/verification/showAddressThunk.ts
@@ -12,7 +12,7 @@ import { type Dispatch, type WithServices } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type WalletSettingsRootState,
-    acquireDevice,
+    acquireDeviceThunk,
     confirmAddressOnDeviceThunk,
     selectAddressDisplayType,
 } from '@suite-common/wallet-core';
@@ -60,7 +60,7 @@ export const showAddressThunk =
         // status below is already up to date; still locked means the user dismissed the prompt, and
         // acquireDevice has reported any real failure itself.
         if (selectIsDevicePinLocked(getState())) {
-            await dispatch(acquireDevice({ requestedDevice: device }));
+            await dispatch(acquireDeviceThunk({ requestedDevice: device }));
 
             if (selectIsDevicePinLocked(getState())) return;
         }

--- a/suite/router/src/routerThunks.test.ts
+++ b/suite/router/src/routerThunks.test.ts
@@ -8,11 +8,11 @@ import * as fixtures from './__fixtures__/routerThunks';
 import { createSuiteRouterHistory } from './createSuiteRouterHistory';
 import { routerReducer } from './routerReducer';
 import {
-    closeModalApp,
-    goto,
-    initialRedirection,
-    onLocationChange,
-    routerInit,
+    closeModalAppThunk,
+    gotoThunk,
+    initialRedirectionThunk,
+    onLocationChangeThunk,
+    routerInitThunk,
 } from './routerThunks';
 
 const EMPTY_ACTION = { type: 'foo' };
@@ -69,13 +69,13 @@ describe('Router thunks', () => {
             const state = getInitialState(f.state);
             const { store, suiteRouterHistory } = initStore(state);
             suiteRouterHistory.navigate(defaultLocation);
-            store.dispatch(routerInit());
+            store.dispatch(routerInitThunk());
             if (f.result) {
                 expect(store.getState().router).toEqual(f.result);
             } else {
                 const actionsWithoutThunkLifecycleEvents = store
                     .getActions()
-                    .filter(a => !a.type.startsWith(routerInit.typePrefix));
+                    .filter(a => !a.type.startsWith(routerInitThunk.typePrefix));
                 expect(actionsWithoutThunkLifecycleEvents.length).toEqual(0);
             }
         });
@@ -86,11 +86,11 @@ describe('Router thunks', () => {
             const state = getInitialState(f.state);
             const { store, suiteRouterHistory } = initStore(state);
             suiteRouterHistory.navigate({ ...defaultLocation, hash: `#${f.hash}` });
-            store.dispatch(onLocationChange(suiteRouterHistory.getLocation()));
+            store.dispatch(onLocationChangeThunk(suiteRouterHistory.getLocation()));
 
             store.dispatch(
-                goto({
-                    routeName: f.url as Parameters<typeof goto>[0]['routeName'],
+                gotoThunk({
+                    routeName: f.url as Parameters<typeof gotoThunk>[0]['routeName'],
                     preserveParams: f.preserveHash,
                 }),
             );
@@ -109,10 +109,10 @@ describe('Router thunks', () => {
             router: { loaded: true },
         });
         const { store } = initStore(state);
-        store.dispatch(onLocationChange({ pathname: '/' }));
+        store.dispatch(onLocationChangeThunk({ pathname: '/' }));
         const actionsWithoutThunkLifecycleEvents = store
             .getActions()
-            .filter(a => !a.type.startsWith(onLocationChange.typePrefix));
+            .filter(a => !a.type.startsWith(onLocationChangeThunk.typePrefix));
         expect(actionsWithoutThunkLifecycleEvents.length).toEqual(0);
     });
 
@@ -124,7 +124,7 @@ describe('Router thunks', () => {
             pathname: '/accounts/send',
         });
 
-        store.dispatch(closeModalApp());
+        store.dispatch(closeModalAppThunk());
         expect(store.getState().router.app).toEqual('wallet');
         expect(store.getState().router.pathname).toEqual('/accounts/send');
     });
@@ -139,7 +139,7 @@ describe('Router thunks', () => {
                 pathname: f.pathname || '/',
             });
 
-            store.dispatch(initialRedirection({ isInitialRun: f.isInitialRun }));
+            store.dispatch(initialRedirectionThunk({ isInitialRun: f.isInitialRun }));
             expect(store.getState().router.app).toEqual(f.app);
         });
     });

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -34,7 +34,7 @@ type OnLocationChangeThunkParams = RouterPathOptional & {
 
 type OnLocationChangeThunkState = LocksRootState & ModalRootState & RouterRootState;
 
-export const onLocationChange = createThunk<
+export const onLocationChangeThunk = createThunk<
     ReturnType<typeof routerLocationChange> | null | undefined,
     OnLocationChangeThunkParams,
     { state: OnLocationChangeThunkState }
@@ -61,7 +61,7 @@ type RouterInitThunkState = LocksRootState & ModalRootState & RouterRootState;
 
 type RouterInitThunkDeps = WithServices<SuiteRouterHistoryDep>;
 
-export const routerInit = createThunk<
+export const routerInitThunk = createThunk<
     void,
     void,
     { state: RouterInitThunkState; extra: RouterInitThunkDeps }
@@ -69,7 +69,7 @@ export const routerInit = createThunk<
     // check if location was not already changed by initialRedirection
     if (selectRouterApp(getState()) === 'unknown') {
         const location = extra.services.suiteRouterHistory.getLocation();
-        dispatch(onLocationChange(location));
+        dispatch(onLocationChangeThunk(location));
     }
 });
 
@@ -84,7 +84,11 @@ export type GotoThunkState = LocksRootState & ModalRootState & RouterRootState;
 
 export type GotoThunkDeps = WithServices<SuiteRouterHistoryDep>;
 
-export const goto = createThunk<void, GotoPayload, { state: GotoThunkState; extra: GotoThunkDeps }>(
+export const gotoThunk = createThunk<
+    void,
+    GotoPayload,
+    { state: GotoThunkState; extra: GotoThunkDeps }
+>(
     '@router/goto',
     ({ routeName, params, preserveParams, anchor }, { dispatch, getState, extra }) => {
         const hasRouterLock = selectIsRouterLocked(getState());
@@ -112,7 +116,7 @@ export const goto = createThunk<void, GotoPayload, { state: GotoThunkState; extr
             return;
         }
 
-        dispatch(onLocationChange({ pathname, hash, anchor }));
+        dispatch(onLocationChangeThunk({ pathname, hash, anchor }));
         if (route?.isForegroundApp) {
             dispatch(lockRouter(true));
 
@@ -144,7 +148,7 @@ type CloseModalAppThunkState = GotoThunkState;
 
 type CloseModalAppThunkDeps = GotoThunkDeps;
 
-export const closeModalApp = createThunk<
+export const closeModalAppThunk = createThunk<
     void,
     boolean | undefined,
     { state: CloseModalAppThunkState; extra: CloseModalAppThunkDeps }
@@ -155,7 +159,7 @@ export const closeModalApp = createThunk<
     const route = findRoute(location.pathname);
 
     if (route?.isForegroundApp) {
-        dispatch(goto({ routeName: 'suite-index' }));
+        dispatch(gotoThunk({ routeName: 'suite-index' }));
 
         return;
     }
@@ -165,7 +169,7 @@ export const closeModalApp = createThunk<
             pathname: location.pathname,
         });
     } else {
-        dispatch(onLocationChange(location));
+        dispatch(onLocationChangeThunk(location));
     }
 });
 
@@ -181,7 +185,7 @@ type InitialRedirectionThunkState = GotoThunkState;
 
 type InitialRedirectionThunkDeps = GotoThunkDeps;
 
-export const initialRedirection = createThunk<
+export const initialRedirectionThunk = createThunk<
     void,
     InitialRedirectionThunkParams,
     { state: InitialRedirectionThunkState; extra: InitialRedirectionThunkDeps }
@@ -196,8 +200,8 @@ export const initialRedirection = createThunk<
     }
 
     if (route.isForegroundApp) {
-        dispatch(goto({ routeName: route.name }));
+        dispatch(gotoThunk({ routeName: route.name }));
     } else if (isInitialRun) {
-        dispatch(goto({ routeName: 'suite-start' }));
+        dispatch(gotoThunk({ routeName: 'suite-start' }));
     }
 });

--- a/suite/sign-verify/src/SignVerifyForm.tsx
+++ b/suite/sign-verify/src/SignVerifyForm.tsx
@@ -14,7 +14,7 @@ import { SignVerifyMessageField } from './SignVerifyMessageField';
 import { SignVerifyPubKeyField } from './SignVerifyPubKeyField';
 import { SignVerifySignatureField } from './SignVerifySignatureField';
 import { SignVerifyTabs } from './SignVerifyTabs';
-import { isVerifySupported, sign, verify } from './signVerifyActions';
+import { isVerifySupported, signThunk, verifyThunk } from './signVerifyActions';
 import { getHasSelectableSignatureFormat } from './signVerifyUtils';
 import { type SignVerifyOutcome, type SignVerifyPage } from './types';
 import { useSignVerifyCopyValue } from './useSignVerifyCopyValue';
@@ -90,7 +90,7 @@ export const SignVerifyForm = ({ account, network, page, onPageChange }: SignVer
 
         if (isSignPage && path !== undefined) {
             const result = await dispatch(
-                sign(account, path, message, hex, isElectrum, cardanoPubKeyCose),
+                signThunk(account, path, message, hex, isElectrum, cardanoPubKeyCose),
             );
 
             if (result) {
@@ -98,7 +98,7 @@ export const SignVerifyForm = ({ account, network, page, onPageChange }: SignVer
                 setOutcome('signed');
             }
         } else if (signature !== undefined) {
-            const result = await dispatch(verify(account, address, message, signature, hex));
+            const result = await dispatch(verifyThunk(account, address, message, signature, hex));
 
             setOutcome(result ? 'verified' : 'failed');
         }

--- a/suite/sign-verify/src/signVerifyActions.test.ts
+++ b/suite/sign-verify/src/signVerifyActions.test.ts
@@ -8,7 +8,12 @@ import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { type SignVerifyRootState, showAddress, sign, verify } from './signVerifyActions';
+import {
+    type SignVerifyRootState,
+    showAddressThunk,
+    signThunk,
+    verifyThunk,
+} from './signVerifyActions';
 
 const PATH = 'PATH';
 const ADDRESS = 'ADDRESS';
@@ -46,7 +51,7 @@ describe('Sign/Verify actions', () => {
             success: true,
             payload: { address: ADDRESS },
         });
-        const res = await showAddress(ACCOUNT, ADDRESS, PATH)(dispatch, getState);
+        const res = await showAddressThunk(ACCOUNT, ADDRESS, PATH)(dispatch, getState);
         expect(res).toStrictEqual({ address: ADDRESS });
     });
 
@@ -58,7 +63,7 @@ describe('Sign/Verify actions', () => {
                 signature: SIGNATURE,
             },
         });
-        const res = await sign(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
+        const res = await signThunk(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
         expect(res).toStrictEqual({ address: ADDRESS, signature: SIGNATURE });
     });
 
@@ -67,7 +72,12 @@ describe('Sign/Verify actions', () => {
             success: true,
             payload: { message: MESSAGE },
         });
-        const res = await verify(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE)(dispatch, getState, deps);
+        const res = await verifyThunk(
+            ACCOUNT,
+            ADDRESS,
+            MESSAGE,
+            SIGNATURE,
+        )(dispatch, getState, deps);
         expect(res).toStrictEqual(true);
     });
 
@@ -80,7 +90,7 @@ describe('Sign/Verify actions', () => {
                 payload: { address: ADDRESS, signature: SIGNATURE },
             });
 
-            await sign(ACCOUNT, PATH, MESSAGE, true)(dispatch, getState, deps);
+            await signThunk(ACCOUNT, PATH, MESSAGE, true)(dispatch, getState, deps);
 
             expect(connect().signMessage).toHaveBeenLastCalledWith(
                 expect.objectContaining({ message: MESSAGE, hex: true, no_script_type: false }),
@@ -93,7 +103,7 @@ describe('Sign/Verify actions', () => {
                 payload: { address: ADDRESS, signature: SIGNATURE },
             });
 
-            await sign(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
+            await signThunk(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
 
             expect(connect().signMessage).toHaveBeenLastCalledWith(
                 expect.objectContaining({ message: MESSAGE, hex: false }),
@@ -103,7 +113,7 @@ describe('Sign/Verify actions', () => {
         it('verifies against the same reading of the message', async () => {
             testMocks.setTrezorConnectFixtures({ success: true, payload: { message: MESSAGE } });
 
-            await verify(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE, true)(dispatch, getState, deps);
+            await verifyThunk(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE, true)(dispatch, getState, deps);
 
             expect(connect().verifyMessage).toHaveBeenLastCalledWith(
                 expect.objectContaining({
@@ -121,7 +131,7 @@ describe('Sign/Verify actions', () => {
                 payload: { address: ADDRESS, signature: SIGNATURE },
             });
 
-            await sign(ACCOUNT, PATH, MESSAGE, true)(dispatch, getState, deps);
+            await signThunk(ACCOUNT, PATH, MESSAGE, true)(dispatch, getState, deps);
 
             expect(deps.services.analytics.report).toHaveBeenCalledWith(
                 expect.objectContaining({ payload: expect.objectContaining({ hex: true }) }),
@@ -136,7 +146,7 @@ describe('Sign/Verify actions', () => {
                 payload: { address: ADDRESS, signature: SIGNATURE },
             });
 
-            await sign(ACCOUNT, PATH, MESSAGE, true, true)(dispatch, getState, deps);
+            await signThunk(ACCOUNT, PATH, MESSAGE, true, true)(dispatch, getState, deps);
 
             expect(deps.services.analytics.report).toHaveBeenCalledTimes(1);
             expect(deps.services.analytics.report).toHaveBeenCalledWith({
@@ -159,7 +169,7 @@ describe('Sign/Verify actions', () => {
                 payload: { address: ADDRESS, signature: SIGNATURE },
             });
 
-            await sign(account, PATH, MESSAGE)(dispatch, getState, deps);
+            await signThunk(account, PATH, MESSAGE)(dispatch, getState, deps);
 
             expect(deps.services.analytics.report).toHaveBeenCalledWith({
                 type: events.coinSignMessageEvent.name,
@@ -173,7 +183,7 @@ describe('Sign/Verify actions', () => {
                 error: { message: 'Signing failed', code: 'Failure_DataError' },
             });
 
-            await sign(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
+            await signThunk(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
 
             expect(deps.services.analytics.report).toHaveBeenCalledTimes(1);
             expect(deps.services.analytics.report).toHaveBeenCalledWith({
@@ -196,7 +206,7 @@ describe('Sign/Verify actions', () => {
                     error: { message: 'Cancelled', code },
                 });
 
-                await sign(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
+                await signThunk(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
 
                 expect(deps.services.analytics.report).toHaveBeenCalledTimes(1);
                 expect(deps.services.analytics.report).toHaveBeenCalledWith(
@@ -211,7 +221,7 @@ describe('Sign/Verify actions', () => {
         it('reports a sign that never reached the device as an error', async () => {
             const getStateWithoutDevice = () => createState(undefined);
 
-            await sign(ACCOUNT, PATH, MESSAGE)(dispatch, getStateWithoutDevice, deps);
+            await signThunk(ACCOUNT, PATH, MESSAGE)(dispatch, getStateWithoutDevice, deps);
 
             expect(deps.services.analytics.report).toHaveBeenCalledTimes(1);
             expect(deps.services.analytics.report).toHaveBeenCalledWith({
@@ -232,7 +242,7 @@ describe('Sign/Verify actions', () => {
                 payload: { message: MESSAGE },
             });
 
-            await verify(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE, true)(dispatch, getState, deps);
+            await verifyThunk(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE, true)(dispatch, getState, deps);
 
             expect(deps.services.analytics.report).toHaveBeenCalledTimes(1);
             expect(deps.services.analytics.report).toHaveBeenCalledWith({
@@ -247,7 +257,7 @@ describe('Sign/Verify actions', () => {
                 error: { message: 'Invalid signature', code: 'Failure_DataError' },
             });
 
-            await verify(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE)(dispatch, getState, deps);
+            await verifyThunk(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE)(dispatch, getState, deps);
 
             expect(deps.services.analytics.report).toHaveBeenCalledTimes(1);
             expect(deps.services.analytics.report).toHaveBeenCalledWith({
@@ -267,7 +277,7 @@ describe('Sign/Verify actions', () => {
                 error: { message: 'Cancelled', code: 'Failure_ActionCancelled' },
             });
 
-            await verify(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE)(dispatch, getState, deps);
+            await verifyThunk(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE)(dispatch, getState, deps);
 
             expect(deps.services.analytics.report).toHaveBeenCalledTimes(1);
             expect(deps.services.analytics.report).toHaveBeenCalledWith(
@@ -283,8 +293,8 @@ describe('Sign/Verify actions', () => {
                 payload: { address: ADDRESS, signature: SIGNATURE },
             });
 
-            await sign(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
-            await verify(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE)(dispatch, getState, deps);
+            await signThunk(ACCOUNT, PATH, MESSAGE)(dispatch, getState, deps);
+            await verifyThunk(ACCOUNT, ADDRESS, MESSAGE, SIGNATURE)(dispatch, getState, deps);
 
             const reported = JSON.stringify(deps.services.analytics.report.mock.calls);
 

--- a/suite/sign-verify/src/signVerifyActions.ts
+++ b/suite/sign-verify/src/signVerifyActions.ts
@@ -213,7 +213,7 @@ const onError =
 
 type ShowAddressThunkState = SignVerifyRootState;
 
-export const showAddress =
+export const showAddressThunk =
     (account: Account, address: string, path: string) =>
     (dispatch: Dispatch, getState: () => ShowAddressThunkState) =>
         getStateParams(account, getState)
@@ -225,7 +225,7 @@ type SignThunkState = SignVerifyRootState;
 
 type SignThunkDeps = WithServices<DesktopAnalyticsDep>;
 
-export const sign =
+export const signThunk =
     (
         account: Account,
         path: string | number[],
@@ -292,7 +292,7 @@ type VerifyThunkState = SignVerifyRootState;
 
 type VerifyThunkDeps = WithServices<DesktopAnalyticsDep>;
 
-export const verify =
+export const verifyThunk =
     (account: Account, address: string, message: string, signature: string, hex = false) =>
     async (dispatch: Dispatch, getState: () => VerifyThunkState, extra: VerifyThunkDeps) => {
         const { analytics } = extra.services;

--- a/suite/suite-sync/src/SuiteSyncBanner.tsx
+++ b/suite/suite-sync/src/SuiteSyncBanner.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectIsDeviceConnected } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
@@ -107,7 +107,7 @@ export const SuiteSyncBanner = ({ deviceStaticSessionId }: SuiteSyncBannerProps)
                             <Banner.Button
                                 onClick={() =>
                                     dispatch(
-                                        goto({
+                                        gotoThunk({
                                             routeName: 'firmware-index',
                                             params: { cancelable: true },
                                         }),

--- a/suite/thp/src/connection/ThpPairingFailedModal.tsx
+++ b/suite/thp/src/connection/ThpPairingFailedModal.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectThpLastCode, thpActions } from '@suite-common/thp';
-import { acquireDevice, selectSelectedFirstThpDevice } from '@suite-common/wallet-core';
+import { acquireDeviceThunk, selectSelectedFirstThpDevice } from '@suite-common/wallet-core';
 import { Column, Modal, Paragraph } from '@trezor/components';
 
 import { ThpPairingCodeEntry } from './ThpPairingCodeEntry';
@@ -18,7 +18,7 @@ export const ThpPairingFailedModal = () => {
     const handleRetry = () => {
         setIsLoading(true);
         // Re-try is simply acquiring the device again which triggers the THP flow
-        dispatch(acquireDevice({ requestedDevice: device }));
+        dispatch(acquireDeviceThunk({ requestedDevice: device }));
     };
 
     const onCancel = () => {

--- a/suite/tor-desktop/src/bootstrap/TorLoader.tsx
+++ b/suite/tor-desktop/src/bootstrap/TorLoader.tsx
@@ -18,7 +18,7 @@ import {
 } from '@trezor/components';
 import { ClockClockwiseIcon, RepeatIcon, TorBrowserIcon } from '@trezor/icons';
 
-import { toggleTor } from '../toggleTorThunk';
+import { toggleTorThunk } from '../toggleTorThunk';
 
 type TorLoaderProps = {
     callback: (value: boolean) => void;
@@ -58,7 +58,7 @@ export const TorLoader = ({ callback }: TorLoaderProps) => {
         dispatch(torActions.setTorStatus(TorStatus.Enabling));
 
         try {
-            await dispatch(toggleTor(true));
+            await dispatch(toggleTorThunk(true));
         } catch {
             dispatch(torActions.setTorStatus(TorStatus.Error));
         }
@@ -69,7 +69,7 @@ export const TorLoader = ({ callback }: TorLoaderProps) => {
         let fakeProgress = 0;
         // We do not wait until toggleTor is done since we want to display fake progress.
         // Errors are swallowed on purpose so the fake disabling progress always completes.
-        void dispatch(toggleTor(false)).catch(() => {});
+        void dispatch(toggleTorThunk(false)).catch(() => {});
 
         // This is a total fake progress, otherwise it would be too fast for user.
         await new Promise(resolve => {

--- a/suite/tor-desktop/src/index.ts
+++ b/suite/tor-desktop/src/index.ts
@@ -6,5 +6,5 @@ export { setTorBootstrapSlowThunk } from './bootstrap/setTorBootstrapSlowThunk';
 export { TorLoader } from './bootstrap/TorLoader';
 export { TorModal, type TorResult } from './TorModal';
 export { TorSettings } from './settings/TorSettings';
-export { toggleTor } from './toggleTorThunk';
+export { toggleTorThunk } from './toggleTorThunk';
 export { useDesktopTorStatus } from './useDesktopTorStatus';

--- a/suite/tor-desktop/src/settings/Tor.tsx
+++ b/suite/tor-desktop/src/settings/Tor.tsx
@@ -10,7 +10,7 @@ import { Switch } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 import { HELP_CENTER_TOR_URL } from '@trezor/urls';
 
-import { toggleTor } from '../toggleTorThunk';
+import { toggleTorThunk } from '../toggleTorThunk';
 
 type TorProps = {
     // Called before Tor is switched off. Resolve `true` to keep Tor running (abort the toggle) —
@@ -41,7 +41,7 @@ export const Tor = ({ onBeforeDisable }: TorProps) => {
         }
         const shouldEnableTor = !isTorEnabled && !isTorLoading;
         try {
-            await dispatch(toggleTor(shouldEnableTor));
+            await dispatch(toggleTorThunk(shouldEnableTor));
         } catch {
             setHasTorError(true);
         }

--- a/suite/tor-desktop/src/toggleTorThunk.ts
+++ b/suite/tor-desktop/src/toggleTorThunk.ts
@@ -21,7 +21,7 @@ export type ToggleTorDispatch = ThunkDispatch<
     UnknownAction
 >;
 
-export const toggleTor =
+export const toggleTorThunk =
     (shouldEnable: boolean) =>
     async (
         dispatch: ToggleTorDispatch,

--- a/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
@@ -5,7 +5,7 @@ import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type CoinProtocol,
     type HandleCoinProtocolUriThunkDeps,
-    handleCoinProtocolUri,
+    handleCoinProtocolUriThunk,
 } from './handleCoinProtocolUri';
 
 const findNetworkSymbolForProtocol: FindNetworkSymbolForProtocol = protocol => {
@@ -31,7 +31,7 @@ const setup = () => {
     };
 
     const run = (uri: string) =>
-        handleCoinProtocolUri(uri, saveCoinProtocol)(dispatch, () => ({}), extra);
+        handleCoinProtocolUriThunk(uri, saveCoinProtocol)(dispatch, () => ({}), extra);
 
     return { dispatch, report, saveCoinProtocol, run };
 };

--- a/suite/transfer-uri/src/handleCoinProtocolUri.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.ts
@@ -30,7 +30,7 @@ export type HandleCoinProtocolUriThunkDeps = WithServices<
  * The protocol send-form reducer lives in the app, so its `saveCoinProtocol`
  * action is injected to keep this package free of an app import cycle.
  */
-export const handleCoinProtocolUri =
+export const handleCoinProtocolUriThunk =
     (uri: string, saveCoinProtocol: SaveCoinProtocol) =>
     (dispatch: Dispatch, _getState: unknown, extra: HandleCoinProtocolUriThunkDeps) => {
         // Report any URI carrying a recognizable scheme (incl. unknown-protocol deeplinks).

--- a/suite/transfer-uri/src/index.ts
+++ b/suite/transfer-uri/src/index.ts
@@ -1,2 +1,2 @@
-export { handleCoinProtocolUri } from './handleCoinProtocolUri';
+export { handleCoinProtocolUriThunk } from './handleCoinProtocolUri';
 export type { CoinProtocol } from './handleCoinProtocolUri';


### PR DESCRIPTION
## Description

Redux thunks can be named inconsistently, making them harder to identify. Add an ESLint rule requiring the Thunk suffix, migrate RTK thunks, and grandfather legacy vanilla thunks by exact file and name. Closes #31889.

Benchmark over 368 files, of which 252 were eligible for the rule, with ESLint cache disabled:

- Rule execution: **47.8 ms total**
- Average: **~0.19 ms per eligible file**
- Share of total rule time: **0.4%**
- Full lint with rule: **24.99 s**
- Full lint without rule: **25.95 s**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/enforce-redux-thunk-suffix/web/](https://dev.suite.sldev.cz/suite-web/chore/enforce-redux-thunk-suffix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/enforce-redux-thunk-suffix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/enforce-redux-thunk-suffix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/enforce-redux-thunk-suffix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T08:19:09.196Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T08:19:54.811Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->