### PR TITLE
fix(suite-native): eth and sol staking translation strings

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3075,17 +3075,13 @@ export const messages = {
                     description: 'Network fee',
                 },
                 second: {
-                    title: {
-                        ethereum: 'Enter staking pool',
-                        solana: 'Enter warm-up period',
-                    },
+                    titleEthereum: 'Enter staking pool',
+                    titleSolana: 'Enter warm-up period',
                     description: '~{entryPeriod} days',
                 },
                 third: {
-                    title: {
-                        ethereum: 'Receive weekly rewards',
-                        solana: 'Receive rewards every ~{days} days',
-                    },
+                    titleEthereum: 'Receive weekly rewards',
+                    titleSolana: 'Receive rewards every ~{days} days',
                     description: '~{apy}% yearly',
                 },
             },
@@ -3096,10 +3092,8 @@ export const messages = {
                     description: 'Network fee',
                 },
                 second: {
-                    title: {
-                        ethereum: 'Leave staking pool',
-                        solana: 'Enter cool-down period',
-                    },
+                    titleEthereum: 'Leave staking pool',
+                    titleSolana: 'Enter cool-down period',
                     description: '~{unstakingPeriod} days',
                 },
                 third: {

--- a/suite-native/module-earn/src/components/earn/HowEarnWorks/stakePresets.tsx
+++ b/suite-native/module-earn/src/components/earn/HowEarnWorks/stakePresets.tsx
@@ -25,18 +25,18 @@ export const createHowStakeWorksPreset = ({
             ? 'earn.howStakeWorksScreen.stakingTimeline.second.description'
             : 'earn.notAvailable';
     const stakingPeriodTitleId = isSolana
-        ? 'earn.howStakeWorksScreen.stakingTimeline.second.title.solana'
-        : 'earn.howStakeWorksScreen.stakingTimeline.second.title.ethereum';
+        ? 'earn.howStakeWorksScreen.stakingTimeline.second.titleSolana'
+        : 'earn.howStakeWorksScreen.stakingTimeline.second.titleEthereum';
     const stakingRewardsTitleId = isSolana
-        ? 'earn.howStakeWorksScreen.stakingTimeline.third.title.solana'
-        : 'earn.howStakeWorksScreen.stakingTimeline.third.title.ethereum';
+        ? 'earn.howStakeWorksScreen.stakingTimeline.third.titleSolana'
+        : 'earn.howStakeWorksScreen.stakingTimeline.third.titleEthereum';
     const stakingRewardsDescriptionId =
         apy != null
             ? 'earn.howStakeWorksScreen.stakingTimeline.third.description'
             : 'earn.notAvailableShort';
     const unstakingPeriodTitleId = isSolana
-        ? 'earn.howStakeWorksScreen.unstakeTimeline.second.title.solana'
-        : 'earn.howStakeWorksScreen.unstakeTimeline.second.title.ethereum';
+        ? 'earn.howStakeWorksScreen.unstakeTimeline.second.titleSolana'
+        : 'earn.howStakeWorksScreen.unstakeTimeline.second.titleEthereum';
     const unstakingPeriodDescriptionId =
         unstakingPeriodInDays !== undefined
             ? 'earn.howStakeWorksScreen.unstakeTimeline.second.description'

--- a/suite-native/module-earn/src/components/staking/UnstakingTimelineCard.tsx
+++ b/suite-native/module-earn/src/components/staking/UnstakingTimelineCard.tsx
@@ -95,7 +95,13 @@ export const UnstakingTimelineCard = ({ accountKey }: UnstakingTimelineCardProps
                         {
                             id: 'unstake.second',
                             title: (
-                                <Translation id="earn.howStakeWorksScreen.unstakeTimeline.second.title" />
+                                <Translation
+                                    id={
+                                        symbol === 'sol'
+                                            ? 'earn.howStakeWorksScreen.unstakeTimeline.second.titleSolana'
+                                            : 'earn.howStakeWorksScreen.unstakeTimeline.second.titleEthereum'
+                                    }
+                                />
                             ),
                             description:
                                 unstakingPeriodInDays !== undefined ? (


### PR DESCRIPTION
## Description

Fix broken nested translation strings for ETH and SOL staking.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/eth-sol-staking-translation-strings&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->