### PR TITLE
fix(trading): show approval signing headline

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -7,7 +7,6 @@ import { selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import type { DeviceRootState } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { selectTradingComposedTransactionInfo } from '@suite-common/trading';
 import {
     type SerializedTx,
     selectIsTxOutputInternal,
@@ -117,7 +116,6 @@ export const TransactionReviewModalBodyInner = ({
     const { options } = precomposedForm;
     const { serializedTx } = txInfoState;
     const routeName = useSelector(selectRouteName);
-    const tradingToken = useSelector(selectTradingComposedTransactionInfo).composed?.token;
 
     const isApprovalTx = isEvmApprovalTx(precomposedForm.transactionData);
     // A contract call's single "address" row is the contract, not a payment recipient, so the
@@ -219,7 +217,7 @@ export const TransactionReviewModalBodyInner = ({
             symbol,
             stakeType,
             precomposedForm,
-            tradingToken,
+            approvalToken: precomposedTx.token,
             routeName,
             isBumpFeeRbfAction,
             isCancelRbfAction,

--- a/packages/suite/src/utils/suite/transactionReview.test.ts
+++ b/packages/suite/src/utils/suite/transactionReview.test.ts
@@ -1,0 +1,114 @@
+import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
+import { type FormState } from '@suite-common/wallet-types';
+import { buildApprovalTransactionData } from '@suite-common/wallet-utils';
+import { type TokenInfo } from '@trezor/blockchain-link-types';
+
+import { getTransactionReviewModalActionTranslation } from './transactionReview';
+
+const TOKEN_CONTRACT = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const SPENDER = '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae';
+
+const usdc: TokenInfo = {
+    standard: 'ERC20',
+    contract: TOKEN_CONTRACT,
+    symbol: 'USDC',
+    decimals: 6,
+};
+
+const getFormState = (overrides: Partial<FormState> = {}): FormState => ({
+    ...DEFAULT_VALUES,
+    options: ['broadcast'],
+    outputs: [{ ...DEFAULT_PAYMENT, address: TOKEN_CONTRACT }],
+    selectedUtxos: [],
+    ...overrides,
+});
+
+const getTranslation = ({
+    precomposedForm,
+    approvalToken,
+    source,
+    isBumpFeeRbfAction = false,
+}: {
+    precomposedForm: FormState;
+    approvalToken: TokenInfo | undefined;
+    source: 'heading' | 'button';
+    isBumpFeeRbfAction?: boolean;
+}) =>
+    getTransactionReviewModalActionTranslation({
+        symbol: 'eth',
+        stakeType: null,
+        precomposedForm,
+        approvalToken,
+        isBumpFeeRbfAction,
+        isCancelRbfAction: false,
+        source,
+    });
+
+describe('getTransactionReviewModalActionTranslation', () => {
+    it('describes an approval signed outside of any trading or earn form state', () => {
+        const precomposedForm = getFormState({
+            transactionData: buildApprovalTransactionData({ amount: '1000000', spender: SPENDER }),
+        });
+
+        expect(getTranslation({ precomposedForm, approvalToken: usdc, source: 'heading' })).toEqual(
+            {
+                id: 'TR_APPROVAL_APPROVE_TOKEN_SPENDING',
+                values: { displaySymbol: 'USDC' },
+            },
+        );
+        expect(getTranslation({ precomposedForm, approvalToken: usdc, source: 'button' })).toEqual({
+            id: 'TR_APPROVE_DATA_TITLE',
+        });
+    });
+
+    it('describes a revocation', () => {
+        const precomposedForm = getFormState({
+            transactionData: buildApprovalTransactionData({ amount: '0', spender: SPENDER }),
+        });
+
+        expect(getTranslation({ precomposedForm, approvalToken: usdc, source: 'heading' })).toEqual(
+            {
+                id: 'TR_APPROVAL_REVOKE_TOKEN_SPENDING',
+                values: { displaySymbol: 'USDC' },
+            },
+        );
+        expect(getTranslation({ precomposedForm, approvalToken: usdc, source: 'button' })).toEqual({
+            id: 'TR_REVOKE_DATA_TITLE',
+        });
+    });
+
+    it('falls back to the symbol-less title when the approved token is unknown', () => {
+        const precomposedForm = getFormState({
+            transactionData: buildApprovalTransactionData({ amount: '1000000', spender: SPENDER }),
+        });
+
+        expect(
+            getTranslation({ precomposedForm, approvalToken: undefined, source: 'heading' }),
+        ).toEqual({ id: 'TR_APPROVE_DATA_TITLE' });
+    });
+
+    it('keeps describing a fee bump of a pending approval as a replacement', () => {
+        const precomposedForm = getFormState({
+            transactionData: buildApprovalTransactionData({ amount: '1000000', spender: SPENDER }),
+        });
+
+        expect(
+            getTranslation({
+                precomposedForm,
+                approvalToken: usdc,
+                source: 'heading',
+                isBumpFeeRbfAction: true,
+            }),
+        ).toEqual({ id: 'TR_REPLACE_TX' });
+    });
+
+    it('keeps describing an exchange transaction without approval calldata as a swap', () => {
+        const precomposedForm = getFormState({
+            trading: { activeSection: 'exchange', isSlip24Active: false },
+        });
+
+        expect(
+            getTranslation({ precomposedForm, approvalToken: undefined, source: 'heading' }),
+        ).toEqual({ id: 'TR_TRADING_SWAP' });
+    });
+});

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -1,27 +1,31 @@
 import { type ExtendedMessageDescriptor } from '@suite/intl';
-import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getDisplaySymbol,
+    getNetworkDisplaySymbol,
+} from '@suite-common/wallet-config';
 import { type FormState, type StakeFormState } from '@suite-common/wallet-types';
 import { getEvmTransactionPurpose } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { getWrappedNativeSymbol } from '@trezor/network-ethereum-suite-common';
 
-interface GetTransactionReviewModalActionTranslationParams {
+type GetTransactionReviewModalActionTranslationParams = {
     symbol: NetworkSymbol;
     stakeType: StakeFormState['stakeType'] | null;
     precomposedForm: FormState | StakeFormState;
-    tradingToken: TokenInfo | undefined;
+    approvalToken: TokenInfo | undefined;
     routeName?: string;
     isBumpFeeRbfAction: boolean;
     isCancelRbfAction: boolean;
     isSending?: boolean;
     source: 'heading' | 'button';
-}
+};
 
 export const getTransactionReviewModalActionTranslation = ({
     symbol,
     stakeType,
     precomposedForm,
-    tradingToken,
+    approvalToken,
     routeName,
     isBumpFeeRbfAction,
     isCancelRbfAction,
@@ -53,48 +57,41 @@ export const getTransactionReviewModalActionTranslation = ({
         // no default
     }
 
-    if (precomposedForm?.trading?.activeSection === 'sell') {
-        return { id: 'TR_TRADING_SELL' };
-    }
-
-    if (precomposedForm?.trading?.activeSection === 'exchange') {
-        switch (txPurpose) {
-            case 'approve':
-                return {
-                    id:
-                        source === 'heading'
-                            ? 'TR_TRADING_APPROVE_TOKEN'
-                            : 'TR_TRADING_APPROVE_TOKEN_BUTTON',
-                    values: { tokenSymbol: tradingToken?.symbol },
-                };
-            case 'revoke':
-                return {
-                    id:
-                        source === 'heading'
-                            ? 'TR_TRADING_REVOKE_TOKEN'
-                            : 'TR_TRADING_REVOKE_TOKEN_BUTTON',
-                    values: { tokenSymbol: tradingToken?.symbol },
-                };
-            default:
-                return { id: 'TR_TRADING_SWAP' };
-        }
-    }
-
-    if (
-        (routeName === 'earn-yield-deposit' || routeName === 'earn-yield-withdraw') &&
-        (txPurpose === 'approve' || txPurpose === 'revoke')
-    ) {
-        return {
-            id: txPurpose === 'approve' ? 'TR_APPROVE_DATA_TITLE' : 'TR_REVOKE_DATA_TITLE',
-        };
-    }
-
     if (isBumpFeeRbfAction) {
         return { id: 'TR_REPLACE_TX' };
     }
 
     if (isCancelRbfAction) {
         return { id: 'TR_CANCEL_TX_BUTTON' };
+    }
+
+    // Approvals are signed from flows that do not share a single form state (trading composes
+    // through the trading thunks, earn through the allowance ones), so the action is resolved
+    // from the calldata rather than from the originating form or route.
+    if (txPurpose === 'approve' || txPurpose === 'revoke') {
+        const isApprove = txPurpose === 'approve';
+        const displaySymbol = approvalToken?.symbol
+            ? getDisplaySymbol(approvalToken.symbol, approvalToken.contract)
+            : undefined;
+
+        if (source === 'button' || !displaySymbol) {
+            return { id: isApprove ? 'TR_APPROVE_DATA_TITLE' : 'TR_REVOKE_DATA_TITLE' };
+        }
+
+        return {
+            id: isApprove
+                ? 'TR_APPROVAL_APPROVE_TOKEN_SPENDING'
+                : 'TR_APPROVAL_REVOKE_TOKEN_SPENDING',
+            values: { displaySymbol },
+        };
+    }
+
+    if (precomposedForm?.trading?.activeSection === 'sell') {
+        return { id: 'TR_TRADING_SELL' };
+    }
+
+    if (precomposedForm?.trading?.activeSection === 'exchange') {
+        return { id: 'TR_TRADING_SWAP' };
     }
 
     if (txPurpose === 'wrap' || txPurpose === 'unwrap') {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1390,22 +1390,6 @@ export const messages = defineMessages({
         defaultMessage: 'Swap unavailable',
         id: 'TR_TRADING_SWAP_UNAVAILABLE',
     },
-    TR_TRADING_APPROVE_TOKEN: {
-        defaultMessage: 'Approve {tokenSymbol} spending',
-        id: 'TR_TRADING_APPROVE_TOKEN',
-    },
-    TR_TRADING_APPROVE_TOKEN_BUTTON: {
-        defaultMessage: 'Approve {tokenSymbol}',
-        id: 'TR_TRADING_APPROVE_TOKEN_BUTTON',
-    },
-    TR_TRADING_REVOKE_TOKEN: {
-        defaultMessage: 'Revoke {tokenSymbol} spending',
-        id: 'TR_TRADING_REVOKE_TOKEN',
-    },
-    TR_TRADING_REVOKE_TOKEN_BUTTON: {
-        defaultMessage: 'Revoke {tokenSymbol}',
-        id: 'TR_TRADING_REVOKE_TOKEN_BUTTON',
-    },
     TR_TRADING_TRANS_ID: {
         defaultMessage: 'Trade ID:',
         id: 'TR_TRADING_TRANS_ID',


### PR DESCRIPTION
## Description

- Resolve approval and revocation review titles from EVM calldata before trading flow labels.
- Pass the precomposed approval token into the review action translation so the heading can show the approved token symbol.
- Add unit coverage for approval, revoke, missing-token fallback, RBF replacement, and non-approval exchange swap cases.

## Notes for QA

- Open Trading > Swap on Ethereum, proceed to an ERC-20 approval, and verify the review modal heading shows Approve token spending with the token symbol.
- In the same flow, verify the confirm button still shows the generic approval action and a regular swap without approval calldata still shows Swap.

## Related Issue

Resolve #31993

## Screenshots:
<img width="634" height="709" alt="Snímek obrazovky 2026-09-02 v 14 29 36" src="https://github.com/user-attachments/assets/13af1065-8b17-4037-b303-e5ab8f4a6dc9" />
<img width="663" height="816" alt="Snímek obrazovky 2026-09-02 v 14 30 37" src="https://github.com/user-attachments/assets/3121b099-4693-44c9-b94b-4e9dc3515e09" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch the shared transaction review modal component and its formatting utilities, which sit on the critical path of every send, stake, trade, and yield transaction in Suite. Because these files are broad dependencies referenced by 139 tests, I selected a small, diverse set of end-to-end flows that actually open and verify the review modal contents across EVM, Solana, Bitcoin, Cardano, staking, DEX swaps, and yield withdrawals. Running these targeted tests will catch regressions in modal rendering, fee/amount formatting, and device-prompt consistency without executing the full suite.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx`
- `packages/suite/src/utils/suite/transactionReview.test.ts`
- `packages/suite/src/utils/suite/transactionReview.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking flow where the transaction review modal displays staking amount, fee, and device confirmation details. Changes to TransactionReviewModalBodyInner or transactionReview utilities directly affect how these staking values are rendered and formatted.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This DEX swap test verifies the Confirm & Send review screen including slippage, minimum received amount, network fee, provider, send/receive amounts, and multiple device review prompts. It directly stresses the transaction review modal body rendering path.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills the ETH send form and verifies the review/device prompt shows the correct amount, gas limit, max fee per gas, max priority fee, and calculated maximum fee. It is a direct end-to-end check of EVM transaction review formatting.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test explicitly opens the Review & Send modal for a Solana transaction and verifies recipient, amount, fee, total, and device confirmation screens. It covers a non-EVM transaction review path that may use different formatting in the modal.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This yield withdrawal test uses the transaction simulation/preview modal to verify sent/received assets, fiat equivalents, max fee, and device review screens. It covers ERC-4626 vault share token flows which rely on transaction review rendering.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking uses a distinct Cardano transaction structure (stake key registration, delegation, vote delegation, deposit). This test checks the review modal/device prompts for these ADA-specific fields, providing confidence the changes don't break non-EVM staking review.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell flow displays a confirmation screen with fiat/crypto amounts, provider, payment method, destination address, and then a device prompt. This covers the trading sell review path, which shares the transaction review modal infrastructure with swaps and sends.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This Bitcoin send test exercises multiple outputs, locktime, OP_RETURN, and unit switching, all of which pass through the transaction review modal before broadcast. It provides coverage for Bitcoin-specific review rendering and output handling.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/utils/suite/transactionReview.test.ts`

_Updated: 2026-09-04T07:22:46.596Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31993-approval-signing-headline/web/](https://dev.suite.sldev.cz/suite-web/fix/31993-approval-signing-headline/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31993-approval-signing-headline&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31993-approval-signing-headline&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T07:22:30.960Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T07:23:12.417Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->