### PR TITLE
refactor(e2e): remove no-op YieldMock.stop()

### DIFF
--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -188,9 +188,7 @@ const test = suiteBaseTest.extend<Fixtures>({
         await use(new YieldConsentModal(page));
     },
     yieldMock: async ({ page }, use) => {
-        const yieldMock = new YieldMock(page);
-        await use(yieldMock);
-        await yieldMock.stop();
+        await use(new YieldMock(page));
     },
     txSimulationModal: async ({ page }, use) => {
         await use(new TxSimulationModal(page));

--- a/suite/e2e/support/mocks/yieldMock.ts
+++ b/suite/e2e/support/mocks/yieldMock.ts
@@ -376,13 +376,4 @@ export class YieldMock {
             route.fulfill({ json: BLOCKAID_REDEEM_RESPONSE }),
         );
     }
-
-    @step()
-    async stop() {
-        await this.page.unroute(BLOCKAID_API_PATTERN);
-        await this.page.unroute(VAULT_ADDRESS_API_PATTERN);
-        await this.page.unroute(MERKL_API_PATTERN);
-        await this.page.unroute(YIELD_DETAIL_API_PATTERN);
-        await this.page.unroute(YIELD_API_PATTERN);
-    }
 }


### PR DESCRIPTION
## Description

`YieldMock.stop()` unrouted its five API patterns in the `yieldMock` fixture
teardown. The browser context (web) and Electron app (desktop) are created per
test, so the routes are discarded with the context anyway — the unroutes did
nothing, and could throw `Target page, context or browser has been closed` if
teardown ordering put them after the page was closed.

The other mock `stop()` methods stay: `metadataMock`, `solanaStakingMock`,
`tradingMockNew` and `tradingChainBackend` shut down real HTTP/WS servers.

## Notes for QA

No product code touched. The three yield e2e tests (deposit, withdrawal,
redeem) should pass unchanged on web and desktop.

## Related Issue

Resolve

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/e2e-remove-dead-yield-mock-stop/web/](https://dev.suite.sldev.cz/suite-web/chore/e2e-remove-dead-yield-mock-stop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/e2e-remove-dead-yield-mock-stop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/e2e-remove-dead-yield-mock-stop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T12:55:34.110Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T12:55:11.224Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->