### PR TITLE
refactor(suite-common): move `selectDeviceThunk` to `@suite-common/device`

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -1,8 +1,7 @@
 import { onSuiteInit, onSuiteReady, updateOnlineStatus } from '@suite/suite-lifecycle';
-import { deviceActions } from '@suite-common/device';
+import { deviceActions, selectNewlyConnectedDeviceThunk } from '@suite-common/device';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { selectNewlyConnectedDeviceThunk } from '@suite-common/wallet-core';
 import { DEVICE, type Device, TRANSPORT } from '@trezor/connect';
 
 import { type AppState } from 'src/types/suite';

--- a/packages/suite/src/actions/suite/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/suiteActions.test.ts
@@ -16,7 +16,12 @@ import {
     mockGetDebugSettings,
     mockGetThpSettings,
 } from '@suite-common/connect-init/mocks';
-import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
+import {
+    deviceActions,
+    prepareDeviceReducer,
+    selectDeviceThunk,
+    selectNewlyConnectedDeviceThunk,
+} from '@suite-common/device';
 import { prepareFirmwareReducer } from '@suite-common/firmware';
 import { type FetchAndSaveMetadataDep } from '@suite-common/metadata-types';
 import { mockFetchAndSaveMetadata } from '@suite-common/metadata-types/mocks';
@@ -33,8 +38,6 @@ import {
     acquireDevice,
     forgetDisconnectedDevices,
     observeSelectedDevice,
-    selectDeviceThunk,
-    selectNewlyConnectedDeviceThunk,
 } from '@suite-common/wallet-core';
 import { type GetTradedAccountKeysDep } from '@suite-common/wallet-types';
 import { mockGetTradedAccountKeys } from '@suite-common/wallet-types/mocks';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx
@@ -4,9 +4,9 @@ import { selectRoundsDurationInHours, selectSessionProgressByAccountKey } from '
 import { type CoinjoinSession } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { goto, selectRouterParams } from '@suite/router';
-import { selectDevices, selectSelectedDevice } from '@suite-common/device';
+import { selectDeviceThunk, selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { selectAccountByKey, selectDeviceThunk } from '@suite-common/wallet-core';
+import { selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey, type WalletParams } from '@suite-common/wallet-types';
 import { ProgressPie } from '@trezor/components';
 import { typography } from '@trezor/theme';

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx
@@ -1,5 +1,6 @@
+import { selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDevice, selectDeviceThunk } from '@suite-common/wallet-core';
+import { acquireDevice } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
 import type { NotificationRendererProps } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -2,12 +2,11 @@ import { HiddenPlaceholder } from '@suite/discreet-mode';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { getTxAnchor, goto, selectRouteName, selectRouterApp } from '@suite/router';
-import { selectDevices, selectSelectedDevice } from '@suite-common/device';
+import { selectDeviceThunk, selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     selectAccounts,
     selectBlockchainState,
-    selectDeviceThunk,
     selectTransactions,
 } from '@suite-common/wallet-core';
 import {

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -11,6 +11,7 @@ import {
     deviceActions,
     isTrezorDeviceWithState,
     selectDevicePath,
+    selectDeviceThunk,
 } from '@suite-common/device';
 import { type WithServices, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
@@ -22,7 +23,6 @@ import {
     forgetDisconnectedDevices,
     handleDeviceDisconnect,
     observeSelectedDevice,
-    selectDeviceThunk,
     selectIsDeviceAutoEjectEnabled,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -3,12 +3,9 @@ import { useState } from 'react';
 import { Translation } from '@suite/intl';
 import { selectIsDeviceOrUiLocked } from '@suite/locks';
 import { closeModalApp, goto } from '@suite/router';
+import { selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import {
-    selectDeviceThunk,
-    selectIsAnyNetworkEnabled,
-    startAddWalletDiscoveryThunk,
-} from '@suite-common/wallet-core';
+import { selectIsAnyNetworkEnabled, startAddWalletDiscoveryThunk } from '@suite-common/wallet-core';
 import { WalletType } from '@suite-common/wallet-types';
 import { Button, Card, Column, IconButton, Row, Text, Tooltip } from '@trezor/components';
 import { FolderOpenIcon, PlusCircleFilledIcon, PlusIcon, XIcon } from '@trezor/icons';

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -6,6 +6,7 @@ import { Labeling } from '@suite/labeling';
 import { selectIsLegacyLabelingVisible, selectLabelingValueBeingEdited } from '@suite/metadata';
 import { SuiteSyncWalletDebug } from '@suite/suite-sync';
 import { useWalletLabel } from '@suite/wallet';
+import { selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     getAccountsByDeviceState,
@@ -13,7 +14,6 @@ import {
     selectAllAccountsToList,
     selectBaseCurrency,
     selectCurrentFiatRates,
-    selectDeviceThunk,
 } from '@suite-common/wallet-core';
 import { getAllAccounts } from '@suite-common/wallet-utils';
 import {

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -1,12 +1,13 @@
 import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { goto } from '@suite/router';
+import { selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     type DeviceStatus as ConnectedDeviceStatus,
     type getStatus,
 } from '@suite-common/suite-utils';
-import { acquireDevice, selectDeviceThunk } from '@suite-common/wallet-core';
+import { acquireDevice } from '@suite-common/wallet-core';
 import { Banner, type BannerIntent } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -18,7 +18,7 @@ import {
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { type Err } from '@trezor/type-utils';
 
-export const DEVICE_MODULE_PREFIX = '@suite/device';
+import { DEVICE_MODULE_PREFIX } from './deviceConstants';
 
 export type DeviceConnectActionPayload = {
     device: Device;

--- a/suite-common/device/src/deviceConstants.ts
+++ b/suite-common/device/src/deviceConstants.ts
@@ -2,6 +2,8 @@ import { type TrezorDevice } from '@suite-common/suite-types';
 import { asDeviceUniquePath } from '@trezor/connect-common';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
+export const DEVICE_MODULE_PREFIX = '@suite/device';
+
 // These hidden device constants are used in mobile app to hold all imported accounts.
 
 // Changing these strings will result in app crash as accounts are persisted.

--- a/suite-common/device/src/index.ts
+++ b/suite-common/device/src/index.ts
@@ -4,6 +4,7 @@ export type * from './deviceDeps';
 export * from './deviceReducer';
 export * from './deviceSelectors';
 export * from './deviceUtils';
+export * from './selectDeviceThunk';
 export * from './sortDevices';
 export * from './usePinHook';
 export { getIsIgnoredEntropyCheckError } from './services/getIsIgnoredEntropyCheckError';

--- a/suite-common/device/src/selectDeviceThunk.ts
+++ b/suite-common/device/src/selectDeviceThunk.ts
@@ -1,15 +1,13 @@
-import {
-    DEVICE_MODULE_PREFIX,
-    type DeviceRootState,
-    deviceActions,
-    selectDevices,
-    selectIsSameOrNewDevice,
-} from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { getSelectedDevice, sortByTimestamp } from '@suite-common/suite-utils';
 import { type Device } from '@trezor/connect';
 import { isNative } from '@trezor/env-utils';
+
+import { deviceActions } from './deviceActions';
+import { DEVICE_MODULE_PREFIX } from './deviceConstants';
+import { type DeviceRootState } from './deviceReducer';
+import { selectDevices, selectIsSameOrNewDevice } from './deviceSelectors';
 
 type SelectDeviceThunkParams = {
     device: Device | TrezorDevice | undefined;

--- a/suite-common/suite-sync/src/suiteSyncMiddleware.ts
+++ b/suite-common/suite-sync/src/suiteSyncMiddleware.ts
@@ -1,10 +1,9 @@
 import { type UnknownAction, isAnyOf } from '@reduxjs/toolkit';
 
-import { deviceActions, isTrezorDeviceWithState } from '@suite-common/device';
+import { deviceActions, isTrezorDeviceWithState, selectDeviceThunk } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
 import { type WithServices, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
-import { selectDeviceThunk } from '@suite-common/wallet-core';
 
 import {
     type WithSuiteSyncAndDeviceState,

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -13,7 +13,9 @@ import {
     deviceActions,
     portfolioTrackerDevice,
     selectDeviceById,
+    selectDeviceThunk,
     selectDevices,
+    selectNewlyConnectedDeviceThunk,
     selectPersistentDeviceDataById,
     selectPhysicalDeviceWallets,
     selectSelectedDevice,
@@ -63,7 +65,6 @@ import { getAddressForNetworkType } from './deviceAddressUtils';
 import { type AccountsRootState } from '../accounts/accountsReducer';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
 import { type RunDiscoveryThunkState, startDiscoveryThunk } from '../discovery/discoveryThunks';
-import { selectDeviceThunk, selectNewlyConnectedDeviceThunk } from '../discovery/selectDeviceThunk';
 import { setAutoEjectEnabled } from '../settings/walletSettingsActions';
 import {
     type WalletSettingsRootState,

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -10,6 +10,7 @@ import {
     selectSelectedDevice,
     shouldDeviceBeRemembered,
 } from '@suite-common/device';
+import { selectDeviceThunk } from '@suite-common/device';
 import { type FetchAndSaveMetadataDep } from '@suite-common/metadata-types';
 import {
     type SuiteCompatibleThunk,
@@ -41,7 +42,6 @@ import type { Bip43Path } from '@trezor/crypto-utils';
 import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { type DiscoveryRootState } from './discoveryReducer';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
-import { selectDeviceThunk } from './selectDeviceThunk';
 import { type CreateAccountActionProps, accountsActions } from '../accounts/accountsActions';
 import { selectAccountsByDeviceState } from '../accounts/accountsSelectors';
 import { reportAccountInfoThunk, reportWalletBalanceThunk } from '../accounts/accountsThunks';

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -25,7 +25,6 @@ export * from './discovery/discoveryActions';
 export * from './discovery/discoveryReducer';
 export * from './discovery/discoverySelectors';
 export * from './discovery/discoveryThunks';
-export * from './discovery/selectDeviceThunk';
 export * from './earn/earnDepositsFiatUtils';
 export * from './explorer/explorerActions';
 export * from './explorer/explorerReducer';

--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -10,6 +10,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import {
     PORTFOLIO_TRACKER_DEVICE_ID,
     selectDeviceStaticSessionId,
+    selectDeviceThunk,
     selectIsDeviceConnected,
     selectIsDeviceInitialized,
     selectIsDeviceProtectedByPassphrase,
@@ -17,7 +18,7 @@ import {
 } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { selectDeviceThunk, selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { AnimatedVStack, VStack } from '@suite-native/atoms';
 import { selectShouldFactoryResetBeVisible } from '@suite-native/device';


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

`selectDeviceThunk` ~~is~~ was defined in `@suite-common/wallet-core/discovery` 🤔 instead of `@suite-common/device`

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily affects device management (SwitchDevice UI components, device actions/thunks, discovery thunks) and Suite Sync middleware, with secondary touches on notification renderers and suite middleware. The highest regression risk is in wallet addition/switching flows and multi-coin discovery. I recommend running the targeted set of device-switcher, passphrase, discovery, and Suite Sync tests above; the broad-utility files with 139 static mappings should not trigger a full suite run because most downstream tests are unaffected by these specific component/thunk changes.

<details><summary><b>Changed files (18)</b></summary>

- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `packages/suite/src/actions/suite/suiteActions.test.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/CoinjoinBars/CoinjoinStatusBar.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx`
- `packages/suite/src/middlewares/suite/suiteMiddleware.ts`
- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx`
- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx`
- `packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx`
- `suite-common/device/src/deviceActions.ts`
- `suite-common/device/src/deviceConstants.ts`
- `suite-common/device/src/index.ts`
- `suite-common/device/src/selectDeviceThunk.ts`
- `suite-common/suite-sync/src/suiteSyncMiddleware.ts`
- `suite-common/wallet-core/src/device/deviceThunks.ts`
- `suite-common/wallet-core/src/discovery/discoveryThunks.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-native/device-manager/src/components/DeviceManagerContent.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test directly exercises the device switcher by ejecting a wallet and adding a standard wallet, then verifying discovery and account balances. It touches AddWalletButton, WalletInstance, device thunks, discovery thunks, and the select-device flow, all of which are heavily modified in this PR.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — The suiteSyncMiddleware file is changed and this test is the most direct end-to-end coverage of Suite Sync label creation and syncing to the Evolu relay. It will catch regressions in the middleware that handles Suite Sync state transitions.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test adds hidden wallets via the device switcher, switches between them, and verifies receive addresses. It directly exercises AddWalletButton, WalletInstance, passphrase wallet thunks, and device selection logic that are central to this change set.
- `suite/e2e/tests/settings/forget-device.test.ts` — This test exercises the forget device flow through the device settings and device switcher, including disconnected device states and Bluetooth unpairing. It directly tests WalletInstance, NeedsAttentionBanner, and device management thunks affected by this PR.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates device session takeover and recovery flows through the device switching panel. It directly exercises device status handling, the switch device UI, and device thunks that are modified in this change set.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coin networks and verifies discovery completes, including recovery after a page reload mid-discovery. It directly exercises discoveryThunks and suiteMiddleware which are changed, and validates device communication does not desync.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/activity/activity-page.test.ts` — The changes to ActionRenderer and TransactionRenderer directly affect how notifications and transaction toasts are rendered. This test exercises the notification system including unseen indicators, toast dismissal, and transaction vs system activity filtering, making it a strong regression guard for the notification renderer changes.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test validates wallet numbering and labeling in the device switcher when adding multiple passphrase wallets. It exercises WalletInstance rendering and wallet management thunks that are affected by the SwitchDevice and device thunk changes.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test verifies the disconnected device banner on device settings and the connection modal behavior in send flows. It exercises NeedsAttentionBanner and disconnected device state handling that are affected by the device UI changes.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `packages/suite/src/actions/suite/suiteActions.test.ts`
- `suite-common/device/src/index.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-native/device-manager/src/components/DeviceManagerContent.tsx`

_Updated: 2026-09-02T13:06:15.603Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/move-selectdevicethunk/web/](https://dev.suite.sldev.cz/suite-web/refactor/move-selectdevicethunk/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/move-selectdevicethunk&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/move-selectdevicethunk&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/move-selectdevicethunk&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T13:08:36.351Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T13:08:10.065Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->