### PR TITLE
chore(suite-common): deprecate `@suite-common/wallet-core/device`

### DIFF
--- a/suite-common/wallet-core/eslint.config.mjs
+++ b/suite-common/wallet-core/eslint.config.mjs
@@ -1,0 +1,30 @@
+import { eslint } from '@trezor/eslint';
+
+export default [
+    ...eslint,
+    {
+        // Existing device files are migrated incrementally to @suite-common/device.
+        files: ['src/device/**/*.{ts,tsx}'],
+        ignores: [
+            'src/device/deviceAddressUtils.ts',
+            'src/device/deviceSelectors.ts',
+            'src/device/deviceThunks.test.ts',
+            'src/device/deviceThunks.ts',
+            'src/device/entropyCheckThunks.ts',
+            'src/device/preparePushNotificationMiddleware.ts',
+            'src/device/publicKeyActions.ts',
+            'src/device/__fixtures__/forgetPersistentDataPreloadedState.ts',
+            'src/device/__fixtures__/handleDeviceDisconnect.ts',
+        ],
+        rules: {
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector: 'Program',
+                    message:
+                        'Do not add files to @suite-common/wallet-core/src/device. Add device code to @suite-common/device instead.',
+                },
+            ],
+        },
+    },
+];

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -50,6 +50,7 @@
         "@trezor/crypto-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
+        "@trezor/eslint": "workspace:*",
         "@trezor/network-ethereum-suite-common": "workspace:*",
         "@trezor/network-module-suite-common-types": "workspace:*",
         "@trezor/network-ripple": "workspace:*",

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -47,6 +47,7 @@
         { "path": "../../packages/crypto-utils" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
+        { "path": "../../packages/eslint" },
         {
             "path": "../../networks/ethereum/network-ethereum-suite-common"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11700,6 +11700,7 @@ __metadata:
     "@trezor/crypto-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
+    "@trezor/eslint": "workspace:*"
     "@trezor/network-ethereum-suite-common": "workspace:*"
     "@trezor/network-module-suite-common-types": "workspace:*"
     "@trezor/network-ripple": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 deprecate `@suite-common/wallet-core/device` -> use `@suite-common/device`

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are configuration-only (package.json and tsconfig.json) for the shared wallet-core package, with no direct static test coverage. The risk is moderate because dependency or TypeScript changes could affect the compilation or runtime behavior of wallet features. I recommend a small set of core wallet smoke tests as a precautionary check, while noting that no test directly references these configuration files.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/package.json`
- `suite-common/wallet-core/tsconfig.json`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin account discovery is a foundational wallet flow that exercises wallet state, network configuration, and account discovery logic likely backed by wallet-core modules. A dependency or TypeScript configuration change in wallet-core could affect how this compiles or behaves at runtime.
- `suite/e2e/tests/wallet/receive.test.ts` — The receive flow covers address derivation, display, and verification across BTC, ETH, SOL, and TRX. Since these flows depend on shared wallet-core infrastructure, config changes in that package could introduce regressions in address handling.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Sending an Ethereum transaction exercises transaction composition, fee calculation, and device signing flows that rely on shared wallet-core modules. This test provides a critical end-to-end check that wallet-core config changes have not broken transaction handling.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/package.json`
- `suite-common/wallet-core/tsconfig.json`

_Updated: 2026-09-02T13:48:47.857Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/deprecate-wallet-core-device/web/](https://dev.suite.sldev.cz/suite-web/chore/deprecate-wallet-core-device/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/deprecate-wallet-core-device&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/deprecate-wallet-core-device&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/deprecate-wallet-core-device&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T13:50:55.009Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T13:50:50.831Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->