### PR TITLE
fix(suite-common): fix false positives in solana rewards out-of-sync report

### DIFF
--- a/networks/solana/network-solana/src/runtime/staking.ts
+++ b/networks/solana/network-solana/src/runtime/staking.ts
@@ -93,12 +93,16 @@ export const getSolanaStakingData = async (
                 if (stakingProvider === 'everstake' && !isEverStake) return;
                 if (stakingProvider === 'non-everstake' && isEverStake) return;
 
+                const activationEpoch = fields[1]?.delegation?.activationEpoch;
+
                 return {
                     rentExemptReserve: fields[0]?.rentExemptReserve.toString(),
                     stake: fields[1]?.delegation?.stake.toString(),
                     status: stakeState,
                     isEverStake,
                     voterPubkey,
+                    activationEpoch:
+                        activationEpoch !== undefined ? Number(activationEpoch) : undefined,
                 };
             }
         })

--- a/networks/solana/network-solana/src/types/common.ts
+++ b/networks/solana/network-solana/src/types/common.ts
@@ -30,6 +30,7 @@ export interface SolanaStakingAccount {
     stake?: string;
     rentExemptReserve: string;
     voterPubkey?: string;
+    activationEpoch?: number;
 }
 
 export type SolanaTokenAccountInfo = {

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -10,6 +10,7 @@ export interface SolanaStakingAccount {
     stake?: string;
     rentExemptReserve: string;
     voterPubkey?: string;
+    activationEpoch?: number;
 }
 
 export type TokenStandard =

--- a/suite-common/earn-staking-api/jest.config.js
+++ b/suite-common/earn-staking-api/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/earn-staking-api/package.json
+++ b/suite-common/earn-staking-api/package.json
@@ -9,6 +9,7 @@
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest",
         "format": "prettier --write './**/*.ts'",
         "orval": "orval --config ./orval.config.ts",
         "api:generate": "yarn orval",
@@ -23,6 +24,7 @@
         "zod": "4.3.6"
     },
     "devDependencies": {
+        "@suite-common/wallet-config": "workspace:*",
         "orval": "8.19.0",
         "prettier": "^3.9.6"
     }

--- a/suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts
+++ b/suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts
@@ -3,67 +3,42 @@ import { captureException, withScope } from '@sentry/core';
 import { commonQueryKeys, keepPreviousData, useQuery } from '@suite-common/react-query';
 import { type Account } from '@suite-common/wallet-types';
 
-import { type SolRewardsHistory } from '../../api/types';
 import { EARN_API_BASE_URL } from '../../constants';
 import { getSolanaRewardsHistory } from '../services';
+import {
+    type SolanaRewardsSyncStatus,
+    areSolanaRewardsNotAvailableYet,
+    getSolanaRewardsSyncStatus,
+} from '../utils';
 
-const isInt = (value: unknown): value is number => Number.isInteger(value);
+// The query refetches periodically and on every screen visit, so one affected account
+// would keep producing identical Sentry events — report it only once per app session.
+const reportedAccountDescriptors = new Set<string>();
 
-function reportSolanaRewardsOutOfSync(account: Account) {
+function reportSolanaRewardsOutOfSync(account: Account, syncStatus: SolanaRewardsSyncStatus) {
+    if (reportedAccountDescriptors.has(account.descriptor)) {
+        return;
+    }
+    reportedAccountDescriptors.add(account.descriptor);
+
     withScope(scope => {
         scope.setTag('error.code', 'solana_rewards_history_out_of_sync');
         scope.setTag('error.source', EARN_API_BASE_URL);
         scope.setTag('error.network', account.networkType);
         scope.setTag('error.service', 'rewards_history');
+        scope.setExtras({
+            activeEpoch: syncStatus.activeEpoch,
+            latestRewardEpoch: syncStatus.latestRewardEpoch,
+            epochsSinceLatestReward: syncStatus.epochsSinceLatestReward,
+            hoursSinceLatestReward: syncStatus.hoursSinceLatestReward,
+            oldestActiveStakeActivationEpoch: syncStatus.oldestActiveStakeActivationEpoch,
+        });
         captureException(
             new Error(
                 'Solana rewards history is out of sync with the current active epoch. Everstake API might return stale data.',
             ),
         );
     });
-}
-
-function rewardsNotAvailableYet(account: Account, rewards: SolRewardsHistory['rewards']) {
-    if (account.networkType !== 'solana') {
-        return false;
-    }
-
-    const currentActiveEpoch = account.misc?.solEpoch;
-    const latestRewardEpoch = rewards[0]?.epoch;
-    const hasActiveStakingAccount = (account.misc?.solStakingAccounts ?? []).some(
-        stakingAccount => stakingAccount.status === 'active',
-    );
-
-    if (!isInt(currentActiveEpoch) || !isInt(latestRewardEpoch) || !hasActiveStakingAccount) {
-        return false;
-    }
-
-    return currentActiveEpoch - 1 !== latestRewardEpoch;
-}
-
-/**
- * Sometimes the API that provides the rewards history is out of sync with the current active epoch. This function detects this situation.
- */
-function rewardsOutOfSync(account: Account, rewards: SolRewardsHistory['rewards']) {
-    if (account.networkType !== 'solana') {
-        return false;
-    }
-
-    const activeEpoch = account.misc?.solEpoch;
-
-    const latestRewardEpoch = rewards[0]?.epoch;
-    const latestRewardTime = rewards[0]?.time;
-
-    if (!isInt(activeEpoch) || !isInt(latestRewardEpoch) || !latestRewardTime) {
-        return false;
-    }
-
-    const sinceLatestRewardInHours = (Date.now() - Date.parse(latestRewardTime)) / 1000 / 60 / 60;
-    const epochDurationLimitInHours = 52; // 2 days + 4h
-
-    const epochsSinceLatestReward = activeEpoch - latestRewardEpoch;
-
-    return sinceLatestRewardInHours > epochDurationLimitInHours || epochsSinceLatestReward > 2;
 }
 
 interface UseSolanaRewardsProps {
@@ -85,10 +60,12 @@ export function useSolanaRewardsHistory(
                 params: { limit, offset },
             });
 
-            const notAvailableYet = offset === 0 && rewardsNotAvailableYet(account, rewards);
-            const outOfSync = offset === 0 && rewardsOutOfSync(account, rewards);
+            const notAvailableYet =
+                offset === 0 && areSolanaRewardsNotAvailableYet(account, rewards);
+            const syncStatus = getSolanaRewardsSyncStatus(account, rewards);
+            const outOfSync = offset === 0 && syncStatus.isOutOfSync;
 
-            if (outOfSync) reportSolanaRewardsOutOfSync(account);
+            if (outOfSync) reportSolanaRewardsOutOfSync(account, syncStatus);
 
             return {
                 rewards,

--- a/suite-common/earn-staking-api/src/staking/utils/index.ts
+++ b/suite-common/earn-staking-api/src/staking/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './solanaRewardsUtils';
 export * from './tronAprUtils';

--- a/suite-common/earn-staking-api/src/staking/utils/solanaRewardsUtils.test.ts
+++ b/suite-common/earn-staking-api/src/staking/utils/solanaRewardsUtils.test.ts
@@ -1,0 +1,188 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import {
+    areSolanaRewardsNotAvailableYet,
+    getSolanaRewardsSyncStatus,
+    hasActiveSolanaStakingAccount,
+} from './solanaRewardsUtils';
+import { type SolRewardsHistoryRewardsItem } from '../../api/types';
+
+type SolanaAccountMisc = Extract<Account, { networkType: 'solana' }>['misc'];
+
+const mockSolanaAccount = (misc: SolanaAccountMisc): Account => {
+    const account = mockWalletAccount({ symbol: asNetworkSymbol('sol') });
+
+    if (account.networkType !== 'solana') {
+        throw new Error('Expected a solana account mock.');
+    }
+
+    return { ...account, misc };
+};
+
+const mockReward = (
+    reward: Partial<SolRewardsHistoryRewardsItem>,
+): SolRewardsHistoryRewardsItem => ({
+    epoch: 1024,
+    delegator: 'delegator-address',
+    amount: '318354',
+    currency: 'SOL',
+    time: '2026-08-30T05:31:04Z',
+    ...reward,
+});
+
+const activeStakingMisc = (solEpoch: number, activationEpoch?: number): SolanaAccountMisc => ({
+    solEpoch,
+    solStakingAccounts: [{ status: 'active', rentExemptReserve: '2282880', activationEpoch }],
+});
+
+const inactiveStakingMisc = (solEpoch: number): SolanaAccountMisc => ({
+    solEpoch,
+    solStakingAccounts: [{ status: 'inactive', rentExemptReserve: '2282880' }],
+});
+
+describe('hasActiveSolanaStakingAccount', () => {
+    it('returns true only when at least one staking account is active', () => {
+        expect(hasActiveSolanaStakingAccount(mockSolanaAccount(activeStakingMisc(1027)))).toBe(
+            true,
+        );
+        expect(hasActiveSolanaStakingAccount(mockSolanaAccount(inactiveStakingMisc(1027)))).toBe(
+            false,
+        );
+        expect(hasActiveSolanaStakingAccount(mockSolanaAccount({ solEpoch: 1027 }))).toBe(false);
+    });
+
+    it('returns false for a non-solana account', () => {
+        expect(hasActiveSolanaStakingAccount(mockWalletAccount({ symbol: 'btc' }))).toBe(false);
+    });
+});
+
+describe('areSolanaRewardsNotAvailableYet', () => {
+    it('returns true when the latest reward lags behind the previous epoch', () => {
+        const account = mockSolanaAccount(activeStakingMisc(1027));
+
+        expect(areSolanaRewardsNotAvailableYet(account, [mockReward({ epoch: 1024 })])).toBe(true);
+    });
+
+    it('returns false when the latest reward is for the previous epoch', () => {
+        const account = mockSolanaAccount(activeStakingMisc(1027));
+
+        expect(areSolanaRewardsNotAvailableYet(account, [mockReward({ epoch: 1026 })])).toBe(false);
+    });
+
+    it('returns false without an active staking account', () => {
+        const account = mockSolanaAccount(inactiveStakingMisc(1027));
+
+        expect(areSolanaRewardsNotAvailableYet(account, [mockReward({ epoch: 1024 })])).toBe(false);
+    });
+});
+
+describe('getSolanaRewardsSyncStatus', () => {
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-09-02T06:01:43Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('is out of sync when the latest reward is more than two epochs behind', () => {
+        const account = mockSolanaAccount(activeStakingMisc(1027));
+
+        expect(
+            getSolanaRewardsSyncStatus(account, [
+                mockReward({ epoch: 1024, time: '2026-08-30T05:31:04Z' }),
+            ]),
+        ).toEqual({
+            isOutOfSync: true,
+            activeEpoch: 1027,
+            latestRewardEpoch: 1024,
+            epochsSinceLatestReward: 3,
+            hoursSinceLatestReward: 73,
+        });
+    });
+
+    it('tolerates the latest reward being up to two epochs behind', () => {
+        const account = mockSolanaAccount(activeStakingMisc(1027));
+
+        expect(getSolanaRewardsSyncStatus(account, [mockReward({ epoch: 1026 })]).isOutOfSync).toBe(
+            false,
+        );
+        expect(getSolanaRewardsSyncStatus(account, [mockReward({ epoch: 1025 })]).isOutOfSync).toBe(
+            false,
+        );
+    });
+
+    it('is not out of sync when a tolerated epoch lag lasts longer than the usual epoch duration', () => {
+        const account = mockSolanaAccount(activeStakingMisc(1026));
+
+        // The latest reward is 55 hours old (a long epoch), but only one epoch behind.
+        const status = getSolanaRewardsSyncStatus(account, [
+            mockReward({ epoch: 1025, time: '2026-08-30T23:01:43Z' }),
+        ]);
+
+        expect(status.isOutOfSync).toBe(false);
+        expect(status.hoursSinceLatestReward).toBe(55);
+    });
+
+    it('is not out of sync when a restaked account only has rewards from its previous staking cycle', () => {
+        // The stake activated in epoch 1025 earns its first reward for epoch 1026,
+        // so the old-cycle reward from epoch 1010 is not a sign of stale API data.
+        const account = mockSolanaAccount(activeStakingMisc(1027, 1025));
+
+        const status = getSolanaRewardsSyncStatus(account, [mockReward({ epoch: 1010 })]);
+
+        expect(status.isOutOfSync).toBe(false);
+        expect(status.oldestActiveStakeActivationEpoch).toBe(1025);
+    });
+
+    it('is out of sync when even the first reward of a restaked cycle is more than two epochs late', () => {
+        const account = mockSolanaAccount(activeStakingMisc(1027, 1023));
+
+        expect(getSolanaRewardsSyncStatus(account, [mockReward({ epoch: 1010 })]).isOutOfSync).toBe(
+            true,
+        );
+    });
+
+    it('is not out of sync without an active staking account', () => {
+        const account = mockSolanaAccount(inactiveStakingMisc(1027));
+
+        expect(getSolanaRewardsSyncStatus(account, [mockReward({ epoch: 1024 })]).isOutOfSync).toBe(
+            false,
+        );
+    });
+
+    it('reports an out-of-sync epoch lag even when the latest reward time is missing or invalid', () => {
+        const account = mockSolanaAccount(activeStakingMisc(1027));
+
+        const status = getSolanaRewardsSyncStatus(account, [mockReward({ epoch: 1024, time: '' })]);
+
+        expect(status.isOutOfSync).toBe(true);
+        expect(status.hoursSinceLatestReward).toBeUndefined();
+
+        expect(
+            getSolanaRewardsSyncStatus(account, [mockReward({ epoch: 1024, time: 'not-a-date' })])
+                .isOutOfSync,
+        ).toBe(true);
+    });
+
+    it('is not out of sync when the epoch or rewards data is incomplete', () => {
+        const accountWithoutEpoch = mockSolanaAccount({
+            solStakingAccounts: [{ status: 'active', rentExemptReserve: '2282880' }],
+        });
+        const account = mockSolanaAccount(activeStakingMisc(1027));
+
+        expect(getSolanaRewardsSyncStatus(accountWithoutEpoch, [mockReward({})]).isOutOfSync).toBe(
+            false,
+        );
+        expect(getSolanaRewardsSyncStatus(account, []).isOutOfSync).toBe(false);
+    });
+
+    it('is not out of sync for a non-solana account', () => {
+        expect(
+            getSolanaRewardsSyncStatus(mockWalletAccount({ symbol: 'btc' }), [mockReward({})])
+                .isOutOfSync,
+        ).toBe(false);
+    });
+});

--- a/suite-common/earn-staking-api/src/staking/utils/solanaRewardsUtils.ts
+++ b/suite-common/earn-staking-api/src/staking/utils/solanaRewardsUtils.ts
@@ -1,0 +1,114 @@
+import { type Account } from '@suite-common/wallet-types';
+
+import { type SolRewardsHistory } from '../../api/types';
+
+// Everstake publishes the reward for an epoch only after the epoch ends, so the latest
+// reward being one or two epochs behind the active epoch is expected; a bigger lag means
+// the rewards history API is out of sync with the chain.
+const MAX_TOLERATED_EPOCH_LAG = 2;
+
+const isInt = (value: unknown): value is number => Number.isInteger(value);
+
+export type SolanaRewardsSyncStatus = {
+    isOutOfSync: boolean;
+    activeEpoch?: number;
+    latestRewardEpoch?: number;
+    epochsSinceLatestReward?: number;
+    hoursSinceLatestReward?: number;
+    oldestActiveStakeActivationEpoch?: number;
+};
+
+const getActiveSolanaStakingAccounts = (account: Account) => {
+    if (account.networkType !== 'solana') {
+        return [];
+    }
+
+    return (account.misc?.solStakingAccounts ?? []).filter(
+        stakingAccount => stakingAccount.status === 'active',
+    );
+};
+
+export const hasActiveSolanaStakingAccount = (account: Account) =>
+    getActiveSolanaStakingAccounts(account).length > 0;
+
+// The oldest active stake tells us since when a reward per epoch is expected again — any
+// older stake among the active ones would already earn every epoch.
+const getOldestActiveStakeActivationEpoch = (account: Account) => {
+    const activationEpochs = getActiveSolanaStakingAccounts(account)
+        .map(stakingAccount => stakingAccount.activationEpoch)
+        .filter(isInt);
+
+    return activationEpochs.length > 0 ? Math.min(...activationEpochs) : undefined;
+};
+
+export const areSolanaRewardsNotAvailableYet = (
+    account: Account,
+    rewards: SolRewardsHistory['rewards'],
+) => {
+    if (account.networkType !== 'solana') {
+        return false;
+    }
+
+    const currentActiveEpoch = account.misc?.solEpoch;
+    const latestRewardEpoch = rewards[0]?.epoch;
+
+    if (
+        !isInt(currentActiveEpoch) ||
+        !isInt(latestRewardEpoch) ||
+        !hasActiveSolanaStakingAccount(account)
+    ) {
+        return false;
+    }
+
+    return currentActiveEpoch - 1 !== latestRewardEpoch;
+};
+
+/**
+ * Detects whether the rewards history API lags behind the current active epoch more than
+ * expected. Only accounts with an active stake are checked — after an unstake the latest
+ * reward legitimately keeps getting older, which is not a sign of stale API data.
+ */
+export const getSolanaRewardsSyncStatus = (
+    account: Account,
+    rewards: SolRewardsHistory['rewards'],
+): SolanaRewardsSyncStatus => {
+    if (account.networkType !== 'solana') {
+        return { isOutOfSync: false };
+    }
+
+    const activeEpoch = account.misc?.solEpoch;
+    const latestRewardEpoch = rewards[0]?.epoch;
+
+    if (
+        !isInt(activeEpoch) ||
+        !isInt(latestRewardEpoch) ||
+        !hasActiveSolanaStakingAccount(account)
+    ) {
+        return { isOutOfSync: false };
+    }
+
+    const epochsSinceLatestReward = activeEpoch - latestRewardEpoch;
+
+    // A stake activated in epoch N earns its first reward for epoch N + 1, so right after a
+    // restake the latest reward may legitimately still come from the previous staking cycle.
+    const oldestActiveStakeActivationEpoch = getOldestActiveStakeActivationEpoch(account);
+    const latestExpectedRewardEpoch = isInt(oldestActiveStakeActivationEpoch)
+        ? Math.max(latestRewardEpoch, oldestActiveStakeActivationEpoch + 1)
+        : latestRewardEpoch;
+
+    // The reward age is diagnostics only — a missing or invalid timestamp must not suppress
+    // the epoch-based decision.
+    const latestRewardTimestamp = Date.parse(rewards[0]?.time ?? '');
+    const hoursSinceLatestReward = Number.isFinite(latestRewardTimestamp)
+        ? Math.round((Date.now() - latestRewardTimestamp) / 1000 / 60 / 60)
+        : undefined;
+
+    return {
+        isOutOfSync: activeEpoch - latestExpectedRewardEpoch > MAX_TOLERATED_EPOCH_LAG,
+        activeEpoch,
+        latestRewardEpoch,
+        epochsSinceLatestReward,
+        hoursSinceLatestReward,
+        oldestActiveStakeActivationEpoch,
+    };
+};

--- a/suite-common/earn-staking-api/tsconfig.json
+++ b/suite-common/earn-staking-api/tsconfig.json
@@ -5,6 +5,7 @@
         { "path": "../http-client" },
         { "path": "../react-query" },
         { "path": "../wallet-types" },
-        { "path": "../../packages/env-utils" }
+        { "path": "../../packages/env-utils" },
+        { "path": "../wallet-config" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10858,6 +10858,7 @@ __metadata:
     "@sentry/core": "npm:10.69.0"
     "@suite-common/http-client": "workspace:*"
     "@suite-common/react-query": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     orval: "npm:8.19.0"


### PR DESCRIPTION
## Description

The "Solana rewards history is out of sync" error was reported even when the Everstake API data was correct:

- an unstaked account has no new rewards, so its aging rewards history triggered the report forever - now only accounts with an active stake are checked
- the fixed 52h condition tripped on long epochs - the decision is now purely epoch-based (> 2 epochs behind)
- after a restake, old-cycle rewards no longer trigger the report (`activationEpoch` newly propagated from on-chain data)

The event now carries epoch/reward-age diagnostics and is reported once per account per app session. Detection logic extracted to `solanaRewardsUtils` and covered by unit tests.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/32027

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set focuses on Solana staking rewards history and the underlying Solana network staking runtime/types. The highest-risk regression is incorrect reward data, so the Solana rewards test should run unconditionally. The Solana initial-stake test adds coverage for the shared Solana staking runtime without expanding to unrelated ADA/ETH staking or analytics suites. Build/config files have no E2E coverage and can be validated by the existing pipeline.

<details><summary><b>Changed files (9)</b></summary>

- `networks/solana/network-solana/src/runtime/staking.ts`
- `networks/solana/network-solana/src/types/common.ts`
- `packages/blockchain-link-types/src/common.ts`
- `suite-common/earn-staking-api/package.json`
- `suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts`
- `suite-common/earn-staking-api/src/staking/utils/index.ts`
- `suite-common/earn-staking-api/src/staking/utils/solanaRewardsUtils.test.ts`
- `suite-common/earn-staking-api/src/staking/utils/solanaRewardsUtils.ts`
- `suite-common/earn-staking-api/tsconfig.json`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test directly validates the Solana rewards list, reward totals, and cache refresh behavior. The changed useSolanaRewardsHistory hook and solanaRewardsUtils are the exact code that fetches and formats Solana reward history, so a regression would be immediately visible here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test exercises the Solana staking runtime path (stake account data, epoch activation, dashboard state) which is affected by the changed Solana network runtime/types. It provides confidence that general Solana staking state propagation still works, even though it does not focus on rewards history.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/earn-staking-api/package.json`
- `suite-common/earn-staking-api/tsconfig.json`
- `suite-common/earn-staking-api/src/staking/utils/solanaRewardsUtils.test.ts`

_Updated: 2026-09-03T08:57:07.906Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-rewards-out-of-sync-false-positives/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-rewards-out-of-sync-false-positives/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-rewards-out-of-sync-false-positives&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-rewards-out-of-sync-false-positives&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/solana-rewards-out-of-sync-false-positives&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T08:59:11.319Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T08:58:48.271Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->