### PR TITLE
refactor(suite-common): move `acquireDeviceThunk` to `@suite-common/device`, drop `startDiscovery` param

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -1,7 +1,10 @@
 import { onSuiteInit, onSuiteReady, updateOnlineStatus } from '@suite/suite-lifecycle';
-import { deviceActions, selectNewlyConnectedDeviceThunk } from '@suite-common/device';
+import {
+    acquireDeviceThunk,
+    deviceActions,
+    selectNewlyConnectedDeviceThunk,
+} from '@suite-common/device';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { notificationsActions } from '@suite-common/toast-notifications';
 import { DEVICE, type Device, TRANSPORT } from '@trezor/connect';
 
 import { type AppState } from 'src/types/suite';
@@ -521,11 +524,12 @@ const acquireDevice = [
                 message: 'getFeatures error',
             },
         },
-        result: notificationsActions.addToast.type,
+        result: acquireDeviceThunk.rejected.type,
     },
     {
         description: `without device`,
         state: { selectedDevice: {} },
+        result: acquireDeviceThunk.rejected.type,
     },
 ];
 

--- a/packages/suite/src/actions/suite/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/suiteActions.test.ts
@@ -17,6 +17,7 @@ import {
     mockGetThpSettings,
 } from '@suite-common/connect-init/mocks';
 import {
+    acquireDeviceThunk,
     deviceActions,
     prepareDeviceReducer,
     selectDeviceThunk,
@@ -35,7 +36,6 @@ import {
 } from '@suite-common/suite-types/mocks';
 import { createTestStore, filterThunkActionTypes, testMocks } from '@suite-common/test-utils';
 import {
-    acquireDeviceThunk,
     forgetDisconnectedDevicesThunk,
     observeSelectedDeviceThunk,
 } from '@suite-common/wallet-core';

--- a/packages/suite/src/components/suite/AcquireDeviceButton.tsx
+++ b/packages/suite/src/components/suite/AcquireDeviceButton.tsx
@@ -2,8 +2,8 @@ import { type MouseEventHandler } from 'react';
 
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
+import { acquireDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
 type AcquireButtonProps = {

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -2,8 +2,8 @@ import { type MouseEventHandler } from 'react';
 
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
+import { acquireDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx
@@ -2,8 +2,8 @@ import { type MouseEventHandler } from 'react';
 
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
+import { acquireDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx
@@ -1,6 +1,5 @@
-import { selectDeviceThunk } from '@suite-common/device';
+import { acquireDeviceThunk, selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { DEVICE } from '@trezor/connect';
 
 import type { NotificationRendererProps } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -7,9 +7,8 @@ import {
 import { closeModal } from '@suite/modal';
 import { closeModalAppThunk } from '@suite/router';
 import { ThpPairingStep } from '@suite/thp';
-import { selectSelectedDevice } from '@suite-common/device';
+import { acquireDeviceThunk, selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Modal } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -1,13 +1,12 @@
 import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { gotoThunk } from '@suite/router';
-import { selectDeviceThunk } from '@suite-common/device';
+import { acquireDeviceThunk, selectDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     type DeviceStatus as ConnectedDeviceStatus,
     type getStatus,
 } from '@suite-common/suite-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import { Banner, type BannerIntent } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 

--- a/suite-common/device/package.json
+++ b/suite-common/device/package.json
@@ -18,6 +18,7 @@
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
+        "@suite-common/toast-notifications": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:*",
         "@trezor/device-utils": "workspace:*",

--- a/suite-common/device/src/acquireDeviceThunk.ts
+++ b/suite-common/device/src/acquireDeviceThunk.ts
@@ -1,0 +1,49 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import TrezorConnect from '@trezor/connect';
+
+import { DEVICE_MODULE_PREFIX } from './deviceConstants';
+import { type DeviceRootState } from './deviceReducer';
+import { selectSelectedDevice } from './deviceSelectors';
+
+/**
+ * Called from <AcquireDevice /> component
+ * Fetch device features without asking for pin/passphrase
+ */
+type AcquireDeviceThunkParams = {
+    requestedDevice?: TrezorDevice | null;
+};
+
+type AcquireDeviceThunkState = DeviceRootState;
+
+export const acquireDeviceThunk = createThunk<
+    void,
+    AcquireDeviceThunkParams,
+    { state: AcquireDeviceThunkState }
+>(
+    `${DEVICE_MODULE_PREFIX}/acquireDeviceThunk`,
+    async ({ requestedDevice }, { dispatch, getState, rejectWithValue }) => {
+        const device = requestedDevice ?? selectSelectedDevice(getState());
+
+        if (!device) {
+            return rejectWithValue({ error: 'Device_NotFound' });
+        }
+
+        const response = await TrezorConnect.getFeatures({ device });
+
+        if (!response.success) {
+            if (response.error.code !== 'Device_ThpPairingTagInvalid') {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'acquire-error',
+                        device,
+                        error: response.error.message,
+                    }),
+                );
+            }
+
+            return rejectWithValue({ error: response.error.message });
+        }
+    },
+);

--- a/suite-common/device/src/index.ts
+++ b/suite-common/device/src/index.ts
@@ -1,3 +1,4 @@
+export * from './acquireDeviceThunk';
 export * from './deviceActions';
 export * from './deviceConstants';
 export type * from './deviceDeps';

--- a/suite-common/device/tsconfig.json
+++ b/suite-common/device/tsconfig.json
@@ -6,6 +6,7 @@
         { "path": "../suite-constants" },
         { "path": "../suite-types" },
         { "path": "../suite-utils" },
+        { "path": "../toast-notifications" },
         { "path": "../../packages/connect" },
         {
             "path": "../../packages/connect-common"

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -10,6 +10,7 @@ import {
     DEVICE_MODULE_PREFIX,
     type DeviceRootState,
     PORTFOLIO_TRACKER_DEVICE_ID,
+    acquireDeviceThunk,
     deviceActions,
     portfolioTrackerDevice,
     selectDeviceById,
@@ -26,7 +27,6 @@ import {
     type FirmwareRootState,
     selectIsFirmwareInstallationRunning,
 } from '@suite-common/firmware';
-import { type FetchAndSaveMetadataDep } from '@suite-common/metadata-types';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type AcquiredDevice,
@@ -64,7 +64,6 @@ import { isChanged } from '@trezor/utils';
 import { getAddressForNetworkType } from './deviceAddressUtils';
 import { type AccountsRootState } from '../accounts/accountsReducer';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
-import { type RunDiscoveryThunkState, startDiscoveryThunk } from '../discovery/discoveryThunks';
 import { setAutoEjectEnabled } from '../settings/walletSettingsActions';
 import {
     type WalletSettingsRootState,
@@ -200,55 +199,6 @@ export const observeSelectedDeviceThunk = createThunk<
     },
 );
 
-/**
- * Called from <AcquireDevice /> component
- * Fetch device features without asking for pin/passphrase
- * this is the only place where useEmptyPassphrase should be always set to "true"
- */
-type AcquireDeviceThunkParams = {
-    requestedDevice?: TrezorDevice | null;
-    startDiscovery?: boolean;
-};
-
-type AcquireDeviceThunkState = RunDiscoveryThunkState;
-
-type AcquireDeviceThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
-    thunks: FetchAndSaveMetadataDep;
-};
-
-export const acquireDeviceThunk = createThunk<
-    void,
-    AcquireDeviceThunkParams,
-    { state: AcquireDeviceThunkState; extra: AcquireDeviceThunkDeps }
->(
-    `${DEVICE_MODULE_PREFIX}/acquireDevice`,
-    async ({ requestedDevice, startDiscovery }, { dispatch, getState }) => {
-        const device = requestedDevice ?? selectSelectedDevice(getState());
-
-        if (!device) return;
-
-        const response = await TrezorConnect.getFeatures({ device });
-
-        if (!response.success) {
-            if (response.error.code !== 'Device_ThpPairingTagInvalid') {
-                dispatch(
-                    notificationsActions.addToast({
-                        type: 'acquire-error',
-                        device,
-                        error: response.error.message,
-                    }),
-                );
-            }
-        } else if (startDiscovery) {
-            dispatch(
-                startDiscoveryThunk({
-                    device,
-                }),
-            );
-        }
-    },
-);
-
 type InitDevicesThunkState = DeviceRootState;
 
 export const initDevicesThunk = createThunk<void, void, { state: InitDevicesThunkState }>(
@@ -347,11 +297,9 @@ type DeviceConnectThunkParams = {
     device: Device;
 };
 
-export type DeviceConnectThunkState = FirmwareRootState & RunDiscoveryThunkState;
+export type DeviceConnectThunkState = FirmwareRootState & DeviceRootState;
 
-export type DeviceConnectThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep> & {
-    thunks: FetchAndSaveMetadataDep;
-};
+export type DeviceConnectThunkDeps = WithServices<AnalyticsDep & GetTradedAccountKeysDep>;
 
 export const deviceConnectThunk = createThunk<
     void,

--- a/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
+++ b/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
@@ -6,12 +6,12 @@ import { useNavigation } from '@react-navigation/native';
 
 import { bluetoothActions } from '@suite-common/bluetooth';
 import {
+    acquireDeviceThunk,
     selectIsAnyPhysicalDeviceConnectedViaUsb,
     selectIsDeviceAuthorized,
     selectIsDeviceThpLocked,
 } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import {
     AuthorizeDeviceStackRoutes,
     type HomeStackParamList,

--- a/suite-native/device/src/hooks/useDetectDeviceError.tsx
+++ b/suite-native/device/src/hooks/useDetectDeviceError.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
 import {
+    acquireDeviceThunk,
     deviceActions,
     selectHasDeviceFirmwareInstalled,
     selectIsConnectedDeviceUninitialized,
@@ -16,7 +17,7 @@ import {
     selectSelectedDevice,
 } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
+import { startDiscoveryThunk } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { selectIsFirmwareInstallationRunning } from '@suite-native/firmware';
@@ -95,6 +96,7 @@ export const useDetectDeviceError = () => {
     // we cannot work with device anymore. Shouldn't happen on mobile app but just in case.
     useEffect(() => {
         if (
+            selectedDevice &&
             isOnboardingFinished &&
             isUnacquiredDevice &&
             !isDevicePinLocked &&
@@ -108,12 +110,13 @@ export const useDetectDeviceError = () => {
                 pictogramVariant: 'critical',
                 primaryButtonTitle: <Translation id="moduleDevice.unacquiredDeviceModal.button" />,
                 appendix: <UnacquiredDeviceModalAppendix />,
-                onPressPrimaryButton: () => {
-                    dispatch(
-                        acquireDeviceThunk({
-                            startDiscovery: true,
-                        }),
+                onPressPrimaryButton: async () => {
+                    const acquireResult = await dispatch(
+                        acquireDeviceThunk({ requestedDevice: selectedDevice }),
                     );
+                    if (acquireResult.type === acquireDeviceThunk.fulfilled.type) {
+                        dispatch(startDiscoveryThunk({ device: selectedDevice }));
+                    }
                 },
                 testID: '@device/errors/alert/unacquired-device',
             });
@@ -121,6 +124,7 @@ export const useDetectDeviceError = () => {
             hideAlert('deviceError');
         }
     }, [
+        selectedDevice,
         isDevicePinLocked,
         isOnboardingFinished,
         isUnacquiredDevice,

--- a/suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts
+++ b/suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts
@@ -3,9 +3,8 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { selectSelectedDevice } from '@suite-common/device';
+import { acquireDeviceThunk, selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
-import { acquireDeviceThunk } from '@suite-common/wallet-core';
 import {
     type AuthorizeDeviceStackParamList,
     AuthorizeDeviceStackRoutes,

--- a/suite/discovery/src/conditions.ts
+++ b/suite/discovery/src/conditions.ts
@@ -16,7 +16,7 @@ type DeviceReadyRootState = DeviceRootState & LocksRootState;
 /**
  * Determines if device is ready for discovery, either:
  * - unlocked
- * - edge case: locked, and just has been acquired. In that case, device-change is emitted right before acquireDevice ends (and unlocks the device).
+ * - edge case: locked, and just has been acquired. In that case, device-change is emitted right before acquireDeviceThunk ends (and unlocks the device).
  *   TODO investigate if the lock state can be synced sooner, so that this case can be removed.
  */
 export const selectIsDeviceReadyToStartDiscovery = (

--- a/suite/receive/src/verification/showAddressThunk.ts
+++ b/suite/receive/src/verification/showAddressThunk.ts
@@ -4,6 +4,7 @@ import { setConnectionModal, setConnectionMode } from '@suite/device';
 import { closeModal, preserveModal, removePreserveModal } from '@suite/modal';
 import {
     type DeviceRootState,
+    acquireDeviceThunk,
     selectIsDevicePinLocked,
     selectSelectedDevice,
 } from '@suite-common/device';
@@ -12,7 +13,6 @@ import { type Dispatch, type WithServices } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type WalletSettingsRootState,
-    acquireDeviceThunk,
     confirmAddressOnDeviceThunk,
     selectAddressDisplayType,
 } from '@suite-common/wallet-core';
@@ -55,10 +55,10 @@ export const showAddressThunk =
         }
 
         // A PIN-locked device stays connected & available, so nothing stops the user from asking for
-        // a verification it cannot answer. Unlock it first — acquireDevice reads features, which
+        // a verification it cannot answer. Unlock it first — acquireDeviceThunk reads features, which
         // makes the device prompt for the PIN. It emits device-change before it resolves, so the
         // status below is already up to date; still locked means the user dismissed the prompt, and
-        // acquireDevice has reported any real failure itself.
+        // acquireDeviceThunk has reported any real failure itself.
         if (selectIsDevicePinLocked(getState())) {
             await dispatch(acquireDeviceThunk({ requestedDevice: device }));
 

--- a/suite/thp/src/connection/ThpPairingFailedModal.tsx
+++ b/suite/thp/src/connection/ThpPairingFailedModal.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Translation } from '@suite/intl';
+import { acquireDeviceThunk } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { selectThpLastCode, thpActions } from '@suite-common/thp';
-import { acquireDeviceThunk, selectSelectedFirstThpDevice } from '@suite-common/wallet-core';
+import { selectSelectedFirstThpDevice } from '@suite-common/wallet-core';
 import { Column, Modal, Paragraph } from '@trezor/components';
 
 import { ThpPairingCodeEntry } from './ThpPairingCodeEntry';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10763,6 +10763,7 @@ __metadata:
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/toast-notifications": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     "@trezor/device-utils": "workspace:*"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

`startDiscovery` param was used only in one place - in `@suite-native` i've replaced it by awaiting acquireDeviceThunk result and calling  `startDiscoveryThunk` explicitly.

since discovery dependency was dropped thunk could be moved to `@suite-common/device` safely.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set refactors device acquisition/session logic, touches THP pairing UI, the firmware modal, notification actions, and discovery/receive thunks. Highest regression risk is in Bridge session handling and THP onboarding, so run the targeted high tests first. Add medium tests for notifications, passphrase reconnect, and discovery because they share the affected thunks and rendering paths. Native-only and unit-test files have no Suite E2E coverage.

<details><summary><b>Changed files (19)</b></summary>

- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `packages/suite/src/actions/suite/suiteActions.test.ts`
- `packages/suite/src/components/suite/AcquireDeviceButton.tsx`
- `packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx`
- `packages/suite/src/components/suite/PrerequisitesGuide/DeviceTrezorHostProtocolPair.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/ActionRenderer.tsx`
- `packages/suite/src/views/firmware/FirmwareModal.tsx`
- `packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx`
- `suite-common/device/package.json`
- `suite-common/device/src/acquireDeviceThunk.ts`
- `suite-common/device/src/index.ts`
- `suite-common/device/tsconfig.json`
- `suite-common/wallet-core/src/device/deviceThunks.ts`
- `suite-native/device/src/hooks/useConnectDeviceHandler.tsx`
- `suite-native/device/src/hooks/useDetectDeviceError.tsx`
- `suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts`
- `suite/discovery/src/conditions.ts`
- `suite/receive/src/verification/showAddressThunk.ts`
- `suite/thp/src/connection/ThpPairingFailedModal.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — The PR changes FirmwareModal.tsx, the shell for firmware flows, and this test directly exercises opening, selecting a binary, and completing custom firmware installation through that modal.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — T3W1 onboarding uses THP pairing, which exercises the changed DeviceTrezorHostProtocolPair component and the THP pairing failure modal in the pairing code path.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Bridge session takeover and reclaim directly exercise device acquisition (AcquireDeviceButton, DeviceAcquire), the SwitchDevice needs-attention banner, and the device thunks refactored into suite-common/device.
- `suite/e2e/tests/wallet/receive.test.ts` — Address verification relies on showAddressThunk and a successfully acquired device session; regressions in the acquisition thunks would break receive address display, copy, and QR code behavior.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/activity/activity-page.test.ts` — Notification action buttons are rendered by ActionRenderer; this test verifies transaction and system toast notifications appear and can be dismissed, providing coverage for notification rendering changes.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Re-connecting a passphrase-protected wallet after power-off depends on device acquisition thunks and address verification, which overlap with the refactored acquisition logic.
- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin discovery after onboarding depends on discovery conditions and device thunks; changes there could cause discovery to stall or fail to recover after a reload.

</details>

⚠️ **Changes with no test coverage (9)**
- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `packages/suite/src/actions/suite/suiteActions.test.ts`
- `suite-common/device/package.json`
- `suite-common/device/src/index.ts`
- `suite-common/device/tsconfig.json`
- `suite-native/device/src/hooks/useConnectDeviceHandler.tsx`
- `suite-native/device/src/hooks/useDetectDeviceError.tsx`
- `suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts`
- `suite/thp/src/connection/ThpPairingFailedModal.tsx`

_Updated: 2026-09-03T14:30:09.827Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/move-acquiredevicethunk/web/](https://dev.suite.sldev.cz/suite-web/refactor/move-acquiredevicethunk/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/move-acquiredevicethunk&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/move-acquiredevicethunk&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/move-acquiredevicethunk&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T14:31:35.936Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T14:31:50.974Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->