### PR TITLE
refactor(e2e-utils): pretty-print Claude stream-json messages in run logs

### DIFF
--- a/packages/e2e-utils/eslint.config.mjs
+++ b/packages/e2e-utils/eslint.config.mjs
@@ -11,6 +11,7 @@ export default [
                     devDependencies: [
                         ...globalNoExtraneousDependenciesDevDependencies,
                         '**/fixBot/**',
+                        '**/llmExploratoryTester/**',
                         '**/llmTestAnalyzer/**',
                         '**/llmTestSelector/**',
                         '**/quarantineBot/**',

--- a/packages/e2e-utils/src/llmExploratoryTester/runClaude.ts
+++ b/packages/e2e-utils/src/llmExploratoryTester/runClaude.ts
@@ -1,8 +1,13 @@
+import { formatMessage } from 'claude-pretty-printer';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
+import { createInterface } from 'node:readline';
 
+import { log } from '../logger';
 import { REPO_ROOT } from './paths';
 import { type ClaudeResult, ClaudeResultSchema } from './schemas';
+
+const MAX_LOG_CHARS = 1000;
 
 export type ClaudeRunResult = {
     output: string;
@@ -47,12 +52,20 @@ export async function runClaude({
     });
 
     child.stdin.end(input);
-    // `{ end: false }` so closing Claude's stdout does not close this process's stderr.
-    child.stdout.pipe(process.stderr, { end: false });
 
     let output = '';
-    child.stdout.on('data', (chunk: Buffer) => {
-        output += chunk.toString('utf-8');
+    createInterface({ input: child.stdout }).on('line', line => {
+        output += `${line}\n`;
+        try {
+            const formatted = formatMessage(JSON.parse(line), false);
+            log(
+                formatted.length > MAX_LOG_CHARS
+                    ? `${formatted.slice(0, MAX_LOG_CHARS)}…`
+                    : formatted,
+            );
+        } catch {
+            log(line);
+        }
     });
 
     const killTimer = setTimeout(() => child.kill('SIGTERM'), timeoutMs);


### PR DESCRIPTION
## Description

Pretty-print Claude's `stream-json` stdout in the LLM exploratory tester run logs.

Each line is parsed, formatted with `claude-pretty-printer`, and logged (truncated to 1000 chars) instead of piping the raw JSON stream to stderr.

## Notes for QA

No Suite QA needed. Change is isolated to CI/dev logging of the LLM exploratory tester (`runClaude.ts`).

## Related Issue

N/A

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file, packages/e2e-utils/src/llmExploratoryTester/runClaude.ts, is an internal exploratory LLM-tester harness. It is not referenced by any of the 53 candidate Playwright E2E tests, either statically or via the LLM-derived behavior/source hints. There is no user-facing functionality at risk and no inferred test path that exercises this harness, so no E2E tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/e2e-utils/src/llmExploratoryTester/runClaude.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/e2e-utils/src/llmExploratoryTester/runClaude.ts`

_Updated: 2026-09-04T08:59:55.398Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/llmtester-tool-text-streaming/web/](https://dev.suite.sldev.cz/suite-web/llmtester-tool-text-streaming/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=llmtester-tool-text-streaming&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=llmtester-tool-text-streaming&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T09:02:59.436Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T09:02:35.340Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->