### PR TITLE
Show the Cardano activation period as a ~5–10 day range

### DIFF
--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnStakingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnStakingInfo.tsx
@@ -4,7 +4,11 @@ import { Translation } from '@suite/intl';
 import { getDaysToAddToPoolInitial } from '@suite-common/staking';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { CARDANO_ACTIVATION_PERIOD_DAYS, CARDANO_EPOCH_DAYS } from '@suite-common/wallet-constants';
+import {
+    CARDANO_ACTIVATION_PERIOD_MAX_DAYS,
+    CARDANO_ACTIVATION_PERIOD_MIN_DAYS,
+    CARDANO_EPOCH_DAYS,
+} from '@suite-common/wallet-constants';
 import { selectEthValidatorsQueue, selectPoolStatsApy } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { StepList } from '@trezor/components';
@@ -125,15 +129,17 @@ const CardanoStakingRows = ({ flow, apy }: EarnStakingRowsProps) => (
                             ? 'TR_EARN_KEEP_EARNING_REWARDS_WITH_CURRENT_PROVIDER'
                             : 'TR_EARN_ENTER_ACTIVATION_PERIOD'
                     }
-                    values={{ days: CARDANO_ACTIVATION_PERIOD_DAYS }}
                 />
             }
             subheading={<Translation id="TR_EARN_TIME_TO_START_EARNING" />}
             content={{
                 text: (
                     <Translation
-                        id="TR_EARN_APPROXIMATE_DAYS"
-                        values={{ count: CARDANO_ACTIVATION_PERIOD_DAYS }}
+                        id="TR_EARN_APPROXIMATE_DAYS_RANGE"
+                        values={{
+                            minDays: CARDANO_ACTIVATION_PERIOD_MIN_DAYS,
+                            maxDays: CARDANO_ACTIVATION_PERIOD_MAX_DAYS,
+                        }}
                     />
                 ),
             }}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/hooks/useProgressLabelsData.tsx
@@ -2,7 +2,11 @@ import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
 import { type NetworkType } from '@suite-common/wallet-config';
-import { CARDANO_ACTIVATION_PERIOD_DAYS, CARDANO_EPOCH_DAYS } from '@suite-common/wallet-constants';
+import {
+    CARDANO_ACTIVATION_PERIOD_MAX_DAYS,
+    CARDANO_ACTIVATION_PERIOD_MIN_DAYS,
+    CARDANO_EPOCH_DAYS,
+} from '@suite-common/wallet-constants';
 import {
     type Account,
     type StakeType,
@@ -173,9 +177,10 @@ const buildCardanoLabels = ({
                     <Translation id="TR_STAKE_ACTIVATION_PERIOD" />
                     <Paragraph typographyStyle="body-xs" intent="neutral" priority="secondary">
                         <Translation
-                            id="TR_UP_TO_DAYS"
+                            id="TR_EARN_APPROXIMATE_DAYS_RANGE"
                             values={{
-                                count: CARDANO_ACTIVATION_PERIOD_DAYS,
+                                minDays: CARDANO_ACTIVATION_PERIOD_MIN_DAYS,
+                                maxDays: CARDANO_ACTIVATION_PERIOD_MAX_DAYS,
                             }}
                         />
                     </Paragraph>

--- a/suite-common/wallet-constants/src/cardanoConstants.ts
+++ b/suite-common/wallet-constants/src/cardanoConstants.ts
@@ -1,8 +1,9 @@
 import { BigNumber } from '@trezor/utils';
 
 export const CARDANO_EPOCH_DAYS = 5;
-const CARDANO_APPROXIMATE_EPOCHS = 2;
-export const CARDANO_ACTIVATION_PERIOD_DAYS = CARDANO_APPROXIMATE_EPOCHS * CARDANO_EPOCH_DAYS;
+// Delegation activates two epoch boundaries after the certificate.
+export const CARDANO_ACTIVATION_PERIOD_MIN_DAYS = CARDANO_EPOCH_DAYS;
+export const CARDANO_ACTIVATION_PERIOD_MAX_DAYS = 2 * CARDANO_EPOCH_DAYS;
 
 export const CARDANO_STAKING_REGISTRATION_DEPOSIT = '2';
 export const MIN_CARDANO_AMOUNT_FOR_STAKING = new BigNumber(0);

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11726,6 +11726,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_APPROXIMATE_DAYS',
         defaultMessage: '~{count, plural, one {# day} other {# days}}',
     },
+    TR_EARN_APPROXIMATE_DAYS_RANGE: {
+        id: 'TR_EARN_APPROXIMATE_DAYS_RANGE',
+        defaultMessage: '~{minDays}–{maxDays} days',
+    },
     TR_STAKE_MAX_REWARD_DAYS: {
         id: 'TR_STAKE_MAX_REWARD_DAYS',
         defaultMessage: 'Max {count, plural, one {# day} other {# days}}',


### PR DESCRIPTION
## Description

Both the "About staking" modal and the live staking progress label showed Cardano's delegation activation as a fixed "~10 days". The real wait depends on where in the epoch the transaction lands, and is anywhere from just over 5 days to just under 10. Both places now show a ~5–10 day range instead.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30056

## Screenshots:
<img width="1209" height="461" alt="Screenshot 2026-09-03 at 09 23 29" src="https://github.com/user-attachments/assets/f6e0ce8f-cc46-47b3-9602-b6d5acf198b7" />
