### PR TITLE
Bump minimum firmware in e2e tests

### DIFF
--- a/packages/connect/e2e/__fixtures__/getAccountInfo.ts
+++ b/packages/connect/e2e/__fixtures__/getAccountInfo.ts
@@ -115,7 +115,7 @@ const getAccountInfo: TestCase = {
             description: 'invalid path',
             params: {
                 coin: 'btc',
-                path: "m/49'/0'",
+                path: "m/49'",
             },
             result: false,
         },

--- a/packages/connect/e2e/__fixtures__/getPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKey.ts
@@ -33,12 +33,14 @@ const getPublicKey: TestCase = {
                 descriptor: `tr([95d8f670/86h/0h/0h]xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)#htg5lhe3`,
                 displayablePublicKey: `tr([95d8f670/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`,
             },
-            legacyResults: [
-                {
-                    rules: ['<1.10.4', '<2.4.3'],
-                    success: false,
-                },
-            ],
+            get legacyResults() {
+                const { descriptor, ...payload } = this.result;
+
+                return [
+                    { rules: ['<1.10.4', '<2.4.3'], success: false },
+                    { rules: ['2.4.3-2.6.9'], payload },
+                ];
+            },
         },
         {
             description: 'Bitcoin bech32 first account',
@@ -139,12 +141,14 @@ const getPublicKey: TestCase = {
             // T1B1 emulator's getScreenContent returns a placeholder; older T2T1 FW
             // doesn't render descriptors.
             deviceScreenSkip: ['1', '<2.7.0'],
-            legacyResults: [
-                {
-                    rules: ['<1.10.4', '<2.4.3'],
-                    success: false,
-                },
-            ],
+            get legacyResults() {
+                const { descriptor, ...payload } = this.result;
+
+                return [
+                    { rules: ['<1.10.4', '<2.4.3'], success: false },
+                    { rules: ['2.4.3-2.6.9'], payload },
+                ];
+            },
         },
         {
             description: 'Bitcoin bech32 first account (showOnTrezor)',

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -91,8 +91,8 @@ const groups = {
     },
 };
 
-const firmwares1 = ['1.9.0', '1-latest', '1-main'];
-const firmwares2 = ['2.3.0', '2-latest', '2-main'];
+const firmwares1 = ['1.12.1', '1-latest', '1-main'];
+const firmwares2 = ['2.5.3', '2-latest', '2-main'];
 
 const inputs = [
     {
@@ -113,7 +113,7 @@ const inputs = [
         value: ({ model, firmware }) =>
             Object.values(groups).filter(group => {
                 if (group.name === 'thp') {
-                    return firmware !== '2.3.0' && model === 'T3W1';
+                    return firmware !== '2.5.3' && model === 'T3W1';
                 }
 
                 return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches Connect e2e fixtures and a CI matrix generator. Only the getAccountInfo fixture has a clear path to a suite e2e test that exercises it. The getPublicKey fixture is not referenced by any listed suite test, and the matrix generator is a build/CI script with no e2e coverage, so running the targeted getAccountInfo test is sufficient.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect/e2e/__fixtures__/getAccountInfo.ts`
- `packages/connect/e2e/__fixtures__/getPublicKey.ts`
- `scripts/ci/connect-test-matrix-generator.js`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — The changed file packages/connect/e2e/__fixtures__/getAccountInfo.ts provides the fixture data used by TrezorConnect.getAccountInfo. This suite test directly calls TrezorConnect.getAccountInfo and verifies account selection and success, so any change to the fixture is likely to be exercised here.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect/e2e/__fixtures__/getPublicKey.ts`
- `scripts/ci/connect-test-matrix-generator.js`

_Updated: 2026-09-03T15:37:38.695Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/bump-e2e-min-fw/web/](https://dev.suite.sldev.cz/suite-web/test/bump-e2e-min-fw/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/bump-e2e-min-fw&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/bump-e2e-min-fw&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/bump-e2e-min-fw&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T15:39:39.731Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T15:40:19.409Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->