### PR TITLE
chore(suite-native): replace deprecated usage of SkPath.addArc()

### DIFF
--- a/suite-native/atoms/src/HoldToConfirmButton.tsx
+++ b/suite-native/atoms/src/HoldToConfirmButton.tsx
@@ -19,6 +19,7 @@ import { useNativeStyles } from '@trezor/styles-native';
 
 import { AnimatedVStack } from './Stack';
 import { Text } from './Text';
+
 const CANVAS_SIZE = 88;
 const CIRCLE_CENTER = CANVAS_SIZE / 2;
 const BORDER_WIDTH = 2;
@@ -44,11 +45,8 @@ export type HoldToConfirmButtonProps = {
 const GESTURE_HIT_SLOP = 20;
 const SUCCESS_VIBRATION_DURATION = 200;
 
-const leftLoaderArcPath = Skia.Path.Make();
-leftLoaderArcPath.addArc(LOADER_ARC_OVAL_CONFIG, 90, 180);
-
-const rightLoaderArcPath = Skia.Path.Make();
-rightLoaderArcPath.addArc(LOADER_ARC_OVAL_CONFIG, 90, -180);
+const leftLoaderArcPath = Skia.PathBuilder.Make().addArc(LOADER_ARC_OVAL_CONFIG, 90, 180).build();
+const rightLoaderArcPath = Skia.PathBuilder.Make().addArc(LOADER_ARC_OVAL_CONFIG, 90, -180).build();
 
 const startOnHoldVibration = () => {
     if (Platform.OS === 'ios') {


### PR DESCRIPTION
## Description

Skia's `SkPath.addArc()` is deprecated and will be removed eventually.
See https://shopify.github.io/react-native-skia/docs/shapes/path-migration/ for further details.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/skia-add-arc&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->