### PR TITLE
fix(suite): update security seal URL mapping for device models

### DIFF
--- a/suite-native/module-device-onboarding/src/components/SecuritySealDescription.tsx
+++ b/suite-native/module-device-onboarding/src/components/SecuritySealDescription.tsx
@@ -11,12 +11,27 @@ import {
     VStack,
     useBottomSheetModal,
 } from '@suite-native/atoms';
+import { type SetupSupportingDeviceModel } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import { Link, useOpenLink } from '@suite-native/link';
-import { DeviceModelInternal } from '@trezor/device-utils';
-import { HELP_CENTER_PACKAGING_T3B1_URL, HELP_CENTER_PACKAGING_T3T1_URL } from '@trezor/urls';
+import {
+    HELP_CENTER_PACKAGING_T2T1_URL,
+    HELP_CENTER_PACKAGING_T3B1_URL,
+    HELP_CENTER_PACKAGING_T3T1_URL,
+    HELP_CENTER_PACKAGING_T3W1_URL,
+    type Url,
+} from '@trezor/urls';
 
 import { SecuritySealImages } from './SecuritySealImages';
+
+const securitySealUrlMap = {
+    T2T1: HELP_CENTER_PACKAGING_T2T1_URL,
+    // T2B1 and T3B1 are the same product (Safe 3), so they share the URL.
+    T2B1: HELP_CENTER_PACKAGING_T3B1_URL,
+    T3B1: HELP_CENTER_PACKAGING_T3B1_URL,
+    T3T1: HELP_CENTER_PACKAGING_T3T1_URL,
+    T3W1: HELP_CENTER_PACKAGING_T3W1_URL,
+} as const satisfies Record<SetupSupportingDeviceModel, Url>;
 
 export const SecuritySealDescription = () => {
     const openLink = useOpenLink();
@@ -33,12 +48,9 @@ export const SecuritySealDescription = () => {
         });
     };
 
-    const deviceModel = useSelector(selectDeviceModel);
+    const deviceModel = useSelector(selectDeviceModel) as SetupSupportingDeviceModel;
 
-    const knowledgeBaseLink =
-        deviceModel === DeviceModelInternal.T3T1
-            ? HELP_CENTER_PACKAGING_T3T1_URL
-            : HELP_CENTER_PACKAGING_T3B1_URL;
+    const knowledgeBaseLink = securitySealUrlMap[deviceModel];
 
     const handleLearnMoreButtonPress = () => {
         openLink(knowledgeBaseLink);


### PR DESCRIPTION


<!--- Describe your changes in detail -->

## Description

The "Learn more" button in the holographic seal step of the mobile Security check screen always opened the **Trezor Safe 3** guide when a **Trezor Safe 7** or **Model T** was connected.

Cause: the URL was resolved by a two-way ternary written before Safe 7 existed — only `T3T1` (Safe 5) was handled, so `T3W1` (Safe 7) and `T2T1` (Model T) silently fell through to the Safe 3 URL:

```ts
const knowledgeBaseLink =
    deviceModel === DeviceModelInternal.T3T1
        ? HELP_CENTER_PACKAGING_T3T1_URL
        : HELP_CENTER_PACKAGING_T3B1_URL;
```

**Before:**

https://github.com/user-attachments/assets/e112d954-24da-4676-ba18-90b68dcd5ee3

**After:**


https://github.com/user-attachments/assets/f96e42a6-4219-4531-bc25-33f4133a75e3


## Notes for QA

-  Link now leads to correct URL with T3W1 or T2T1 connected



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-security-seal-url&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->