### PR TITLE
refactor(suite): single canonical owner for the yield amount per step

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -47,6 +47,7 @@ import { type YieldAmountCardFiatToggleProps } from '../common/YieldAmountCard';
 import {
     type YieldApprovalAction,
     getYieldApprovalAction,
+    getYieldModifyAmountInput,
     isAmountGreaterThan,
     shouldInitializeYieldAllowance,
 } from '../yieldFlowUtils';
@@ -74,7 +75,6 @@ export type UseYieldFlowResult = {
     maxAmount: string;
     flowType: YieldPositionFlowType;
     liveAmount: string;
-    actionAmount: string | null;
     completedAmount: string;
     completedReceiptAmount: string;
     unwrappedAmount: string | null;
@@ -315,8 +315,18 @@ export const useYieldFlow = ({
     );
 
     const enterModifyApproval = useCallback(() => {
-        dispatch(yieldActions.enterModifyMode({ flowType, flowKey }));
-    }, [dispatch, flowType, flowKey]);
+        dispatch(
+            yieldActions.enterModifyMode({
+                flowType,
+                flowKey,
+                amount: getYieldModifyAmountInput({
+                    liveAmount: methodsRef.current.getValues('amountInput'),
+                    actionAmount: sessionRef.current.action.amount,
+                    maxAmount,
+                }),
+            }),
+        );
+    }, [dispatch, flowType, flowKey, methodsRef, sessionRef, maxAmount]);
 
     const openDeviceConnectionModal = useCallback(() => {
         if (device?.descriptor?.apiType === 'bluetooth') {
@@ -706,7 +716,6 @@ export const useYieldFlow = ({
         maxAmount,
         flowType,
         liveAmount,
-        actionAmount: session.action.amount,
         completedAmount: session.result.completedAmount,
         completedReceiptAmount: session.result.completedReceiptAmount,
         unwrappedAmount: session.result.unwrappedAmount,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldForm.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldForm.test.ts
@@ -227,6 +227,70 @@ describe('useYieldForm', () => {
         });
     });
 
+    it('carries the committed wrapped amount into the approve step uncapped', () => {
+        mockSession.step = 'wrap';
+        const { result, rerender } = renderYieldForm();
+
+        // '30' exceeds the token balance (25), so the uncapped carry is observable.
+        mockSession = {
+            ...mockSession,
+            step: 'approve',
+            action: { ...mockSession.action, amount: '30' },
+        };
+        rerender();
+
+        expect(result.current.methods.getValues('amountInput')).toBe('30');
+    });
+
+    it('caps the committed amount to the action max when the approval advances', () => {
+        mockSession.step = 'approve';
+        const { result, rerender } = renderYieldForm();
+
+        mockSession = {
+            ...mockSession,
+            step: 'action',
+            action: { ...mockSession.action, amount: '30' },
+        };
+        rerender();
+
+        expect(result.current.methods.getValues('amountInput')).toBe('25');
+    });
+
+    it('clears the amount when returning to the wrap step', () => {
+        mockSession.step = 'approve';
+        const { result, rerender } = renderYieldForm();
+
+        act(() => result.current.setAmountInput('5'));
+
+        mockSession = { ...mockSession, step: 'wrap' };
+        rerender();
+
+        expect(result.current.methods.getValues()).toEqual({
+            amountInput: '',
+            fiatInput: '',
+        });
+    });
+
+    it('clears both amount fields in fiat mode when the flow completes', () => {
+        mockSession.step = 'action';
+        const { result, rerender } = renderYieldForm();
+
+        act(() => result.current.setAmountInput('5'));
+        act(() => result.current.fiatToggle?.onToggle());
+
+        mockSession = {
+            ...mockSession,
+            step: 'complete',
+            action: { ...mockSession.action, amount: '5' },
+        };
+        rerender();
+
+        expect(result.current.methods.getValues()).toEqual({
+            amountInput: '',
+            fiatInput: '',
+        });
+    });
+
     it('restores the pending amount when re-entering a resumable flow', () => {
         mockSession = {
             ...mockSession,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldForm.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldForm.ts
@@ -20,7 +20,7 @@ import { useYieldFiatInput } from './useYieldFiatInput';
 import { type YieldAmountCardFiatToggleProps } from '../common/YieldAmountCard';
 import {
     getYieldFiatRateToken,
-    getYieldModifyAmountInput,
+    getYieldStepEntryAmount,
     getYieldUnwrapDefaultAmount,
     isAmountGreaterThan,
 } from '../yieldFlowUtils';
@@ -130,46 +130,6 @@ export const useYieldForm = ({
 
     const prevStepRef = useRef<YieldFlowStepId | null>(null);
 
-    // Redux thunks can transition steps outside this hook, so synchronize the form reactively.
-    useEffect(() => {
-        const prevStep = prevStepRef.current;
-        const nextStep = session.step;
-
-        if (prevStep !== null && prevStep !== nextStep) {
-            if (prevStep === 'wrap' && nextStep === 'approve') {
-                resetAmountsRef.current(session.action.amount ?? '');
-            }
-
-            if (nextStep === 'wrap') {
-                resetAmountsRef.current('');
-            }
-
-            if (prevStep === 'approve' && nextStep === 'action') {
-                const actionAmount = session.action.amount ?? '';
-                const cappedAmount = isAmountGreaterThan({
-                    amount: actionAmount,
-                    threshold: maxAmount,
-                })
-                    ? maxAmount
-                    : actionAmount;
-
-                resetAmountsRef.current(cappedAmount);
-            }
-
-            if (prevStep === 'action' && nextStep === 'approve') {
-                resetAmountsRef.current(
-                    getYieldModifyAmountInput({
-                        liveAmount: methodsRef.current.getValues('amountInput'),
-                        actionAmount: session.action.amount,
-                        maxAmount,
-                    }),
-                );
-            }
-        }
-
-        prevStepRef.current = nextStep;
-    }, [session.step, session.action.amount, methodsRef, resetAmountsRef, maxAmount]);
-
     // The unwrap step defaults to the amount just withdrawn, not the whole wrapped-native balance
     // — that would sweep in unrelated WETH (trezor/trezor-suite#30559).
     const pricePerShareState = vault.state?.pricePerShareState;
@@ -187,6 +147,25 @@ export const useYieldForm = ({
             fallbackAmount: token.balance,
         });
     }, [flowType, pricePerShareState, receiptToken, session.result.completedAmount, token]);
+
+    useEffect(() => {
+        const prevStep = prevStepRef.current;
+        const nextStep = session.step;
+        prevStepRef.current = nextStep;
+
+        if (prevStep === null || prevStep === nextStep) {
+            return;
+        }
+
+        resetAmountsRef.current(
+            getYieldStepEntryAmount({
+                step: nextStep,
+                committedAmount: session.action.amount,
+                maxAmount,
+                unwrapDefaultAmount,
+            }),
+        );
+    }, [session.step, session.action.amount, maxAmount, unwrapDefaultAmount, resetAmountsRef]);
 
     useEffect(() => {
         if (session.step !== 'unwrap') {

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -7,6 +7,8 @@ import {
     getYieldFiatRateToken,
     getYieldFlowSteps,
     getYieldMaxFiatInputValue,
+    getYieldModifyAmountInput,
+    getYieldStepEntryAmount,
     getYieldUnwrapDefaultAmount,
     shouldInitializeYieldAllowance,
 } from './yieldFlowUtils';
@@ -200,6 +202,79 @@ describe('yieldFlowUtils', () => {
                     fallbackAmount: '5',
                 }),
             ).toBe('5');
+        });
+    });
+
+    describe('getYieldStepEntryAmount', () => {
+        const baseEntryParams = {
+            committedAmount: '3',
+            maxAmount: '25',
+            unwrapDefaultAmount: '0.5',
+        };
+
+        it.each(['wrap', 'complete'] as const)('opens the %s step empty', step => {
+            expect(getYieldStepEntryAmount({ ...baseEntryParams, step })).toBe('');
+        });
+
+        it('carries the committed amount into the approve step', () => {
+            expect(getYieldStepEntryAmount({ ...baseEntryParams, step: 'approve' })).toBe('3');
+        });
+
+        it('does not cap the approve entry to the max amount', () => {
+            expect(
+                getYieldStepEntryAmount({
+                    ...baseEntryParams,
+                    step: 'approve',
+                    committedAmount: '30',
+                }),
+            ).toBe('30');
+        });
+
+        it('caps the action entry to the max amount', () => {
+            expect(
+                getYieldStepEntryAmount({
+                    ...baseEntryParams,
+                    step: 'action',
+                    committedAmount: '30',
+                }),
+            ).toBe('25');
+        });
+
+        it('carries the committed amount into the action step when it fits the max', () => {
+            expect(getYieldStepEntryAmount({ ...baseEntryParams, step: 'action' })).toBe('3');
+        });
+
+        it.each(['approve', 'action'] as const)(
+            'opens the %s step empty without a committed amount',
+            step => {
+                expect(
+                    getYieldStepEntryAmount({ ...baseEntryParams, step, committedAmount: null }),
+                ).toBe('');
+            },
+        );
+
+        it('pre-fills the unwrap step with the unwrap default', () => {
+            expect(getYieldStepEntryAmount({ ...baseEntryParams, step: 'unwrap' })).toBe('0.5');
+        });
+    });
+
+    describe('getYieldModifyAmountInput', () => {
+        it('prefers the live amount over the committed one', () => {
+            expect(
+                getYieldModifyAmountInput({ liveAmount: '2', actionAmount: '3', maxAmount: '25' }),
+            ).toBe('2');
+        });
+
+        it('falls back to the committed amount when the field was cleared', () => {
+            expect(
+                getYieldModifyAmountInput({ liveAmount: '', actionAmount: '3', maxAmount: '25' }),
+            ).toBe('3');
+        });
+
+        it('clamps the committed fallback to the max amount', () => {
+            expect(
+                getYieldModifyAmountInput({ liveAmount: '', actionAmount: '30', maxAmount: '25' }),
+            ).toBe('25');
         });
     });
 

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -16,6 +16,7 @@ import {
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
 import type { StepListItemState } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
 export { getYieldApprovalAction, type YieldApprovalAction } from '@suite-common/wallet-core';
@@ -46,6 +47,41 @@ export const getYieldModifyAmountInput = ({
     return isAmountGreaterThan({ amount: nextAmount, threshold: maxAmount })
         ? maxAmount
         : nextAmount;
+};
+
+type YieldStepEntryAmountParams = {
+    step: YieldFlowStepId;
+    committedAmount: string | null;
+    maxAmount: string;
+    unwrapDefaultAmount: string;
+};
+
+/**
+ * Amount the form is re-initialized with on step entry. The approve entry stays uncapped — the
+ * wrapped balance may be stale right after a wrap confirms, which would truncate the amount.
+ */
+export const getYieldStepEntryAmount = ({
+    step,
+    committedAmount,
+    maxAmount,
+    unwrapDefaultAmount,
+}: YieldStepEntryAmountParams): string => {
+    switch (step) {
+        case 'wrap':
+        case 'complete':
+            return '';
+        case 'approve':
+            return committedAmount ?? '';
+        case 'action': {
+            const amount = committedAmount ?? '';
+
+            return isAmountGreaterThan({ amount, threshold: maxAmount }) ? maxAmount : amount;
+        }
+        case 'unwrap':
+            return unwrapDefaultAmount;
+        default:
+            return exhaustive(step);
+    }
 };
 
 type YieldUnwrapDefaultAmountParams = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The yield amount lived in two state machines (RHF form + `session.action.amount`) synced by a per-transition effect. Now the form owns it while a step is active, the redux snapshot owns it between steps (written on step exit), and step entry is one generic re-init of both amount fields via a per-step policy (`getYieldStepEntryAmount`). Reducer untouched, so suite-native is unaffected.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #30922

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are tightly scoped to yield/earn flow hooks and utilities. The static coverage maps are inflated (139 tests per file), so I ignored the broad dependency signal and focused on the two E2E tests that specifically exercise yield functionality. Both the redeem and withdrawal flows are highly likely to invoke the changed form logic and flow utilities, making them the minimal, high-confidence regression suite.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldForm.test.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldForm.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — The static coverage mapping for the changed files is extremely broad (139 tests each), but the LLM analysis shows this test explicitly exercises the yield withdraw/redeem flow, including amount input, max button behavior, share-token switching, and transaction confirmation, which directly depends on useYieldForm, useYieldFlow, and yieldFlowUtils.
- `suite/e2e/tests/yield/withdrawal.test.ts` — The static coverage mapping is broad, but the LLM analysis shows this test explicitly exercises the yield withdrawal flow, including amount input, summary display, transaction simulation, and on-device confirmation, which directly depends on the changed yield form and flow utilities.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/yield/hooks/useYieldForm.test.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`

_Updated: 2026-09-03T12:17:52.698Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/yield-amount-canonical-owner/web/](https://dev.suite.sldev.cz/suite-web/refactor/yield-amount-canonical-owner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/yield-amount-canonical-owner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/yield-amount-canonical-owner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T12:20:40.778Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T12:20:25.290Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->