### PR TITLE
chore(suite-common): correct wrap/unwrap analytics schema

### DIFF
--- a/suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts
+++ b/suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts
@@ -5,6 +5,9 @@ import type { AttributeDef } from '../eventDefinition';
 /**
  * Shared by `yieldWrapEvent` and `yieldUnwrapEvent`, which are structurally identical.
  *
+ * These events cover only the standalone wrap/unwrap pages — a wrap/unwrap running as an in-flow
+ * step of a yield deposit/withdraw reports through `yield/deposit` / `yield/withdraw` instead.
+ *
  * Carries no amount/balance/txid/descriptor — those are device-confidential and must never leave
  * the device (see CLAUDE.md).
  */
@@ -14,7 +17,6 @@ export type WrappedNativeFlowAttributes = {
         'submit' | 'tx-simulation-modal' | 'sent' | 'success' | 'error' | 'leftPending'
     >;
     networkSymbol?: AttributeDef<string>;
-    vaultId?: AttributeDef<string>;
     durationMs?: AttributeDef<number>;
     errorMessage?: AttributeDef<string>;
 };
@@ -27,18 +29,13 @@ export const wrappedNativeFlowAttributes = {
     },
     type: {
         description:
-            '`submit` = user confirmed the wrap/unwrap form, `tx-simulation-modal` = simulation modal shown (with `action` continue/cancel), `sent` = transaction signed &amp; broadcast accepted — emitted with `action=continue` when the "transaction sent" toast is shown and again with `action=close` if the user dismisses that toast (letting it auto-close is not reported), `success` / `error` / `leftPending` = on-chain resolution of the broadcast transaction. Mobile shows a pending-transaction sheet instead of a toast and only reports `sent` with `action=continue`.',
+            '`submit` = user confirmed the wrap/unwrap form, `tx-simulation-modal` = simulation modal shown (with `action` continue/cancel), `sent` = transaction signed &amp; broadcast accepted — emitted with `action=continue` when the "transaction sent" toast is shown and again with `action=close` if the user dismisses that toast (letting it auto-close is not reported), `success` / `leftPending` = on-chain resolution of the broadcast transaction, `error` = a pre-broadcast or on-chain failure — see `errorMessage` for the classification. Mobile shows a pending-transaction sheet instead of a toast and only reports `sent` with `action=continue`.',
         changelog: [
             { version: '26.8.0', notes: 'added' },
             { version: '26.8.1', notes: 'reported from mobile as well' },
         ],
     },
     networkSymbol: {
-        changelog: [{ version: '26.8.0', notes: 'added' }],
-    },
-    vaultId: {
-        description:
-            'Internal vault identifier (vault.id) when the wrap/unwrap runs as an in-flow step of a yield deposit/withdraw; absent for the standalone wrap/unwrap pages.',
         changelog: [{ version: '26.8.0', notes: 'added' }],
     },
     durationMs: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Corrects the `yield/wrap` / `yield/unwrap` analytics schema: removes the `vaultId` attribute (never populated — in-flow wrap/unwrap reports exclusively through `yield/deposit`/`yield/withdraw`, which the shared JSDoc now documents) and fixes the `type=error` description (it covers pre-broadcast failures as well, not just on-chain resolution — classification lives in `errorMessage`). Point 3 of the issue (`account-detail` note on `yieldNavigateEvent`) was already fixed on develop. Docs/schema only, nothing reported changes.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #30905

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared analytics event attributes module for yield wrapped native tokens. It maps transitively to many tests, but its domain is narrowly yield-related. The highest-confidence coverage comes from the two yield end-to-end tests, which exercise the relevant user flows. No other tests in the suite specifically target yield wrapped native analytics, so the recommendation is tightly scoped to those two.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — This test exercises the yield/earn redeem flow end-to-end. Since the changed file defines analytics event attributes for yield wrapped native tokens, this is the most direct functional coverage available; a regression in how those attributes are constructed could surface during the yield flow.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test covers the yield/earn withdrawal flow, which is the core user journey tied to the yield wrapped native analytics attributes. Running it validates that the changed analytics event code does not break the yield feature.

</details>

_Updated: 2026-09-03T12:59:30.468Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-wrap-analytics-schema/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-wrap-analytics-schema/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-wrap-analytics-schema&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-wrap-analytics-schema&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-wrap-analytics-schema&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T13:01:55.127Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T13:01:52.382Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->