### PR TITLE
refactor(suite-common): model the yield approval origin explicitly

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -592,7 +592,7 @@ export const useYieldFlow = ({
     const approvalAction = getYieldApprovalAction({
         liveAmount,
         allowanceAmount: session.approval.allowanceAmount,
-        isModifyMode: session.approval.isModifyMode,
+        shouldConsiderAllowance: session.approval.origin === 'modify',
         isRevokeRequired: session.approval.isRevokeRequired,
         tokenContractAddress: token?.contractAddress,
     });
@@ -697,7 +697,7 @@ export const useYieldFlow = ({
     const allowanceAmount = session.approval.allowanceAmount ?? '0';
     const canRevokeAllowance = isAmountGreaterThan({ amount: allowanceAmount, threshold: '0' });
     const isApprovalInsufficient =
-        !session.approval.isModifyMode &&
+        session.approval.origin !== 'modify' &&
         session.approval.allowanceStatus === 'loaded' &&
         isAmountGreaterThan({
             amount: liveAmount,

--- a/suite-common/wallet-core/src/yield/utils/yieldApprovalActionUtils.ts
+++ b/suite-common/wallet-core/src/yield/utils/yieldApprovalActionUtils.ts
@@ -4,7 +4,7 @@ import { BigNumber } from '@trezor/utils';
 type GetYieldApprovalActionParams = {
     liveAmount: string;
     allowanceAmount?: string | null;
-    isModifyMode: boolean;
+    shouldConsiderAllowance: boolean;
     isRevokeRequired: boolean;
     tokenContractAddress?: string | null;
 };
@@ -14,11 +14,11 @@ export type YieldApprovalAction = 'approve' | 'continue' | 'increase' | 'revoke'
 export const getYieldApprovalAction = ({
     liveAmount,
     allowanceAmount,
-    isModifyMode,
+    shouldConsiderAllowance,
     isRevokeRequired,
     tokenContractAddress,
 }: GetYieldApprovalActionParams): YieldApprovalAction => {
-    if (!isModifyMode) {
+    if (!shouldConsiderAllowance) {
         return 'approve';
     }
 

--- a/suite-common/wallet-core/src/yield/yieldReducer.test.ts
+++ b/suite-common/wallet-core/src/yield/yieldReducer.test.ts
@@ -198,6 +198,45 @@ describe('yieldReducer', () => {
             expect(getSession(state, 'deposit')?.step).toBe('wrap');
         });
 
+        it('keeps the modify origin across a wrap-step detour', () => {
+            const sessionPayload = { flowType: 'deposit', flowKey: FLOW_KEY } as const;
+            const atAction = yieldReducer(
+                yieldReducer(
+                    initSession('deposit', true),
+                    yieldActions.resolveWrappedNativeStep({ ...sessionPayload, step: 'wrap' }),
+                ),
+                yieldActions.skipApprovalStep(sessionPayload),
+            );
+            const atWrap = yieldReducer(
+                yieldReducer(atAction, yieldActions.enterModifyMode(sessionPayload)),
+                yieldActions.returnToWrapStep(sessionPayload),
+            );
+            const state = yieldReducer(
+                atWrap,
+                yieldActions.resolveWrappedNativeStep({ ...sessionPayload, step: 'wrap' }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+            expect(getSession(state, 'deposit')?.approval.origin).toBe('modify');
+        });
+
+        it('ends the modify origin when the approval completes', () => {
+            const modifying = yieldReducer(
+                initSession('deposit'),
+                yieldActions.enterModifyMode({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+            const state = yieldReducer(
+                modifying,
+                yieldActions.completeApproval({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '10',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.approval.origin).toBe('flow');
+        });
+
         it('does not return to the wrap step for a non-wrapped vault', () => {
             const state = yieldReducer(
                 initSession('deposit'),
@@ -326,12 +365,33 @@ describe('yieldReducer', () => {
             expect(getSession(state, 'deposit')?.action.amount).toBe('25');
         });
 
-        it('clears modify mode when the approval step is skipped so the action step re-guards allowance', () => {
+        it('keeps the committed amount when a skip carries an empty amount', () => {
+            const state = yieldReducer(
+                yieldReducer(
+                    initSession('deposit'),
+                    yieldActions.enterModifyMode({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                        amount: '25',
+                    }),
+                ),
+                yieldActions.skipApprovalStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('action');
+            expect(getSession(state, 'deposit')?.action.amount).toBe('25');
+        });
+
+        it('ends the modify origin when the approval step is skipped so the action step re-guards allowance', () => {
             const modifying = yieldReducer(
                 initSession('deposit'),
                 yieldActions.enterModifyMode({ flowType: 'deposit', flowKey: FLOW_KEY }),
             );
-            expect(getSession(modifying, 'deposit')?.approval.isModifyMode).toBe(true);
+            expect(getSession(modifying, 'deposit')?.approval.origin).toBe('modify');
 
             const state = yieldReducer(
                 modifying,
@@ -343,7 +403,7 @@ describe('yieldReducer', () => {
             );
 
             expect(getSession(state, 'deposit')?.step).toBe('action');
-            expect(getSession(state, 'deposit')?.approval.isModifyMode).toBe(false);
+            expect(getSession(state, 'deposit')?.approval.origin).toBe('flow');
         });
 
         it('does not skip the wrap step when an allowance check resolves early', () => {
@@ -606,7 +666,7 @@ describe('yieldReducer', () => {
 
             expect(getSession(state, 'deposit')?.step).toBe('approve');
             expect(getSession(state, 'deposit')?.action.amount).toBeNull();
-            expect(getSession(state, 'deposit')?.approval.isModifyMode).toBe(false);
+            expect(getSession(state, 'deposit')?.approval.origin).toBe('flow');
         });
 
         it('opens a fresh wrapped-native deposit past the wrap step when the wrapped token is held', () => {
@@ -802,6 +862,18 @@ describe('yieldReducer', () => {
 
             expect(getSession(state, 'deposit')?.approval.allowanceAmount).toBe('0');
             expect(getSession(state, 'deposit')?.approval.allowanceStatus).toBe('loaded');
+        });
+
+        it('ends the modify origin when a revoke completes', () => {
+            const modifying = yieldReducer(
+                loadAllowance(initSession('deposit'), '100'),
+                yieldActions.enterModifyMode(sessionPayload),
+            );
+            expect(getSession(modifying, 'deposit')?.approval.origin).toBe('modify');
+
+            const state = yieldReducer(modifying, yieldActions.revokeSuccess(sessionPayload));
+
+            expect(getSession(state, 'deposit')?.approval.origin).toBe('flow');
         });
 
         // A confirmed approval dispatches these two back to back — the state the read must catch.

--- a/suite-common/wallet-core/src/yield/yieldReducer.ts
+++ b/suite-common/wallet-core/src/yield/yieldReducer.ts
@@ -14,6 +14,7 @@ import { YIELD_PREFIX } from './yieldConstants';
 import {
     type WrappedNativeStepId,
     YIELD_FLOW_TYPES,
+    type YieldApprovalOrigin,
     type YieldApproveModalState,
     type YieldClaimUnsignedTransaction,
     type YieldFlowCompleteRewardItem,
@@ -101,7 +102,7 @@ export type YieldSessionState = {
         allowanceStatus: YieldAllowanceStatus;
         /** Set when the step was left without approving, i.e. the allowance already covered it. */
         isSkipped: boolean;
-        isModifyMode: boolean;
+        origin: YieldApprovalOrigin;
         isRevokeRequired: boolean;
     };
     action: {
@@ -146,7 +147,7 @@ export const initialStablecoinYieldSessionState: YieldSessionState = {
         isSubmitting: false,
         isSkipped: false,
         allowanceStatus: 'idle',
-        isModifyMode: false,
+        origin: 'flow',
         isRevokeRequired: false,
     },
     action: {
@@ -233,6 +234,31 @@ const withSession = (
     }
 
     updater(session);
+};
+
+type YieldStepTransition = {
+    nextStep: YieldFlowStepId;
+    amountSnapshot?: string;
+    approvalJourney?: 'modify';
+};
+
+const applyYieldStepTransition = (
+    session: YieldSessionState,
+    { nextStep, amountSnapshot, approvalJourney }: YieldStepTransition,
+): void => {
+    if (amountSnapshot !== undefined) {
+        session.action.amount = amountSnapshot;
+    }
+
+    if (approvalJourney === 'modify') {
+        session.approval.origin = 'modify';
+    } else if (session.step === 'approve' && nextStep === 'action') {
+        // Leaving the approve step forward ends the modify journey, re-enabling the action
+        // step's insufficient-allowance guard.
+        session.approval.origin = 'flow';
+    }
+
+    session.step = nextStep;
 };
 
 const yieldSlice = createSlice({
@@ -422,14 +448,16 @@ const yieldSlice = createSlice({
             action: PayloadAction<YieldSessionActionPayload & { amount?: string }>,
         ) {
             withSession(state, action.payload, session => {
-                session.approval.isModifyMode = true;
                 session.approval.modalState = null;
                 // The pendingTransaction is intentionally preserved — an in-flight action tx must
                 // stay tracked so its confirmation is still processed into `completeAction`.
                 session.action.review = null;
                 session.error = null;
-                session.action.amount = action.payload.amount ?? session.action.amount;
-                session.step = 'approve';
+                applyYieldStepTransition(session, {
+                    nextStep: 'approve',
+                    amountSnapshot: action.payload.amount,
+                    approvalJourney: 'modify',
+                });
             });
         },
         completeApproval(
@@ -448,18 +476,19 @@ const yieldSlice = createSlice({
                     return;
                 }
 
-                session.approval.isModifyMode = false;
                 session.approval.modalState = null;
                 session.approval.isRevokeRequired = false;
                 session.approval.isSkipped = false;
-                session.action.amount = action.payload.amount;
                 session.action.pendingTransaction = null;
                 session.action.review = null;
-                session.step = getNextYieldFlowStep(
-                    action.payload.flowType,
-                    'approve',
-                    session.isWrappedNativeVault,
-                );
+                applyYieldStepTransition(session, {
+                    nextStep: getNextYieldFlowStep(
+                        action.payload.flowType,
+                        'approve',
+                        session.isWrappedNativeVault,
+                    ),
+                    amountSnapshot: action.payload.amount,
+                });
             });
         },
         skipApprovalStep(
@@ -475,22 +504,17 @@ const yieldSlice = createSlice({
                     return;
                 }
 
-                // A user-triggered skip carries the entered amount so the action step opens
-                // with it; the automatic allowance-check skip omits it and keeps the existing one.
-                if (action.payload.amount) {
-                    session.action.amount = action.payload.amount;
-                }
-                // Leaving the approve step forward clears modify mode (mirrors `completeApproval`)
-                // so the action step's insufficient-allowance guard applies — otherwise a skip
-                // with an amount above the current allowance would slip past it.
-                session.approval.isModifyMode = false;
                 session.approval.isRevokeRequired = false;
                 session.approval.isSkipped = true;
-                session.step = getNextYieldFlowStep(
-                    action.payload.flowType,
-                    'approve',
-                    session.isWrappedNativeVault,
-                );
+                applyYieldStepTransition(session, {
+                    nextStep: getNextYieldFlowStep(
+                        action.payload.flowType,
+                        'approve',
+                        session.isWrappedNativeVault,
+                    ),
+                    // The automatic allowance-check skip carries no amount; keep the snapshot.
+                    amountSnapshot: action.payload.amount || undefined,
+                });
             });
         },
         resolveWrappedNativeStep(
@@ -513,16 +537,21 @@ const yieldSlice = createSlice({
                 }
 
                 if (action.payload.step === 'wrap' && action.payload.amount) {
-                    session.action.amount = action.payload.amount;
                     // Record that a wrap happened so the completed deposit can be shown in the
                     // native asset (the user's original asset), mirroring `unwrappedAmount`.
                     session.result.wrappedAmount = action.payload.amount;
                 }
-                session.step = getNextYieldFlowStep(
-                    action.payload.flowType,
-                    action.payload.step,
-                    session.isWrappedNativeVault,
-                );
+                applyYieldStepTransition(session, {
+                    nextStep: getNextYieldFlowStep(
+                        action.payload.flowType,
+                        action.payload.step,
+                        session.isWrappedNativeVault,
+                    ),
+                    amountSnapshot:
+                        action.payload.step === 'wrap'
+                            ? action.payload.amount || undefined
+                            : undefined,
+                });
             });
         },
         returnToWrapStep(state: YieldState, action: PayloadAction<YieldSessionActionPayload>) {
@@ -545,12 +574,12 @@ const yieldSlice = createSlice({
                     return;
                 }
 
-                session.step = 'wrap';
+                applyYieldStepTransition(session, { nextStep: 'wrap' });
             });
         },
         revokeSuccess(state: YieldState, action: PayloadAction<YieldSessionActionPayload>) {
             withSession(state, action.payload, session => {
-                session.approval.isModifyMode = false;
+                session.approval.origin = 'flow';
                 session.approval.allowanceAmount = '0';
                 session.approval.allowanceStatus = 'loaded';
                 session.approval.isRevokeRequired = false;
@@ -682,11 +711,13 @@ const yieldSlice = createSlice({
 
                 session.action.pendingTransaction = null;
                 session.action.review = null;
-                session.step = getNextYieldFlowStep(
-                    action.payload.flowType,
-                    'action',
-                    session.isWrappedNativeVault,
-                );
+                applyYieldStepTransition(session, {
+                    nextStep: getNextYieldFlowStep(
+                        action.payload.flowType,
+                        'action',
+                        session.isWrappedNativeVault,
+                    ),
+                });
             });
         },
         transactionFailed(state: YieldState, action: PayloadAction<YieldSessionActionPayload>) {

--- a/suite-common/wallet-core/src/yield/yieldTypes.ts
+++ b/suite-common/wallet-core/src/yield/yieldTypes.ts
@@ -12,6 +12,7 @@ export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;
 export type YieldWithdrawFlowType = Extract<YieldFlowType, 'withdraw' | 'redeem'>;
 export type YieldFlowStepId = (typeof YIELD_FLOW_STEPS)[number];
 export type WrappedNativeStepId = Extract<YieldFlowStepId, 'wrap' | 'unwrap'>;
+export type YieldApprovalOrigin = 'flow' | 'modify';
 
 export type YieldFlowFormValues = {
     // Crypto/token amount — the single source of truth submitted to every yield thunk.

--- a/suite-native/module-earn/src/hooks/yield/useYieldDepositApprovalSubmit.ts
+++ b/suite-native/module-earn/src/hooks/yield/useYieldDepositApprovalSubmit.ts
@@ -75,7 +75,7 @@ export const useYieldDepositApprovalSubmit = ({
                 const approvalAction = getYieldApprovalAction({
                     liveAmount: amount,
                     allowanceAmount: sessionWithAllowance.approval.allowanceAmount,
-                    isModifyMode: true,
+                    shouldConsiderAllowance: true,
                     isRevokeRequired: sessionWithAllowance.approval.isRevokeRequired,
                     tokenContractAddress: flowData.token.contractAddress,
                 });

--- a/suite-native/module-earn/src/screens/yield/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/yield/YieldDepositApprovalScreen.tsx
@@ -139,7 +139,9 @@ export const YieldDepositApprovalScreen = () => {
     const hasWrappedAmount = !!session?.result.wrappedAmount;
     const depositForm = useYieldDepositForm({
         defaultAmount:
-            session?.approval.isModifyMode || hasWrappedAmount ? session?.action.amount : undefined,
+            session?.approval.origin === 'modify' || hasWrappedAmount
+                ? session?.action.amount
+                : undefined,
         token,
         tokenSymbol,
         wrappedAmount: session?.result.wrappedAmount,
@@ -166,7 +168,7 @@ export const YieldDepositApprovalScreen = () => {
             ? getYieldApprovalAction({
                   liveAmount: amountValue ?? '',
                   allowanceAmount,
-                  isModifyMode: hasApprovedAmount,
+                  shouldConsiderAllowance: hasApprovedAmount,
                   isRevokeRequired: session?.approval.isRevokeRequired ?? false,
                   tokenContractAddress: token?.contractAddress,
               })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`approval.isModifyMode` is kept (the issue confirmed it cannot be derived from step + allowance) but remodeled as `approval.origin: 'flow' | 'modify'` - a marker of an unfinished allowance modification. Its lifecycle now lives in one place: every step change goes through a new reducer-internal `applyYieldStepTransition`, which also maintains the step-exit amount snapshot ('modify' is set only by `enterModifyMode`, reset by leaving the approve step forward or a completed revoke, and deliberately survives a wrap-step detour - now pinned by tests). `getYieldApprovalAction`'s overloaded `isModifyMode` param is renamed to `shouldConsiderAllowance` to match how both platforms actually use it. Behavior-preserving; no redux action contract changed, suite-native only picks up the renames.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #30912

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on yield/earn flow state and approval action handling in both web and mobile code. The highest-value E2E coverage comes from the two yield flow tests (redeem and withdrawal), which directly exercise the web useYieldFlow hook and wallet-core yield state. No E2E tests cover the native deposit approval screen or the yield reducer unit test, so those changes must be validated by other CI jobs.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/yield/utils/yieldApprovalActionUtils.ts`
- `suite-common/wallet-core/src/yield/yieldReducer.test.ts`
- `suite-common/wallet-core/src/yield/yieldReducer.ts`
- `suite-common/wallet-core/src/yield/yieldTypes.ts`
- `suite-native/module-earn/src/hooks/yield/useYieldDepositApprovalSubmit.ts`
- `suite-native/module-earn/src/screens/yield/YieldDepositApprovalScreen.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — This test exercises the full yield withdraw/redeem flow, which directly uses the changed useYieldFlow hook and depends on the yield reducer/types and approval action utilities for state transitions and transaction construction. A regression in these files would likely break the redeem modal, device prompts, or post-redemption dashboard update.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test validates the yield withdrawal flow including transaction simulation, device confirmation, and dashboard state updates, all of which are governed by the changed yield flow logic and reducer/types. It is a direct end-to-end consumer of the modified web yield code.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/yield/yieldReducer.test.ts`
- `suite-native/module-earn/src/hooks/yield/useYieldDepositApprovalSubmit.ts`
- `suite-native/module-earn/src/screens/yield/YieldDepositApprovalScreen.tsx`

_Updated: 2026-09-03T14:46:04.148Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/yield-approval-origin/web/](https://dev.suite.sldev.cz/suite-web/refactor/yield-approval-origin/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/yield-approval-origin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/yield-approval-origin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/yield-approval-origin&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T14:49:29.823Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T14:48:51.750Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->