### PR TITLE
Pr: 31738 31736

### DIFF
--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -651,6 +651,13 @@ export const signMessage = async (api: TrezorConnect) => {
         payload.address.toLowerCase();
         payload.signature.toLowerCase();
     }
+
+    // optional scriptType override
+    api.signMessage({ path: 'm/44', coin: 'btc', message: 'foo', scriptType: 'SPENDTAPROOT' });
+
+    // @ts-expect-error unknown scriptType
+    api.signMessage({ path: 'm/44', coin: 'btc', message: 'foo', scriptType: 'NOT_A_SCRIPT_TYPE' });
+
     const verify = await api.verifyMessage({
         address: 'a',
         signature: 'a',

--- a/packages/connect-common/src/types/api/bitcoin/common.ts
+++ b/packages/connect-common/src/types/api/bitcoin/common.ts
@@ -1,6 +1,6 @@
 import type { AccountAddresses } from '@trezor/blockchain-link';
 import type { BlockbookTransaction } from '@trezor/blockchain-link-types';
-import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 import type {
@@ -22,6 +22,7 @@ export const SignMessage = Type.Object({
     message: Type.String(),
     hex: Type.Optional(Type.Boolean()),
     no_script_type: Type.Optional(Type.Boolean()),
+    scriptType: Type.Optional(PROTO.InternalInputScriptType),
 });
 
 // signTransaction

--- a/packages/connect-common/src/types/params.ts
+++ b/packages/connect-common/src/types/params.ts
@@ -118,7 +118,7 @@ export const PublicKey = Type.Object({
      * Canonical user-facing representation of the public key for the given coin.
      * - Bitcoin: `xpubSegwit ?? xpub` (SLIP-132 form matching the requested
      *   scriptType, e.g. ypub/zpub for SegWit, `tr(...)` descriptor for Taproot)
-     * - Ethereum: `xpub`
+     * - Ethereum: hex-encoded compressed public key (same value as `publicKey`)
      * - Cardano: extended public key (xpub)
      * - Solana: base58-encoded address (same value as `publicKeyBase58`)
      * - Tezos: base58check-encoded public key, `edpk…` (same value as `publicKey`)
@@ -138,11 +138,8 @@ export const PublicKey = Type.Object({
      *   while this field is the BIP-389 multipath descriptor with `'`-notation
      *   and trailing `/<0;1>/*` used to derive both external and change
      *   addresses (e.g. `tr([fp/86'/0'/0']xpub…/<0;1>/*)`).
-     * - Ethereum: firmware shows the raw compressed public key (`publicKey`,
-     *   33 bytes hex); this field is the `xpub` because that's the more useful
-     *   identifier in host-side UIs. Suite displays the xpub, the device shows
-     *   the compressed key — both are correct representations of the same
-     *   underlying secp256k1 point at the requested path.
+     * - Ethereum: byte-identical to the raw compressed public key (`publicKey`,
+     *   33 bytes hex) shown by firmware.
      */
     displayablePublicKey: Type.String(),
 });

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetPublicKey.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumGetPublicKey.mdx
@@ -85,16 +85,10 @@ Result with only one public key
         childNum: number,             // BIP32 serialization format
         fingerprint: number,          // BIP32 serialization format
         depth: number,                // BIP32 serialization format
-        displayablePublicKey: string, // canonical user-facing form (= xpub)
+        displayablePublicKey: string, // canonical user-facing form (= publicKey)
     }
 }
 ```
-
-> **`displayablePublicKey` vs. firmware display.** With `showOnTrezor: true` the
-> device shows the raw compressed `publicKey` (33-byte hex). This field is the
-> `xpub` instead, because that's the more useful identifier in host-side UIs
-> (Trezor Suite displays the xpub in its address-confirmation modal). Both are
-> correct representations of the same secp256k1 point at the requested path.
 
 [Read more about BIP32 serialization format](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Serialization_format)
 

--- a/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts
@@ -13,7 +13,7 @@ const generatedTests = commonFixtures.tests.flatMap(({ parameters, result }) => 
         chainCode: result.chain_code,
         publicKey: result.public_key,
         xpub: result.xpub,
-        displayablePublicKey: result.xpub,
+        displayablePublicKey: result.public_key,
     },
 }));
 

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -100,7 +100,7 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
                 publicKey: publicKey.node.public_key,
                 fingerprint: publicKey.node.fingerprint,
                 depth: publicKey.node.depth,
-                displayablePublicKey: publicKey.xpub,
+                displayablePublicKey: publicKey.node.public_key,
             };
 
             responses.push(response);

--- a/packages/connect/src/api/signMessage.test.ts
+++ b/packages/connect/src/api/signMessage.test.ts
@@ -1,0 +1,63 @@
+import type { SignMessage as SignMessageSchema } from '@trezor/connect-common';
+
+import { default as SignMessageBase } from './signMessage';
+
+class SignMessage extends SignMessageBase {
+    getParams() {
+        return this.params;
+    }
+}
+
+// The method constructor is enough to exercise the script_type resolution: it derives
+// proto.script_type from either the caller-supplied scriptType or, failing that, the path
+// (getScriptType). getBitcoinNetwork reads statically-loaded coin data, so no device is needed.
+const createMethodProto = (params: SignMessageSchema) =>
+    new SignMessage({ payload: { method: 'signMessage', ...params } }).getParams().proto;
+
+const base: SignMessageSchema = {
+    path: "m/44'/0'/0'/0/0",
+    coin: 'btc',
+    message: 'This is an example of a signed message.',
+};
+
+describe('SignMessage script_type resolution', () => {
+    it('derives script_type from the path when no scriptType is given', () => {
+        // m/44' -> legacy, m/84' -> native segwit
+        expect(createMethodProto({ ...base, path: "m/44'/0'/0'/0/0" }).script_type).toBe(
+            'SPENDADDRESS',
+        );
+        expect(createMethodProto({ ...base, path: "m/84'/0'/0'/0/0" }).script_type).toBe(
+            'SPENDWITNESS',
+        );
+    });
+
+    it('prefers an explicit scriptType over the path-derived one', () => {
+        // legacy path, but the caller overrides to native segwit
+        expect(
+            createMethodProto({ ...base, path: "m/44'/0'/0'/0/0", scriptType: 'SPENDWITNESS' })
+                .script_type,
+        ).toBe('SPENDWITNESS');
+        expect(
+            createMethodProto({ ...base, path: "m/44'/0'/0'/0/0", scriptType: 'SPENDTAPROOT' })
+                .script_type,
+        ).toBe('SPENDTAPROOT');
+    });
+
+    it("coerces SPENDMULTISIG to SPENDADDRESS (firmware rejects 'SPENDMULTISIG')", () => {
+        expect(
+            createMethodProto({ ...base, path: "m/44'/0'/0'/0/0", scriptType: 'SPENDMULTISIG' })
+                .script_type,
+        ).toBe('SPENDADDRESS');
+    });
+
+    it('rejects an unknown scriptType via schema validation', () => {
+        expect(() =>
+            createMethodProto({
+                ...base,
+                path: "m/44'/0'/0'/0/0",
+                // @ts-expect-error
+                scriptType: 'NOT_A_SCRIPT_TYPE',
+            }),
+        ).toThrow();
+    });
+});

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -37,7 +37,7 @@ export default class SignMessage extends AbstractMethod<'signMessage', Params> {
 
         const readableMessage = payload.hex ? hexToText(payload.message) : payload.message;
 
-        const scriptType = getScriptType(path);
+        const scriptType = payload.scriptType || getScriptType(path);
         const proto = {
             address_n: path,
             message: messageHex,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cherrypick from https://github.com/trezor/trezor-suite/pull/31901

 2 uncontroversial commits, leaving `"m/45'"` #31737 for further discussion

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily touches the connect signMessage implementation and shared connect-common type definitions for Bitcoin/Ethereum APIs. The highest-risk user-facing flow is Bitcoin message signing, so the Bitcoin sign-and-verify test should run. Public-key export for BTC/LTC/ADA shares the same common type layer and is worth a medium-priority check. The Ethereum public key and internal signMessage unit changes have no Suite E2E coverage and should be validated by lower-level connect tests.

<details><summary><b>Changed files (7)</b></summary>

- `packages/connect-common/src/types/api/bitcoin.type-test.ts`
- `packages/connect-common/src/types/api/bitcoin/common.ts`
- `packages/connect-common/src/types/params.ts`
- `packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts`
- `packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts`
- `packages/connect/src/api/signMessage.test.ts`
- `packages/connect/src/api/signMessage.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — This test covers the end-to-end Bitcoin sign/verify message flow in Trezor Suite, which directly invokes the connect signMessage API. Changes to packages/connect/src/api/signMessage.ts and the connect-common bitcoin/params type definitions are most likely to affect this flow, including standard and Electrum-compatible signature formats.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — This test exercises GetPublicKey calls for BTC, LTC and ADA accounts and verifies displayed XPUBs. The changed connect-common bitcoin/common.ts and params.ts files define the shared Bitcoin API parameter types used by getPublicKey, so a type or validation change there could affect account public key export.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/connect-common/src/types/api/bitcoin.type-test.ts`
- `packages/connect/e2e/__fixtures__/ethereumGetPublicKey.ts`
- `packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts`
- `packages/connect/src/api/signMessage.test.ts`

_Updated: 2026-09-03T15:46:31.345Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=pr/31738_31736&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=pr/31738_31736&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=pr/31738_31736&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T15:49:26.971Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T15:48:23.923Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/pr/31738_31736/web/](https://dev.suite.sldev.cz/suite-web/pr/31738_31736/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->