### PR TITLE
chore(suite-desktop): enable TrezorConnect logs using `--log-level=debug`

### DIFF
--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -18,6 +18,7 @@ import { looselyTypedIpcMain } from '../ipcMain';
 import { APP_NAME } from '../libs/constants';
 import { getComputerName } from '../libs/info';
 import { PowerSaveBlocker } from '../libs/power-save-blocker';
+import { getSwitchValue } from '../libs/process-switches';
 
 export const SERVICE_NAME = '@trezor/connect';
 
@@ -119,6 +120,7 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
                     // Core runs in this (main) process; the renderer cannot send a logger factory
                     // across IPC, so build it here from the serializable `debug` enabled hint.
                     // TODO(logger-unification): build from a unified app-wide logger instead of initLog.
+                    settings.debug = settings.debug || getSwitchValue('log-level') === 'debug';
                     createLogger = (prefix: string) => initLog(prefix, !!settings.debug);
                     settings.createLogger = createLogger;
                     settings.transports = getTransportsParam(settings.transports, createLogger);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Self explanatory

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is the desktop TrezorConnect integration module, so no static coverage existed. The most relevant tests are the desktop Connect suites that explicitly run with coreMode 'suite-desktop'; they cover initialization, permissions, signing, address export, silent mode, and account selection. Running this focused set provides broad coverage of the module's surface area without invoking unrelated web or trading tests.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-core/src/modules/trezor-connect.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test initializes TrezorConnect with coreMode 'suite-desktop' and exercises the desktop Connect error popup path, which is served by the changed suite-desktop-core TrezorConnect module.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Uses TrezorConnect.init with coreMode 'suite-desktop' and covers the in-app permissions and sign-message modal flows that the changed module wires up.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Runs TrezorConnect.ethereumSignTransaction through the desktop core integration, verifying permissions, device prompts, and signing end-to-end.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Exercises the desktop Connect account-info flow (permissions modal → account selection → API response), directly relying on the changed module.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Covers Bitcoin address export with coreMode 'suite-desktop', including permissions, address confirmation, and verification states handled by the module.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Directly tests permission granting, remembering, revoking, and the Connect settings tab, all of which are managed by the desktop TrezorConnect module.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Uses TrezorConnect.selectAccount with coreMode 'suite-desktop' and exercises the permissions/account-selection modal path implemented by the changed module.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Signs a Bitcoin transaction via TrezorConnect in desktop core mode, covering permissions, device prompts, and signing error handling.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Specifically tests silent-mode focus suppression and app/focus IPC behavior, which is implemented in the desktop TrezorConnect module.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Uses TrezorConnect.init with requestedPermissions and verifies the upfront permission consent flow, a feature controlled by the changed module.

</details>

_Updated: 2026-09-03T20:50:04.400Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/suite-trezor-connect-logs-debug/web/](https://dev.suite.sldev.cz/suite-web/chore/suite-trezor-connect-logs-debug/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite-trezor-connect-logs-debug&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite-trezor-connect-logs-debug&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-03T20:52:50.786Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-03T20:52:32.634Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->