### PR TITLE
fix(suite-native): fetch fee info before composing Stellar trustline

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -149,6 +149,15 @@ export const composeRippleStellarTransactionFeeLevelsThunk = createThunk<
             });
         }
 
+        // Fee info without any level cannot be composed, and the custom level fallback below
+        // reads the last predefined level, which would throw on an empty list.
+        if (predefinedLevels.length === 0) {
+            return rejectWithValue({
+                error: 'fee-levels-compose-failed',
+                message: 'No fee levels available.',
+            });
+        }
+
         let requiredAmount: BigNumber | undefined;
         // additional check if recipient address is empty
         // it will set requiredAmount to recipient account reserve value

--- a/suite-native/module-stellar-token-management/src/thunks.test.ts
+++ b/suite-native/module-stellar-token-management/src/thunks.test.ts
@@ -1,0 +1,104 @@
+import {
+    composeSendFormTransactionFeeLevelsThunk,
+    selectAccountByKey,
+    selectConvertedNetworkFeeInfo,
+    updateFeeInfoThunk,
+} from '@suite-common/wallet-core';
+import { type FeeInfo, type TokenAddress } from '@suite-common/wallet-types';
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { createStoreFromPreloadedState } from '@suite-native/test-utils-store';
+
+import { composeStellarTrustlineFeesThunk } from './thunks';
+
+jest.mock('@suite-common/wallet-core', () => ({
+    ...jest.requireActual('@suite-common/wallet-core'),
+    selectAccountByKey: jest.fn(),
+    selectConvertedNetworkFeeInfo: jest.fn(),
+    updateFeeInfoThunk: jest.fn(),
+    composeSendFormTransactionFeeLevelsThunk: jest.fn(),
+}));
+
+const accountKey = mockAccountKey({ symbol: 'xlm', descriptor: 'stellar1' });
+const tokenContract =
+    'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' as TokenAddress;
+
+const mockAccount = {
+    key: accountKey,
+    symbol: 'xlm',
+    networkType: 'stellar',
+    descriptor: 'GAXSFOOGF4ELO5HT5PTN23T5XE6D5QWL3YBHSVQ2HWOFEJNYYMRJENBV',
+    availableBalance: '10000000000',
+    tokens: [],
+};
+
+const backendFeeInfo: FeeInfo = {
+    blockHeight: 0,
+    blockTime: -1,
+    minFee: 100,
+    maxFee: 10000000,
+    minPriorityFee: -1,
+    levels: [{ label: 'normal', feePerUnit: '150', blocks: -1 }],
+};
+
+const emptyFeeInfo: FeeInfo = { ...backendFeeInfo, levels: [] };
+
+const composedLevels = { normal: { type: 'final', feePerByte: '150' } };
+
+const getComposeContext = () =>
+    jest.mocked(composeSendFormTransactionFeeLevelsThunk).mock.calls[0]?.[0].composeContext;
+
+describe('composeStellarTrustlineFeesThunk', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        jest.mocked(selectAccountByKey).mockReturnValue(mockAccount as any);
+        jest.mocked(updateFeeInfoThunk).mockImplementation((() => ({
+            type: 'fees/updateFeeInfoThunk',
+        })) as any);
+        jest.mocked(composeSendFormTransactionFeeLevelsThunk).mockImplementation((() => ({
+            type: 'send/composeSendFormTransactionThunk/fulfilled',
+            payload: composedLevels,
+            meta: { requestStatus: 'fulfilled', requestId: 'compose', arg: undefined },
+        })) as any);
+    });
+
+    const dispatchThunk = () => {
+        const store = createStoreFromPreloadedState();
+
+        return store.dispatch(
+            composeStellarTrustlineFeesThunk({ accountKey, tokenContract }) as any,
+        );
+    };
+
+    it('composes with the fee info from the store without refetching it', async () => {
+        jest.mocked(selectConvertedNetworkFeeInfo).mockReturnValue(backendFeeInfo);
+
+        const result = await dispatchThunk();
+
+        expect(updateFeeInfoThunk).not.toHaveBeenCalled();
+        expect(getComposeContext()?.feeInfo).toBe(backendFeeInfo);
+        expect(result.payload).toEqual(composedLevels);
+    });
+
+    it('fetches the fee info when it is missing from the store', async () => {
+        jest.mocked(selectConvertedNetworkFeeInfo)
+            .mockReturnValueOnce(null)
+            .mockReturnValueOnce(backendFeeInfo);
+
+        const result = await dispatchThunk();
+
+        expect(updateFeeInfoThunk).toHaveBeenCalledWith({ networkSymbol: 'xlm' });
+        expect(getComposeContext()?.feeInfo).toBe(backendFeeInfo);
+        expect(result.payload).toEqual(composedLevels);
+    });
+
+    it('does not compose when the fee info stays unavailable after the fetch', async () => {
+        jest.mocked(selectConvertedNetworkFeeInfo).mockReturnValue(emptyFeeInfo);
+
+        const result = await dispatchThunk();
+
+        expect(updateFeeInfoThunk).toHaveBeenCalledWith({ networkSymbol: 'xlm' });
+        expect(composeSendFormTransactionFeeLevelsThunk).not.toHaveBeenCalled();
+        expect(result.payload).toBe('Fee info not available');
+    });
+});

--- a/suite-native/module-stellar-token-management/src/thunks.ts
+++ b/suite-native/module-stellar-token-management/src/thunks.ts
@@ -12,9 +12,11 @@ import {
     selectAccountByKey,
     selectConvertedNetworkFeeInfo,
     selectDeepCopyOfFormDraft,
+    updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import {
     type AccountKey,
+    type FeeInfo,
     type FormState,
     type PrecomposedLevels,
     type PrecomposedLevelsCardano,
@@ -29,6 +31,11 @@ import {
 const STELLAR_TOKEN_MODULE_PREFIX = '@suite-native/stellar-token';
 
 const STELLAR_DEFAULT_FEE_STROOPS = '100';
+
+// A network with no fee data yet is converted into an empty level list, while one with data gets
+// a synthetic 'custom' level appended. Only the predefined levels can be composed with.
+const hasPredefinedFeeLevels = (feeInfo: FeeInfo | null): feeInfo is FeeInfo =>
+    !!feeInfo?.levels.some(level => level.label !== 'custom');
 
 const STELLAR_TOKEN_FORM_DRAFT_PREFIX = 'stellar-token';
 
@@ -133,8 +140,15 @@ export const composeStellarTrustlineFeesThunk = createThunk<
             return rejectWithValue('Account not found');
         }
 
-        const feeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);
-        if (!feeInfo) {
+        // Fees are preloaded only for the networks enabled at app start and are not persisted, so
+        // they can be missing here. Nothing else in the trustline flow fetches them.
+        let feeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);
+        if (!hasPredefinedFeeLevels(feeInfo)) {
+            await dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol }));
+            feeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);
+        }
+
+        if (!hasPredefinedFeeLevels(feeInfo)) {
             return rejectWithValue('Fee info not available');
         }
 


### PR DESCRIPTION
## Description

Tapping a token in the Stellar **Inactive** tab could fail instantly with "Activation failed", never reaching device confirmation.

`composeStellarTrustlineFeesThunk` gave up whenever XLM fee info was missing from the store. Fees are preloaded once at app start for the networks enabled *at that moment* and the slice is not persisted, so enabling Stellar mid-session left `wallet.fees.xlm` empty for the rest of the session. The thunk now fetches fees on demand — like the send, trading and earn flows already do — and only rejects if they are still unavailable.

Also hardens `composeRippleStellarTransactionFeeLevelsThunk`, which threw a `TypeError` on level-less fee info instead of rejecting.

## Notes for QA

Enable Stellar in Settings **while the app is running**, run discovery, then open a Stellar account → Inactive tab → tap any token. Expected: fee screen, then device confirmation. Before the fix: instant "Activation failed".

- Repeat after an app restart with Stellar already enabled — unchanged, no extra delay on tap.
- Offline → still "Activation failed / Try again" (expected; no fee is invented).
- Same thunk backs deactivation, manual token input and trading activation.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31705

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files fall into two categories with no actionable E2E coverage in this Suite web/desktop test suite. `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts` is specific to Ripple (XRP) and Stellar (XLM) send forms; although static analysis maps it to 134 tests, none of those tests' described behaviors exercise XRP or XLM send flows (XRP only appears in a discovery test, and XLM/Stellar are not mentioned at all). The two `suite-native/module-stellar-token-management` files belong to the native/mobile app, which is outside the scope of the web/desktop E2E tests listed. Therefore, no tests in this suite provide meaningful coverage of the changes.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`
- `suite-native/module-stellar-token-management/src/thunks.test.ts`
- `suite-native/module-stellar-token-management/src/thunks.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts`
- `suite-native/module-stellar-token-management/src/thunks.test.ts`
- `suite-native/module-stellar-token-management/src/thunks.ts`

_Updated: 2026-09-08T10:37:45.682Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/native/fix-stellar/web/](https://dev.suite.sldev.cz/suite-web/native/fix-stellar/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=native/fix-stellar&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=native/fix-stellar&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=native/fix-stellar&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T10:39:28.353Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T10:39:48.719Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
