### PR TITLE
refactor(suite-desktop): remove dead bridge rollout settings

### DIFF
--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -113,7 +113,6 @@ export type Status = {
 // todo: duplicate, see prev comment
 export type BridgeSettings = {
     doNotStartOnStartup: boolean;
-    legacy?: boolean;
 };
 
 export type BioAuthSettings = {

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -114,7 +114,6 @@ export type Status = {
 export type BridgeSettings = {
     doNotStartOnStartup: boolean;
     legacy?: boolean;
-    newBridgeRollout?: number;
 };
 
 export type BioAuthSettings = {

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -121,10 +121,6 @@ declare type BridgeSettings = {
      * Force suite not to start bridge on application startup
      */
     doNotStartOnStartup: boolean;
-    /**
-     * Should run trezord-go
-     */
-    legacy?: boolean;
 };
 
 declare type TraySettings = {

--- a/packages/suite-desktop-core/src/index.d.ts
+++ b/packages/suite-desktop-core/src/index.d.ts
@@ -125,10 +125,6 @@ declare type BridgeSettings = {
      * Should run trezord-go
      */
     legacy?: boolean;
-    /**
-     * Should run the new bridge?
-     */
-    newBridgeRollout?: number;
 };
 
 declare type TraySettings = {

--- a/packages/suite-desktop-core/src/libs/store.ts
+++ b/packages/suite-desktop-core/src/libs/store.ts
@@ -91,7 +91,6 @@ export class Store {
     public getBridgeSettings() {
         return this.store.get('bridgeSettings', {
             doNotStartOnStartup: false,
-            legacy: false,
         });
     }
 


### PR DESCRIPTION
## Description

Removes two dead fields from the desktop `BridgeSettings` type, both leftovers of the old trezord-go-vs-node-bridge rollout:

- **`newBridgeRollout?: number`** — never read or written anywhere. Only existed in the two `BridgeSettings` type declarations.
- **`legacy?: boolean`** — no longer read as a decision input. The bridge module now always runs the bundled node bridge (`TrezordNode` from `@trezor/transport-bridge`) unconditionally and never branches on this flag.

The last reader of both was removed in `8a74cb2a65` ("feat(suite-desktop): remove node-bridge rollout"). Since then the fields have been pure vestiges.

## Why

Dead code. `git grep newBridgeRollout` returns exactly two hits (both type declarations, zero property accesses); `legacy` on `BridgeSettings` has no remaining readers. Keeping them around is misleading — they suggest a rollout/legacy branch that no longer exists.

## Changes (2 commits)

1. `refactor(suite-desktop): remove dead newBridgeRollout bridge setting` — drop the field from `packages/suite-desktop-api/src/messages.ts` and the hand-maintained ambient duplicate in `packages/suite-desktop-core/src/index.d.ts`.
2. `refactor(suite-desktop): remove dead legacy bridge setting` — drop `legacy` from both declarations plus its `false` default in the electron-store getter (`store.ts`).

## Notes for QA

- The two `BridgeSettings` declarations are a deliberate, un-codegen'd duplication (see the `// todo: duplicate` comment in `messages.ts`; `suite-desktop-api` can't depend on `suite-desktop`), so both copies are updated together.
- Backwards compatible: `electron-store` has no schema/migrations, so a value persisted by an older Suite simply lingers on disk unread — no runtime path ever consumed it.
- Both fields were optional and never read, so removal is type-safe; the only object literal typed as `BridgeSettings` (the store default) had `legacy: false` removed to avoid an excess-property error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/newbridgerollout-dead-code/web/](https://dev.suite.sldev.cz/suite-web/newbridgerollout-dead-code/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on desktop-only infrastructure (IPC message definitions, core typings, and the Electron store). The main risk is broken main/renderer communication or app startup, not user-facing Suite logic. Run the silent-mode test for direct IPC coverage and the two bridge spawn tests as a smoke test of the desktop app lifecycle; broader desktop Connect tests are unlikely to add signal unless the IPC changes affect their specific channels.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite-desktop-api/src/messages.ts`
- `packages/suite-desktop-core/src/index.d.ts`
- `packages/suite-desktop-core/src/libs/store.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test directly exercises the desktop IPC layer (app/focus events) and desktopApi/contextBridge integration, which maps directly to changes in suite-desktop-api messages and the desktop core. It is the strongest signal that IPC message routing and main/renderer communication still work.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Launches the Electron app in daemon mode and verifies main-process lifecycle behavior (bridge spawning, UI init, shutdown). A regression in desktop core initialization or store setup would likely surface here.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Exercises standard Electron app launch, renderer window lifecycle, and bridge management. Changes to desktop core store or startup plumbing could cause launch or initialization failures visible in this test.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop-core/src/libs/store.ts`

_Updated: 2026-09-04T06:46:20.677Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=newbridgerollout-dead-code&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=newbridgerollout-dead-code&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T06:48:16.092Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T06:48:38.935Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->