### PR TITLE
test(e2e-utils): cut analyzer rework and report harness problems to Slack

### DIFF
--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -294,6 +294,7 @@ jobs:
         if: ${{ !cancelled() && steps.run-fix-agent.outcome != 'skipped' }}
         env:
           GH_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+          TASK_ID: ${{ matrix.task-id }}
         run: yarn workspace @trezor/e2e-utils fix-bot:publish
 
       - name: Upload Slack fix summary artifact
@@ -303,6 +304,14 @@ jobs:
           name: slack-fix-summary-${{ matrix.task-id }}
           path: slack-fix-summary-${{ matrix.task-id }}.json
           if-no-files-found: warn
+
+      - name: Upload errors artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: fix-errors-${{ matrix.task-id }}
+          path: fixbot-errors-${{ matrix.task-id }}.txt
+          if-no-files-found: ignore
 
       - name: Docker Compose Down
         if: always()
@@ -356,10 +365,19 @@ jobs:
           merge-multiple: true
         continue-on-error: true
 
+      - name: Download fix errors artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: fix-errors-*
+          path: fix-errors/
+          merge-multiple: true
+        continue-on-error: true
+
       - name: Send Slack notification
         env:
           REPORT_PATH: ${{ github.workspace }}/report-download/report.json
           SUMMARIES_DIR: ${{ github.workspace }}/summaries
+          FIX_ERRORS_DIR: ${{ github.workspace }}/fix-errors
           ANALYZE_COST_FILE: ${{ github.workspace }}/analyze-cost-download/llm-token-usage.json
           SLACK_FIX_AGENT_WEBHOOK: ${{ secrets.SLACK_FIX_AGENT_WEBHOOK }}
         run: yarn workspace @trezor/e2e-utils fix-bot:notify

--- a/.github/workflows/test-suite-nightly-fix-agent.yml
+++ b/.github/workflows/test-suite-nightly-fix-agent.yml
@@ -40,7 +40,11 @@ jobs:
         run: yarn workspaces focus @trezor/e2e-utils
 
       - name: Install Playwright trace skill
-        run: yarn workspace @trezor/e2e-utils exec playwright trace install-skill
+        # Must run from the repo root — the skill installs to <cwd>/.claude/skills and the agent's cwd is the root
+        run: npx playwright trace install-skill
+
+      - name: Install Playwright headless shell for trace snapshot inspection
+        run: npx playwright install chromium-headless-shell
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
@@ -203,7 +207,8 @@ jobs:
         run: yarn workspace @trezor/suite-e2e exec playwright install chromium --with-deps
 
       - name: Install Playwright trace skill
-        run: yarn workspace @trezor/suite-e2e exec playwright trace install-skill
+        # Must run from the repo root — the skill installs to <cwd>/.claude/skills and the agent's cwd is the root
+        run: npx playwright trace install-skill
 
       - name: Build message system config
         run: yarn message-system-sign-config 1>/dev/null

--- a/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/ANALYSIS_AGENT.md
@@ -54,6 +54,15 @@ file path.
 > which instances need investigation. It does **not** contain per-test error messages or artifact
 > URLs. Those only come from `currents-get-spec-instance` in Step 3, which is always required.
 
+> The response is large, so the harness saves it to a file. Its shape is stable — do not probe it;
+> extract everything you need in one pass:
+>
+> ```bash
+> jq -r '.data.specs[]
+>   | select((.results.stats.failures // 0) > 0 or (.results.stats.pending // 0) > 0)
+>   | [.instanceId, .groupId, .spec] | @tsv' <saved-file>
+> ```
+
 **Excluded directories:** Skip any instance whose spec path starts with
 `suite/e2e/tests/trading-live`. Do not investigate, diagnose, or include these in fix tasks
 or the skipped list — omit them entirely from the report.
@@ -67,15 +76,28 @@ For each failed or pending `instanceId`, use `currents-get-spec-instance` and ex
 - `electron-logs.txt` attachment URL (desktop runs only — useful for Electron startup
   crashes or main process errors)
 
+> Do **not** use `currents-get-context` for pending/quarantined tests — it reports them as
+> `PASSED`/`NO_TESTS` with zero failures and hides their errors and artifact URLs. Only
+> `currents-get-spec-instance` exposes them.
+
+Once you have the error data, compare each failure against the known-failures ledger (see Step 7,
+rule 1). An instance that is a **confident ledger match** skips Steps 4–5 entirely — its error
+signature is the evidence.
+
 ## Step 4 — Fetch and analyze trace artifacts (MANDATORY — do not skip)
 
 **Do not write any diagnosis until you have completed this step for every failed instance.**
+The one exception: a **confident ledger match** (Step 7, rule 1) is verified by error signature
+only — skip this step and Step 5 for it.
 
 **Trace (primary).** Download the trace, then read it with the **`playwright-trace` skill**:
 
 ```bash
 python3 -c "import urllib.request; urllib.request.urlretrieve('<trace-url>', '/tmp/trace-<instanceId>.zip')"
 ```
+
+If the skill is not available under that name, read `.claude/skills/playwright-trace/SKILL.md`
+at the repo root and use its `npx playwright trace` commands directly.
 
 If a trace is not available for an instance, state this explicitly and note that visual analysis
 was not possible.
@@ -143,10 +165,21 @@ Route each cluster by the **first** rule that applies:
 
 1. **Already in the known-failures ledger** (the section at the end of this prompt) — compare each
    cluster against every entry's `rootCause` and `validations` (platform/group/spec), not just an
-   overlapping spec path — a failure may be specific to a platform or device group (e.g. `T1B1`):
-    - **Confident match → skipped**, reusing the entry's `reason`.
-    - **rootCause match, but different validations → treat as new** — continue to rules 2–4.
-    - **Unsure → treat as new** — continue to rules 2–4.
+   overlapping spec path — a failure may be specific to a platform or device group (e.g. `T1B1`).
+   A **confident match** requires **both**, verified from the `currents-get-spec-instance` error
+   data:
+    - the per-test error signature (message, failing locator/assertion, stack location) matches the
+      failure mode described by the entry's `rootCause`, **and**
+    - every affected platform/group/spec combination is covered by the entry's `validations`.
+
+    Routing:
+    - **Confident match → skipped**, reusing the entry's `reason`. The error signature is
+      sufficient evidence — do not download or read traces for it.
+    - **rootCause match, but different validations → treat as new** — continue to rules 2–4, with
+      full trace analysis (Steps 4–5).
+    - **Same spec but a different error, or unsure → treat as new** — continue to rules 2–4, with
+      full trace analysis (Steps 4–5).
+
 2. **Fixable** — the **entire** remedy fits inside `suite/e2e/` and/or adding `data-testid`
    attributes in product source → **fix_task**.
 3. **Needs a product-logic change** → **skipped**, `reason: "PRODUCT_BUG"`.
@@ -197,7 +230,10 @@ Return a JSON object (validated against a matching JSON Schema) with:
 - **Visual evidence is mandatory.** Do not write a diagnosis for any test until you have
   fetched and read its trace. Every **Root cause** must cite something you actually
   observed — an action's selector or result, a DOM snapshot, a failed request, or a stack
-  trace. If it does not, you are speculating.
+  trace. If it does not, you are speculating. The one exception is a **confident ledger
+  match** (Step 7, rule 1): its evidence is the error signature from
+  `currents-get-spec-instance` — no trace is required, and its report entry should say
+  "confident ledger match — verified by error signature" under **Visual evidence**.
 - Never speculate. Base every diagnosis strictly on what the error, stack trace, and visual
   evidence directly show.
 - If a failure looks like a flaky timing issue, say so explicitly and explain the signal.

--- a/packages/e2e-utils/src/fixBot/analyze.ts
+++ b/packages/e2e-utils/src/fixBot/analyze.ts
@@ -6,6 +6,7 @@ import { prettifyError } from 'zod';
 
 import { error, log } from '../logger';
 import { loadLedger, runAgent } from './common';
+import { reportToSlack } from './errors';
 import { AnalysisReportJsonSchema, AnalysisReportSchema } from './schemas';
 
 const MODEL = 'claude-opus-4-8';
@@ -31,6 +32,7 @@ async function main(): Promise<void> {
 
     if (!process.env.CURRENTS_API_KEY) {
         error('CURRENTS_API_KEY is not set. It must be provided via the workflow environment.');
+        reportToSlack('CURRENTS_API_KEY is not set, so no nightly runs could be analyzed.');
         process.exit(1);
     }
 
@@ -71,16 +73,19 @@ async function main(): Promise<void> {
         error(
             `Analysis agent exceeded the ${TIMEOUT_MS / 60000}-minute timeout and was killed; no report produced.`,
         );
+        reportToSlack('Analysis agent hit its timeout and was killed; no report was produced.');
         process.exit(1);
     }
 
     if (runError) {
         error(`Failed to run the analysis agent: ${runError}`);
+        reportToSlack('Analysis agent could not be started; no report was produced.');
         process.exit(1);
     }
 
     if (result?.subtype !== 'success') {
         error(`Analysis agent ended with '${result?.subtype ?? 'no result'}'; no report produced.`);
+        reportToSlack('Analysis agent ended without a result; no report was produced.');
         process.exit(1);
     }
 
@@ -89,6 +94,9 @@ async function main(): Promise<void> {
     if (!report.success) {
         writeFileSync(reportJsonPath, `${JSON.stringify(result.structured_output, null, 2)}\n`);
         error(`structured output failed schema validation: ${prettifyError(report.error)}`);
+        reportToSlack(
+            "Analysis agent's report did not match the expected schema; no fix tasks were created.",
+        );
         process.exit(1);
     }
 

--- a/packages/e2e-utils/src/fixBot/common.ts
+++ b/packages/e2e-utils/src/fixBot/common.ts
@@ -36,6 +36,7 @@ export function loadLedger(path: string): Ledger {
     return EMPTY_LEDGER;
 }
 
+/** Skips schema-invalid files instead of throwing — see docs.md "Partial runs, missing summaries". */
 export function readSummaries(summariesDir: string | undefined): SlackFixSummary[] {
     if (!summariesDir || !existsSync(summariesDir)) return [];
 

--- a/packages/e2e-utils/src/fixBot/common.ts
+++ b/packages/e2e-utils/src/fixBot/common.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { log, warn } from '../logger';
+import { reportToSlack } from './errors';
 import {
     type AgentName,
     type Ledger,
@@ -21,7 +22,13 @@ import {
 export const EMPTY_LEDGER: Ledger = { version: 1, updatedAt: '1970-01-01', entries: [] };
 
 export function loadLedger(path: string): Ledger {
-    if (!existsSync(path)) return EMPTY_LEDGER;
+    if (!existsSync(path)) {
+        reportToSlack(
+            `[ledger] not found at ${path} — the S3 download failed or no ledger exists yet.`,
+        );
+
+        return EMPTY_LEDGER;
+    }
 
     try {
         const parsed = LedgerSchema.safeParse(JSON.parse(readFileSync(path, 'utf-8')));
@@ -33,14 +40,21 @@ export function loadLedger(path: string): Ledger {
         warn(`[ledger] could not read ${path} (${(e as Error).message}) — starting from empty.`);
     }
 
+    reportToSlack('[ledger] could not be loaded — this run analyzed with an empty ledger.');
+
     return EMPTY_LEDGER;
 }
 
-/** Skips schema-invalid files instead of throwing — see docs.md "Partial runs, missing summaries". */
-export function readSummaries(summariesDir: string | undefined): SlackFixSummary[] {
-    if (!summariesDir || !existsSync(summariesDir)) return [];
+export interface ReadSummariesResult {
+    summaries: SlackFixSummary[];
+    problemsByTaskId: Record<string, string>;
+}
 
-    const parsedSummaries: SlackFixSummary[] = [];
+export function readSummaries(summariesDir: string | undefined): ReadSummariesResult {
+    const result: ReadSummariesResult = { summaries: [], problemsByTaskId: {} };
+
+    if (!summariesDir || !existsSync(summariesDir)) return result;
+
     const allSummariesFiles = readdirSync(summariesDir).filter(
         n => n.startsWith('slack-fix-summary-') && n.endsWith('.json'),
     );
@@ -51,13 +65,16 @@ export function readSummaries(summariesDir: string | undefined): SlackFixSummary
 
         if (!parsed.success) {
             warn(`[summaries] Failed to parse ${filename}: ${parsed.error.message}`);
+            const taskId = filename.slice('slack-fix-summary-'.length, -'.json'.length);
+            result.problemsByTaskId[taskId] =
+                'Its result file could not be read, so this task shows as not completed.';
             continue;
         }
 
-        parsedSummaries.push(parsed.data);
+        result.summaries.push(parsed.data);
     }
 
-    return parsedSummaries;
+    return result;
 }
 
 /** Prefers subprocess stderr, which usually holds the real cause, over the wrapper message. */
@@ -140,8 +157,9 @@ function writeCostFile(totalCostUsd: number | undefined): void {
             '/tmp/llm-token-usage.json',
             JSON.stringify({ total_cost_usd: totalCostUsd }),
         );
-    } catch {
-        // non-critical
+    } catch (e) {
+        warn(`[cost] could not write the cost file: ${(e as Error).message}`);
+        reportToSlack('Agent cost could not be recorded — the cost shown here is incomplete.');
     }
 }
 

--- a/packages/e2e-utils/src/fixBot/docs.md
+++ b/packages/e2e-utils/src/fixBot/docs.md
@@ -211,20 +211,23 @@ run — so `notify` and `update-ledger` must degrade per task, never all-or-noth
 downloads carry `continue-on-error: true`: the Slack message goes out even on a night where analyze
 failed or zero fix jobs completed.
 
-The per-task channel is the summary file, `slack-fix-summary-<task-id>.json`:
+Per-task results travel in `slack-fix-summary-<task-id>.json`, harness problems in the separate
+`fixbot-errors-<task-id>.txt` artifact (see `errors.ts`):
 
-- **Agent completed, publish succeeded** — summary carries the result and `prUrl`.
+- **Agent completed, publish succeeded** — the summary carries the result and `prUrl`.
 - **Agent completed, publish failed** (push, `gh pr create`, or project assignment) — `publish.ts`
-  catches the error, stores it in the summary's `error` field, and still writes the file; `notify`
-  renders it as `⚠️ publish failed: …`. The step exits non-zero so the job is red, but the night's
-  aggregation is unaffected.
+  appends a fixed message to the error artifact and still writes the summary; `notify` renders the
+  message in that task's `⚠️ Errors:` block. The step exits non-zero so the job is red, but the
+  night's aggregation is unaffected.
 - **Agent/job died before publish** — no summary exists. `notify` renders the task as
   `job did not complete`; `buildLedger()` logs a warning and writes **no ledger entry** for it.
-- **Summary exists but fails schema validation** — `readSummaries()` warns and skips that file
-  (e.g. schema drift between code versions, or a truncated write from a dying runner), so one
-  malformed file cannot cost the other tasks their Slack line and ledger entry. A summary with
-  invalid JSON, by contrast, throws and fails the aggregating job — that is corruption, not a
-  partial run.
+  Errors reported before the agent died still reach Slack, which is why they do not ride the
+  summary.
+- **Summary unreadable** — invalid JSON from a truncated write, or a shape that fails schema
+  validation after a schema change. `readSummaries()` warns, skips the file, and returns a problem
+  keyed by the task id from its filename, which `notify` renders in that task's `⚠️ Errors:` block.
+  One unreadable file therefore costs neither the other tasks their Slack line and ledger entry,
+  nor the notification itself.
 
 **Why dropping unknown outcomes is safe:** absence from the ledger means "re-attempt next night".
 The only alternatives would be recording `FIX_FAILED` or `FIX_DELIVERED` — and both _suppress_

--- a/packages/e2e-utils/src/fixBot/docs.md
+++ b/packages/e2e-utils/src/fixBot/docs.md
@@ -200,3 +200,33 @@ never read.
 A ledger match is never re-attempted. A `not_duplicated` result records nothing (failure not
 reproduced — flaky or resolved). `buildLedger()` is pure and deterministic; matching is the agent's
 judgment at Step 7, not a computed key (the same spec can fail for different reasons across runs).
+
+---
+
+## Partial runs, missing summaries, and error passing
+
+The aggregation after the fix matrix is **fail-open per task, by design**. Fix jobs are independent
+and unreliable by assumption — a matrix job can be cancelled or die at any point of its up-to-210-minute
+run — so `notify` and `update-ledger` must degrade per task, never all-or-nothing. All their artifact
+downloads carry `continue-on-error: true`: the Slack message goes out even on a night where analyze
+failed or zero fix jobs completed.
+
+The per-task channel is the summary file, `slack-fix-summary-<task-id>.json`:
+
+- **Agent completed, publish succeeded** — summary carries the result and `prUrl`.
+- **Agent completed, publish failed** (push, `gh pr create`, or project assignment) — `publish.ts`
+  catches the error, stores it in the summary's `error` field, and still writes the file; `notify`
+  renders it as `⚠️ publish failed: …`. The step exits non-zero so the job is red, but the night's
+  aggregation is unaffected.
+- **Agent/job died before publish** — no summary exists. `notify` renders the task as
+  `job did not complete`; `buildLedger()` logs a warning and writes **no ledger entry** for it.
+- **Summary exists but fails schema validation** — `readSummaries()` warns and skips that file
+  (e.g. schema drift between code versions, or a truncated write from a dying runner), so one
+  malformed file cannot cost the other tasks their Slack line and ledger entry. A summary with
+  invalid JSON, by contrast, throws and fails the aggregating job — that is corruption, not a
+  partial run.
+
+**Why dropping unknown outcomes is safe:** absence from the ledger means "re-attempt next night".
+The only alternatives would be recording `FIX_FAILED` or `FIX_DELIVERED` — and both _suppress_
+future attempts, so a wrong guess silences a real failure permanently, while a drop costs at most
+one duplicate attempt. Drop-what-you-can't-verify is strictly safer than any recorded guess.

--- a/packages/e2e-utils/src/fixBot/errors.ts
+++ b/packages/e2e-utils/src/fixBot/errors.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { createLogger } from '../logger';
+
+const logger = createLogger('fixBot');
+
+export const ANALYZE_ERRORS_FILE = 'packages/e2e-utils/src/fixBot/reports/errors.txt';
+export const fixErrorsFile = (taskId: string) => `fixbot-errors-${taskId}.txt`;
+
+/** A fix job identifies itself by TASK_ID; the analyze job writes into its report dir. */
+function errorsFilePath(): string {
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        encoding: 'utf-8',
+    }).trim();
+    const taskId = process.env.TASK_ID;
+
+    return join(root, taskId ? fixErrorsFile(taskId) : ANALYZE_ERRORS_FILE);
+}
+
+/**
+ * Channel for problems the harness cannot throw on. The call site passes the message humans
+ * should read in the nightly Slack notification and logs the original error itself, so the
+ * stack stays in the CI log and never reaches Slack.
+ */
+export function reportToSlack(message: string): void {
+    logger.error(message);
+
+    try {
+        const path = errorsFilePath();
+        mkdirSync(dirname(path), { recursive: true });
+        appendFileSync(path, `${message}\n`);
+    } catch (e) {
+        logger.warn(`[errors] could not record the message: ${(e as Error).message}`);
+    }
+}
+
+export function readErrors(path: string | undefined): string[] {
+    if (!path || !existsSync(path)) return [];
+
+    try {
+        return readFileSync(path, 'utf-8').split('\n').filter(Boolean);
+    } catch (e) {
+        logger.warn(`[errors] could not read ${path}: ${(e as Error).message}`);
+
+        return [];
+    }
+}
+
+/** Per-task errors from a directory of downloaded `fixbot-errors-<taskId>.txt` files. */
+export function readTaskErrors(dir: string | undefined): Record<string, string[]> {
+    if (!dir || !existsSync(dir)) return {};
+
+    const byTaskId: Record<string, string[]> = {};
+
+    for (const filename of readdirSync(dir)) {
+        const taskId = /^fixbot-errors-(.+)\.txt$/.exec(filename)?.[1];
+        if (!taskId) continue;
+
+        const errors = readErrors(join(dir, filename));
+        if (errors.length > 0) byTaskId[taskId] = errors;
+    }
+
+    return byTaskId;
+}

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -5,6 +5,7 @@ import { prettifyError } from 'zod';
 
 import { error, log } from '../logger';
 import { runAgent } from './common';
+import { reportToSlack } from './errors';
 import { AnalysisReportSchema, FixResultJsonSchema, FixResultSchema } from './schemas';
 
 const MODEL = 'claude-opus-5';
@@ -35,6 +36,7 @@ async function main(): Promise<void> {
 
     if (!task) {
         error(`Task '${taskId}' not found in ${reportPath}`);
+        reportToSlack('This task is missing from the analysis report, so no fix was attempted.');
         process.exit(1);
     }
 
@@ -65,16 +67,19 @@ async function main(): Promise<void> {
         error(
             `Fix agent exceeded the ${TIMEOUT_MS / 60000}-minute timeout and was killed; no result produced.`,
         );
+        reportToSlack('Fix agent hit its timeout and was killed; nothing was published.');
         process.exit(1);
     }
 
     if (runError) {
         error(`Failed to run the fix agent: ${runError}`);
+        reportToSlack('Fix agent could not be started; nothing was published.');
         process.exit(1);
     }
 
     if (result?.subtype !== 'success') {
         error(`Fix agent ended with '${result?.subtype ?? 'no result'}'; no result produced.`);
+        reportToSlack('Fix agent ended without a result; nothing was published.');
         process.exit(1);
     }
 
@@ -82,6 +87,9 @@ async function main(): Promise<void> {
     if (!fixResult.success) {
         error(
             `structured output failed schema validation: ${prettifyError(fixResult.error)} \nRaw structured output:\n${JSON.stringify(result.structured_output, null, 2)}`,
+        );
+        reportToSlack(
+            "Fix agent's result did not match the expected schema; nothing was published.",
         );
         process.exit(1);
     }

--- a/packages/e2e-utils/src/fixBot/ledger.ts
+++ b/packages/e2e-utils/src/fixBot/ledger.ts
@@ -55,7 +55,7 @@ function main(): void {
         process.exit(1);
     }
 
-    const summaries = readSummaries(summariesDir);
+    const { summaries } = readSummaries(summariesDir);
     const newLedger = buildLedger(report.data, summaries, report.data.runDate);
 
     writeFileSync(ledgerFilePath, `${JSON.stringify(newLedger, null, 2)}\n`);

--- a/packages/e2e-utils/src/fixBot/notify.ts
+++ b/packages/e2e-utils/src/fixBot/notify.ts
@@ -1,8 +1,10 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import { error, log } from '../logger';
 import { githubRunLink, postSlackMessage } from '../slack';
 import { readSummaries } from './common';
+import { readErrors, readTaskErrors } from './errors';
 import { type AnalysisReport, AnalysisReportSchema, type SlackFixSummary } from './schemas';
 
 const DIVIDER = '──────────────────────────────────────';
@@ -41,6 +43,12 @@ function runLink(): string {
     return githubRunLink('GHA Run') ?? 'local run';
 }
 
+function errorLines(errors: string[], indent: string): string[] {
+    if (errors.length === 0) return [];
+
+    return [`${indent}⚠️ *Errors:*`, ...errors.map(err => `${indent}    • ${err}`)];
+}
+
 function readReport(reportPath: string): AnalysisReport | null {
     try {
         const parsed = AnalysisReportSchema.safeParse(
@@ -59,6 +67,8 @@ function buildMessage(
     report: AnalysisReport,
     summaries: SlackFixSummary[],
     analyzeCost: number | null,
+    analyzeErrors: string[],
+    taskErrors: Record<string, string[]>,
 ): string {
     const summaryById = new Map(summaries.map(s => [s.taskId, s]));
 
@@ -86,6 +96,7 @@ function buildMessage(
     const fixable = report.fixTasks.length;
     const skipped = report.skipped.length;
     lines.push(`*Analyzer* — ${fixable} fixable · ${skipped} skipped`);
+    lines.push(...errorLines(analyzeErrors, ''));
 
     // Fix agents summaries
     if (report.fixTasks.length > 0) {
@@ -101,6 +112,7 @@ function buildMessage(
                 lines.push(`❓ *${task.rootCause}*`);
                 lines.push(formatTestRef(task.validations));
                 lines.push(`    ${task.id} · job did not complete`);
+                lines.push(...errorLines(taskErrors[task.id] ?? [], '    '));
                 continue;
             }
 
@@ -121,9 +133,7 @@ function buildMessage(
                 lines.push(`    ${task.id} · ${prPart} · ${iterStr} · ${countStr} · ${costPart}`);
             }
 
-            if (summary.error) {
-                lines.push(`    ⚠️ publish failed: ${summary.error.split('\n')[0]}`);
-            }
+            lines.push(...errorLines(taskErrors[task.id] ?? [], '    '));
         }
     }
 
@@ -152,23 +162,35 @@ async function main(): Promise<void> {
         process.exit(1);
     }
 
+    const analyzeErrors = readErrors(join(dirname(reportPath), 'errors.txt'));
+    const taskErrors = readTaskErrors(process.env.FIX_ERRORS_DIR);
     const report = readReport(reportPath);
 
     if (!report) {
-        await postSlackMessage(
-            process.env.SLACK_FIX_AGENT_WEBHOOK,
-            `🤖 *Nightly Fix Agent*  ${runLink()}\n\n❓ Analysis agent did not complete correctly.`,
-        );
+        const failureLines = [
+            `🤖 *Nightly Fix Agent*  ${runLink()}`,
+            '',
+            '❓ Analysis agent did not complete correctly.',
+            ...errorLines(analyzeErrors, ''),
+        ];
+        await postSlackMessage(process.env.SLACK_FIX_AGENT_WEBHOOK, failureLines.join('\n'));
 
         return;
     }
 
-    const summaries = readSummaries(summariesDir);
+    const { summaries, problemsByTaskId } = readSummaries(summariesDir);
     const analyzeCost = readAnalysisCost(analyzeCostFile);
 
-    log(`[notify] ${report.fixTasks.length} fix tasks · ${summaries.length} summaries loaded`);
+    // notify is the reader of the error files, so its own problems go straight into the message
+    for (const [taskId, problem] of Object.entries(problemsByTaskId)) {
+        taskErrors[taskId] = [...(taskErrors[taskId] ?? []), problem];
+    }
 
-    const message = buildMessage(report, summaries, analyzeCost);
+    log(
+        `[notify] ${report.fixTasks.length} fix tasks · ${summaries.length} summaries · ${analyzeErrors.length} analyze errors · ${Object.keys(taskErrors).length} tasks with errors`,
+    );
+
+    const message = buildMessage(report, summaries, analyzeCost, analyzeErrors, taskErrors);
 
     await postSlackMessage(process.env.SLACK_FIX_AGENT_WEBHOOK, message);
 }

--- a/packages/e2e-utils/src/fixBot/publish.ts
+++ b/packages/e2e-utils/src/fixBot/publish.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import { error, log } from '../logger';
 import { getErrorText } from './common';
+import { reportToSlack } from './errors';
 import { type FixResult, FixResultSchema, type SlackFixSummary } from './schemas';
 
 const BASE_BRANCH = 'develop';
@@ -128,8 +129,10 @@ function runPublish(
         summary.prUrl = createPr(prArgs);
         assignToProject(summary.prUrl);
     } catch (err) {
-        summary.error = getErrorText(err);
-        error(`Publish failed: ${summary.error}`);
+        error(`Publish failed: ${getErrorText(err)}`);
+        reportToSlack(
+            'Pushing the branch or creating the PR failed, so no PR exists for this fix.',
+        );
         process.exitCode = 1;
     }
 }
@@ -150,6 +153,7 @@ function publishPR(): void {
     if (!existsSync(resultFile)) {
         error(`Result: ❌  fix-result.json missing — agent did not complete`);
         error(`         expected at: ${resultFile}`);
+        reportToSlack('The fix agent produced no result, so nothing was published.');
 
         return;
     }
@@ -159,7 +163,6 @@ function publishPR(): void {
         ...fixResult,
         prUrl: null,
         costUsd: readCostUsd(),
-        error: null,
     };
 
     log(`Raw result summary: \n\n${JSON.stringify(summary, null, 2)}`);

--- a/packages/e2e-utils/src/fixBot/schemas.ts
+++ b/packages/e2e-utils/src/fixBot/schemas.ts
@@ -56,7 +56,6 @@ export const FixResultSchema = z.object({
 export const SlackFixSummarySchema = FixResultSchema.extend({
     prUrl: z.string().nullable().default(null),
     costUsd: z.number().nullable().default(null),
-    error: z.string().nullable().default(null),
 });
 
 // ── Cross-run ledger ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Two changes to the nightly fix agent, both from reading the agent logs and
report artifacts of the recent runs.

**Analyzer stops repeating work.** The `playwright-trace` skill was installed
per workspace, so it never loaded for an agent running from the repo root —
every run fell back to hand-parsing trace archives. It now installs at the
root. The prompt also documents the saved run-details shape (the agent probed
it with jq at the start of every run) and the `currents-get-context` blind
spot, where quarantined tests are reported as passing with their errors
hidden. A confident ledger match — same error signature, same
platform/group/spec coverage — is now verified from that signature alone
instead of downloading and reading traces again.

**Harness problems reach Slack.** A degraded ledger, an unreadable fix
summary or a failed publish only ever landed in a CI log. `reportToSlack`
now takes one fixed sentence from the call site, which the notify job renders
under the analyzer line and under each fix task; the original error and its
stack stay in the log and never reach Slack. The messages travel in their own
file rather than in the fix summary, because a fix agent that dies before
writing a summary is exactly the case worth reporting. `SlackFixSummary.error`
is gone, replaced by that channel.

## Notes for QA

No product code is touched — this is CI tooling for the nightly fix agent, so
no Suite regression testing is needed.

Worth a look after the next scheduled nightly: the Slack notification should
render as before when nothing went wrong, and an `⚠️ Errors:` block should
appear only when something did. The analyze job now also has two extra setup
steps (trace skill, headless shell) that must not fail the job.

## Related Issue

Resolve <!--- link the issue here -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-bot-low-hanging-fruit/web/](https://dev.suite.sldev.cz/suite-web/fix-bot-low-hanging-fruit/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-bot-low-hanging-fruit&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-bot-low-hanging-fruit&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T08:28:13.370Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T08:27:51.731Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->