### PR TITLE
fix(suite-native): handle tokens without metadata

### DIFF
--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts
@@ -117,6 +117,14 @@ describe('CryptoAmountFormatter', () => {
             ).toBe('0.000003');
         });
 
+        it('renders the amount alone when the symbol is empty (token without metadata)', () => {
+            expect(
+                CryptoAmountFormatter.format('300', {
+                    symbol: '' as TokenSymbol,
+                }),
+            ).toBe('300');
+        });
+
         it.each([
             ['0.3', '0.3 BTC'],
             ['0.3000', '0.3 BTC'],

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -198,7 +198,9 @@ const appendSymbol = ({
               })
             : symbol;
 
-    return `${value} ${formattedSymbol}`;
+    const symbolSuffix = formattedSymbol ? ` ${formattedSymbol}` : '';
+
+    return `${value}${symbolSuffix}`;
 };
 
 export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>

--- a/suite-common/wallet-config/src/utils.test.ts
+++ b/suite-common/wallet-config/src/utils.test.ts
@@ -2,6 +2,7 @@ import { networks } from './networksConfig';
 import { asNetworkSymbol } from './types';
 import {
     filterNetworksByName,
+    getDisplaySymbol,
     getMainnets,
     getNetworksWithMevProtection,
     getNetworksWithNativeTokenReserve,
@@ -145,5 +146,23 @@ describe(getNetworksWithNativeTokenReserve.name, () => {
         expect(getNetworksWithNativeTokenReserve()).toEqual(
             'Base, Optimism, Robinhood Chain, Solana',
         );
+    });
+});
+
+describe(getDisplaySymbol.name, () => {
+    it('returns an empty string for an empty symbol', () => {
+        expect(getDisplaySymbol('')).toBe('');
+    });
+
+    it('returns the network display symbol for a native coin symbol', () => {
+        expect(getDisplaySymbol('eth')).toBe('ETH');
+    });
+
+    it('returns the token symbol unchanged when it also has a contract address', () => {
+        expect(getDisplaySymbol('USDC', '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')).toBe('USDC');
+    });
+
+    it('truncates symbols longer than the maximum length', () => {
+        expect(getDisplaySymbol('SUPERLONGTOKEN')).toBe('SUPERLONGT...');
     });
 });

--- a/suite-native/module-accounts-management/src/components/YourPositionCard.tsx
+++ b/suite-native/module-accounts-management/src/components/YourPositionCard.tsx
@@ -51,6 +51,9 @@ export const YourPositionCard = ({ account, token }: YourPositionCardProps) => {
     const tokenSymbol = token?.symbol ?? getDisplaySymbol(symbol);
     const tokenName = token?.name ?? getNetworkDisplaySymbolName(symbol);
     const balance = token?.balance ?? account?.formattedBalance ?? '0';
+    const tokenAmountSymbol = token?.symbol
+        ? (getDisplaySymbol(token.symbol) as TokenSymbol)
+        : null;
 
     return (
         <Card style={applyStyle(cardStyle)} noShadow>
@@ -111,7 +114,7 @@ export const YourPositionCard = ({ account, token }: YourPositionCardProps) => {
                         {token ? (
                             <CompactTokenAmountFormatter
                                 value={asDecimalTokenAmount(token.balance ?? '0')}
-                                tokenSymbol={getDisplaySymbol(token.symbol) as TokenSymbol}
+                                tokenSymbol={tokenAmountSymbol}
                                 tokenDecimals={token.decimals}
                                 numberOfLines={1}
                                 adjustsFontSizeToFit


### PR DESCRIPTION
## Description
Fixes a mobile crash when opening an account that contains an ERC-20 token without optional symbol metadata. The crash happened in the account position card because `token.symbol` was passed directly to `getDisplaySymbol`.

- Guard the native position-card token amount before calling `getDisplaySymbol`.
- Keep `getDisplaySymbol(coinSymbol: string, ...)` strict instead of widening the shared utility API to nullable input.
- Update the shared crypto amount formatter so it only inserts the symbol separator when a displayable symbol exists. Missing token symbols now render the amount alone, without a trailing space.
- Add focused tests for empty token symbols and existing `getDisplaySymbol` behavior.

## Related issues
Closes #31904.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is dominated by a shared crypto amount formatter and its unit tests, with a mobile component that has no web E2E coverage. The main regression risk is malformed crypto amount strings (value, symbol, decimals, truncation) appearing in staking, trading, send, and balance flows. A small representative set of tests across ADA, BTC, ETH, and SOL provides high confidence without running the full 139 mapped tests. The native component and unit-test-only changes have no E2E coverage and do not need Suite web E2E validation.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts`
- `suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts`
- `suite-common/wallet-config/src/utils.test.ts`
- `suite-native/module-accounts-management/src/components/YourPositionCard.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test asserts multiple precise Cardano amount strings (deposit, fee, reward, balance) that are rendered through the crypto amount formatter. A regression in prepareCryptoAmountFormatter would likely fail these exact ADA formatting assertions.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — The test verifies exact ETH send amount and fee formatting on both the app prompt and the device emulator, making it a direct consumer of the changed formatter for cross-chain swap amounts.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — It checks Bitcoin balance display, ellipsis truncation for long balances, and balance updates after receives—behaviors that depend directly on crypto amount formatting.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test validates the send amount, maximum fee, gas limit, max fee per gas, and max priority fee values shown in the device prompt, all of which rely on the crypto amount formatter.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — It exercises send-max balance, fee, reserve, and total-sent formatting for Solana, which shares the formatter infrastructure but is somewhat covered by the other high-priority tests.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts`
- `suite-common/wallet-config/src/utils.test.ts`
- `suite-native/module-accounts-management/src/components/YourPositionCard.tsx`

_Updated: 2026-09-04T14:55:22.995Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/fix-issue-31904/web/](https://dev.suite.sldev.cz/suite-web/juriczech/fix-issue-31904/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/fix-issue-31904&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/fix-issue-31904&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T14:58:20.435Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T14:57:57.603Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->