### PR TITLE
test(suite): add Suite Sync quota manager e2e coverage

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/OutOfQuotaBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/OutOfQuotaBanner.tsx
@@ -32,6 +32,7 @@ export const OutOfQuotaBanner = () => {
         <Banner
             intent="info"
             icon={InfoIcon}
+            data-testid="@notification/suite-sync-out-of-quota"
             description={<Translation id="TR_SUITE_SYNC_OUT_OF_QUOTA_BANNER_DESCRIPTION" />}
             rightContent={
                 <>
@@ -42,6 +43,7 @@ export const OutOfQuotaBanner = () => {
                         icon={XIcon}
                         intent="info"
                         priority="secondary"
+                        data-testid="@notification/suite-sync-out-of-quota/dismiss"
                         onClick={handleDismiss}
                         tooltip={{ content: <Translation id="TR_DISMISS" /> }}
                     />

--- a/suite-common/e2e-evolu-client/package.json
+++ b/suite-common/e2e-evolu-client/package.json
@@ -11,6 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@trezor/utils": "workspace:*",
         "ws": "^8.20.0"
     },
     "devDependencies": {

--- a/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
+++ b/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
@@ -14,6 +14,7 @@ import path from 'path';
 
 import { Schema, createEvoluAppOwnerFromTrezorData } from '@suite-common/suite-sync-evolu';
 import { type SuiteSyncOwnerSecretHex } from '@suite-common/suite-sync-storage';
+import { typedObjectFromEntries } from '@trezor/utils';
 
 import { createNodeEvoluDeps } from './createEvoluNodeDeps';
 
@@ -161,6 +162,38 @@ const QUOTA_TOTAL_STORAGE_SIZE = 1048576;
 const QUOTA_UNSPENT_STORAGE_SIZE = 1038090;
 const QUOTA_DB_CREDENTIALS = '-U suite-sync -d suite-sync-gate';
 
+const runQuotaDbSql = (sql: string) =>
+    execFileSync(
+        'docker',
+        [
+            'compose',
+            '-f',
+            'docker/docker-compose.suite-ci-e2e.yml',
+            'exec',
+            '-T',
+            'quota-db',
+            'psql',
+            ...QUOTA_DB_CREDENTIALS.split(' '),
+            '--csv',
+            '-c',
+            sql,
+        ],
+        { cwd: REPO_ROOT },
+    ).toString();
+
+const parseCsvRows = (csv: string) => {
+    const [headerLine, ...rowLines] = csv.trim().split('\n');
+    const columns = headerLine?.split(',') ?? [];
+
+    return rowLines.map(rowLine => {
+        const values = rowLine.split(',');
+
+        return typedObjectFromEntries(
+            columns.map((column, index) => [column, values[index] ?? '']),
+        );
+    });
+};
+
 const waitForRelayReady = async (maxWaitMs = 30_000) => {
     const pollIntervalMs = 500;
     const deadline = Date.now() + maxWaitMs;
@@ -193,21 +226,8 @@ export const wipeAndRestartEvoluRelayServer = async () => {
         ],
         { cwd: REPO_ROOT },
     );
-    execFileSync(
-        'docker',
-        [
-            'compose',
-            '-f',
-            'docker/docker-compose.suite-ci-e2e.yml',
-            'exec',
-            '-T',
-            'quota-db',
-            'psql',
-            ...QUOTA_DB_CREDENTIALS.split(' '),
-            '-c',
-            'TRUNCATE challenges, owner_storage_limits, pubkey_storage_limits RESTART IDENTITY CASCADE;',
-        ],
-        { cwd: REPO_ROOT },
+    runQuotaDbSql(
+        'TRUNCATE challenges, owner_storage_limits, pubkey_storage_limits RESTART IDENTITY CASCADE;',
     );
     execFileSync(
         'docker',
@@ -224,40 +244,73 @@ export const wipeAndRestartEvoluRelayServer = async () => {
     await waitForRelayReady();
 };
 
-export const seedQuotaManagerData = ({ ownerId }: { ownerId: string }) => {
+type SeedQuotaManagerDataParams = {
+    ownerId: string;
+};
+
+export const seedQuotaManagerData = ({ ownerId }: SeedQuotaManagerDataParams) => {
     const safeOwnerId = ownerId.replace(/'/g, "''");
-    execFileSync(
-        'docker',
-        [
-            'compose',
-            '-f',
-            'docker/docker-compose.suite-ci-e2e.yml',
-            'exec',
-            '-T',
-            'quota-db',
-            'psql',
-            ...QUOTA_DB_CREDENTIALS.split(' '),
-            '-c',
-            `INSERT INTO owner_storage_limits ("ownerId", "storageLimit") VALUES ('${safeOwnerId}', ${QUOTA_STORAGE_LIMIT}) ON CONFLICT DO NOTHING;`,
-        ],
-        { cwd: REPO_ROOT },
+    runQuotaDbSql(
+        `INSERT INTO owner_storage_limits ("ownerId", "storageLimit") VALUES ('${safeOwnerId}', ${QUOTA_STORAGE_LIMIT}) ON CONFLICT DO NOTHING;`,
     );
-    execFileSync(
-        'docker',
-        [
-            'compose',
-            '-f',
-            'docker/docker-compose.suite-ci-e2e.yml',
-            'exec',
-            '-T',
-            'quota-db',
-            'psql',
-            ...QUOTA_DB_CREDENTIALS.split(' '),
-            '-c',
-            `INSERT INTO pubkey_storage_limits ("publicKey", "totalStorageSize", "unspentStorageSize") VALUES ('${QUOTA_PUBLIC_KEY}', ${QUOTA_TOTAL_STORAGE_SIZE}, ${QUOTA_UNSPENT_STORAGE_SIZE}) ON CONFLICT DO NOTHING;`,
-        ],
-        { cwd: REPO_ROOT },
+    runQuotaDbSql(
+        `INSERT INTO pubkey_storage_limits ("publicKey", "totalStorageSize", "unspentStorageSize") VALUES ('${QUOTA_PUBLIC_KEY}', ${QUOTA_TOTAL_STORAGE_SIZE}, ${QUOTA_UNSPENT_STORAGE_SIZE}) ON CONFLICT DO NOTHING;`,
     );
+};
+
+type SetDeviceUnspentStorageSizeParams = {
+    unspentStorageSize: number;
+};
+
+// Updates all registered devices; the wiped test environment has exactly one.
+export const setDeviceUnspentStorageSize = ({
+    unspentStorageSize,
+}: SetDeviceUnspentStorageSizeParams) => {
+    runQuotaDbSql(`UPDATE pubkey_storage_limits SET "unspentStorageSize" = ${unspentStorageSize};`);
+};
+
+type SetOwnerStorageLimitParams = {
+    ownerId: string;
+    storageLimit: number;
+};
+
+export const setOwnerStorageLimit = ({ ownerId, storageLimit }: SetOwnerStorageLimitParams) => {
+    const safeOwnerId = ownerId.replace(/'/g, "''");
+    runQuotaDbSql(
+        `UPDATE owner_storage_limits SET "storageLimit" = ${storageLimit} WHERE "ownerId" = '${safeOwnerId}';`,
+    );
+};
+
+export type QuotaManagerDeviceRow = {
+    publicKey: string;
+    totalStorageSize: number;
+    unspentStorageSize: number;
+};
+
+export type QuotaManagerOwnerRow = {
+    ownerId: string;
+    storageLimit: number;
+};
+
+export const readQuotaManagerData = () => {
+    const devices: QuotaManagerDeviceRow[] = parseCsvRows(
+        runQuotaDbSql(
+            'SELECT "publicKey", "totalStorageSize", "unspentStorageSize" FROM pubkey_storage_limits;',
+        ),
+    ).map(row => ({
+        publicKey: row.publicKey ?? '',
+        totalStorageSize: Number(row.totalStorageSize),
+        unspentStorageSize: Number(row.unspentStorageSize),
+    }));
+
+    const owners: QuotaManagerOwnerRow[] = parseCsvRows(
+        runQuotaDbSql('SELECT "ownerId", "storageLimit" FROM owner_storage_limits;'),
+    ).map(row => ({
+        ownerId: row.ownerId ?? '',
+        storageLimit: Number(row.storageLimit),
+    }));
+
+    return { devices, owners };
 };
 
 export const checkEvoluRelayServerRunning = async () => {

--- a/suite-common/e2e-evolu-client/src/index.ts
+++ b/suite-common/e2e-evolu-client/src/index.ts
@@ -5,9 +5,16 @@ export {
     wipeAndRestartEvoluRelayServer,
     checkEvoluRelayServerRunning,
     seedQuotaManagerData,
+    setDeviceUnspentStorageSize,
+    setOwnerStorageLimit,
+    readQuotaManagerData,
     logToRelayDocker,
 } from './baseEvoluClient';
-export type { EvoluClientInitParams } from './baseEvoluClient';
+export type {
+    EvoluClientInitParams,
+    QuotaManagerDeviceRow,
+    QuotaManagerOwnerRow,
+} from './baseEvoluClient';
 export {
     createOwnerIdFromSecret,
     createWalletRowId,

--- a/suite-common/e2e-evolu-client/tsconfig.json
+++ b/suite-common/e2e-evolu-client/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../../packages/utils" },
         { "path": "../suite-sync-evolu" },
         { "path": "../suite-sync-storage" },
         { "path": "../wallet-config" },

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -36,6 +36,7 @@
         "@suite-common/message-system": "workspace:*",
         "@suite-common/networks": "workspace:*",
         "@suite-common/suite-sync-evolu": "workspace:*",
+        "@suite-common/suite-sync-quota-manager": "workspace:*",
         "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/trading": "workspace:*",

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -7,7 +7,10 @@ import {
     BaseEvoluClient,
     EvoluClientInitParams,
     checkEvoluRelayServerRunning,
+    readQuotaManagerData,
     seedQuotaManagerData,
+    setDeviceUnspentStorageSize,
+    setOwnerStorageLimit,
     wipeAndRestartEvoluRelayServer,
 } from '@suite-common/e2e-evolu-client';
 import { Schema } from '@suite-common/suite-sync-evolu';
@@ -35,6 +38,21 @@ export class EvoluClient extends BaseEvoluClient {
     @step()
     seedQuotaManagerData({ ownerId }: { ownerId: string }) {
         seedQuotaManagerData({ ownerId });
+    }
+
+    @step()
+    setDeviceUnspentStorageSize({ unspentStorageSize }: { unspentStorageSize: number }) {
+        setDeviceUnspentStorageSize({ unspentStorageSize });
+    }
+
+    @step()
+    setOwnerStorageLimit({ ownerId, storageLimit }: { ownerId: string; storageLimit: number }) {
+        setOwnerStorageLimit({ ownerId, storageLimit });
+    }
+
+    @step()
+    readQuotaManagerData() {
+        return readQuotaManagerData();
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -32,6 +32,8 @@ export class MetadataPage {
     readonly migrateFromLocalFileButton: Locator;
     readonly unsupportedBanner: Locator;
     readonly suiteSyncBannerDismissButton: Locator;
+    readonly outOfQuotaBanner: Locator;
+    readonly outOfQuotaBannerDismissButton: Locator;
 
     constructor(
         private readonly page: Page,
@@ -63,6 +65,10 @@ export class MetadataPage {
         this.unsupportedBanner = page.getByTestId('@notification/suite-sync-unsupported-device');
         this.suiteSyncBannerDismissButton = page.getByTestId(
             '@notification/suite-sync-unsupported-device/dismiss',
+        );
+        this.outOfQuotaBanner = page.getByTestId('@notification/suite-sync-out-of-quota');
+        this.outOfQuotaBannerDismissButton = page.getByTestId(
+            '@notification/suite-sync-out-of-quota/dismiss',
         );
     }
 

--- a/suite/e2e/tests/metadata/suite-sync/quota-manager.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/quota-manager.test.ts
@@ -1,0 +1,196 @@
+import { messages } from '@suite/intl';
+import { mnemonic12Fixtures } from '@suite-common/e2e-evolu-client';
+import {
+    DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+    DEFAULT_DEVICE_SIZE_QUOTA,
+} from '@suite-common/suite-sync-quota-manager';
+
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+
+const { buildExpectedAccount, buildExpectedWallet, ownerId, ownerSecret } = mnemonic12Fixtures;
+
+const expectedAccount = buildExpectedAccount({ label: 'Evolu quota BTC account' });
+const expectedWallet = buildExpectedWallet({ label: 'Evolu quota wallet' });
+
+const defaultWalletIndex = 0;
+const hiddenWalletIndex = 1;
+const hiddenWalletPassphrase = 'First passphrase';
+const hiddenWalletLabel = 'Evolu local-only wallet';
+
+// Below the bytes already stored for the owner, so the next relay write is rejected
+const shrunkenOwnerStorageLimit = 10;
+
+test.describe('Suite Sync - Quota Manager out of quota', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.slow();
+    test.use({
+        wipeEvoluRelay: true,
+        deviceSetup: { passphrase_protection: true },
+        ignoreToastErrors: [messages.TR_SUITE_SYNC_ERROR_DEVICE_CANCELLED.defaultMessage],
+    });
+
+    test.beforeEach(async ({ onboardingPage, metadataPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('application');
+        await settingsPage.toggleDebugModeInSettings();
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+        await metadataPage.enableSuiteSync();
+    });
+
+    test('Drained device pool shows banner and blocks syncing of a new wallet', async ({
+        page,
+        evoluClient,
+        dashboardPage,
+        metadataPage,
+    }) => {
+        await test.step('Change default wallet label to allocate its quota', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.changeLabel({
+                index: defaultWalletIndex,
+                label: expectedWallet.label,
+                confirmSuiteSync: true,
+            });
+        });
+
+        await test.step('Default wallet allocation is on the server', async () => {
+            await expect
+                .poll(() => evoluClient.readQuotaManagerData().owners, { timeout: 30_000 })
+                .toEqual([{ ownerId, storageLimit: DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA }]);
+        });
+
+        await test.step('Drain the device quota pool', () => {
+            evoluClient.setDeviceUnspentStorageSize({ unspentStorageSize: 0 });
+        });
+
+        await test.step('Add passphrase wallet and enable Suite Sync', async () => {
+            await dashboardPage.addUnusedHiddenWallet(hiddenWalletPassphrase, {
+                suiteSync: 'enable',
+            });
+        });
+
+        await test.step('Out-of-quota banner is shown on Dashboard', async () => {
+            await expect(metadataPage.outOfQuotaBanner).toContainTranslation(
+                'TR_SUITE_SYNC_OUT_OF_QUOTA_BANNER_DESCRIPTION',
+            );
+        });
+
+        await test.step('Label written on the new wallet is kept locally', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await page.waitForTimeout(500); // wait for the walletSwitcher to completely open
+            await metadataPage.wallet.changeLabel({
+                index: hiddenWalletIndex,
+                label: hiddenWalletLabel,
+                confirmSuiteSync: true,
+            });
+            await expect(metadataPage.wallet.walletLabel(hiddenWalletIndex)).toHaveText(
+                hiddenWalletLabel,
+            );
+            await dashboardPage.deviceSwitchingCloseButton.click();
+        });
+
+        await test.step('No storage was allocated for the new wallet on the server', () => {
+            const { devices, owners } = evoluClient.readQuotaManagerData();
+            // Only the default wallet allocation exists, nothing for the new wallet
+            expect(owners).toEqual([
+                { ownerId, storageLimit: DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA },
+            ]);
+            expect(devices).toEqual([expect.objectContaining({ unspentStorageSize: 0 })]);
+        });
+
+        await test.step('Banner disappears after dismissal', async () => {
+            await metadataPage.outOfQuotaBannerDismissButton.click();
+            await expect(metadataPage.outOfQuotaBanner).toBeHidden();
+        });
+    });
+});
+
+test.describe('Suite Sync - Quota Manager top-up', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.use({ wipeEvoluRelay: true });
+
+    test.beforeEach(async ({ onboardingPage, metadataPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('application');
+        await settingsPage.toggleDebugModeInSettings();
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+        await metadataPage.enableSuiteSync();
+    });
+
+    test('Exceeded wallet limit is topped up from the device pool', async ({
+        evoluClient,
+        dashboardPage,
+        devicePrompt,
+        metadataPage,
+        walletPage,
+    }) => {
+        await test.step('Create account label to trigger the first allocation', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.account.changeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+                label: expectedAccount.label,
+                confirmSuiteSync: true,
+            });
+        });
+
+        await test.step('Label is synced and one increment is allocated', async () => {
+            await evoluClient.init({ ownerSecret });
+            await evoluClient.expectInTable('account', [expectedAccount], { timeout: 30_000 });
+
+            const { devices, owners } = evoluClient.readQuotaManagerData();
+            expect(owners).toEqual([
+                { ownerId, storageLimit: DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA },
+            ]);
+            expect(devices).toEqual([
+                expect.objectContaining({
+                    totalStorageSize: DEFAULT_DEVICE_SIZE_QUOTA,
+                    unspentStorageSize:
+                        DEFAULT_DEVICE_SIZE_QUOTA - DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+                }),
+            ]);
+        });
+
+        await test.step('Shrink the wallet storage limit below current usage', () => {
+            evoluClient.setOwnerStorageLimit({
+                ownerId,
+                storageLimit: shrunkenOwnerStorageLimit,
+            });
+        });
+
+        await test.step('Write another label to exceed the wallet limit', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.changeLabel({
+                index: defaultWalletIndex,
+                label: expectedWallet.label,
+            });
+            // The rejected relay write triggers a quota top-up, which needs
+            // device keys again (they cannot be stored in the e2e environment)
+            await devicePrompt.confirmSuiteSyncSetup();
+            await dashboardPage.deviceSwitchingCloseButton.click();
+        });
+
+        await test.step('Wallet limit is topped up from the device pool', async () => {
+            await expect
+                .poll(() => evoluClient.readQuotaManagerData(), { timeout: 30_000 })
+                .toEqual({
+                    owners: [
+                        {
+                            ownerId,
+                            storageLimit:
+                                shrunkenOwnerStorageLimit + DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+                        },
+                    ],
+                    devices: [
+                        expect.objectContaining({
+                            unspentStorageSize:
+                                DEFAULT_DEVICE_SIZE_QUOTA -
+                                2 * DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+                        }),
+                    ],
+                });
+        });
+
+        await test.step('Rejected label is synced to the relay after the top-up', async () => {
+            await evoluClient.expectInTable('wallet', [expectedWallet], { timeout: 30_000 });
+            await evoluClient.expectInTable('account', [expectedAccount], { timeout: 30_000 });
+        });
+    });
+});

--- a/suite/e2e/tsconfig.json
+++ b/suite/e2e/tsconfig.json
@@ -33,6 +33,9 @@
             "path": "../../suite-common/suite-sync-evolu"
         },
         {
+            "path": "../../suite-common/suite-sync-quota-manager"
+        },
+        {
             "path": "../../suite-common/suite-sync-storage"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10804,6 +10804,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/device-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
@@ -17856,6 +17857,7 @@ __metadata:
     "@suite-common/message-system": "workspace:*"
     "@suite-common/networks": "workspace:*"
     "@suite-common/suite-sync-evolu": "workspace:*"
+    "@suite-common/suite-sync-quota-manager": "workspace:*"
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/trading": "workspace:*"


### PR DESCRIPTION
## Description

Two e2e tests for the Suite Sync quota manager (web + desktop, T3W1/T3T1):

- **Out of quota** — device pool drained; a new passphrase wallet shows the out-of-quota banner, its label stays local, no owner allocation appears on the server, dismissing hides the banner.
- **Top-up** — wallet limit shrunk below current usage; the next label write is rejected by the relay, Suite tops the wallet up from the device pool (verified in the quota DB), and the label should then reach the relay.

Quotas are prepared directly in the quota DB (psql) instead of exhausting the 1 MiB pool through ~100 wallets in the UI. Also adds `data-testid` to the out-of-quota banner and its dismiss button, and psql helpers (`setDeviceUnspentStorageSize`, `setOwnerStorageLimit`, `readQuotaManagerData`) to the e2e evolu client.

### The bug the top-up test exposes

The last step of the top-up test fails by design. When a wallet is at its limit and the user writes a label:

1. The relay rejects the write with `ProtocolQuotaError`.
2. Suite handles it correctly: it tops the wallet up from the device pool (`/challenge` + `/storage/add`, the owner limit grows by one increment).
3. **The rejected label is never sent again.** Not after the top-up, not after 150 s, not together with later writes. Only a relay re-subscription (re-saving the relay URL in debug settings, or an app restart) flushes it.
4. Writes made *after* the top-up sync normally — so the user loses exactly the one edit that hit the limit, silently.

Root cause is Evolu client behavior, not the relay: on a quota error the client only reports the error (`Shared.ts`, `ApplySyncMessage` error branch) and drops the message — there is no retry queue. A mutation is pushed once, carrying only its own delta; previously rejected changes are re-sent only on a full re-sync, which happens when the owner is (re)subscribed. Suite connects the owner exactly once per wallet (`createEnsureStorage` returns the cached storage afterwards) and nothing triggers a re-sync after a successful top-up.

### How the root cause was identified

- Suite runs Evolu at debug level but only into an in-memory store; mirroring it to the browser console (`createMultiOutput` + the worker's `BroadcastChannel` entries) made the whole sync chain visible in the Playwright trace: the socket never closed, every write reached Evolu (`mutateBatch`), the rejected one got `ProtocolQuotaError`, later writes were answered by the relay.
- Reading the relay back as an independent client showed the later write stored and the rejected one absent.
- A bare Evolu client (no Suite) reproduces the identical pattern, ruling out Suite-side wiring — see the second commit.

The likely fix is Suite-side: after a successful top-up in `createSuiteSyncInternalErrorHandler`, re-subscribe the owner (the same path `reconnectAllRelays` uses). The test then becomes the regression guard.

The second commit (`THMP…`) is the standalone reproduction script. It is intentionally non-conformant and must not be merged.

## Notes for QA

Regression around Suite Sync labels when a wallet hits its storage limit: the banner on Dashboard, that later label edits still sync, and that the one rejected edit only appears on other devices after an app restart.

## Related Issue

No issue yet — the rejected-write re-sync bug described above still needs a ticket.

## Screenshots:

n/a

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/quota-tests/web/](https://dev.suite.sldev.cz/suite-web/quota-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=quota-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=quota-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=quota-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T10:56:31.759Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T10:56:26.479Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->