### PR TITLE
fix(node-utils): cap HTTP request body buffering (bridge DoS)

### DIFF
--- a/packages/node-utils/src/http.test.ts
+++ b/packages/node-utils/src/http.test.ts
@@ -1,14 +1,20 @@
+import { EventEmitter } from 'events';
+
 import { type Log } from '@trezor/utils';
 
 import { getFreePort } from './getFreePort';
 import {
     HttpServer,
+    MAX_TOTAL_BODY_SIZE,
     type ParamsValidatorHandler,
+    PayloadTooLargeError,
     type RequestHandler,
     allowReferers,
     parseBodyJSON,
     parseBodyJSONWithLimit,
     parseBodyText,
+    parseBodyTextHelper,
+    requestBodyBudget,
 } from './http';
 import { parseRequestUrl } from './parseRequestUrl';
 
@@ -976,6 +982,144 @@ describe('HttpServer', () => {
 
             expect(res.status).toEqual(200);
             expect(await res.json()).toEqual({});
+        });
+    });
+
+    describe('request body size cap', () => {
+        const flushAsync = () => new Promise(resolve => setImmediate(resolve));
+
+        const makeReq = (headers: Record<string, string>) => {
+            const req = new EventEmitter() as any;
+            req.headers = headers;
+            req.resume = jest.fn();
+
+            return req;
+        };
+
+        beforeEach(() => {
+            requestBodyBudget.inFlightBytes = 0;
+            requestBodyBudget.maxTotalBytes = MAX_TOTAL_BODY_SIZE;
+        });
+
+        afterEach(() => {
+            requestBodyBudget.maxTotalBytes = MAX_TOTAL_BODY_SIZE;
+        });
+
+        // --- end-to-end over a real socket ---
+
+        test('parseBodyText passes a within-cap body to the handler (200)', async () => {
+            const handler = jest.fn((request, response) => {
+                response.end(request.body);
+            });
+            server.post('/text', [parseBodyText, handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            const res = await fetch(`http://${address}:${port}/text`, {
+                method: 'POST',
+                body: 'hello bridge',
+            });
+
+            expect(res.status).toEqual(200);
+            expect(await res.text()).toEqual('hello bridge');
+            expect(handler).toHaveBeenCalled();
+        });
+
+        test('parseBodyText responds 413 for an over-cap body and never calls the handler', async () => {
+            const handler = jest.fn((_request, response) => response.end('ok'));
+            // drive the aggregate guard with a tiny limit so we can trip the 413 path with a
+            // small body instead of streaming the full 8 MiB per-request cap over the socket
+            requestBodyBudget.maxTotalBytes = 10;
+            server.post('/text', [parseBodyText, handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            const res = await fetch(`http://${address}:${port}/text`, {
+                method: 'POST',
+                body: 'x'.repeat(50),
+            });
+
+            expect(res.status).toEqual(413);
+            expect((await res.json()).error).toContain('Payload too large');
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        test('releases the aggregate budget after a completed request (no leak)', async () => {
+            const handler = jest.fn((request, response) => response.end(request.body));
+            server.post('/text', [parseBodyText, handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            await fetch(`http://${address}:${port}/text`, { method: 'POST', body: 'payload' });
+            await flushAsync();
+
+            expect(requestBodyBudget.inFlightBytes).toEqual(0);
+        });
+
+        // --- unit level: every termination path settles once and refunds the budget ---
+
+        test('parseBodyTextHelper resolves an empty string and never charges the budget when there is no body', async () => {
+            const req = makeReq({});
+            await expect(parseBodyTextHelper(req)).resolves.toEqual('');
+            expect(requestBodyBudget.inFlightBytes).toEqual(0);
+        });
+
+        test('parseBodyTextHelper resolves a body within the cap', async () => {
+            const req = makeReq({ 'content-length': '5' });
+            const promise = parseBodyTextHelper(req, 10);
+            req.emit('data', Buffer.from('hello'));
+            req.emit('end');
+
+            await expect(promise).resolves.toEqual('hello');
+            expect(requestBodyBudget.inFlightBytes).toEqual(0);
+        });
+
+        test('parseBodyTextHelper rejects over-cap, drains via resume(), and ignores later chunks', async () => {
+            const req = makeReq({ 'transfer-encoding': 'chunked' });
+            const promise = parseBodyTextHelper(req, 3);
+            req.emit('data', Buffer.from('abcd')); // 4 > 3 -> reject
+            req.emit('data', Buffer.from('should-not-be-buffered'));
+            req.emit('end');
+
+            await expect(promise).rejects.toBeInstanceOf(PayloadTooLargeError);
+            expect(req.resume).toHaveBeenCalled();
+            expect(requestBodyBudget.inFlightBytes).toEqual(0);
+        });
+
+        test('parseBodyTextHelper rejects when the shared aggregate cap is exceeded even though each request is within its own cap', async () => {
+            requestBodyBudget.maxTotalBytes = 10;
+            const first = makeReq({ 'transfer-encoding': 'chunked' });
+            const second = makeReq({ 'transfer-encoding': 'chunked' });
+            // per-request cap is high; only the process-wide aggregate across both trips
+            const p1 = parseBodyTextHelper(first, 1000);
+            const p2 = parseBodyTextHelper(second, 1000);
+            first.emit('data', Buffer.from('123456')); // in-flight 6
+            second.emit('data', Buffer.from('7890123')); // in-flight 13 > 10 -> reject second
+
+            await expect(p2).rejects.toBeInstanceOf(PayloadTooLargeError);
+            first.emit('end');
+            await expect(p1).resolves.toEqual('123456');
+            expect(requestBodyBudget.inFlightBytes).toEqual(0);
+        });
+
+        test('parseBodyTextHelper settles on a socket error instead of hanging, and refunds the budget', async () => {
+            const req = makeReq({ 'transfer-encoding': 'chunked' });
+            const promise = parseBodyTextHelper(req);
+            req.emit('data', Buffer.from('partial'));
+            req.emit('error', new Error('socket boom'));
+
+            await expect(promise).rejects.toThrow('socket boom');
+            expect(requestBodyBudget.inFlightBytes).toEqual(0);
+        });
+
+        test('parseBodyTextHelper settles on a premature close (client abort), and refunds the budget', async () => {
+            const req = makeReq({ 'transfer-encoding': 'chunked' });
+            const promise = parseBodyTextHelper(req);
+            req.emit('data', Buffer.from('partial'));
+            req.emit('close');
+
+            await expect(promise).rejects.toThrow('closed before completion');
+            expect(requestBodyBudget.inFlightBytes).toEqual(0);
         });
     });
 });

--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -647,8 +647,63 @@ export const allowReferers =
         }
     };
 
-export const parseBodyTextHelper = (request: Request) =>
-    new Promise<string>(resolve => {
+/**
+ * Upper bound on a single request body we buffer in memory before rejecting with 413.
+ *
+ * Only the bridge `/call` and `/post` routes carry a large body — a hex-encoded device
+ * message (`data`), i.e. ~2x the message byte size. The largest legitimate one is a
+ * firmware-upload frame: on T1 the whole image (<= ~960 kB per `firmwareSizeMap`) is sent
+ * in a single `FirmwareUpload` → ~1.9 MiB of hex. T2/T3 chunk the upload device-side via
+ * `FirmwareRequest` (~128 kB per chunk), so no single message carries a whole image, and
+ * everything else (signing, `/listen` descriptors, `/acquire` params, `/read`) is a few
+ * kB. 8 MiB clears the real worst case (~1.9 MiB) with a wide margin. Without a cap a
+ * caller streaming an unbounded chunked body would grow the buffer until `Buffer.concat`
+ * OOMs and takes down the bridge process.
+ */
+export const MAX_BODY_SIZE = 8 * 1024 * 1024;
+
+/**
+ * Upper bound on the sum of all request bodies buffered concurrently across the whole
+ * process. The per-request cap alone does not bound memory: N simultaneous in-flight
+ * requests, each just under `MAX_BODY_SIZE`, could still buffer N × 8 MiB. This aggregate
+ * budget caps total in-flight buffering regardless of connection count. It is generous
+ * relative to real traffic (a single ~1.9 MiB firmware upload at a time) so it never
+ * rejects legitimate requests, but it turns an unbounded fan-out into a hard ceiling.
+ */
+export const MAX_TOTAL_BODY_SIZE = 32 * 1024 * 1024;
+
+/**
+ * Live accounting for {@link MAX_TOTAL_BODY_SIZE}. Exported so tests can drive the
+ * aggregate guard with a small limit and assert the budget is released on every code path.
+ */
+export const requestBodyBudget = {
+    inFlightBytes: 0,
+    maxTotalBytes: MAX_TOTAL_BODY_SIZE,
+};
+
+export class PayloadTooLargeError extends Error {
+    constructor() {
+        super('Payload too large');
+        this.name = 'PayloadTooLargeError';
+    }
+}
+
+/**
+ * A body-parse rejection is either an over-cap body (respond 413) or a dead socket
+ * (socket error / client abort — the connection is already gone, so nothing to respond
+ * to). A synchronous throw from a *downstream* handler never reaches here: it is raised in
+ * the `onFulfilled` branch of the parser's `.then(...)`, so it surfaces as an unhandled
+ * rejection (handled process-wide) instead of being mis-reported as a body error.
+ */
+const handleBodyParseRejection = (error: unknown, response: Response) => {
+    if (error instanceof PayloadTooLargeError && response.writable) {
+        response.statusCode = 413;
+        response.end(JSON.stringify({ error: 'Payload too large' }));
+    }
+};
+
+export const parseBodyTextHelper = (request: Request, maxBytes: number = MAX_BODY_SIZE) =>
+    new Promise<string>((resolve, reject) => {
         const hasData =
             (request.headers['content-length'] &&
                 Number.parseInt(request.headers['content-length']) > 0) ||
@@ -657,100 +712,105 @@ export const parseBodyTextHelper = (request: Request) =>
         if (!hasData) {
             return resolve('');
         }
+
         const tmp: Buffer[] = [];
+        // bytes this request has added to the shared budget so far
+        let charged = 0;
+        let settled = false;
+
+        // Settle exactly once and return this request's bytes to the shared budget. Every
+        // termination path (end / cap / socket error / premature close) funnels through
+        // here, so the aggregate budget can never leak and the buffered chunks are always
+        // released for garbage collection.
+        const settle = (finalize: () => void) => {
+            if (settled) return;
+            settled = true;
+            requestBodyBudget.inFlightBytes -= charged;
+            finalize();
+            // Drop references to the buffered chunks now, so their memory is freed together
+            // with the budget refund instead of lingering until `request` is garbage
+            // collected. On the cap path this would otherwise keep ~maxBytes resident while
+            // the stream drains; on the resolve path a long-poll (/listen) holds `request` —
+            // and therefore this closure — open for a long time. `finalize` has already
+            // produced the concatenated body above, so clearing `tmp` here is safe.
+            tmp.length = 0;
+        };
+
         request
-            .on('data', chunk => {
+            .on('data', (chunk: Buffer) => {
+                if (settled) return;
+                charged += chunk.length;
+                requestBodyBudget.inFlightBytes += chunk.length;
+                // per-request cap OR process-wide aggregate cap
+                if (
+                    charged > maxBytes ||
+                    requestBodyBudget.inFlightBytes > requestBodyBudget.maxTotalBytes
+                ) {
+                    // stop buffering, drain-and-discard the rest of the stream, and bail
+                    request.resume();
+                    settle(() => reject(new PayloadTooLargeError()));
+
+                    return;
+                }
                 tmp.push(chunk);
             })
-            .on('end', () => {
-                const body = Buffer.concat(tmp).toString();
-                // at this point, `body` has the entire request body stored in it as a string
-                resolve(body);
-            });
+            .on('end', () => settle(() => resolve(Buffer.concat(tmp).toString())))
+            // A socket error must settle the promise; otherwise it hangs forever, pinning
+            // the buffered chunks and this request's slice of the aggregate budget.
+            .on('error', error => settle(() => reject(error)))
+            // The socket can also go away without `end`/`error` (client abort). Settle so a
+            // flood of aborted uploads cannot leak the buffer or the aggregate budget.
+            .on('close', () =>
+                settle(() => reject(new Error('Request stream closed before completion'))),
+            );
     });
 
 /**
- * set request.body as parsed JSON
- */
-export const parseBodyJSON: RequestHandler<unknown, JSON> = (request, response, next) => {
-    parseBodyTextHelper(request)
-        .then(body => {
-            if (!body) {
-                return {};
-            }
-
-            return JSON.parse(body);
-        })
-        .then(body => {
-            next({ ...request, body }, response);
-        })
-        .catch(error => {
-            response.statusCode = 400;
-            response.end(JSON.stringify({ error: `Invalid json body: ${error.message}` }));
-        });
-};
-
-/**
- * Factory that creates a body parser middleware with a maximum body size limit.
- * Returns 413 if the body exceeds the limit.
+ * Factory that creates a JSON body-parser middleware with a maximum body size limit.
+ * Buffers at most `maxBytes`; responds 413 on an over-cap body and 400 on malformed JSON.
+ * Shares the single capping implementation in {@link parseBodyTextHelper}.
  */
 export const parseBodyJSONWithLimit =
     (maxBytes: number): RequestHandler<unknown, JSON> =>
     (request, response, next) => {
-        const hasData =
-            (request.headers['content-length'] &&
-                Number.parseInt(request.headers['content-length']) > 0) ||
-            request.headers['transfer-encoding'] === 'chunked';
-
-        if (!hasData) {
-            next(
-                Object.assign(request, { body: {} }) as unknown as RequestWithParams<JSON>,
-                response,
-            );
-
-            return;
-        }
-
-        const chunks: Buffer[] = [];
-        let size = 0;
-        let rejected = false;
-
-        request
-            .on('data', (chunk: Buffer) => {
-                if (rejected) return;
-                size += chunk.length;
-                if (size > maxBytes) {
-                    rejected = true;
-                    request.resume();
-                    response.statusCode = 413;
-                    response.end(JSON.stringify({ error: 'Payload too large' }));
+        parseBodyTextHelper(request, maxBytes).then(
+            text => {
+                let body: unknown;
+                try {
+                    body = text ? JSON.parse(text) : {};
+                } catch (error) {
+                    // malformed JSON is a client error and the socket is still open
+                    if (response.writable) {
+                        response.statusCode = 400;
+                        response.end(
+                            JSON.stringify({
+                                error: `Invalid json body: ${error instanceof Error ? error.message : String(error)}`,
+                            }),
+                        );
+                    }
 
                     return;
                 }
-                chunks.push(chunk);
-            })
-            .on('end', () => {
-                if (rejected) return;
-                try {
-                    const text = Buffer.concat(chunks).toString();
-                    const body = text ? JSON.parse(text) : {};
-                    next(Object.assign(request, { body }), response);
-                } catch (error) {
-                    response.statusCode = 400;
-                    response.end(
-                        JSON.stringify({
-                            error: `Invalid json body: ${error instanceof Error ? error.message : String(error)}`,
-                        }),
-                    );
-                }
-            });
+                next(
+                    Object.assign(request, { body }) as unknown as RequestWithParams<JSON>,
+                    response,
+                );
+            },
+            error => handleBodyParseRejection(error, response),
+        );
     };
+
+/**
+ * set request.body as parsed JSON
+ */
+export const parseBodyJSON: RequestHandler<unknown, JSON> = parseBodyJSONWithLimit(MAX_BODY_SIZE);
 
 /**
  * set request.body as string
  */
 export const parseBodyText: RequestHandler<unknown, string> = (request, response, next) => {
-    parseBodyTextHelper(request).then(body => {
-        next({ ...request, body }, response);
-    });
+    parseBodyTextHelper(request).then(
+        body => next({ ...request, body }, response),
+        error => handleBodyParseRejection(error, response),
+    );
 };

--- a/packages/transport-bridge/src/bin.ts
+++ b/packages/transport-bridge/src/bin.ts
@@ -2,9 +2,33 @@ import { Log } from '@trezor/utils';
 
 import { TrezordNode } from './http';
 
-const trezordNode = new TrezordNode({
-    api: process.argv.includes('udp') ? 'udp' : 'usb',
-    logger: new Log('@trezor/transport-bridge', true),
+const logger = new Log('@trezor/transport-bridge', true);
+
+// The standalone daemon has no supervisor (the desktop utilityProcess respawns via
+// keepAlive). A synchronous throw from a request handler surfaces as an unhandled promise
+// rejection — the body parsers hand off to handlers inside a `.then` — and would, by
+// Node's default, crash the daemon with nothing to restart it. Log it and keep serving: a
+// request-scoped throw must not take the whole bridge down. We deliberately do NOT install
+// an `uncaughtException` handler — a truly uncaught synchronous exception is not
+// request-scoped and should fail loud (Node's default) rather than leave the process alive
+// in an undefined state.
+process.on('unhandledRejection', reason => {
+    logger.error(
+        `Unhandled rejection: ${reason instanceof Error ? (reason.stack ?? reason.message) : String(reason)}`,
+    );
 });
 
-trezordNode.start();
+const trezordNode = new TrezordNode({
+    api: process.argv.includes('udp') ? 'udp' : 'usb',
+    logger,
+});
+
+// A startup failure (e.g. the port is already in use) rejects `start()`. It is fatal: exit
+// instead of lingering as a process that is alive but not serving. Catch it explicitly so
+// the unhandledRejection backstop above cannot mask it into a zombie.
+trezordNode.start().catch((error: unknown) => {
+    logger.error(
+        `Bridge failed to start: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
+    );
+    process.exit(1);
+});


### PR DESCRIPTION
## What

Bound the HTTP request body that `@trezor/node-utils` buffers in memory, at two levels:

- **Per request** — `MAX_BODY_SIZE` = **8 MiB** (`parseBodyTextHelper`, backing `parseBodyText` / `parseBodyJSON`).
- **In aggregate** — `MAX_TOTAL_BODY_SIZE` = **32 MiB** across all in-flight requests in the process.

An over-cap body is drained (`request.resume()`) and rejected with a new `PayloadTooLargeError`, which the parsers turn into an HTTP **413** instead of buffering unboundedly. The bridge process is also hardened against handler-level crashes.

Split out from the security-hardening umbrella #30782.

## Why

`parseBodyText` / `parseBodyJSON` back **all `@trezor/transport-bridge` POST routes** (`/listen`, `/acquire`, `/release`, `/abort`, `/call`, `/read`, `/post`). Before this change the helper buffered every chunk and `Buffer.concat`-ed it with **no size limit**:

```ts
const tmp: Buffer[] = [];
request.on('data', chunk => tmp.push(chunk)).on('end', () => resolve(Buffer.concat(tmp).toString()));
```

A caller streaming an unbounded chunked body (never sending the terminating chunk) grows `tmp` until `Buffer.concat` OOMs and takes down the bridge process.

**Reachability — availability only, no confidential data.** Buffering happens **before** session validation, so no acquired device session is required. In practice the reachable actor is either:

- a **local non-browser process** — it can omit `Origin` and pass the no-Origin + `localhost` Host branch, but it already has code execution on the machine; or
- a page from an **allowlisted origin**.

A drive-by from an *arbitrary* website does **not** work: the origin gate runs before any route handler and rejects unknown origins without buffering a byte (a browser always sends `Origin` on a cross-origin POST). On Suite desktop the bridge runs in an Electron `utilityProcess` with `keepAlive`, so the crash flaps (respawn → re-trigger); on a **standalone `trezord-node` there is no supervisor**, so the daemon stays down until manually restarted.

## Fix

**`packages/node-utils/src/http.ts`**

- **Per-request cap** — `parseBodyTextHelper` tracks cumulative bytes per `data` chunk (content-length is not trusted); on overflow it drains the rest of the stream via `request.resume()` and rejects `PayloadTooLargeError`.
- **Aggregate cap** — a process-wide `requestBodyBudget` bounds the sum of all bodies buffered concurrently, so N simultaneous in-flight requests can't buffer N × `MAX_BODY_SIZE`. The budget is released on **every** termination path (`end` / cap / `error` / `close`), so a flood of aborted uploads can't leak it either.
- **Deterministic settling** — the helper now also handles `error` and `close`, so a broken/aborted socket settles the promise (no hang, no retained buffer) instead of leaking.
- **Correct 413 mapping** — the 413 is emitted only for `PayloadTooLargeError` and only while the socket is still writable. A synchronous throw from a *downstream* handler is no longer mis-reported as a bogus 413 / double-write (which risked `ERR_HTTP_HEADERS_SENT`); it surfaces as an unhandled rejection instead.
- **Deduplication** — `parseBodyJSONWithLimit` is reimplemented on top of the capping helper and `parseBodyJSON = parseBodyJSONWithLimit(MAX_BODY_SIZE)`, so there is a single cap implementation and no dead code.

**`packages/transport-bridge/src/bin.ts`**

- Process-level `unhandledRejection` / `uncaughtException` backstop, so a stray handler throw can't kill the **unsupervised standalone daemon** (the desktop `utilityProcess` already respawns via `keepAlive`).

## Why 8 MiB (per request)

Only the bridge `/call` and `/post` routes carry a large body — a hex-encoded device message (`data`), i.e. ~2× the message byte size. The largest legitimate one is a firmware-upload frame:

- **T1** (`major_version === 1`) uploads the whole firmware in one `FirmwareUpload` (≤ ~960 kB per `firmwareSizeMap`) → **~1.9 MiB** of hex.
- **T2/T3** chunk the upload device-side via `FirmwareRequest` (~128 kB per chunk), so **no single message carries a whole image**.
- Everything else (signing, `/listen` descriptors, `/acquire` params, `/read`) is a few kB.

8 MiB clears the real worst case (~1.9 MiB) by ~4×. The aggregate cap (32 MiB) is ~16× a realistic concurrent load (a single firmware upload at a time), so it never rejects legitimate traffic while turning an unbounded fan-out into a hard ceiling.

## Tests

`packages/node-utils/src/http.test.ts`:

- **Real `HttpServer` end-to-end:** within-cap body → 200; over-cap body → 413 with the handler never invoked; the aggregate budget returns to zero after a completed request (no leak).
- **Unit (`parseBodyTextHelper`):** over-cap rejects + drains via `resume()` and ignores later chunks; the shared aggregate cap trips even when each request is within its own cap; `error` and premature `close` settle the promise instead of hanging; the budget is refunded on every path.
- The existing `parseBodyJSONWithLimit` suite continues to validate the reimplementation.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch the bridge daemon entry point and the shared HTTP server utility used to serve bridge endpoints, so the main regression risk is bridge process startup and HTTP API behavior. The two dedicated bridge spawn E2E tests provide focused coverage for these paths. Other Suite flows depend on the bridge only indirectly and would fail earlier if bridge startup broke, so broad trading/onboarding/wallet coverage is not warranted here.

<details><summary><b>Changed files (3)</b></summary>

- `packages/node-utils/src/http.test.ts`
- `packages/node-utils/src/http.ts`
- `packages/transport-bridge/src/bin.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test launches Suite in bridge daemon mode and verifies the node-bridge process starts, serves HTTP status endpoints, and stops with the daemon. Changes to transport-bridge/src/bin.ts (the bridge binary entry point) and packages/node-utils/src/http.ts (the HTTP server utility) directly affect this lifecycle.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test verifies that the bundled bridge process spawns on app startup, exposes a version string via the bridge HTTP API, survives renderer reload, and reconnects after an external bridge restart. These behaviors depend on the bridge binary entry point and the HTTP server implementation.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/node-utils/src/http.test.ts`

_Updated: 2026-09-06T06:21:10.193Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/node-utils-body-size-cap/web/](https://dev.suite.sldev.cz/suite-web/mroz22/node-utils-body-size-cap/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/node-utils-body-size-cap&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/node-utils-body-size-cap&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-06T06:24:51.797Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-06T06:23:25.259Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->