### PR TITLE
chore(suite-native): migrate deprecated Skia path methods

### DIFF
--- a/suite-native/icons/src/CryptoIconWithPercentage.tsx
+++ b/suite-native/icons/src/CryptoIconWithPercentage.tsx
@@ -41,8 +41,7 @@ export const CryptoIconWithPercentage = ({
     const { utils } = useNativeStyles();
     const colorScheme = useActiveColorScheme();
 
-    const path = Skia.Path.Make();
-    path.addCircle(CANVAS_SIZE / 2, CANVAS_SIZE / 2, RADIUS);
+    const path = Skia.Path.Circle(CANVAS_SIZE / 2, CANVAS_SIZE / 2, RADIUS);
 
     const animationProgress = useSharedValue(0);
 

--- a/suite-native/icons/src/PizzaIcon.tsx
+++ b/suite-native/icons/src/PizzaIcon.tsx
@@ -69,14 +69,12 @@ export const PizzaIcon = ({
 
         const oval = rect(cx - radius, cy - radius, cx + radius, cy + radius);
 
-        const path = Skia.Path.Make();
-
-        path.moveTo(cx, cy)
+        return Skia.PathBuilder.Make()
+            .moveTo(cx, cy)
             .lineTo(startX, startY)
             .arcToOval(oval, startAnglePosition, sweepAngle, false)
-            .close();
-
-        return path;
+            .close()
+            .build();
     });
 
     return (

--- a/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
+++ b/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
@@ -144,15 +144,15 @@ export function AnimatedLineGraph<TEventPayload extends object>({
     }, []);
 
     const straightLine = useMemo(() => {
-        const path = Skia.Path.Make();
-        path.moveTo(0, height / 2);
+        const pathBuilder = Skia.PathBuilder.Make();
+        pathBuilder.moveTo(0, height / 2);
         for (let i = 0; i < width - 1; i += 2) {
             const x = i;
             const y = height / 2;
-            path.cubicTo(x, y, x, y, x, y);
+            pathBuilder.cubicTo(x, y, x, y, x, y);
         }
 
-        return path;
+        return pathBuilder.build();
     }, [height, width]);
 
     const paths = useSharedValue<{ from?: SkPath; to?: SkPath }>({});
@@ -452,13 +452,10 @@ export function AnimatedLineGraph<TEventPayload extends object>({
     }, [indicatorPulsating]);
 
     const dashedLine = useDerivedValue(() => {
-        const line = Skia.Path.Make();
         const y = path.value?.getPoint(0).y ?? height / 2;
-        line.moveTo(0, y);
-        line.lineTo(width, y);
-        line.dash(2, 5, 0);
+        const line = Skia.Path.Line(Skia.Point(0, y), Skia.Point(width, y));
 
-        return line;
+        return Skia.Path.Dash(line, 2, 5, 0)!;
     });
 
     const axisLabelContainerStyle = {

--- a/suite-native/react-native-graph/src/CreateGraphPath.ts
+++ b/suite-native/react-native-graph/src/CreateGraphPath.ts
@@ -110,14 +110,16 @@ function createGraphPathBase({
     canvasWidth: width,
     shouldFillGradient,
 }: GraphPathConfigWithGradient | GraphPathConfigWithoutGradient): SkPath | GraphPathWithGradient {
-    const path = Skia.Path.Make();
+    const pathBuilder = Skia.PathBuilder.Make();
 
     // Canvas width substracted by the horizontal padding => Actual drawing width
     const drawingWidth = width - 2 * horizontalPadding;
     // Canvas height substracted by the vertical padding => Actual drawing height
     const drawingHeight = height - 2 * verticalPadding;
 
-    if (graphData[0] == null) return path;
+    if (graphData[0] == null) {
+        return pathBuilder.build();
+    }
 
     const points: SkPoint[] = [];
 
@@ -166,12 +168,16 @@ function createGraphPathBase({
         const point = points[i]!;
 
         // first point needs to start the path
-        if (i === 0) path.moveTo(point.x, point.y);
+        if (i === 0) {
+            pathBuilder.moveTo(point.x, point.y);
+        }
 
         const prev = points[i - 1];
         const prevPrev = points[i - 2];
 
-        if (prev == null) continue;
+        if (prev == null) {
+            continue;
+        }
 
         const p0 = prevPrev ?? prev;
         const p1 = prev;
@@ -182,21 +188,23 @@ function createGraphPathBase({
         const cp3x = (p0.x + 4 * p1.x + point.x) / 6;
         const cp3y = (p0.y + 4 * p1.y + point.y) / 6;
 
-        path.cubicTo(cp1x, cp1y, cp2x, cp2y, cp3x, cp3y);
+        pathBuilder.cubicTo(cp1x, cp1y, cp2x, cp2y, cp3x, cp3y);
 
         if (i === points.length - 1) {
-            path.cubicTo(point.x, point.y, point.x, point.y, point.x, point.y);
+            pathBuilder.cubicTo(point.x, point.y, point.x, point.y, point.x, point.y);
         }
     }
 
-    if (!shouldFillGradient) return path;
+    if (!shouldFillGradient) {
+        return pathBuilder.build();
+    }
 
-    const gradientPath = path.copy();
+    const path = pathBuilder.build();
 
-    gradientPath.lineTo(endX, height + verticalPadding);
-    gradientPath.lineTo(0 + horizontalPadding, height + verticalPadding);
+    pathBuilder.lineTo(endX, height + verticalPadding);
+    pathBuilder.lineTo(horizontalPadding, height + verticalPadding);
 
-    return { path, gradientPath };
+    return { path, gradientPath: pathBuilder.build() };
 }
 
 export function createGraphPath(props: GraphPathConfig): SkPath {


### PR DESCRIPTION
## Description

Usage of deprecated Skia path methods migrated to the new API.

## Notes for QA

Check the graph and crypto icons on dashboard.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/skia-deprecated-methods&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->