### PR TITLE
chore(suite-native): resolve legacy browser-field packages without exports

### DIFF
--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -16,6 +16,13 @@ const sourceExts = [...additionalSourceExts, ...defaultSourceExts];
 
 const cjsOnlyPackages = ['@sinclair/typebox', 'kysely'];
 
+const legacyBrowserFieldPackages = ['uint8arrays', 'multiformats', '@noble/hashes'];
+
+const isModuleFrom = (packageNames, moduleName) =>
+    packageNames.some(
+        packageName => moduleName === packageName || moduleName.startsWith(`${packageName}/`),
+    );
+
 /**
  * Metro configuration
  * https://facebook.github.io/metro/docs/configuration
@@ -61,14 +68,26 @@ const config = {
             // - `kysely`: its ESM `FileMigrationProvider` calls `await import()` with a computed
             //   specifier, which Hermes refuses to compile ('Invalid expression encountered').
             //   The CJS build emits a plain `require()` there.
-            if (
-                cjsOnlyPackages.some(
-                    packageName =>
-                        moduleName === packageName || moduleName.startsWith(`${packageName}/`),
-                )
-            ) {
+            if (isModuleFrom(cjsOnlyPackages, moduleName)) {
                 return context.resolveRequest(
                     { ...context, isESMImport: false },
+                    moduleName,
+                    platform,
+                );
+            }
+
+            // Packages that predate `exports` and mirror their subpath map into the `browser`
+            // field using deep paths (`"./basics": "./cjs/src/basics.js"`). Metro applies that
+            // redirect before it validates the result against `exports`, where the deep path is
+            // never listed, so every import logs a "not listed in the exports" warning and then
+            // falls back to file-based resolution.
+            // Resolving them without `exports`, the way we did before package exports were
+            // enabled, keeps the `browser` targets these packages intend for us - `multiformats`'
+            // `exports` resolves `./hashes/sha2` to a build that requires Node's `crypto`, while
+            // `browser` points at the WebCrypto one.
+            if (isModuleFrom(legacyBrowserFieldPackages, moduleName)) {
+                return context.resolveRequest(
+                    { ...context, unstable_enablePackageExports: false },
                     moduleName,
                     platform,
                 );

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -14,9 +14,39 @@ const defaultSourceExts = [...jsonExpoConfig.resolver.sourceExts, 'md'];
 const additionalSourceExts = process.env.RN_SRC_EXT ? process.env.RN_SRC_EXT.split(',') : [];
 const sourceExts = [...additionalSourceExts, ...defaultSourceExts];
 
-const cjsOnlyPackages = ['@sinclair/typebox', 'kysely'];
+// Packages whose ESM build Metro would pick via `exports`, but which we need to resolve to
+// their CommonJS build instead.
+const cjsOnlyPackages = [
+    // Subpaths ('./value', './errors') resolve to CJS while the package root resolves to ESM,
+    // so two TypeBox instances end up in the bundle. Custom kinds registered in one instance's
+    // `TypeRegistry` are then invisible to the validator from the other one.
+    // See https://github.com/expo/expo/issues/37171
+    '@sinclair/typebox',
+    // Its ESM `FileMigrationProvider` calls `await import()` with a computed specifier, which
+    // Hermes refuses to compile ('Invalid expression encountered'). The CJS build emits a plain
+    // `require()` there.
+    'kysely',
+    // Its ESM and CJS entry points load disjoint chunks (`*.require.js` vs `*.require.cjs`), so
+    // the `require()` in `./rozeniteBootRecording` and the `import` in `useRozenitePlugins` would
+    // each get their own copy of the plugin's module state. Boot recording would then patch
+    // `globalThis.fetch` in one copy while the DevTools hook reads the other one's empty event
+    // queue.
+    '@rozenite/network-activity-plugin',
+];
 
-const legacyBrowserFieldPackages = ['uint8arrays', 'multiformats', '@noble/hashes'];
+// Packages that predate `exports` and mirror their subpath map into the `browser` field using
+// deep paths (`"./basics": "./cjs/src/basics.js"`). Metro applies that redirect before it
+// validates the result against `exports`, where the deep path is never listed, so every import
+// logs a "not listed in the exports" warning and then falls back to file-based resolution.
+// Resolving them without `exports`, the way we did before package exports were enabled, keeps
+// the `browser` targets these packages intend for us.
+const legacyBrowserFieldPackages = [
+    'uint8arrays',
+    // Its `exports` resolves `./hashes/sha2` to a build that requires Node's `crypto`, while
+    // `browser` points at the WebCrypto one.
+    'multiformats',
+    '@noble/hashes',
+];
 
 const isModuleFrom = (packageNames, moduleName) =>
     packageNames.some(
@@ -59,15 +89,6 @@ const config = {
                 originModulePath: context.originModulePath,
             });
 
-            // Packages whose ESM build Metro would pick via `exports`, but which we need to
-            // resolve to their CommonJS build instead:
-            // - `@sinclair/typebox`: subpaths ('./value', './errors') resolve to CJS while the
-            //   package root resolves to ESM, so two TypeBox instances end up in the bundle.
-            //   Custom kinds registered in one instance's `TypeRegistry` are then invisible to
-            //   the validator from the other one. See https://github.com/expo/expo/issues/37171
-            // - `kysely`: its ESM `FileMigrationProvider` calls `await import()` with a computed
-            //   specifier, which Hermes refuses to compile ('Invalid expression encountered').
-            //   The CJS build emits a plain `require()` there.
             if (isModuleFrom(cjsOnlyPackages, moduleName)) {
                 return context.resolveRequest(
                     { ...context, isESMImport: false },
@@ -76,15 +97,6 @@ const config = {
                 );
             }
 
-            // Packages that predate `exports` and mirror their subpath map into the `browser`
-            // field using deep paths (`"./basics": "./cjs/src/basics.js"`). Metro applies that
-            // redirect before it validates the result against `exports`, where the deep path is
-            // never listed, so every import logs a "not listed in the exports" warning and then
-            // falls back to file-based resolution.
-            // Resolving them without `exports`, the way we did before package exports were
-            // enabled, keeps the `browser` targets these packages intend for us - `multiformats`'
-            // `exports` resolves `./hashes/sha2` to a build that requires Node's `crypto`, while
-            // `browser` points at the WebCrypto one.
             if (isModuleFrom(legacyBrowserFieldPackages, moduleName)) {
                 return context.resolveRequest(
                     { ...context, unstable_enablePackageExports: false },


### PR DESCRIPTION
## Description

Since #31937 enabled Metro's `exports` resolution, every dev bundle logs 12 `Attempted to import the module … which is not listed in the "exports" of …` warnings.

`uint8arrays@3.1.1`, `multiformats@9.9.0` and `@noble/hashes@1.8.0` predate `exports` and mirror their subpath map into the legacy `browser` field using **deep** paths:

```json
"browser": { "./basics": "./cjs/src/basics.js" }   // multiformats
"browser": { "./crypto": "./crypto.js" }           // @noble/hashes
```

Metro applies that `browser` redirect in [`redirectModulePath`](https://github.com/facebook/metro/blob/main/packages/metro-resolver/src/PackageResolve.js) *before* it validates the result against `exports` in `resolvePackage`. The redirected deep path is never an `exports` key, so resolution throws `PackagePathNotExportedError`, warns, and falls back to file-based resolution — which then finds the correct file. Harmless, but 12 lines of noise on every bundle.

Instrumenting `unstable_logWarning` shows the 12 warnings come from just 3 call sites:

| specifier | importer |
| --- | --- |
| `@noble/hashes/crypto` | `@noble/hashes/{,esm/}utils.js` (10x across nested copies) |
| `multiformats/basics` | `uint8arrays/cjs/src/util/bases.js` |
| `uint8arrays/from-string` | `@walletconnect/core/dist/index.cjs` |

This resolves those three packages without `exports`, the way we did before #31937, via a per-request `unstable_enablePackageExports: false` in `resolveRequest`.

Note the fix deliberately goes this way round rather than making `exports` win (e.g. by dropping `browser` from `resolverMainFields`): `multiformats`' `exports` resolves `./hashes/sha2` to a build that does `require('crypto')`, while its `browser` field points at the WebCrypto `sha2-browser.js`. The `browser` targets are the ones we want on React Native.

### Measurements

`expo export:embed --dev true --reset-cache`, before vs. after:

| | android warnings | ios warnings | android bundle |
| --- | --- | --- | --- |
| `develop` | 12 | 12 | 61 529 551 B / 12 454 modules |
| this branch | **0** | **0** | 61 437 758 B / 12 445 modules |

The only resolution change is `@noble/hashes`, which goes back to its CommonJS build for the ESM importers (`viem`, `bs58check`, `@scure/bip39`). That drops 11 duplicate copies of the hash implementations from the bundle (-92 KB) and is the pre-#31937 state; `@noble/hashes` is stateless pure functions, so there is no dual-instance concern like the one that pins `@sinclair/typebox`. `uint8arrays` and `multiformats` resolve to byte-identical output.

Verified no `cryptoNode.js` / `node:crypto` module enters the bundle on either platform.

## Notes for QA

Please smoke-test on a real device on both iOS and Android: get an address, sign a transaction (BTC + ETH), and verify suite-sync works.

## Related Issue

Follow-up to #31937
Fixes  https://github.com/trezor/trezor-suite/issues/20733

## Screenshots:

No more concole warnings
<img width="500" alt="image" src="https://github.com/user-attachments/assets/77b20956-cb2d-4fd9-8def-caed42ed3723" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/metro-package-exports-warnings&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->