### PR TITLE
refactor(suite-native): simplify RoundedIcon atom interface

### DIFF
--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -8,8 +8,8 @@ import { type Color } from '@trezor/theme';
 
 import { BannerInline, type BannerInlineProps } from '../BannerInline/BannerInline';
 import { Box } from '../Box';
+import { RoundedIcon, type RoundedIconIntent } from '../Icon/RoundedIcon';
 import { Loader } from '../Loader';
-import { RoundedIcon, type RoundedIconIntent } from '../RoundedIcon';
 import { HStack, VStack } from '../Stack';
 import { Text } from '../Text';
 import { useTapGesture } from '../useTapGesture';

--- a/suite-native/atoms/src/Icon/RoundedIcon.tsx
+++ b/suite-native/atoms/src/Icon/RoundedIcon.tsx
@@ -4,7 +4,7 @@ import { Icon, type IconName, type IconSize, TokenIcon, icons } from '@suite-nat
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
 
-import { Box } from './Box';
+import { Box } from '../Box';
 
 export const ROUNDED_ICON_INTENTS = ['neutral', 'brand', 'warning', 'critical', 'info'] as const;
 export type RoundedIconIntent = (typeof ROUNDED_ICON_INTENTS)[number];

--- a/suite-native/atoms/src/RoundedIcon.tsx
+++ b/suite-native/atoms/src/RoundedIcon.tsx
@@ -4,7 +4,7 @@ import { Icon, type IconName, type IconSize, TokenIcon, icons } from '@suite-nat
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
 
-import { Box, type BoxProps } from './Box';
+import { Box } from './Box';
 
 export const ROUNDED_ICON_INTENTS = ['neutral', 'brand', 'warning', 'critical', 'info'] as const;
 export type RoundedIconIntent = (typeof ROUNDED_ICON_INTENTS)[number];
@@ -18,7 +18,8 @@ export type RoundedIconProps = {
     contractAddress?: TokenAddress;
     intent?: RoundedIconIntent;
     size?: RoundedIconSize;
-} & BoxProps;
+    accessibilityLabel?: string;
+};
 
 type RoundedIconStyle = {
     backgroundColor: Color;
@@ -73,9 +74,7 @@ export const RoundedIcon = ({
     contractAddress,
     intent = 'neutral',
     size = 48,
-    children,
-    style,
-    ...boxProps
+    accessibilityLabel,
 }: RoundedIconProps) => {
     const { applyStyle } = useNativeStyles();
     const { backgroundColor, iconColor } = roundedIconIntentToStylePropsMap[intent];
@@ -83,15 +82,15 @@ export const RoundedIcon = ({
 
     return (
         <Box
-            style={[applyStyle(iconContainerStyle, { backgroundColor, size }), style]}
-            {...boxProps}
+            style={applyStyle(iconContainerStyle, { backgroundColor, size })}
+            accessibilityLabel={accessibilityLabel}
+            accessibilityRole="image"
         >
-            {children ??
-                (name && name in icons ? (
-                    <Icon name={name} color={iconColor} size={iconSize} />
-                ) : (
-                    symbol && <TokenIcon symbol={symbol} contractAddress={contractAddress} />
-                ))}
+            {name && name in icons ? (
+                <Icon name={name} color={iconColor} size={iconSize} />
+            ) : (
+                symbol && <TokenIcon symbol={symbol} contractAddress={contractAddress} />
+            )}
         </Box>
     );
 };

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -60,7 +60,7 @@ export * from './Pictogram/Pictogram';
 export * from './TitleHeader/PictogramTitleHeader';
 export * from './TitleHeader/TitleHeader';
 export * from './TitleHeader/CenteredTitleHeader';
-export * from './RoundedIcon';
+export * from './Icon/RoundedIcon';
 export * from './CompoundRoundedIcon';
 export * from './TrezorSuiteHeader';
 export * from './Skeleton/BoxSkeleton';

--- a/suite-native/atoms/src/stories/Icon/RoundedIcon.stories.tsx
+++ b/suite-native/atoms/src/stories/Icon/RoundedIcon.stories.tsx
@@ -7,7 +7,7 @@ import {
     ROUNDED_ICON_SIZES,
     RoundedIcon as RoundedIconComponent,
     type RoundedIconProps,
-} from '../RoundedIcon';
+} from '../../Icon/RoundedIcon';
 
 type RoundedIconStory = StoryObj<RoundedIconProps>;
 

--- a/suite-native/trading-history/src/components/TradeHistoryListItem/TradeStatusIcon.tsx
+++ b/suite-native/trading-history/src/components/TradeHistoryListItem/TradeStatusIcon.tsx
@@ -85,8 +85,6 @@ export const TradeStatusIcon = ({ status }: TradeStatusIconProps) => {
             intent={config.intent}
             size={24}
             accessibilityLabel={translate(config.accessibilityLabelId)}
-            accessibilityRole="image"
-            testID="@trading/history/status-icon"
         />
     );
 };


### PR DESCRIPTION
## Description

- Unused atom properties removed.
- Component moved to `Icon` directory.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/rounded-icon&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->