### PR TITLE
Yield allowance modal icons + padding

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
@@ -32,7 +32,7 @@ export const AllowanceModalProviderInfo = ({
     const providerName = provider.companyName ?? provider.name;
 
     return (
-        <CardList.Item paddingType={showSpender ? 'medium' : 'normal'}>
+        <CardList.Item>
             <Text typographyStyle="body-sm">
                 <Translation id={provider.label} />
             </Text>

--- a/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.test.ts
+++ b/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.test.ts
@@ -9,6 +9,10 @@ const underlyingTokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 const receiptTokenAddress = '0xde6c23e561f3e55846207ec45a91b777e0f7c889';
 const yieldId = 'ethereum-usdc-steakusdc';
 
+// Blockbook returns EVM token contracts checksummed rather than lowercased. The exact
+// checksum does not matter here, only that the casing differs from the normalized form.
+const toBackendContractCasing = (address: string) => `0x${address.slice(2).toUpperCase()}`;
+
 const account = {
     key: accountKey,
     symbol: 'eth',
@@ -118,6 +122,27 @@ describe('getResolvedYieldFlowData', () => {
 
         expect(result.flowKey).toBe(`${accountKey}:${yieldId}:${receiptTokenAddress}`);
         expect(result.depositedSharesAmount).toBe('1.5');
+    });
+
+    it('normalizes the contract casing the backend returns for held tokens', () => {
+        const checksummedAccount = {
+            ...account,
+            tokens: account.tokens?.map(accountToken => ({
+                ...accountToken,
+                contract: toBackendContractCasing(accountToken.contract),
+            })),
+        } as unknown as Account;
+
+        const result = getResolvedYieldFlowData({ account: checksummedAccount, vault });
+
+        // The tokens must still be matched and their balances kept ...
+        expect(result.token?.balance).toBe('25');
+        expect(result.depositedSharesAmount).toBe('1.5');
+        // ... while the exposed contracts stay normalized, so that the derived asset logo URLs
+        // and fiat rate tickers keep resolving.
+        expect(result.token?.contractAddress).toBe(underlyingTokenAddress);
+        expect(result.receiptToken?.contractAddress).toBe(receiptTokenAddress);
+        expect(result.flowKey).toBe(`${accountKey}:${yieldId}:${underlyingTokenAddress}`);
     });
 
     it('falls back to the vault token data when the account does not hold the token', () => {

--- a/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts
+++ b/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts
@@ -193,12 +193,19 @@ export const getResolvedYieldFlowData = ({
         token: vault.outputToken,
     });
 
+    const matchedTokenContract = matchedToken
+        ? getContractAddressForNetworkSymbol(account.symbol, matchedToken.contract)
+        : null;
+    const matchedReceiptTokenContract = matchedReceiptToken
+        ? getContractAddressForNetworkSymbol(account.symbol, matchedReceiptToken.contract)
+        : null;
+
     const token: YieldFlowToken = {
         networkSymbol: account.symbol,
         symbol:
             matchedToken?.symbol ?? vault.token.symbol ?? getNetworkDisplaySymbol(account.symbol),
         decimals: matchedToken?.decimals ?? vault.token.decimals,
-        contractAddress: matchedToken?.contract ?? underlyingTokenContract,
+        contractAddress: matchedTokenContract ?? underlyingTokenContract,
         coingeckoId: vault.token.coinGeckoId,
         balance: matchedToken?.balance ?? '0',
     };
@@ -207,7 +214,7 @@ export const getResolvedYieldFlowData = ({
         networkSymbol: account.symbol,
         symbol: matchedReceiptToken?.symbol ?? vault.outputToken.symbol,
         decimals: matchedReceiptToken?.decimals ?? vault.outputToken.decimals,
-        contractAddress: matchedReceiptToken?.contract ?? receiptTokenContract,
+        contractAddress: matchedReceiptTokenContract ?? receiptTokenContract,
         coingeckoId: vault.outputToken.coinGeckoId ?? vault.token.coinGeckoId,
     };
 


### PR DESCRIPTION
## Description

This PR:
- fixes yield allowance modal padding for the vault row
- wrong icon URLs for vault tokens

## Screenshots:

<img width="564" height="573" alt="Screenshot 2026-09-04 at 13 18 28" src="https://github.com/user-attachments/assets/934ecca1-d226-4685-9d36-6b27df32c425" />

<img width="573" height="626" alt="Screenshot 2026-09-04 at 14 10 41" src="https://github.com/user-attachments/assets/8a8cc55b-8945-4933-859d-2136f6e02a16" />

<img width="572" height="623" alt="Screenshot 2026-09-04 at 14 10 51" src="https://github.com/user-attachments/assets/1ba4d768-d517-46c2-8e98-e235a0696185" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrow: an allowance-modal provider-info component and a yield-flow data resolution utility. The broad static coverage mapping (139 tests per file) indicates these are global/shared imports, so only tests that actually traverse the allowance or yield flows should run. The highest-value coverage is the DEX approval modal test for the UI component and the two yield redeem/withdrawal tests for the utility.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx`
- `suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.test.ts`
- `suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — This test directly exercises the token allowance approval modal for a DEX swap, verifying the provider name (LI.FI), approval limits, and fee details. The AllowanceModalProviderInfo component renders provider information inside allowance modals, so any regression here would be immediately visible.
- `suite/e2e/tests/yield/redeem.test.ts` — The yield redeem flow converts vault share tokens to USDC and depends on getResolvedYieldFlowData for share/amount resolution and vault metadata. A regression in this utility would produce incorrect redeemable amounts or asset labels in the flow.
- `suite/e2e/tests/yield/withdrawal.test.ts` — The yield withdrawal flow uses the same resolved-yield-data logic to compute deposited positions, share amounts, and fiat equivalents. It is the primary end-to-end coverage for the changed yield utility.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.test.ts`

_Updated: 2026-09-04T12:30:05.556Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/allowance-modal-provider-padding/web/](https://dev.suite.sldev.cz/suite-web/fix/allowance-modal-provider-padding/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/allowance-modal-provider-padding&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/allowance-modal-provider-padding&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/allowance-modal-provider-padding&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T12:32:34.024Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T12:32:41.430Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->