### PR TITLE
fix: Fix wallet balance in descreete mode

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -128,8 +128,8 @@ export const WalletInstance = ({
         >
             <Box padding={{ vertical: 12, right: 12, left: 16 }}>
                 <Collapsible isOpen={isEjecting}>
-                    <Column gap={8}>
-                        <Row justifyContent="space-between">
+                    <Column gap={8} alignItems="flex-start">
+                        <Row justifyContent="space-between" width="100%">
                             <Text
                                 as="div"
                                 intent="neutral"

--- a/suite/discreet-mode/src/HiddenPlaceholder.tsx
+++ b/suite/discreet-mode/src/HiddenPlaceholder.tsx
@@ -18,7 +18,9 @@ type WrapperProps = {
 
 const Wrapper = styled.span<WrapperProps>`
     font-variant-numeric: tabular-nums;
-    display: inline;
+    display: inline-block;
+    width: fit-content;
+    max-width: 100%;
 
     ${({ $intensity, $discreetMode }: WrapperProps) =>
         $discreetMode &&
@@ -34,7 +36,6 @@ const Wrapper = styled.span<WrapperProps>`
     ${({ $minWidth }: WrapperProps) =>
         !!$minWidth &&
         css`
-            display: inline-block;
             min-width: ${$minWidth}px;
         `}
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

amount is not leaking while hovering right side of the element

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/29561

## Screenshots:

https://github.com/user-attachments/assets/a45c78c7-5fb0-4cdb-b3b6-68f6e8a33199




<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches two presentation components: WalletInstance in the device switcher and HiddenPlaceholder for discreet balance masking. Regression risk is highest in wallet switching/labeling flows and discreet-mode balance display. The recommended tests narrowly target these behaviors rather than the 139 tests that transitively import WalletInstance.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx`
- `suite/discreet-mode/src/HiddenPlaceholder.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test directly exercises the HiddenPlaceholder component by verifying balances are masked as '###' and revealed on hover across dashboard, account, asset, and device switcher elements. Any change to HiddenPlaceholder would be immediately visible here.
- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — Directly edits wallet labels for standard and hidden wallets via the device switcher, which is exactly where WalletInstance renders wallet instances and their labels.
- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — Adds a hidden wallet through the device switcher and verifies the passphrase flow can be cancelled; WalletInstance is the component presenting the wallet instance in the switcher.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Tests duplicate passphrase detection when adding hidden wallets via the device switcher, directly depending on WalletInstance's rendering and state in the switcher.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Verifies hidden wallet numbering and standard/passphrase wallet labels in the device switcher, which are rendered by WalletInstance.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Checks that passphrase wallets remain listed in the device switcher after device reconnect and re-confirms addresses; WalletInstance renders the cached wallet entries.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Adds, switches between, and verifies hidden wallets through the device switcher, directly exercising WalletInstance's wallet instance rendering and selection.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Uses the device switcher to eject and re-add a standard wallet, exercising WalletInstance in a common wallet management flow alongside discovery state.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Creates multiple passphrase wallets and edits their labels through the device switcher, sharing the WalletInstance rendering path and Suite Sync label state.

</details>

_Updated: 2026-09-04T11:35:14.866Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-wallet-balance-in-descreet-mode/web/](https://dev.suite.sldev.cz/suite-web/fix-wallet-balance-in-descreet-mode/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-wallet-balance-in-descreet-mode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-wallet-balance-in-descreet-mode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T11:38:48.077Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T11:37:35.709Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->