### PR TITLE
Regenerate THP credentials fixture

### DIFF
--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -439,7 +439,7 @@ const TOTAL_COLLATERAL = '1000';
 const legacyResults = {
     minConnectVersion: {
         // older FW does support Cardano but Connect does not
-        rules: ['<2.4.3', '1'],
+        rules: ['<2.6.0', '1'],
         payload: false,
     },
     beforeConway: {

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts
@@ -10,12 +10,6 @@ const legacyResults: Record<string, LegacyResult[]> = {
             success: false,
         },
     ],
-    'Hoodi Testnet, testnet path': [
-        {
-            // Hoodi testnet (chain_id 560048) definitions sent from host since 2.6.0
-            rules: ['<2.6.0'],
-        },
-    ],
 };
 
 const ethereumSignTransaction: TestCase = {

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts
@@ -2,14 +2,15 @@ import { loadCommonFixture } from './commonFixtures';
 
 const commonFixtures = loadCommonFixture('ethereum/sign_tx_eip1559.json');
 
+const forbiddenKeyPath = {
+    // 'Forbidden key path between these versions (T1B1 does not have starting fw, too much effort to find)
+    rules: ['2.3.4-2.5.4', '<1.12.2'],
+    success: false,
+};
+
 const legacyResults: Record<string, LegacyResult[]> = {
-    'Ledger Live legacy path': [
-        {
-            // 'Forbidden key path between these versions (T1B1 does not have starting fw, too much effort to find)
-            rules: ['2.3.4-2.5.4', '<1.12.2'],
-            success: false,
-        },
-    ],
+    'Ledger Live legacy path': [forbiddenKeyPath],
+    Base: [forbiddenKeyPath],
 };
 
 const legacyResultsCommon = [

--- a/packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts
@@ -63,17 +63,6 @@ const fixtures = [...ethereumDefinitionFixture, ...commonFixtures.tests]
                 ? { ...restParams, show_message_hash: true }
                 : restParams;
 
-        if (typeof rawShowHash === 'string') {
-            legacyResults = [
-                ...legacyResults,
-                {
-                    // show_message_hash proto field added in firmware 2.10.0
-                    rules: ['<2.10.0'],
-                    success: false,
-                },
-            ];
-        }
-
         const fixture: Fixture = {
             description: `${name}`,
             params,

--- a/packages/connect/e2e/common-thp-credentials.ts
+++ b/packages/connect/e2e/common-thp-credentials.ts
@@ -18,6 +18,14 @@ export const THP_CREDENTIALS = [
         autoconnect: false,
         host_static_key: '8154f21fd32368bfaa2912faa8cb8b2eadf09f60b49c49d76c22f787fa8be39a',
     },
+    {
+        trezor_static_public_key:
+            '96308b4f2ed64275e442bf9b3e1fe95d6c5bee1b06ab00e892f5e74591d03015',
+        credential:
+            '0a1c0a0974657374733a65326510001a0d5472657a6f72436f6e6e65637412201d522728c8285d53b95856c4fd29f911d963e801ed5485a00b9e91239db3e0e4',
+        autoconnect: false,
+        host_static_key: '5d0cc8f62d19b3faee9f361e88f1753e6f95cd46d053bf48f8770dca2493f91e',
+    },
 ];
 
 export const THP_CREDENTIALS_AUTOCONNECT = [
@@ -37,5 +45,13 @@ export const THP_CREDENTIALS_AUTOCONNECT = [
             '0a1c0a0974657374733a65326510011a0d5472657a6f72436f6e6e656374122025c5bd5495c6908f95bdd1faeace4dbea317ab27991f30f339f57cb51654d33b',
         autoconnect: true,
         host_static_key: '3217c896fa2767becdc1aaac541e4a7e6527e19c1f00d2472dd11d424e2867b2',
+    },
+    {
+        trezor_static_public_key:
+            '96308b4f2ed64275e442bf9b3e1fe95d6c5bee1b06ab00e892f5e74591d03015',
+        credential:
+            '0a1c0a0974657374733a65326510011a0d5472657a6f72436f6e6e65637412202664bddf66b3cd39c5876bfa26881d78f227870a4801ee0a23f4771645a41ee1',
+        autoconnect: true,
+        host_static_key: '5d0cc8f62d19b3faee9f361e88f1753e6f95cd46d053bf48f8770dca2493f91e',
     },
 ];


### PR DESCRIPTION
## Description

By bumping user-env from https://github.com/trezor/trezor-user-env/commit/7ad5442d8c4092e832bf0293aec63f1717412dbb to https://github.com/trezor/trezor-user-env/commit/a54bf6660f17b053169fbd5665386f9a87028cfb, THP pairing stopped working for T3W1 2-main e2e tests.

Resolved by generating new THP credentials.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set updates Connect transaction-signing fixtures for Ethereum (standard and EIP-1559), Cardano, and typed-data signing, plus THP credentials. The highest-risk regressions are in Ethereum transaction signing and THP pairing, so the direct Connect Ethereum test and the T3W1 onboarding test are prioritized. Cardano staking and an Ethereum send test provide secondary coverage for signing payloads. The typed-data fixture has no known Suite test coverage.

<details><summary><b>Changed files (5)</b></summary>

- `packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts`
- `packages/connect/e2e/common-thp-credentials.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This is the only Suite test that directly invokes TrezorConnect.ethereumSignTransaction, so it exercises the exact API path covered by the changed ethereumSignTransaction and ethereumSignTransactionEip1559 fixtures. A fixture change affecting transaction payloads, fee handling, or device prompts would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — The test explicitly walks through THP (Trezor Host Protocol) device pairing during the T3W1 onboarding flow. Changes to common-thp-credentials could alter the THP authentication handshake, and this test verifies the pairing step end-to-end.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test performs a full Cardano stake delegation transaction, which under the hood relies on the connect cardanoSignTransaction flow. If the changed Cardano transaction fixtures reflect new signing expectations, this user-facing staking path is the most likely Suite test to surface a regression.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Like the stake test, this exercises Cardano transaction signing (stake key deregistration) and is affected by the same cardanoSignTransaction fixture changes, providing coverage for a different transaction type.
- `suite/e2e/tests/wallet/send-eth.test.ts` — The test sends an Ethereum transaction with custom EIP-1559 fees and on-device confirmation, covering the same ethereumSignTransaction code path from the Suite UI perspective. It is a good secondary check for EIP-1559 fixture-related regressions in real user sends.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts`

_Updated: 2026-09-04T13:59:36.624Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/ts7-e2e-fix/web/](https://dev.suite.sldev.cz/suite-web/test/ts7-e2e-fix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/ts7-e2e-fix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/ts7-e2e-fix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/ts7-e2e-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T13:59:52.399Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T14:01:42.879Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->