### PR TITLE
refactor(suite-native): use TokenIcon instead of misused RoundedIcon

### DIFF
--- a/suite-native/accounts/src/components/SelectableNetworkItem.tsx
+++ b/suite-native/accounts/src/components/SelectableNetworkItem.tsx
@@ -1,7 +1,7 @@
 import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { Badge, Box, HStack, PressableOpacity, RoundedIcon, Text } from '@suite-native/atoms';
-import { Icon, type IconName } from '@suite-native/icons';
+import { Badge, Box, HStack, PressableOpacity, Text } from '@suite-native/atoms';
+import { Icon, type IconName, TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { isNetworkWithTokens } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -12,12 +12,11 @@ type SelectableAssetItemProps = {
     onPress?: (symbol: NetworkSymbol) => void;
 };
 
-const selectableAssetContentStyle = prepareNativeStyle(utils => ({
+const selectableAssetContentStyle = prepareNativeStyle(_ => ({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     flex: 1,
-    marginLeft: utils.spacings.sp12,
 }));
 
 const tokensBadgeStyle = prepareNativeStyle(utils => ({
@@ -43,8 +42,8 @@ export const SelectableNetworkItem = ({ symbol, onPress, rightIcon }: Selectable
             onPress={handlePress}
             testID={`@onboarding/select-coin/${symbol}`}
         >
-            <Box flexDirection="row" alignItems="center">
-                <RoundedIcon symbol={symbol} />
+            <HStack alignItems="center" spacing="sp16">
+                <TokenIcon symbol={symbol} />
                 <Box style={applyStyle(selectableAssetContentStyle)}>
                     <Box flex={1} justifyContent="space-between" alignItems="flex-start">
                         <Text variant="body-md">{networkName}</Text>
@@ -68,7 +67,7 @@ export const SelectableNetworkItem = ({ symbol, onPress, rightIcon }: Selectable
                     </Box>
                 </Box>
                 {rightIcon && <Icon name={rightIcon} color="contentDisabled" size="large" />}
-            </Box>
+            </HStack>
         </PressableOpacity>
     );
 };

--- a/suite-native/atoms/src/Icon/RoundedIcon.tsx
+++ b/suite-native/atoms/src/Icon/RoundedIcon.tsx
@@ -1,6 +1,4 @@
-import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type TokenAddress } from '@suite-common/wallet-types';
-import { Icon, type IconName, type IconSize, TokenIcon, icons } from '@suite-native/icons';
+import { Icon, type IconName, type IconSize } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
 
@@ -13,9 +11,7 @@ export const ROUNDED_ICON_SIZES = [20, 24, 32, 40, 48] as const;
 export type RoundedIconSize = (typeof ROUNDED_ICON_SIZES)[number];
 
 export type RoundedIconProps = {
-    name?: IconName;
-    symbol?: NetworkSymbol;
-    contractAddress?: TokenAddress;
+    name: IconName;
     intent?: RoundedIconIntent;
     size?: RoundedIconSize;
     accessibilityLabel?: string;
@@ -70,8 +66,6 @@ const iconContainerStyle = prepareNativeStyle<{ backgroundColor: Color; size: Ro
 
 export const RoundedIcon = ({
     name,
-    symbol,
-    contractAddress,
     intent = 'neutral',
     size = 48,
     accessibilityLabel,
@@ -86,11 +80,7 @@ export const RoundedIcon = ({
             accessibilityLabel={accessibilityLabel}
             accessibilityRole="image"
         >
-            {name && name in icons ? (
-                <Icon name={name} color={iconColor} size={iconSize} />
-            ) : (
-                symbol && <TokenIcon symbol={symbol} contractAddress={contractAddress} />
-            )}
+            <Icon name={name} color={iconColor} size={iconSize} />
         </Box>
     );
 };

--- a/suite-native/atoms/src/stories/Icon/RoundedIcon.stories.tsx
+++ b/suite-native/atoms/src/stories/Icon/RoundedIcon.stories.tsx
@@ -38,8 +38,5 @@ export const RoundedIcon: RoundedIconStory = {
             control: { type: 'select' },
             options: ROUNDED_ICON_SIZES,
         },
-        symbol: {
-            control: false,
-        },
     },
 };

--- a/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
@@ -7,13 +7,14 @@ import {
     AccountLabelFieldHint,
     MAX_ACCOUNT_LABEL_LENGTH,
 } from '@suite-native/accounts';
-import { RoundedIcon, VStack } from '@suite-native/atoms';
+import { VStack } from '@suite-native/atoms';
 import {
     BaseCurrencyAmountLargeFormatter,
     ExactCryptoAmountFormatter,
     useFiatFromCryptoValue,
 } from '@suite-native/formatters';
 import { TextInputField } from '@suite-native/forms';
+import { TokenIcon } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
 
 import { AccountImportOverviewCard } from './AccountImportOverviewCard';
@@ -38,7 +39,7 @@ export const AccountImportOverview = ({ balance, symbol, formControl }: AssetsOv
 
     return (
         <AccountImportOverviewCard
-            icon={<RoundedIcon symbol={symbol} />}
+            icon={<TokenIcon symbol={symbol} />}
             coinName={getNetwork(symbol).name}
             cryptoAmount={
                 <ExactCryptoAmountFormatter

--- a/suite-native/module-accounts-import/src/components/AccountImportOverviewCard.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverviewCard.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { Box, Card, Text } from '@suite-native/atoms';
+import { Box, Card, HStack, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 const assetCardStyle = prepareNativeStyle(utils => ({
@@ -26,15 +26,13 @@ export const AccountImportOverviewCard = ({
 
     return (
         <Card style={applyStyle(assetCardStyle)}>
-            <Box flexDirection="row" marginBottom="sp24" justifyContent="space-between">
-                <Box flexDirection="row">
-                    {icon}
-                    <Box marginLeft="sp16">
-                        <Text>{coinName}</Text>
-                        {cryptoAmount}
-                    </Box>
+            <HStack marginBottom="sp24" spacing="sp16" alignItems="center">
+                {icon}
+                <Box>
+                    <Text>{coinName}</Text>
+                    {cryptoAmount}
                 </Box>
-            </Box>
+            </HStack>
             {children}
         </Card>
     );

--- a/suite-native/module-transactions/src/components/TransactionDetailListItem.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailListItem.tsx
@@ -1,5 +1,6 @@
 import { type AccountKey } from '@suite-common/wallet-types';
-import { Box, PressableOpacity, RoundedIcon, Text } from '@suite-native/atoms';
+import { Box, PressableOpacity, Text } from '@suite-native/atoms';
+import { TokenIcon } from '@suite-native/icons';
 import { useNavigateToTransactionDetail } from '@suite-native/navigation';
 import { type TypedTokenTransfer, type WalletAccountTransaction } from '@suite-native/tokens';
 import {
@@ -52,7 +53,7 @@ export const TransactionDetailListItem = ({
         >
             <Box flexDirection="row" alignItems="center" flex={1}>
                 <Box marginRight="sp16">
-                    <RoundedIcon
+                    <TokenIcon
                         symbol={transaction.symbol}
                         contractAddress={tokenTransfer?.contract}
                     />


### PR DESCRIPTION
## Description

- `TokenIcon` used instead of misused `RoundedIcon`.
- `symbol` and `contractAddress` props removed from `RoundedIcon`

## Screenshots:

| Before | After |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/03560b3f-cefd-40ee-b4e1-e33ebe33627c" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/fa5dabd9-6e11-46dc-bc38-3e0e136aa621" /> |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/8ba2d067-c724-4b85-b804-70809b7b2307" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/0c6e1bd1-2e86-479c-873b-c289945f1403" /> |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/bb522815-326a-46a7-afd3-e9163d1d2f21" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/84e5bd8f-f20c-4379-9bc1-4f0bbe491826" /> |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/8d91f96b-07c2-4008-bf43-da5188b41d83" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/ad5d9b63-575a-4a23-8776-15da3120295f" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/rounded-icon-misuse&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->