### PR TITLE
feat(eslint): disallow inline destructured parameter types

### DIFF
--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -9,6 +9,7 @@ const { analyticsEventNameRule } = require('./analytics-event-name/rule');
 const { enforceE2eTestStreamRule } = require('./enforce-e2e-test-stream/rule');
 const { enforceDiFactoryContractsRule } = require('./named-contracts/di/rule');
 const { enforceThunkContractsRule } = require('./named-contracts/thunks/rule');
+const { enforceNamedParameterTypesRule } = require('./named-parameter-types/rule');
 const { noOverrideDsComponentRule } = require('./no-override-ds-component/rule');
 const { noPackageDeepImportsRule } = require('./no-package-deep-imports/rule');
 const { noSuiteImportsInSuiteCommonRule } = require('./no-suite-imports-in-suite-common/rule');
@@ -19,6 +20,7 @@ module.exports = {
     'analytics-event-name': analyticsEventNameRule,
     'enforce-di-factory-contracts': enforceDiFactoryContractsRule,
     'enforce-e2e-test-stream': enforceE2eTestStreamRule,
+    'enforce-named-parameter-types': enforceNamedParameterTypesRule,
     'enforce-thunk-contracts': enforceThunkContractsRule,
     'enforce-thunk-names': enforceThunkNamesRule,
     'no-override-ds-component': noOverrideDsComponentRule,

--- a/eslint-local-rules/named-parameter-types/rule.test.ts
+++ b/eslint-local-rules/named-parameter-types/rule.test.ts
@@ -1,0 +1,232 @@
+import { RuleTester } from 'eslint';
+import { parser } from 'typescript-eslint';
+
+import { enforceNamedParameterTypesRule } from './rule';
+
+const typescriptRuleTester = new RuleTester({
+    languageOptions: {
+        parser,
+        parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+    },
+});
+
+typescriptRuleTester.run('enforce-named-parameter-types', enforceNamedParameterTypesRule, {
+    valid: [
+        {
+            code: `
+                    type FormatValueParams = { value: string };
+
+                    const formatValue = ({ value }: FormatValueParams) => value;
+                `,
+        },
+        {
+            code: `
+                    type AccountCardProps = { accountKey: string };
+
+                    const AccountCard = ({ accountKey }: AccountCardProps) => accountKey;
+                `,
+        },
+        {
+            code: `
+                    type FormatValueParams = { value: string };
+
+                    function formatValue({ value }: FormatValueParams) {
+                        return value;
+                    }
+                `,
+        },
+        {
+            code: `
+                    const formatValue = (params: { value: string }) => params.value;
+                `,
+        },
+        {
+            code: `
+                    type FormatValueParams = { value: string };
+
+                    const formatter = {
+                        formatValue({ value }: FormatValueParams) {
+                            return value;
+                        },
+                    };
+                `,
+        },
+        {
+            code: `
+                    type ItemParams = { value: string };
+
+                    items.map(({ value }: ItemParams) => value);
+                `,
+        },
+        {
+            code: `
+                    items.map(({ value }) => value);
+                `,
+        },
+        {
+            code: `
+                    type Item = { value: string };
+
+                    items.map(({ value }: Item) => value);
+                `,
+        },
+        {
+            code: `
+                    type NavigateToReviewParams = { transaction: string };
+
+                    const navigateToReview = useCallback(
+                        ({ transaction }: NavigateToReviewParams) => transaction,
+                        [],
+                    );
+                `,
+        },
+        {
+            code: `
+                    type AccountCardProps = { accountKey: string };
+
+                    const AccountCard = memo(({ accountKey }: AccountCardProps) => accountKey);
+                `,
+        },
+        {
+            code: `
+                    callback(
+                        ({ options }: yup.TestContext<SendFormContext>) => options,
+                    );
+                `,
+        },
+        {
+            code: `
+                    const formatValue = ({ value }) => value;
+                `,
+        },
+        {
+            code: `
+                    type Services = {
+                        formatValue: (params: { value: string }) => string;
+                    };
+
+                    const services: Services = {
+                        formatValue: ({ value }) => value,
+                    };
+                `,
+        },
+        {
+            code: `
+                    type Callback = { getValue: () => string };
+                    type Action = { result: string };
+
+                    const actionCallback = (
+                        { getValue }: Callback,
+                        { result }: Action,
+                    ) => getValue() + result;
+                `,
+        },
+        {
+            code: `
+                    type Input = { value: string };
+
+                    const formatValue = ({ value }: Input) => value;
+                `,
+        },
+        {
+            code: `
+                    type Args = { value: string };
+
+                    const formatValue = ({ value }: Args) => value;
+                `,
+        },
+        {
+            code: `
+                    type CreateCardanoAccountProps = { value: string };
+
+                    const createCardanoAccount = ({ value }: CreateCardanoAccountProps) => value;
+                `,
+        },
+        {
+            code: `
+                    const formatValue = ({ value }: Wrapper<{ value: string }>) => value;
+                `,
+        },
+        {
+            code: `
+                    items.map(({ value }: Pick<{ value: string }, 'value'>) => value);
+                `,
+        },
+    ],
+    invalid: [
+        {
+            code: `
+                    const formatValue = ({ value }: { value: string }) => value;
+                `,
+            errors: [
+                {
+                    messageId: 'inlineObjectType',
+                },
+            ],
+        },
+        {
+            code: `
+                    type Callback = { getValue: () => string };
+
+                    const actionCallback = (
+                        { getValue }: Callback,
+                        { result }: { result: string },
+                    ) => getValue() + result;
+                `,
+            errors: [
+                {
+                    messageId: 'inlineObjectType',
+                },
+            ],
+        },
+        {
+            code: `
+                    function formatValue({ value }: { value: string }) {
+                        return value;
+                    }
+                `,
+            errors: [
+                {
+                    messageId: 'inlineObjectType',
+                },
+            ],
+        },
+        {
+            code: `
+                    const formatter = {
+                        formatValue({ value }: { value: string }) {
+                            return value;
+                        },
+                    };
+                `,
+            errors: [
+                {
+                    messageId: 'inlineObjectType',
+                },
+            ],
+        },
+        {
+            code: `
+                    items.map(({ value }: { value: string }) => value);
+                `,
+            errors: [
+                {
+                    messageId: 'inlineObjectType',
+                },
+            ],
+        },
+        {
+            code: `
+                    const navigateToReview = useCallback(
+                        ({ transaction }: { transaction: string }) => transaction,
+                        [],
+                    );
+                `,
+            errors: [
+                {
+                    messageId: 'inlineObjectType',
+                },
+            ],
+        },
+    ],
+} as Parameters<typeof typescriptRuleTester.run>[2]);

--- a/eslint-local-rules/named-parameter-types/rule.ts
+++ b/eslint-local-rules/named-parameter-types/rule.ts
@@ -1,0 +1,76 @@
+import type { Rule } from 'eslint';
+import ts from 'typescript';
+
+import { createTypeScriptNodeReporter, getTypeScriptParserServices } from '../utils';
+
+type SupportedFunction =
+    | ts.ArrowFunction
+    | ts.FunctionDeclaration
+    | ts.FunctionExpression
+    | ts.GetAccessorDeclaration
+    | ts.MethodDeclaration
+    | ts.SetAccessorDeclaration;
+
+const isSupportedFunction = (node: ts.Node): node is SupportedFunction =>
+    ts.isArrowFunction(node) ||
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node);
+
+/** Enforces separately declared types for destructured object parameters. */
+export const enforceNamedParameterTypesRule: Rule.RuleModule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallows direct inline object types on destructured parameters.',
+            category: 'Best Practices',
+            recommended: false,
+        },
+        messages: {
+            inlineObjectType:
+                'An inline object type on a destructured parameter must be declared separately.',
+        },
+        schema: [],
+    },
+    create: context => {
+        const parserServices = getTypeScriptParserServices(context);
+
+        if (parserServices === undefined) {
+            return {};
+        }
+
+        const report = createTypeScriptNodeReporter(context, parserServices);
+
+        const validateFunction = (node: SupportedFunction) => {
+            node.parameters.forEach(parameter => {
+                if (
+                    ts.isObjectBindingPattern(parameter.name) &&
+                    parameter.type !== undefined &&
+                    ts.isTypeLiteralNode(parameter.type)
+                ) {
+                    report(parameter.type, 'inlineObjectType', {});
+                }
+            });
+        };
+
+        const visitNode = (node: ts.Node) => {
+            if (isSupportedFunction(node)) {
+                validateFunction(node);
+            }
+
+            ts.forEachChild(node, visitNode);
+        };
+
+        return {
+            'Program:exit': programNode => {
+                const sourceFile = parserServices.getTypeScriptNode(programNode as Rule.Node);
+
+                if (sourceFile !== undefined) {
+                    visitNode(sourceFile);
+                }
+            },
+        };
+    },
+};

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -96,6 +96,17 @@ export const localRulesConfig = [
         },
     },
     {
+        files: [
+            'networks/**/*.{ts,tsx}',
+            'packages/suite/**/*.{ts,tsx}',
+            'suite/**/*.{ts,tsx}',
+            'suite-common/**/*.{ts,tsx}',
+        ],
+        rules: {
+            'local-rules/enforce-named-parameter-types': 'error',
+        },
+    },
+    {
         files: ['**/src/**/*.{ts,tsx}'],
         ignores: ['**/__fixtures__/**', '**/*.test.{ts,tsx}', '**/*.type-test.ts'],
         rules: {

--- a/suite-common/bluetooth/src/bluetoothActions.ts
+++ b/suite-common/bluetooth/src/bluetoothActions.ts
@@ -10,10 +10,11 @@ import {
 } from './types';
 
 export const BLUETOOTH_PREFIX = '@suite/bluetooth';
+type StatusParams = { status: BluetoothAdapterStatus };
 
 const adapterEventAction = createAction(
     `${BLUETOOTH_PREFIX}/adapter-event`,
-    ({ status }: { status: BluetoothAdapterStatus }) => ({ payload: { status } }),
+    ({ status }: StatusParams) => ({ payload: { status } }),
 );
 
 type BluetoothNearbyDevicesUpdateActionPayload = {
@@ -37,37 +38,38 @@ const knownDevicesUpdateAction = createAction(
         payload: { knownDevices },
     }),
 );
+type IdParams = { id: BluetoothDeviceId };
 
 const removeKnownDeviceAction = createAction(
     `${BLUETOOTH_PREFIX}/remove-known-device`,
-    ({ id }: { id: BluetoothDeviceId }) => ({
+    ({ id }: IdParams) => ({
         payload: { id },
     }),
 );
+type DeviceParams = { device: BluetoothDeviceCommon };
 
 const deviceUpdateAction = createAction(
     `${BLUETOOTH_PREFIX}/device-update-event`,
-    ({ device }: { device: BluetoothDeviceCommon }) => ({
+    ({ device }: DeviceParams) => ({
         payload: { device },
     }),
 );
+type DeviceIdConnectionStatusParams = {
+    deviceId: BluetoothDeviceId;
+    connectionStatus: DeviceBluetoothConnectionStatus;
+};
 
 const updateDeviceConnectionStatus = createAction(
     `${BLUETOOTH_PREFIX}/update-device-connection-status`,
-    ({
-        deviceId,
-        connectionStatus,
-    }: {
-        deviceId: BluetoothDeviceId;
-        connectionStatus: DeviceBluetoothConnectionStatus;
-    }) => ({
+    ({ deviceId, connectionStatus }: DeviceIdConnectionStatusParams) => ({
         payload: { deviceId, connectionStatus },
     }),
 );
+type StatusParams2 = { status: BluetoothScanStatus };
 
 const scanStatusAction = createAction(
     `${BLUETOOTH_PREFIX}/scan-status`,
-    ({ status }: { status: BluetoothScanStatus }) => ({ payload: { status } }),
+    ({ status }: StatusParams2) => ({ payload: { status } }),
 );
 
 const enableAutoConnect = createAction(

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -45,6 +45,7 @@ export const prepareInitialState = <T extends BluetoothDeviceCommon>(): Bluetoot
 });
 
 export type BluetoothReducerDeps = ActionTypesDep<'storageLoad'>;
+type DescriptorDeviceIdParams = { payload: DeviceConnectActionPayload };
 
 export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() =>
     createReducerWithExtraDeps(prepareInitialState<T>(), (builder, extra: BluetoothReducerDeps) =>
@@ -155,7 +156,7 @@ export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>(
                         payload: {
                             device: { descriptor, id: deviceId },
                         },
-                    }: { payload: DeviceConnectActionPayload },
+                    }: DescriptorDeviceIdParams,
                 ) => {
                     if (descriptor.apiType !== 'bluetooth' || !descriptor.id) {
                         return;

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -23,14 +23,15 @@ import { selectConnectPopupCall } from '../connectPopupReducer';
 import { type PostCallHookParams, type PreCallHookParams } from './types';
 
 const temporaryAccounts: Account[] = [];
+type _storePrecomposedTransactionParams = {
+    typedPayload: EthereumSignTransaction;
+    txSigningPrecomposed: PrecomposedTransactionFinal;
+};
 
 const _storePrecomposedTransaction = ({
     typedPayload,
     txSigningPrecomposed,
-}: {
-    typedPayload: EthereumSignTransaction;
-    txSigningPrecomposed: PrecomposedTransactionFinal;
-}) =>
+}: _storePrecomposedTransactionParams) =>
     sendFormActions.storePrecomposedTransaction({
         formState: {
             // Can be left empty, not used in tx review modal

--- a/suite-common/delegated-identity-key/src/loadDelegatedIdentityKeyFromState.test.ts
+++ b/suite-common/delegated-identity-key/src/loadDelegatedIdentityKeyFromState.test.ts
@@ -1,7 +1,7 @@
 import {
+    type DecryptParams,
     DecryptionFailed,
     type EncryptableBranded,
-    type EncryptedHex,
     EncryptionUnavailable,
     asEncryptedHex,
 } from '@suite-common/platform-encryption';
@@ -18,7 +18,7 @@ describe(createLoadDelegatedIdentityKeyFromState.name, () => {
                 encrypt: () => {
                     throw new Error('Not expected!');
                 },
-                decrypt: <T extends EncryptableBranded>({ value }: { value: EncryptedHex<T> }) =>
+                decrypt: <T extends EncryptableBranded>({ value }: DecryptParams<T>) =>
                     Promise.resolve(ok(value.replace('<encrypted>', '') as T)),
             },
         });
@@ -42,7 +42,7 @@ describe(createLoadDelegatedIdentityKeyFromState.name, () => {
                 encrypt: () => {
                     throw new Error('Not expected!');
                 },
-                decrypt: <T extends EncryptableBranded>(_: { value: EncryptedHex<T> }) =>
+                decrypt: <T extends EncryptableBranded>(_: DecryptParams<T>) =>
                     Promise.resolve(err(error)),
             },
         });

--- a/suite-common/delegated-identity-key/src/saveDelegatedIdentityKey.test.ts
+++ b/suite-common/delegated-identity-key/src/saveDelegatedIdentityKey.test.ts
@@ -1,6 +1,10 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 
-import { type EncryptableBranded, asEncryptedHex } from '@suite-common/platform-encryption';
+import {
+    type EncryptParams,
+    type EncryptableBranded,
+    asEncryptedHex,
+} from '@suite-common/platform-encryption';
 import { asDelegatedIdentityKey } from '@suite-common/suite-types';
 import { ok } from '@trezor/type-utils';
 
@@ -17,7 +21,7 @@ describe(createSaveDelegatedIdentityKey.name, () => {
                 return action;
             },
             platformEncryption: {
-                encrypt: <T extends EncryptableBranded>({ value }: { value: T }) =>
+                encrypt: <T extends EncryptableBranded>({ value }: EncryptParams<T>) =>
                     Promise.resolve(ok(asEncryptedHex<T>(`${value}-<encrypted>`))),
                 decrypt: () => {
                     throw new Error('Not expected!');

--- a/suite-common/device/src/deviceUtils.ts
+++ b/suite-common/device/src/deviceUtils.ts
@@ -25,14 +25,15 @@ export const DeviceNotConnectedError = (
     type: 'DeviceNotConnectedError' as const,
     message: message ?? 'Device is not connected',
 });
+type ShouldDeviceBeRememberedParams = {
+    device: TrezorDevice | Device;
+    isAutoEjectEnabled?: boolean;
+};
 
 export const shouldDeviceBeRemembered = ({
     device,
     isAutoEjectEnabled = false,
-}: {
-    device: TrezorDevice | Device;
-    isAutoEjectEnabled?: boolean;
-}) => {
+}: ShouldDeviceBeRememberedParams) => {
     if (device.mode !== 'normal') return false;
 
     if (device.type !== 'acquired') return false;

--- a/suite-common/e2e-evolu-client/src/suiteSyncFixtures.ts
+++ b/suite-common/e2e-evolu-client/src/suiteSyncFixtures.ts
@@ -76,8 +76,11 @@ const createSuiteSyncFixtures = ({
             outputIndex,
             txId,
         }) as OutputSeed;
+    type BuildExpectedWalletParams<T extends string | null> = { label: T };
 
-    const buildExpectedWallet = <T extends string | null>({ label }: { label: T }) => ({
+    const buildExpectedWallet = <T extends string | null>({
+        label,
+    }: BuildExpectedWalletParams<T>) => ({
         id: createWalletRowId(walletDescriptor),
         updatedAt: null,
         isDeleted: null,
@@ -85,8 +88,11 @@ const createSuiteSyncFixtures = ({
         walletDescriptor,
         label,
     });
+    type BuildExpectedAccountParams<T extends string | null> = { label: T };
 
-    const buildExpectedAccount = <T extends string | null>({ label }: { label: T }) => ({
+    const buildExpectedAccount = <T extends string | null>({
+        label,
+    }: BuildExpectedAccountParams<T>) => ({
         id: createAccountRowId(accountDescriptor, networkSymbol),
         updatedAt: null,
         isDeleted: null,
@@ -95,14 +101,15 @@ const createSuiteSyncFixtures = ({
         networkSymbol,
         label,
     });
+    type BuildExpectedAddressParams<T extends string | null> = {
+        address: string;
+        label: T;
+    };
 
     const buildExpectedAddress = <T extends string | null>({
         address,
         label,
-    }: {
-        address: string;
-        label: T;
-    }) => ({
+    }: BuildExpectedAddressParams<T>) => ({
         id: createAddressRowId(address, networkSymbol),
         updatedAt: null,
         isDeleted: null,
@@ -112,16 +119,17 @@ const createSuiteSyncFixtures = ({
         address,
         label,
     });
+    type BuildExpectedOutputParams<T extends string | null> = {
+        txId: string;
+        outputIndex: string;
+        label: T;
+    };
 
     const buildExpectedOutput = <T extends string | null>({
         txId,
         outputIndex,
         label,
-    }: {
-        txId: string;
-        outputIndex: string;
-        label: T;
-    }) => ({
+    }: BuildExpectedOutputParams<T>) => ({
         id: createOutputRowId(txId, asTxTargetId(outputIndex)),
         updatedAt: null,
         isDeleted: null,

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -50,16 +50,17 @@ const DEFAULT_LOCALE: Locale = 'en-US';
 const isLocale = (value: string): value is Locale => Object.hasOwn(LANGUAGES, value);
 
 const getSafeLocale = (locale: string): Locale => (isLocale(locale) ? locale : DEFAULT_LOCALE);
+type AppendEllipsisParams = {
+    value: string;
+    wasResultRounded: boolean;
+    formatterContext: Partial<CryptoAmountFormatterDataContext>;
+};
 
 const appendEllipsis = ({
     value,
     wasResultRounded,
     formatterContext,
-}: {
-    value: string;
-    wasResultRounded: boolean;
-    formatterContext: Partial<CryptoAmountFormatterDataContext>;
-}): string => {
+}: AppendEllipsisParams): string => {
     const { isEllipsisAppended = true } = formatterContext;
 
     if (wasResultRounded && isEllipsisAppended) {
@@ -68,16 +69,17 @@ const appendEllipsis = ({
 
     return value;
 };
+type FormatExactCryptoAmountParams = {
+    value: string;
+    locale: Locale;
+    formatterContext: Partial<CryptoAmountFormatterDataContext>;
+};
 
 const formatExactCryptoAmount = ({
     value,
     locale,
     formatterContext,
-}: {
-    value: string;
-    locale: Locale;
-    formatterContext: Partial<CryptoAmountFormatterDataContext>;
-}): string => {
+}: FormatExactCryptoAmountParams): string => {
     const { maxDisplayedDecimals = BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } = formatterContext;
     const cryptoAmount = new BigNumber(value);
     const truncatedCryptoAmount = cryptoAmount.isFinite()
@@ -96,16 +98,17 @@ type NormalizedCryptoAmount = {
     value: string;
     areSubunitsDisplayed: boolean;
 };
+type NormalizeCryptoAmountForDisplayParams = {
+    value: string;
+    config: FormatterConfig;
+    formatterContext: Partial<CryptoAmountFormatterDataContext>;
+};
 
 const normalizeCryptoAmountForDisplay = ({
     value,
     config,
     formatterContext,
-}: {
-    value: string;
-    config: FormatterConfig;
-    formatterContext: Partial<CryptoAmountFormatterDataContext>;
-}): NormalizedCryptoAmount => {
+}: NormalizeCryptoAmountForDisplayParams): NormalizedCryptoAmount => {
     const { symbol, isBalance = false, smallestUnitsOverride } = formatterContext;
     const { bitcoinAmountUnit } = config;
     const decimals = getNetworkOptional(symbol)?.decimals ?? 0;
@@ -145,18 +148,19 @@ const normalizeCryptoAmountForDisplay = ({
     // branch above.
     return { value, areSubunitsDisplayed: !isBalance };
 };
+type FormatCryptoAmountForDisplayParams = {
+    value: string;
+    config: FormatterConfig;
+    formatterContext: Partial<CryptoAmountFormatterDataContext>;
+    areSubunitsDisplayed: boolean;
+};
 
 const formatCryptoAmountForDisplay = ({
     value,
     config,
     formatterContext,
     areSubunitsDisplayed,
-}: {
-    value: string;
-    config: FormatterConfig;
-    formatterContext: Partial<CryptoAmountFormatterDataContext>;
-    areSubunitsDisplayed: boolean;
-}): string => {
+}: FormatCryptoAmountForDisplayParams): string => {
     const { formatStyle = 'exact', tokenDecimals } = formatterContext;
     const locale = getSafeLocale(config.locale);
 
@@ -174,16 +178,13 @@ const formatCryptoAmountForDisplay = ({
             return exhaustive(formatStyle);
     }
 };
-
-const appendSymbol = ({
-    value,
-    config,
-    formatterContext,
-}: {
+type AppendSymbolParams = {
     value: string;
     config: FormatterConfig;
     formatterContext: Partial<CryptoAmountFormatterDataContext>;
-}) => {
+};
+
+const appendSymbol = ({ value, config, formatterContext }: AppendSymbolParams) => {
     const { symbol, smallestUnitsOverride, withSymbol = true } = formatterContext;
 
     if (!withSymbol) {

--- a/suite-common/formatters/src/utils/formatCompactCryptoAmount.ts
+++ b/suite-common/formatters/src/utils/formatCompactCryptoAmount.ts
@@ -31,41 +31,36 @@ const getCompactCryptoAmountScale = (absoluteValue: BigNumber): CompactCryptoAmo
 
     return null;
 };
+type FormatTruncatedCryptoAmountParams = {
+    value: BigNumber;
+    locale: Locale;
+    minDecimalPlaces?: number;
+    decimalPlaces: number;
+};
 
 const formatTruncatedCryptoAmount = ({
     value,
     locale,
     minDecimalPlaces = 0,
     decimalPlaces,
-}: {
-    value: BigNumber;
-    locale: Locale;
-    minDecimalPlaces?: number;
-    decimalPlaces: number;
-}): string => {
+}: FormatTruncatedCryptoAmountParams): string => {
     const truncatedValue = truncateCryptoAmount(value, decimalPlaces);
 
     return localizeNumber(truncatedValue.toFixed(), locale, minDecimalPlaces, decimalPlaces);
+};
+type FormatCompactDustLimitParams = {
+    limit: BigNumber;
+    locale: Locale;
+    decimalPlaces: number;
 };
 
 const formatCompactDustLimit = ({
     limit,
     locale,
     decimalPlaces,
-}: {
-    limit: BigNumber;
-    locale: Locale;
-    decimalPlaces: number;
-}): string => `<${localizeNumber(limit.toFixed(), locale, decimalPlaces, decimalPlaces)}`;
-
-export const formatCompactCryptoAmount = ({
-    value,
-    locale,
-    // Money-like values (e.g. tokens with 6 decimals such as stablecoins) are rendered with
-    // two decimals to resemble fiat, with a higher `<0.01` dust threshold.
-    isMoneyLike = false,
-    areSubunitsDisplayed = false,
-}: {
+}: FormatCompactDustLimitParams): string =>
+    `<${localizeNumber(limit.toFixed(), locale, decimalPlaces, decimalPlaces)}`;
+type FormatCompactCryptoAmountParams = {
     value: string;
     locale: Locale;
     isMoneyLike?: boolean;
@@ -75,7 +70,16 @@ export const formatCompactCryptoAmount = ({
      * unit the user deliberately switched to.
      */
     areSubunitsDisplayed?: boolean;
-}): string => {
+};
+
+export const formatCompactCryptoAmount = ({
+    value,
+    locale,
+    // Money-like values (e.g. tokens with 6 decimals such as stablecoins) are rendered with
+    // two decimals to resemble fiat, with a higher `<0.01` dust threshold.
+    isMoneyLike = false,
+    areSubunitsDisplayed = false,
+}: FormatCompactCryptoAmountParams): string => {
     const cryptoAmount = new BigNumber(value);
     const absoluteCryptoAmount = cryptoAmount.abs();
 

--- a/suite-common/graph/src/balanceHistoryUtils.ts
+++ b/suite-common/graph/src/balanceHistoryUtils.ts
@@ -317,19 +317,20 @@ const getAccountHistoryMovementItemETH = ({
         tokens: sortedTokensSummaries,
     };
 };
+type GetAccountHistoryMovementFromTransactionsParams = {
+    transactions: WalletAccountTransaction[];
+    // We need to revaluate if we want to calculate BTC history from transactions or use blockbook
+    symbol: LocalBalanceHistoryCoin | 'btc';
+    from?: number;
+    to?: number;
+};
 
 export const getAccountHistoryMovementFromTransactions = ({
     transactions,
     symbol,
     from,
     to,
-}: {
-    transactions: WalletAccountTransaction[];
-    // We need to revaluate if we want to calculate BTC history from transactions or use blockbook
-    symbol: LocalBalanceHistoryCoin | 'btc';
-    from?: number;
-    to?: number;
-}): AccountHistoryMovement => {
+}: GetAccountHistoryMovementFromTransactionsParams): AccountHistoryMovement => {
     switch (symbol) {
         case 'btc':
             return getAccountHistoryMovementItemBTC({ transactions, from, to });

--- a/suite-common/graph/src/graphBalanceEvents.ts
+++ b/suite-common/graph/src/graphBalanceEvents.ts
@@ -70,21 +70,17 @@ export const groupBalanceMovementEvents = (
 
     return groups;
 };
-
-/**
- * Reduces each balance movements group to a single balance movement point.
- */
-export const mergeGroups = ({
-    groups,
-    symbol,
-    tokenAddress,
-    accountKey,
-}: {
+type MergeGroupsParams = {
     groups: BalanceMovementEvent[][];
     symbol: NetworkSymbol;
     accountKey: AccountKey;
     tokenAddress?: TokenAddress;
-}) =>
+};
+
+/**
+ * Reduces each balance movements group to a single balance movement point.
+ */
+export const mergeGroups = ({ groups, symbol, tokenAddress, accountKey }: MergeGroupsParams) =>
     A.map(groups, group => {
         const averageTimestamp =
             group.reduce((sum, nextBalanceObject) => sum + nextBalanceObject.date, 0) /
@@ -122,18 +118,19 @@ export const mergeGroups = ({
 
 /**  Relative number that ensure that there is no more than 30 points in each graph.  */
 const GROUPING_DIVISOR = 30000;
+type GetAccountMovementEventsParams = {
+    account: AccountItem;
+    startOfTimeFrameDate: Date | null;
+    endOfTimeFrameDate: Date;
+    dispatch: Dispatch;
+};
 
 export const getAccountMovementEvents = async ({
     account,
     startOfTimeFrameDate,
     endOfTimeFrameDate,
     dispatch,
-}: {
-    account: AccountItem;
-    startOfTimeFrameDate: Date | null;
-    endOfTimeFrameDate: Date;
-    dispatch: Dispatch;
-}) => {
+}: GetAccountMovementEventsParams) => {
     const { symbol, identity, descriptor, tokensFilter, accountKey } = account;
     const tokenAddress = tokensFilter?.[0]; // This is only for graph on detail screen where we have always only one token
 

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -74,16 +74,17 @@ const addBalanceForAccountMovementHistory = (
 
     return historyWithBalance;
 };
+type GetLatestAccountInfoParams = {
+    symbol: NetworkSymbol;
+    identity?: string;
+    descriptor: string;
+};
 
 const getLatestAccountInfo = async ({
     symbol,
     identity,
     descriptor,
-}: {
-    symbol: NetworkSymbol;
-    identity?: string;
-    descriptor: string;
-}) => {
+}: GetLatestAccountInfoParams) => {
     const accountInfo = await TrezorConnect.getAccountInfo({
         coin: asCoinSymbol(symbol),
         identity,
@@ -98,16 +99,17 @@ const getLatestAccountInfo = async ({
 
     return accountInfo.payload;
 };
+type GetBalanceFromAccountInfoParams = {
+    accountInfo: AccountInfo;
+    symbol: NetworkSymbol;
+    contractId?: string;
+};
 
 const getBalanceFromAccountInfo = ({
     accountInfo,
     symbol,
     contractId,
-}: {
-    accountInfo: AccountInfo;
-    symbol: NetworkSymbol;
-    contractId?: string;
-}) => {
+}: GetBalanceFromAccountInfoParams) => {
     const networkType = getNetworkType(symbol);
 
     const findTokenBalance = () => {
@@ -138,6 +140,13 @@ const getBalanceFromAccountInfo = ({
 };
 
 const accountBalanceHistoryCache: Record<string, AccountBalanceHistoryWithTokens> = {};
+type GetAccountBalanceHistoryParams = {
+    accountItem: AccountItem;
+    endOfTimeFrameDate: Date;
+    startOfTimeFrameDate: Date | null;
+    forceRefetch?: boolean;
+    dispatch: Dispatch;
+};
 
 const getAccountBalanceHistory = async ({
     accountItem,
@@ -147,13 +156,7 @@ const getAccountBalanceHistory = async ({
     // We pass dispatch because we need to fetch all transactions using redux thunk. This is a workaround for now to keep things simple.
     // In future we should convert this to proper thunk so we can use dispatch and selectors from thunkAPI.
     dispatch,
-}: {
-    accountItem: AccountItem;
-    endOfTimeFrameDate: Date;
-    startOfTimeFrameDate: Date | null;
-    forceRefetch?: boolean;
-    dispatch: Dispatch;
-}): Promise<AccountBalanceHistoryWithTokens> => {
+}: GetAccountBalanceHistoryParams): Promise<AccountBalanceHistoryWithTokens> => {
     const { symbol, identity, descriptor, accountKey, tokensFilter } = accountItem;
     const endTimeFrameTimestamp = getUnixTime(endOfTimeFrameDate);
     const startOfTimeFrameDateTimestamp = startOfTimeFrameDate
@@ -492,13 +495,13 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
     ];
 
     type CoinKey = `${NetworkSymbol}-${TokenAddress}` | `${NetworkSymbol}-`;
-    const getCoinKey = ({
-        symbol,
-        contractId,
-    }: {
+    type GetCoinKeyParams = {
         symbol: NetworkSymbol;
         contractId?: TokenAddress;
-    }): CoinKey => `${symbol}-${contractId ?? ''}`;
+    };
+
+    const getCoinKey = ({ symbol, contractId }: GetCoinKeyParams): CoinKey =>
+        `${symbol}-${contractId ?? ''}`;
 
     // Using Set is faster than A.uniq because it's O(n) instead of O(n^2)
     const coinsSet = new Set<CoinKey>();

--- a/suite-common/icons/scripts/utils/downloadVaultIcons.test.ts
+++ b/suite-common/icons/scripts/utils/downloadVaultIcons.test.ts
@@ -52,16 +52,18 @@ const fakeResponse = ({ status = 200, json, buffer }: FakeResponseInit): Respons
 
     return response as unknown as Response;
 };
-
-const vault = ({
-    address,
-    underlyingToken,
-    coingeckoId,
-}: {
+type VaultParams = {
     address: string;
     underlyingToken: string;
     coingeckoId: string;
-}) => ({ yieldId: `vault-${address}`, address, underlyingToken, coingeckoId });
+};
+
+const vault = ({ address, underlyingToken, coingeckoId }: VaultParams) => ({
+    yieldId: `vault-${address}`,
+    address,
+    underlyingToken,
+    coingeckoId,
+});
 
 const iconUrl = (coingeckoId: string, size: (typeof COIN_IMAGE_SIZES)[number]) =>
     `${ICONS_URL_BASE}/${createCoinImageName({ coingeckoId, size })}`;

--- a/suite-common/platform-encryption/src/index.ts
+++ b/suite-common/platform-encryption/src/index.ts
@@ -2,6 +2,8 @@ export type {
     PlatformEncryption,
     EncryptedHex,
     EncryptableBranded,
+    EncryptParams,
+    DecryptParams,
     DecryptionError,
     EncryptionError,
 } from './platformEncryption';

--- a/suite-common/platform-encryption/src/platformEncryption.ts
+++ b/suite-common/platform-encryption/src/platformEncryption.ts
@@ -27,6 +27,10 @@ export const DecryptionFailed = (): DecryptionFailed => ({
 export type EncryptionError = EncryptionUnavailable;
 export type DecryptionError = EncryptionUnavailable | DecryptionFailed;
 
+export type EncryptParams<T extends EncryptableBranded> = { value: T };
+
+export type DecryptParams<T extends EncryptableBranded> = { value: EncryptedHex<T> };
+
 export type PlatformEncryptionDep = { platformEncryption: PlatformEncryption };
 
 export const selectPlatformEncryptionDep = (services: any): PlatformEncryptionDep => ({
@@ -34,11 +38,11 @@ export const selectPlatformEncryptionDep = (services: any): PlatformEncryptionDe
 });
 
 export interface PlatformEncryption {
-    encrypt: <T extends EncryptableBranded>(params: {
-        value: T;
-    }) => Promise<Result<EncryptedHex<T>, EncryptionError>>;
+    encrypt: <T extends EncryptableBranded>(
+        params: EncryptParams<T>,
+    ) => Promise<Result<EncryptedHex<T>, EncryptionError>>;
 
-    decrypt: <T extends EncryptableBranded>(params: {
-        value: EncryptedHex<T>;
-    }) => Promise<Result<T, DecryptionError>>;
+    decrypt: <T extends EncryptableBranded>(
+        params: DecryptParams<T>,
+    ) => Promise<Result<T, DecryptionError>>;
 }

--- a/suite-common/receive/src/receiveSlice.test.ts
+++ b/suite-common/receive/src/receiveSlice.test.ts
@@ -22,18 +22,18 @@ const ethereumAccount = mockWalletAccount(
     { symbol: asNetworkSymbol('eth') },
     networkSpecificDefaultEthereum,
 );
+type StorageLoadReceiveAccountsParams = {
+    payload: {
+        receive?: { key: string; value: ReceiveAccountState }[];
+    };
+};
+
 const extraDependencies: ReceiveSliceDeps = {
     actionTypes: { storageLoad: mockActionType('storageLoad') },
     reducers: {
         storageLoadReceiveAccounts: (
             state: ReceiveState,
-            {
-                payload,
-            }: {
-                payload: {
-                    receive?: { key: string; value: ReceiveAccountState }[];
-                };
-            },
+            { payload }: StorageLoadReceiveAccountsParams,
         ) => {
             state.accounts =
                 payload.receive?.reduce<ReceiveState['accounts']>((accounts, { key, value }) => {

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerUrl.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerUrl.ts
@@ -54,8 +54,9 @@ const getTorVariant = (isTorEnabled: boolean): TorVariant => (isTorEnabled ? 'on
 
 export const getQuotaManagerUrl = ({ env, isTorEnabled }: GetQuotaManagerUrlParams) =>
     QUOTA_MANAGER_URL[env][getTorVariant(isTorEnabled)];
+type GetQuotaManagerDefaultUrlParams = { isTorEnabled: boolean };
 
-export const getQuotaManagerDefaultUrl = ({ isTorEnabled }: { isTorEnabled: boolean }) =>
+export const getQuotaManagerDefaultUrl = ({ isTorEnabled }: GetQuotaManagerDefaultUrlParams) =>
     getQuotaManagerUrl({ env: getQuotaManagerUrlEnvironment(), isTorEnabled });
 
 export const selectQuotaManagerCustomUrl = (state: WithSuiteSyncQuotaManagerState) => {

--- a/suite-common/suite-sync/src/relay/relayUrl.ts
+++ b/suite-common/suite-sync/src/relay/relayUrl.ts
@@ -50,8 +50,11 @@ export const getSuiteSyncRelayUrl = ({ env, isTorEnabled }: GetSuiteSyncRelayUrl
     SUITE_SYNC_RELAY_URL[env][getTorVariant(isTorEnabled)];
 
 const getSuiteSyncRelayUrlEnvironment = (): Environment => (isCodesignBuild() ? 'prod' : 'dev');
+type GetSuiteSyncDefaultRelayUrlParams = { isTorEnabled: boolean };
 
-export const getSuiteSyncDefaultRelayUrl = ({ isTorEnabled }: { isTorEnabled: boolean }): string =>
+export const getSuiteSyncDefaultRelayUrl = ({
+    isTorEnabled,
+}: GetSuiteSyncDefaultRelayUrlParams): string =>
     getSuiteSyncRelayUrl({
         env: getSuiteSyncRelayUrlEnvironment(),
         isTorEnabled,

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -521,22 +521,25 @@ export const getDeviceModelWithFlagshipFallback = (
 export const getIsThpDevice = <T extends Device | TrezorDevice>(
     device: T,
 ): device is T & { thp: NonNullable<Device['thp']> } => device.thp !== undefined;
+type GetIsDeviceInitializedParams = {
+    deviceMode?: DeviceMode | null;
+    deviceFeatures?: PROTO.Features;
+};
 
 export const getIsDeviceInitialized = ({
     deviceMode,
     deviceFeatures,
-}: {
-    deviceMode?: DeviceMode | null;
+}: GetIsDeviceInitializedParams) =>
+    deviceMode !== 'initialize' && deviceMode !== 'seedless' && !!deviceFeatures?.initialized;
+type GetIsDeviceConnectedAndAuthorizedParams = {
+    deviceState: TrezorDevice['state'];
     deviceFeatures?: PROTO.Features;
-}) => deviceMode !== 'initialize' && deviceMode !== 'seedless' && !!deviceFeatures?.initialized;
+};
 
 export const getIsDeviceConnectedAndAuthorized = ({
     deviceState,
     deviceFeatures,
-}: {
-    deviceState: TrezorDevice['state'];
-    deviceFeatures?: PROTO.Features;
-}) => !!deviceState && !!deviceFeatures;
+}: GetIsDeviceConnectedAndAuthorizedParams) => !!deviceState && !!deviceFeatures;
 
 export const getIsDeviceDescriptorApiTypeBluetooth = (device: Device | TrezorDevice) =>
     device.descriptor?.apiType === 'bluetooth';

--- a/suite-common/test-utils/src/createTestStore.ts
+++ b/suite-common/test-utils/src/createTestStore.ts
@@ -35,14 +35,12 @@ export type CreateTestStoreParams<S, A extends UnknownAction, Extra> = {
 // createThunk represents `void` dependencies as an empty object internally. Mirror that here so
 // dependency-free thunks remain dispatchable while tests still have to pass `extra: undefined`.
 type MockStoreExtra<Extra> = [Extra] extends [void] ? Record<never, never> : Extra;
-
-export const initPreloadedState = ({
-    rootReducer,
-    partialState,
-}: {
+type InitPreloadedStateParams = {
     rootReducer: Reducer<any, any, any>;
     partialState: any;
-}) =>
+};
+
+export const initPreloadedState = ({ rootReducer, partialState }: InitPreloadedStateParams) =>
     mergeDeepObject.withOptions(
         { mergeArrays: false },
         rootReducer(undefined, { type: 'test-init' }),

--- a/suite-common/test-utils/src/renderWithQueryClient.tsx
+++ b/suite-common/test-utils/src/renderWithQueryClient.tsx
@@ -10,13 +10,14 @@ export const newTestQueryClient = () =>
     new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
 
 type Options<Props> = RenderHookOptions<Props> & { queryClient?: QueryClient };
+type WrapperParams = { children: ReactNode };
 
 export const renderHookWithQueryClient = <Result, Props>(
     callback: (props: Props) => Result,
     { wrapper: Wrapper, queryClient = newTestQueryClient(), ...options }: Options<Props> = {},
 ) =>
     renderHook(callback, {
-        wrapper: ({ children }: { children: ReactNode }) => (
+        wrapper: ({ children }: WrapperParams) => (
             <QueryClientProvider client={queryClient}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
             </QueryClientProvider>

--- a/suite-common/trading/src/hooks/usePreferredCurrencyUsdThreshold.ts
+++ b/suite-common/trading/src/hooks/usePreferredCurrencyUsdThreshold.ts
@@ -21,16 +21,17 @@ const BTC_TICKERS: TickerId[] = [{ symbol: 'btc' }];
 const NO_MISSING_TICKERS: TickerId[] = [];
 
 type PreferredCurrencyUsdThresholdRootState = FiatRatesRootState;
+type CalculatePreferredCurrencyUsdThresholdParams = {
+    baseCurrency: BaseCurrencyCode;
+    btcUsdRate: number | undefined;
+    btcBaseCurrencyRate: number | undefined;
+};
 
 export const calculatePreferredCurrencyUsdThreshold = ({
     baseCurrency,
     btcUsdRate,
     btcBaseCurrencyRate,
-}: {
-    baseCurrency: BaseCurrencyCode;
-    btcUsdRate: number | undefined;
-    btcBaseCurrencyRate: number | undefined;
-}): BaseCurrencyAmount | null => {
+}: CalculatePreferredCurrencyUsdThresholdParams): BaseCurrencyAmount | null => {
     if (baseCurrency === 'usd') {
         return asBaseCurrencyAmount(USD_ASSET_THRESHOLD);
     }

--- a/suite-common/trading/src/hooks/useTradingAssets.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.ts
@@ -242,9 +242,10 @@ export function useTradingAssets() {
         () => new Set(networkModuleRepository.getSupportedNetworks()),
         [networkModuleRepository],
     );
+    type BuildAssetOptionsParams = { includedCryptoIds?: Set<CryptoId> };
 
     const buildAssetOptions = useCallback(
-        ({ includedCryptoIds = new Set() }: { includedCryptoIds?: Set<CryptoId> }) => {
+        ({ includedCryptoIds = new Set() }: BuildAssetOptionsParams) => {
             const { coins, platforms } = getCoinsAndPlatforms();
 
             const assets = Array.from(includedCryptoIds)

--- a/suite-common/trading/src/hooks/useTradingRequestedAmountShortfall.ts
+++ b/suite-common/trading/src/hooks/useTradingRequestedAmountShortfall.ts
@@ -133,18 +133,19 @@ const getExchangeRequestedAndQuoteAmounts = (
         cryptoId: quote.send,
     };
 };
+type GetRequestedAndQuoteAmountsParams = {
+    quote: TradingTradeType;
+    buyQuotesRequest: ReturnType<typeof selectTradingBuyQuotesRequest>;
+    sellQuotesRequest: ReturnType<typeof selectTradingSellQuotesRequest>;
+    exchangeQuotesRequest: ReturnType<typeof selectTradingExchangeQuotesRequest>;
+};
 
 const getRequestedAndQuoteAmounts = ({
     quote,
     buyQuotesRequest,
     sellQuotesRequest,
     exchangeQuotesRequest,
-}: {
-    quote: TradingTradeType;
-    buyQuotesRequest: ReturnType<typeof selectTradingBuyQuotesRequest>;
-    sellQuotesRequest: ReturnType<typeof selectTradingSellQuotesRequest>;
-    exchangeQuotesRequest: ReturnType<typeof selectTradingExchangeQuotesRequest>;
-}) => {
+}: GetRequestedAndQuoteAmountsParams) => {
     if (isBuyTrade(quote)) {
         return getBuyRequestedAndQuoteAmounts(quote, buyQuotesRequest);
     }

--- a/suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.test.ts
@@ -229,9 +229,10 @@ describe('prefetchDexQuoteApprovalThunk', () => {
 
         let resolveA: (() => void) | undefined;
         let resolveB: (() => void) | undefined;
+        type TradeParams = { trade: ExchangeTrade };
 
         jest.spyOn(tradeApi, 'doExchangeTrade').mockImplementation(
-            ({ trade }: { trade: ExchangeTrade }) =>
+            ({ trade }: TradeParams) =>
                 new Promise(resolve => {
                     const done = () => resolve({ quoteId: trade.quoteId } as ExchangeTrade);
                     if (trade.quoteId === quoteA.quoteId) {

--- a/suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts
+++ b/suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts
@@ -21,10 +21,11 @@ const usdcAssetDiff = {
     in: [{ raw_value: '0xee6b280', value: '250' }],
     out: [],
 };
+type CreateSimulationResultParams = { simulationStatus?: 'Success' | 'Error' };
 
 const createSimulationResult = (
     assetsDiffs: unknown[],
-    { simulationStatus = 'Success' }: { simulationStatus?: 'Success' | 'Error' } = {},
+    { simulationStatus = 'Success' }: CreateSimulationResultParams = {},
 ): NetworkTxSimulationResult =>
     ({
         method: 'ethereumSignTransaction',

--- a/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
+++ b/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
@@ -40,16 +40,18 @@ export const isResolvedTradeError = (value: unknown): value is ResolvedTradeErro
 
 export type TradingErrorDisplay =
     { kind: 'detailed'; values: TradingErrorValuesRecord } | { kind: 'base'; message?: string };
+type GetTradingErrorDisplayParams = {
+    values?: TradingErrorValuesRecord;
+    message?: string;
+};
 
 // This helper is prepared for using in desktop and native mobile apps,
 // where we can use rich text formatting for structured error messages.
 export const getTradingErrorDisplay = ({
     values,
     message,
-}: {
-    values?: TradingErrorValuesRecord;
-    message?: string;
-}): TradingErrorDisplay => (values ? { kind: 'detailed', values } : { kind: 'base', message });
+}: GetTradingErrorDisplayParams): TradingErrorDisplay =>
+    values ? { kind: 'detailed', values } : { kind: 'base', message };
 
 export const resolveExchangeTradeError = (
     source: Partial<TradeError>,

--- a/suite-common/trading/src/utils/sell/sellUtils.ts
+++ b/suite-common/trading/src/utils/sell/sellUtils.ts
@@ -81,14 +81,15 @@ const getStatusMessage = (status: SellTradeStatus) => {
             return 'TR_SELL_STATUS_PENDING';
     }
 };
+type NeedToRegisterOrVerifyBankAccountParams = {
+    sellInfo: TradingSellInfoSelector;
+    quote: SellFiatTrade;
+};
 
 const needToRegisterOrVerifyBankAccount = ({
     sellInfo,
     quote,
-}: {
-    sellInfo: TradingSellInfoSelector;
-    quote: SellFiatTrade;
-}) => {
+}: NeedToRegisterOrVerifyBankAccountParams) => {
     const provider = quote.exchange ? sellInfo.providerInfos[quote.exchange] : undefined;
 
     // for BANK_ACCOUNT flow a message is shown if bank account is not verified

--- a/suite-common/trading/src/utils/signature/signatureUtils.ts
+++ b/suite-common/trading/src/utils/signature/signatureUtils.ts
@@ -13,14 +13,15 @@ import { validatePath } from '@trezor/connect-common';
 import { BigNumber, formatBigUintToLE } from '@trezor/utils';
 
 import { cryptoIdToNetworkAndContractAddress } from '../../utils';
+type FormatSlip24SendAmountByNetworkParams = {
+    value: string | number;
+    network: Network;
+};
 
 export const formatSlip24SendAmountByNetwork = ({
     value,
     network,
-}: {
-    value: string | number;
-    network: Network;
-}): string => {
+}: FormatSlip24SendAmountByNetworkParams): string => {
     // SLIP-24: 8 bytes for Bitcoin-like coins and 32 bytes for EVM assets
     const bytesLength = network.networkType === 'ethereum' ? 32 : 8;
 
@@ -28,6 +29,11 @@ export const formatSlip24SendAmountByNetwork = ({
         value: new BigNumber(value),
         bytesLength,
     });
+};
+type FormatSlip24AddressByNetworkParams = {
+    address: string;
+    network: Network;
+    destinationTag?: string;
 };
 
 /**
@@ -46,11 +52,7 @@ export const formatSlip24AddressByNetwork = ({
     address,
     network,
     destinationTag,
-}: {
-    address: string;
-    network: Network;
-    destinationTag?: string;
-}): string => {
+}: FormatSlip24AddressByNetworkParams): string => {
     switch (network.networkType) {
         case 'ethereum':
             return toChecksumAddress(address);

--- a/suite-common/trading/src/utils/tradeableAssetBalanceUtils.ts
+++ b/suite-common/trading/src/utils/tradeableAssetBalanceUtils.ts
@@ -25,16 +25,17 @@ type AggregatedCryptoAmount = {
     symbol: Parameters<typeof getFiatRateKey>[0];
     contractAddress?: TokenAddress;
 };
+type AggregateTradeableAssetBalancesParams = {
+    accounts: readonly Account[];
+    fiatRates: RatesByKey | undefined;
+    baseCurrency: BaseCurrencyCode;
+};
 
 export const aggregateTradeableAssetBalances = ({
     accounts,
     fiatRates,
     baseCurrency,
-}: {
-    accounts: readonly Account[];
-    fiatRates: RatesByKey | undefined;
-    baseCurrency: BaseCurrencyCode;
-}): TradeableAssetBalances => {
+}: AggregateTradeableAssetBalancesParams): TradeableAssetBalances => {
     const amountsByCryptoId = new Map<CryptoId, AggregatedCryptoAmount>();
 
     const addAmount = (

--- a/suite-common/trading/src/utils/tradeableAssetGroupUtils.ts
+++ b/suite-common/trading/src/utils/tradeableAssetGroupUtils.ts
@@ -5,18 +5,19 @@ export type TradeableAssetGroups<TAsset> = {
     lowBalanceAssets: TAsset[];
     nonTradeableAssets: TAsset[];
 };
+type GroupTradeableAssetsByTradabilityParams<TAsset> = {
+    assets: readonly TAsset[];
+    threshold: BaseCurrencyAmount | null;
+    getFiatBalance: (asset: TAsset) => BaseCurrencyAmount | null;
+    getIsTradeable: (asset: TAsset) => boolean;
+};
 
 export const groupTradeableAssetsByTradability = <TAsset>({
     assets,
     threshold,
     getFiatBalance,
     getIsTradeable,
-}: {
-    assets: readonly TAsset[];
-    threshold: BaseCurrencyAmount | null;
-    getFiatBalance: (asset: TAsset) => BaseCurrencyAmount | null;
-    getIsTradeable: (asset: TAsset) => boolean;
-}): TradeableAssetGroups<TAsset> => {
+}: GroupTradeableAssetsByTradabilityParams<TAsset>): TradeableAssetGroups<TAsset> => {
     const regularAssets: TAsset[] = [];
     const lowBalanceAssets: TAsset[] = [];
     const nonTradeableAssets: TAsset[] = [];

--- a/suite-common/trading/src/utils/tradeableAssetListUtils.test.ts
+++ b/suite-common/trading/src/utils/tradeableAssetListUtils.test.ts
@@ -58,16 +58,17 @@ const createBalances = (
     );
 
 const threshold = asBaseCurrencyAmount(new BigNumber('0.1'));
+type OrderAssetsParams = {
+    assets: TestAsset[];
+    balances?: TradeableAssetBalances;
+    thresholdAmount?: BaseCurrencyAmount | null;
+};
 
 const orderAssets = ({
     assets,
     balances = new Map(),
     thresholdAmount = threshold,
-}: {
-    assets: TestAsset[];
-    balances?: TradeableAssetBalances;
-    thresholdAmount?: BaseCurrencyAmount | null;
-}) =>
+}: OrderAssetsParams) =>
     orderTradeableAssetsByOwnership({
         assets,
         balances,

--- a/suite-common/trading/src/utils/tradeableAssetListUtils.ts
+++ b/suite-common/trading/src/utils/tradeableAssetListUtils.ts
@@ -28,6 +28,12 @@ export type TradeableAssetSearchFields = {
 export type TradeableAssetSearchEntry = TradeableAssetSearchFields & { sortName: string };
 
 export type TradeableAssetSearchIndex<TAsset> = ReadonlyMap<TAsset, TradeableAssetSearchEntry>;
+type OrderTradeableAssetsByOwnershipParams<TAsset> = {
+    assets: readonly TAsset[];
+    balances: TradeableAssetBalances;
+    threshold: BaseCurrencyAmount | null;
+    getAssetCryptoId: (asset: TAsset) => CryptoId;
+};
 
 /**
  * Featured assets first in their fixed order, then owned assets worth more than the threshold
@@ -38,12 +44,7 @@ export const orderTradeableAssetsByOwnership = <TAsset>({
     balances,
     threshold,
     getAssetCryptoId,
-}: {
-    assets: readonly TAsset[];
-    balances: TradeableAssetBalances;
-    threshold: BaseCurrencyAmount | null;
-    getAssetCryptoId: (asset: TAsset) => CryptoId;
-}): TAsset[] => {
+}: OrderTradeableAssetsByOwnershipParams<TAsset>): TAsset[] => {
     const featuredAssets = new Array<TAsset | undefined>(FEATURED_ASSET_CRYPTO_IDS.length);
     const ownedAssets: TAsset[] = [];
     const remainingAssets: TAsset[] = [];
@@ -82,14 +83,15 @@ export const orderTradeableAssetsByOwnership = <TAsset>({
         ...remainingAssets,
     ];
 };
+type BuildTradeableAssetSearchIndexParams<TAsset extends object> = {
+    assets: readonly TAsset[];
+    getSearchFields: (asset: TAsset) => TradeableAssetSearchFields;
+};
 
 export const buildTradeableAssetSearchIndex = <TAsset extends object>({
     assets,
     getSearchFields,
-}: {
-    assets: readonly TAsset[];
-    getSearchFields: (asset: TAsset) => TradeableAssetSearchFields;
-}): TradeableAssetSearchIndex<TAsset> =>
+}: BuildTradeableAssetSearchIndexParams<TAsset>): TradeableAssetSearchIndex<TAsset> =>
     new Map(
         assets.map(asset => {
             const fields = getSearchFields(asset);
@@ -160,6 +162,11 @@ const getAssetWeight = (searchFields: TradeableAssetSearchFields, query: string)
 
     return 13;
 };
+type FilterTradeableAssetsBySearchParams<TAsset extends object> = {
+    assets: readonly TAsset[];
+    searchIndex: TradeableAssetSearchIndex<TAsset>;
+    search: string;
+};
 
 /**
  * Keeps only assets matching the search, ranked by how well they match — an exact name hit wins
@@ -169,11 +176,7 @@ export const filterTradeableAssetsBySearch = <TAsset extends object>({
     assets,
     searchIndex,
     search,
-}: {
-    assets: readonly TAsset[];
-    searchIndex: TradeableAssetSearchIndex<TAsset>;
-    search: string;
-}): TAsset[] => {
+}: FilterTradeableAssetsBySearchParams<TAsset>): TAsset[] => {
     const query = normalizeForSearch(search);
 
     if (!query) {

--- a/suite-common/wallet-config/src/earnRewardsProvider.ts
+++ b/suite-common/wallet-config/src/earnRewardsProvider.ts
@@ -9,10 +9,11 @@ const MERKL_XYZ_CONTRACT: Partial<Record<NetworkSymbol, `0x${string}`>> = {
     base: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
     op: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
 };
+type IsEarnYieldClaimSupportedParams = { isDebugMode?: boolean };
 
 export const isEarnYieldClaimSupported = (
     networkSymbol: NetworkSymbol,
-    { isDebugMode = false }: { isDebugMode?: boolean } = {},
+    { isDebugMode = false }: IsEarnYieldClaimSupportedParams = {},
 ) => {
     const hasClaimContract = MERKL_XYZ_CONTRACT[networkSymbol] !== undefined;
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -265,23 +265,16 @@ const applyDeviceStateErrorThunk = createThunk<
         );
     },
 );
+type CompleteDiscoveryParams = {
+    getState: () => DiscoveryReportingThunkState;
+    dispatch: ThunkDispatch<DiscoveryReportingThunkState, DiscoveryReportingDeps, UnknownAction>;
+    fetchAndSaveMetadata: SuiteCompatibleThunk<StaticSessionId>;
+};
 
 const completeDiscovery = (
     devicePath: DeviceUniquePath,
     deviceState: TrezorDeviceWithState['state'],
-    {
-        dispatch,
-        fetchAndSaveMetadata,
-        getState,
-    }: {
-        getState: () => DiscoveryReportingThunkState;
-        dispatch: ThunkDispatch<
-            DiscoveryReportingThunkState,
-            DiscoveryReportingDeps,
-            UnknownAction
-        >;
-        fetchAndSaveMetadata: SuiteCompatibleThunk<StaticSessionId>;
-    },
+    { dispatch, fetchAndSaveMetadata, getState }: CompleteDiscoveryParams,
 ) => {
     dispatch(discoveryActions.updateDiscovery({ status: 'complete' }, devicePath));
     dispatch(fetchAndSaveMetadata(deviceState.staticSessionId));

--- a/suite-common/wallet-core/src/named-address/useResolveNamedAddress.test.tsx
+++ b/suite-common/wallet-core/src/named-address/useResolveNamedAddress.test.tsx
@@ -32,10 +32,11 @@ const namedAddressResolver: SymbolNamedAddressResolver = {
 const networkModuleRepository = {
     get: () => ({ namedAddressResolver }),
 } as unknown as NetworkModuleRepository;
+type WrapperParams = { children: ReactNode };
 
 const renderResolveHook = (value: string, symbol: NetworkSymbol | null) =>
     renderHookWithQueryClient(() => useResolveNamedAddress(value, symbol), {
-        wrapper: ({ children }: { children: ReactNode }) => (
+        wrapper: ({ children }: WrapperParams) => (
             <ServicesProvider services={{ networkModuleRepository }}>{children}</ServicesProvider>
         ),
     });

--- a/suite-common/wallet-core/src/send/__fixtures__/evmFixtures.ts
+++ b/suite-common/wallet-core/src/send/__fixtures__/evmFixtures.ts
@@ -16,6 +16,12 @@ type EvmGas = {
 };
 
 export const FOREIGN_SIGNER = '0x0F6666bC699aec39b846E898473e9CAec5a6b821';
+type EvmTxParams = {
+    confirmed?: boolean;
+    type?: WalletAccountTransaction['type'];
+    gas?: EvmGas;
+    signer?: string;
+};
 
 /**
  * Minimal EVM `WalletAccountTransaction` for nonce/fee unit tests. Only the fields the code under
@@ -25,17 +31,7 @@ export const FOREIGN_SIGNER = '0x0F6666bC699aec39b846E898473e9CAec5a6b821';
  */
 export const evmTx = (
     nonce: number,
-    {
-        confirmed = true,
-        type = 'sent',
-        gas,
-        signer = ethAccount.descriptor,
-    }: {
-        confirmed?: boolean;
-        type?: WalletAccountTransaction['type'];
-        gas?: EvmGas;
-        signer?: string;
-    } = {},
+    { confirmed = true, type = 'sent', gas, signer = ethAccount.descriptor }: EvmTxParams = {},
 ): WalletAccountTransaction =>
     ({
         type,

--- a/suite-common/wallet-core/src/send/sendFormReducer.test.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.test.ts
@@ -16,11 +16,11 @@ const extraDependencies: SendFormReducerDeps = {
     actionTypes: { storageLoad: mockActionType('storageLoad') },
     reducers: {
         storageLoadFormDrafts: (state, { payload }) => {
-            payload.sendFormDrafts.forEach(
-                ({ key, value }: { key: AccountKey; value: FormState }) => {
-                    state.drafts[key] = value;
-                },
-            );
+            type KeyValueParams = { key: AccountKey; value: FormState };
+
+            payload.sendFormDrafts.forEach(({ key, value }: KeyValueParams) => {
+                state.drafts[key] = value;
+            });
         },
     },
 };

--- a/suite-common/wallet-core/src/send/tron/feeLevel.ts
+++ b/suite-common/wallet-core/src/send/tron/feeLevel.ts
@@ -5,6 +5,13 @@ import { asCoinSymbol } from '@trezor/connect-common';
 import { type EstimateFeeLevel } from './types';
 
 type ContractCallFeeResult = EstimateFeeLevel | { error: string };
+type EstimateContractCallFeeLevelParams = {
+    symbol: NetworkSymbol;
+    identity: string | undefined;
+    from: string;
+    to: string;
+    data: string;
+};
 
 export const estimateContractCallFeeLevel = async ({
     symbol,
@@ -12,13 +19,7 @@ export const estimateContractCallFeeLevel = async ({
     from,
     to,
     data,
-}: {
-    symbol: NetworkSymbol;
-    identity: string | undefined;
-    from: string;
-    to: string;
-    data: string;
-}): Promise<ContractCallFeeResult> => {
+}: EstimateContractCallFeeLevelParams): Promise<ContractCallFeeResult> => {
     const estimatedFee = await TrezorConnect.blockchainEstimateFee({
         coin: asCoinSymbol(symbol),
         identity,

--- a/suite-common/wallet-core/src/send/tron/resolveCalldata.ts
+++ b/suite-common/wallet-core/src/send/tron/resolveCalldata.ts
@@ -3,18 +3,19 @@ import { type TokenInfo } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
 type CalldataResult = { data: string } | { data: null } | { error: string };
+type ResolveCalldataParams = {
+    token: TokenInfo | undefined;
+    outputAddress: string;
+    amountInSubunits: string;
+    userCallDataHex: string;
+};
 
 export const resolveCalldata = ({
     token,
     outputAddress,
     amountInSubunits,
     userCallDataHex,
-}: {
-    token: TokenInfo | undefined;
-    outputAddress: string;
-    amountInSubunits: string;
-    userCallDataHex: string;
-}): CalldataResult => {
+}: ResolveCalldataParams): CalldataResult => {
     if (token) {
         const result = Calldata.tron.trc20.transfer.encode({
             to: outputAddress,

--- a/suite-common/wallet-core/src/staking/ethereum/ethereumStaking.ts
+++ b/suite-common/wallet-core/src/staking/ethereum/ethereumStaking.ts
@@ -110,17 +110,18 @@ export const buildClaimWithdrawRequestData = () => {
 
     return data;
 };
+type VerifyEthereumStakingCalldataParams = {
+    stakeType: StakeType;
+    calldata: string;
+    source?: string;
+};
 
 // Re-verifies calldata that was produced at compose time. Returns the Verifier issues so callers can fail with a specific message instead of throwing. For unstake the user-typed amount is not persisted in the form draft, so only the function selector and the SDK `source` field are checked — enough to reject calldata that targets a different function or wasn't produced by our SDK.
 export const verifyEthereumStakingCalldata = ({
     stakeType,
     calldata,
     source = WALLET_SDK_SOURCE,
-}: {
-    stakeType: StakeType;
-    calldata: string;
-    source?: string;
-}): { isValid: boolean; issues: VerifyIssue[] } => {
+}: VerifyEthereumStakingCalldataParams): { isValid: boolean; issues: VerifyIssue[] } => {
     const data = calldata as `0x${string}`;
     const sourceBigInt = BigInt(source);
 

--- a/suite-common/wallet-core/src/staking/stakingThunks.test.ts
+++ b/suite-common/wallet-core/src/staking/stakingThunks.test.ts
@@ -52,14 +52,15 @@ const validationError = {
     code: 'upstream_validation_error',
     message: 'Invalid response shape',
 } satisfies StakingBatchErrorsItem;
+type InitStoreParams = {
+    enabledNetworks?: NetworkSymbol[];
+    stake?: StakeState;
+};
 
 const initStore = ({
     enabledNetworks = [ethSymbol, solSymbol, adaSymbol, trxSymbol],
     stake = stakeInitialState,
-}: {
-    enabledNetworks?: NetworkSymbol[];
-    stake?: StakeState;
-} = {}) =>
+}: InitStoreParams = {}) =>
     createTestStore({
         extra: undefined,
         preloadedState: {

--- a/suite-common/wallet-core/src/staking/tron/actions/claim/claimContract.ts
+++ b/suite-common/wallet-core/src/staking/tron/actions/claim/claimContract.ts
@@ -1,7 +1,8 @@
 import { type Account, type FormState } from '@suite-common/wallet-types';
 import * as tronUtils from '@trezor/network-tron/utils';
+type BuildWithdrawBalanceContractParams = { ownerHex: string };
 
-export const buildWithdrawBalanceContract = ({ ownerHex }: { ownerHex: string }) =>
+export const buildWithdrawBalanceContract = ({ ownerHex }: BuildWithdrawBalanceContractParams) =>
     ({
         type: 'WithdrawBalanceContract' as const,
         parameter: {

--- a/suite-common/wallet-core/src/staking/tron/actions/withdraw/withdrawContract.ts
+++ b/suite-common/wallet-core/src/staking/tron/actions/withdraw/withdrawContract.ts
@@ -1,7 +1,10 @@
 import { type Account, type FormState } from '@suite-common/wallet-types';
 import * as tronUtils from '@trezor/network-tron/utils';
+type BuildWithdrawExpireUnfreezeContractParams = { ownerHex: string };
 
-export const buildWithdrawExpireUnfreezeContract = ({ ownerHex }: { ownerHex: string }) =>
+export const buildWithdrawExpireUnfreezeContract = ({
+    ownerHex,
+}: BuildWithdrawExpireUnfreezeContractParams) =>
     ({
         type: 'WithdrawExpireUnfreezeContract' as const,
         parameter: {

--- a/suite-common/wallet-core/src/staking/tron/shared/signTronContract.ts
+++ b/suite-common/wallet-core/src/staking/tron/shared/signTronContract.ts
@@ -20,16 +20,17 @@ type TronStakeContract =
     | TronClaimContract;
 
 type SignTronContractResult = { serializedTx: string; txid: string } | { error: TronStakeError };
+type SignTronContractParams = {
+    account: Account;
+    device: TrezorDevice;
+    contract: TronStakeContract;
+};
 
 export const signTronContract = async ({
     account,
     device,
     contract,
-}: {
-    account: Account;
-    device: TrezorDevice;
-    contract: TronStakeContract;
-}): Promise<SignTronContractResult> => {
+}: SignTronContractParams): Promise<SignTronContractResult> => {
     const blockchainInfo = await TrezorConnect.blockchainGetInfo({
         coin: asCoinSymbol(account.symbol),
         identity: getAccountIdentity(account),

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts
@@ -175,14 +175,15 @@ describe('selectNonPhishingTransactionNotifications', () => {
         FiatRatesRootState &
         PhishingRootState &
         DeviceRootState;
+    type GetPhishingStateParams = {
+        amount: string;
+        isDustPhishingEnabled?: boolean;
+    };
 
     const getPhishingState = ({
         amount,
         isDustPhishingEnabled = true,
-    }: {
-        amount: string;
-        isDustPhishingEnabled?: boolean;
-    }): PhishingState =>
+    }: GetPhishingStateParams): PhishingState =>
         ({
             notifications: [receivedNotification],
             device: { selectedDevice: { state: { staticSessionId: DEVICE_STATE } } },

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -239,6 +239,16 @@ export const addFakePendingTxThunk = createThunk<
         });
     },
 );
+type BuildFakePendingEvmTxParams = {
+    precomposedTransaction: PrecomposedTransactionFinal;
+    precomposedForm: FormState;
+    txid: string;
+    account: Account;
+    nonce: string;
+    blockHeight: number;
+    deadline: number;
+    token?: TokenInfo;
+};
 
 const buildFakePendingEvmTx = ({
     precomposedTransaction,
@@ -249,16 +259,7 @@ const buildFakePendingEvmTx = ({
     blockHeight,
     deadline,
     token,
-}: {
-    precomposedTransaction: PrecomposedTransactionFinal;
-    precomposedForm: FormState;
-    txid: string;
-    account: Account;
-    nonce: string;
-    blockHeight: number;
-    deadline: number;
-    token?: TokenInfo;
-}): AccountTransaction & Partial<WalletAccountTransaction> => {
+}: BuildFakePendingEvmTxParams): AccountTransaction & Partial<WalletAccountTransaction> => {
     const { outputs: precomposedOutputs } = precomposedTransaction;
     // @ts-expect-error: indexing with noUncheckedIndexedAccess
     const output: (typeof precomposedOutputs)[number] = precomposedOutputs[0];

--- a/suite-common/wallet-core/src/yield/utils/yieldClaimRewards.test.ts
+++ b/suite-common/wallet-core/src/yield/utils/yieldClaimRewards.test.ts
@@ -5,14 +5,12 @@ import { BigNumber } from '@trezor/utils';
 import { getYieldClaimRewardsSnapshot } from './yieldClaimRewards';
 
 const ethSymbol = asNetworkSymbol('eth');
-
-const createReward = ({
-    claimable,
-    fiatClaimable,
-}: {
+type CreateRewardParams = {
     claimable: string;
     fiatClaimable: string | null;
-}) => ({
+};
+
+const createReward = ({ claimable, fiatClaimable }: CreateRewardParams) => ({
     token: {
         address: '0x0000000000000000000000000000000000000001',
         symbol: 'USDC',

--- a/suite-common/wallet-core/src/yield/utils/yieldUtils.test.ts
+++ b/suite-common/wallet-core/src/yield/utils/yieldUtils.test.ts
@@ -542,6 +542,16 @@ describe('yieldUtils', () => {
         const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
         const USDT_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
         const RECEIPT_ADDRESS = '0x58d97b57bb95320f9a05dc918aef65434969c2b2';
+        type CreateVaultFixtureParams = {
+            network?: YieldDtoV2['network'];
+            tokenAddress?: string;
+            tokenSymbol?: string;
+            tokenDecimals?: number;
+            outputTokenAddress?: string;
+            underMaintenance?: boolean;
+            deprecated?: boolean;
+            enter?: boolean;
+        };
 
         const createVaultFixture = ({
             network = 'ethereum',
@@ -552,16 +562,7 @@ describe('yieldUtils', () => {
             underMaintenance = false,
             deprecated = false,
             enter = true,
-        }: {
-            network?: YieldDtoV2['network'];
-            tokenAddress?: string;
-            tokenSymbol?: string;
-            tokenDecimals?: number;
-            outputTokenAddress?: string;
-            underMaintenance?: boolean;
-            deprecated?: boolean;
-            enter?: boolean;
-        }) =>
+        }: CreateVaultFixtureParams) =>
             ({
                 metadata: { name: 'Vault', underMaintenance, deprecated },
                 network,

--- a/suite-common/wallet-core/src/yield/utils/yieldUtils.ts
+++ b/suite-common/wallet-core/src/yield/utils/yieldUtils.ts
@@ -156,14 +156,16 @@ export const getNextYieldFlowStep = (
 
     return sequence[stepIndex + 1] ?? step;
 };
+type GetYieldWithdrawInputTokenParams = {
+    flowData: YieldFlowResolvedData;
+    flowType: YieldWithdrawFlowType;
+};
 
 export const getYieldWithdrawInputToken = ({
     flowData,
     flowType,
-}: {
-    flowData: YieldFlowResolvedData;
-    flowType: YieldWithdrawFlowType;
-}): YieldFlowDisplayToken => (flowType === 'redeem' ? flowData.receiptToken : flowData.token);
+}: GetYieldWithdrawInputTokenParams): YieldFlowDisplayToken =>
+    flowType === 'redeem' ? flowData.receiptToken : flowData.token;
 
 export const buildYieldWithdrawCalldata = ({
     amount,

--- a/suite-common/wallet-types/mocks/mockAccountKey.ts
+++ b/suite-common/wallet-types/mocks/mockAccountKey.ts
@@ -5,6 +5,11 @@ import { type AccountKey, asAccountDescriptor, createAccountKey } from '../src/a
 
 const MOCK_DEVICE_STATIC_SESSION_ID: StaticSessionId =
     'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@448CCE89D32A733A1632F345:0';
+type MockAccountKeyParams = {
+    descriptor?: string;
+    symbol?: NetworkSymbol;
+    deviceStaticSessionId?: StaticSessionId;
+};
 
 /**
  * Build a valid `AccountKey` for tests without typing out the
@@ -17,11 +22,7 @@ export const mockAccountKey = ({
     descriptor = 'mockDescriptor',
     symbol = 'btc',
     deviceStaticSessionId = MOCK_DEVICE_STATIC_SESSION_ID,
-}: {
-    descriptor?: string;
-    symbol?: NetworkSymbol;
-    deviceStaticSessionId?: StaticSessionId;
-} = {}): AccountKey =>
+}: MockAccountKeyParams = {}): AccountKey =>
     createAccountKey({
         accountDescriptor: asAccountDescriptor(descriptor),
         networkSymbol: symbol,

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -919,6 +919,13 @@ export const accountSearchFn = (
         tokenMatch
     );
 };
+type GetUtxoFromSignedTransactionParams = {
+    account: Account;
+    receivingAccount?: boolean;
+    tx: GeneralPrecomposedTransactionFinal;
+    txid: string;
+    prevTxid?: string;
+};
 
 export const getUtxoFromSignedTransaction = ({
     account,
@@ -926,13 +933,7 @@ export const getUtxoFromSignedTransaction = ({
     tx,
     txid,
     prevTxid,
-}: {
-    account: Account;
-    receivingAccount?: boolean;
-    tx: GeneralPrecomposedTransactionFinal;
-    txid: string;
-    prevTxid?: string;
-}) => {
+}: GetUtxoFromSignedTransactionParams) => {
     if (tx.type !== 'final') return [];
 
     // find utxo to replace
@@ -1006,6 +1007,12 @@ export const getAccountAddresses = (account: Account) =>
     account.addresses
         ? account.addresses.unused.concat(account.addresses.used).concat(account.addresses.change)
         : [];
+type GetPendingAccountParams = {
+    account: Account;
+    receivingAccount?: boolean;
+    tx: GeneralPrecomposedTransactionFinal;
+    txid: string;
+};
 
 // update account before BLOCKCHAIN.NOTIFICATION or BLOCKCHAIN.BLOCK events
 // solves race condition between pushing transaction and received notification
@@ -1014,12 +1021,7 @@ export const getPendingAccount = ({
     receivingAccount,
     tx,
     txid,
-}: {
-    account: Account;
-    receivingAccount?: boolean;
-    tx: GeneralPrecomposedTransactionFinal;
-    txid: string;
-}): Account => {
+}: GetPendingAccountParams): Account => {
     // calculate availableBalance
     let availableBalanceBig = new BigNumber(account.availableBalance);
 
@@ -1163,6 +1165,15 @@ export const parseAccountKey = (accountKey: AccountKey) => {
  * @deprecated use createAccountKey directly
  */
 export const getAccountKey = createAccountKey;
+type PrepareNewAccountPayloadParams = {
+    accountType: AccountType;
+    networkSymbol: NetworkSymbol;
+    index: number;
+    backendType?: TrezorConnectBackendType;
+    selectedAccount?: NetworkAccount;
+    accountTypes?: NetworkAccount[];
+    device: TrezorDevice;
+};
 
 export const prepareNewAccountPayload = async ({
     accountType,
@@ -1172,15 +1183,7 @@ export const prepareNewAccountPayload = async ({
     selectedAccount,
     accountTypes,
     device,
-}: {
-    accountType: AccountType;
-    networkSymbol: NetworkSymbol;
-    index: number;
-    backendType?: TrezorConnectBackendType;
-    selectedAccount?: NetworkAccount;
-    accountTypes?: NetworkAccount[];
-    device: TrezorDevice;
-}) => {
+}: PrepareNewAccountPayloadParams) => {
     const network = getNetwork(networkSymbol);
     const networkAccount =
         selectedAccount ?? accountTypes?.find(v => v.accountType === accountType);

--- a/suite-common/wallet-utils/src/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/ethUtils.test.ts
@@ -311,16 +311,13 @@ describe('eth utils', () => {
         const DEPOSIT = '0xd0e30db0';
         const WITHDRAW =
             '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000';
-
-        const tx = ({
-            targets = [],
-            internalTransfers = [],
-            data,
-        }: {
+        type TxParams = {
             targets?: { addresses?: string[] }[];
             internalTransfers?: { from: string }[];
             data?: string;
-        }) =>
+        };
+
+        const tx = ({ targets = [], internalTransfers = [], data }: TxParams) =>
             ({
                 symbol: 'eth',
                 targets,
@@ -369,16 +366,13 @@ describe('eth utils', () => {
         const ERC4626_WITHDRAW = `0xb460af94${AMOUNT}${RECEIVER}${RECEIVER}`;
         const ERC4626_REDEEM = `0xba087652${AMOUNT}${RECEIVER}${RECEIVER}`;
         const TRANSFER = `0xa9059cbb${RECEIVER}${AMOUNT}`;
-
-        const tx = ({
-            targets = [],
-            internalTransfers = [],
-            data,
-        }: {
+        type TxParams = {
             targets?: { addresses?: string[] }[];
             internalTransfers?: { from: string }[];
             data?: string;
-        }) =>
+        };
+
+        const tx = ({ targets = [], internalTransfers = [], data }: TxParams) =>
             ({
                 symbol: 'eth',
                 targets,
@@ -430,14 +424,12 @@ describe('eth utils', () => {
     describe('getWrappedNativeTxTarget', () => {
         const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
         const OTHER = '0x1111111111111111111111111111111111111111';
-
-        const tx = ({
-            targets = [],
-            internalTransfers = [],
-        }: {
+        type TxParams = {
             targets?: { addresses?: string[] }[];
             internalTransfers?: { from: string }[];
-        }) =>
+        };
+
+        const tx = ({ targets = [], internalTransfers = [] }: TxParams) =>
             ({
                 symbol: 'eth',
                 targets,

--- a/suite-common/wallet-utils/src/evmPendingTxUtils.test.ts
+++ b/suite-common/wallet-utils/src/evmPendingTxUtils.test.ts
@@ -11,6 +11,15 @@ const vaultDepositData =
 
 const accountDescriptor = '0x09ea3721b5bf3b64b4418c38b603154d2d597fae3';
 const foreignSigner = '0x0f6666bc699aec39b846e898473e9caec5a6b821';
+type CreateTransactionParams = {
+    txid: string;
+    nonce: number;
+    data?: string;
+    targetAddress?: string;
+    blockHeight?: number;
+    type?: WalletAccountTransaction['type'];
+    signer?: string;
+};
 
 // `signer` decides authorship (see isSignedByAccount): only a transaction this account signed
 // carries the account's own nonce, so a foreign one must never be mistaken for a replacement.
@@ -22,15 +31,7 @@ const createTransaction = ({
     blockHeight = 1,
     type = 'sent',
     signer = accountDescriptor,
-}: {
-    txid: string;
-    nonce: number;
-    data?: string;
-    targetAddress?: string;
-    blockHeight?: number;
-    type?: WalletAccountTransaction['type'];
-    signer?: string;
-}) =>
+}: CreateTransactionParams) =>
     ({
         txid,
         symbol: 'eth',

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -106,16 +106,17 @@ const buildUpdatedDevice = () =>
         minor_version: 12,
         patch_version: 4,
     });
+type BuildPrecomposedTransactionParams = {
+    isTokenKnown?: boolean;
+    to: string;
+    token?: TokenInfo;
+};
 
 const buildPrecomposedTransaction = ({
     isTokenKnown = true,
     to,
     token,
-}: {
-    isTokenKnown?: boolean;
-    to: string;
-    token?: TokenInfo;
-}): GeneralPrecomposedTransactionFinal =>
+}: BuildPrecomposedTransactionParams): GeneralPrecomposedTransactionFinal =>
     ({
         outputs: [{ address: to, amount: '1000000' }],
         fee: '21000',

--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -63,16 +63,17 @@ const ethereumAccount = mockWalletAccount({
     symbol: ethSymbol,
     descriptor: asAccountDescriptor(RBF_ACCOUNT_DESCRIPTOR),
 });
+type GetPendingTokenMovingContractTransactionParams = {
+    data: string;
+    nativeValue: string;
+    tokenAmount: string;
+};
 
 const getPendingTokenMovingContractTransaction = ({
     data,
     nativeValue,
     tokenAmount,
-}: {
-    data: string;
-    nativeValue: string;
-    tokenAmount: string;
-}) =>
+}: GetPendingTokenMovingContractTransactionParams) =>
     getWalletTransaction({
         descriptor: asAccountDescriptor(RBF_ACCOUNT_DESCRIPTOR),
         symbol: ethSymbol,
@@ -804,7 +805,9 @@ describe('transaction utils', () => {
     });
 
     describe('getEvmPrivatePendingHint', () => {
-        const pendingTx = (nonce: number, { txid = `0x${nonce}` }: { txid?: string } = {}) =>
+        type PendingTxParams = { txid?: string };
+
+        const pendingTx = (nonce: number, { txid = `0x${nonce}` }: PendingTxParams = {}) =>
             getOwnEvmTransaction({ nonce, blockHeight: -1, txid });
 
         it('returns undefined when there is no pending own-nonce tx', () => {

--- a/suite-common/wallet-utils/src/tronUtils.ts
+++ b/suite-common/wallet-utils/src/tronUtils.ts
@@ -11,18 +11,19 @@ import { asAmountSubunit } from './AmountTypes';
 import { subunitsToUnits } from './amountUtils';
 
 export type TronFeeLevel = ResponseTypes.EstimateFee['payload'][number];
+type ComputeBandwidthFeeLevelParams = {
+    availableStakedBandwidth: number;
+    availableFreeBandwidth: number;
+    bytes: number;
+    isNewAccount?: boolean;
+};
 
 export const computeBandwidthFeeLevel = ({
     availableStakedBandwidth,
     availableFreeBandwidth,
     bytes,
     isNewAccount = false,
-}: {
-    availableStakedBandwidth: number;
-    availableFreeBandwidth: number;
-    bytes: number;
-    isNewAccount?: boolean;
-}): TronFeeLevel => {
+}: ComputeBandwidthFeeLevelParams): TronFeeLevel => {
     if (isNewAccount) {
         const feeInSun = availableStakedBandwidth < bytes ? TRON_CREATE_ACCOUNT_FEE_SUN : 0;
 

--- a/suite/backup/src/MultiShareBackup.tsx
+++ b/suite/backup/src/MultiShareBackup.tsx
@@ -11,8 +11,9 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { useDispatch } from '@suite-common/redux-utils';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 import { HELP_CENTER_MULTI_SHARE_BACKUP_URL } from '@trezor/urls';
+type MultiShareBackupProps = { isDeviceLocked: boolean };
 
-export const MultiShareBackup = ({ isDeviceLocked }: { isDeviceLocked: boolean }) => {
+export const MultiShareBackup = ({ isDeviceLocked }: MultiShareBackupProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();

--- a/suite/desktop-update/src/appUpdateAnalytics.ts
+++ b/suite/desktop-update/src/appUpdateAnalytics.ts
@@ -1,17 +1,18 @@
 import type { AppUpdateEvent } from '@suite/analytics';
 import { type UpdateInfo } from '@trezor/suite-desktop-api';
+type GetAppUpdatePayloadParams = {
+    status: AppUpdateEvent['status'];
+    earlyAccessProgram: boolean;
+    updateInfo?: UpdateInfo;
+    isAutoUpdated?: boolean;
+};
 
 export const getAppUpdatePayload = ({
     status,
     earlyAccessProgram,
     updateInfo,
     isAutoUpdated,
-}: {
-    status: AppUpdateEvent['status'];
-    earlyAccessProgram: boolean;
-    updateInfo?: UpdateInfo;
-    isAutoUpdated?: boolean;
-}): AppUpdateEvent => ({
+}: GetAppUpdatePayloadParams): AppUpdateEvent => ({
     fromVersion: process.env.VERSION || '',
     toVersion: updateInfo?.version,
     status,

--- a/suite/desktop-update/src/desktopUpdateActionsThunks.ts
+++ b/suite/desktop-update/src/desktopUpdateActionsThunks.ts
@@ -94,8 +94,10 @@ type InstallUpdateThunkState = DesktopUpdateRootState;
 
 type InstallUpdateThunkDeps = WithServices<DesktopAnalyticsDep>;
 
+type InstallUpdateThunkParams = { installNow: boolean };
+
 export const installUpdateThunk =
-    ({ installNow }: { installNow: boolean }) =>
+    ({ installNow }: InstallUpdateThunkParams) =>
     (_: Dispatch, getState: () => InstallUpdateThunkState, extra: InstallUpdateThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { desktopUpdate } = getState();

--- a/suite/labeling/src/selectIsLabelActionEnabled.test.ts
+++ b/suite/labeling/src/selectIsLabelActionEnabled.test.ts
@@ -124,18 +124,19 @@ describe(selectIsLabelActionEnabled.name, () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
+    type TestLabelActionEnabledParams = {
+        deviceOverrides?: Parameters<typeof mockSuiteDevice>[0];
+        unavailableCapabilities: UnavailableCapabilities;
+        isSuiteSyncFeatureEnabled: boolean;
+        isSuiteSyncEnabled?: boolean;
+    };
 
     const testLabelActionEnabled = ({
         deviceOverrides,
         unavailableCapabilities,
         isSuiteSyncFeatureEnabled,
         isSuiteSyncEnabled = false,
-    }: {
-        deviceOverrides?: Parameters<typeof mockSuiteDevice>[0];
-        unavailableCapabilities: UnavailableCapabilities;
-        isSuiteSyncFeatureEnabled: boolean;
-        isSuiteSyncEnabled?: boolean;
-    }) => {
+    }: TestLabelActionEnabledParams) => {
         const state = createMockState(
             { unavailableCapabilities, ...deviceOverrides },
             {

--- a/suite/platform-encryption-electron/src/electronPlatformEncryption.ts
+++ b/suite/platform-encryption-electron/src/electronPlatformEncryption.ts
@@ -1,6 +1,7 @@
 import {
+    type DecryptParams,
+    type EncryptParams,
     type EncryptableBranded,
-    type EncryptedHex,
     type PlatformEncryption,
     asEncryptedHex,
 } from '@suite-common/platform-encryption';
@@ -15,13 +16,13 @@ export type ElectronPlatformEncryptionDeps = {
 export const createElectronPlatformEncryption = (
     deps: ElectronPlatformEncryptionDeps,
 ): PlatformEncryption => ({
-    encrypt: async <T extends EncryptableBranded>({ value }: { value: T }) => {
+    encrypt: async <T extends EncryptableBranded>({ value }: EncryptParams<T>) => {
         const result = await deps.desktopApi.safeStoreEncrypt({ value });
 
         return result.success ? ok(asEncryptedHex(result.payload as T)) : result;
     },
 
-    decrypt: async <T extends EncryptableBranded>({ value }: { value: EncryptedHex<T> }) => {
+    decrypt: async <T extends EncryptableBranded>({ value }: DecryptParams<T>) => {
         const result = await deps.desktopApi.safeStoreDecrypt({ value });
 
         return result.success ? ok(result.payload as T) : result;

--- a/suite/receive/src/address/revealNextAddressThunk.ts
+++ b/suite/receive/src/address/revealNextAddressThunk.ts
@@ -29,8 +29,10 @@ type RevealNextAddressThunkState = AccountsRootState &
 
 type RevealNextAddressThunkDeps = WithServices<DesktopAnalyticsDep>;
 
+type RevealNextAddressThunkParams = { accountKey: AccountKey };
+
 export const revealNextAddressThunk =
-    ({ accountKey }: { accountKey: AccountKey }) =>
+    ({ accountKey }: RevealNextAddressThunkParams) =>
     (
         dispatch: Dispatch,
         getState: () => RevealNextAddressThunkState,

--- a/suite/receive/src/verification/showAddressThunk.ts
+++ b/suite/receive/src/verification/showAddressThunk.ts
@@ -25,8 +25,10 @@ type ShowAddressThunkState = DeviceRootState &
 
 type ShowAddressThunkDeps = WithServices<DesktopAnalyticsDep>;
 
+type ShowAddressThunkParams = { path: string };
+
 export const showAddressThunk =
-    ({ path }: { path: string }) =>
+    ({ path }: ShowAddressThunkParams) =>
     async (
         dispatch: Dispatch,
         getState: () => ShowAddressThunkState,

--- a/suite/router/src/routerParams.ts
+++ b/suite/router/src/routerParams.ts
@@ -64,16 +64,17 @@ export const decodeEarnVaultAddress = (rawVaultAddress?: string): string | undef
         return undefined;
     }
 };
+type ValidateAccountRouteParamsParams = {
+    symbol?: string;
+    index?: string;
+    rawAccountType?: string;
+};
 
 export const validateAccountRouteParams = ({
     symbol,
     index,
     rawAccountType,
-}: {
-    symbol?: string;
-    index?: string;
-    rawAccountType?: string;
-}): CommonWalletParams => {
+}: ValidateAccountRouteParamsParams): CommonWalletParams => {
     if (!index) return;
 
     const network = getNetworkOptional(symbol);

--- a/suite/sign-verify/src/SignAddressInput.tsx
+++ b/suite/sign-verify/src/SignAddressInput.tsx
@@ -9,8 +9,9 @@ import { type AddressItem, useSignAddressOptions } from './useSignAddressOptions
 
 const optionToAddress = (option: AddressItem | null) =>
     option ? { address: option.label, path: option.value } : null;
+type WrappingSingleValueProps = { children?: ReactNode };
 
-const WrappingSingleValue = ({ children }: { children?: ReactNode }) => (
+const WrappingSingleValue = ({ children }: WrappingSingleValueProps) => (
     <Text as="div" maxWidth="100%" intent="neutral" priority="primary" padding={{ vertical: 8 }}>
         {children}
     </Text>

--- a/suite/sign-verify/src/useSignVerifyForm.ts
+++ b/suite/sign-verify/src/useSignVerifyForm.ts
@@ -151,6 +151,7 @@ export const useSignVerifyForm = (isSignPage: boolean, account: Account) => {
             ...overrideValues,
         });
     }, [reset, isSignPage, account?.key, account?.networkType, account?.path, account?.descriptor]);
+    type FormSetSignatureParams = { signature: string; pubKey?: string };
 
     return {
         isFormDirty: isDirty,
@@ -159,7 +160,7 @@ export const useSignVerifyForm = (isSignPage: boolean, account: Account) => {
         formSubmit: handleSubmit,
         formValues,
         formErrors: errors,
-        formSetSignature: ({ signature, pubKey }: { signature: string; pubKey?: string }) => {
+        formSetSignature: ({ signature, pubKey }: FormSetSignatureParams) => {
             setValue('signature', signature);
             setValue('pubKey', pubKey || '');
         },

--- a/suite/suite-sync/src/settings/SuiteSyncConnectionStatus.tsx
+++ b/suite/suite-sync/src/settings/SuiteSyncConnectionStatus.tsx
@@ -27,8 +27,9 @@ const formatLogEntry = (entry: SuiteSyncRelayConnectionLogEntry) => {
 
     return `${timestamp} ${message}`;
 };
+type LogProps = { entries: SuiteSyncRelayConnectionLogEntry[] };
 
-const Log = ({ entries }: { entries: SuiteSyncRelayConnectionLogEntry[] }) => {
+const Log = ({ entries }: LogProps) => {
     if (entries.length === 0) return null;
 
     return (

--- a/suite/test-utils/src/initStoreForTests.ts
+++ b/suite/test-utils/src/initStoreForTests.ts
@@ -4,19 +4,20 @@ import { type SuiteRouterHistory, createSuiteRouterHistory } from '@suite/router
 import { asGetter } from '@suite-common/dependency-injection';
 import { asEncryptedHex } from '@suite-common/platform-encryption';
 import {
+    type DecryptParams,
+    type EncryptParams,
     type EncryptableBranded,
-    type EncryptedHex,
     type PlatformEncryption,
 } from '@suite-common/platform-encryption';
 import { type PreloadedState, type SuiteStore, initStore } from '@trezor/suite';
 import { type DeepPartial, ok } from '@trezor/type-utils';
 
 const testPlatformEncryption: PlatformEncryption = {
-    encrypt<T extends EncryptableBranded>({ value }: { value: T }) {
+    encrypt<T extends EncryptableBranded>({ value }: EncryptParams<T>) {
         return Promise.resolve(ok(asEncryptedHex<T>(value as string)));
     },
 
-    decrypt<T extends EncryptableBranded>({ value }: { value: EncryptedHex<T> }) {
+    decrypt<T extends EncryptableBranded>({ value }: DecryptParams<T>) {
         return Promise.resolve(ok(value as unknown as T));
     },
 };

--- a/suite/thp/src/firmware/ThpPairingStep.tsx
+++ b/suite/thp/src/firmware/ThpPairingStep.tsx
@@ -10,9 +10,10 @@ import { ThpCodeEntryStep } from './ThpCodeEntryStep';
 import { ThpCodeInvalidStep } from './ThpCodeInvalidStep';
 import { ThpPairingConfirmStep } from './ThpPairingConfirmStep';
 import { ThpPairingStartStep } from './ThpPairingStartStep';
+type ThpPairingStepProps = { heading: ReactNode };
 
 // reflection of packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingStep.tsx
-export const ThpPairingStep = ({ heading }: { heading: ReactNode }) => {
+export const ThpPairingStep = ({ heading }: ThpPairingStepProps) => {
     const device = useSelector(selectSelectedDevice);
     const thpStep = useSelector(selectThpStep);
     const prevStepRef = useRef(thpStep);

--- a/suite/tor-desktop/src/settings/TorExternal.tsx
+++ b/suite/tor-desktop/src/settings/TorExternal.tsx
@@ -51,8 +51,9 @@ export const TorExternal = () => {
         const matchedOption = options.find(o => o.value === externalPort);
         setSelectedOption(matchedOption);
     }, [torSettings]);
+    type OnChangeParams = { value: number };
 
-    const onChange = async ({ value }: { value: number }) => {
+    const onChange = async ({ value }: OnChangeParams) => {
         if (!torSettings) return;
         await desktopApi.changeTorSettings({
             ...torSettings,

--- a/suite/ui-animations/src/loadingSkeletonSelectors.test.ts
+++ b/suite/ui-animations/src/loadingSkeletonSelectors.test.ts
@@ -4,14 +4,15 @@ import { type DeviceRootState } from '@suite-common/device';
 import { selectShouldAnimateLoadingSkeleton } from './loadingSkeletonSelectors';
 
 type LoadingSkeletonRootState = DeviceRootState & ModalRootState;
+type GetStateParams = {
+    hasActiveModal?: boolean;
+    isDeviceAuthorized?: boolean;
+};
 
 const getState = ({
     hasActiveModal = false,
     isDeviceAuthorized = true,
-}: {
-    hasActiveModal?: boolean;
-    isDeviceAuthorized?: boolean;
-} = {}): LoadingSkeletonRootState =>
+}: GetStateParams = {}): LoadingSkeletonRootState =>
     ({
         device: {
             selectedDevice: isDeviceAuthorized


### PR DESCRIPTION
## Description

Add a local ESLint rule that rejects direct inline object annotations on destructured parameters while accepting any named type. Enable it for networks/**, @suite/*, @suite-common/*, and @trezor/suite, excluding Connect and other @trezor packages; migrate 99 violations in 71 files and reuse shared encryption parameter types. Benchmark: ESLint per-rule timing over 4,679 scoped TypeScript files, three no-cache runs: 194.6 ms median (187.1-233.7 ms), 0.3-0.4% of aggregate rule time.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/eslint-named-parameter-types/web/](https://dev.suite.sldev.cz/suite-web/feat/eslint-named-parameter-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/eslint-named-parameter-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/eslint-named-parameter-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T06:12:06.684Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T06:11:00.810Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->