### PR TITLE
refactor(walletconnect): remove dead WalletConnectSession fields and adapter getChainId

### DIFF
--- a/suite-common/walletconnect/src/adapters/bitcoin.ts
+++ b/suite-common/walletconnect/src/adapters/bitcoin.ts
@@ -4,7 +4,7 @@ import type { ProposalTypes } from '@walletconnect/types';
 import * as trezorConnectPopupActions from '@suite-common/connect-popup';
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
-import { type Network, getNetwork, networksCollection } from '@suite-common/wallet-config';
+import { getNetwork, networksCollection } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccounts } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getAccountIdentity } from '@suite-common/wallet-utils';
@@ -215,14 +215,6 @@ const bitcoinRequestThunk = createThunk<
     }
 });
 
-export const getChainId = (network: Network) => {
-    if (network.caipId) {
-        return [network.caipId];
-    }
-
-    return [];
-};
-
 export const getNamespace = (accounts: Account[]): Record<string, WalletConnectNamespace> => {
     const bip122 = {
         chains: [],
@@ -293,7 +285,6 @@ export const bitcoinAdapter = {
     networkType: 'bitcoin',
     namespaceId: 'bip122',
     requestThunk: bitcoinRequestThunk,
-    getChainId,
     getNamespace,
     processNamespaces,
 } satisfies WalletConnectAdapter;

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -322,6 +322,5 @@ export const ethereumAdapter = {
     namespaceId: 'eip155',
     requestThunk: ethereumRequestThunk,
     getNamespace,
-    getChainId,
     processNamespaces,
 } satisfies WalletConnectAdapter;

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -261,7 +261,6 @@ export const solanaAdapter = {
     networkType: 'solana',
     namespaceId: 'solana',
     requestThunk: solanaRequestThunk,
-    getChainId,
     getNamespace,
     processNamespaces,
 } satisfies WalletConnectAdapter;

--- a/suite-common/walletconnect/src/adapters/stellar.ts
+++ b/suite-common/walletconnect/src/adapters/stellar.ts
@@ -227,7 +227,6 @@ export const stellarAdapter = {
     networkType: 'stellar',
     namespaceId: 'stellar',
     requestThunk: stellarRequestThunk,
-    getChainId,
     getNamespace,
     processNamespaces,
 } satisfies WalletConnectAdapter;

--- a/suite-common/walletconnect/src/adapters/tron.ts
+++ b/suite-common/walletconnect/src/adapters/tron.ts
@@ -194,7 +194,6 @@ export const tronAdapter = {
     networkType: 'tron',
     namespaceId: 'tron',
     requestThunk: tronRequestThunk,
-    getChainId,
     getNamespace,
     processNamespaces,
 } satisfies WalletConnectAdapter;

--- a/suite-common/walletconnect/src/walletConnectTypes.ts
+++ b/suite-common/walletconnect/src/walletConnectTypes.ts
@@ -2,7 +2,6 @@ import { type AsyncThunk } from '@reduxjs/toolkit';
 import { type WalletKitTypes } from '@reown/walletkit';
 import type { ProposalTypes } from '@walletconnect/types';
 
-import { type Network } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
 export interface WalletConnectAdapter {
@@ -10,7 +9,6 @@ export interface WalletConnectAdapter {
     namespaceId: string;
     methods: string[];
     requestThunk: AsyncThunk<any, { event: WalletKitTypes.SessionRequest }, any>;
-    getChainId: (network: Network) => string[];
     getNamespace: (accounts: Account[]) => Record<string, WalletConnectNamespace>;
     processNamespaces: (
         accounts: Account[],
@@ -30,21 +28,12 @@ export interface WalletConnectNamespace {
 export interface WalletConnectSession {
     topic: string;
     validation?: 'VALID' | 'INVALID' | 'UNKNOWN';
-    pairingTopic: string;
-    expiry: number;
-    acknowledged: boolean;
     namespaces: Record<string, Partial<WalletConnectNamespace>>;
-    requiredNamespaces: ProposalTypes.RequiredNamespaces;
-    optionalNamespaces: ProposalTypes.OptionalNamespaces;
-    sessionProperties?: ProposalTypes.SessionProperties;
     peer: {
-        publicKey: string;
         metadata: {
             name: string;
-            description: string;
             url: string;
             icons: string[];
-            verifyUrl?: string;
         };
     };
     lastAccount?: Account;
@@ -63,7 +52,6 @@ export interface PendingConnectionProposal {
     params: ProposalTypes.Struct;
     origin: string;
     validation: 'UNKNOWN' | 'VALID' | 'INVALID';
-    verifyUrl: string;
     isScam?: boolean;
     expired: boolean;
     networks: PendingConnectionProposalNetwork[];


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (6 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `suite-common/walletconnect/src/adapters/bitcoin.ts`
- `suite-common/walletconnect/src/adapters/ethereum.ts`
- `suite-common/walletconnect/src/adapters/solana.ts`
- `suite-common/walletconnect/src/adapters/stellar.ts`
- `suite-common/walletconnect/src/adapters/tron.ts`
- `suite-common/walletconnect/src/walletConnectTypes.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are WalletConnect adapter implementations and shared types. The broad static coverage mapping (139 tests per file) appears to be a global-dependency artifact; no other candidate test actually targets WalletConnect behavior. The focused WalletConnect analytics events test should catch regressions in initialization, pairing, and proposal handling without running the full suite.

<details><summary><b>Changed files (6)</b></summary>

- `suite-common/walletconnect/src/adapters/bitcoin.ts`
- `suite-common/walletconnect/src/adapters/ethereum.ts`
- `suite-common/walletconnect/src/adapters/solana.ts`
- `suite-common/walletconnect/src/adapters/stellar.ts`
- `suite-common/walletconnect/src/adapters/tron.ts`
- `suite-common/walletconnect/src/walletConnectTypes.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This is the only E2E test that directly exercises the WalletConnect integration: it triggers WalletConnect initialization, pairing, proposal approval/rejection, and asserts the correct analytics events. Changes to the WalletConnect adapters and shared types are most likely to affect this flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/walletconnect/src/walletConnectTypes.ts`

_Updated: 2026-09-05T16:20:09.429Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-props-02-walletconnect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-props-02-walletconnect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-02-walletconnect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-02-walletconnect/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-02-walletconnect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-05T16:23:20.652Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-05T16:21:51.513Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

---

🙏 Kindly requesting a review from @martykan and @marekrjpolak — thanks!