### PR TITLE
refactor(components): remove dead type properties

### DIFF
--- a/packages/components/src/components/Card/utils.tsx
+++ b/packages/components/src/components/Card/utils.tsx
@@ -5,7 +5,6 @@ import { type Padding } from '../../utils/frameProps';
 
 type PaddingMapArgs = {
     paddingType: PaddingType;
-    hasHeading?: boolean;
 };
 
 type CardTypeMapArgs = {

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -36,7 +36,6 @@ export type PopoverProps = {
     isOpen?: boolean;
     content?: React.ReactNode;
     onOpenChange?: (isOpen: boolean) => void;
-    onInteraction?: () => void;
     popoverOffset?: number;
     zIndex?: number;
     'data-testid'?: string;

--- a/packages/components/src/components/form/Textarea/Textarea.tsx
+++ b/packages/components/src/components/form/Textarea/Textarea.tsx
@@ -40,7 +40,6 @@ type TextareaHTMLProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 export type TextareaProps = AllowedFrameProps &
     TextareaHTMLProps &
     Omit<FormCellProps, 'children'> & {
-        isDisabled?: boolean;
         label?: ReactNode;
         innerRef?: Ref<HTMLTextAreaElement>;
         value?: string;


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (3 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/components/src/components/Card/utils.tsx`
- `packages/components/src/components/Popover/Popover.tsx`
- `packages/components/src/components/form/Textarea/Textarea.tsx`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

---

🙏 Kindly requesting a review from @seibei-iguchi and @dahaca — thanks!