### PR TITLE
refactor(product-components): remove dead type properties

### DIFF
--- a/packages/product-components/src/components/Notifications/ExchangeInfoNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/ExchangeInfoNotification.stories.tsx
@@ -44,13 +44,11 @@ const exchangeInfoContent = (
             symbol: 'sol',
             amount: 3,
             displaySymbol: 'SOL',
-            coingeckoId: 'solana',
         }}
         receive={{
             symbol: 'eth',
             amount: 0.0051663,
             displaySymbol: 'ETH',
-            coingeckoId: 'ethereum',
         }}
     />
 );

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -17,7 +17,6 @@ export type ExchangeInfoAmountSide = 'send' | 'receive';
 export type ExchangeInfoAsset = Pick<ExchangeToastAssetData, 'symbol' | 'contractAddress'> & {
     amount: ReactNode;
     displaySymbol?: string;
-    coingeckoId?: string;
     icon?: ReactNode;
 };
 

--- a/packages/product-components/src/components/NumberInput/NumberInput.tsx
+++ b/packages/product-components/src/components/NumberInput/NumberInput.tsx
@@ -73,7 +73,6 @@ export type NumberInputProps<TFieldValues extends FieldValues> = Omit<
     'defaultValue' | 'name' | 'onChange'
 > &
     Omit<UseControllerProps<TFieldValues>, 'rules'> & {
-        decimalScale?: number;
         onChange?: (value: string) => void;
         rules?: UseControllerProps['rules'];
         locale: Locale;

--- a/packages/product-components/src/components/PasswordStrengthIndicator/PasswordStrengthIndicator.tsx
+++ b/packages/product-components/src/components/PasswordStrengthIndicator/PasswordStrengthIndicator.tsx
@@ -23,7 +23,6 @@ const Wrapper = styled.div<WrapperProps>`
 `;
 
 interface LineProps {
-    $width?: number;
     $isFilled: boolean;
 }
 

--- a/packages/product-components/src/components/TrezorLogo/trezorLogos.stories.tsx
+++ b/packages/product-components/src/components/TrezorLogo/trezorLogos.stories.tsx
@@ -5,11 +5,7 @@ import { StoryColumn } from '@trezor/components';
 
 import { TrezorLogo } from './TrezorLogo';
 
-interface WrapperProps {
-    isDark?: boolean;
-}
-
-const LogoWrapper = styled.div<WrapperProps>`
+const LogoWrapper = styled.div`
     display: flex;
     min-height: 100px;
     flex-direction: column;


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (5 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/product-components/src/components/Notifications/ExchangeInfoNotification.stories.tsx`
- `packages/product-components/src/components/Notifications/notificationsTypes.ts`
- `packages/product-components/src/components/NumberInput/NumberInput.tsx`
- `packages/product-components/src/components/PasswordStrengthIndicator/PasswordStrengthIndicator.tsx`
- `packages/product-components/src/components/TrezorLogo/trezorLogos.stories.tsx`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

---

🙏 Kindly requesting a review from @izmy and @yanascz — thanks!