### PR TITLE
refactor(wallet-core): remove dead yield and blockchain-subscribe type properties

### DIFF
--- a/suite-common/token-definitions/src/tokenDefinitionsTypes.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsTypes.ts
@@ -1,6 +1,5 @@
 import { type Getter } from '@suite-common/dependency-injection';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type Rate } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import type { PartialRecord } from '@trezor/type-utils';
 
@@ -55,4 +54,4 @@ export type TokenDefinitions = {
 
 export type TokenManagementStorage = { key: string; value: SimpleTokenStructure };
 
-export type EnhancedTokenInfo = TokenInfo & { fiatRate?: Rate };
+export type EnhancedTokenInfo = TokenInfo;

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -169,7 +169,6 @@ const isAccountSubscribable = (account: Account) =>
 
 type SubscribeBlockchainThunkParams = {
     symbol: NetworkSymbol;
-    fiatRates?: boolean;
     onConnect?: boolean;
 };
 
@@ -356,9 +355,7 @@ export const onBlockchainConnectThunk = createThunk<
 
     await dispatch(getOrFetchRawFeeInfoThunk({ networkSymbol: network.symbol }));
 
-    await dispatch(
-        subscribeBlockchainThunk({ symbol: network.symbol, fiatRates: true, onConnect: true }),
-    );
+    await dispatch(subscribeBlockchainThunk({ symbol: network.symbol, onConnect: true }));
     // update accounts for connected network
     await dispatch(syncAccountsWithBlockchainThunk(network.symbol));
     dispatch(blockchainActions.connected(network.symbol));

--- a/suite-common/wallet-core/src/yield/thunks/yieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/yield/thunks/yieldApprovalThunks.ts
@@ -59,14 +59,12 @@ type OpenYieldApproveModalParams = YieldSessionDataPayload & {
     dispatch: Dispatch;
     amount: string;
     spender: string;
-    preapprovedAmount?: string;
     txType: 'approve' | 'revoke';
 };
 
 type OpenYieldRevokeModalParams = YieldSessionDataPayload & {
     dispatch: Dispatch;
     approveAmount: string;
-    allowanceAmount: string;
     spender: string | null;
 };
 
@@ -125,7 +123,6 @@ export const openYieldApproveModal = ({
     flowData,
     amount,
     spender,
-    preapprovedAmount,
     txType,
 }: OpenYieldApproveModalParams) => {
     const contractAddress = getApprovalContractAddress({ flowType, flowData });
@@ -144,7 +141,6 @@ export const openYieldApproveModal = ({
                 amount,
                 contractAddress,
                 spender,
-                preapprovedAmount,
                 txType,
             },
         }),
@@ -159,7 +155,6 @@ export const openYieldRevokeModal = ({
     flowType,
     flowData,
     approveAmount,
-    allowanceAmount,
     spender,
 }: OpenYieldRevokeModalParams) => {
     if (!spender) {
@@ -175,7 +170,6 @@ export const openYieldRevokeModal = ({
         flowData,
         amount: getRevokeModalAmount({ flowType, amount: approveAmount, flowData }),
         spender,
-        preapprovedAmount: allowanceAmount || undefined,
         txType: 'revoke',
     });
 };
@@ -304,28 +298,23 @@ export const submitYieldRevokeThunk = createThunk<
     void,
     YieldSessionDataAmountPayload,
     { state: SubmitYieldRevokeThunkState }
->(
-    `${YIELD_THUNK_PREFIX}/submitRevoke`,
-    ({ flowKey, flowType, flowData, amount }, { dispatch, getState }) => {
-        const { approval } = selectYieldSession(getState(), flowType, flowKey);
-        const spender = getYieldVaultAddress(flowData);
+>(`${YIELD_THUNK_PREFIX}/submitRevoke`, ({ flowKey, flowType, flowData, amount }, { dispatch }) => {
+    const spender = getYieldVaultAddress(flowData);
 
-        dispatch(yieldActions.clearError({ flowType, flowKey }));
-        dispatch(yieldActions.startSubmittingApproval({ flowType, flowKey }));
+    dispatch(yieldActions.clearError({ flowType, flowKey }));
+    dispatch(yieldActions.startSubmittingApproval({ flowType, flowKey }));
 
-        openYieldRevokeModal({
-            dispatch,
-            flowKey,
-            flowType,
-            flowData,
-            approveAmount: amount,
-            allowanceAmount: approval.allowanceAmount ?? '',
-            spender,
-        });
+    openYieldRevokeModal({
+        dispatch,
+        flowKey,
+        flowType,
+        flowData,
+        approveAmount: amount,
+        spender,
+    });
 
-        dispatch(yieldActions.finishSubmittingApproval({ flowType, flowKey }));
-    },
-);
+    dispatch(yieldActions.finishSubmittingApproval({ flowType, flowKey }));
+});
 
 export const submitYieldApproveThunk = createThunk<void, SubmitYieldApprovePayload, void>(
     `${YIELD_THUNK_PREFIX}/submitApprove`,

--- a/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts
+++ b/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts
@@ -206,7 +206,6 @@ export const getResolvedYieldFlowData = ({
             matchedToken?.symbol ?? vault.token.symbol ?? getNetworkDisplaySymbol(account.symbol),
         decimals: matchedToken?.decimals ?? vault.token.decimals,
         contractAddress: matchedTokenContract ?? underlyingTokenContract,
-        coingeckoId: vault.token.coinGeckoId,
         balance: matchedToken?.balance ?? '0',
     };
 
@@ -215,7 +214,6 @@ export const getResolvedYieldFlowData = ({
         symbol: matchedReceiptToken?.symbol ?? vault.outputToken.symbol,
         decimals: matchedReceiptToken?.decimals ?? vault.outputToken.decimals,
         contractAddress: matchedReceiptTokenContract ?? receiptTokenContract,
-        coingeckoId: vault.outputToken.coinGeckoId ?? vault.token.coinGeckoId,
     };
 
     const flowData: YieldFlowResolvedData = { account, vault, token, receiptToken };

--- a/suite-common/wallet-core/src/yield/yieldTypes.ts
+++ b/suite-common/wallet-core/src/yield/yieldTypes.ts
@@ -25,7 +25,6 @@ export type YieldFlowDisplayToken = {
     symbol: string;
     decimals: number;
     contractAddress?: string | null;
-    coingeckoId?: string;
 };
 
 export type YieldFlowToken = YieldFlowDisplayToken & {
@@ -68,7 +67,6 @@ export type YieldApproveModalState = {
     amount: string;
     contractAddress: string;
     spender: string;
-    preapprovedAmount?: string;
     txType: Extract<YieldPendingTransactionState['type'], 'approve' | 'revoke'>;
 };
 

--- a/suite-native/blockchain/src/blockchainThunks.ts
+++ b/suite-native/blockchain/src/blockchainThunks.ts
@@ -106,9 +106,7 @@ export const onBlockchainConnectThunk = createThunk<
     const network = getNetworkOptional(symbol.toLowerCase());
     if (!network) return;
 
-    await dispatch(
-        subscribeBlockchainThunk({ symbol: network.symbol, fiatRates: true, onConnect: true }),
-    );
+    await dispatch(subscribeBlockchainThunk({ symbol: network.symbol, onConnect: true }));
 
     // update accounts for connected network
     await dispatch(syncAccountsWithBlockchainThunk({ symbol: network.symbol }));


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (6 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `suite-common/token-definitions/src/tokenDefinitionsTypes.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-common/wallet-core/src/yield/thunks/yieldApprovalThunks.ts`
- `suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts`
- `suite-common/wallet-core/src/yield/yieldTypes.ts`
- `suite-native/blockchain/src/blockchainThunks.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-05-wallet-core-yield&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-props-05-wallet-core-yield&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-props-05-wallet-core-yield&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set centers on wallet-core yield flows and the generic blockchain thunks that back them, plus token-definition types. The highest-confidence coverage comes from the two yield E2E tests that directly drive deposit/withdraw/redeem logic and vault-share token handling. A custom-backend discovery test provides a focused sanity check for regressions in the shared blockchain thunk layer. The suite-native blockchain thunk change has no corresponding E2E coverage in this list.

<details><summary><b>Changed files (6)</b></summary>

- `suite-common/token-definitions/src/tokenDefinitionsTypes.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-common/wallet-core/src/yield/thunks/yieldApprovalThunks.ts`
- `suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts`
- `suite-common/wallet-core/src/yield/yieldTypes.ts`
- `suite-native/blockchain/src/blockchainThunks.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — Directly exercises the yield redeem/withdraw flow for ERC-4626 vault shares (trSHUSDCp/USDC), which relies on getResolvedYieldFlowData, yieldTypes, and yieldApprovalThunks. It also loads token definitions for the vault share token and depends on wallet-core blockchain thunks for ETH backend state.
- `suite/e2e/tests/yield/withdrawal.test.ts` — Directly exercises the yield withdrawal flow from a USDC vault, covering the same yield thunks/utils/types and token-definition dependencies as the redeem flow. A regression in yield flow resolution or approval handling would be immediately visible here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Configuring custom Blockbook backends and running discovery directly exercises wallet-core blockchain thunks (backend connections, account discovery, and loading). Changes to those thunks could break backend handling that yield flows also rely on, so this is a targeted sanity check.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-native/blockchain/src/blockchainThunks.ts`

_Updated: 2026-09-05T16:21:22.577Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-05-wallet-core-yield/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-05-wallet-core-yield/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-05T16:23:17.979Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-05T16:23:01.843Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

---

🙏 Kindly requesting a review from @tomasklim and @peter-sanderson — thanks!