### PR TITLE
refactor: remove dead baseFeePerGas from fee and claim forms

### DIFF
--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -23,7 +23,6 @@ export type FeesFormValues = Pick<
     | 'feePerUnit'
     | 'maxPriorityFeePerGas'
     | 'maxFeePerGas'
-    | 'baseFeePerGas'
 >;
 
 interface Props<TFieldValues extends FeesFormValues> extends UseFormReturn<TFieldValues> {

--- a/suite-common/earn-stablecoin/src/signing/claimSigningUtils.test.ts
+++ b/suite-common/earn-stablecoin/src/signing/claimSigningUtils.test.ts
@@ -118,7 +118,6 @@ describe('claimSigningUtils', () => {
             feePerUnit: '2',
             maxFeePerGas: '2',
             maxPriorityFeePerGas: '1',
-            baseFeePerGas: '1',
             transactionData: CLAIM_CALLDATA,
         });
         expect(result.precomposedTransaction).toMatchObject({
@@ -158,7 +157,6 @@ describe('claimSigningUtils', () => {
             feePerUnit: '1',
             maxFeePerGas: undefined,
             maxPriorityFeePerGas: undefined,
-            baseFeePerGas: undefined,
         });
         expect(result.precomposedTransaction).toMatchObject({
             fee: '21000000000000',

--- a/suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts
+++ b/suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts
@@ -93,7 +93,6 @@ type BuildClaimTransactionReviewResult = BuildClaimReviewStateResult & {
 type ClaimEip1559Fields = {
     maxFeePerGas?: string;
     maxPriorityFeePerGas?: string;
-    baseFeePerGas?: string;
 };
 
 const getNonceHex = (nonceValue: string | number): `0x${string}` => {
@@ -123,7 +122,6 @@ const getClaimFeeData = (fee: EvmFeeHex) => {
             ? {
                   maxFeePerGas: fromHex(fee.maxFeePerGas).asWei().toGwei(),
                   maxPriorityFeePerGas: fromHex(fee.maxPriorityFeePerGas).asWei().toGwei(),
-                  baseFeePerGas: fromHex(fee.baseFeePerGas).asWei().toGwei(),
               }
             : {}) satisfies ClaimEip1559Fields,
     };
@@ -234,7 +232,6 @@ export const buildClaimReviewState = ({
         feeLimit: feeLimitWei,
         maxFeePerGas: eip1559Fields.maxFeePerGas,
         maxPriorityFeePerGas: eip1559Fields.maxPriorityFeePerGas,
-        baseFeePerGas: eip1559Fields.baseFeePerGas,
         options: ['broadcast', 'transactionData'],
         transactionData: data,
         isCoinControlEnabled: false,

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -67,7 +67,6 @@ export interface FormState {
     feePerUnit: string; // bitcoin/ethereum/ripple custom fee field (satB/gasPrice/drops)
     maxPriorityFeePerGas?: string; // ethereum eip1559 only
     maxFeePerGas?: string; // ethereum eip1559 only
-    baseFeePerGas?: string; // ethereum eip1559 only
     feeLimit: string; // ethereum: gas limit; tron: fee_limit cap in SUN for TRC-20 transfers
     estimatedFeeLimit?: string; // ethereum: estimated gas limit; tron: estimated fee_limit cap in SUN for TRC-20 transfers
 

--- a/suite-native/module-trading/src/utils/tradingFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradingFormUtils.ts
@@ -137,7 +137,6 @@ export const createFormStateForSendForm = ({
         feePerUnit: feeLevel.feePerUnit || '',
         maxPriorityFeePerGas: feeLevel?.maxPriorityFeePerGas || '',
         maxFeePerGas: feeLevel?.maxFeePerGas || '',
-        baseFeePerGas: '',
         feeLimit: feeLevel.feeLimit || '',
         estimatedFeeLimit: '',
         baseFee: undefined,


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (5 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/suite/src/hooks/wallet/form/useFees.ts`
- `suite-common/earn-stablecoin/src/signing/claimSigningUtils.test.ts`
- `suite-common/earn-stablecoin/src/signing/claimSigningUtils.ts`
- `suite-common/wallet-types/src/sendForm.ts`
- `suite-native/module-trading/src/utils/tradingFormUtils.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-07-basefeepergas&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

---

🙏 Kindly requesting a review from @szymonlesisz and @komret — thanks!