### PR TITLE
refactor(suite): remove dead send-form hook properties

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -56,7 +56,6 @@ export interface SendFormProps {
     localCurrency: BaseCurrencyCode;
     fees: AppState['wallet']['fees'];
     online: boolean;
-    sendRaw?: boolean;
     metadataEnabled: boolean;
     targetAnonymity?: number;
     prison?: Record<string, unknown>;

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -40,7 +40,6 @@ type Props = UseFormReturn<FormState> & {
     updateContext: SendContextValues['updateContext'];
     setLoading: Dispatch<SetStateAction<boolean>>;
     setAmount: (index: number, amount: string) => void;
-    targetAnonymity?: number;
     prison?: Record<string, unknown>;
     setShowReserveBanner: SendContextValues['setShowReserveBanner'];
 };

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -6,7 +6,6 @@ import {
     type FormOptions,
     type FormState,
     type Output,
-    type Rate,
     type TokenAddress,
 } from '@suite-common/wallet-types';
 import {
@@ -27,7 +26,6 @@ export type GetCurrentRateParams = {
 };
 
 type UseSendFormFieldsParams = UseFormReturn<FormState> & {
-    fiatRate?: Rate;
     network: UseSendFormState['network'];
 };
 

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -8,7 +8,6 @@ import { updateFiatRatesThunk } from '@suite-common/wallet-core';
 import {
     type FiatRatesResult,
     type Output,
-    type Rate,
     type RatesByKey,
     type Timestamp,
 } from '@suite-common/wallet-types';
@@ -29,7 +28,6 @@ type useSendFormImportProps = {
     network: UseSendFormState['network'];
     tokens: UseSendFormState['account']['tokens'];
     localCurrencyOption: UseSendFormState['localCurrencyOption'];
-    fiatRate?: Rate;
     currentRates?: RatesByKey;
 };
 

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -83,7 +83,6 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
         localCurrency,
         fees,
         online,
-        sendRaw,
         metadataEnabled,
         targetAnonymity,
         prison,


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (5 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/suite/src/hooks/wallet/useSendForm.ts`
- `packages/suite/src/hooks/wallet/useSendFormCompose.ts`
- `packages/suite/src/hooks/wallet/useSendFormFields.ts`
- `packages/suite/src/hooks/wallet/useSendFormImport.ts`
- `packages/suite/src/views/wallet/send/index.tsx`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

---

🙏 Kindly requesting a review from @szymonlesisz and @peter-sanderson — thanks!