### PR TITLE
refactor(wallet-types): remove dead WalletParams and cardano-staking properties

### DIFF
--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -43,9 +43,7 @@ export const useCardanoStaking = (): CardanoStaking => {
         status: false,
     });
 
-    const { rewards: rewardsAmount, isActive: isStakingActive } = isCardano
-        ? account.misc.staking
-        : {};
+    const { rewards: rewardsAmount } = isCardano ? account.misc.staking : {};
 
     const isStakingDisabled =
         (account?.availableBalance === '0' || !delegatingAvailable.status || hasPendingTx) &&
@@ -109,7 +107,6 @@ export const useCardanoStaking = (): CardanoStaking => {
             loading: false,
             delegatingAvailable: { status: false },
             withdrawingAvailable: { status: false },
-            isActive: false,
             rewards: '0',
             calculateFeeAndDeposit: () => Promise.resolve(),
         };
@@ -122,7 +119,6 @@ export const useCardanoStaking = (): CardanoStaking => {
         loading,
         delegatingAvailable,
         withdrawingAvailable,
-        isActive: isStakingActive,
         rewards: rewardsAmount,
         calculateFeeAndDeposit,
     };

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -219,7 +219,6 @@ export type WalletParams =
           symbol: NetworkSymbol;
           accountIndex: number;
           accountType: AccountType | 'normal';
-          contractAddress?: string;
       }>
     | undefined;
 

--- a/suite-common/wallet-types/src/cardanoStaking.ts
+++ b/suite-common/wallet-types/src/cardanoStaking.ts
@@ -12,7 +12,6 @@ export type CardanoStaking = {
     loading: boolean;
     fee?: string;
     deposit?: string;
-    isActive?: boolean;
     rewards?: string;
     calculateFeeAndDeposit: (action: CardanoAction) => Promise<void>;
     isStakingDisabled: boolean;


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (3 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/suite/src/hooks/earn/useCardanoStaking.ts`
- `suite-common/wallet-types/src/account.ts`
- `suite-common/wallet-types/src/cardanoStaking.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-09-wallet-types-cardano&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

---

🙏 Kindly requesting a review from @peter-sanderson and @tomasklim — thanks!