### PR TITLE
refactor(trading): remove dead trading reducer, selector and form-type properties

### DIFF
--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -30,7 +30,6 @@ import type {
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
 import {
-    type AccountsState,
     type ConfirmAddressOnDeviceThunkState,
     type WalletSettingsRootState,
 } from '@suite-common/wallet-core';
@@ -119,7 +118,6 @@ export interface TradingSellFormContextProps
     isComposing: boolean;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     feeInfo: FeeInfo;
-    suiteReceiveAccounts?: AccountsState;
     // form - additional helpers for form
     form: {
         state: TradingFormStateProps;
@@ -152,7 +150,6 @@ export interface TradingExchangeFormContextProps
         helpers: TradingUseFormActionsReturnProps;
     };
 
-    suiteReceiveAccounts?: AccountsState;
     feeInfo: FeeInfo;
 
     amountLimits?: CryptoAmountLimitProps;
@@ -207,8 +204,6 @@ export type TradingFormContextValues<T extends TradingType> = TradingFormMapProp
 
 export interface TradingFormInputDefaultProps {
     label?: TranslationKey;
-    placeholder?: TranslationKey;
-    'data-testid'?: string;
 }
 
 export interface TradingFormInputFiatCryptoProps {
@@ -287,7 +282,6 @@ export interface TradingUseComposeTransactionReturnProps extends TradingUseCompo
 }
 
 export interface TradingOfferCommonProps {
-    account?: Account;
     selectedQuote: TradingTradeType;
     providers: TradingGetProvidersInfoProps;
     type: TradingType;
@@ -305,5 +299,4 @@ export interface TradingOfferBuyProps {
 export interface TradingSelectedOfferInfoProps extends TradingOfferCommonProps {
     selectedAccount?: Account;
     receiveAddress?: string;
-    transactionId?: string;
 }

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -85,7 +85,6 @@ const composedTransactionInfo: TradingComposedTransactionInfo = {
         feePerByte: '10',
         feeLimit: '100',
         fee: '1000',
-        outputs: [],
     },
 };
 

--- a/suite-common/trading/src/reducers/tradingCommonReducer.ts
+++ b/suite-common/trading/src/reducers/tradingCommonReducer.ts
@@ -8,17 +8,13 @@ import {
 } from 'invity-api';
 
 import { type AccountKey, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import { type CardanoOutput, type FeeLevel, type PROTO } from '@trezor/connect';
+import { type FeeLevel } from '@trezor/connect';
 
 import { type TradingTransaction, type TradingType, type TradingVerifiedAddress } from '../types';
 import { type TradingBuyState, buyInitialState } from './buyReducer';
 import { TRADING_PREFIX } from '../constants';
 import { type TradingExchangeState, exchangeInitialState } from './exchangeReducer';
 import { type TradingSellState, sellInitialState } from './sellReducer';
-
-type TradingComposedTransactionInfoOutputs = {
-    outputs?: PROTO.TxOutputType[] | CardanoOutput[];
-};
 
 export interface TradingComposedTransactionInfo {
     composed?: Pick<
@@ -30,8 +26,7 @@ export interface TradingComposedTransactionInfo {
         | 'maxFeePerGas'
         | 'maxPriorityFeePerGas'
         | 'token'
-    > &
-        TradingComposedTransactionInfoOutputs;
+    >;
     selectedFee?: FeeLevel['label'];
 }
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -144,9 +144,7 @@ export type TradingSellInfoSelector = Omit<
     supportedFiatCurrencies: Set<FiatCurrencyCode>;
 };
 
-export type TradingSellStateSelector = Omit<TradingSellState, 'sellInfo'> & {
-    sell?: TradingSellInfoSelector;
-};
+export type TradingSellStateSelector = Omit<TradingSellState, 'sellInfo'>;
 
 export type TradingStateSelector = Omit<TradingState, 'buy' | 'exchange' | 'sell'> & {
     buy: TradingBuyStateSelector;

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -875,7 +875,6 @@ describe('recomposeAndSignTxThunk', () => {
                     feeLimit: '64285', // energy units
                     token: { contract: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' } as TokenInfo,
                     fee: '6428500',
-                    outputs: [],
                 },
             },
         });
@@ -930,7 +929,6 @@ describe('recomposeAndSignTxThunk', () => {
                     // Offers-page estimate against the cold stand-in recipient:
                     // 0.1 create-account fee + 1 activation.
                     fee: '1100000',
-                    outputs: [],
                 },
             },
         });
@@ -985,7 +983,6 @@ describe('recomposeAndSignTxThunk', () => {
                     feeLimit: '64285',
                     token: { contract: '0x123457' } as TokenInfo,
                     fee: '1000',
-                    outputs: [],
                 },
             },
         });


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (6 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/suite/src/types/trading/trading.ts`
- `packages/suite/src/types/trading/tradingForm.ts`
- `suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts`
- `suite-common/trading/src/reducers/tradingCommonReducer.ts`
- `suite-common/trading/src/selectors/tradingSelectors.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-10-trading-core&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-props-10-trading-core&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-props-10-trading-core&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in core trading infrastructure: form types, common reducer, selectors, and the recompose/sign transaction thunk. These touch every buy/sell/swap user flow that composes and signs transactions. The recommended set focuses on representative end-to-end trading flows plus targeted form-validation and fee tests, avoiding the 142-test long tail of indirect consumers. This provides high confidence that transaction composition, signing, and form state still work across the main trading modalities.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/types/trading/tradingForm.ts`
- `suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts`
- `suite-common/trading/src/reducers/tradingCommonReducer.ts`
- `suite-common/trading/src/selectors/tradingSelectors.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Exercises the full buy flow from quote fetching through confirmation to transaction detail status, directly depending on trading form state, tradingCommonReducer, and tradingSelectors. A regression in any of these would break trade request payloads or status transitions.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Covers the complete sell flow including device signing, send amount/fee verification, and transaction status progression. This directly exercises the recomposeAndSignTxThunk path and trading reducer state that is changed.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Validates a full cross-chain swap including composedTransactionInfo, device prompts, signing, and transaction detail status updates. The changed selectors and recompose/sign thunk are on the critical path for this test.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Directly asserts on wallet.trading.composedTransactionInfo and custom Ethereum fee values shown in the device prompt, making it a precise regression test for changes to trading selectors and the recompose/sign logic.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Focused on trading form input validation, percentage/max buttons, and crypto/fiat switching. These behaviors are tightly coupled to the tradingForm types and the selectors that derive form state.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Another buy flow that exercises the asset picker, buy form state, and confirmation screen. It shares the same trading reducer/selectors infrastructure as the changed files but covers a different asset/network entry point.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Validates ETH sell confirmation, device prompt details, and fee display. It uses the same signing and form infrastructure as the changed files but for a different coin and transaction type.
- `suite/e2e/tests/trading/staking-form.test.ts` — The ETH staking form reuses trading form components and validation logic. Changes to tradingForm types or form selectors could affect input validation, minimum amounts, or crypto/fiat switching in this flow.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — A more complex DEX swap path that exercises quote selection, simulation data, and multi-step device review. It relies on the same trading selectors and reducer state that were modified.

</details>

_Updated: 2026-09-12T07:43:16.209Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-10-trading-core/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-10-trading-core/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH USDC token to SOL USDT token | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-12T07:43:32.700Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |

</details>

_Updated: 2026-09-12T07:43:52.172Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

---

🙏 Kindly requesting a review from @adderpositive and @sherpaPSX — thanks!