### PR TITLE
refactor(extra-dependencies): remove unused DI-seam services and thunks

### DIFF
--- a/packages/suite/src/support/createSuiteCompositionRoot.ts
+++ b/packages/suite/src/support/createSuiteCompositionRoot.ts
@@ -199,14 +199,9 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
             deps.getState,
             (state: AppState) => state.wallet.selectedAccount,
         ),
-        getSelectedAccountStatus: toGetter(
-            deps.getState,
-            (state: AppState) => state.wallet.selectedAccount.status,
-        ),
         getIsWindowVisible: toGetter(deps.getState, selectIsWindowVisible),
         getTradingEnvironment: toGetter(deps.getState, selectTradeServerEnvironment),
         getTradedAccountKeys: toGetter(deps.getState, selectTradedAccountKeys),
-        getIsViewOnlyByDefaultEnabled: toGetter(deps.getState, (_: AppState) => true),
         getThpSettings: toGetter(deps.getState, (state: AppState) => ({
             appName: 'Trezor Suite', // NOTE: this is displayed on Trezor. not the same as manifest.appName
             pairingMethods: ['CodeEntry'],

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -43,9 +43,7 @@ export type ExtraDependenciesSuite = ExtraDependenciesStatic &
 
 export const extraDependencies: ExtraDependenciesStatic & TokenDefinitionsMiddlewareDeps = {
     thunks: {
-        initMetadata: metadataLabelingActions.initThunk,
         fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadataThunk,
-        addAccountMetadata: metadataLabelingActions.addAccountMetadataThunk,
         forgetBluetoothDevice: forgetBluetoothDeviceThunk,
     },
     actions: {

--- a/suite-common/extra-dependencies/src/CommonServices.ts
+++ b/suite-common/extra-dependencies/src/CommonServices.ts
@@ -56,12 +56,10 @@ export type CommonServices = SuiteSyncDep &
         getTokenDefinitionsEnabledNetworks: Getter<[], NetworkSymbol[]>;
         getDebugSettings: Getter<[], any>;
         getSelectedAccount: Getter<[], SelectedAccountStatus>;
-        getSelectedAccountStatus: Getter<[], SelectedAccountStatus['status']>;
         getTradingEnvironment: Getter<
             [],
             'production' | 'staging' | 'dev' | 'localhost' | undefined
         >;
-        getIsViewOnlyByDefaultEnabled: Getter<[], boolean>;
         getThpSettings: Getter<[], ThpSettings>;
     } & ReportSecurityCheckDep &
     ReloadAppDep &

--- a/suite-common/extra-dependencies/src/ExtraDependenciesStatic.ts
+++ b/suite-common/extra-dependencies/src/ExtraDependenciesStatic.ts
@@ -1,9 +1,6 @@
 import { type ActionCreatorWithPreparedPayload } from '@reduxjs/toolkit';
 
-import {
-    type FetchAndSaveMetadataDep,
-    type MetadataAddPayload,
-} from '@suite-common/metadata-types';
+import { type FetchAndSaveMetadataDep } from '@suite-common/metadata-types';
 import { type SuiteCompatibleThunk } from '@suite-common/redux-utils';
 import { type OnModalCancelDep, type OpenModalDep } from '@suite-common/suite-types';
 import { type Account } from '@suite-common/wallet-types';
@@ -16,10 +13,6 @@ type StorageLoadTransactionsReducer = (state: any, action: { type: any; payload:
 export type ExtraDependenciesStatic = {
     /** @deprecated Do not add any thunks here, this is antipattern. */
     thunks: FetchAndSaveMetadataDep & {
-        initMetadata: SuiteCompatibleThunk<boolean>;
-        addAccountMetadata: SuiteCompatibleThunk<
-            Exclude<MetadataAddPayload, { type: 'walletLabel' }>
-        >;
         forgetBluetoothDevice: SuiteCompatibleThunk<{
             bluetoothId: BluetoothDeviceId;
             skipToggleModalConnection?: boolean;

--- a/suite-native/state/src/createNativeCompositionRoot.ts
+++ b/suite-native/state/src/createNativeCompositionRoot.ts
@@ -178,9 +178,7 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
         getBinFilesBaseUrl: asGetter(() => resolveConnectPath('data')),
 
         // Not implemented. We assume those are NEVER called on Native.
-        getSelectedAccountStatus: notImplementedGetter('getSelectedAccountStatus', 'loaded'),
         getIsWindowVisible: notImplementedGetter('getIsWindowVisible', true),
-        getIsViewOnlyByDefaultEnabled: notImplementedGetter('getIsViewOnlyByDefaultEnabled', true),
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,

--- a/suite-native/state/src/createNativeExtraDependencies.ts
+++ b/suite-native/state/src/createNativeExtraDependencies.ts
@@ -19,8 +19,6 @@ export const extraDependencies: ExtraDependenciesStatic = {
         // need for this is architectural mistake. Please DO NOT add more and try
         // to remove them.
         fetchAndSaveMetadata: notImplementedThunk('fetchAndSaveMetadata'),
-        initMetadata: notImplementedThunk('initMetadata'),
-        addAccountMetadata: notImplementedThunk('addAccountMetadata'),
     },
     actions: {
         // Not implemented. We assume those are NEVER called on Native


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (6 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/suite/src/support/createSuiteCompositionRoot.ts`
- `packages/suite/src/support/extraDependencies.ts`
- `suite-common/extra-dependencies/src/CommonServices.ts`
- `suite-common/extra-dependencies/src/ExtraDependenciesStatic.ts`
- `suite-native/state/src/createNativeCompositionRoot.ts`
- `suite-native/state/src/createNativeExtraDependencies.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-12-extra-deps-di&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-props-12-extra-deps-di&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-props-12-extra-deps-di&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

---

🙏 Kindly requesting a review from @peter-sanderson and @vojtatranta — thanks!

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-12-extra-deps-di/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-12-extra-deps-di/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T07:41:27.625Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T07:39:16.450Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are composition-root and dependency-injection infrastructure for the Suite (and native) Redux/store layer. Because these files are global wiring, regressions would most visibly break app initialization, state persistence, and cross-cutting services. The recommended tests focus on cold-start behavior, database migration, browser loading, and core service wiring rather than feature-specific flows. The native state files are not covered by this web/desktop E2E suite.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/support/createSuiteCompositionRoot.ts`
- `packages/suite/src/support/extraDependencies.ts`
- `suite-common/extra-dependencies/src/CommonServices.ts`
- `suite-common/extra-dependencies/src/ExtraDependenciesStatic.ts`
- `suite-native/state/src/createNativeCompositionRoot.ts`
- `suite-native/state/src/createNativeExtraDependencies.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — Verifies the Suite app loads completely in Firefox. A regression in the suite composition root or extra dependencies wiring would prevent app initialization and cause this test to fail before any functional assertions run.
- `suite/e2e/tests/browser/safari.test.ts` — Verifies the Suite app loads and bypasses the unsupported-browser gate in Safari. Composition root or dependency wiring failures would prevent the app shell from initializing.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Loads an older Suite version's persisted IndexedDB state and verifies locale settings survive migration to develop. This directly exercises store initialization, persistence, and dependency wiring paths affected by composition root changes.
- `suite/e2e/tests/suite/db-migration.test.ts` — Loads a persisted wallet/settings state from an older Suite version and verifies the auto-eject setting survives database migration. This tests store rehydration and Redux service wiring through the composition root.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the cold-start onboarding flow from first app load through analytics consent to completion, including reloads at each stage. A regression in the composition root or extra dependencies would break state initialization and persistence across reloads.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Validates analytics services capture lifecycle and settings events with correct payloads. Analytics is a cross-cutting service wired through the composition root, so wiring regressions could break event dispatch or session/instance tracking.
- `suite/e2e/tests/analytics/toggle.test.ts` — Tests enabling/disabling analytics during onboarding and in settings, including persistence across reloads. This exercises the analytics service integration with the store and persistence layer wired by the composition root.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests bridge session acquisition, takeover, and reload behavior across browser tabs. Core transport and session services are wired through the composition root; regressions could break device status and session management.
- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — Loads a remembered wallet from IndexedDB without a connected device and verifies account rendering. This exercises store rehydration, account discovery initialization, and device-state services wired through the composition root.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/state/src/createNativeCompositionRoot.ts`
- `suite-native/state/src/createNativeExtraDependencies.ts`

_Updated: 2026-09-08T07:40:46.670Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->