### PR TITLE
refactor(suite-native): remove dead atom and screen props

### DIFF
--- a/suite-native/atoms/src/Text.tsx
+++ b/suite-native/atoms/src/Text.tsx
@@ -25,7 +25,6 @@ export interface PressableTextProps extends Omit<RNTextProps, 'style'>, TestProp
     color?: Color;
     priority?: TextPriority;
     textAlign?: TextStyle['textAlign'];
-    alignSelf?: TextStyle['alignSelf'];
     style?: NativeStyleObject;
 }
 

--- a/suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenFooter.tsx
+++ b/suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenFooter.tsx
@@ -1,4 +1,3 @@
-import { type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
@@ -7,13 +6,10 @@ import { Translation } from '@suite-native/intl';
 
 import { selectIsFirmwareUpdateFeatureEnabled } from '../hooks/useIsFirmwareUpdateFeatureEnabled';
 
-type ConfirmFirmwareUpdateScreenProps = {
+type ConfirmFirmwareUpdateScreenFooterProps = {
     onUpdateConfirmation: () => void;
     onSkipUpdate?: () => void;
-    header?: ReactNode;
 };
-
-type ConfirmFirmwareUpdateScreenFooterProps = Exclude<ConfirmFirmwareUpdateScreenProps, 'header'>;
 
 export const ConfirmFirmwareUpdateScreenFooter = ({
     onUpdateConfirmation,

--- a/suite-native/module-home/src/screens/HomeScreen/components/NoNetworksConfigured.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/NoNetworksConfigured.tsx
@@ -40,7 +40,6 @@ export const NoNetworksConfigured = () => {
                         subtitle={
                             <Translation id="moduleHome.emptyState.initializedDevice.subtitle" />
                         }
-                        alignSelf="stretch"
                     />
                     <Button
                         onPress={navigateToNetworkConfiguration}

--- a/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
@@ -59,7 +59,6 @@ export const UninitializedConnectedDeviceState = () => {
                         <Translation id="moduleHome.emptyState.uninitializedDevice.subtitle" />
                     }
                     testID="@homescreen/uninitializedConnectedDeviceText"
-                    alignSelf="stretch"
                 />
                 <Button onPress={navigateToDeviceOnboarding} style={applyStyle(buttonStyle)}>
                     <Translation id="moduleHome.emptyState.uninitializedDevice.button" />

--- a/suite-native/thp/src/components/DigitBox.tsx
+++ b/suite-native/thp/src/components/DigitBox.tsx
@@ -6,7 +6,6 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 type DigitBoxProps = {
     value?: string;
     isFocused: boolean;
-    testID?: string;
 };
 
 const digitBoxStyle = prepareNativeStyle<{ isFocused: boolean }>(


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (5 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `suite-native/atoms/src/Text.tsx`
- `suite-native/firmware/src/components/ConfirmFirmwareUpdateScreenFooter.tsx`
- `suite-native/module-home/src/screens/HomeScreen/components/NoNetworksConfigured.tsx`
- `suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx`
- `suite-native/thp/src/components/DigitBox.tsx`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-13-native-atoms-screens&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

---

🙏 Kindly requesting a review from @PeKne and @juriczech — thanks!