### PR TITLE
refactor(suite-native): remove dead component and hook props

### DIFF
--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -15,5 +15,4 @@ export type LaunchArguments = {
     isTradingDebugEnabled?: boolean;
     isTradingSlip24Enabled?: boolean;
     isN4w1BackupEnabled?: boolean;
-    isN4W1BackupEnabled?: boolean;
 };

--- a/suite-native/formatters/src/hooks/useCryptoFiatConverters.ts
+++ b/suite-native/formatters/src/hooks/useCryptoFiatConverters.ts
@@ -29,10 +29,8 @@ import { type BigNumber } from '@trezor/utils';
 type UseConvertFiatToCryptoParams = {
     symbol: NetworkSymbol | null;
     tokenContract?: TokenAddress;
-    tokenDecimals?: number;
     historicRate?: number;
     useHistoricRate?: boolean;
-    isBalance?: boolean;
 };
 
 export const useCryptoFiatConverters = ({

--- a/suite-native/module-check-backup/src/components/CheckBackupScreenWithExitButton.tsx
+++ b/suite-native/module-check-backup/src/components/CheckBackupScreenWithExitButton.tsx
@@ -19,10 +19,6 @@ import {
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 
-type DeviceOnboardingExitButtonScreenHeaderProps = {
-    onAlertContinueButtonPress?: () => void;
-};
-
 type NavigationProps = StackToStackCompositeNavigationProps<
     DeviceCheckBackupStackParamList,
     DeviceCheckBackupStackRoutes,
@@ -60,11 +56,7 @@ export const useHandleCheckBackupExitButtonPress = () => {
     return handleExitButtonPress;
 };
 
-export const CheckBackupScreenWithExitButton = ({
-    children,
-    onAlertContinueButtonPress,
-    ...screenProps
-}: ScreenProps & DeviceOnboardingExitButtonScreenHeaderProps) => {
+export const CheckBackupScreenWithExitButton = ({ children, ...screenProps }: ScreenProps) => {
     const handleExitButtonPress = useHandleCheckBackupExitButtonPress();
 
     useOverrideBackNavigation({

--- a/suite-native/navigation/src/hooks/useOverrideBackNavigation.tsx
+++ b/suite-native/navigation/src/hooks/useOverrideBackNavigation.tsx
@@ -7,7 +7,7 @@ import { useDisableIOSGesture } from './useDisableIOSGesture';
 /** @deprecated Use `useNavigationRemoveActionInterceptor` instead. */
 export const useOverrideBackNavigation = ({
     onNavigateBack,
-}: { onNavigateBack?: () => void; gestureEnabled?: boolean } = {}) => {
+}: { onNavigateBack?: () => void } = {}) => {
     useDisableIOSGesture();
     const navigation = useNavigation();
 

--- a/suite-native/transaction-management/src/types/fees.ts
+++ b/suite-native/transaction-management/src/types/fees.ts
@@ -1,9 +1,4 @@
-import {
-    type AccountKey,
-    type FeeLevelLabel,
-    type FormDraftKeyPrefix,
-    type TokenAddress,
-} from '@suite-common/wallet-types';
+import { type AccountKey, type FeeLevelLabel, type TokenAddress } from '@suite-common/wallet-types';
 
 export type NativeSupportedPredefinedFeeLevel = Exclude<FeeLevelLabel, 'custom'>;
 export type FeeLevelsMaxAmount = Record<FeeLevelLabel, string | undefined>;
@@ -17,7 +12,6 @@ export type UpdateFeeLimitThunkParams = {
 export type UpdateSelectedFeeLevelThunkParams = {
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
-    formDraftPrefix?: FormDraftKeyPrefix;
     formDraftKey?: string;
 } & (
     | {

--- a/suite-native/transactions/src/components/TransactionTarget.tsx
+++ b/suite-native/transactions/src/components/TransactionTarget.tsx
@@ -97,7 +97,6 @@ export const TransactionListItemValues = ({
 type TransactionTargetProps = Target & {
     transaction: WalletAccountTransaction;
     accountKey: AccountKey;
-    isActionDisabled?: boolean;
     isPhishingTransaction?: boolean;
 };
 


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (6 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `suite-native/config/src/types.ts`
- `suite-native/formatters/src/hooks/useCryptoFiatConverters.ts`
- `suite-native/module-check-backup/src/components/CheckBackupScreenWithExitButton.tsx`
- `suite-native/navigation/src/hooks/useOverrideBackNavigation.tsx`
- `suite-native/transaction-management/src/types/fees.ts`
- `suite-native/transactions/src/components/TransactionTarget.tsx`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-14-native-misc&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

---

🙏 Kindly requesting a review from @PeKne and @BrantalikP — thanks!