### PR TITLE
refactor: remove dead type properties in desktop, connect-explorer and theme

### DIFF
--- a/packages/connect-explorer-theme/src/components/theme-switch.tsx
+++ b/packages/connect-explorer-theme/src/components/theme-switch.tsx
@@ -13,7 +13,6 @@ import { type themeOptionsSchema } from '../schema';
 
 type ThemeSwitchProps = {
     lite?: boolean;
-    className?: string;
 };
 
 type ThemeOptions = z.infer<typeof themeOptionsSchema>;

--- a/packages/connect-explorer/src/components/GuideIndex.tsx
+++ b/packages/connect-explorer/src/components/GuideIndex.tsx
@@ -18,7 +18,6 @@ interface Page {
     frontMatter?: {
         title?: string;
         description?: string;
-        date?: string;
     };
     name: string;
 }

--- a/packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts
@@ -2,7 +2,7 @@ import { TOR_CONTROLLER_STATUS, TorControllerExternal } from '@trezor/request-ma
 
 import { type Status } from './BaseProcess';
 
-export type TorProcessStatus = Status & { isBootstrapping?: boolean };
+export type TorProcessStatus = Status;
 
 export class TorExternalProcess {
     torController: TorControllerExternal;
@@ -29,7 +29,6 @@ export class TorExternalProcess {
         return {
             service: torControllerStatus === TOR_CONTROLLER_STATUS.ExternalTorRunning,
             process: torControllerStatus === TOR_CONTROLLER_STATUS.ExternalTorRunning,
-            isBootstrapping: false, // For Tor external we fake bootstrap process.
         };
     }
 

--- a/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/TorProcess.ts
@@ -3,7 +3,7 @@ import { type TorConnectionOptions } from '@trezor/request-manager/src/types';
 
 import { BaseProcess, type Status } from './BaseProcess';
 
-export type TorProcessStatus = Status & { isBootstrapping?: boolean };
+export type TorProcessStatus = Status;
 
 export class TorProcess extends BaseProcess {
     torController: TorController;
@@ -42,7 +42,6 @@ export class TorProcess extends BaseProcess {
         return {
             service: torControllerStatus === TOR_CONTROLLER_STATUS.CircuitEstablished,
             process: Boolean(this.process),
-            isBootstrapping: torControllerStatus === TOR_CONTROLLER_STATUS.Bootstrapping,
         };
     }
 

--- a/packages/suite-desktop-native/src/winHelloManager.ts
+++ b/packages/suite-desktop-native/src/winHelloManager.ts
@@ -150,9 +150,7 @@ export class WinHelloProcessManager implements WinHelloManager {
 
     private sendRequest<T extends 'isHelloAvailable' | 'requestHello'>(
         method: T,
-        params?: T extends 'requestHello'
-            ? { message?: string; windowHandle?: Buffer | null }
-            : undefined,
+        params?: T extends 'requestHello' ? { message?: string } : undefined,
     ): Promise<T extends 'isHelloAvailable' ? boolean : string> {
         if (!this.childProcess || !this.isReady) {
             throw new Error('Child process not initialized. Call create() first.');

--- a/packages/theme/src/typography.ts
+++ b/packages/theme/src/typography.ts
@@ -26,7 +26,6 @@ type TypographyStyleDefinition = {
     lineHeight: number;
     fontWeight: FontWeightValue;
     letterSpacing: number;
-    fontFamily?: string;
 };
 
 export type NativeTypographyStyleDefinition = {


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (6 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/connect-explorer-theme/src/components/theme-switch.tsx`
- `packages/connect-explorer/src/components/GuideIndex.tsx`
- `packages/suite-desktop-core/src/libs/processes/TorExternalProcess.ts`
- `packages/suite-desktop-core/src/libs/processes/TorProcess.ts`
- `packages/suite-desktop-native/src/winHelloManager.ts`
- `packages/theme/src/typography.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

---

🙏 Kindly requesting a review from @karliatto and @jvaclavik — thanks!