### PR TITLE
refactor(suite-common): remove dead shared type and config properties

### DIFF
--- a/packages/suite-data/src/browser-detection/index.ts
+++ b/packages/suite-data/src/browser-detection/index.ts
@@ -27,8 +27,6 @@ type MainHtmlProps = {
     supportedDevicesList?: boolean;
     supportedBrowsers?: SupportedBrowser[];
     shouldUpdate?: boolean;
-    iosAppBanner?: boolean;
-    androidAppBanner?: boolean;
     metaTags?: string[];
 };
 
@@ -197,7 +195,6 @@ window.addEventListener('load', () => {
         subtitle:
             'Trezor Safe 7 can connect via Bluetooth using the Trezor Suite desktop app. Trezor Suite is also available on:',
         supportedDevicesList: true,
-        iosAppBanner: true,
         metaTags: [
             '<meta name="apple-itunes-app" content="app-id=1631884497, affiliate-data=, app-argument=https://trezor.io/suite" />',
         ],

--- a/packages/suite/src/config/suite/settings.ts
+++ b/packages/suite/src/config/suite/settings.ts
@@ -1,4 +1,3 @@
-import { settingsCommonConfig } from '@suite-common/suite-config';
 import { type NotificationEntry } from '@suite-common/toast-notifications';
 
 const IMPORTANT_NOTIFICATION_TYPES: Array<NotificationEntry['type']> = [
@@ -15,7 +14,6 @@ const IMPORTANT_NOTIFICATION_TYPES: Array<NotificationEntry['type']> = [
 ];
 
 export default {
-    ...settingsCommonConfig,
     DEFAULT_GRAPH_RANGE: {
         label: 'all',
         startDate: null,

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -48,8 +48,6 @@ export type MetadataAddPayload = { skipSave?: boolean } & (
           entityKey: string;
           defaultValue: string;
           value?: string;
-          networkType?: string;
-          path?: string;
       }
     | {
           type: 'walletLabel';

--- a/suite-common/suite-config/src/index.ts
+++ b/suite-common/suite-config/src/index.ts
@@ -1,3 +1,2 @@
 export * from './features';
 export * from './tor';
-export * from './settings';

--- a/suite-common/suite-config/src/settings.ts
+++ b/suite-common/suite-config/src/settings.ts
@@ -1,5 +1,0 @@
-export const settingsCommonConfig = {
-    MAX_ACCOUNTS: 10,
-    FRESH_ADDRESS_LIMIT: 20,
-    TXS_PER_PAGE: 25,
-} as const;

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -13,7 +13,6 @@ export type NotificationId = number;
 
 export interface NotificationOptions {
     seen?: boolean;
-    resolved?: boolean;
     autoClose?: number | false;
     style?: CSSProperties;
 }
@@ -272,7 +271,6 @@ export type NotificationEventPayload = (
     | {
           type: typeof DEVICE.CONNECT | typeof DEVICE.CONNECT_UNACQUIRED;
           device: TrezorDevice;
-          needAttention?: boolean;
       }
 ) &
     NotificationOptions;

--- a/suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts
+++ b/suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts
@@ -66,7 +66,7 @@ const getStellarValidation = (
     validation: StellarValidation | null | undefined,
 ): ValidationLike | undefined => (validation && 'features' in validation ? validation : undefined);
 
-export type TxSimulationFailure = { error: string; description?: string };
+export type TxSimulationFailure = { error: string };
 
 // Beyond each network's own error arm, the three readers below share one rule: a scan that answers
 // with a success status but no account summary has nothing to show and nothing to trust, so it
@@ -79,7 +79,7 @@ export const getEvmSimulationFailure = (
     const { simulation } = response;
 
     if (simulation?.status === 'Error') {
-        return { error: simulation.error, description: simulation.description };
+        return { error: simulation.error };
     }
 
     if (simulation && !getEvmSimulationSummary(response)) {


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (7 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/suite-data/src/browser-detection/index.ts`
- `packages/suite/src/config/suite/settings.ts`
- `suite-common/metadata-types/src/metadataTypes.ts`
- `suite-common/suite-config/src/index.ts`
- `suite-common/suite-config/src/settings.ts`
- `suite-common/toast-notifications/src/types.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-17-common-types-config&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

---

🙏 Kindly requesting a review from @peter-sanderson and @tomasklim — thanks!