### PR TITLE
refactor(suite): remove dead wallet-view component props

### DIFF
--- a/packages/suite/src/components/earn/providers/providerMetadata.ts
+++ b/packages/suite/src/components/earn/providers/providerMetadata.ts
@@ -1,11 +1,9 @@
-import { type GetAssetLogoUrlParams } from '@trezor/asset-utils';
 import { type ImageType } from '@trezor/components';
 
 type ProviderMetadata = {
     name: string;
     companyName: string;
     logo: ImageType;
-    tokenLogo?: Required<Pick<GetAssetLogoUrlParams, 'coingeckoId' | 'contractAddress'>>;
 };
 
 export const EARN_PROVIDER_METADATA = {
@@ -18,10 +16,6 @@ export const EARN_PROVIDER_METADATA = {
         name: 'Morpho',
         companyName: 'Morpho',
         logo: 'MORPHO_LOGO',
-        tokenLogo: {
-            coingeckoId: 'ethereum',
-            contractAddress: '0x58d97b57bb95320f9a05dc918aef65434969c2b2',
-        },
     },
 } as const satisfies Record<string, ProviderMetadata>;
 

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
@@ -13,7 +13,6 @@ interface GraphTooltipDashboardProps extends TooltipProps<number, any> {
     localCurrency: string;
     sentValueFn: FiatGraphProps['sentValueFn'];
     receivedValueFn: FiatGraphProps['receivedValueFn'];
-    balanceValueFn?: FiatGraphProps['balanceValueFn'];
     onShow?: (index: number) => void;
     extendedDataForInterval?: CommonAggregatedHistory[];
 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx
@@ -15,10 +15,7 @@ import { ConfirmActionModal } from './DeviceContextModal/ConfirmActionModal';
 import { ConnectAddressConfirmation } from './UserContextModal/ConnectAddressConfirmation';
 
 export const ConfirmXpubModal = (
-    props: Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel'> & {
-        descriptor?: string;
-        descriptorChecksum?: string;
-    },
+    props: Pick<ConfirmValueModalProps, 'isConfirmed' | 'onCancel'>,
 ) => {
     const device = useSelector(selectSelectedDevice);
     const account = useSelector(selectSelectedAccount);

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -56,7 +56,6 @@ type NftsRowProps = {
     selectedAccount: SelectedAccountStatus;
     isShown?: boolean;
     isEmptyCollection?: boolean;
-    setIsEmptyCollectionsOpen?: (open: boolean) => void;
     isEmptyCollectionsOpen?: boolean;
 };
 

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceError.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceError.tsx
@@ -7,7 +7,7 @@ const StyledBalanceContainer = styled.div`
     padding: 0 24px;
 `;
 
-const Heading = styled.p<{ $color?: string }>`
+const Heading = styled.p`
     margin-bottom: 4px;
     color: ${({ theme, color }) => color || theme.contentSecondary};
     ${typography['body-xs']}

--- a/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
@@ -95,7 +95,6 @@ export const useFetchTransactions = (
         (
             page: number,
             options: {
-                recursive?: boolean;
                 noLoading?: boolean;
             } = {},
         ) => {


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (6 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/suite/src/components/earn/providers/providerMetadata.ts`
- `packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/ConfirmXpubModal.tsx`
- `packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx`
- `packages/suite/src/views/wallet/transactions/CoinjoinSummary/CoinjoinBalanceError.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

---

🙏 Kindly requesting a review from @peter-sanderson and @seibei-iguchi — thanks!