### PR TITLE
refactor(suite): remove dead shell, device and storage type properties

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -13,7 +13,6 @@ import {
 
 type BluetoothConnectDeviceThunkResult = {
     success: boolean;
-    unpaired?: boolean;
 };
 
 export const bluetoothConnectDeviceThunk = createThunk<

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -64,7 +64,6 @@ export type NavigationItemProps = {
     hasNewContentIndicator?: boolean;
     isNewContentIndicatorAnimated?: boolean;
     'data-testid'?: string;
-    className?: string;
     values?: ExtendedMessageDescriptor['values'];
     onClick?: () => void;
     shortcut?: ShortcutBadgeProps['shortcut'];

--- a/packages/suite/src/storage/migrations/versions/26.8.0.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.ts
@@ -11,7 +11,7 @@ type LegacyReceiveInfo = {
 
 type LegacyReceiveAccountState = {
     touchedAddresses?: LegacyReceiveInfo[];
-    revealedAddresses?: (LegacyReceiveInfo & { isVerified?: boolean })[];
+    revealedAddresses?: LegacyReceiveInfo[];
     currentFreshAddress?: LegacyReceiveInfo;
 };
 

--- a/packages/suite/src/support/suite/useConnectPopupWebextension.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWebextension.tsx
@@ -14,7 +14,6 @@ import {
  */
 interface ChromeRuntime {
     sendMessage: (extensionId: string, message: Record<string, unknown>) => void;
-    lastError?: { message: string };
 }
 
 declare const chrome: { runtime?: ChromeRuntime } | undefined;

--- a/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
@@ -23,7 +23,6 @@ type CardWithDeviceProps = {
     actions?: ReactNode | null;
     onCancel?: ForegroundAppProps['onCancel'];
     device: TrezorDevice;
-    isFindTrezorVisible?: boolean;
     onBackButtonClick?: () => void;
     isDeviceStatusVisible?: boolean;
 };

--- a/packages/suite/src/views/suite/udev/index.tsx
+++ b/packages/suite/src/views/suite/udev/index.tsx
@@ -19,8 +19,6 @@ interface UdevInfo {
         name: string;
         platform: string[];
         url: string;
-        signature?: string;
-        preferred?: boolean;
     }[];
 }
 
@@ -37,7 +35,6 @@ const udev: UdevInfo = {
             name: 'DEB package',
             platform: ['deb32', 'deb64'],
             url: '/udev/trezor-udev_2_all.deb',
-            preferred: true, // DEB package is the most common
         },
     ],
 };

--- a/suite/modal/src/modalActions.ts
+++ b/suite/modal/src/modalActions.ts
@@ -37,7 +37,6 @@ export const preserveModalOnTxTimeout = createAction(MODAL_PRESERVE_ON_TX_TIMEOU
 type OnReceiveConfirmationThunkState = {
     modal: {
         context: string;
-        requestId?: string;
     };
 };
 


### PR DESCRIPTION
## Description

Part of the dead-code cleanup tracked in #32104 (umbrella / staging PR — not meant to be merged as-is).

This slice removes only **dead / unused type properties** (7 files) — no runtime behaviour change. Every removed member was verified to have zero readers; the umbrella branch is fully green (type-check, lint, unit tests, e2e, builds).

**Files:**
- `packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx`
- `packages/suite/src/storage/migrations/versions/26.8.0.ts`
- `packages/suite/src/support/suite/useConnectPopupWebextension.tsx`
- `packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx`
- `packages/suite/src/views/suite/udev/index.tsx`
- `suite/modal/src/modalActions.ts`

Split out of #32104 for reviewable, per-concern PRs. See the umbrella for the full context and the list of sibling PRs.

## Notes for QA

Pure dead-code (unused TypeScript type properties) removal — no user-facing or runtime behaviour change is expected. No functional testing needed beyond green CI.

---

🙏 Kindly requesting a review from @seibei-iguchi and @jvaclavik — thanks!