### PR TITLE
refactor(token-definitions): replace redundant EnhancedTokenInfo alias with TokenInfo

### DIFF
--- a/packages/suite/src/utils/wallet/__fixtures__/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/tokenUtils.ts
@@ -1,8 +1,4 @@
-import {
-    type EnhancedTokenInfo,
-    type TokenDefinition,
-    type TokenDefinitionsState,
-} from '@suite-common/token-definitions';
+import { type TokenDefinition, type TokenDefinitionsState } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenInfo } from '@trezor/connect';
 
@@ -10,8 +6,8 @@ export const getTokensFixtures = [
     {
         testName: 'tokens with definitions and balance',
         tokens: [
-            { contract: '0x1', balance: '100' } as EnhancedTokenInfo,
-            { contract: '0x2', balance: '200' } as EnhancedTokenInfo,
+            { contract: '0x1', balance: '100' } as TokenInfo,
+            { contract: '0x2', balance: '200' } as TokenInfo,
         ],
         symbol: 'eth' as const,
         coinDefinitions: {
@@ -24,8 +20,8 @@ export const getTokensFixtures = [
         searchQuery: '',
         result: {
             shownWithBalance: [
-                { contract: '0x1', balance: '100' } as EnhancedTokenInfo,
-                { contract: '0x2', balance: '200' } as EnhancedTokenInfo,
+                { contract: '0x1', balance: '100' } as TokenInfo,
+                { contract: '0x2', balance: '200' } as TokenInfo,
             ],
             shownWithoutBalance: [],
             hiddenWithBalance: [],
@@ -37,9 +33,9 @@ export const getTokensFixtures = [
     {
         testName: 'hidden token with legit tokens',
         tokens: [
-            { contract: '0x1', balance: '100' } as EnhancedTokenInfo,
-            { contract: '0x2', balance: '200' } as EnhancedTokenInfo,
-            { contract: '0x3', balance: '0' } as EnhancedTokenInfo,
+            { contract: '0x1', balance: '100' } as TokenInfo,
+            { contract: '0x2', balance: '200' } as TokenInfo,
+            { contract: '0x3', balance: '0' } as TokenInfo,
         ],
         symbol: 'eth' as const,
         coinDefinitions: {
@@ -51,9 +47,9 @@ export const getTokensFixtures = [
         } as TokenDefinition,
         searchQuery: '',
         result: {
-            shownWithBalance: [{ contract: '0x1', balance: '100' } as EnhancedTokenInfo],
-            shownWithoutBalance: [{ contract: '0x3', balance: '0' } as EnhancedTokenInfo],
-            hiddenWithBalance: [{ contract: '0x2', balance: '200' } as EnhancedTokenInfo],
+            shownWithBalance: [{ contract: '0x1', balance: '100' } as TokenInfo],
+            shownWithoutBalance: [{ contract: '0x3', balance: '0' } as TokenInfo],
+            hiddenWithBalance: [{ contract: '0x2', balance: '200' } as TokenInfo],
             hiddenWithoutBalance: [],
             unverifiedWithBalance: [],
             unverifiedWithoutBalance: [],
@@ -62,9 +58,9 @@ export const getTokensFixtures = [
     {
         testName: 'unverified tokens with legit token',
         tokens: [
-            { contract: '0x1', balance: '100' } as EnhancedTokenInfo,
-            { contract: '0x2', balance: '200' } as EnhancedTokenInfo,
-            { contract: '0x3', balance: '0' } as EnhancedTokenInfo,
+            { contract: '0x1', balance: '100' } as TokenInfo,
+            { contract: '0x2', balance: '200' } as TokenInfo,
+            { contract: '0x3', balance: '0' } as TokenInfo,
         ],
         symbol: 'eth' as const,
         coinDefinitions: {
@@ -76,22 +72,22 @@ export const getTokensFixtures = [
         } as TokenDefinition,
         searchQuery: '',
         result: {
-            shownWithBalance: [{ contract: '0x1', balance: '100' } as EnhancedTokenInfo],
+            shownWithBalance: [{ contract: '0x1', balance: '100' } as TokenInfo],
             shownWithoutBalance: [],
             hiddenWithBalance: [],
             hiddenWithoutBalance: [],
-            unverifiedWithBalance: [{ contract: '0x2', balance: '200' } as EnhancedTokenInfo],
-            unverifiedWithoutBalance: [{ contract: '0x3', balance: '0' } as EnhancedTokenInfo],
+            unverifiedWithBalance: [{ contract: '0x2', balance: '200' } as TokenInfo],
+            unverifiedWithoutBalance: [{ contract: '0x3', balance: '0' } as TokenInfo],
         },
     },
     {
         testName: 'mix of shown, hidden, and unverified tokens',
         tokens: [
-            { contract: '0x1', balance: '100' } as EnhancedTokenInfo,
-            { contract: '0x2', balance: '200' } as EnhancedTokenInfo,
-            { contract: '0x3', balance: '300' } as EnhancedTokenInfo,
-            { contract: '0x4', balance: '0' } as EnhancedTokenInfo,
-            { contract: '0x5', balance: '0' } as EnhancedTokenInfo,
+            { contract: '0x1', balance: '100' } as TokenInfo,
+            { contract: '0x2', balance: '200' } as TokenInfo,
+            { contract: '0x3', balance: '300' } as TokenInfo,
+            { contract: '0x4', balance: '0' } as TokenInfo,
+            { contract: '0x5', balance: '0' } as TokenInfo,
         ],
         symbol: 'eth' as const,
         coinDefinitions: {
@@ -104,25 +100,25 @@ export const getTokensFixtures = [
         searchQuery: '',
         result: {
             shownWithBalance: [
-                { contract: '0x1', balance: '100' } as EnhancedTokenInfo,
-                { contract: '0x3', balance: '300' } as EnhancedTokenInfo,
+                { contract: '0x1', balance: '100' } as TokenInfo,
+                { contract: '0x3', balance: '300' } as TokenInfo,
             ],
             shownWithoutBalance: [],
-            hiddenWithBalance: [{ contract: '0x2', balance: '200' } as EnhancedTokenInfo],
+            hiddenWithBalance: [{ contract: '0x2', balance: '200' } as TokenInfo],
             hiddenWithoutBalance: [],
             unverifiedWithBalance: [],
             unverifiedWithoutBalance: [
-                { contract: '0x4', balance: '0' } as EnhancedTokenInfo,
-                { contract: '0x5', balance: '0' } as EnhancedTokenInfo,
+                { contract: '0x4', balance: '0' } as TokenInfo,
+                { contract: '0x5', balance: '0' } as TokenInfo,
             ],
         },
     },
     {
         testName: 'legitokens search',
         tokens: [
-            { contract: '0x1', balance: '100', symbol: 'ABC' } as EnhancedTokenInfo,
-            { contract: '0x2', balance: '200', symbol: 'DEF' } as EnhancedTokenInfo,
-            { contract: '0x3', balance: '0', symbol: 'GHI' } as EnhancedTokenInfo,
+            { contract: '0x1', balance: '100', symbol: 'ABC' } as TokenInfo,
+            { contract: '0x2', balance: '200', symbol: 'DEF' } as TokenInfo,
+            { contract: '0x3', balance: '0', symbol: 'GHI' } as TokenInfo,
         ],
         symbol: 'eth' as const,
         coinDefinitions: {
@@ -134,9 +130,7 @@ export const getTokensFixtures = [
         } as TokenDefinition,
         searchQuery: 'AB',
         result: {
-            shownWithBalance: [
-                { contract: '0x1', balance: '100', symbol: 'ABC' } as EnhancedTokenInfo,
-            ],
+            shownWithBalance: [{ contract: '0x1', balance: '100', symbol: 'ABC' } as TokenInfo],
             shownWithoutBalance: [],
             hiddenWithBalance: [],
             hiddenWithoutBalance: [],

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -8,7 +8,7 @@ import { gotoThunk } from '@suite/router';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     DefinitionType,
-    type EnhancedTokenInfo,
+    type TokenInfo,
     TokenManagementAction,
     tokenDefinitionsActions,
 } from '@suite-common/token-definitions';
@@ -51,7 +51,7 @@ import { DropdownRow } from '../../tokens/DropdownRow';
 import { BlurUrls } from '../../tokens/common/BlurUrls';
 
 type NftsRowProps = {
-    nft: EnhancedTokenInfo;
+    nft: TokenInfo;
     network: Network;
     selectedAccount: SelectedAccountStatus;
     isShown?: boolean;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
-    type EnhancedTokenInfo,
+    type TokenInfo,
     type TokenManagementAction,
     selectIsSpecificCoinDefinitionKnown,
 } from '@suite-common/token-definitions';
@@ -31,7 +31,7 @@ import type { TokensTableType } from './types';
 type TokenRowProps = {
     type?: TokensTableType;
     account: Account;
-    token: EnhancedTokenInfo;
+    token: TokenInfo;
     network: Network;
     tokenStatusType: TokenManagementAction;
     hideRates?: boolean;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -17,7 +17,7 @@ import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     DefinitionType,
-    type EnhancedTokenInfo,
+    type TokenInfo,
     TokenManagementAction,
     tokenDefinitionsActions,
 } from '@suite-common/token-definitions';
@@ -81,7 +81,7 @@ import type { TokensTableType } from './types';
 
 interface TokenRowBasicActionsProps {
     type?: TokensTableType;
-    token: EnhancedTokenInfo;
+    token: TokenInfo;
     tokenStatusType: TokenManagementAction;
     account: Account;
     network: Network;
@@ -641,7 +641,7 @@ const TokenRowBasicActions = ({
 
 interface TokenRowActionsProps {
     type?: TokensTableType;
-    token: EnhancedTokenInfo;
+    token: TokenInfo;
     tokenStatusType: TokenManagementAction;
     account: Account;
     network: Network;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -3,10 +3,7 @@ import { useEffect, useState } from 'react';
 import { Translation } from '@suite/intl';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { useDispatch } from '@suite-common/redux-utils';
-import {
-    type EnhancedTokenInfo,
-    type TokenManagementAction,
-} from '@suite-common/token-definitions';
+import { type TokenInfo, type TokenManagementAction } from '@suite-common/token-definitions';
 import { tradingThunks } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
@@ -31,8 +28,8 @@ export const NoSearchResultsWrapped = () => (
 interface TokensTableProps {
     type?: TokensTableType;
     account: Account;
-    tokensWithBalance: EnhancedTokenInfo[];
-    tokensWithoutBalance: EnhancedTokenInfo[];
+    tokensWithBalance: TokenInfo[];
+    tokensWithoutBalance: TokenInfo[];
     network: Network;
     tokenStatusType: TokenManagementAction;
     hideRates?: boolean;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 
 import { selectBestEnabledYieldVault } from '@suite-common/earn-stablecoin';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { type EnhancedTokenInfo } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     getYieldVaultForOutputToken,
@@ -19,7 +18,7 @@ import type { TokensTableType } from '../types';
 
 type UseTokenYieldBadgeParams = {
     networkSymbol: NetworkSymbol;
-    token: EnhancedTokenInfo;
+    token: TokenInfo;
     accountTokens: TokenInfo[] | undefined;
     type: TokensTableType;
     yieldOpportunities?: YieldDtoV2[];

--- a/suite-common/token-definitions/src/tokenDefinitionsTypes.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsTypes.ts
@@ -54,4 +54,4 @@ export type TokenDefinitions = {
 
 export type TokenManagementStorage = { key: string; value: SimpleTokenStructure };
 
-export type EnhancedTokenInfo = TokenInfo;
+export type { TokenInfo };

--- a/suite-common/wallet-core/src/tokens/tokenUtils.ts
+++ b/suite-common/wallet-core/src/tokens/tokenUtils.ts
@@ -1,8 +1,4 @@
-import {
-    type EnhancedTokenInfo,
-    type TokenDefinition,
-    isTokenDefinitionKnown,
-} from '@suite-common/token-definitions';
+import { type TokenDefinition, isTokenDefinitionKnown } from '@suite-common/token-definitions';
 import {
     type NetworkSymbol,
     getNetworkDisplaySymbol,
@@ -13,7 +9,7 @@ import { isNftMatchesSearch, isNftToken, isTokenMatchesSearch } from '@suite-com
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
 
-type GetTokensInput<T extends EnhancedTokenInfo | TokenInfo> = {
+type GetTokensInput<T extends TokenInfo> = {
     tokens?: T[];
     symbol: NetworkSymbol;
     tokenDefinitions?: TokenDefinition;
@@ -21,7 +17,7 @@ type GetTokensInput<T extends EnhancedTokenInfo | TokenInfo> = {
     isNft?: boolean;
 };
 
-export type GetTokensOutputType<T extends EnhancedTokenInfo | TokenInfo = EnhancedTokenInfo> = {
+export type GetTokensOutputType<T extends TokenInfo = TokenInfo> = {
     shownWithBalance: T[];
     shownWithoutBalance: T[];
     hiddenWithBalance: T[];
@@ -30,7 +26,7 @@ export type GetTokensOutputType<T extends EnhancedTokenInfo | TokenInfo = Enhanc
     unverifiedWithoutBalance: T[];
 };
 
-export const getTokens = <T extends EnhancedTokenInfo | TokenInfo = EnhancedTokenInfo>({
+export const getTokens = <T extends TokenInfo = TokenInfo>({
     tokens = [],
     symbol,
     tokenDefinitions,

--- a/suite-native/module-earn/src/hooks/yield/useYieldBadge.tsx
+++ b/suite-native/module-earn/src/hooks/yield/useYieldBadge.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { selectBestEnabledYieldVault } from '@suite-common/earn-stablecoin';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type MessageSystemRootState } from '@suite-common/message-system';
-import { type EnhancedTokenInfo } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     getYieldVaultForOutputToken,
@@ -23,7 +22,7 @@ interface YieldBadgeData {
 
 interface UseYieldBadgeProps {
     networkSymbol?: NetworkSymbol;
-    token?: EnhancedTokenInfo;
+    token?: TokenInfo;
     accountTokens: TokenInfo[] | undefined;
     type: 'default' | 'defi';
     yieldOpportunities?: YieldDtoV2[];


### PR DESCRIPTION
## Description

Follow-up to #32112, stacked on its branch. In #32112 the dead `fiatRate` field was removed from `EnhancedTokenInfo`, which left `EnhancedTokenInfo` as a plain alias of `TokenInfo` — a misleading name (flagged by Copilot review). This PR collapses the alias: replaces `EnhancedTokenInfo` with `TokenInfo` across all consumers and re-exports `TokenInfo` from `@suite-common/token-definitions` so import sites stay stable. The generic `getTokens<T extends EnhancedTokenInfo | TokenInfo = EnhancedTokenInfo>` collapses to `<T extends TokenInfo = TokenInfo>`.

Type-check green (`@trezor/suite` + 175 deps).

## Notes for QA

Pure type-level rename/cleanup — no runtime or user-facing behaviour change. No functional testing needed beyond green CI.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-props-05b-collapse-enhancedtokeninfo&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-props-05b-collapse-enhancedtokeninfo&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-props-05b-collapse-enhancedtokeninfo&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

---

🙏 Kindly requesting a review from @peter-sanderson and @tomasklim — thanks!

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set focuses on token/NFT table UI components and the token yield badge hook, with the highest regression risk in token row rendering and actions. The recommended strategy is to run the token-trading navigation test as the primary validator, add the two live token swap tests for broader token-row coverage, and use the general link-check test as a lightweight smoke test for the /accounts/tokens and /accounts/nfts routes. Several changed files (token definitions types, tokenUtils fixture, and the native yield badge hook) have no Suite web e2e coverage and should be covered by unit/native tests instead.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/utils/wallet/__fixtures__/tokenUtils.ts`
- `packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts`
- `suite-common/token-definitions/src/tokenDefinitionsTypes.ts`
- `suite-common/wallet-core/src/tokens/tokenUtils.ts`
- `suite-native/module-earn/src/hooks/yield/useYieldBadge.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to token-specific trading pages (TUSD/USDC on ETH) and verifies the correct form opens. Those entry points are reached through token row actions in the account tokens table, so it directly exercises TokenRow, TokenRowActions, TokensTable, and the yield badge hook rendered on token rows.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — The swap flow starts from a Solana account and targets a USDC token on Base, interacting with token balances and token-related account pages. Changes to the token table components or yield badge could affect token visibility or actions during the flow.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — This test swaps an SPL token (USDT) on Solana, so it traverses token rows and token actions in the Solana account. A regression in token row rendering or actions would likely surface here.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — It visits /accounts/tokens and /accounts/nfts and extracts links from those pages. If TokensTable or NftsRow fails to render or crashes, the page load/link extraction would fail, making this a cheap smoke test for the affected routes.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/utils/wallet/__fixtures__/tokenUtils.ts`
- `suite-common/token-definitions/src/tokenDefinitionsTypes.ts`
- `suite-native/module-earn/src/hooks/yield/useYieldBadge.tsx`

_Updated: 2026-09-06T16:41:28.819Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-05b-collapse-enhancedtokeninfo/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-props-05b-collapse-enhancedtokeninfo/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-06T16:42:45.907Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-06T16:42:36.989Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->