### PR TITLE
Keep valid networks when one staking batch entry drifts

### DIFF
--- a/suite-common/earn-staking-api/jest.config.js
+++ b/suite-common/earn-staking-api/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/earn-staking-api/package.json
+++ b/suite-common/earn-staking-api/package.json
@@ -9,6 +9,7 @@
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest",
         "format": "prettier --write './**/*.ts'",
         "orval": "orval --config ./orval.config.ts",
         "api:generate": "yarn orval",

--- a/suite-common/earn-staking-api/src/staking/services/index.ts
+++ b/suite-common/earn-staking-api/src/staking/services/index.ts
@@ -1,8 +1,8 @@
 import { createHttpClient } from '@suite-common/http-client';
 
+import { resilientStakingBatchResponse } from './resilientStakingBatchResponse';
 import {
     reportStakingTxIdsResponse,
-    stakingBatchResponse,
     stakingCardanoPoolsResponse,
     stakingEthereumValidatorsQueueResponse,
     stakingSolanaRewardsHistoryResponse,
@@ -40,7 +40,7 @@ export const getStakingBatch: (
     options?: RequestOptions & { params?: StakingBatchRequestParams },
 ) => Promise<StakingBatch> = earnHttpClient('/', {
     method: 'GET',
-    schema: stakingBatchResponse,
+    schema: resilientStakingBatchResponse,
     timeout: 60_000,
 });
 

--- a/suite-common/earn-staking-api/src/staking/services/resilientStakingBatchResponse.test.ts
+++ b/suite-common/earn-staking-api/src/staking/services/resilientStakingBatchResponse.test.ts
@@ -1,0 +1,144 @@
+import type { resilientStakingBatchResponse as importedSchema } from './resilientStakingBatchResponse';
+import { type StakingBatchDataItem, type StakingBatchErrorsItem } from '../../api/types';
+
+const mockCaptureException = jest.fn();
+
+jest.mock('@sentry/core', () => ({
+    captureException: mockCaptureException,
+    withScope: (callback: (scope: { setTag: jest.Mock }) => void) =>
+        callback({ setTag: jest.fn() }),
+}));
+
+type SchemaModule = { resilientStakingBatchResponse: typeof importedSchema };
+
+let resilientStakingBatchResponse: typeof importedSchema;
+
+const ethSection = {
+    symbol: 'eth',
+    stats: { apy: 3.08, nextRewardPayout: 3600 },
+    validators: { activationTime: 600, exitTime: 1200 },
+} satisfies StakingBatchDataItem;
+
+const solSection = {
+    symbol: 'sol',
+    stats: { apy: 7.5 },
+} satisfies StakingBatchDataItem;
+
+const adaSection = {
+    symbol: 'ada',
+    pools: [{ apy: 2.4, saturation: 80.77, id: 'pool1' }],
+} satisfies StakingBatchDataItem;
+
+const trxSection = {
+    symbol: 'trx',
+    representatives: [
+        { address: 'TR7Nb', name: 'LugaNodes', url: 'https://luganodes.com', apr: 4.2 },
+    ],
+} satisfies StakingBatchDataItem;
+
+const upstreamError = {
+    code: 'upstream_unknown_error',
+    message: 'Failed to fetch from upstream',
+} satisfies StakingBatchErrorsItem;
+
+// The apr an upstream drift could plausibly start sending as a string, which is what makes the
+// whole `trx` entry unparseable.
+const driftedTrxSection = {
+    ...trxSection,
+    representatives: [{ ...trxSection.representatives[0], apr: '4.2' }],
+};
+
+const driftedAdaSection = {
+    ...adaSection,
+    pools: [{ ...adaSection.pools[0], saturation: '80.77' }],
+};
+
+describe('resilientStakingBatchResponse', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.resetModules();
+        ({ resilientStakingBatchResponse } =
+            require('./resilientStakingBatchResponse') as SchemaModule);
+    });
+
+    it('passes through a batch in which every network matched the expected shape', () => {
+        const batch = {
+            data: [ethSection, solSection, adaSection, trxSection],
+            errors: [upstreamError],
+        };
+
+        expect(resilientStakingBatchResponse.parse(batch)).toEqual(batch);
+        expect(mockCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('keeps the networks that parsed when another network no longer matches its shape', () => {
+        const result = resilientStakingBatchResponse.parse({
+            data: [ethSection, solSection, adaSection, driftedTrxSection],
+            errors: [upstreamError],
+        });
+
+        expect(result.data).toEqual([ethSection, solSection, adaSection]);
+        expect(result.errors).toEqual([
+            upstreamError,
+            {
+                code: 'upstream_validation_error',
+                message: 'Suite schema mismatch, dropped trx',
+            },
+        ]);
+    });
+
+    it('names a dropped entry by its symbol, or by its position when it carries none', () => {
+        const { data, errors } = resilientStakingBatchResponse.parse({
+            data: [{ symbol: 'btc', stats: { apy: 1 } }, { stats: { apy: 7.5 } }, 'nonsense'],
+            errors: [],
+        });
+
+        expect(data).toEqual([]);
+        expect(errors.map(({ message }) => message)).toEqual([
+            'Suite schema mismatch, dropped btc',
+            'Suite schema mismatch, dropped data[1]',
+            'Suite schema mismatch, dropped data[2]',
+        ]);
+    });
+
+    it('keeps an error entry whose code the app does not know yet, instead of rejecting the batch', () => {
+        const result = resilientStakingBatchResponse.parse({
+            data: [ethSection, solSection, adaSection, trxSection],
+            errors: [{ code: 'upstream_timeout', message: 'Upstream timed out' }],
+        });
+
+        expect(result.data).toEqual([ethSection, solSection, adaSection, trxSection]);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]?.code).toBe('upstream_unknown_error');
+        expect(result.errors[0]?.message).toContain('upstream_timeout');
+        expect(result.errors[0]?.message).toContain('Upstream timed out');
+    });
+
+    it('rejects a response whose top-level shape is unusable, so the caller still sees a failure', () => {
+        expect(resilientStakingBatchResponse.safeParse({ data: null, errors: [] }).success).toBe(
+            false,
+        );
+        expect(resilientStakingBatchResponse.safeParse({ data: [ethSection] }).success).toBe(false);
+        expect(resilientStakingBatchResponse.safeParse('not an object').success).toBe(false);
+    });
+
+    it('reports a drift to Sentry once per signature, since the caller only logs it at warn level', () => {
+        const drifted = { data: [ethSection, driftedTrxSection], errors: [] };
+
+        resilientStakingBatchResponse.parse(drifted);
+        resilientStakingBatchResponse.parse(drifted);
+
+        expect(mockCaptureException).toHaveBeenCalledTimes(1);
+        expect(mockCaptureException.mock.calls[0]?.[0]).toEqual(
+            new Error('Staking batch entries no longer match the generated schemas: trx'),
+        );
+
+        resilientStakingBatchResponse.parse({
+            data: [ethSection, driftedTrxSection, driftedAdaSection],
+            errors: [],
+        });
+
+        expect(mockCaptureException).toHaveBeenCalledTimes(2);
+        expect(mockCaptureException.mock.calls[1]?.[0].message).toContain('trx, ada');
+    });
+});

--- a/suite-common/earn-staking-api/src/staking/services/resilientStakingBatchResponse.ts
+++ b/suite-common/earn-staking-api/src/staking/services/resilientStakingBatchResponse.ts
@@ -1,0 +1,71 @@
+import { captureException, withScope } from '@sentry/core';
+import { z } from 'zod';
+
+import { stakingBatchResponse } from '../../api/schemas';
+import type { StakingBatch, StakingBatchDataItem, StakingBatchErrorsItem } from '../../api/types';
+import { EARN_API_BASE_URL } from '../../constants';
+
+// Derived from the generated schema rather than restated, so a regenerated shape flows through.
+const stakingBatchDataItem = stakingBatchResponse.shape.data.element;
+const stakingBatchErrorsItem = stakingBatchResponse.shape.errors.element;
+
+const symbolCarrier = z.object({ symbol: z.string() });
+
+const getDroppedItemLabel = (item: unknown, index: number) =>
+    symbolCarrier.safeParse(item).data?.symbol ?? `data[${index}]`;
+
+const reportedDriftSignatures = new Set<string>();
+
+const reportStakingBatchSchemaDrift = (labels: string[]) => {
+    const signature = labels.join(', ');
+
+    if (reportedDriftSignatures.has(signature)) return;
+
+    reportedDriftSignatures.add(signature);
+
+    withScope(scope => {
+        scope.setTag('error.code', 'staking_batch_schema_drift');
+        scope.setTag('error.source', EARN_API_BASE_URL);
+        scope.setTag('error.service', 'staking_batch');
+        captureException(
+            new Error(`Staking batch entries no longer match the generated schemas: ${signature}`),
+        );
+    });
+};
+
+export const resilientStakingBatchResponse = stakingBatchResponse
+    .extend({
+        data: z.array(z.unknown()),
+        // An error code the generated enum does not know yet must not fail the whole batch either.
+        errors: z.array(
+            stakingBatchErrorsItem.catch(({ value }) => ({
+                code: 'upstream_unknown_error' as const,
+                message: `Unrecognized error entry: ${JSON.stringify(value)}`,
+            })),
+        ),
+    })
+    .transform(({ data, errors }): StakingBatch => {
+        const parsedData: StakingBatchDataItem[] = [];
+        const droppedLabels: string[] = [];
+
+        data.forEach((item, index) => {
+            const result = stakingBatchDataItem.safeParse(item);
+
+            if (result.success) {
+                parsedData.push(result.data);
+            } else {
+                droppedLabels.push(getDroppedItemLabel(item, index));
+            }
+        });
+
+        if (droppedLabels.length) {
+            reportStakingBatchSchemaDrift(droppedLabels);
+        }
+
+        const validationErrors: StakingBatchErrorsItem[] = droppedLabels.map(label => ({
+            code: 'upstream_validation_error',
+            message: `Suite schema mismatch, dropped ${label}`,
+        }));
+
+        return { data: parsedData, errors: [...errors, ...validationErrors] };
+    });


### PR DESCRIPTION
## Description

Previously, if one network's payload in the staking batch drifted from its expected schema, the entire response was rejected and staking data failed for every network. Each entry is now validated independently, so the valid networks are kept and only the drifted one is dropped and reported in `errors[]`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30041