### PR TITLE
fix(suite): guard recovery back button against an out-of-bounds status index

### DIFF
--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -69,9 +69,12 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
     };
 
     const handleBackClick = () => {
-        const previousIndex = statesInProgressBar.indexOf(recovery.status) - 1;
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const previousState: SeedInputStatus = statesInProgressBar[previousIndex];
+        const currentIndex = statesInProgressBar.indexOf(recovery.status);
+        // Fall back to 'initial' when the current status is not part of this device model's progress
+        // bar (e.g. a T1B1-only status lingering after hot-swapping to a touch device), which would
+        // otherwise produce an out-of-bounds index and dispatch setStatus(undefined).
+        const previousState: SeedInputStatus =
+            (currentIndex > 0 ? statesInProgressBar[currentIndex - 1] : undefined) ?? 'initial';
         dispatch(recoveryActions.setStatus(previousState));
     };
 


### PR DESCRIPTION
## Description

Split out of #30851 (one atomic recovery-flow fix per PR).

`statesInProgressBar` is derived from the **currently connected** device model — T1B1 exposes five progress states (`initial`, `select-word-count`, `select-recovery-type`, `waiting-for-confirmation`, `in-progress`), whereas touch devices expose only `initial`, `in-progress`. But `recovery.status` is persistent and can still hold a T1B1-only value (`select-word-count` / `select-recovery-type`) after the connected device model has changed.

In `handleBackClick`, `statesInProgressBar.indexOf(recovery.status)` then returns `-1`, `previousIndex` becomes `-2`, and `statesInProgressBar[-2]` is `undefined` (previously masked by a `@ts-expect-error`), so the code dispatched `setStatus(undefined)` → the recovery modal rendered blank.

The fix reads the current index once and falls back to `'initial'` whenever the status is not part of this device model's progress bar (index `<= 0` or not found), instead of indexing out of bounds.

## Notes for QA

The **Back** button (`handleBackClick`) is only reachable while `recovery.status` is `select-word-count` or `select-recovery-type` — both **T1B1-only** flow states. To hit the bug the connected device must be a **touch** model while the status still holds one of those values, so its `statesInProgressBar` (`['initial', 'in-progress']`) does not contain the status.

**Likely repro (hardware / emulator):**
1. Connect a **Trezor Model One (T1B1)** and start Check recovery seed (Settings → Device → Check backup), or onboarding recovery.
2. Advance to the **"Select number of words"** or **"Select recovery type"** screen — this sets `recovery.status` to `select-word-count` / `select-recovery-type`, and the **Back** button becomes visible.
3. Without finishing, **hot-swap** the device: disconnect the T1B1 and connect a **touch model** (T2T1 / T2B1 / T3T1 / T3B1) while the recovery modal stays open, so `recovery.status` keeps its T1B1-only value.
4. Click **Back**.
   - **Before:** the modal goes blank (`setStatus(undefined)`).
   - **After:** it falls back to the recovery **Start** (`initial`) screen.

**Easier deterministic simulation (no hot-swap needed):** with a touch device connected and the recovery modal open, inject `recovery.status = 'select-recovery-type'` via Redux DevTools (dispatch the `@suite/recovery` `setStatus` action), then click **Back**. Before the fix this blanks the modal; after it, the modal returns to `initial`.

---
Split out of #30851 · 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is the main recovery view component, which is heavily imported across the suite (139 static matches), so we apply the broad-utility heuristic and narrow the recommendation to tests that directly exercise recovery behavior. These cover both major entry points—onboarding recovery and device-settings dry-run—across the supported device models and include error/retry/persistence paths. No changes are left uncovered.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/recovery/index.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Directly exercises the T1B1 advanced recovery flow within the recovery view, including word count selection, advanced recovery input fields, and disconnect/retry handling. A change to the recovery view would immediately affect this user-visible flow.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Tests the recovery view's error/retry path when the device disconnects mid-recovery on T1B1. The retry recovery button and reconnect prompt rendering are part of the recovery view.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Covers the complete successful recovery flow for T1B1 including word count selection, standard recovery mode, and PIN skip. This is the core happy path through the recovery view.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Validates the recovery view's device-disconnect handling and retry flow for T2T1 during wallet recovery. UI state transitions after disconnect are rendered by the recovery view.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests recovery state persistence across page reloads and device reconnects for T2T1, including Shamir share entry. The recovery view must correctly restore and render persisted recovery state.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Tests the full successful 12-word recovery flow on T2T1, which is one of the primary entry points into the recovery view during onboarding.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Directly exercises the recovery dry-run (seed check) flow from device settings, including disconnect and reload recovery paths. This is a second major entry point into the recovery view.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — Tests the T1B1-specific dry-run recovery UI, including PIN entry, mnemonic input, and success confirmation rendered by the recovery view.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Tests the T2T1 dry-run recovery flow from device settings, including disconnect/reload resilience and success state in the recovery view.

</details>

_Updated: 2026-09-06T07:28:48.073Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-recovery-back-button-oob/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-recovery-back-button-oob/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-recovery-back-button-oob&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-recovery-back-button-oob&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-06T07:32:04.829Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-06T07:31:05.764Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->