### PR TITLE
chore(eslint): expose local rules as Git package

### DIFF
--- a/eslint-local-rules/README.md
+++ b/eslint-local-rules/README.md
@@ -1,0 +1,51 @@
+# ESLint local rules
+
+This private workspace can be consumed directly from the Trezor Suite Git repository without
+publishing it to a package registry. Pin the dependency to a commit so installs remain reproducible.
+
+pnpm can install the workspace directory directly:
+
+```json
+{
+    "devDependencies": {
+        "@trezor/eslint-local-rules": "github:trezor/trezor-suite#<commit>&path:eslint-local-rules"
+    }
+}
+```
+
+Yarn can select the workspace by name:
+
+```json
+{
+    "devDependencies": {
+        "@trezor/eslint-local-rules": "https://github.com/trezor/trezor-suite.git#workspace=@trezor/eslint-local-rules&commit=<commit>"
+    }
+}
+```
+
+Yarn consumers must also allow this Git source in `.yarnrc.yml`:
+
+```yaml
+approvedGitRepositories:
+    - https://github.com/trezor/trezor-suite.git
+```
+
+The package exports the complete local rule map. Register it as an ESLint plugin and enable only the
+rules needed by the consumer:
+
+```js
+import trezorLocalRules from '@trezor/eslint-local-rules';
+
+export default [
+    {
+        plugins: {
+            '@trezor/local-rules': {
+                rules: trezorLocalRules,
+            },
+        },
+        rules: {
+            '@trezor/local-rules/enforce-di-factory-contracts': 'error',
+        },
+    },
+];
+```

--- a/eslint-local-rules/analytics-event-name/rule.ts
+++ b/eslint-local-rules/analytics-event-name/rule.ts
@@ -55,7 +55,6 @@ export const analyticsEventNameRule: Rule.RuleModule = {
         docs: {
             description:
                 'Enforces analytics EventType enum values to use format Domain/event with allowed domains and kebab-case for the event part.',
-            category: 'Best Practices',
             recommended: false,
         },
         messages: {

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 require('ts-node').register({
     transpileOnly: true,
-    project: path.join(__dirname, 'tsconfig.json'),
+    project: path.join(__dirname, 'tsconfig.runtime.json'),
 });
 
 const { analyticsEventNameRule } = require('./analytics-event-name/rule');

--- a/eslint-local-rules/named-contracts/di/rule.ts
+++ b/eslint-local-rules/named-contracts/di/rule.ts
@@ -21,7 +21,6 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
         docs: {
             description:
                 'Enforces explicit, named dependency and return contracts for dependency-injected service factories.',
-            category: 'Best Practices',
             recommended: false,
         },
         fixable: 'code',
@@ -126,12 +125,14 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
                         }
 
                         const serviceProperties = getServiceDependencyMembers(statement).filter(
-                            member =>
+                            (member): member is ts.PropertySignature =>
                                 ts.isPropertySignature(member) &&
                                 getTypeReferenceName(member.type) === serviceName,
                         );
 
                         serviceProperties.forEach(property => {
+                            const propertyName = property.name;
+
                             if (statement.name.text !== expectedServiceDepName) {
                                 report(statement.name, 'contractMustBeNamed', {
                                     consumerName: serviceName,
@@ -140,10 +141,11 @@ export const enforceDiFactoryContractsRule: Rule.RuleModule = {
                             }
 
                             if (
-                                !ts.isIdentifier(property.name) ||
-                                property.name.text !== expectedServicePropertyName
+                                propertyName === undefined ||
+                                !ts.isIdentifier(propertyName) ||
+                                propertyName.text !== expectedServicePropertyName
                             ) {
-                                report(property.name, 'serviceDependencyProperty', {
+                                report(propertyName ?? property, 'serviceDependencyProperty', {
                                     serviceName,
                                     propertyName: expectedServicePropertyName,
                                 });

--- a/eslint-local-rules/named-contracts/thunks/rule.ts
+++ b/eslint-local-rules/named-contracts/thunks/rule.ts
@@ -64,7 +64,6 @@ export const enforceThunkContractsRule: Rule.RuleModule = {
         type: 'problem',
         docs: {
             description: 'Enforces explicit, named State and Deps contracts for thunks.',
-            category: 'Best Practices',
             recommended: false,
         },
         fixable: 'code',

--- a/eslint-local-rules/no-override-ds-component/rule.ts
+++ b/eslint-local-rules/no-override-ds-component/rule.ts
@@ -60,7 +60,6 @@ export const noOverrideDsComponentRule: Rule.RuleModule = {
             description:
                 'Disallows overriding components imported from a specific package using styled-components',
 
-            category: 'Best Practices',
             recommended: false,
         },
         messages: {

--- a/eslint-local-rules/no-package-deep-imports/rule.ts
+++ b/eslint-local-rules/no-package-deep-imports/rule.ts
@@ -53,7 +53,6 @@ export const noPackageDeepImportsRule: Rule.RuleModule = {
         docs: {
             description:
                 'Disallows deep imports from selected package scopes and enforces package entry points.',
-            category: 'Best Practices',
             recommended: false,
         },
         messages: {

--- a/eslint-local-rules/no-suite-imports-in-suite-common/rule.ts
+++ b/eslint-local-rules/no-suite-imports-in-suite-common/rule.ts
@@ -15,7 +15,6 @@ export const noSuiteImportsInSuiteCommonRule: Rule.RuleModule = {
         docs: {
             description:
                 'Disallows imports from suite and suite-native packages in suite-common code.',
-            category: 'Best Practices',
             recommended: false,
         },
         messages: {

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -1073,8 +1073,17 @@ const addDispatchedThunkUsages = (
     contractsBySymbol: ReadonlyMap<ts.Symbol, IntersectionContract[]>,
     checker: ts.TypeChecker,
 ) => {
+    const isFunctionLikeDeclaration = (node: ts.Node): node is ts.FunctionLikeDeclaration =>
+        ts.isArrowFunction(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node);
+
     const visitNode = (node: ts.Node) => {
-        if (ts.isFunctionLike(node)) {
+        if (isFunctionLikeDeclaration(node)) {
             addVanillaThunkUsages(node, contractsBySymbol, checker);
         }
 
@@ -1111,19 +1120,23 @@ const addDispatchedThunkUsages = (
 };
 
 const getWrappedServicesIntersection = (node: ts.TypeNode, checker: ts.TypeChecker) => {
+    const typeArgument = ts.isTypeReferenceNode(node) ? node.typeArguments?.[0] : undefined;
+
     if (
         !ts.isTypeReferenceNode(node) ||
         node.typeArguments?.length !== 1 ||
-        !ts.isIntersectionTypeNode(node.typeArguments[0])
+        typeArgument === undefined ||
+        !ts.isIntersectionTypeNode(typeArgument)
     ) {
         return undefined;
     }
 
-    const servicesIntersection = node.typeArguments[0];
+    const servicesIntersection = typeArgument;
     const wrapperType = checker.getTypeFromTypeNode(node);
     const wrapperProperties = checker.getPropertiesOfType(wrapperType);
+    const wrapperProperty = wrapperProperties[0];
 
-    if (wrapperProperties.length !== 1 || wrapperProperties[0].name !== 'services') {
+    if (wrapperProperties.length !== 1 || wrapperProperty?.name !== 'services') {
         return undefined;
     }
 
@@ -1161,7 +1174,6 @@ export const noUnusedIntersectionMembersRule: Rule.RuleModule = {
         docs: {
             description:
                 'Reports contract members that are not required by their local implementation.',
-            category: 'Best Practices',
             recommended: false,
         },
         messages: {

--- a/eslint-local-rules/package.json
+++ b/eslint-local-rules/package.json
@@ -1,0 +1,39 @@
+{
+    "name": "@trezor/eslint-local-rules",
+    "version": "1.0.0",
+    "private": true,
+    "main": "index.js",
+    "files": [
+        "README.md",
+        "analytics-event-name/rule.ts",
+        "index.js",
+        "named-contracts/di/rule.ts",
+        "named-contracts/thunks/rule.ts",
+        "named-contracts/utils.ts",
+        "no-override-ds-component/rule.ts",
+        "no-package-deep-imports/rule.ts",
+        "no-suite-imports-in-suite-common/rule.ts",
+        "no-unused-intersection-members/rule.ts",
+        "thunk-names/rule.ts",
+        "thunks/utils.ts",
+        "tsconfig.runtime.json",
+        "utils.ts"
+    ],
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest --config jest.config.js --runInBand",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "npm:@typescript/typescript6@6.0.2"
+    },
+    "devDependencies": {
+        "eslint": "^10.8.1",
+        "typescript-eslint": "^8.67.0"
+    },
+    "peerDependencies": {
+        "eslint": "^10.8.1"
+    }
+}

--- a/eslint-local-rules/thunk-names/rule.ts
+++ b/eslint-local-rules/thunk-names/rule.ts
@@ -14,7 +14,6 @@ export const enforceThunkNamesRule: Rule.RuleModule = {
         type: 'problem',
         docs: {
             description: 'Enforces the Thunk suffix for Redux thunk declarations.',
-            category: 'Best Practices',
             recommended: false,
         },
         fixable: 'code',

--- a/eslint-local-rules/tsconfig.runtime.json
+++ b/eslint-local-rules/tsconfig.runtime.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "module": "Node16",
+        "moduleResolution": "Node16",
+        "rootDir": ".",
+        "target": "ES2023"
+    },
+    "include": ["./**/*.ts"]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,6 @@ export default [
                     devDependencies: [
                         ...globalNoExtraneousDependenciesDevDependencies,
                         '**/connect-examples/**', // This must be here, connect-examples are not a package
-                        '**/eslint-local-rules/**', // Uses ts-node at runtime when loaded by ESLint
                     ],
                 },
             ],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     },
     "workspaces": {
         "packages": [
+            "eslint-local-rules",
             "networks/*/*",
             "packages/*",
             "packages/connect-examples/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17228,6 +17228,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@trezor/eslint-local-rules@workspace:eslint-local-rules":
+  version: 0.0.0-use.local
+  resolution: "@trezor/eslint-local-rules@workspace:eslint-local-rules"
+  dependencies:
+    eslint: "npm:^10.8.1"
+    ts-node: "npm:^10.9.2"
+    typescript: "npm:@typescript/typescript6@6.0.2"
+    typescript-eslint: "npm:^8.67.0"
+  peerDependencies:
+    eslint: ^10.8.1
+  languageName: unknown
+  linkType: soft
+
 "@trezor/eslint@workspace:*, @trezor/eslint@workspace:^, @trezor/eslint@workspace:packages/eslint":
   version: 0.0.0-use.local
   resolution: "@trezor/eslint@workspace:packages/eslint"


### PR DESCRIPTION
## Description

The local ESLint rules can only load inside the monorepo because they lack package metadata and inherit their runtime TypeScript configuration from the repository root. Turn them into a private workspace with self-contained runtime dependencies and configuration so Yarn and pnpm consumers can install a pinned Git revision without publishing it to npm.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are exclusively custom ESLint rules and their build/package configuration. These operate only at lint/build time and do not alter application runtime behavior, so no Playwright E2E tests are needed to validate them. The appropriate verification is running the lint rule unit tests and the lint command itself; E2E coverage is not applicable.

<details><summary><b>Changed files (12)</b></summary>

- `eslint-local-rules/analytics-event-name/rule.ts`
- `eslint-local-rules/index.js`
- `eslint-local-rules/named-contracts/di/rule.ts`
- `eslint-local-rules/named-contracts/thunks/rule.ts`
- `eslint-local-rules/no-override-ds-component/rule.ts`
- `eslint-local-rules/no-package-deep-imports/rule.ts`
- `eslint-local-rules/no-suite-imports-in-suite-common/rule.ts`
- `eslint-local-rules/no-unused-intersection-members/rule.ts`
- `eslint-local-rules/package.json`
- `eslint-local-rules/thunk-names/rule.ts`
- `eslint-local-rules/tsconfig.runtime.json`
- `package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (12)**
- `eslint-local-rules/analytics-event-name/rule.ts`
- `eslint-local-rules/index.js`
- `eslint-local-rules/named-contracts/di/rule.ts`
- `eslint-local-rules/named-contracts/thunks/rule.ts`
- `eslint-local-rules/no-override-ds-component/rule.ts`
- `eslint-local-rules/no-package-deep-imports/rule.ts`
- `eslint-local-rules/no-suite-imports-in-suite-common/rule.ts`
- `eslint-local-rules/no-unused-intersection-members/rule.ts`
- `eslint-local-rules/package.json`
- `eslint-local-rules/thunk-names/rule.ts`
- `eslint-local-rules/tsconfig.runtime.json`
- `package.json`

_Updated: 2026-09-06T10:21:48.990Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/reusable-eslint-local-rules/web/](https://dev.suite.sldev.cz/suite-web/chore/reusable-eslint-local-rules/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/reusable-eslint-local-rules&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/reusable-eslint-local-rules&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-06T10:24:42.124Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-06T10:24:37.496Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->