### PR TITLE
refactor(suite): remove dead exported types

### DIFF
--- a/packages/suite/src/actions/suite/windowActions.ts
+++ b/packages/suite/src/actions/suite/windowActions.ts
@@ -17,6 +17,3 @@ export const updateBreakpoints = createAction(
         payload: breakpointFlags,
     }),
 );
-
-export type WindowAction =
-    ReturnType<typeof updateWindowVisibility> | ReturnType<typeof updateBreakpoints>;

--- a/packages/suite/src/components/earn/forms/StakeFormContext.ts
+++ b/packages/suite/src/components/earn/forms/StakeFormContext.ts
@@ -43,6 +43,3 @@ export type WithdrawalContextValues = UseFormReturn<WithdrawalFormState> &
         onFiatAmountChange: (amount: string) => void;
         currentRate: Rate | undefined;
     };
-
-export type UnstakeFormState = WithdrawalFormState;
-export type UnstakeContextValues = WithdrawalContextValues;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
@@ -23,5 +23,3 @@ export function useFilterAccounts(accounts: AccountOption[]) {
         [accounts, networkSymbol, search],
     );
 }
-
-export type FilteredAccountOption = ReturnType<typeof useFilterAccounts>[number];

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.ts
@@ -196,5 +196,3 @@ export const useTradingExchangeTradeActions = () => {
         signDataAndConfirm,
     };
 };
-
-export type TradingExchangeTradeActionsValues = ReturnType<typeof useTradingExchangeTradeActions>;

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts
@@ -170,5 +170,3 @@ export const useTradingSellTradeActions = () => {
         sendTransaction,
     };
 };
-
-export type TradingSellTradeActionsValues = ReturnType<typeof useTradingSellTradeActions>;

--- a/packages/suite/src/slices/wallet/globalSendReceiveFilters.ts
+++ b/packages/suite/src/slices/wallet/globalSendReceiveFilters.ts
@@ -47,7 +47,3 @@ const globalSendReceiveFiltersSlice = createSlice({
 export const globalSendReceiveFiltersActions = globalSendReceiveFiltersSlice.actions;
 export const globalSendReceiveFiltersReducer = globalSendReceiveFiltersSlice.reducer;
 export const globalSendReceiveFiltersSelectors = globalSendReceiveFiltersSlice.selectors;
-
-export type GlobalSendReceiveAction = ReturnType<
-    (typeof globalSendReceiveFiltersActions)[keyof typeof globalSendReceiveFiltersActions]
->;

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -14,8 +14,6 @@ import type {
     TradingProviderInfo,
     TradingSellInfoSelector,
     TradingSellType,
-    TradingStateSelector,
-    TradingTransaction,
     TradingTransactionBuy,
     TradingTransactionExchange,
     TradingTransactionSell,
@@ -42,31 +40,9 @@ export type TradingTradeInfoMapProps = {
     exchange: TradingExchangeInfoSelector;
 };
 
-export interface TradingGetTypedTradeProps {
-    trades: TradingTransaction[];
-    tradeType: TradingType;
-    transactionId: string | undefined;
-}
-
-export interface TradingGetDetailDataProps {
-    trading: TradingStateSelector;
-    tradeType: TradingType;
-    infos: {
-        buy: TradingBuyInfoSelector | undefined;
-        sell: TradingSellInfoSelector | undefined;
-        exchange: TradingExchangeInfoSelector | undefined;
-    };
-}
-
 export interface TradingUseWatchTradeProps<T extends TradingType> {
     account: Account | undefined;
     trade: TradingTradeMapProps[T] | undefined;
-}
-
-export interface TradingCryptoListProps {
-    value: CryptoId;
-    label: string; // token shortcut
-    cryptoName?: string | undefined; // full name
 }
 
 export type TradingCoinLogoProps = {

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { FieldPath, UseFormReturn } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 
 import { type UnknownAction } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId, ExchangeTrade, FiatCurrencyCode } from 'invity-api';
@@ -62,10 +62,6 @@ export type TradingAllFormProps =
 
 export interface TradingSellFormDefaultValuesProps {
     defaultValues: TradingSellFormProps;
-}
-
-export interface TradingExchangeFormDefaultValuesProps {
-    defaultValues: TradingExchangeFormProps;
 }
 
 interface TradingFormStateProps {
@@ -201,8 +197,6 @@ export interface TradingExchangeFormContextProps
     setShowReserveBanner: (showReserveBanner: boolean) => void;
 }
 
-export type TradingExchangeApprovalType = 'APPROVE' | 'REVOKE';
-
 export type TradingFormMapProps = {
     buy: TradingBuyFormContextProps;
     sell: TradingSellFormContextProps;
@@ -215,16 +209,6 @@ export interface TradingFormInputDefaultProps {
     label?: TranslationKey;
     placeholder?: TranslationKey;
     'data-testid'?: string;
-}
-
-export interface TradingFormInputCryptoSelectProps<
-    TFieldValues extends TradingAllFormProps,
-> extends TradingFormInputDefaultProps {
-    cryptoSelectName: FieldPath<TFieldValues>;
-    supportedCryptoCurrencies: Set<CryptoId> | undefined;
-    methods: UseFormReturn<TFieldValues>;
-    isDisabled?: boolean;
-    sortTokensByFiatBalanceInDesc?: boolean;
 }
 
 export interface TradingFormInputFiatCryptoProps {
@@ -316,13 +300,6 @@ export interface TradingOfferBuyProps {
     selectedQuote: BuyTrade;
     isConfirmDisabled: boolean;
     confirmTrade: () => Promise<BuyTrade | undefined>;
-}
-
-export interface TradingOfferExchangeProps extends Omit<
-    TradingOfferCommonProps,
-    'paymentMethod' | 'paymentMethodName'
-> {
-    selectedQuote: ExchangeTrade;
 }
 
 export interface TradingSelectedOfferInfoProps extends TradingOfferCommonProps {

--- a/packages/suite/src/types/trading/tradingVerify.ts
+++ b/packages/suite/src/types/trading/tradingVerify.ts
@@ -1,4 +1,3 @@
-import { type ReactNode } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 
 import { type CryptoId } from 'invity-api';
@@ -39,19 +38,3 @@ export interface TradingVerifyAccountReturnProps {
     selectNonSuiteAddress: (address?: string) => void;
     openAddSuiteAccount: () => void;
 }
-
-export type TradingVerifyOptionsProps = {
-    receiveNetwork: CryptoId;
-    label: ReactNode;
-    isDisabled?: boolean;
-} & Pick<
-    TradingVerifyAccountReturnProps,
-    | 'suiteReceiveAccounts'
-    | 'selectedAccount'
-    | 'canAddSuiteAccount'
-    | 'canUseNonSuiteAccount'
-    | 'onChangeAccount'
-    | 'selectNonSuiteAddress'
-    | 'openAddSuiteAccount'
-    | 'isMenuOpen'
->;

--- a/packages/suite/src/utils/wallet/trading/exchangeUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/exchangeUtils.ts
@@ -1,16 +1,10 @@
-import { type ExchangeTrade, type ExchangeTradeQuoteRequest } from 'invity-api';
+import { type ExchangeTradeQuoteRequest } from 'invity-api';
 
 import { type TradingComposedTransactionInfo } from '@suite-common/trading';
 import { getLocationOrigin, isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { type Account } from 'src/types/wallet';
-
-export type ExchangeQuotesByType = {
-    fixed: ExchangeTrade[];
-    float: ExchangeTrade[];
-    dex: ExchangeTrade[];
-};
 
 export const createQuoteLink = async (
     request: ExchangeTradeQuoteRequest,


### PR DESCRIPTION
## Description

Removes unused exported types in @trezor/suite (mostly trading types) plus the imports they left orphaned.

Split from the knip dead-code hygiene batch for isolated, per-owner review. Pure removal of code with zero references across all workspaces (verified via a whole-word reference scan); no behavior change. type-check / lint / translations are the safety oracle.

## Notes for QA
Pure dead-code removal, no behavior change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes concentrate on global send/receive account filtering and trading sell/exchange execution paths. The highest regression risk is in the global receive modal filters and in confirming/sending sell and swap trades, so those flows should be run first. The type-only trading files carry minimal runtime risk, and windowActions.ts is a broad global dependency with no specific behavioral evidence to target.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/actions/suite/windowActions.ts`
- `packages/suite/src/components/earn/forms/StakeFormContext.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts`
- `packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.ts`
- `packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.ts`
- `packages/suite/src/slices/wallet/globalSendReceiveFilters.ts`
- `packages/suite/src/types/trading/trading.ts`
- `packages/suite/src/types/trading/tradingForm.ts`
- `packages/suite/src/types/trading/tradingVerify.ts`
- `packages/suite/src/utils/wallet/trading/exchangeUtils.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test executes the full sell trade flow including confirming the sell offer and initiating send, which directly exercises useTradingSellTradeActions. Changes to sell-trade action logic or exchangeUtils helpers used for sell payload formatting would likely surface here.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Exercises the ETH sell flow with custom fees and device confirmation, touching useTradingSellTradeActions and related trading form/verify types. A regression in sell-trade action handling for EVM coins would be visible here.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Covers the Solana sell flow including trade confirmation, device send prompt, and status polling, directly depending on useTradingSellTradeActions and exchangeUtils. Useful for catching regressions specific to Solana sell actions.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Validates the cross-chain swap/exchange flow end-to-end, which is the primary code path for useTradingExchangeTradeActions. Changes to exchange-trade action logic, composed transaction handling, or exchangeUtils would be exercised here.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Directly tests the GlobalReceiveModal account filtering behavior that useFilterAccounts.ts and the globalSendReceiveFilters slice implement. This is the only test statically mapped to the changed filter hook, making it essential for any account-filtering regression.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — Inferred coverage for StakeFormContext.ts (no static mapping). The test exercises ETH staking form inputs and validation, which likely consumes the changed staking form context. Useful if the context change affects form state or validation.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests token-specific sell behavior (USDC on ETH), providing a variation of the sell-trade action path that may exercise different branches in useTradingSellTradeActions and trading form/verify types than native-coin sells.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Another swap path (SOL to BTC) that exercises exchange-trade actions and status polling, complementing the ETH-to-SOL swap test by covering a different network pair and provider status flow.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/types/trading/trading.ts`
- `packages/suite/src/types/trading/tradingForm.ts`
- `packages/suite/src/types/trading/tradingVerify.ts`

_Updated: 2026-09-07T05:53:22.581Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-types/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T05:54:53.330Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T05:54:19.726Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->