### PR TITLE
refactor(suite): remove redundant barrel re-exports

### DIFF
--- a/packages/suite/src/components/earn/index.ts
+++ b/packages/suite/src/components/earn/index.ts
@@ -1,13 +1,7 @@
 export { EarnInANutshellModal } from './modals/EarnInANutshell/EarnInANutshellModal';
-export { StakingEarnInANutshellModal } from './modals/EarnInANutshell/StakingEarnInANutshellModal';
-export { YieldEarnInANutshellModal } from './modals/EarnInANutshell/YieldEarnInANutshellModal';
-export { UpdateEarnInANutshellModal } from './modals/EarnInANutshell/UpdateEarnInANutshellModal';
 export { TronStakeInANutshellModal } from './modals/EarnInANutshell/TronStakeInANutshellModal';
 export { EarnClaimModal } from './modals/EarnClaimModal/EarnClaimModal';
 export { EarnProviderConsentModal } from './modals/EarnProviderConsent/EarnProviderConsentModal';
-export { StakingEarnProviderConsentModal } from './modals/EarnProviderConsent/StakingEarnProviderConsentModal';
-export { YieldEarnProviderConsentModal } from './modals/EarnProviderConsent/YieldEarnProviderConsentModal';
-export { UpdateEarnProviderConsentModal } from './modals/EarnProviderConsent/UpdateEarnProviderConsentModal';
 export { StakeModal } from './modals/StakeModal/StakeModal';
 export { UnstakeModal } from './modals/UnstakeModal/UnstakeModal';
 export { EarnDashboard } from './dashboard/EarnDashboard';
@@ -26,13 +20,7 @@ export { TronWithdraw } from './staking/tron/TronWithdraw';
 export { TronClaim } from './staking/tron/TronClaim';
 export { YieldDeposit } from './yield/deposit/YieldDeposit';
 export { YieldWithdraw } from './yield/withdraw/YieldWithdraw';
-export { EarnStakingInfo } from './modals/EarnInANutshell/components/EarnStakingInfo';
-export { EarnWithdrawingInfo } from './modals/EarnInANutshell/components/EarnWithdrawingInfo';
 
-export { VotingDelegations } from './modals/shared/VotingDelegations/VotingDelegations';
 export { VotingDelegationsOptions } from './modals/shared/VotingDelegations/VotingDelegationsOptions';
 
 export { PoweredByBadge } from './providers/PoweredByBadge';
-
-export { getEarnProviderName } from './utils/getEarnProviderName';
-export { getApyRate } from './utils/earnApyUtils';

--- a/packages/suite/src/views/wallet/trading/common/index.ts
+++ b/packages/suite/src/views/wallet/trading/common/index.ts
@@ -1,6 +1,2 @@
-export { TradingCryptoAmount } from 'src/views/wallet/trading/common/TradingCryptoAmount';
-export { TradingFiatAmount } from 'src/views/wallet/trading/common/TradingFiatAmount';
 export { TradingFooter } from 'src/views/wallet/trading/common/TradingFooter/TradingFooter';
-export { TradingProviderInfo } from 'src/views/wallet/trading/common/TradingProviderInfo';
-export { TradingTag } from 'src/views/wallet/trading/common/TradingTag';
 export { TradingTransactionId } from 'src/views/wallet/trading/common/TradingTransactionId';


### PR DESCRIPTION
## Description

Removes 15 unused re-exports from two @trezor/suite barrels (nothing imports them through the barrel).

Split from the knip dead-code hygiene batch for isolated, per-owner review. Pure removal of code with zero references across all workspaces (verified via a whole-word reference scan); no behavior change. type-check / lint / translations are the safety oracle.

## Notes for QA
Pure dead-code removal, no behavior change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files are barrel/index files that export shared components for the earn/yield and trading feature areas. Because static coverage found no direct mappings, the recommendations are inferred: run a small set of representative end-to-end flows that actually render the affected components. The yield and major trading (buy/sell/swap) tests provide high confidence with minimal redundancy; a navigation test adds medium confidence for routing/entry-point wiring.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/index.ts`
- `packages/suite/src/views/wallet/trading/common/index.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the full buy trading flow including the form, quotes, confirmation, and transaction detail views. Since `packages/suite/src/views/wallet/trading/common/index.ts` likely exports shared trading UI components used across buy/sell/swap flows, a regression in those common components would be caught here.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test covers the sell trading flow end-to-end, including the sell form, quotes, confirmation, and device prompt. Changes to the common trading view components exported by the modified index file directly affect this flow.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test validates the complete swap flow (SOL to BTC), which relies heavily on shared trading common components for the swap form, quotes, confirmation modal, and transaction status. It is a representative test for swap-specific usage of the common trading index.
- `suite/e2e/tests/yield/redeem.test.ts` — This test exercises the earn/yield withdrawal/redeem flow including the dashboard, flow components, transaction simulation, and device prompts. It directly depends on components exported from `packages/suite/src/components/earn/index.ts`.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test covers the yield withdrawal flow from the earn dashboard through device confirmation. It is a direct consumer of earn components and would detect missing or broken exports from the modified earn index file.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test verifies navigation into buy/sell/swap forms from multiple entry points. While less about the common components themselves, it ensures that trading routes and entry-point buttons still function if the common index reorganization affects how trading views are wired.

</details>

_Updated: 2026-09-07T05:52:29.848Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-exports/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-exports/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-exports&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-exports&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T05:55:11.778Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T05:54:25.637Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->