### PR TITLE
refactor(suite-native): remove dead type in module-trading

### DIFF
--- a/suite-native/module-trading/src/components/general/HistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/HistoryButton.tsx
@@ -20,10 +20,6 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { useMountedRecentlyFlag } from '../../hooks/general/useMountedRecentlyFlag';
 import { useWatchAllTrades } from '../../hooks/general/useWatchAllTrades';
 
-export type HistoryButtonProps = {
-    isFormMountedRecently?: boolean;
-};
-
 export type NavigationProps = StackToStackCompositeNavigationProps<
     TradingStackParamList,
     TradingStackRoutes.Trading,


### PR DESCRIPTION
## Description

Removes an unused exported type (HistoryButtonProps) in @suite-native/module-trading.

Split from the knip dead-code hygiene batch for isolated, per-owner review. Pure removal of code with zero references across all workspaces (verified via a whole-word reference scan); no behavior change. type-check / lint / translations are the safety oracle.

## Notes for QA
Pure dead-code removal, no behavior change.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dead-code-module-trading&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->