### PR TITLE
refactor(analytics-docs): remove dead type

### DIFF
--- a/packages/analytics-docs/src/utils/useLatestReleases.ts
+++ b/packages/analytics-docs/src/utils/useLatestReleases.ts
@@ -7,11 +7,6 @@ type GitHubRelease = {
     prerelease: boolean;
 };
 
-export type LatestReleases = {
-    desktop: string | null;
-    mobile: string | null;
-};
-
 const parseVersionFromTag = (tagName: string): string => {
     const withoutPrefix = tagName.startsWith('v') ? tagName.slice(1) : tagName;
 


### PR DESCRIPTION
## Description

Removes an unused exported type (LatestReleases) in @trezor/analytics-docs.

Split from the knip dead-code hygiene batch for isolated, per-owner review. Pure removal of code with zero references across all workspaces (verified via a whole-word reference scan); no behavior change. type-check / lint / translations are the safety oracle.

## Notes for QA
Pure dead-code removal, no behavior change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file, `packages/analytics-docs/src/utils/useLatestReleases.ts`, is part of the standalone `analytics-docs` package and has no static coverage mapping to any Suite E2E tests. The candidate test suite covers the main Trezor Suite application (onboarding, wallet, trading, settings, etc.), and none of the test descriptions reference `analytics-docs` or latest-release fetching functionality. There is no concrete evidence that this change affects any of the listed E2E tests, so no tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/analytics-docs/src/utils/useLatestReleases.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/analytics-docs/src/utils/useLatestReleases.ts`

_Updated: 2026-09-07T05:52:52.275Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-analytics-docs/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-analytics-docs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-analytics-docs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-analytics-docs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T05:55:52.972Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T05:55:48.423Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->