### PR TITLE
refactor(suite): remove dead earn code

### DIFF
--- a/packages/suite/src/components/earn/dashboard/common/EarnNotAvailableText.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnNotAvailableText.tsx
@@ -1,8 +1,0 @@
-import { Translation } from '@suite/intl';
-import { Paragraph } from '@trezor/components';
-
-export const EarnNotAvailableText = () => (
-    <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
-        <Translation id="TR_EARN_NOT_AVAILABLE" />
-    </Paragraph>
-);

--- a/packages/suite/src/components/earn/forms/StakeFormContext.ts
+++ b/packages/suite/src/components/earn/forms/StakeFormContext.ts
@@ -43,6 +43,3 @@ export type WithdrawalContextValues = UseFormReturn<WithdrawalFormState> &
         onFiatAmountChange: (amount: string) => void;
         currentRate: Rate | undefined;
     };
-
-export type UnstakeFormState = WithdrawalFormState;
-export type UnstakeContextValues = WithdrawalContextValues;


### PR DESCRIPTION
## Description

Removes dead earn code in @trezor/suite: an unreferenced component and unused exported types (UnstakeFormState, UnstakeContextValues).

Split by domain out of the knip dead-code hygiene batch for per-owner review. Pure removal of code with zero references across all workspaces; no behavior change. Supersedes the earlier by-category split (#32140 files, #32141 types).

## Notes for QA
Pure dead-code removal, no behavior change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrow, touching earn dashboard copy rendering and the staking form context. The highest confidence comes from the ETH staking form tests, which directly exercise the changed form context. Ada and Solana staking plus yield flows are included as medium safeguards in case the context or unavailable-state component is shared more broadly. No static coverage exists, so all recommendations are inferred from the earn/staking user flows.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/dashboard/common/EarnNotAvailableText.tsx`
- `packages/suite/src/components/earn/forms/StakeFormContext.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test walks through the full ETH staking flow from an empty account, opening the staking form, filling the amount, and confirming on device. It directly exercises the StakeFormContext-backed staking form UI.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The test opens the staking form for an already-staked ETH account, fills an amount, and confirms the stake. It relies on the same StakeFormContext state as the initial-stake flow and is a prime regression target.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test specifically validates the ETH staking form inputs, percentages, max amount, fiat switching, and error states. It is the most direct end-to-end coverage of the StakeFormContext behavior.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking uses a form-based staking flow that may share the generic earn staking form/context components; a regression in StakeFormContext or EarnNotAvailableText could affect this flow.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana first-time staking opens the staking form and submits an amount. If StakeFormContext is reused across networks, this flow could be impacted by context changes.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Similar to the Solana initial stake test, this fills the staking form on an already-staked Solana account and is a reasonable sanity check for shared form context.
- `suite/e2e/tests/yield/redeem.test.ts` — The yield redeem/withdraw flow renders earn dashboard components and form state. If EarnNotAvailableText is shown when earn features are unavailable, this path could exercise related rendering logic.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test navigates the earn/yield dashboard and withdrawal form; it may render EarnNotAvailableText or share earn form context components, so it is a useful secondary check.

</details>

_Updated: 2026-09-07T07:09:11.162Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-earn/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-earn/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-earn&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-earn&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T07:11:32.752Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T07:10:26.687Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->