### PR TITLE
refactor(suite): remove dead send/receive types

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
@@ -23,5 +23,3 @@ export function useFilterAccounts(accounts: AccountOption[]) {
         [accounts, networkSymbol, search],
     );
 }
-
-export type FilteredAccountOption = ReturnType<typeof useFilterAccounts>[number];

--- a/packages/suite/src/slices/wallet/globalSendReceiveFilters.ts
+++ b/packages/suite/src/slices/wallet/globalSendReceiveFilters.ts
@@ -47,7 +47,3 @@ const globalSendReceiveFiltersSlice = createSlice({
 export const globalSendReceiveFiltersActions = globalSendReceiveFiltersSlice.actions;
 export const globalSendReceiveFiltersReducer = globalSendReceiveFiltersSlice.reducer;
 export const globalSendReceiveFiltersSelectors = globalSendReceiveFiltersSlice.selectors;
-
-export type GlobalSendReceiveAction = ReturnType<
-    (typeof globalSendReceiveFiltersActions)[keyof typeof globalSendReceiveFiltersActions]
->;


### PR DESCRIPTION
## Description

Removes unused exported types in @trezor/suite send/receive (FilteredAccountOption, GlobalSendReceiveAction).

Split by domain out of the knip dead-code hygiene batch for per-owner review. Pure removal of code with zero references across all workspaces; no behavior change. Supersedes the earlier by-category split (#32140 files, #32141 types).

## Notes for QA
Pure dead-code removal, no behavior change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly scoped to account filtering within the global send/receive modals. Although globalSendReceiveFilters.ts is statically referenced by 139 tests, that broad mapping indicates it is a globally-imported Redux slice rather than behavior each test exercises. Only global-receive-send.test.ts directly covers the relevant user flow, so running it provides targeted confidence with minimal cost.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts`
- `packages/suite/src/slices/wallet/globalSendReceiveFilters.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This is the only test that directly exercises the global send/receive account filtering flows described in the changed files. It verifies opening global receive/send forms, filtering accounts by network, and selecting accounts — exactly the functionality implemented in useFilterAccounts.ts and globalSendReceiveFilters.ts.

</details>

_Updated: 2026-09-07T06:32:54.254Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-send-receive/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dead-code-suite-send-receive/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dead-code-suite-send-receive&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dead-code-suite-send-receive&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T06:35:42.421Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T06:35:36.397Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->