### PR TITLE
fix(suite): staking dashboard copy/card fixes for Cardano and ETH/SOL

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/AdaStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/AdaStakingDashboard.tsx
@@ -4,7 +4,6 @@ import { useDispatch } from '@suite-common/redux-utils';
 import {
     CARDANO_EPOCH_DAYS,
     fetchAllTransactionsForAccountThunk,
-    getStakingDataForNetwork,
     hasPendingStakeTypeTransaction,
     isCardanoStakedWithEverstake,
     selectAccountIsStakingActive,
@@ -13,15 +12,14 @@ import {
     selectPoolStatsApy,
 } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { Column, Flex, Grid } from '@trezor/components';
+import { Column, Flex } from '@trezor/components';
 
 import { DashboardSection } from 'src/components/dashboard';
-import { useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useSelector } from 'src/hooks/suite';
 
 import { CardanoNewProviderCard } from './CardanoNewProviderCard';
 import { StakingDashboard } from '../StakingDashboard/StakingDashboard';
 import { ApyCard } from '../StakingDashboard/components/ApyCard';
-import { ClaimCard } from '../StakingDashboard/components/ClaimCard';
 import { DebugOnlyCardanoStakingCard } from '../StakingDashboard/components/DebugOnlyCardanoStakingCard';
 import { DiscoveryWarning } from '../StakingDashboard/components/DiscoveryWarning';
 import { EmptyStakingCard } from '../StakingDashboard/components/EmptyStakingCard/EmptyStakingCard';
@@ -37,7 +35,6 @@ export const AdaStakingDashboard = ({ selectedAccount }: AdaStakingDashboardProp
     const { account } = selectedAccount;
     const accountKey = account?.key ?? '';
 
-    const { isBelowLaptop } = useLayoutSize();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const dispatch = useDispatch();
@@ -52,8 +49,6 @@ export const AdaStakingDashboard = ({ selectedAccount }: AdaStakingDashboardProp
             );
         }
     }, [accountKey, dispatch]);
-
-    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
 
     const apy = useSelector(state => selectPoolStatsApy(state, { account }));
 
@@ -77,15 +72,12 @@ export const AdaStakingDashboard = ({ selectedAccount }: AdaStakingDashboardProp
 
                                 <CardanoNewProviderCard account={account} />
 
-                                <Grid columns={isBelowLaptop || !canClaim ? 1 : 2} gap={12}>
-                                    <ClaimCard />
-                                    <Flex direction={canClaim ? 'column' : 'row'} gap={12}>
-                                        <ApyCard apy={isStakedWithEverstake ? apy : undefined} />
-                                        <PayoutCardFrequencyRewards
-                                            rewardFrequency={CARDANO_EPOCH_DAYS}
-                                        />
-                                    </Flex>
-                                </Grid>
+                                <Flex gap={12}>
+                                    <ApyCard apy={isStakedWithEverstake ? apy : undefined} />
+                                    <PayoutCardFrequencyRewards
+                                        rewardFrequency={CARDANO_EPOCH_DAYS}
+                                    />
+                                </Flex>
                                 <StakingCard
                                     account={account}
                                     isValidatorsQueueLoading={undefined}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardContent.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardContent.tsx
@@ -131,10 +131,10 @@ const getCardanoContent = ({ data, dispatch }: UseNetworkContentProps): EmptySta
 
     const text =
         !hasEnoughBalanceForStaking || !hasPotentialRewards ? (
-            <Translation id="TR_STAKING_CARD_TEXT_EMPTY" values={{ displaySymbol }} />
+            <Translation id="TR_STAKING_CARD_TEXT_EMPTY_FUNDS_STAY" values={{ displaySymbol }} />
         ) : (
             <Translation
-                id="TR_STAKING_CARD_TEXT_EMPTY"
+                id="TR_STAKING_CARD_TEXT_FUNDS_STAY"
                 values={{ potentialRewards, displaySymbol }}
             />
         );
@@ -214,10 +214,10 @@ const getDefaultContent = ({ data, dispatch }: UseNetworkContentProps): EmptySta
 
     const text =
         !hasEnoughBalanceForStaking || !hasPotentialRewards ? (
-            <Translation id="TR_STAKING_CARD_TEXT_EMPTY_FUNDS_STAY" values={{ displaySymbol }} />
+            <Translation id="TR_STAKING_CARD_TEXT_EMPTY" values={{ displaySymbol }} />
         ) : (
             <Translation
-                id="TR_STAKING_CARD_TEXT_FUNDS_STAY"
+                id="TR_STAKING_CARD_TEXT_EMPTY"
                 values={{ potentialRewards, displaySymbol }}
             />
         );


### PR DESCRIPTION
## Description
Two independent fixes to the staking dashboard, both need to be cherry-picked to the active release branch:

1. The empty-staking promo card's hero copy was assigned to the wrong network branch: ETH/SOL showed "your funds stay available anytime" even though ETH/SOL staking has an unbonding period (and directly contradicted the "Lock in with flexibility" card right next to it), while Cardano showed "temporarily locking your ADA" even though Cardano staking never locks funds (and contradicted its own "Use anytime" card). Fixed by swapping which existing message id each network branch uses — no new copy needed.
2. The Cardano staking dashboard rendered a `ClaimCard` that doesn't apply to Cardano — Cardano rewards compound automatically into the balance, there's nothing to explicitly claim. Removed it from `AdaStakingDashboard` and simplified the surrounding layout (it was the only reason for the two-column grid / conditional flex direction).

## Notes for QA
- Staking dashboard promo card (before staking is active): ETH/SOL should say funds are temporarily locked; Cardano should say funds stay available/liquid.
- Cardano staking dashboard (account with staking rewards > 0): no "Claim" card should appear next to the APY/payout cards.

## Related Issue
Resolves #32155
Resolves #32138

## Screenshots

<img width="1170" height="672" alt="Screenshot 2026-09-07 at 8 43 40" src="https://github.com/user-attachments/assets/e37df48a-d914-482b-8ea5-8a388307e3e1" />
<img width="1176" height="615" alt="Screenshot 2026-09-07 at 8 43 35" src="https://github.com/user-attachments/assets/df0d7a67-678e-4f1c-8c33-a1e772c71881" />
<img width="1180" height="587" alt="Screenshot 2026-09-07 at 8 43 26" src="https://github.com/user-attachments/assets/e147650c-0f4a-4b8e-9819-4e4826438a2f" />
<img width="1179" height="579" alt="Screenshot 2026-09-07 at 8 43 06" src="https://github.com/user-attachments/assets/6e93cd7b-b7f0-4138-939b-0a6783821e9b" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches a Cardano-specific staking dashboard component and a shared empty-staking-card hook. High priority should go to the three ADA staking lifecycle tests, which directly render AdaStakingDashboard. ETH and SOL initial-stake tests are medium priority because they assert on the empty staking card content produced by the shared hook. Remaining tests cover already-staked states, non-dashboard flows, or analytics and are unlikely to be affected.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/AdaStakingDashboard.tsx`
- `packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardContent.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Directly exercises the Cardano staking dashboard UI (reward amounts, claim/unstake buttons, full balance indicator) that AdaStakingDashboard renders. A regression here would be immediately visible to Cardano staking users.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Walks through the Cardano staking flow and asserts on dashboard elements rendered by AdaStakingDashboard, including stake button visibility, reward amounts, and full balance text. Changes to AdaStakingDashboard are likely to break these assertions.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests the Cardano unstaking dashboard state transitions (staked → unstaked) and sidebar staking entry, which are rendered by AdaStakingDashboard. This is directly impacted by changes to the Cardano staking dashboard component.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Verifies the empty staking card shown before any ETH staking activity. Since useEmptyStakingCardContent generates content for the shared empty staking card, changes to it could affect what this test observes on the empty dashboard.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Asserts that the empty staking card is visible before any SOL staking and hidden afterwards. The shared useEmptyStakingCardContent hook directly contributes to this empty state, so it is meaningfully exposed to changes there.

</details>

_Updated: 2026-09-07T06:36:42.616Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/cardano-eth-sol-staking-card-copy/web/](https://dev.suite.sldev.cz/suite-web/fix/cardano-eth-sol-staking-card-copy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-eth-sol-staking-card-copy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-eth-sol-staking-card-copy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T06:39:00.421Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T06:38:51.064Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->