### PR TITLE
feat(suite-desktop-core): disable electron fuse RunAsNode

### DIFF
--- a/packages/suite-desktop-core/scripts/setElectronFuses.mjs
+++ b/packages/suite-desktop-core/scripts/setElectronFuses.mjs
@@ -2,44 +2,67 @@ import { FuseV1Options, FuseVersion, flipFuses } from '@electron/fuses';
 import path from 'node:path';
 /**
  * @typedef {import('app-builder-lib').Hooks} Hooks
+ * @typedef {'darwin' | 'win32' | 'linux'} SupportedPlatformName
  */
+
+/** @type {readonly SupportedPlatformName[]} */
+const supportedPlatformNames = ['darwin', 'win32', 'linux'];
+
+/**
+ * @param {string} platformName
+ * @returns {platformName is SupportedPlatformName}
+ */
+const isSupportedPlatformName = platformName =>
+    supportedPlatformNames.includes(/** @type {SupportedPlatformName} */ (platformName));
 
 // copied from https://github.com/electron-userland/electron-builder/blob/04be5699c664e6a93e093b820a16ad516355b5c7/packages/app-builder-lib/src/platformPackager.ts#L430-L434
 /* @type {{ darwin: string, win32: string, linux: string }} */
-const binaryExtensionByPlaformNameMap = {
+const binaryExtensionByPlatformNameMap = {
     darwin: '.app',
     win32: '.exe',
     linux: '',
+};
+
+const fusesToFlipByPlatformNameMap = {
+    darwin: {
+        [FuseV1Options.RunAsNode]: false,
+        [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+        [FuseV1Options.OnlyLoadAppFromAsar]: true,
+    },
+    win32: {
+        [FuseV1Options.RunAsNode]: false,
+        [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+        [FuseV1Options.OnlyLoadAppFromAsar]: true,
+    },
+    // As of Electron 39, ASAR integrity is not supported on Linux
+    linux: {
+        [FuseV1Options.RunAsNode]: false,
+    },
 };
 
 /** @type {Hooks['afterPack']} **/
 const afterPackHookSetElectronFuses = async context => {
     const { electronPlatformName, appOutDir } = context;
 
-    // As of Electron 39, ASAR integrity is not supported on Linux, so we set the appropriate fuses for Windows and macOS
-    if (electronPlatformName !== 'win32' && electronPlatformName !== 'darwin') {
-        // eslint-disable-next-line no-console
-        console.log('Skipping electron fuses ');
+    if (!isSupportedPlatformName(electronPlatformName)) {
+        console.warn('Skipping electron fuses (unknown platform).');
 
         return;
     }
-
-    const ext = binaryExtensionByPlaformNameMap[electronPlatformName];
+    const fusesToFlip = fusesToFlipByPlatformNameMap[electronPlatformName];
+    const ext = binaryExtensionByPlatformNameMap[electronPlatformName];
     const appName = context.packager.appInfo.productFilename;
     const binaryFilename = `${appName}${ext}`;
     const binaryPath = path.join(appOutDir, binaryFilename);
 
-    // eslint-disable-next-line no-console
-    console.log(`Setting electron fuses on ${binaryPath}`);
+    console.info(`Setting electron fuses on ${binaryPath}`);
 
     await flipFuses(binaryPath, {
         version: FuseVersion.V1,
-        [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
-        [FuseV1Options.OnlyLoadAppFromAsar]: true,
+        ...fusesToFlip,
     });
 
-    // eslint-disable-next-line no-console
-    console.log('Successfully set electron fuses');
+    console.info('Successfully set electron fuses');
 };
 
 // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
## Description

Disable Electron fuse `RunAsNode` on all platforms, because it is a minor security security concern – not a vulnerability in Suite, but it allows Suite's electron binary to be misused for "Living of the land" attacks.
On a typical environment, there are likely more than enough opportunities for "Living of the land" (e.g. Powershell, bash, zsh), so IMO this is not very meaningful security point, but then again, there is no reason against it, it costs us nothing :slightly_smiling_face: 
[statement from electron devs for details](https://az.electronjs.org/blog/statement-run-as-node-cves)

**TL;DR:** this fuse is on by default, then you can set env variable `ELECTRON_RUN_AS_NODE=true` which makes the electron executable act as a `node` binary (allowing local code execution). Turning off the fuse: electron ignores the env variable and cannot be used as a node interpreter.

## Notes for QA

N/A, we don't use `ELECTRON_RUN_AS_NODE` anywhere.

I personally tested local Suite Desktop builds on all platforms. 

## Screenshots:

Desktop app installs and runs on all platform (can be tested as part of release checks).

### Dev testing
Correct fuses are set as per all platforms:

```
# Linux local build
$ npx @electron/fuses read --app "./packages/suite-desktop/build-electron/linux-unpacked/trezor-suite"
Analyzing app: trezor-suite
Fuse Version: v1
  RunAsNode is Disabled
  EnableCookieEncryption is Disabled
  EnableNodeOptionsEnvironmentVariable is Enabled
  EnableNodeCliInspectArguments is Enabled
  EnableEmbeddedAsarIntegrityValidation is Disabled
  OnlyLoadAppFromAsar is Disabled
  LoadBrowserProcessSpecificV8Snapshot is Disabled
  GrantFileProtocolExtraPrivileges is Enabled
  WasmTrapHandlers is Enabled

# Windows local build from Linux
$ npx @electron/fuses read --app "./packages/suite-desktop/build-electron/win-unpacked/Trezor Suite.exe"
Analyzing app: Trezor Suite.exe
Fuse Version: v1
  RunAsNode is Disabled
  EnableCookieEncryption is Disabled
  EnableNodeOptionsEnvironmentVariable is Enabled
  EnableNodeCliInspectArguments is Enabled
  EnableEmbeddedAsarIntegrityValidation is Enabled
  OnlyLoadAppFromAsar is Enabled
  LoadBrowserProcessSpecificV8Snapshot is Disabled
  GrantFileProtocolExtraPrivileges is Enabled
  WasmTrapHandlers is Enabled

# macOS installed app
$ npx @electron/fuses read --app "/Applications/Trezor Suite.app/Contents/MacOS/Trezor Suite"
npm notice run trezor-suite@1.0.0 npx
npm notice run 'electron-fuses' read --app /Applications/Trezor Suite.app/Contents/MacOS/Trezor Suite
Analyzing app: Trezor Suite
Fuse Version: v1
  RunAsNode is Disabled
  EnableCookieEncryption is Disabled
  EnableNodeOptionsEnvironmentVariable is Enabled
  EnableNodeCliInspectArguments is Enabled
  EnableEmbeddedAsarIntegrityValidation is Enabled
  OnlyLoadAppFromAsar is Enabled
  LoadBrowserProcessSpecificV8Snapshot is Disabled
  GrantFileProtocolExtraPrivileges is Enabled
  WasmTrapHandlers is Enabled
```

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-09-07T09:19:01.718Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tighten-electron-fuses/web/](https://dev.suite.sldev.cz/suite-web/feat/tighten-electron-fuses/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tighten-electron-fuses&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tighten-electron-fuses&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T09:22:31.791Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T09:22:47.636Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->