### PR TITLE
test(connect): use Lido wstETH wrap for clearsigning e2e

### DIFF
--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts
@@ -5,25 +5,26 @@ const ethereumSignTransactionDefinitions: TestCase = {
     },
     tests: [
         {
-            // Uniswap V3 Universal Router — exactInputSingle (WETH → USDT).
-            // The router contract triggers an EthereumDefinitionRequest with func_sig
+            // Lido wstETH — wrap(uint256) (0.999999999999999998 stETH → wstETH).
+            // The wstETH contract triggers an EthereumDefinitionRequest with func_sig
             // so the device can request a display-format definition for the call.
             // We fetch definitions from data.trezor.io and respond with EthereumDefinitionAck.
-            description: 'Uniswap V3 exactInputSingle',
+            // Calldata taken from the clear-signing ERC-7730 registry "Wrap stETH" vector.
+            description: 'Lido wstETH wrap',
             params: {
                 path: "m/44'/60'/0'",
                 transaction: {
                     nonce: '0x0',
                     gasPrice: '0x14',
                     gasLimit: '0x14',
-                    to: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
+                    to: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
                     value: '0x0',
                     chainId: 1,
-                    data: '0x04e45aaf000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec70000000000000000000000000000000000000000000000000000000000000bb800000000000000000000000051117eb63623aee74a39b63bd9efa3a728800dbb000000000000000000000000000000000000000000000000002386f26fc1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+                    data: '0xea598cb00000000000000000000000000000000000000000000000000de0b6b3a763fffe',
                 },
             },
             result: {},
-            deviceScreen: /"body":"UniswapV3Router".*"body":"Swap".*0\.01WETH.*0USDT.*0\.3%/,
+            deviceScreen: /"body":"LidoDAO".*"body":"WrapstETH".*0\.999999999999999998STETH/,
             deviceScreenSkip: ['1', '<2.12.1'],
         },
     ],


### PR DESCRIPTION
## Description

Firmware dropped support for the Uniswap V3 `exactInputSingle` call that the `ethereumSignTransaction` definitions e2e test relied on.

 This swaps it for a Lido `wstETH.wrap(uint256)` call, using the calldata from the clear-signing ERC-7730 registry "Wrap stETH" vector (amount `0.999999999999999998 stETH`). The `to`, calldata, and `deviceScreen` regex (contract name → intent → amount) are updated accordingly; the rest of the fixture (path, gas fields, `deviceScreenSkip`) is unchanged.

## Notes for QA

N/A E2E only

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/honiara/web/](https://dev.suite.sldev.cz/suite-web/honiara/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=honiara&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=honiara&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=honiara&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T10:07:22.098Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T10:07:39.009Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to a Connect package test fixture for Ethereum transaction signing, with no direct static references in the Suite E2E suite. The regression risk to Suite is low, but the closest functional coverage is the Suite Connect test for ethereumSignTransaction. Broader trading, staking, or yield tests are not recommended because the fixture change does not alter Connect source behavior or Suite transaction flows.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/e2e/__fixtures__/ethereumSignTransactionDefinitions.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test directly exercises TrezorConnect.ethereumSignTransaction in Suite desktop, the same API area that the changed Connect fixture targets. Since static mapping found no Suite tests referencing the fixture, this recommendation is inferred from functional coverage and provides the closest end-to-end proxy for validating Ethereum transaction signing behavior.

</details>

_Updated: 2026-09-07T10:05:59.516Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->