### PR TITLE
Show full receive addresses

### DIFF
--- a/packages/product-components/src/components/EditableText/EditableText.tsx
+++ b/packages/product-components/src/components/EditableText/EditableText.tsx
@@ -42,6 +42,7 @@ export type EditableTextProps = AllowedFrameProps & {
     leftAddon?: ReactNode;
     rightAddon?: ReactNode;
     gap?: SpacingValue;
+    isDisplayValueMultiline?: boolean;
     'data-testid'?: string;
 } & (
         | { defaultValue?: undefined; displayValue?: undefined }
@@ -109,6 +110,7 @@ type ContainerProps = {
     $gap: SpacingValue;
     $isActive: boolean;
     $isAlwaysActive: boolean;
+    $isDisplayValueMultiline: boolean;
 } & TransientProps<AllowedFrameProps>;
 
 const Container = styled.span<ContainerProps>`
@@ -119,12 +121,18 @@ const Container = styled.span<ContainerProps>`
     position: relative;
     max-width: 100%;
     gap: ${({ $gap }) => $gap}px;
-    overflow: hidden;
-    height: 28px;
+    min-height: 28px;
     box-sizing: content-box;
     padding: var(--padding);
     padding-left: ${({ $gap }) => $gap}px;
     cursor: ${({ $isAlwaysActive }) => ($isAlwaysActive ? 'pointer' : 'inherit')};
+
+    ${({ $isDisplayValueMultiline }) =>
+        !$isDisplayValueMultiline &&
+        css`
+            overflow: hidden;
+            height: 28px;
+        `}
 
     &::before {
         content: '';
@@ -175,6 +183,7 @@ export const EditableText = ({
     leftAddon,
     rightAddon,
     gap = 8,
+    isDisplayValueMultiline = false,
     'data-testid': dataTestId,
     ...rest
 }: EditableTextProps) => {
@@ -418,6 +427,7 @@ export const EditableText = ({
             $gap={gap}
             $isActive={isActive && !isDisabled}
             $isAlwaysActive={isAlwaysActive && !isDisabled}
+            $isDisplayValueMultiline={isDisplayValueMultiline}
             {...frameProps}
         >
             {leftAddon && (
@@ -441,7 +451,7 @@ export const EditableText = ({
                     alignSelf="baseline"
                     maxWidth="100%"
                     display="inline-flex"
-                    overflow="hidden"
+                    overflow={isDisplayValueMultiline ? 'visible' : 'hidden'}
                     zIndex={zIndex}
                 >
                     <EditableContainer
@@ -467,8 +477,9 @@ export const EditableText = ({
                     </EditableContainer>
                     {hasDisplayValue && (
                         <Text
-                            ellipsisLineCount={1}
+                            ellipsisLineCount={isDisplayValueMultiline ? undefined : 1}
                             as="div"
+                            minWidth={0}
                             pointerEvents="none"
                             color={isActive ? 'contentPrimary' : undefined}
                         >

--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -17,7 +17,7 @@ const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     model === Model.T3W1 ? btcDiscoveryFinishedStateT3W1 : btcDiscoveryFinishedStateT3T1,
 );
-const expectedReceiveAddress = 'bc1q czeu ... xlma n6';
+const expectedReceiveAddress = 'bc1q czeu 64q3 86jv rdd7 ks8g m3t9 jfwa rs83 xlma n6';
 
 describe('Receive [@androidOnly @T3T1 @T3W1]', () => {
     beforeEach(async () => {

--- a/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
@@ -74,7 +74,7 @@ export const ReceiveAddressDetails = ({
                 <ClipboardCopyMenu onCopy={handleCopyAddress} style={applyStyle(addressContainer)}>
                     <AddressFormatter
                         value={address}
-                        format="long"
+                        format="full"
                         variant="headline-sm"
                         textAlign="center"
                         testID="@receive/confirmed-receive-address"

--- a/suite/address/src/AddressLabeling.tsx
+++ b/suite/address/src/AddressLabeling.tsx
@@ -2,7 +2,9 @@ import { useTranslation } from '@suite/intl';
 import { Labeling } from '@suite/labeling';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
+import { Text } from '@trezor/components';
 import { type StaticSessionId } from '@trezor/device-utils';
+import { type TypographyStyle } from '@trezor/theme';
 
 import { Address } from './Address';
 
@@ -13,6 +15,10 @@ type AddressLabelingProps = {
     address: string;
     label?: string;
     maxWidth?: number;
+    typographyStyle?: TypographyStyle;
+    isAddressTruncated?: boolean;
+    isDisplayValueMultiline?: boolean;
+    addressDataTestId?: string;
 };
 
 export const AddressLabeling = ({
@@ -22,29 +28,42 @@ export const AddressLabeling = ({
     address,
     label,
     maxWidth,
+    typographyStyle,
+    isAddressTruncated = true,
+    isDisplayValueMultiline = false,
+    addressDataTestId,
 }: AddressLabelingProps) => {
     const { translationString } = useTranslation();
 
     return (
-        <Labeling
-            payload={{
-                type: 'addressLabel',
-                entityKey: createAccountKey({
-                    accountDescriptor,
+        <Text typographyStyle={typographyStyle}>
+            <Labeling
+                payload={{
+                    type: 'addressLabel',
+                    entityKey: createAccountKey({
+                        accountDescriptor,
+                        networkSymbol,
+                        deviceStaticSessionId,
+                    }),
+                    defaultValue: address,
                     networkSymbol,
-                    deviceStaticSessionId,
-                }),
-                defaultValue: address,
-                networkSymbol,
-                accountDescriptor,
-            }}
-            deviceStaticSessionId={deviceStaticSessionId}
-            displayValue={<Address value={address} isTruncated />}
-            placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}
-            minHeight={28}
-            maxWidth={maxWidth}
-        >
-            {label}
-        </Labeling>
+                    accountDescriptor,
+                }}
+                deviceStaticSessionId={deviceStaticSessionId}
+                displayValue={
+                    <Address
+                        value={address}
+                        isTruncated={isAddressTruncated}
+                        data-testid={addressDataTestId}
+                    />
+                }
+                placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}
+                minHeight={28}
+                maxWidth={maxWidth}
+                isDisplayValueMultiline={isDisplayValueMultiline}
+            >
+                {label}
+            </Labeling>
+        </Text>
     );
 };

--- a/suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts
@@ -164,7 +164,7 @@ test.describe('Suite Sync - Update and Remove Labels', { tag: ['@T3W1', '@T3T1']
             await metadataPage.address.removeLabel({ address: addressSeed.address });
             await expect
                 .soft(metadataPage.address.addressHoverContainer(addressSeed.address))
-                .toHaveText('bc1q kkr2 ... qfxy fa');
+                .toHaveText('bc1q kkr2 uvry 034t sj4p 52za 2pg4 2ug4 pxg5 qfxy fa');
         });
 
         await test.step('Remove output label', async () => {

--- a/suite/receive/src/AddressCardDetail.tsx
+++ b/suite/receive/src/AddressCardDetail.tsx
@@ -17,6 +17,9 @@ import { CoinQrCode } from './CoinQrCode';
 import { type ReceiveAddressItem } from './address/buildReceiveAddressItems';
 import { canShareAddress, shareAddress } from './sharing/share';
 
+const QR_CODE_SIZE = 200;
+const COMPACT_QR_CODE_SIZE = 148;
+
 type AddressCardDetailProps = {
     item: ReceiveAddressItem;
     accountKey: AccountKey;
@@ -66,16 +69,22 @@ export const AddressCardDetail = ({
 
     const isUtxo = isUtxoBased(account);
     const hasLabel = !!item.label;
+    const qrCodeSize = isBelowTablet ? COMPACT_QR_CODE_SIZE : QR_CODE_SIZE;
 
     return (
         <Box padding={24}>
             <Grid
-                columns={isBelowTablet ? '1fr' : 'minmax(max-content, 1fr) auto'}
+                columns={isBelowTablet ? '1fr' : 'minmax(0, 1fr) auto'}
                 gap={24}
                 alignItems="stretch"
             >
-                <Column gap={32} alignItems="flex-start" justifyContent="space-between">
-                    <Column gap={isUtxo ? 8 : 16} alignItems="flex-start">
+                <Column
+                    gap={32}
+                    alignItems="flex-start"
+                    justifyContent="space-between"
+                    minWidth={0}
+                >
+                    <Column gap={isUtxo ? 8 : 16} alignItems="flex-start" minWidth={0}>
                         {isUtxo ? (
                             item.pathIndex !== undefined && (
                                 <Text
@@ -91,29 +100,28 @@ export const AddressCardDetail = ({
                                 <Translation id="RECEIVE_ADDRESS_TITLE" />
                             </Text>
                         )}
-                        <Column gap={8} alignItems="flex-start">
-                            <Text
+                        <Column gap={8} alignItems="flex-start" minWidth={0}>
+                            <AddressLabeling
+                                accountDescriptor={account.descriptor}
+                                networkSymbol={account.symbol}
+                                deviceStaticSessionId={account.deviceState}
+                                address={item.address}
+                                label={item.label}
                                 typographyStyle={hasLabel ? 'headline-sm' : 'headline-md'}
-                                data-testid="@wallet/receive/address"
-                            >
-                                <AddressLabeling
-                                    accountDescriptor={account.descriptor}
-                                    networkSymbol={account.symbol}
-                                    deviceStaticSessionId={account.deviceState}
-                                    address={item.address}
-                                    label={item.label}
-                                />
-                            </Text>
+                                isAddressTruncated={false}
+                                isDisplayValueMultiline
+                                addressDataTestId={hasLabel ? undefined : '@wallet/receive/address'}
+                            />
                             {hasLabel && (
                                 <Address
                                     value={item.address}
-                                    isTruncated
                                     typographyStyle="headline-sm"
+                                    data-testid="@wallet/receive/address"
                                 />
                             )}
                         </Column>
                     </Column>
-                    <Row gap={12} flexWrap="wrap">
+                    <Row gap={12} flexWrap="wrap" width="100%">
                         <Button
                             size="large"
                             iconLeft={CopyIcon}
@@ -148,12 +156,7 @@ export const AddressCardDetail = ({
                         </Button>
                     </Row>
                 </Column>
-                <Box
-                    aspectRatio="1"
-                    width={isBelowTablet ? 148 : undefined}
-                    height={isBelowTablet ? 148 : '100%'}
-                    maxHeight={200}
-                >
+                <Box aspectRatio="1" width={qrCodeSize} maxWidth="100%">
                     <CoinQrCode value={item.address} symbol={account.symbol} />
                 </Box>
             </Grid>

--- a/suite/receive/src/AddressHistoryRow.tsx
+++ b/suite/receive/src/AddressHistoryRow.tsx
@@ -19,7 +19,6 @@ import { type ReceiveAddressItem } from './address/buildReceiveAddressItems';
 import { type ReceiveAmountComponent } from './receive';
 import { canShareAddress, shareAddress } from './sharing/share';
 
-const ADDRESS_MAX_WIDTH = 300;
 // Labeling reserves room next to the address for its edit button, but only while the label action
 // is enabled, and it takes more of it on hover. The actions have to keep out of the way of both.
 const ACTIONS_GAP_WITHOUT_LABEL_ACTION = 8;
@@ -33,6 +32,7 @@ const revealed = css`
 
 const Label = styled.div`
     min-width: 0;
+    flex: 1;
 `;
 
 const Actions = styled.div<{ $hasLabelAction: boolean }>`
@@ -132,18 +132,18 @@ export const AddressHistoryRow = ({
                             {item.pathIndex}
                         </Text>
                     )}
-                    <Row minWidth={0}>
+                    <Row minWidth={0} flex="1">
                         <Label>
-                            <Text typographyStyle="body-sm">
-                                <AddressLabeling
-                                    accountDescriptor={account.descriptor}
-                                    networkSymbol={account.symbol}
-                                    deviceStaticSessionId={account.deviceState}
-                                    address={item.address}
-                                    label={item.label}
-                                    maxWidth={ADDRESS_MAX_WIDTH}
-                                />
-                            </Text>
+                            <AddressLabeling
+                                accountDescriptor={account.descriptor}
+                                networkSymbol={account.symbol}
+                                deviceStaticSessionId={account.deviceState}
+                                address={item.address}
+                                label={item.label}
+                                typographyStyle="body-sm"
+                                isAddressTruncated={false}
+                                isDisplayValueMultiline
+                            />
                         </Label>
                         <Actions $hasLabelAction={isLabelActionEnabled}>
                             <Row gap={4}>


### PR DESCRIPTION
## Description
- show the full receive address on Suite desktop receive cards and history rows
- show the full receive address on Suite Native receive detail
- keep mobile receive list rows shortened, since they can be opened into detail

## Related issues
Resolve https://github.com/trezor/trezor-suite/issues/32160
Resolve https://github.com/trezor/trezor-suite/issues/32159

## Screenshots

### Before

https://github.com/user-attachments/assets/426331f8-6630-465f-a333-93683d36b3ab

https://github.com/user-attachments/assets/a32c90aa-4de9-4e3f-a3fa-a51287ae1814



### After

https://github.com/user-attachments/assets/02742c62-9432-4271-8fe3-8643cb608a03

https://github.com/user-attachments/assets/d174a2b6-2ace-40e2-9aad-8fef7038a06a





<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes concentrate on receive-address UI components and address labeling, with suite-web risk concentrated in the receive flow and editable label interactions. The recommended tests focus on those two areas. Two suite-native files are not exercised by the available suite-web E2E candidates and would need to be validated separately via the native test run.

<details><summary><b>Changed files (7)</b></summary>

- `packages/product-components/src/components/EditableText/EditableText.tsx`
- `suite-native/app/e2e/tests/receive.test.ts`
- `suite-native/module-receive/src/components/ReceiveAddressDetails.tsx`
- `suite/address/src/AddressLabeling.tsx`
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts`
- `suite/receive/src/AddressCardDetail.tsx`
- `suite/receive/src/AddressHistoryRow.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — Directly exercises adding and editing address labels on receive addresses, which is the primary user flow affected by changes to suite/address/src/AddressLabeling.tsx and the shared EditableText component.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — This test file was modified in the PR and covers updating/removing BTC address labels on the receive screen via Suite Sync, directly touching the receive and address-labeling code paths.
- `suite/e2e/tests/wallet/receive.test.ts` — Validates the core receive-address flow including address display, copying, QR code, and device verification, directly impacted by changes to suite/receive/src/AddressCardDetail.tsx and AddressHistoryRow.tsx.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Account label editing shares the same EditableText/labeling infrastructure and state management as address labels, so a regression in the shared component could surface here.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Transaction output labels use the same editable labeling components and metadata state as address labels, making this a good neighbor test for EditableText changes.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Creates address labels on the receive screen through Suite Sync and verifies relay sync, overlapping with the receive-address labeling path.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Verifies that synced address labels render correctly on the BTC receive screen, which relies on the receive components and address labeling logic.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Exercises the global receive flow including address generation, selection, and device verification, sharing receive UI components with the changed receive module files.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/app/e2e/tests/receive.test.ts`
- `suite-native/module-receive/src/components/ReceiveAddressDetails.tsx`

_Updated: 2026-09-07T14:44:17.744Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/receive-address-ux/web/](https://dev.suite.sldev.cz/suite-web/juriczech/receive-address-ux/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/receive-address-ux&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/receive-address-ux&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/receive-address-ux&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T14:46:11.733Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T14:46:58.125Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->