### PR TITLE
feat(suite-native): persist historic fiat rates

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
@@ -6,7 +6,11 @@ import {
 import { type Timestamp } from '@suite-common/wallet-types';
 import { getFiatRateKeyFromTicker, isTestnet } from '@suite-common/wallet-utils';
 
-import { updateFiatRatesThunk, updateTxsFiatRatesThunk } from './fiatRatesThunks';
+import {
+    pruneHistoricFiatRatesThunk,
+    updateFiatRatesThunk,
+    updateTxsFiatRatesThunk,
+} from './fiatRatesThunks';
 import { type FiatRatesState } from './fiatRatesTypes';
 
 export const fiatRatesInitialState: FiatRatesState = {
@@ -138,6 +142,11 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
                         ),
                     };
                 });
+            })
+            .addCase(pruneHistoricFiatRatesThunk.fulfilled, (state, action) => {
+                if (!action.payload) return;
+
+                state.historic = action.payload;
             })
             .addMatcher(
                 action => action.type === extra.actionTypes.storageLoad,

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
-import { updateTxsFiatRatesThunk } from './fiatRatesThunks';
+import { pruneHistoricFiatRatesThunk, updateTxsFiatRatesThunk } from './fiatRatesThunks';
 import { blockchainInitialState } from '../blockchain/blockchainReducer';
 
 jest.mock('@suite-common/fiat-services', () => ({
@@ -31,11 +31,15 @@ const ethAccount = {
     ],
 } as unknown as Account;
 
+// Historic rates are keyed by the transaction's block time rounded down to the whole hour.
+const HOUR = 1700002800;
+const NEXT_HOUR = HOUR + 3600;
+
 const tokenTransaction = (contract: TokenAddress): WalletAccountTransaction =>
     ({
         txid: `tx-${contract}`,
         symbol: 'eth',
-        blockTime: 1700002800,
+        blockTime: HOUR,
         tokens: [{ contract, standard: 'ERC20', amount: '1000000', decimals: 6 }],
     }) as unknown as WalletAccountTransaction;
 
@@ -88,5 +92,70 @@ describe('updateTxsFiatRatesThunk', () => {
 
         expect(tokenAddresses).toContain(USDT_CONTRACT);
         expect(tokenAddresses).not.toContain(VAULT_CONTRACT);
+    });
+});
+
+const USDT_RATE_KEY = `eth-${USDT_CONTRACT}-usd`;
+
+const btcTransaction = {
+    txid: 'btc-tx',
+    symbol: 'btc',
+    blockTime: HOUR,
+    tokens: [],
+} as unknown as WalletAccountTransaction;
+
+const initPruneStore = ({
+    transactions,
+    historic,
+}: {
+    transactions: Record<string, Array<WalletAccountTransaction | null>>;
+    historic: Record<string, Record<number, number>>;
+}) =>
+    createTestStore({
+        extra: undefined,
+        preloadedState: {
+            wallet: {
+                fiat: { current: {}, lastWeek: {}, historic },
+                transactions: { transactions },
+            },
+        },
+    });
+
+describe('pruneHistoricFiatRatesThunk', () => {
+    it('keeps token rates of a referenced transaction', async () => {
+        const store = initPruneStore({
+            transactions: { 'acc-a': [tokenTransaction(USDT_CONTRACT)] },
+            historic: {
+                'eth-usd': { [HOUR]: 3000 },
+                [USDT_RATE_KEY]: { [HOUR]: 1 },
+                'btc-usd': { [HOUR]: 50000 },
+            },
+        });
+
+        const { payload } = await store.dispatch(pruneHistoricFiatRatesThunk());
+
+        expect(payload).toEqual({ 'eth-usd': { [HOUR]: 3000 }, [USDT_RATE_KEY]: { [HOUR]: 1 } });
+    });
+
+    it('returns nothing when every rate is still referenced', async () => {
+        const store = initPruneStore({
+            transactions: { 'acc-a': [btcTransaction] },
+            historic: { 'btc-usd': { [HOUR]: 50000 } },
+        });
+
+        const { payload } = await store.dispatch(pruneHistoricFiatRatesThunk());
+
+        expect(payload).toBeUndefined();
+    });
+
+    it('drops unreferenced rates, ignoring empty slots in a paginated transaction list', async () => {
+        const store = initPruneStore({
+            transactions: { 'acc-a': [null, btcTransaction, null] },
+            historic: { 'btc-usd': { [HOUR]: 50000, [NEXT_HOUR]: 51000 } },
+        });
+
+        const { payload } = await store.dispatch(pruneHistoricFiatRatesThunk());
+
+        expect(payload).toEqual({ 'btc-usd': { [HOUR]: 50000 } });
     });
 });

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -15,6 +15,7 @@ import {
     type AccountKey,
     type FiatRatesResult,
     type RateTypeWithoutHistoric,
+    type RatesByTimestamps,
     type TickerId,
     type TickerResult,
     type Timestamp,
@@ -27,13 +28,20 @@ import {
     getErc4626Contracts,
     groupTokensTransactionsByContractAddress,
     isTestnet,
+    selectHistoricRatesByTransactions,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { type TimerId, exhaustive } from '@trezor/type-utils';
-import { BigNumber, isNotUndefined, typedObjectKeys } from '@trezor/utils';
+import {
+    BigNumber,
+    deepEqual,
+    isNotNullOrUndefined,
+    isNotUndefined,
+    typedObjectKeys,
+} from '@trezor/utils';
 
 import { FIAT_RATES_MODULE_PREFIX, REFETCH_INTERVAL } from './fiatRatesConstants';
-import { selectTickersToBeUpdated } from './fiatRatesSelectors';
+import { selectHistoricFiatRates, selectTickersToBeUpdated } from './fiatRatesSelectors';
 import { type FiatRatesRootState } from './fiatRatesTypes';
 import { type AccountsRootState } from '../accounts/accountsReducer';
 import { selectAccountByKey } from '../accounts/accountsSelectors';
@@ -43,7 +51,10 @@ import {
     selectIsElectrumBackendSelected,
 } from '../blockchain/blockchainSelectors';
 import { type TransactionsRootState } from '../transactions/transactionsReducerTypes';
-import { selectTransactionsWithMissingRates } from '../transactions/transactionsSelectors';
+import {
+    selectTransactions,
+    selectTransactionsWithMissingRates,
+} from '../transactions/transactionsSelectors';
 
 interface FetchErc4626FiatRateProps {
     ticker: TickerId;
@@ -315,6 +326,29 @@ export const updateMissingTxFiatRatesThunk = createThunk<
         });
     },
 );
+
+export type PruneHistoricFiatRatesThunkState = FiatRatesRootState & TransactionsRootState;
+
+/**
+ * Drops historic rates no transaction refers to any more, left behind by forgotten devices and
+ * removed accounts.
+ */
+export const pruneHistoricFiatRatesThunk = createThunk<
+    RatesByTimestamps | undefined,
+    void,
+    { state: PruneHistoricFiatRatesThunkState }
+>(`${FIAT_RATES_MODULE_PREFIX}/pruneHistoricRates`, (_, { getState }) => {
+    const historicRates = selectHistoricFiatRates(getState());
+    if (!historicRates) return;
+
+    const transactions = Object.values(selectTransactions(getState()))
+        .flat()
+        .filter(isNotNullOrUndefined);
+
+    const referencedRates = selectHistoricRatesByTransactions(historicRates, transactions);
+
+    return deepEqual(referencedRates, historicRates) ? undefined : referencedRates;
+});
 
 type FetchFiatRatesThunkPayload = {
     rateType: RateTypeWithoutHistoric;

--- a/suite-common/wallet-utils/src/fiatRatesUtils.test.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.test.ts
@@ -1,43 +1,140 @@
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
+import {
+    type RatesByTimestamps,
+    type Timestamp,
+    type TokenAddress,
+    type WalletAccountTransaction,
+} from '@suite-common/wallet-types';
 
 import {
     getFiatRateKey,
     getFiatRateKeyFromTicker,
     roundTimestampToNearestPastHour,
+    selectHistoricRatesByTransactions,
 } from './fiatRatesUtils';
 
 const ethSymbol = asNetworkSymbol('eth');
+
+const DAI = '0x6b175474e89094c44da98b954eedeac495271d0f' as TokenAddress;
+const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7' as TokenAddress;
+// Stellar classic assets are identified by `CODE-ISSUER`, so the contract itself contains a dash.
+const STELLAR_USDC =
+    'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' as TokenAddress;
+const STELLAR_EURC =
+    'EURC-GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP2' as TokenAddress;
 
 describe('fiat rates utils', () => {
     it('formats fiat rate key', () => {
         expect(getFiatRateKey(ethSymbol, 'usd')).toMatch('eth-usd');
 
-        const result = getFiatRateKey(
-            ethSymbol,
-            'usd',
-            '0x6b175474e89094c44da98b954eedeac495271d0f' as TokenAddress,
-        );
+        const result = getFiatRateKey(ethSymbol, 'usd', DAI);
 
-        expect(result).toMatch('eth-0x6b175474e89094c44da98b954eedeac495271d0f-usd');
+        expect(result).toMatch(`eth-${DAI}-usd`);
     });
     it('formats fiat rate key from ticker', () => {
         expect(getFiatRateKeyFromTicker({ symbol: ethSymbol }, 'usd')).toMatch('eth-usd');
 
-        const result = getFiatRateKeyFromTicker(
-            {
-                symbol: ethSymbol,
-                tokenAddress: '0x6b175474e89094c44da98b954eedeac495271d0f' as TokenAddress,
-            },
-            'usd',
-        );
+        const result = getFiatRateKeyFromTicker({ symbol: ethSymbol, tokenAddress: DAI }, 'usd');
 
-        expect(result).toMatch('eth-0x6b175474e89094c44da98b954eedeac495271d0f-usd');
+        expect(result).toMatch(`eth-${DAI}-usd`);
     });
     it('rounds timestamp to the nearest past hour', () => {
         const timestamp = new Date('2024-03-19T15:45:00Z').getTime() / 1000;
         const expected = new Date('2024-03-19T15:00:00Z').getTime() / 1000;
 
         expect(roundTimestampToNearestPastHour(timestamp as Timestamp)).toBe(expected);
+    });
+});
+
+// Historic rates are keyed by the block time rounded down to the whole hour.
+const HOUR = 1700002800;
+const NEXT_HOUR = HOUR + 3600;
+
+const transaction = ({
+    symbol = 'eth',
+    blockTime = HOUR,
+    contracts = [] as TokenAddress[],
+} = {}): WalletAccountTransaction =>
+    ({
+        symbol,
+        blockTime,
+        tokens: contracts.map(contract => ({ contract })),
+    }) as unknown as WalletAccountTransaction;
+
+const rates = (entries: Record<string, Record<number, number>>) => entries as RatesByTimestamps;
+
+describe('selectHistoricRatesByTransactions', () => {
+    it('keeps only the token rates a transaction actually moves', () => {
+        const result = selectHistoricRatesByTransactions(
+            rates({
+                'eth-usd': { [HOUR]: 3000 },
+                [getFiatRateKey(ethSymbol, 'usd', DAI)]: { [HOUR]: 1 },
+                [getFiatRateKey(ethSymbol, 'usd', USDT)]: { [HOUR]: 1 },
+            }),
+            [transaction({ contracts: [DAI] })],
+        );
+
+        expect(result).toEqual({
+            'eth-usd': { [HOUR]: 3000 },
+            [getFiatRateKey(ethSymbol, 'usd', DAI)]: { [HOUR]: 1 },
+        });
+    });
+
+    it('keeps a coin rate for a transaction without tokens', () => {
+        const result = selectHistoricRatesByTransactions(
+            rates({
+                'eth-usd': { [HOUR]: 3000 },
+                [getFiatRateKey(ethSymbol, 'usd', DAI)]: { [HOUR]: 1 },
+            }),
+            [transaction()],
+        );
+
+        expect(result).toEqual({ 'eth-usd': { [HOUR]: 3000 } });
+    });
+
+    it('keeps rates across every base currency the transaction was priced in', () => {
+        const result = selectHistoricRatesByTransactions(
+            rates({ 'eth-usd': { [HOUR]: 3000 }, 'eth-eur': { [HOUR]: 2800 } }),
+            [transaction()],
+        );
+
+        expect(result).toEqual({ 'eth-usd': { [HOUR]: 3000 }, 'eth-eur': { [HOUR]: 2800 } });
+    });
+
+    it('drops rates of another network and of unreferenced timestamps', () => {
+        const result = selectHistoricRatesByTransactions(
+            rates({
+                'eth-usd': { [HOUR]: 3000, [NEXT_HOUR]: 3100 },
+                'btc-usd': { [HOUR]: 50000 },
+            }),
+            [transaction()],
+        );
+
+        expect(result).toEqual({ 'eth-usd': { [HOUR]: 3000 } });
+    });
+
+    it('matches a stellar token whose contract contains a dash', () => {
+        const result = selectHistoricRatesByTransactions(
+            rates({
+                'xlm-usd': { [HOUR]: 0.1 },
+                [getFiatRateKey(asNetworkSymbol('xlm'), 'usd', STELLAR_USDC)]: { [HOUR]: 1 },
+                [getFiatRateKey(asNetworkSymbol('xlm'), 'usd', STELLAR_EURC)]: { [HOUR]: 1.1 },
+            }),
+            [transaction({ symbol: 'xlm', contracts: [STELLAR_USDC] })],
+        );
+
+        expect(result).toEqual({
+            'xlm-usd': { [HOUR]: 0.1 },
+            [getFiatRateKey(asNetworkSymbol('xlm'), 'usd', STELLAR_USDC)]: { [HOUR]: 1 },
+        });
+    });
+
+    it('does not confuse a network with one whose symbol it prefixes', () => {
+        const result = selectHistoricRatesByTransactions(
+            rates({ 'eth-usd': { [HOUR]: 3000 }, 'ethw-usd': { [HOUR]: 4 } }),
+            [transaction()],
+        );
+
+        expect(result).toEqual({ 'eth-usd': { [HOUR]: 3000 } });
     });
 });

--- a/suite-common/wallet-utils/src/fiatRatesUtils.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.ts
@@ -106,33 +106,74 @@ export const buildHistoricRatesFromStorage = (storageHistoricRates: RatesByTimes
     return historicFiatRates;
 };
 
+type SymbolRateKeys = {
+    coinKeys: CryptoBaseCurrencyPair[];
+    tokenKeys: Map<string, CryptoBaseCurrencyPair[]>;
+};
+
+// A token key is `${symbol}-${tokenAddress}-${baseCurrency}` and a coin key
+// `${symbol}-${baseCurrency}` (see getFiatRateKey), so a prefix match would keep every token rate
+// of the network. Stellar contracts contain a dash of their own, hence the slice rather than a
+// fixed part index.
+const indexRateKeysBySymbol = (historicRates: RatesByTimestamps) => {
+    const keysBySymbol = new Map<string, SymbolRateKeys>();
+
+    typedObjectKeys(historicRates).forEach(fiatRateKey => {
+        const parts = fiatRateKey.split('-');
+        const symbol = parts[0] ?? fiatRateKey;
+        const tokenAddress = parts.slice(1, -1).join('-');
+
+        let symbolKeys = keysBySymbol.get(symbol);
+        if (!symbolKeys) {
+            symbolKeys = { coinKeys: [], tokenKeys: new Map() };
+            keysBySymbol.set(symbol, symbolKeys);
+        }
+
+        if (tokenAddress === '') {
+            symbolKeys.coinKeys.push(fiatRateKey);
+
+            return;
+        }
+
+        const tokenKeys = symbolKeys.tokenKeys.get(tokenAddress);
+        if (tokenKeys) {
+            tokenKeys.push(fiatRateKey);
+        } else {
+            symbolKeys.tokenKeys.set(tokenAddress, [fiatRateKey]);
+        }
+    });
+
+    return keysBySymbol;
+};
+
 export const selectHistoricRatesByTransactions = (
     historicRates: RatesByTimestamps,
     txs: WalletAccountTransaction[],
 ) => {
     const selectedRates: RatesByTimestamps = {};
+    const keysBySymbol = indexRateKeysBySymbol(historicRates);
 
-    txs.forEach(tx => {
-        const { symbol, blockTime, tokens } = tx;
+    const keepRate = (fiatRateKey: CryptoBaseCurrencyPair, timestamp: Timestamp) => {
+        const rate = historicRates[fiatRateKey]?.[timestamp];
+        if (!rate) return;
+
+        const ratesForKey = selectedRates[fiatRateKey] ?? {};
+        ratesForKey[timestamp] = rate;
+        selectedRates[fiatRateKey] = ratesForKey;
+    };
+
+    txs.forEach(({ symbol, blockTime, tokens }) => {
+        const symbolKeys = keysBySymbol.get(symbol);
+        if (!symbolKeys) return;
+
         const timestamp = roundTimestampToNearestPastHour(asTimestamp(blockTime ?? 0));
 
-        typedObjectKeys(historicRates).forEach(fiatRateKey => {
-            if (
-                fiatRateKey.startsWith(symbol) ||
-                tokens.some(token => fiatRateKey.startsWith(`[${symbol}-${token.contract}]`))
-            ) {
-                // @ts-expect-error: indexing with noUncheckedIndexedAccess
-                const historicRatesForKey: Record<Timestamp, number> = historicRates[fiatRateKey];
-                if (historicRatesForKey[timestamp]) {
-                    if (!selectedRates[fiatRateKey]) {
-                        selectedRates[fiatRateKey] = {};
-                    }
-                    const selectedRatesForKey: Record<Timestamp, number> =
-                        selectedRates[fiatRateKey];
-                    selectedRatesForKey[timestamp] = historicRatesForKey[timestamp];
-                }
-            }
-        });
+        symbolKeys.coinKeys.forEach(fiatRateKey => keepRate(fiatRateKey, timestamp));
+        tokens.forEach(token =>
+            symbolKeys.tokenKeys
+                .get(token.contract)
+                ?.forEach(fiatRateKey => keepRate(fiatRateKey, timestamp)),
+        );
     });
 
     return selectedRates;

--- a/suite-native/app-init/src/appInitThunks.ts
+++ b/suite-native/app-init/src/appInitThunks.ts
@@ -26,11 +26,13 @@ import {
     type InitStakeDataThunkState,
     type PeriodicFetchFiatRatesThunkDeps,
     type PeriodicFetchFiatRatesThunkState,
+    type PruneHistoricFiatRatesThunkState,
     createImportedDeviceThunk,
     initBlockchainThunk,
     initDevicesThunk,
     initStakeDataThunk,
     periodicFetchFiatRatesThunk,
+    pruneHistoricFiatRatesThunk,
     selectBaseCurrency,
 } from '@suite-common/wallet-core';
 import {
@@ -107,6 +109,7 @@ export const postOnboardingInitThunk = createThunk<
 type ApplicationInitThunkState = SettingsSliceRootState &
     MessageSystemRootState &
     InitAnalyticsThunkState &
+    PruneHistoricFiatRatesThunkState &
     PostOnboardingInitThunkState;
 
 type ApplicationInitThunkDeps = InitAnalyticsThunkDeps & PostOnboardingInitThunkDeps;
@@ -128,6 +131,9 @@ export const applicationInitThunk = createThunk<
 
     // Select latest remembered device or Portfolio Tracker device.
     dispatch(initDevicesThunk());
+
+    // Rehydration is finished by the time this runs (PersistGate).
+    dispatch(pruneHistoricFiatRatesThunk());
 
     if (selectIsOnboardingFinished(getState())) {
         await dispatch(postOnboardingInitThunk());

--- a/suite-native/app/e2e/fixtures/historicFiatRatesState.ts
+++ b/suite-native/app/e2e/fixtures/historicFiatRatesState.ts
@@ -1,0 +1,105 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type RatesByTimestamps, type WalletAccountTransaction } from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+import { type PreloadedState } from '@suite-native/state';
+
+import {
+    PRELOADED_BTC_ACCOUNT_DESCRIPTOR,
+    PRELOADED_BTC_ACCOUNT_KEY,
+    PRELOADED_BTC_DEVICE_STATE,
+} from './portfolioTrackerBtcAccountState';
+
+/**
+ * The only transaction in the mainnet history of PRELOADED_BTC_ACCOUNT_DESCRIPTOR, so a backend
+ * refresh returns exactly this and leaves the preloaded list alone.
+ */
+export const SENTINEL_TX_ID = 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393';
+
+const SENTINEL_TX_BLOCK_TIME = 1644984426;
+const SENTINEL_TX_AMOUNT_SATS = '1063';
+
+/** Historic rates are keyed by the block time rounded down to the whole hour. */
+const SENTINEL_TX_HOUR = 1644984000;
+
+/**
+ * Deliberately absurd: BTC never traded at $10M, so a fiat amount derived from this rate cannot
+ * have come from the rates API. 1063 sats * $10M/BTC = $106.30, against ~$0.47 at the real
+ * February 2022 price.
+ */
+const SENTINEL_RATE = 10_000_000;
+
+export const SENTINEL_FIAT_AMOUNT = '106.30';
+
+// Branded key/timestamp types cannot be expressed by an object literal, hence the single cast.
+const sentinelHistoricRates = {
+    [getFiatRateKey(asNetworkSymbol('btc'), 'usd')]: { [SENTINEL_TX_HOUR]: SENTINEL_RATE },
+} as unknown as RatesByTimestamps;
+
+const sentinelTransaction = {
+    type: 'sent',
+    txid: SENTINEL_TX_ID,
+    blockTime: SENTINEL_TX_BLOCK_TIME,
+    blockHeight: 723535,
+    blockHash: '000000000000000000072040469b223ea7102586584ffe1c544a01bc8a027f35',
+    amount: SENTINEL_TX_AMOUNT_SATS,
+    fee: '129',
+    vsize: 110,
+    feeRate: '1.17',
+    symbol: 'btc',
+    descriptor: PRELOADED_BTC_ACCOUNT_DESCRIPTOR,
+    deviceState: PRELOADED_BTC_DEVICE_STATE,
+    targets: [
+        {
+            n: 0,
+            addresses: ['bc1qlzk7w0u23gpem4zy6jgfqn8lh06lclhkntm5xq'],
+            isAddress: true,
+            amount: SENTINEL_TX_AMOUNT_SATS,
+        },
+    ],
+    tokens: [],
+    internalTransfers: [],
+    details: {
+        vin: [
+            {
+                txid: 'b6afb70a2b91c80339cc4bbbbc8d09a38d44ee59d85d8073fb112733e8f904f6',
+                vout: 1,
+                sequence: 4294967295,
+                n: 0,
+                addresses: ['bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa'],
+                isAddress: true,
+                isOwn: true,
+                value: '1192',
+                isAccountOwned: true,
+            },
+        ],
+        vout: [
+            {
+                value: SENTINEL_TX_AMOUNT_SATS,
+                n: 0,
+                hex: '0014f8ade73f8a8a039dd444d490904cffbbf5fc7ef6',
+                addresses: ['bc1qlzk7w0u23gpem4zy6jgfqn8lh06lclhkntm5xq'],
+                isAddress: true,
+            },
+        ],
+        size: 192,
+        totalInput: '1192',
+        totalOutput: SENTINEL_TX_AMOUNT_SATS,
+    },
+} as unknown as WalletAccountTransaction; // to omit unnecessary fields
+
+/**
+ * State fragment that gives the preloaded BTC account one transaction and a historic rate for it,
+ * so the account detail screen renders a fiat amount that could only come from this rate.
+ */
+export const historicFiatRatesState: PreloadedState = {
+    wallet: {
+        transactions: {
+            transactions: {
+                [PRELOADED_BTC_ACCOUNT_KEY]: [sentinelTransaction],
+            },
+        },
+        fiat: {
+            historic: sentinelHistoricRates,
+        },
+    },
+};

--- a/suite-native/app/e2e/fixtures/portfolioTrackerBtcAccountState.ts
+++ b/suite-native/app/e2e/fixtures/portfolioTrackerBtcAccountState.ts
@@ -1,7 +1,12 @@
-import { Account } from '@suite-common/wallet-types';
+import { Account, type AccountKey } from '@suite-common/wallet-types';
 import { PreloadedState } from '@suite-native/state';
 
 export const PRELOADED_BTC_ACCOUNT_LABEL = 'BTC SegWit';
+export const PRELOADED_BTC_ACCOUNT_DESCRIPTOR =
+    'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT';
+export const PRELOADED_BTC_DEVICE_STATE = 'state@hiddenDeviceWithImportedAccounts:1';
+export const PRELOADED_BTC_ACCOUNT_KEY =
+    `${PRELOADED_BTC_ACCOUNT_DESCRIPTOR}-btc-${PRELOADED_BTC_DEVICE_STATE}` as AccountKey;
 
 /**
  * State fragment that inserts BTC account to a portfolio tracker wallet.
@@ -15,15 +20,14 @@ export const portfolioTrackerBtcAccountState: PreloadedState = {
                 addresses: [],
                 availableBalance: '0',
                 balance: '0',
-                descriptor:
-                    'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
-                deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
+                descriptor: PRELOADED_BTC_ACCOUNT_DESCRIPTOR,
+                deviceState: PRELOADED_BTC_DEVICE_STATE,
                 empty: false,
                 formattedBalance: '0',
                 history: [],
                 imported: true,
                 index: 0,
-                key: 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT-btc-state@hiddenDeviceWithImportedAccounts:1',
+                key: PRELOADED_BTC_ACCOUNT_KEY,
                 metadata: [],
                 networkType: 'bitcoin',
                 page: [],

--- a/suite-native/app/e2e/tests/historicFiatRatesPersistence.test.ts
+++ b/suite-native/app/e2e/tests/historicFiatRatesPersistence.test.ts
@@ -1,0 +1,61 @@
+import {
+    SENTINEL_FIAT_AMOUNT,
+    SENTINEL_TX_ID,
+    historicFiatRatesState,
+} from '../fixtures/historicFiatRatesState';
+import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
+import {
+    PRELOADED_BTC_ACCOUNT_LABEL,
+    portfolioTrackerBtcAccountState,
+} from '../fixtures/portfolioTrackerBtcAccountState';
+import { onHome } from '../pageObjects/homeActions';
+import { onMyAssets } from '../pageObjects/myAssetsActions';
+import { onTabBar } from '../pageObjects/tabBarActions';
+import { openApp, preparePreloadedReduxState } from '../support/setup';
+import { scrollUntilVisible, wait, waitToHaveRegex } from '../support/utils';
+
+const preloadedState = preparePreloadedReduxState(
+    onboardingCompletedState,
+    portfolioTrackerBtcAccountState,
+    historicFiatRatesState,
+);
+
+// The fiat slice is persisted with a 1s throttle, so a write can still be queued when the
+// assertion passes. Outwait it before killing the app.
+const PERSIST_SETTLE_MS = 3_000;
+
+const openTransactionList = async () => {
+    await onHome.assertIsPortfolioGraphVisible();
+    await onTabBar.navigateToMyAssets();
+    await onMyAssets.openAccountDetail({ accountName: PRELOADED_BTC_ACCOUNT_LABEL });
+};
+
+const expectSentinelFiatAmount = async () => {
+    // The list sits below the graph, which cannot be dragged, so the row starts off screen.
+    await scrollUntilVisible(element(by.id(`@transactions/item/${SENTINEL_TX_ID}`)), {
+        startPositionY: 0.8,
+    });
+
+    await waitToHaveRegex(
+        by.id(`@transactions/item/${SENTINEL_TX_ID}/fiatAmount`),
+        new RegExp(SENTINEL_FIAT_AMOUNT.replace('.', '\\.')),
+    );
+};
+
+describe('Historic fiat rates persistence [@noDevice]', () => {
+    it('restores historic rates from storage instead of refetching them after a restart', async () => {
+        await openApp({ args: { preloadedState } });
+        await openTransactionList();
+        await expectSentinelFiatAmount();
+
+        await wait(PERSIST_SETTLE_MS);
+        await device.terminateApp();
+
+        // Keep the storage but preload nothing: the account, its transaction and the rate can now
+        // only come from MMKV. The rate is deliberately one the API would never return, so seeing
+        // it again also proves updateMissingTxFiatRatesThunk did not refetch over it.
+        await openApp({ wipeData: false, args: {} });
+        await openTransactionList();
+        await expectSentinelFiatAmount();
+    });
+});

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -264,12 +264,25 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
         storage: deps.mmkvStorage,
     });
 
+    const fiatRatesPersistedReducer = preparePersistReducer({
+        reducer: fiatRatesReducer,
+        // Its own `fiat` key keeps the per-timestamp historic writes off the root blob;
+        // current/lastWeek refresh on their own timer and are not persisted.
+        persistedKeys: ['historic'],
+        key: 'fiat',
+        version: 1,
+        // The whole map is one storage value, so coalesce the per-account rate updates of a
+        // refresh burst into one serialization instead of one per updateTxsFiatRatesThunk.
+        throttle: 1000,
+        storage: deps.mmkvStorage,
+    });
+
     const walletReducers = combineReducers({
         accounts: accountsReducer,
         accountsRefreshTime: accountsRefreshTimeReducer,
         blockchain: blockchainPersistedReducer,
         explorer: explorerPersistedReducer,
-        fiat: fiatRatesReducer,
+        fiat: fiatRatesPersistedReducer,
         transactions: transactionsReducer,
         phishing: phishingPersistedReducer,
         discovery: discoveryReducer,

--- a/suite-native/storage/src/typedPersistReducer.test.ts
+++ b/suite-native/storage/src/typedPersistReducer.test.ts
@@ -1,0 +1,38 @@
+import { type Reducer } from '@reduxjs/toolkit';
+
+import { createMMKVStorageMock } from './mmkvStorage.mock';
+import { preparePersistReducer } from './typedPersistReducer';
+
+type FiatState = {
+    current: Record<string, unknown>;
+    lastWeek: Record<string, unknown>;
+    historic: Record<string, Record<number, number>>;
+};
+
+const stubFiatReducer: Reducer<FiatState> = (state = { current: {}, lastWeek: {}, historic: {} }) =>
+    state;
+
+describe('preparePersistReducer', () => {
+    it('restores whitelisted keys without clobbering the rest of the slice', () => {
+        const reducer = preparePersistReducer({
+            reducer: stubFiatReducer,
+            persistedKeys: ['historic'],
+            key: 'fiat',
+            version: 1,
+            storage: createMMKVStorageMock(),
+        });
+
+        const rehydrated = reducer(
+            { current: { 'btc-usd': 60000 }, lastWeek: {}, historic: {} },
+            {
+                type: 'persist/REHYDRATE',
+                key: 'fiat',
+                payload: { historic: { 'btc-usd': { 1700002800: 50000 } } },
+            },
+        );
+
+        expect(rehydrated.historic).toEqual({ 'btc-usd': { 1700002800: 50000 } });
+        expect(rehydrated.current).toEqual({ 'btc-usd': 60000 });
+        expect(rehydrated.lastWeek).toEqual({});
+    });
+});

--- a/suite-native/storage/src/typedPersistReducer.ts
+++ b/suite-native/storage/src/typedPersistReducer.ts
@@ -17,6 +17,7 @@ export const preparePersistReducer = <TReducer extends Reducer<any, any>>({
     migrations,
     transforms,
     mergeLevel = 1,
+    throttle,
     storage,
 }: {
     reducer: TReducer;
@@ -26,6 +27,8 @@ export const preparePersistReducer = <TReducer extends Reducer<any, any>>({
     migrations?: MigrationsManifest;
     transforms?: Array<Transform<any, any>>;
     mergeLevel?: 1 | 2;
+    /** Minimum delay between writes, in ms. Defaults to redux-persist's 0 (write per changed tick). */
+    throttle?: number;
     storage: MMKVStorage;
 }): TReducer => {
     const persistConfig = {
@@ -33,6 +36,7 @@ export const preparePersistReducer = <TReducer extends Reducer<any, any>>({
         storage,
         whitelist: persistedKeys as string[],
         version,
+        throttle,
         migrate: createAsyncMigrate<ReducerState<TReducer>>(migrations ?? {}),
         transforms,
         stateReconciler: (mergeLevel === 2 ? autoMergeLevel2 : autoMergeLevel1) as any,

--- a/suite-native/transactions/src/components/TransactionTarget.tsx
+++ b/suite-native/transactions/src/components/TransactionTarget.tsx
@@ -76,6 +76,7 @@ export const TransactionListItemValues = ({
                         useHistoricRate={!!historicRate}
                         isForcedDiscreetMode={isPhishingTransaction}
                         style={applyStyle(failedTxStyle, { isFailedTx })}
+                        testID={`@transactions/item/${transaction.txid}/fiatAmount`}
                     />
                 </Box>
             )}


### PR DESCRIPTION
## Description

Historic fiat rates are bound to a transaction's timestamp and never change, but the mobile app refetched all of them on every launch. They are now persisted under their own `fiat` MMKV key (only the `historic` sub-key; current/lastWeek keep refreshing on their timer), so `updateMissingTxFiatRatesThunk` only fetches what is genuinely missing.

Three supporting changes:

- **`selectHistoricRatesByTransactions` matched token rate keys as `[symbol-contract]`**, while `getFiatRateKey` writes `symbol-contract-currency`. That branch was dead code, so token rates were kept by a plain symbol prefix — every token rate of the network rather than the ones a transaction actually moves. Keys are now parsed once into a symbol index and matched exactly. Stellar classic assets (`CODE-ISSUER`) parse correctly too. Also drops the scan from O(txs × keys) to roughly O(keys + txs).
- **`pruneHistoricFiatRatesThunk`** drops rates no transaction refers to any more. Transactions of a device the user did not remember are stripped at write time; the rates derived from them were not, and nothing removed them.
- **`preparePersistReducer` gained an optional `throttle`.** The historic map is one storage value, so a refresh burst would otherwise re-serialize all of it once per account. Unchanged for every other slice.

## Notes for QA

Mobile only. Desktop is affected only by the tighter key matching in `saveAccountHistoricRatesThunk` — fewer rows written per account, same rows read.

- Restart the app with BTC/ETH accounts that have history. Transaction fiat amounts should render without refetching; the network tab should show no historic-rate requests for transactions already seen.
- Token transactions: confirm a token still shows its own historic value, not another token's from the same network.
- Forget a device or remove an account, then relaunch. Its orphaned rates are dropped on the *next* launch, not immediately.
- Known and deliberate: rates for a wallet you chose *not* to remember still reach disk and are only pruned on the next launch. Accounts and transactions are gated at write time; historic rates are not. Worth a decision if that is not acceptable.
- The new Detox test (`historicFiatRatesPersistence`) has not been run locally — no emulator available. It runs in the Android E2E job on this PR.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28274

## Screenshots:

Network-tab comparison across a cold restart to follow.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies fiat-rates state management/thunks/utilities and mobile historic-rate persistence. Because fiat rates are a broad dependency, the static map touches many tests, but only a few E2E specs actually assert fiat-denominated output. Run the high-priority tests that verify fiat currency display, dashboard balance conversion, staking fiat input, and the native historic-rates persistence flow. Add medium-priority tests for analytics currency events and yield fiat equivalents as regression guards. Avoid running the full broad list.

<details><summary><b>Changed files (13)</b></summary>

- `suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.test.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts`
- `suite-common/wallet-utils/src/fiatRatesUtils.test.ts`
- `suite-common/wallet-utils/src/fiatRatesUtils.ts`
- `suite-native/app-init/src/appInitThunks.ts`
- `suite-native/app/e2e/fixtures/historicFiatRatesState.ts`
- `suite-native/app/e2e/fixtures/portfolioTrackerBtcAccountState.ts`
- `suite-native/app/e2e/tests/historicFiatRatesPersistence.test.ts`
- `suite-native/state/src/reducers.ts`
- `suite-native/storage/src/typedPersistReducer.test.ts`
- `suite-native/storage/src/typedPersistReducer.ts`
- `suite-native/transactions/src/components/TransactionTarget.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — The test hides and reveals fiat-denominated dashboard values (portfolio, asset cards, wallet amounts). These values are computed from crypto balances via fiat rates, so a regression in fiatRatesReducer/Utils would be directly visible here.
- `suite/e2e/tests/settings/general.test.ts` — It changes the fiat currency from USD to EUR and verifies the dashboard updates from $0.00 to €0.00, directly exercising fiat-rate currency selection, fetching, and formatting.
- `suite/e2e/tests/trading/staking-form.test.ts` — It switches the ETH staking input to fiat mode and asserts the USD value equals the crypto amount multiplied by the mocked exchange rate, directly relying on fiat conversion utilities.
- `suite-native/app/e2e/tests/historicFiatRatesPersistence.test.ts` — This native E2E test is the one directly related to historic fiat rates persistence; it validates that historic fiat rates state survives app restarts and covers the new native fixtures and persist reducer changes. (Inferred, not present in the static candidate list.)

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — It changes the fiat currency to CZK and checks that the SuiteReady analytics event reflects the new localCurrency, validating the settings→fiat-rate state path.
- `suite/e2e/tests/analytics/toggle.test.ts` — It changes fiat currency and verifies the settingsGeneralChangeFiatEvent payload; a fiat-rate utility regression could break the emitted currency value or the persisted setting.
- `suite/e2e/tests/yield/withdrawal.test.ts` — The yield withdraw flow displays fiat equivalents in the transaction simulation modal (e.g. '-$5.00', '+$5.00', '≈ $0.00'), which depend on fiat rates for token-to-fiat conversion.

</details>

⚠️ **Changes with no test coverage (6)**
- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.test.ts`
- `suite-common/wallet-utils/src/fiatRatesUtils.test.ts`
- `suite-native/app-init/src/appInitThunks.ts`
- `suite-native/state/src/reducers.ts`
- `suite-native/storage/src/typedPersistReducer.test.ts`
- `suite-native/transactions/src/components/TransactionTarget.tsx`

_Updated: 2026-09-08T09:14:56.165Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/53gur0/historical-fiat-rates/web/](https://dev.suite.sldev.cz/suite-web/53gur0/historical-fiat-rates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=53gur0/historical-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=53gur0/historical-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=53gur0/historical-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T09:14:12.441Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T09:14:30.619Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->