### PR TITLE
Review fixes for #26056 (composePsbt / PSBT parser)

### DIFF
--- a/packages/connect-common/src/callableMethods.ts
+++ b/packages/connect-common/src/callableMethods.ts
@@ -75,6 +75,7 @@ const connectPublicCallableMethodGroups = {
     bitcoin: [
         'sendTransaction',
         'signTransaction',
+        'composePsbt',
         'composeTransaction',
         'authorizeCoinjoin',
         'cancelCoinjoinAuthorization',

--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -516,6 +516,34 @@ export const sendTransaction = async (api: TrezorConnect) => {
     }
 };
 
+export const composePsbt = async (api: TrezorConnect) => {
+    const precompose = await api.composePsbt({
+        account: {
+            path: 'm/49',
+            addresses: {
+                used: [],
+                unused: [],
+                change: [],
+            },
+            utxo: [],
+        },
+        coin: 'btc',
+        psbtData: '70736274ff01000a0000000000000000000000',
+    });
+
+    if (precompose.success) {
+        const { payload } = precompose;
+        const tx = payload;
+        if (tx.type === 'final') {
+            tx.inputs.map(a => a.prev_index.toFixed());
+            tx.outputs.map(a => a.amount.toString());
+        }
+    } else {
+        precompose.error.message.toLowerCase();
+        precompose.error.code.toLowerCase();
+    }
+};
+
 export const composeTransaction = async (api: TrezorConnect) => {
     const precompose = await api.composeTransaction({
         outputs: [],
@@ -530,8 +558,6 @@ export const composeTransaction = async (api: TrezorConnect) => {
         },
         feeLevels: [{ feePerUnit: '1' }],
         coin: 'btc',
-        // @ts-expect-error
-        push: true,
     });
 
     if (precompose.success) {
@@ -544,16 +570,15 @@ export const composeTransaction = async (api: TrezorConnect) => {
         if (tx.type === 'nonfinal') {
             tx.bytes.toFixed();
             tx.feePerByte.toLowerCase();
-            tx.inputs.map((a: any) => a);
+            tx.inputs.map(a => a.prev_index.toFixed());
         }
         if (tx.type === 'final') {
-            tx.inputs.map((a: any) => a);
-            tx.outputs.map((a: any) => a);
+            tx.inputs.map(a => a.prev_index.toFixed());
+            tx.outputs.map(a => a.amount.toString());
         }
     } else {
         precompose.error.message.toLowerCase();
-        // @ts-expect-error
-        precompose.payload.type.toLowerCase();
+        precompose.error.code.toLowerCase();
     }
 };
 

--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -557,6 +557,8 @@ export const composeTransaction = async (api: TrezorConnect) => {
         },
         feeLevels: [{ feePerUnit: '1' }],
         coin: 'btc',
+        // @ts-expect-error `push` is not a valid composeTransaction param
+        push: true,
     });
 
     if (precompose.success) {

--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -519,7 +519,6 @@ export const sendTransaction = async (api: TrezorConnect) => {
 export const composePsbt = async (api: TrezorConnect) => {
     const precompose = await api.composePsbt({
         account: {
-            path: 'm/49',
             addresses: {
                 used: [],
                 unused: [],

--- a/packages/connect-common/src/types/api/bitcoin/composePsbt.ts
+++ b/packages/connect-common/src/types/api/bitcoin/composePsbt.ts
@@ -1,0 +1,22 @@
+import type { AccountAddresses, Utxo as AccountUtxo } from '@trezor/blockchain-link';
+import type { ComposeInput as ComposeInputBase } from '@trezor/utxo-lib';
+
+import type { PrecomposeResultFinal } from './composeTransaction';
+import { type CoinSymbol } from '../../coinInfo';
+import type { Params, Response } from '../../params';
+
+export type ComposeUtxo = AccountUtxo & Partial<ComposeInputBase>;
+
+export type ComposePsbtParams = {
+    account: {
+        path: string;
+        addresses: AccountAddresses;
+        utxo: ComposeUtxo[];
+    };
+    coin: CoinSymbol;
+    psbtData: string;
+};
+
+export declare function composePsbt(
+    params: Params<ComposePsbtParams>,
+): Response<PrecomposeResultFinal>;

--- a/packages/connect-common/src/types/api/bitcoin/composePsbt.ts
+++ b/packages/connect-common/src/types/api/bitcoin/composePsbt.ts
@@ -9,7 +9,8 @@ export type ComposeUtxo = AccountUtxo & Partial<ComposeInputBase>;
 
 export type ComposePsbtParams = {
     account: {
-        path: string;
+        // composePsbt derives every path from the per-utxo / per-change-address entries,
+        // so no account-level `path` is needed (unlike composeTransaction).
         addresses: AccountAddresses;
         utxo: ComposeUtxo[];
     };

--- a/packages/connect-common/src/types/api/bitcoin/index.ts
+++ b/packages/connect-common/src/types/api/bitcoin/index.ts
@@ -3,6 +3,7 @@ import { Type } from '@trezor/schema-utils';
 
 import type { authorizeCoinjoin } from './authorizeCoinjoin';
 import type { cancelCoinjoinAuthorization } from './cancelCoinjoinAuthorization';
+import type { composePsbt } from './composePsbt';
 import type { composeTransaction } from './composeTransaction';
 import type { sendTransaction } from './sendTransaction';
 import type { signTransaction } from './signTransaction';
@@ -11,6 +12,7 @@ import type { signTransaction } from './signTransaction';
 export const TrezorConnectBitcoin = Type.Object({
     signTransaction: Type.Unsafe<typeof signTransaction>(),
     sendTransaction: Type.Unsafe<typeof sendTransaction>(),
+    composePsbt: Type.Unsafe<typeof composePsbt>(),
     composeTransaction: Type.Unsafe<typeof composeTransaction>(),
     authorizeCoinjoin: Type.Unsafe<typeof authorizeCoinjoin>(),
     cancelCoinjoinAuthorization: Type.Unsafe<typeof cancelCoinjoinAuthorization>(),

--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -22,6 +22,7 @@ export * from './api/tron/common';
 export * from './api/nostr/common';
 
 // types used in @trezor/suite. if you need a type, reexport it from ./api/<method>
+export type { ComposePsbtParams } from './api/bitcoin/composePsbt';
 export type {
     PrecomposeResultError,
     PrecomposeResultNonFinal,

--- a/packages/connect/e2e/__fixtures__/composePsbt.ts
+++ b/packages/connect/e2e/__fixtures__/composePsbt.ts
@@ -1,0 +1,111 @@
+const composePsbt: TestCase = {
+    method: 'composePsbt',
+    setup: {
+        mnemonic: 'mnemonic_all',
+    },
+    tests: [
+        {
+            description: 'Bitcoin (P2PKH)',
+            params: {
+                account: {
+                    path: "m/44'/0'/0'",
+                    utxo: [
+                        {
+                            txid: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
+                            vout: 1,
+                            amount: '50000',
+                            blockHeight: 343014,
+                            path: "m/44'/0'/0'/0/5",
+                            address: '1GA9u9TfCG7SWmKCveBumdA1TZpfom6ZdJ',
+                        },
+                    ],
+                    addresses: {
+                        used: [],
+                        unused: [],
+                        change: [
+                            {
+                                address: '1EcL6AyfQTyWKGvXwNSfsWoYnD3whzVFdu',
+                                path: "m/44'/0'/0'/1/3",
+                            },
+                        ],
+                    },
+                },
+                psbtData:
+                    '70736274ff01007701000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f6500100000000ffffffff0230750000000000001976a914954820f1de627a703596ac0396f986d958e3de4c88ac10270000000000001976a91405427736705cfbfaff76b1cff48283707fb1037088ac00000000000100e101000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f650010000006a47304402203429bd3ce7b38c5c1e8a15340edd79ced41a2939aae62e259d2e3d18e0c5ee7602201b83b10ebc4d6dcee3f9eb42ba8f1ef8a059a05397e0c1b9223d1565a3e6ec01012102a7a079c1ef9916b289c2ff21a992c808d0de3dfcf8a9f163205c5c9e21f55d5cffffffff0230750000000000001976a914954820f1de627a703596ac0396f986d958e3de4c88ac10270000000000001976a91405427736705cfbfaff76b1cff48283707fb1037088ac00000000000000',
+                coin: 'btc',
+            },
+            result: {
+                type: 'final',
+                bytes: 119,
+                fee: '10000',
+                feePerByte: '84.03361344537815',
+                totalSpent: '20000',
+                inputs: [{ script_type: 'SPENDADDRESS' }],
+                outputs: [
+                    {
+                        amount: '30000',
+                        script_type: 'PAYTOADDRESS',
+                        address_n: [2147483692, 2147483648, 2147483648, 1, 3],
+                    },
+                    {
+                        amount: '10000',
+                        script_type: 'PAYTOADDRESS',
+                        address: '1Up15Msx4sbvUCGm8Xgo2Zp5FQim3wE59',
+                    },
+                ],
+            },
+        },
+        {
+            description: 'Testnet (Bech32/P2WPKH)',
+            params: {
+                account: {
+                    path: "m/84'/1'/0'",
+                    utxo: [
+                        {
+                            txid: 'ae0949b1b050ac6f92c7d9c1570f2f06c21a997eef8be9ef5edc2a38cb92a879',
+                            vout: 1,
+                            amount: '7802513',
+                            blockHeight: 343014,
+                            path: "m/84'/1'/0'/1/4",
+                            address: 'tb1qguznsd2hyl69gjx2axd6f5qu9k274qj9waffqy',
+                        },
+                    ],
+                    addresses: {
+                        used: [],
+                        unused: [],
+                        change: [
+                            {
+                                address: 'tb1q8zx9dlztqz9apm7y5gtx8a0tlz57fhncx343ya',
+                                path: "m/84'/1'/0'/1/5",
+                            },
+                        ],
+                    },
+                },
+                psbtData:
+                    '70736274ff010061010000000179a892cb382adc5eefe98bef7e991ac2062f0f57c1d9c7926fac50b0b14909ae010000000000000000020000000000000000066a04deadbeeffb0d770000000000160014388c56fc4b008bd0efc4a21663f5ebf8a9e4de7800000000000100cf0100000000010179a892cb382adc5eefe98bef7e991ac2062f0f57c1d9c7926fac50b0b14909ae010000000000000000020000000000000000066a04deadbeeffb0d770000000000160014388c56fc4b008bd0efc4a21663f5ebf8a9e4de7802483045022100a87aa2338d0e7401d26b67b76a6446052ef148186893fe4bdceba467b00b5c2c022073159df4b4bb4514d23c8f9b0566098da47da383a829a941b54e95068beba491012102e7477af80286177f60fbf529b8bd3004dd2f0f407ce9f852b3e88fbe295c0f2700000000000000',
+                coin: 'test',
+            },
+            result: {
+                type: 'final',
+                bytes: 97,
+                fee: '150',
+                feePerByte: '1.5463917525773196',
+                totalSpent: '150',
+                inputs: [{ script_type: 'SPENDWITNESS' }],
+                outputs: [
+                    {
+                        amount: '0',
+                        script_type: 'PAYTOOPRETURN',
+                        op_return_data: 'deadbeef',
+                    },
+                    {
+                        amount: '7802363',
+                        script_type: 'PAYTOWITNESS',
+                    },
+                ],
+            },
+        },
+    ],
+};
+
+export default composePsbt;

--- a/packages/connect/e2e/__fixtures__/composePsbt.ts
+++ b/packages/connect/e2e/__fixtures__/composePsbt.ts
@@ -36,9 +36,9 @@ const composePsbt: TestCase = {
             },
             result: {
                 type: 'final',
-                bytes: 119,
+                bytes: 226,
                 fee: '10000',
-                feePerByte: '84.03361344537815',
+                feePerByte: '44.24778761061947',
                 totalSpent: '20000',
                 inputs: [{ script_type: 'SPENDADDRESS' }],
                 outputs: [
@@ -87,9 +87,9 @@ const composePsbt: TestCase = {
             },
             result: {
                 type: 'final',
-                bytes: 97,
+                bytes: 125,
                 fee: '150',
-                feePerByte: '1.5463917525773196',
+                feePerByte: '1.2',
                 totalSpent: '150',
                 inputs: [{ script_type: 'SPENDWITNESS' }],
                 outputs: [

--- a/packages/connect/e2e/__fixtures__/composePsbt.ts
+++ b/packages/connect/e2e/__fixtures__/composePsbt.ts
@@ -105,6 +105,24 @@ const composePsbt: TestCase = {
                 ],
             },
         },
+        {
+            description: 'Fails when a PSBT input is not among the account utxos',
+            params: {
+                account: {
+                    path: "m/44'/0'/0'",
+                    utxo: [],
+                    addresses: {
+                        used: [],
+                        unused: [],
+                        change: [],
+                    },
+                },
+                psbtData:
+                    '70736274ff01007701000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f6500100000000ffffffff0230750000000000001976a914954820f1de627a703596ac0396f986d958e3de4c88ac10270000000000001976a91405427736705cfbfaff76b1cff48283707fb1037088ac00000000000100e101000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f650010000006a47304402203429bd3ce7b38c5c1e8a15340edd79ced41a2939aae62e259d2e3d18e0c5ee7602201b83b10ebc4d6dcee3f9eb42ba8f1ef8a059a05397e0c1b9223d1565a3e6ec01012102a7a079c1ef9916b289c2ff21a992c808d0de3dfcf8a9f163205c5c9e21f55d5cffffffff0230750000000000001976a914954820f1de627a703596ac0396f986d958e3de4c88ac10270000000000001976a91405427736705cfbfaff76b1cff48283707fb1037088ac00000000000000',
+                coin: 'btc',
+            },
+            result: false,
+        },
     ],
 };
 

--- a/packages/connect/e2e/__fixtures__/index.ts
+++ b/packages/connect/e2e/__fixtures__/index.ts
@@ -7,6 +7,7 @@ export { default as cardanoGetPublicKey } from './cardanoGetPublicKey';
 export { default as cardanoSignTransaction } from './cardanoSignTransaction';
 export { default as cardanoSignMessage } from './cardanoSignMessage';
 export { default as changeLanguage } from './changeLanguage';
+export { default as composePsbt } from './composePsbt';
 export { default as composeTransaction } from './composeTransaction';
 export { default as ethereumGetAddress } from './ethereumGetAddress';
 export { default as ethereumGetPublicKey } from './ethereumGetPublicKey';

--- a/packages/connect/src/api/bitcoin/outputs.ts
+++ b/packages/connect/src/api/bitcoin/outputs.ts
@@ -8,7 +8,8 @@ import type {
     ProtoWithDerivationPath,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import type { ComposeOutput as ComposeOutputBase } from '@trezor/utxo-lib';
+import type { ComposeOutput as ComposeOutputBase, Network } from '@trezor/utxo-lib';
+import { address as BitcoinJsAddress, payments as BitcoinJsPayments } from '@trezor/utxo-lib';
 
 import { isValidAddress } from '../../utils/addressUtils';
 import { convertMultisigPubKey } from '../../utils/hdnodeUtils';
@@ -163,4 +164,21 @@ export const outputToTrezor = (
         amount: output.amount,
         script_type: 'PAYTOADDRESS',
     };
+};
+
+export const parseOutputScript = (output: Buffer, network?: Network) => {
+    try {
+        const address = BitcoinJsAddress.fromOutputScript(output, network);
+
+        return { type: 'address', address } as const;
+    } catch {
+        try {
+            const { data: embedScript } = BitcoinJsPayments.embed({ output }, { validate: true });
+            const data = embedScript?.shift()?.toString('hex'); // shift OP code
+
+            return { type: 'data', data } as const;
+        } catch {
+            return { type: 'unknown' } as const;
+        }
+    }
 };

--- a/packages/connect/src/api/bitcoin/outputs.ts
+++ b/packages/connect/src/api/bitcoin/outputs.ts
@@ -174,9 +174,15 @@ export const parseOutputScript = (output: Buffer, network?: Network) => {
     } catch {
         try {
             const { data: embedScript } = BitcoinJsPayments.embed({ output }, { validate: true });
-            const data = embedScript?.shift()?.toString('hex'); // shift OP code
+            // `embed.data` already excludes the OP_RETURN opcode. Trezor's PAYTOOPRETURN carries a
+            // single data blob, so anything other than exactly one push cannot be represented
+            // faithfully — treat it as unknown rather than silently dropping the extra pushes.
+            const [chunk, ...rest] = embedScript ?? [];
+            if (!chunk || rest.length > 0) {
+                return { type: 'unknown' } as const;
+            }
 
-            return { type: 'data', data } as const;
+            return { type: 'data', data: chunk.toString('hex') } as const;
         } catch {
             return { type: 'unknown' } as const;
         }

--- a/packages/connect/src/api/bitcoin/parsePsbt.test.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.test.ts
@@ -1,0 +1,145 @@
+import type { AccountAddresses, AccountUtxo } from '@trezor/connect-common';
+
+import { parsePsbt } from './parsePsbt';
+import { getBitcoinNetworkOrThrow } from '../../data/coinInfo';
+
+// Bitcoin P2PKH PSBT: 1 input (50000), 2 outputs (30000 change + 10000 external).
+const P2PKH_PSBT =
+    '70736274ff01007701000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f6500100000000ffffffff0230750000000000001976a914954820f1de627a703596ac0396f986d958e3de4c88ac10270000000000001976a91405427736705cfbfaff76b1cff48283707fb1037088ac00000000000100e101000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f650010000006a47304402203429bd3ce7b38c5c1e8a15340edd79ced41a2939aae62e259d2e3d18e0c5ee7602201b83b10ebc4d6dcee3f9eb42ba8f1ef8a059a05397e0c1b9223d1565a3e6ec01012102a7a079c1ef9916b289c2ff21a992c808d0de3dfcf8a9f163205c5c9e21f55d5cffffffff0230750000000000001976a914954820f1de627a703596ac0396f986d958e3de4c88ac10270000000000001976a91405427736705cfbfaff76b1cff48283707fb1037088ac00000000000000';
+
+// Testnet P2WPKH PSBT: 1 input (7802513), 2 outputs (OP_RETURN "deadbeef" + change).
+const TESTNET_PSBT =
+    '70736274ff010061010000000179a892cb382adc5eefe98bef7e991ac2062f0f57c1d9c7926fac50b0b14909ae010000000000000000020000000000000000066a04deadbeeffb0d770000000000160014388c56fc4b008bd0efc4a21663f5ebf8a9e4de7800000000000100cf0100000000010179a892cb382adc5eefe98bef7e991ac2062f0f57c1d9c7926fac50b0b14909ae010000000000000000020000000000000000066a04deadbeeffb0d770000000000160014388c56fc4b008bd0efc4a21663f5ebf8a9e4de7802483045022100a87aa2338d0e7401d26b67b76a6446052ef148186893fe4bdceba467b00b5c2c022073159df4b4bb4514d23c8f9b0566098da47da383a829a941b54e95068beba491012102e7477af80286177f60fbf529b8bd3004dd2f0f407ce9f852b3e88fbe295c0f2700000000000000';
+
+const utxo = (
+    part: Pick<AccountUtxo, 'txid' | 'vout' | 'amount' | 'path' | 'address'>,
+): AccountUtxo => ({
+    confirmations: 100,
+    blockHeight: 343014,
+    ...part,
+});
+
+const addresses = (change: { address: string; path: string }[]): AccountAddresses => ({
+    used: [],
+    unused: [],
+    change: change.map(c => ({
+        address: c.address,
+        path: c.path,
+        transfers: 0,
+        balance: '0',
+        sent: '0',
+        received: '0',
+    })),
+});
+
+describe('api/bitcoin/parsePsbt', () => {
+    it('maps a P2PKH PSBT with a change and an external output', () => {
+        const result = parsePsbt({
+            psbtTransactionData: P2PKH_PSBT,
+            coinInfo: getBitcoinNetworkOrThrow('btc'),
+            addresses: addresses([
+                { address: '1EcL6AyfQTyWKGvXwNSfsWoYnD3whzVFdu', path: "m/44'/0'/0'/1/3" },
+            ]),
+            utxos: [
+                utxo({
+                    txid: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
+                    vout: 1,
+                    amount: '50000',
+                    path: "m/44'/0'/0'/0/5",
+                    address: '1GA9u9TfCG7SWmKCveBumdA1TZpfom6ZdJ',
+                }),
+            ],
+        });
+
+        expect(result).toMatchObject({
+            type: 'final',
+            bytes: 226,
+            fee: '10000',
+            feePerByte: '44.24778761061947',
+            totalSpent: '20000',
+            outputsPermutation: [0, 1],
+            inputs: [{ script_type: 'SPENDADDRESS', prev_index: 1, amount: '50000' }],
+            outputs: [
+                {
+                    script_type: 'PAYTOADDRESS',
+                    amount: '30000',
+                    address_n: [2147483692, 2147483648, 2147483648, 1, 3],
+                },
+                {
+                    script_type: 'PAYTOADDRESS',
+                    amount: '10000',
+                    address: '1Up15Msx4sbvUCGm8Xgo2Zp5FQim3wE59',
+                },
+            ],
+        });
+    });
+
+    it('maps a P2WPKH PSBT with an OP_RETURN and a change output', () => {
+        const result = parsePsbt({
+            psbtTransactionData: TESTNET_PSBT,
+            coinInfo: getBitcoinNetworkOrThrow('test'),
+            addresses: addresses([
+                { address: 'tb1q8zx9dlztqz9apm7y5gtx8a0tlz57fhncx343ya', path: "m/84'/1'/0'/1/5" },
+            ]),
+            utxos: [
+                utxo({
+                    txid: 'ae0949b1b050ac6f92c7d9c1570f2f06c21a997eef8be9ef5edc2a38cb92a879',
+                    vout: 1,
+                    amount: '7802513',
+                    path: "m/84'/1'/0'/1/4",
+                    address: 'tb1qguznsd2hyl69gjx2axd6f5qu9k274qj9waffqy',
+                }),
+            ],
+        });
+
+        expect(result).toMatchObject({
+            type: 'final',
+            bytes: 125,
+            fee: '150',
+            feePerByte: '1.2',
+            totalSpent: '150',
+            outputsPermutation: [0, 1],
+            inputs: [{ script_type: 'SPENDWITNESS' }],
+            outputs: [
+                { script_type: 'PAYTOOPRETURN', amount: '0', op_return_data: 'deadbeef' },
+                {
+                    script_type: 'PAYTOWITNESS',
+                    amount: '7802363',
+                    address_n: [2147483732, 2147483649, 2147483648, 1, 5],
+                },
+            ],
+        });
+    });
+
+    it('throws when a PSBT input is not found among the account utxos', () => {
+        expect(() =>
+            parsePsbt({
+                psbtTransactionData: P2PKH_PSBT,
+                coinInfo: getBitcoinNetworkOrThrow('btc'),
+                addresses: addresses([]),
+                utxos: [],
+            }),
+        ).toThrow('parsePsbt: Utxo [0] not found');
+    });
+
+    it('throws when outputs exceed inputs (non-positive fee)', () => {
+        expect(() =>
+            parsePsbt({
+                psbtTransactionData: P2PKH_PSBT,
+                coinInfo: getBitcoinNetworkOrThrow('btc'),
+                addresses: addresses([
+                    { address: '1EcL6AyfQTyWKGvXwNSfsWoYnD3whzVFdu', path: "m/44'/0'/0'/1/3" },
+                ]),
+                utxos: [
+                    utxo({
+                        txid: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
+                        vout: 1,
+                        amount: '30000',
+                        path: "m/44'/0'/0'/0/5",
+                        address: '1GA9u9TfCG7SWmKCveBumdA1TZpfom6ZdJ',
+                    }),
+                ],
+            }),
+        ).toThrow('parsePsbt: Transaction fee is non-positive');
+    });
+});

--- a/packages/connect/src/api/bitcoin/parsePsbt.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.ts
@@ -1,0 +1,113 @@
+import type { AccountAddresses, AccountUtxo, PrecomposeResultFinal } from '@trezor/connect-common';
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { bufferUtils } from '@trezor/utils';
+import type { Network } from '@trezor/utxo-lib';
+import { Psbt } from '@trezor/utxo-lib';
+
+import { parseOutputScript } from './outputs';
+import { getHDPath, getOutputScriptType, getScriptType } from '../../utils/pathUtils';
+
+type ParsePsbtParams = {
+    psbtTransactionData: string;
+    network: Network;
+    addresses: AccountAddresses;
+    utxos: AccountUtxo[];
+};
+
+export const parsePsbt = ({
+    psbtTransactionData,
+    network,
+    addresses,
+    utxos,
+}: ParsePsbtParams): PrecomposeResultFinal => {
+    const psbt = Psbt.fromHex(psbtTransactionData, { network });
+
+    const inputs: PROTO.TxInputType[] = [];
+    const outputs: PROTO.TxOutputType[] = [];
+
+    let totalSpent = BigInt(0);
+    let sumOfInputs = BigInt(0);
+    let sumOfOutputs = BigInt(0);
+
+    for (const [index, input] of psbt.unsignedTx.ins.entries()) {
+        const txid = bufferUtils.reverseBuffer(input.hash).toString('hex');
+        const utxo = utxos.find(u => u.vout === input.index && u.txid === txid);
+        if (!utxo) {
+            // TODO: external utxo
+            throw TypedError('Method_InvalidParameter', `parsePsbt: Utxo [${index}] not found`);
+        }
+
+        const address_n = getHDPath(utxo.path);
+        inputs.push({
+            prev_hash: utxo.txid,
+            prev_index: input.index,
+            amount: utxo.amount,
+            address_n,
+            script_type: getScriptType(address_n),
+            sequence: input.sequence,
+        });
+
+        sumOfInputs += BigInt(utxo.amount);
+    }
+
+    const knownAddresses = addresses.used.concat(addresses.unused).concat(addresses.change);
+
+    for (const [index, output] of psbt.unsignedTx.outs.entries()) {
+        const outputScript = parseOutputScript(output.script, network);
+        if (outputScript.type === 'address') {
+            const changeAddress = knownAddresses.find(a => a.address === outputScript.address);
+            if (changeAddress) {
+                const address_n = getHDPath(changeAddress.path);
+                outputs.push({
+                    script_type: getOutputScriptType(address_n),
+                    address_n,
+                    amount: output.value,
+                });
+            } else {
+                outputs.push({
+                    script_type: 'PAYTOADDRESS',
+                    address: outputScript.address,
+                    amount: output.value,
+                });
+                totalSpent += BigInt(output.value);
+            }
+
+            sumOfOutputs += BigInt(output.value);
+        } else if (outputScript.type === 'data') {
+            if (typeof outputScript.data !== 'string') {
+                throw TypedError(
+                    'Method_InvalidParameter',
+                    `parsePsbt: Invalid op_return_data at [${index}]`,
+                );
+            }
+            outputs.push({
+                script_type: 'PAYTOOPRETURN',
+                amount: '0',
+                op_return_data: outputScript.data,
+            });
+            totalSpent += BigInt(output.value);
+            sumOfOutputs += BigInt(output.value);
+        } else {
+            throw TypedError(
+                'Method_InvalidParameter',
+                `parsePsbt: Unknown output type at [${index}]`,
+            );
+        }
+    }
+
+    const fee = sumOfInputs - sumOfOutputs;
+    const bytes = psbt.unsignedTx.virtualSize();
+    const feePerByte = Number(fee) / bytes;
+
+    return {
+        type: 'final',
+        totalSpent: (totalSpent + fee).toString(),
+        fee: fee.toString(),
+        feePerByte: feePerByte.toString(),
+        bytes,
+        inputs,
+        outputs,
+        outputsPermutation: [],
+    };
+};

--- a/packages/connect/src/api/bitcoin/parsePsbt.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.ts
@@ -1,26 +1,32 @@
-import type { AccountAddresses, AccountUtxo, PrecomposeResultFinal } from '@trezor/connect-common';
+import type {
+    AccountAddresses,
+    AccountUtxo,
+    BitcoinNetworkInfo,
+    PrecomposeResultFinal,
+} from '@trezor/connect-common';
 import { TypedError } from '@trezor/connect-common/src/constants/errors';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { bufferUtils } from '@trezor/utils';
-import type { Network } from '@trezor/utxo-lib';
 import { Psbt } from '@trezor/utxo-lib';
 
 import { parseOutputScript } from './outputs';
+import { getTransactionVbytes } from './transactionBytes';
 import { getHDPath, getOutputScriptType, getScriptType } from '../../utils/pathUtils';
 
 type ParsePsbtParams = {
     psbtTransactionData: string;
-    network: Network;
+    coinInfo: BitcoinNetworkInfo;
     addresses: AccountAddresses;
     utxos: AccountUtxo[];
 };
 
 export const parsePsbt = ({
     psbtTransactionData,
-    network,
+    coinInfo,
     addresses,
     utxos,
 }: ParsePsbtParams): PrecomposeResultFinal => {
+    const { network } = coinInfo;
     const psbt = Psbt.fromHex(psbtTransactionData, { network });
 
     const inputs: PROTO.TxInputType[] = [];
@@ -101,7 +107,10 @@ export const parsePsbt = ({
         // A non-positive fee (outputs >= inputs) is not a signable transaction.
         throw TypedError('Method_InvalidParameter', 'parsePsbt: Transaction fee is non-positive');
     }
-    const bytes = psbt.unsignedTx.virtualSize();
+    // Estimate the SIGNED virtual size. The unsigned tx has empty scriptSigs and no
+    // witnesses, so its size would understate the real tx and inflate the fee rate.
+    // Fall back to the unsigned size only if the weight calculator cannot process the inputs.
+    const bytes = getTransactionVbytes(inputs, outputs, coinInfo) || psbt.unsignedTx.virtualSize();
     const feePerByte = Number(fee) / bytes;
 
     return {

--- a/packages/connect/src/api/bitcoin/parsePsbt.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.ts
@@ -97,6 +97,10 @@ export const parsePsbt = ({
     }
 
     const fee = sumOfInputs - sumOfOutputs;
+    if (fee <= BigInt(0)) {
+        // A non-positive fee (outputs >= inputs) is not a signable transaction.
+        throw TypedError('Method_InvalidParameter', 'parsePsbt: Transaction fee is non-positive');
+    }
     const bytes = psbt.unsignedTx.virtualSize();
     const feePerByte = Number(fee) / bytes;
 

--- a/packages/connect/src/api/bitcoin/parsePsbt.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.ts
@@ -121,6 +121,7 @@ export const parsePsbt = ({
         bytes,
         inputs,
         outputs,
-        outputsPermutation: [],
+        // PSBT output order is fixed and preserved 1:1, so the permutation is the identity.
+        outputsPermutation: outputs.map((_, index) => index),
     };
 };

--- a/packages/connect/src/api/bitcoin/parsePsbt.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.ts
@@ -87,6 +87,14 @@ export const parsePsbt = ({
                     `parsePsbt: Invalid op_return_data at [${index}]`,
                 );
             }
+            if (BigInt(output.value) !== BigInt(0)) {
+                // Trezor forces OP_RETURN amount to 0; a non-zero value here would make the
+                // reported fee/totalSpent diverge from the transaction that gets signed.
+                throw TypedError(
+                    'Method_InvalidParameter',
+                    `parsePsbt: OP_RETURN output must have zero value at [${index}]`,
+                );
+            }
             outputs.push({
                 script_type: 'PAYTOOPRETURN',
                 amount: '0',

--- a/packages/connect/src/api/bitcoin/parsePsbt.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.ts
@@ -45,12 +45,26 @@ export const parsePsbt = ({
         }
 
         const address_n = getHDPath(utxo.path);
+        const script_type = getScriptType(address_n);
+        if (!script_type) {
+            throw TypedError(
+                'Method_InvalidParameter',
+                `parsePsbt: Unsupported input script type at [${index}]`,
+            );
+        }
+        if (script_type === 'SPENDMULTISIG') {
+            // Multisig inputs require a `multisig` (pubkeys) field that cannot be derived here.
+            throw TypedError(
+                'Method_InvalidParameter',
+                `parsePsbt: Multisig inputs are not supported at [${index}]`,
+            );
+        }
         inputs.push({
             prev_hash: utxo.txid,
             prev_index: input.index,
             amount: utxo.amount,
             address_n,
-            script_type: getScriptType(address_n),
+            script_type,
             sequence: input.sequence,
         });
 

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -13,14 +13,13 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 import { bufferUtils } from '@trezor/utils';
 import {
-    address as BitcoinJsAddress,
     type TxInput as BitcoinJsInput,
     type TxOutput as BitcoinJsOutput,
-    payments as BitcoinJsPayments,
     Transaction as BitcoinJsTransaction,
     type Network,
 } from '@trezor/utxo-lib';
 
+import { parseOutputScript } from './outputs';
 import { getHDPath, getOutputScriptType, getScriptType } from '../../utils/pathUtils';
 
 // Referenced transactions are not required if:
@@ -90,22 +89,6 @@ const enhanceTransaction = (refTx: RefTransaction, srcTx: BitcoinJsTransaction):
     return refTx;
 };
 
-const parseOutputScript = (output: Buffer, network?: Network) => {
-    try {
-        const address = BitcoinJsAddress.fromOutputScript(output, network);
-
-        return { type: 'address', address } as const;
-    } catch {
-        try {
-            const { data } = BitcoinJsPayments.embed({ output }, { validate: true });
-
-            return { type: 'data', data } as const;
-        } catch {
-            return { type: 'unknown' } as const;
-        }
-    }
-};
-
 // Transform orig transactions from Blockbook (blockchain-link) to Trezor format
 const transformOrigTransaction = (
     tx: BitcoinJsTransaction,
@@ -149,8 +132,7 @@ const transformOrigTransaction = (
         const parsed = parseOutputScript(output.script, coinInfo.network);
         switch (parsed.type) {
             case 'data': {
-                const op_return_data = parsed.data?.shift()?.toString('hex'); // shift OP code
-                if (typeof op_return_data !== 'string') {
+                if (typeof parsed.data !== 'string') {
                     throw TypedError(
                         'Method_InvalidParameter',
                         `transformOrigTransactions: invalid op_return_data at ${tx.getId()} [${i}]`,
@@ -160,7 +142,7 @@ const transformOrigTransaction = (
                 return {
                     script_type: 'PAYTOOPRETURN',
                     amount: '0',
-                    op_return_data,
+                    op_return_data: parsed.data,
                 };
             }
             case 'address': {

--- a/packages/connect/src/api/composePsbt.ts
+++ b/packages/connect/src/api/composePsbt.ts
@@ -1,0 +1,64 @@
+import {
+    type BitcoinNetworkInfo,
+    type ComposePsbtParams,
+    ERRORS,
+    type PermissionRequest,
+} from '@trezor/connect-common';
+
+import type { MethodMessage } from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
+import { getBitcoinNetwork } from '../data/coinInfo';
+import { parsePsbt } from './bitcoin/parsePsbt';
+import { validateParams } from './common/paramsValidator';
+
+type Params = Omit<ComposePsbtParams, 'coin'> & {
+    coinInfo: BitcoinNetworkInfo;
+};
+
+export default class ComposePsbt extends AbstractMethod<'composePsbt', Params> {
+    constructor(message: MethodMessage<'composePsbt'>) {
+        const { payload } = message;
+        // validate incoming parameters
+        validateParams(payload, [
+            { name: 'account', type: 'object', required: true },
+            { name: 'psbtData', type: 'string', required: true },
+            { name: 'coin', type: 'string', required: true },
+        ]);
+
+        const coinInfo = getBitcoinNetwork(payload.coin);
+        if (!coinInfo) {
+            throw ERRORS.TypedError('Method_UnknownCoin');
+        }
+
+        const params = {
+            account: payload.account,
+            psbtData: payload.psbtData,
+            coinInfo,
+        };
+
+        super(message, params);
+
+        this.useDevice = false;
+        this.useUi = false;
+        this.requiredFirmwareCoins = [coinInfo];
+    }
+
+    get requiredPermissions(): PermissionRequest[] {
+        return [];
+    }
+
+    get info() {
+        return `Compose PSBT transaction`;
+    }
+
+    run() {
+        const tx = parsePsbt({
+            psbtTransactionData: this.params.psbtData,
+            network: this.params.coinInfo.network,
+            addresses: this.params.account.addresses,
+            utxos: this.params.account.utxo,
+        });
+
+        return Promise.resolve(tx);
+    }
+}

--- a/packages/connect/src/api/composePsbt.ts
+++ b/packages/connect/src/api/composePsbt.ts
@@ -64,7 +64,7 @@ export default class ComposePsbt extends AbstractMethod<'composePsbt', Params> {
     run() {
         const tx = parsePsbt({
             psbtTransactionData: this.params.psbtData,
-            network: this.params.coinInfo.network,
+            coinInfo: this.params.coinInfo,
             addresses: this.params.account.addresses,
             utxos: this.params.account.utxo,
         });

--- a/packages/connect/src/api/composePsbt.ts
+++ b/packages/connect/src/api/composePsbt.ts
@@ -1,13 +1,12 @@
 import {
     type BitcoinNetworkInfo,
     type ComposePsbtParams,
-    ERRORS,
     type PermissionRequest,
 } from '@trezor/connect-common';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getBitcoinNetwork } from '../data/coinInfo';
+import { getBitcoinNetworkOrThrow } from '../data/coinInfo';
 import { parsePsbt } from './bitcoin/parsePsbt';
 import { validateParams } from './common/paramsValidator';
 
@@ -25,10 +24,7 @@ export default class ComposePsbt extends AbstractMethod<'composePsbt', Params> {
             { name: 'coin', type: 'string', required: true },
         ]);
 
-        const coinInfo = getBitcoinNetwork(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getBitcoinNetworkOrThrow(payload.coin);
 
         const params = {
             account: payload.account,

--- a/packages/connect/src/api/composePsbt.ts
+++ b/packages/connect/src/api/composePsbt.ts
@@ -23,6 +23,20 @@ export default class ComposePsbt extends AbstractMethod<'composePsbt', Params> {
             { name: 'psbtData', type: 'string', required: true },
             { name: 'coin', type: 'string', required: true },
         ]);
+        validateParams(payload.account, [
+            { name: 'addresses', type: 'object', required: true },
+            // an empty utxo set is a valid shape; parsePsbt then throws the precise
+            // "Utxo not found" for any input that is not owned by the account.
+            { name: 'utxo', type: 'array', required: true, allowEmpty: true },
+        ]);
+        // `type: 'object'` also accepts arrays, so validate the address sub-arrays that
+        // parsePsbt dereferences (`addresses.used`/`unused`/`change`) to reject a malformed
+        // `addresses` up front instead of leaking a raw TypeError to the caller.
+        validateParams(payload.account.addresses, [
+            { name: 'used', type: 'array', required: true, allowEmpty: true },
+            { name: 'unused', type: 'array', required: true, allowEmpty: true },
+            { name: 'change', type: 'array', required: true, allowEmpty: true },
+        ]);
 
         const coinInfo = getBitcoinNetworkOrThrow(payload.coin);
 

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -30,6 +30,7 @@ export { default as evoluSignRegistrationRequest } from './evoluSignRegistration
 export { default as evoluGetDelegatedIdentityKey } from './evoluGetDelegatedIdentityKey';
 export { default as nostrGetPublicKey } from './nostr/nostrGetPublicKey';
 export { default as nostrSignEvent } from './nostr/nostrSignEvent';
+export { default as composePsbt } from './composePsbt';
 export { default as composeTransaction } from './composeTransaction';
 export { default as discoverAccounts } from './discoverAccounts';
 export { default as getAccountInfo } from './getAccountInfo';

--- a/packages/utxo-lib/src/__fixtures__/psbt.ts
+++ b/packages/utxo-lib/src/__fixtures__/psbt.ts
@@ -1,0 +1,24 @@
+export const PSBT_FIXTURES = [
+    {
+        description: 'parses the BIP174 valid vector with 0 inputs and 2 outputs',
+        source: 'BIP174 test vector "PSBT with 0 inputs" from https://en.bitcoin.it/wiki/BIP_0174#Test_Vectors.',
+        hex: '70736274ff01004c020000000002d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300000000',
+        inputCount: 0,
+        outputCount: 2,
+    },
+    {
+        description: 'parses the bitcoinjs/bip174 addInputOutput round-trip vector',
+        source: 'bitcoinjs/bip174 ts_src/tests/addInputOutput.ts from https://github.com/bitcoinjs/bip174.',
+        hex: '70736274ff01009c0100000002d4a76ff95de1f4c0161a3e53ea876a91ed95331ae8d012d81f97138498ce5d860300000000ffffffffd4a76ff95de1f4c0161a3e53ea876a91ed95331ae8d012d81f97138498ce5dff0100000000ffffffff02d20296490000000017a914e18870f2c297fbfca54c5c6f645c7745a5b66eda87b168de3a0000000017a914e18870f2c297fbfca54c5c6f645c7745a5b66eda87000000000000000000',
+        inputCount: 2,
+        outputCount: 2,
+    },
+    {
+        description:
+            'parses a variant of the bitcoinjs/bip174 round-trip vector with the first output set to the suite fixture funded utxo address',
+        source: 'Derived from bitcoinjs/bip174 ts_src/tests/addInputOutput.ts by replacing the first output script with bc1qannfxke2tfd4l7vhepehpvt05y83v3qsf6nfkk and resizing outputs to 4000 and 8000 sats.',
+        hex: '70736274ff01009b0100000002d4a76ff95de1f4c0161a3e53ea876a91ed95331ae8d012d81f97138498ce5d860300000000ffffffffd4a76ff95de1f4c0161a3e53ea876a91ed95331ae8d012d81f97138498ce5dff0100000000ffffffff02a00f000000000000160014ece6935b2a5a5b5ff997c87370b16fa10f164410401f00000000000017a914e18870f2c297fbfca54c5c6f645c7745a5b66eda87000000000000000000',
+        inputCount: 2,
+        outputCount: 2,
+    },
+] as const;

--- a/packages/utxo-lib/src/index.ts
+++ b/packages/utxo-lib/src/index.ts
@@ -12,6 +12,7 @@ import * as script from './script';
 import { TxWeightCalculator } from './txWeightCalculator';
 
 export { Transaction } from './transaction';
+export { Psbt } from './psbt';
 
 export {
     address,

--- a/packages/utxo-lib/src/psbt.test.ts
+++ b/packages/utxo-lib/src/psbt.test.ts
@@ -1,0 +1,120 @@
+import { address, networks } from '../src';
+import { BufferWriter, varIntSize } from '../src/bufferutils';
+import { PSBT_MAGIC, Psbt } from '../src/psbt';
+import { PSBT_FIXTURES } from './__fixtures__/psbt';
+
+const UNSIGNED_TX_KEY = Buffer.from([0x00]);
+const MAP_SEPARATOR = Buffer.from([0x00]);
+
+const TX_HEX =
+    '0100000001f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe000000006b4830450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ffffffff01a0860100000000001976a914c42e7ef92fdb603af844d064faad95db9bcdfd3d88ac00000000';
+
+function toVarSlice(buffer: Buffer) {
+    const out = Buffer.allocUnsafe(varIntSize(buffer.length) + buffer.length);
+    const writer = new BufferWriter(out);
+    writer.writeVarSlice(buffer);
+
+    return out;
+}
+
+function getSimplePsbtBuffer(unsignedTxHex: string) {
+    const unsignedTx = Buffer.from(unsignedTxHex, 'hex');
+
+    const globalUnsignedTx = Buffer.concat([toVarSlice(UNSIGNED_TX_KEY), toVarSlice(unsignedTx)]);
+
+    return Buffer.concat([
+        PSBT_MAGIC,
+        globalUnsignedTx,
+        MAP_SEPARATOR,
+        MAP_SEPARATOR,
+        MAP_SEPARATOR,
+    ]);
+}
+
+describe('Psbt', () => {
+    it.each(PSBT_FIXTURES)('$description', ({ hex, inputCount, outputCount, source }) => {
+        const psbt = Psbt.fromHex(hex);
+
+        expect(psbt.inputs).toHaveLength(inputCount);
+        expect(psbt.outputs).toHaveLength(outputCount);
+        expect(psbt.unsignedTx.ins).toHaveLength(inputCount);
+        expect(psbt.unsignedTx.outs).toHaveLength(outputCount);
+        expect(psbt.toHex()).toEqual(hex);
+
+        expect(source).toBeTruthy();
+    });
+
+    it('parses a minimal synthetic PSBT and extracts unsigned transaction', () => {
+        const psbtHex = getSimplePsbtBuffer(TX_HEX).toString('hex');
+
+        const psbt = Psbt.fromHex(psbtHex);
+
+        expect(psbt.unsignedTx.toHex()).toEqual(TX_HEX);
+        expect(psbt.inputs).toHaveLength(1);
+        expect(psbt.outputs).toHaveLength(1);
+        expect(psbt.toHex()).toEqual(psbtHex);
+    });
+
+    it('serializes current unsigned transaction state after mutation', () => {
+        const psbtHex = getSimplePsbtBuffer(TX_HEX).toString('hex');
+        const psbt = Psbt.fromHex(psbtHex);
+
+        psbt.unsignedTx.locktime = 123;
+
+        const reparsed = Psbt.fromBuffer(psbt.toBuffer());
+
+        expect(reparsed.unsignedTx.locktime).toEqual(123);
+        expect(reparsed.inputs).toHaveLength(1);
+        expect(reparsed.outputs).toHaveLength(1);
+    });
+
+    it('serializes added unsigned transaction outputs with empty PSBT output maps', () => {
+        const psbtHex = getSimplePsbtBuffer(TX_HEX).toString('hex');
+        const psbt = Psbt.fromHex(psbtHex);
+
+        psbt.unsignedTx.outs.push({
+            value: '500',
+            script: address.toOutputScript('1JAd7XCBzGudGpJQSDSfpmJhiygtLQWaGL', networks.bitcoin),
+        });
+
+        const reparsed = Psbt.fromBuffer(psbt.toBuffer(), { network: networks.bitcoin });
+
+        expect(reparsed.unsignedTx.outs).toHaveLength(2);
+        expect(reparsed.outputs).toHaveLength(2);
+        expect(reparsed.outputs[1]).toEqual([]);
+        expect(reparsed.unsignedTx.outs[1]?.value).toEqual('500');
+    });
+
+    it('throws when there are more PSBT output maps than unsigned transaction outputs', () => {
+        const psbtHex = getSimplePsbtBuffer(TX_HEX).toString('hex');
+        const psbt = Psbt.fromHex(psbtHex);
+
+        psbt.outputs.push([]);
+
+        expect(() => psbt.toBuffer()).toThrow(
+            'PSBT has more output maps than unsigned transaction outputs.',
+        );
+    });
+
+    it('throws when global map is missing unsigned transaction', () => {
+        const missingUnsignedTx = Buffer.concat([PSBT_MAGIC, MAP_SEPARATOR]);
+
+        expect(() => Psbt.fromBuffer(missingUnsignedTx)).toThrow(
+            'PSBT must contain exactly one unsigned transaction.',
+        );
+    });
+
+    it('throws on trailing data in strict mode', () => {
+        const psbtBuffer = Buffer.concat([getSimplePsbtBuffer(TX_HEX), Buffer.from([0xaa])]);
+
+        expect(() => Psbt.fromBuffer(psbtBuffer)).toThrow('PSBT has unexpected data.');
+    });
+
+    it('allows trailing data with nostrict', () => {
+        const psbtBuffer = Buffer.concat([getSimplePsbtBuffer(TX_HEX), Buffer.from([0xaa])]);
+
+        const psbt = Psbt.fromBuffer(psbtBuffer, { nostrict: true });
+
+        expect(psbt.unsignedTx.toHex()).toEqual(TX_HEX);
+    });
+});

--- a/packages/utxo-lib/src/psbt.test.ts
+++ b/packages/utxo-lib/src/psbt.test.ts
@@ -6,8 +6,9 @@ import { PSBT_FIXTURES } from './__fixtures__/psbt';
 const UNSIGNED_TX_KEY = Buffer.from([0x00]);
 const MAP_SEPARATOR = Buffer.from([0x00]);
 
+// Unsigned transaction (empty scriptSig) as required by BIP-174 for the PSBT global tx.
 const TX_HEX =
-    '0100000001f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe000000006b4830450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ffffffff01a0860100000000001976a914c42e7ef92fdb603af844d064faad95db9bcdfd3d88ac00000000';
+    '0100000001f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0000000000ffffffff01a0860100000000001976a914c42e7ef92fdb603af844d064faad95db9bcdfd3d88ac00000000';
 
 function toVarSlice(buffer: Buffer) {
     const out = Buffer.allocUnsafe(varIntSize(buffer.length) + buffer.length);

--- a/packages/utxo-lib/src/psbt.test.ts
+++ b/packages/utxo-lib/src/psbt.test.ts
@@ -33,7 +33,7 @@ function getSimplePsbtBuffer(unsignedTxHex: string) {
 }
 
 describe('Psbt', () => {
-    it.each(PSBT_FIXTURES)('$description', ({ hex, inputCount, outputCount, source }) => {
+    it.each(PSBT_FIXTURES)('$description', ({ hex, inputCount, outputCount }) => {
         const psbt = Psbt.fromHex(hex);
 
         expect(psbt.inputs).toHaveLength(inputCount);
@@ -41,8 +41,6 @@ describe('Psbt', () => {
         expect(psbt.unsignedTx.ins).toHaveLength(inputCount);
         expect(psbt.unsignedTx.outs).toHaveLength(outputCount);
         expect(psbt.toHex()).toEqual(hex);
-
-        expect(source).toBeTruthy();
     });
 
     it('parses a minimal synthetic PSBT and extracts unsigned transaction', () => {

--- a/packages/utxo-lib/src/psbt.test.ts
+++ b/packages/utxo-lib/src/psbt.test.ts
@@ -118,4 +118,34 @@ describe('Psbt', () => {
 
         expect(psbt.unsignedTx.toHex()).toEqual(TX_HEX);
     });
+
+    it('throws on invalid magic bytes', () => {
+        expect(() => Psbt.fromBuffer(Buffer.from('0000000000', 'hex'))).toThrow(
+            'Invalid PSBT magic bytes.',
+        );
+    });
+
+    it('throws on a duplicate key within a map', () => {
+        // global map with two identical key/value entries (key 0x0102, value 0x03)
+        const duplicateKeyMap = Buffer.concat([PSBT_MAGIC, Buffer.from('02010201030201020103', 'hex')]);
+
+        expect(() => Psbt.fromBuffer(duplicateKeyMap)).toThrow('PSBT map has duplicate key.');
+    });
+
+    it('throws when there are more PSBT input maps than unsigned transaction inputs', () => {
+        const psbt = Psbt.fromHex(getSimplePsbtBuffer(TX_HEX).toString('hex'));
+
+        psbt.inputs.push([]);
+
+        expect(() => psbt.toBuffer()).toThrow(
+            'PSBT has more input maps than unsigned transaction inputs.',
+        );
+    });
+
+    it('rejects an oversized key length without allocating', () => {
+        // key length varint claims 0xffffffff bytes but none follow → bounded read must throw
+        const oversized = Buffer.concat([PSBT_MAGIC, Buffer.from('feffffffff', 'hex')]);
+
+        expect(() => Psbt.fromBuffer(oversized)).toThrow();
+    });
 });

--- a/packages/utxo-lib/src/psbt.ts
+++ b/packages/utxo-lib/src/psbt.ts
@@ -1,0 +1,198 @@
+// Minimal BIP-174 (PSBTv0) parser/serializer.
+//
+// Handles the raw key-value map structure and the unsigned transaction.
+// Field-level interpretation is left to consumers.
+//
+// Spec: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+//
+
+import { BufferReader, BufferWriter, varIntSize } from './bufferutils';
+import { Transaction, type TransactionOptions } from './transaction';
+
+// 5-byte header: ASCII "psbt" followed by 0xff separator.
+export const PSBT_MAGIC = Buffer.from('70736274ff', 'hex');
+
+// BIP-174 global key type for the unsigned transaction (key 0x00, no key data).
+export const UNSIGNED_TX_KEY = 0x00;
+
+export type PsbtKeyValue = {
+    key: Buffer;
+    value: Buffer;
+};
+
+export type PsbtOptions = TransactionOptions;
+
+// Read key-value pairs from a single map section until the 0x00 separator.
+// Each pair is encoded as: <varint key_len> <key> <varint value_len> <value>.
+// Duplicate keys within a map are rejected per BIP-174.
+function readMap(bufferReader: BufferReader): PsbtKeyValue[] {
+    const map: PsbtKeyValue[] = [];
+    const keySet = new Set<string>();
+
+    while (true) {
+        const key = bufferReader.readVarSlice();
+        if (key.length === 0) {
+            return map;
+        }
+
+        const keyHex = key.toString('hex');
+        if (keySet.has(keyHex)) {
+            throw new Error('PSBT map has duplicate key.');
+        }
+        keySet.add(keyHex);
+
+        map.push({
+            key,
+            value: bufferReader.readVarSlice(),
+        });
+    }
+}
+
+function getUnsignedTx(map: PsbtKeyValue[], options: PsbtOptions) {
+    const unsignedTxEntries = map.filter(
+        kv => kv.key.length === 1 && kv.key[0] === UNSIGNED_TX_KEY,
+    );
+
+    if (unsignedTxEntries.length !== 1 || !unsignedTxEntries[0]) {
+        throw new Error('PSBT must contain exactly one unsigned transaction.');
+    }
+
+    return Transaction.fromBuffer(unsignedTxEntries[0].value, {
+        network: options.network,
+        nostrict: false,
+    });
+}
+
+function getMapByteLength(map: PsbtKeyValue[]) {
+    return map.reduce(
+        (size, { key, value }) =>
+            size + varIntSize(key.length) + key.length + varIntSize(value.length) + value.length,
+        1,
+    );
+}
+
+// Serialize key-value pairs and terminate the map with a 0x00 byte.
+function writeMap(bufferWriter: BufferWriter, map: PsbtKeyValue[]) {
+    map.forEach(({ key, value }) => {
+        bufferWriter.writeVarSlice(key);
+        bufferWriter.writeVarSlice(value);
+    });
+
+    bufferWriter.writeUInt8(0);
+}
+
+export class Psbt {
+    readonly unsignedTx: Transaction;
+    readonly globalMap: PsbtKeyValue[];
+    readonly inputs: PsbtKeyValue[][];
+    readonly outputs: PsbtKeyValue[][];
+
+    private constructor({
+        unsignedTx,
+        globalMap,
+        inputs,
+        outputs,
+    }: {
+        unsignedTx: Transaction;
+        globalMap: PsbtKeyValue[];
+        inputs: PsbtKeyValue[][];
+        outputs: PsbtKeyValue[][];
+    }) {
+        this.unsignedTx = unsignedTx;
+        this.globalMap = globalMap;
+        this.inputs = inputs;
+        this.outputs = outputs;
+    }
+
+    static fromBuffer(buffer: Buffer, options: PsbtOptions = {}) {
+        const bufferReader = new BufferReader(buffer);
+        if (!bufferReader.readSlice(PSBT_MAGIC.length).equals(PSBT_MAGIC)) {
+            throw new Error('Invalid PSBT magic bytes.');
+        }
+
+        const globalMap = readMap(bufferReader);
+        const unsignedTx = getUnsignedTx(globalMap, options);
+
+        const inputs: PsbtKeyValue[][] = [];
+        for (let i = 0; i < unsignedTx.ins.length; i++) {
+            inputs.push(readMap(bufferReader));
+        }
+
+        const outputs: PsbtKeyValue[][] = [];
+        for (let i = 0; i < unsignedTx.outs.length; i++) {
+            outputs.push(readMap(bufferReader));
+        }
+
+        if (!options.nostrict && bufferReader.offset !== buffer.length) {
+            throw new Error('PSBT has unexpected data.');
+        }
+
+        return new Psbt({
+            unsignedTx,
+            globalMap,
+            inputs,
+            outputs,
+        });
+    }
+
+    static fromHex(hex: string, options: PsbtOptions = {}) {
+        return this.fromBuffer(Buffer.from(hex, 'hex'), { ...options, nostrict: false });
+    }
+
+    toBuffer() {
+        const unsignedTxBuffer = this.unsignedTx.toBuffer();
+        const globalMap = this.globalMap.map(keyValue => {
+            if (keyValue.key.length === 1 && keyValue.key[0] === UNSIGNED_TX_KEY) {
+                return {
+                    ...keyValue,
+                    value: unsignedTxBuffer,
+                };
+            }
+
+            return keyValue;
+        });
+
+        const globalUnsignedTxEntries = globalMap.filter(
+            ({ key }) => key.length === 1 && key[0] === UNSIGNED_TX_KEY,
+        );
+
+        if (globalUnsignedTxEntries.length !== 1) {
+            throw new Error('PSBT must contain exactly one unsigned transaction.');
+        }
+
+        if (this.inputs.length > this.unsignedTx.ins.length) {
+            throw new Error('PSBT has more input maps than unsigned transaction inputs.');
+        }
+
+        if (this.outputs.length > this.unsignedTx.outs.length) {
+            throw new Error('PSBT has more output maps than unsigned transaction outputs.');
+        }
+
+        const inputMaps = Array.from({ length: this.unsignedTx.ins.length }, (_, index) =>
+            this.inputs[index] ? this.inputs[index].map(keyValue => ({ ...keyValue })) : [],
+        );
+        const outputMaps = Array.from({ length: this.unsignedTx.outs.length }, (_, index) =>
+            this.outputs[index] ? this.outputs[index].map(keyValue => ({ ...keyValue })) : [],
+        );
+
+        const byteLength =
+            PSBT_MAGIC.length +
+            getMapByteLength(globalMap) +
+            inputMaps.reduce((size, map) => size + getMapByteLength(map), 0) +
+            outputMaps.reduce((size, map) => size + getMapByteLength(map), 0);
+
+        const buffer = Buffer.allocUnsafe(byteLength);
+        const bufferWriter = new BufferWriter(buffer);
+
+        bufferWriter.writeSlice(PSBT_MAGIC);
+        writeMap(bufferWriter, globalMap);
+        inputMaps.forEach(map => writeMap(bufferWriter, map));
+        outputMaps.forEach(map => writeMap(bufferWriter, map));
+
+        return buffer;
+    }
+
+    toHex() {
+        return this.toBuffer().toString('hex');
+    }
+}

--- a/packages/utxo-lib/src/psbt.ts
+++ b/packages/utxo-lib/src/psbt.ts
@@ -57,10 +57,19 @@ function getUnsignedTx(map: PsbtKeyValue[], options: PsbtOptions) {
         throw new Error('PSBT must contain exactly one unsigned transaction.');
     }
 
-    return Transaction.fromBuffer(unsignedTxEntries[0].value, {
+    const unsignedTx = Transaction.fromBuffer(unsignedTxEntries[0].value, {
         network: options.network,
         nostrict: false,
     });
+
+    // BIP-174: the global unsigned transaction must have empty scriptSigs and carry
+    // no witness data. Reject anything else so a (partially) signed transaction cannot
+    // masquerade as an unsigned one.
+    if (unsignedTx.ins.some(input => input.script.length > 0) || unsignedTx.hasWitnesses()) {
+        throw new Error('PSBT unsigned transaction must not contain signatures.');
+    }
+
+    return unsignedTx;
 }
 
 function getMapByteLength(map: PsbtKeyValue[]) {

--- a/packages/utxo-lib/src/psbt.ts
+++ b/packages/utxo-lib/src/psbt.ts
@@ -136,7 +136,9 @@ export class Psbt {
     }
 
     static fromHex(hex: string, options: PsbtOptions = {}) {
-        return this.fromBuffer(Buffer.from(hex, 'hex'), { ...options, nostrict: false });
+        // `fromBuffer` already defaults to strict parsing when `nostrict` is unset,
+        // so forward the caller's options instead of hard-overriding `nostrict`.
+        return this.fromBuffer(Buffer.from(hex, 'hex'), options);
     }
 
     toBuffer() {

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -38,7 +38,7 @@ const groups = {
         name: 'btc-others',
         pattern: 'methods',
         includeFilter:
-            'getAccountInfo,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof',
+            'getAccountInfo,getAddress,getPublicKey,signMessage,verifyMessage,composePsbt,composeTransaction,getOwnershipId,getOwnershipProof',
     },
     stellar: {
         name: 'stellar',


### PR DESCRIPTION
## Overview

Review follow-ups for **#26056** (`composePsbt` + minimal BIP-174 PSBT parser). This branch is **stacked on `feat/connect-psbt`**, so the diff shows only the fixes. Each finding is its **own commit** so they can be reviewed / cherry-picked / dropped independently.

Findings come from a multi-dimensional adversarial review of #26056 (PSBT-parser correctness, `parsePsbt` mapping, method/API surface, integration, refactor safety, confidential-data & DoS, tests). For the record, the review found **no confidential-data leak and no DoS** in #26056 — these are robustness, accuracy and coverage improvements.

> ⚠️ Base is `feat/connect-psbt`, **not** `develop`. Rebase/merge #26056 first, or retarget as you prefer.

**Local validation:** `type-check` clean for `@trezor/connect`, `@trezor/connect-common`, `@trezor/utxo-lib`; unit tests `utxo-lib/psbt.test.ts` 14/14 and `connect/parsePsbt.test.ts` 4/4; eslint clean on all changed files. The new signed-size fixture values were produced by actually running `parsePsbt` on the fixtures.

---

## Split-out PRs

Some of these commits are also offered as **standalone single-commit PRs into `feat/connect-psbt`**, so the base-branch author can take them individually (independent of the rest of this stack). If any is merged into `feat/connect-psbt`, it drops out of this stack automatically on the next rebase.

| PR | commit |
|----|--------|
| [#32182](https://github.com/trezor/trezor-suite/pull/32182) | `refactor(connect-common): drop unused account.path from composePsbt params` |
| [#32183](https://github.com/trezor/trezor-suite/pull/32183) | `refactor(connect): use getBitcoinNetworkOrThrow in composePsbt` |
| [#32184](https://github.com/trezor/trezor-suite/pull/32184) | `fix(connect): reject non-positive fee in parsePsbt` |

---

## `@trezor/utxo-lib` — PSBT parser

### `fix(utxo-lib): honor caller nostrict option in Psbt.fromHex` &nbsp;·&nbsp; [`53e40bc`](https://github.com/trezor/trezor-suite/pull/32177/commits/53e40bc8a7a088fc49c650dd4e563d8a3dcbd2b7)
- **Change:** `fromHex` forwards the caller's `options` to `fromBuffer` instead of spreading them and then hard-setting `nostrict: false`.
- **Why (problem):** spreading `options` signals intent to honor them, but the trailing `nostrict: false` always wins, so a caller's `Psbt.fromHex(hex, { nostrict: true })` was a dead no-op and threw `PSBT has unexpected data.` This diverges from `fromBuffer`, which honors `nostrict` (its own unit test relies on it). `Psbt` is a public export of `@trezor/utxo-lib`, so this was a real external-API footgun.
- **Why better:** `fromBuffer` already defaults to strict parsing when `nostrict` is unset (the trailing-data check runs unless `nostrict`), so forwarding preserves strict-by-default for existing callers **and** makes the documented opt-in actually work — one source of truth for strictness, no silent override.

### `fix(utxo-lib): reject PSBT unsigned tx that carries signatures` &nbsp;·&nbsp; [`1d7074c`](https://github.com/trezor/trezor-suite/pull/32177/commits/1d7074cca376a3b4b600e21b3a76a4df6344f159)
- **Change:** after parsing the global unsigned transaction, assert every input has an empty scriptSig and there are no witnesses; throw otherwise. The synthetic test vector is updated to a proper unsigned tx (empty scriptSig).
- **Why (problem):** BIP-174 requires the global unsigned tx to have empty scriptSigs and no witness data; `getUnsignedTx` never enforced it (the parser even accepted a fully-signed scriptSig in its own test). A (partially) signed transaction could masquerade as unsigned, and the interop contract was looser than the spec / bitcoinjs-lib.
- **Why better:** a cheap invariant check at the single choke point (`getUnsignedTx`) that matches the spec and bitcoinjs-lib and fails fast with a clear message. This is conformance / defense-in-depth (downstream `parsePsbt` ignores the scriptSig and Trezor signs itself, so it is not a signature-safety fix) — kept as its own commit so it can be dropped if you prefer to stay lenient.

### `test(utxo-lib): cover PSBT parser guard paths` &nbsp;·&nbsp; [`6e8932e`](https://github.com/trezor/trezor-suite/pull/32177/commits/6e8932eac488875468cb33eaad27e1a32fd3015f)
- **Change:** add negative cases for invalid magic bytes, a duplicate key within a map, more input maps than unsigned-tx inputs, and an oversized key-length varint.
- **Why (problem):** those guards (and the bounded-read behavior) had zero coverage; only the output-map-count guard was tested.
- **Why better:** locks in both the structural guards and the security-relevant property that an attacker-supplied huge length field triggers a bounded read that throws rather than allocating — so a future change that drops a guard or makes `readSlice` allocate fails a test.

### `test(utxo-lib): drop tautological source assertion` &nbsp;·&nbsp; [`f73cce9`](https://github.com/trezor/trezor-suite/pull/32177/commits/f73cce9efbfa7d9878613599debda915d073ad2a)
- **Change:** remove `expect(source).toBeTruthy()` and the now-unused `source` destructure.
- **Why (problem):** `source` is a constant non-empty string literal in every fixture, so the assertion can never fail — dead weight that reads as coverage.
- **Why better:** removes a false coverage signal; `source` stays as fixture documentation metadata.

---

## `@trezor/connect` — `parsePsbt` / `composePsbt`

### `fix(connect): reject non-positive fee in parsePsbt` &nbsp;·&nbsp; [`f06060e`](https://github.com/trezor/trezor-suite/pull/32177/commits/f06060e6b0d6c5ae84417c348b4945ecfcc0dd56) &nbsp;·&nbsp; **split out → [#32184](https://github.com/trezor/trezor-suite/pull/32184)**
- **Change:** throw `Method_InvalidParameter` when `fee = sumOfInputs - sumOfOutputs <= 0`, before building the result.
- **Why (problem):** with attacker/dApp-controlled input, outputs can meet or exceed the owned inputs, making `fee` a zero/negative `BigInt`. `parsePsbt` still returned `type: 'final'` with a negative fee/feePerByte and a skewed `totalSpent`. `signTransaction.payloadToPrecomposed` guards this (`if (fee.lte(0)) throw`), but that lives in a different path; `composePsbt` handed the malformed "final" straight to the caller.
- **Why better:** mirrors the existing `signTransaction` guard so both compose paths behave consistently, and fails at the `composePsbt` boundary with a clear error instead of returning a nonsensical signable-looking result.

### `fix(connect): estimate signed vsize for parsePsbt bytes/feePerByte` &nbsp;·&nbsp; [`a994615`](https://github.com/trezor/trezor-suite/pull/32177/commits/a994615e43e7054cdf3a567c94387ce067ab30c4)
- **Change:** compute `bytes` with `getTransactionVbytes(inputs, outputs, coinInfo)` (falling back to `unsignedTx.virtualSize()` only if the weight calculator can't process the inputs). `parsePsbt` now takes `coinInfo` (the estimator needs it; `network` is derived from it). e2e expected values updated to the signed estimates (P2PKH `bytes 119→226`, `feePerByte 84.03→44.25`; testnet `97→125`, `1.546→1.2`).
- **Why (problem):** `psbt.unsignedTx.virtualSize()` measures the unsigned skeleton (empty scriptSigs, no witnesses), so `bytes` was far below the real signed vsize and `feePerByte` was inflated (~2× for legacy inputs). This is inconsistent with every other final-result producer — the reference compose (`compose/result.ts`) and `signTransaction.payloadToPrecomposed` both estimate the **signed** size — and the fixtures baked in the wrong numbers.
- **Why better:** reuses the single existing signed-size estimator instead of introducing a second, wrong size source, so the reported rate matches `signTransaction` and what the user actually pays. `feePerByte` is informational (not sent to the device), so accuracy matters for any dApp/UI display or fee-bump. The fallback keeps `composePsbt` from hard-failing on exotic inputs.

### `fix(connect): return identity outputsPermutation from parsePsbt` &nbsp;·&nbsp; [`6d99328`](https://github.com/trezor/trezor-suite/pull/32177/commits/6d993280eb84d8c654584e0fcfa65ea2ea96a599)
- **Change:** return `outputs.map((_, i) => i)` instead of `[]`.
- **Why (problem):** `PrecomposeResultFinal.outputsPermutation` maps composed-output index → original output index. PSBT output order is fixed and preserved 1:1, so the correct value is the identity permutation; `[]` is a contract violation. A generic consumer that maps through it (`sendFormThunks` `outputsPermutation.findIndex(...)`) gets `-1` for every output.
- **Why better:** satisfies the documented contract and matches every sibling producer (`signTransaction`, utxo-lib `noneSortingStrategy`). The direct-`signTransaction` path recomputes its own permutation and thus masked the bug; the identity value makes the result correct for any generic `PrecomposeResultFinal` consumer too.

### `fix(connect): reject non-zero-value OP_RETURN output in parsePsbt` &nbsp;·&nbsp; [`de45b74`](https://github.com/trezor/trezor-suite/pull/32177/commits/de45b7414635e87b89aa2f062686981dbf0c2c66)
- **Change:** throw `Method_InvalidParameter` if an OP_RETURN output carries a non-zero value.
- **Why (problem):** the OP_RETURN protobuf output hard-codes `amount: '0'`, but the fee sums used the raw `output.value`. For a standard OP_RETURN (value 0) they agree; for a non-standard PSBT with a non-zero-value OP_RETURN, the reported fee/`totalSpent` would diverge from the transaction Trezor actually signs (it forces the amount to 0), so the on-chain fee would silently be higher than reported.
- **Why better:** preserves the invariant "reported fee == signed-tx fee". Rejecting is safer than silently reconciling, because a non-zero-value OP_RETURN is non-standard/likely-malformed — failing loudly avoids a fee surprise.

### `fix(connect): reject unsupported and multisig inputs in parsePsbt` &nbsp;·&nbsp; [`0536402`](https://github.com/trezor/trezor-suite/pull/32177/commits/0536402a1ce006061db574d0659757b73a8ac89e)
- **Change:** compute the input `script_type` once and throw `Method_InvalidParameter` for `undefined` (unknown path) and for `SPENDMULTISIG`; single-sig types (`SPENDADDRESS`/`SPENDWITNESS`/`SPENDP2SHWITNESS`/`SPENDTAPROOT`) are unchanged.
- **Why (problem):** `getScriptType(getHDPath(utxo.path))` can return `SPENDMULTISIG` (BIP48) or `undefined`, but the emitted `TxInputType` never populated the required `multisig` (pubkeys) field — so signing failed later at the device with an opaque error (or an input with `script_type: undefined` was produced).
- **Why better:** turns a confusing late device failure into a clear, actionable error at the `composePsbt` boundary and documents the single-sig scope (consistent with the existing `// TODO external utxo` limitation). No behavior change for the supported single-sig LI.FI case.

### `fix(connect): reject multi-push OP_RETURN instead of truncating` &nbsp;·&nbsp; [`1e6a90c`](https://github.com/trezor/trezor-suite/pull/32177/commits/1e6a90c491389ad6aa02bc0a03ae74444462cd15)
- **Change:** in `parseOutputScript`, return `{ type: 'unknown' }` unless the OP_RETURN has exactly one data push; otherwise return the single push as `data`. Fixed the misleading `shift OP code` comment.
- **Why (problem):** `embedScript?.shift()` took only the **first** data push (`payments.embed().data` already excludes the OP_RETURN opcode). An `OP_RETURN <a> <b>` passed embed validation but silently collapsed to `<a>`; Trezor's `PAYTOOPRETURN` holds a single blob, so the signed transaction's OP_RETURN differed from the source (different txid, and for a routing/memo swap the wrong memo) with no error.
- **Why better:** the composer never silently produces a different output than the input specified — a real correctness/safety property for a memo-carrying swap. Fixing it in the shared helper covers both consumers (`parsePsbt` and `refTx`) at one place. Note this also changes `refTx`'s orig-tx handling: a multi-push OP_RETURN now errors instead of building truncated data — a strict improvement (the old path produced wrong `op_return_data` anyway). Called out here so you can drop this commit if you want `refTx` byte-identical.

### `fix(connect): validate nested account fields in composePsbt` &nbsp;·&nbsp; [`55786e8`](https://github.com/trezor/trezor-suite/pull/32177/commits/55786e8c81925835aff2bafcaf41857cc6e336d6)
- **Change:** validate `addresses` as an object **and** its `used`/`unused`/`change` sub-arrays, and validate `utxo` as an array with `allowEmpty` (an empty utxo set is a valid shape).
- **Why (problem):** only the top-level `account` was validated as an object, and `{}`/`[]` pass (arrays are `typeof 'object'`). `account.utxo`/`account.addresses` were never validated, so `run() → parsePsbt` dereferenced `utxos.find(...)` / `addresses.used.concat(...)` and surfaced a raw `TypeError` to the dApp. `validateParams` treats an array as type `object`, so validating only that `addresses` is an object still let `addresses: []` through — hence the explicit sub-array checks.
- **Why better:** returns a clean `Method_InvalidParameter` for malformed input like every other connect method, instead of leaking a V8 runtime error. The top-level check already guarantees `account` is non-null, so the nested `validateParams` can't itself NPE.

### `refactor(connect): use getBitcoinNetworkOrThrow in composePsbt` &nbsp;·&nbsp; [`04a5f24`](https://github.com/trezor/trezor-suite/pull/32177/commits/04a5f240ccb945d43f75c1deeb571a62d5e67269) &nbsp;·&nbsp; **split out → [#32183](https://github.com/trezor/trezor-suite/pull/32183)**
- **Change:** replace `getBitcoinNetwork(x)` + manual `if (!coinInfo) throw Method_UnknownCoin` with `getBitcoinNetworkOrThrow(x)`; drop the now-unused `ERRORS` import.
- **Why (problem):** `coinInfo.ts` documents `getBitcoinNetworkOrThrow` as existing specifically to replace exactly this pattern, and the sibling `composeTransaction` in the same PR already uses it — so `composePsbt` duplicated the pattern the helper was meant to eliminate.
- **Why better:** DRY and consistent with the sibling method; identical runtime behavior.

### `test(connect): add unit tests for parsePsbt` &nbsp;·&nbsp; [`56912a1`](https://github.com/trezor/trezor-suite/pull/32177/commits/56912a118677b3c5dcc558b252c540c8fae772e3)
- **Change:** add `parsePsbt.test.ts` covering P2PKH change+external mapping, P2WPKH OP_RETURN+change mapping, the `Utxo not found` throw, and the non-positive-fee throw.
- **Why (problem):** `parsePsbt` maps attacker/dApp-controlled data and does the fee math, yet was only exercised by the device e2e (`methods.test.ts`, needs a live emulator) and not by ordinary unit CI. A regression (mis-classified change output, off-by-one fee, dropped `totalSpent`) would ship green.
- **Why better:** the mapping is a pure function of a hex string plus plain utxo/address arrays — no device needed — so it belongs in fast unit CI where it actually runs on every change.

### `test(connect): add negative composePsbt e2e fixture` &nbsp;·&nbsp; [`bdec453`](https://github.com/trezor/trezor-suite/pull/32177/commits/bdec453785bccb889ad1bbf1689f50cf3273a35e)
- **Change:** add an e2e case where a PSBT input is not in the account utxo set, asserting `result: false` (success:false) via the existing harness convention.
- **Why (problem):** the e2e fixtures were happy-path only; none of the code's failure modes were exercised end-to-end.
- **Why better:** covers the error path through the real method wiring, not just the success path.

---

## `@trezor/connect-common` — types / type-tests

### `refactor(connect-common): drop unused account.path from composePsbt params` &nbsp;·&nbsp; [`68e0c37`](https://github.com/trezor/trezor-suite/pull/32177/commits/68e0c379a527de60b115f4c3c130c2c72a83a7b1) &nbsp;·&nbsp; **split out → [#32182](https://github.com/trezor/trezor-suite/pull/32182)**
- **Change:** remove `account.path` from `ComposePsbtParams` entirely (and from the type-test literal).
- **Why (problem):** `path` was copied from composeTransaction's account shape, but `composePsbt`/`parsePsbt` never read it — every derivation path comes from the per-utxo and per-change-address entries. A required-but-unused field forced integrators to pass a value the method ignores, and making it merely optional would still advertise a dead field.
- **Why better:** the public type now reflects exactly what the method consumes — no dead field to reason about. composeTransaction keeps its `path` (which it genuinely uses), so the two account shapes correctly differ. No production caller exists yet, and callers passing a full account *variable* are unaffected — only inline object literals that include `path` need it dropped.

### `test(connect-common): restore composeTransaction push-rejection type-test` &nbsp;·&nbsp; [`ae871e8`](https://github.com/trezor/trezor-suite/pull/32177/commits/ae871e8ce28d5ce79c4286a9af907167275055a0)
- **Change:** re-add the `// @ts-expect-error push: true` negative case to the pre-existing `composeTransaction` type-test.
- **Why (problem):** alongside adding the `composePsbt` type-test, #26056 deleted this case, removing the compile-time guard that `composeTransaction` rejects an unexpected `push` param. (Verified this wasn't driven by an API change — `ComposeParams` still has no `push` field.)
- **Why better:** restores lost negative coverage so a future regression that silently accepts `push` is caught at type-check time, while keeping the other (legitimate) type-test tightening from #26056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-psbt-review-fixes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->