### PR TITLE
fix(suite-native): handle non-Error objects in getGraphError

### DIFF
--- a/suite-native/graph/src/graphThunks.ts
+++ b/suite-native/graph/src/graphThunks.ts
@@ -23,7 +23,7 @@ import {
 } from './graphThunkTypes';
 import { portfolioGraphAtoms } from './portfolioGraphAtoms';
 import { type TimeframeHoursValue } from './types';
-import { checkAndReportGraphError, omitErrorMessageSensitiveData } from './utils';
+import { checkAndReportGraphError, getGraphError, omitErrorMessageSensitiveData } from './utils';
 
 const GRAPH_MODULE_PREFIX = '@suite-native/graph';
 const GRAPH_NOT_AVAILABLE_ERROR_MESSAGE = 'Graph is not available for testnet coins.';
@@ -72,14 +72,6 @@ const setGraphPointsForInstanceId = (
         accountDetailGraphAtoms.graphPointsAtom,
         points as FiatGraphPointWithCryptoBalance[],
     );
-};
-
-const getGraphError = (error: unknown): Error => {
-    if (error instanceof Error) {
-        return error;
-    }
-
-    return new Error(String(error));
 };
 
 const fetchGraphDataToAtoms = async ({

--- a/suite-native/graph/src/utils.test.ts
+++ b/suite-native/graph/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { type FiatGraphPoint } from '@suite-common/graph';
 
-import { getExtremaFromGraphPoints, omitErrorMessageSensitiveData } from './utils';
+import { getExtremaFromGraphPoints, getGraphError, omitErrorMessageSensitiveData } from './utils';
 
 describe('Suite native graph utils', () => {
     test('getExtremaFromGraphPoints', () => {
@@ -88,5 +88,51 @@ describe('omitErrorMessageSensitiveData', () => {
 
     it('should handle empty string', () => {
         expect(omitErrorMessageSensitiveData('')).toBe('');
+    });
+});
+
+describe('getGraphError', () => {
+    it('should return the same Error instance unchanged', () => {
+        const error = new Error('boom');
+        expect(getGraphError(error)).toBe(error);
+    });
+
+    it('should return a subclassed Error instance unchanged', () => {
+        class RippledError extends Error {}
+        const error = new RippledError('invalidParams');
+        expect(getGraphError(error)).toBe(error);
+    });
+
+    it('should rebuild an Error from a worker-boundary plain object, preserving name and stack', () => {
+        // blockchain-link workers post errors across the worker boundary as plain objects,
+        // so `instanceof Error` is false even though the shape looks like an Error.
+        const workerError = {
+            message: 'XRP: RippledError invalidParams',
+            name: 'RippledError',
+            stack: 'Error: RippledError invalidParams\n    at ?anon_0_',
+        };
+
+        const result = getGraphError(workerError);
+
+        expect(result).toBeInstanceOf(Error);
+        expect(result.message).toBe('XRP: RippledError invalidParams');
+        expect(result.name).toBe('RippledError');
+        expect(result.stack).toBe(workerError.stack);
+    });
+
+    it('should keep the default name and stack when the plain object omits them', () => {
+        const result = getGraphError({ message: 'partial error' });
+
+        expect(result).toBeInstanceOf(Error);
+        expect(result.message).toBe('partial error');
+        expect(result.name).toBe('Error');
+        expect(typeof result.stack).toBe('string');
+    });
+
+    it('should fall back to String() for primitive values', () => {
+        expect(getGraphError('plain string').message).toBe('plain string');
+        expect(getGraphError(42).message).toBe('42');
+        expect(getGraphError(null).message).toBe('null');
+        expect(getGraphError(undefined).message).toBe('undefined');
     });
 });

--- a/suite-native/graph/src/utils.ts
+++ b/suite-native/graph/src/utils.ts
@@ -99,6 +99,36 @@ export const omitErrorMessageSensitiveData = (string: string) => {
     return msg;
 };
 
+export const getGraphError = (error: unknown): Error => {
+    if (error instanceof Error) {
+        return error;
+    }
+
+    // Errors thrown inside blockchain-link workers cross the worker boundary as plain
+    // `{ message, name, stack }` objects, so `instanceof Error` fails and `String(error)`
+    // would yield "[object Object]". Rebuild a real Error, preserving the original name and
+    // stack so `checkAndReportGraphError` still forwards them to Sentry.
+    if (
+        typeof error === 'object' &&
+        error !== null &&
+        'message' in error &&
+        typeof error.message === 'string'
+    ) {
+        const graphError = new Error(error.message);
+
+        if ('name' in error && typeof error.name === 'string') {
+            graphError.name = error.name;
+        }
+        if ('stack' in error && typeof error.stack === 'string') {
+            graphError.stack = error.stack;
+        }
+
+        return graphError;
+    }
+
+    return new Error(String(error));
+};
+
 export const checkAndReportGraphError = (error: Error | null) => {
     if (error) {
         // A new Error object has to be created, to not override the original data.


### PR DESCRIPTION
## Description

- Blockchain-link worker errors (e.g. XRP `RippledError`) cross the worker boundary as plain `{ message, name, stack }` objects, so `instanceof Error` is false.
- `getGraphError` fell through to `new Error(String(error))`, producing the unreadable `Error: [object Object]` seen in Sentry.
- Now rebuilds a real `Error` from such objects, preserving `name` and `stack` for accurate Sentry reports.
- Moved `getGraphError` from `graphThunks.ts` to `utils.ts` and added unit tests.

## Notes for QA


Nothing to test, no user-facing UI change.— only affects how graph fetch errors are reported to Sentry.

## Related Issue

Resolve #32174

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/graph-error-object-handling&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->