### PR TITLE
fix(suite): do not show insufficient funds when yield tx is pending

### DIFF
--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -99,9 +99,9 @@ export const YieldDepositForm = () => {
     const isAmountInvalidDecimals = amountIssues.includes('amount-invalid-decimals');
     const hasBlockingAmountIssue = amountIssues.length > 0;
 
-    const shouldCheckWrapAmount = !isAmountInvalidDecimals && !!wrapPendingTransaction;
-    const shouldCheckApproveAmount = !isAmountInvalidDecimals && !!approvalPendingTransaction;
-    const shouldCheckDepositAmount = !isAmountInvalidDecimals && !!depositPendingTransaction;
+    const shouldCheckWrapAmount = !isAmountInvalidDecimals && !wrapPendingTransaction;
+    const shouldCheckApproveAmount = !isAmountInvalidDecimals && !approvalPendingTransaction;
+    const shouldCheckDepositAmount = !isAmountInvalidDecimals && !depositPendingTransaction;
 
     // Wrapping into the gas reserve is allowed — Max keeps it aside only while the balance covers
     // it — so recommend keeping it rather than blocking. `isAmountTooHigh` only fires above the

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -100,7 +100,7 @@ export const UnwrapNativeToken = ({
     const isAmountTooHigh = amount.gt(tokenBalance);
     const isAmountValid = amount.gt(0) && !isAmountTooHigh && methods.formState.isValid;
 
-    const shouldCheckUnwrapAmount = !!broadcast;
+    const shouldCheckUnwrapAmount = !broadcast;
 
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
 

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -94,8 +94,8 @@ export const YieldWithdrawForm = () => {
         isWrappedNativeVault: flow.isWrappedNativeVault,
     });
 
-    const shouldCheckWithdrawAmount = !isAmountInvalidDecimals && !!withdrawPendingTransaction;
-    const shouldCheckUnwrapAmount = !isAmountInvalidDecimals && !!unwrapPendingTransaction;
+    const shouldCheckWithdrawAmount = !isAmountInvalidDecimals && !withdrawPendingTransaction;
+    const shouldCheckUnwrapAmount = !isAmountInvalidDecimals && !unwrapPendingTransaction;
 
     const handleOnWithdraw = () => {
         const apyBreakdown = getApyBreakdown(vault.rewardRate?.components);

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -103,7 +103,7 @@ export const WrapNativeToken = ({ account, token, onFlowCompleteChange }: WrapNa
     const isReserveRecommended = shouldRecommendWrapReserve(amountInput, account.formattedBalance);
     const isAmountValid = amount.gt(0) && !isAmountTooHigh && methods.formState.isValid;
 
-    const shouldCheckWrapAmount = !!broadcast;
+    const shouldCheckWrapAmount = !broadcast;
 
     useEffect(() => {
         if (pendingTxStatus !== 'failed') {


### PR DESCRIPTION
## Description

Do not show `Insufficient funds` warning banner in yield flow when transaction is pending.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31880

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to Earn/Yield UI components. Only the yield withdrawal flow has direct e2e coverage in the current suite. Run the two yield tests to validate YieldWithdrawForm changes. The deposit, wrap, and unwrap components have no direct e2e tests (the static mapping for YieldDepositForm is a broad/global dependency and does not represent behavioral coverage).

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — This test directly exercises the yield redeem/withdraw flow from the earn dashboard, including the withdraw/redeem form and transaction simulation. Changes to YieldWithdrawForm.tsx could directly affect form validation, amount handling, or the review modal shown in this flow.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test covers the full withdrawal flow from a USDC yield vault, including entering withdrawal amounts and confirming via the yield flow form. It is the most direct end-to-end coverage for YieldWithdrawForm.tsx.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`

_Updated: 2026-09-07T11:42:29.342Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-pending-tx-insufficient-funds/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-pending-tx-insufficient-funds/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-pending-tx-insufficient-funds&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T11:44:47.971Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T11:44:46.292Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->