### PR TITLE
fix(receive): restore "including tokens" on the account receive screen

### DIFF
--- a/suite/receive/src/ReceiveContent.tsx
+++ b/suite/receive/src/ReceiveContent.tsx
@@ -1,10 +1,14 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { useDispatch } from '@suite-common/redux-utils';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    getNetwork,
+    getNetworkDisplaySymbol,
+    getNetworkFeatures,
+} from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { Banner, Column, H2 } from '@trezor/components';
+import { Banner, Column, H2, Text } from '@trezor/components';
 
 import { AddressHistory } from './AddressHistory';
 import { NewestAddressCard } from './NewestAddressCard';
@@ -32,6 +36,11 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
     const [verifyingAddressPath, setVerifyingAddressPath] = useState<string | undefined>();
 
     const disabled = locked || isReceiveDisabled;
+
+    const supportsTokens = useMemo(
+        () => getNetworkFeatures(account.symbol).includes('tokens'),
+        [account.symbol],
+    );
 
     const handleVerifyAddress = async (path: string) => {
         if (verifyingAddressPath !== undefined) {
@@ -70,12 +79,19 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
                 />
             )}
 
-            <H2>
-                <Translation
-                    id="RECEIVE_TITLE"
-                    values={{ networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol) }}
-                />
-            </H2>
+            <Column gap={4} alignItems="stretch">
+                <H2>
+                    <Translation
+                        id="RECEIVE_TITLE"
+                        values={{ networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol) }}
+                    />
+                </H2>
+                {supportsTokens && (
+                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                        <Translation id="TR_INCLUDING_TOKENS" />
+                    </Text>
+                )}
+            </Column>
 
             <NewestAddressCard
                 accountKey={account.key}


### PR DESCRIPTION
The redesigned receive screen dropped the line telling users the address also receives the network's tokens. The old screen carried it as a per-network paragraph under the heading (RECEIVE_DESC_ETHEREUM, "Use this address to receive tokens as well."), and that component is no longer rendered, so the heading is now just "Receive ETH".

Restore it the way the other two receive surfaces already do it — the asset picker and the global receive modal both render TR_INCLUDING_TOKENS when getNetworkFeatures(symbol) includes 'tokens'. Driving it off the network feature rather than networkType === 'ethereum' also covers Solana and every other token-bearing network, which the old ethereum-only paragraph did not.

Closes #31277

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

Just check it fixes the ticket.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="1409" height="631" alt="Screenshot 2026-09-07 at 1 55 59 PM" src="https://github.com/user-attachments/assets/f1e6b70f-ef86-456c-9fbd-74e00c4245dd" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the ReceiveContent component, so the main risk is regressions in receive address rendering, verification, copying, QR code generation, and address labels. No static mapping was available, so recommendations are inferred from behavior descriptions. Run the wallet/receive test first; if capacity allows, add the Cardano receive, global receive, and legacy address-label tests to cover coin-specific and label-related receive paths.

<details><summary><b>Changed files (1)</b></summary>

- `suite/receive/src/ReceiveContent.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test directly exercises the receive flow for BTC, ETH, SOL and TRX, including address display, copy-to-clipboard, QR code, and on-device address verification. It is the strongest inferred coverage for ReceiveContent because it renders the component across multiple coin receive routes.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — The test adds and edits Bitcoin address labels from the receive address view. Address label rendering and editing UI is part of the receive screen, so a change to ReceiveContent could affect label display or save feedback here.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test verifies the Cardano receive flow, which is not covered by the multi-coin receive test. It exercises ReceiveContent for a coin-specific account type and confirms address display, device verification and copy actions.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — The test opens the global receive form from the dashboard, selects an account, and verifies the generated receive address. This reaches ReceiveContent through a different entry point than the wallet account receive tab.

</details>

_Updated: 2026-09-07T12:01:23.177Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31277-restore-including-tokens-on-receive-screen&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31277-restore-including-tokens-on-receive-screen&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T12:03:40.312Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T12:02:40.378Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31277-restore-including-tokens-on-receive-screen/web/](https://dev.suite.sldev.cz/suite-web/fix/31277-restore-including-tokens-on-receive-screen/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->