### PR TITLE
refactor(connect-common): drop unused account.path from composePsbt params

### DIFF
--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -519,7 +519,6 @@ export const sendTransaction = async (api: TrezorConnect) => {
 export const composePsbt = async (api: TrezorConnect) => {
     const precompose = await api.composePsbt({
         account: {
-            path: 'm/49',
             addresses: {
                 used: [],
                 unused: [],

--- a/packages/connect-common/src/types/api/bitcoin/composePsbt.ts
+++ b/packages/connect-common/src/types/api/bitcoin/composePsbt.ts
@@ -9,7 +9,8 @@ export type ComposeUtxo = AccountUtxo & Partial<ComposeInputBase>;
 
 export type ComposePsbtParams = {
     account: {
-        path: string;
+        // composePsbt derives every path from the per-utxo / per-change-address entries,
+        // so no account-level `path` is needed (unlike composeTransaction).
         addresses: AccountAddresses;
         utxo: ComposeUtxo[];
     };


### PR DESCRIPTION
Standalone extraction from the review of #26056 — a single self-contained commit, so it can be taken (or not) independently of the rest of the review follow-ups.

**Change:** remove `account.path` from `ComposePsbtParams` entirely (and from the type-test literal).

**Why:** `path` was copied from composeTransaction's account shape, but `composePsbt` / `parsePsbt` never read it — every derivation path comes from the per-utxo and per-change-address entries. Dropping it makes the public type reflect exactly what the method consumes. composeTransaction keeps its `path` (which it genuinely uses), so the two account shapes correctly differ. Callers passing a full account *variable* are unaffected; only inline object literals that include `path` need it dropped.

Type-check clean for `@trezor/connect-common` and `@trezor/connect`. Based on `feat/connect-psbt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
