### PR TITLE
refactor(connect): use getBitcoinNetworkOrThrow in composePsbt

### DIFF
--- a/packages/connect/src/api/composePsbt.ts
+++ b/packages/connect/src/api/composePsbt.ts
@@ -1,13 +1,12 @@
 import {
     type BitcoinNetworkInfo,
     type ComposePsbtParams,
-    ERRORS,
     type PermissionRequest,
 } from '@trezor/connect-common';
 
 import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getBitcoinNetwork } from '../data/coinInfo';
+import { getBitcoinNetworkOrThrow } from '../data/coinInfo';
 import { parsePsbt } from './bitcoin/parsePsbt';
 import { validateParams } from './common/paramsValidator';
 
@@ -25,10 +24,7 @@ export default class ComposePsbt extends AbstractMethod<'composePsbt', Params> {
             { name: 'coin', type: 'string', required: true },
         ]);
 
-        const coinInfo = getBitcoinNetwork(payload.coin);
-        if (!coinInfo) {
-            throw ERRORS.TypedError('Method_UnknownCoin');
-        }
+        const coinInfo = getBitcoinNetworkOrThrow(payload.coin);
 
         const params = {
             account: payload.account,


### PR DESCRIPTION
Standalone extraction from the review of #26056 — a single self-contained commit, so it can be taken (or not) independently of the rest of the review follow-ups.

**Change:** replace `getBitcoinNetwork(coin)` + manual `if (!coinInfo) throw Method_UnknownCoin` with `getBitcoinNetworkOrThrow(coin)` in the `composePsbt` method; drop the now-unused `ERRORS` import.

**Why:** `getBitcoinNetworkOrThrow` exists specifically to replace exactly this pattern, and the sibling `composeTransaction` already uses it — so `composePsbt` duplicated the pattern the helper was meant to eliminate. Identical runtime behaviour (still throws `Method_UnknownCoin` for an unknown coin), just DRY and consistent with the sibling method.

Type-check clean for `@trezor/connect`. Based on `feat/connect-psbt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/composepsbt-use-getbitcoinnetworkorthrow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->