### PR TITLE
fix(connect): reject non-positive fee in parsePsbt

### DIFF
--- a/packages/connect/src/api/bitcoin/parsePsbt.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.ts
@@ -97,6 +97,10 @@ export const parsePsbt = ({
     }
 
     const fee = sumOfInputs - sumOfOutputs;
+    if (fee <= BigInt(0)) {
+        // A non-positive fee (outputs >= inputs) is not a signable transaction.
+        throw TypedError('Method_InvalidParameter', 'parsePsbt: Transaction fee is non-positive');
+    }
     const bytes = psbt.unsignedTx.virtualSize();
     const feePerByte = Number(fee) / bytes;
 


### PR DESCRIPTION
Standalone extraction from the review of #26056 — a single self-contained commit, so it can be taken (or not) independently of the rest of the review follow-ups.

**Change:** in `parsePsbt`, throw `Method_InvalidParameter` when `fee = sumOfInputs - sumOfOutputs <= 0`, before building the result.

**Why:** `composePsbt` is a public SDK method and `psbtData` is caller-controlled, so a PSBT whose output values meet or exceed the referenced (owned) input amounts yields a zero/negative `BigInt` fee. Without the guard, `parsePsbt` returns `type: 'final'` with a negative `fee`/`feePerByte` — a misleading "successful" precompose. A successful response should return functional data, so this fails fast at the boundary instead. It mirrors the existing `signTransaction.payloadToPrecomposed` guard (`if (fee.lte(0)) throw`).

**Scope note:** this is defensive hygiene, not a funds-safety fix. It cannot occur for a well-formed PSBT with correct account data (a real transaction always has a positive fee), and the device / `signTransaction` reject a non-positive-fee transaction regardless. The value is only that `composePsbt` returns a clean error instead of a nonsensical `final` result.

Based on `feat/connect-psbt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/composepsbt-reject-non-positive-fee&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->