### PR TITLE
fix(suite-32158): reduce heavy network requests in trade form

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/TradeApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TradeApi.tsx
@@ -1,6 +1,6 @@
 import { selectTradeServerEnvironment, suiteSettingsActions } from '@suite/settings';
 import { useDispatch } from '@suite-common/redux-utils';
-import { type TradeServerEnvironment, tradeApi } from '@suite-common/trading';
+import { type TradeServerEnvironment, tradeApi, tradingActions } from '@suite-common/trading';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
 
 import { useSelector } from 'src/hooks/suite';
@@ -21,6 +21,7 @@ export const TradeApi = () => {
         dispatch(suiteSettingsActions.setDebugMode({ tradeServerEnvironment: item.value }));
         tradeApi.setServersEnvironment(item.value);
         tradeApi.resetCurrentAccount();
+        dispatch(tradingActions.invalidateCatalog());
     };
 
     return (

--- a/suite-common/trading/src/reducers/tradingCommonReducer.ts
+++ b/suite-common/trading/src/reducers/tradingCommonReducer.ts
@@ -141,6 +141,9 @@ const tradingCommonSlice = createSlice({
             state.isLoading = action.payload.isLoading;
             state.lastLoadedTimestamp = action.payload.lastLoadedTimestamp ?? 0;
         },
+        invalidateCatalog(state: TradingState) {
+            state.lastLoadedTimestamp = 0;
+        },
         setTradingActiveSection(state: TradingState, action: PayloadAction<TradingType>) {
             state.activeSection = action.payload;
         },

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts
@@ -1,364 +1,376 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
-import { createTestStore } from '@suite-common/test-utils';
+import { mockActionType } from '@suite-common/redux-utils/mocks';
+import { createTestCompositionRoot } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import { prepareAccountsReducer } from '@suite-common/wallet-core';
-import { mockSetAccountAddMetadata } from '@suite-common/wallet-core/mocks';
-import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-types';
+import { type SelectedAccountStatus, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { createDeferred } from '@trezor/utils';
 
-import { loadInitialDataThunk } from './loadInitialDataThunk';
+import { type LoadInitialDataThunkDeps, loadInitialDataThunk } from './loadInitialDataThunk';
 import coinsFixture from '../../__fixtures__/coins.json';
 import platformsFixture from '../../__fixtures__/platforms.json';
-import { accountBtc, accountEth } from '../../__fixtures__/utils';
-import { TRADING_FALLBACK_API_KEY } from '../../constants';
+import { TRADE_API_RELOAD_DATA_AFTER_MS, TRADING_FALLBACK_API_KEY } from '../../constants';
 import { tradingBuyActions } from '../../reducers/buyReducer';
-import { exchangeInitialState, tradingExchangeActions } from '../../reducers/exchangeReducer';
-import { type SellInfo, tradingSellActions } from '../../reducers/sellReducer';
+import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import {
     type TradingState,
     initialState,
     tradingActions,
 } from '../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../reducers/tradingReducer';
-import { regional } from '../../regional';
 import { tradeApi } from '../../tradeApi';
-import { buyThunks } from '../buy';
-import { exchangeThunks } from '../exchange';
-import { sellThunks } from '../sell';
 
 jest.mock('../../tradeApi');
-tradeApi.setServersEnvironment = () => {};
 
+const account = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('firstAccount'),
+});
+const otherAccount = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('secondAccount'),
+});
+const info = { coins: {}, platforms: {}, config: {} };
 const tradingReducer = prepareTradingReducer({
     actionTypes: { storageLoad: mockActionType('storageLoad') },
 });
-const mockedAccountReducer = prepareAccountsReducer({
-    actionTypes: { storageLoad: mockActionType('storageLoad') },
-    actions: { setAccountAddMetadata: mockSetAccountAddMetadata() },
-    reducers: { storageLoadAccounts: mockReducer() },
-});
-const defaultAccount = accountBtc as Account;
-const defaultSelectedAccount: SelectedAccountStatus = {
-    status: 'loaded',
-    account: defaultAccount,
-    network: getNetwork(defaultAccount.symbol),
-    params: undefined,
-};
 
-const initStore = (
-    localInitialState?: Partial<TradingState>,
-    selectedAccount: SelectedAccountStatus = defaultSelectedAccount,
-) =>
-    createTestStore({
-        extra: {
-            services: {
-                getSelectedAccount: () => selectedAccount,
-                getTradingEnvironment: () => 'localhost' as const,
-            },
+const initRoot = (tradingState: Partial<TradingState> = {}) => {
+    const getSelectedAccount = jest.fn<SelectedAccountStatus, []>(() => ({
+        status: 'none',
+        account: undefined,
+    }));
+    const extra: LoadInitialDataThunkDeps = {
+        services: {
+            getSelectedAccount,
+            getTradingEnvironment: () => 'localhost',
         },
-        reducer: combineReducers({
+    };
+
+    const root = createTestCompositionRoot({
+        extra,
+        reducer: {
             wallet: combineReducers({
                 trading: tradingReducer,
-                accounts: mockedAccountReducer,
+                accounts: () => [account, otherAccount],
             }),
-        }),
+        },
         preloadedState: {
-            wallet: {
-                trading: {
-                    ...initialState,
-                    ...localInitialState,
-                },
-                accounts: [accountEth],
-            },
+            wallet: { trading: { ...initialState, ...tradingState } },
         },
     });
 
-const testUpdatedInfoData = async (type: 'outdated' | 'account-changed') => {
-    tradeApi.getCurrentAccountDescriptor = () =>
-        type === 'account-changed' ? 'FakeDescriptor' : accountBtc.descriptor;
-    tradeApi.getInfo = () =>
-        Promise.resolve({
-            coins: {},
-            platforms: {},
-            config: {},
-        });
-
-    const getCurrentAccountDescriptorMock = jest.spyOn(tradeApi, 'getCurrentAccountDescriptor');
-    const setServersEnvironmentMock = jest.spyOn(tradeApi, 'setServersEnvironment');
-
-    const mockedLastLoadedTimestamp = new Date().getTime();
-    jest.spyOn(Date, 'now').mockImplementation(() => mockedLastLoadedTimestamp);
-
-    const store = initStore({
-        info: {},
-        lastLoadedTimestamp: type === 'outdated' ? 0 : mockedLastLoadedTimestamp,
-    });
-
-    await store.dispatch(loadInitialDataThunk({ activeSection: 'buy' }));
-
-    const mockBuyInfo = {
-        buyInfo: {
-            country: regional.UNKNOWN_COUNTRY,
-            providers: [],
-            defaultAmountsOfFiatCurrencies: {},
-        },
-        providerInfos: {},
-        supportedFiatCurrencies: [],
-        supportedCryptoCurrencies: [],
-    };
-
-    const mockExchangeInfo = {
-        providerInfos: {},
-        buyCryptoIds: [],
-        sellCryptoIds: [],
-    };
-
-    const mockSellInfo: SellInfo = {
-        providerInfos: {},
-        supportedCryptoCurrencies: [],
-        supportedFiatCurrencies: [],
-        country: regional.UNKNOWN_COUNTRY,
-    };
-
-    expect(store.getActions()).toEqual([
-        {
-            payload: undefined,
-            meta: {
-                arg: {
-                    activeSection: 'buy',
-                },
-                requestId: expect.any(String),
-                requestStatus: 'pending',
-            },
-            type: `${loadInitialDataThunk.typePrefix}/pending`,
-        },
-        {
-            payload: 'buy',
-            type: tradingActions.setTradingActiveSection.type,
-        },
-        {
-            type: tradingActions.setLoading.type,
-            payload: {
-                isLoading: true,
-            },
-        },
-        {
-            type: tradingActions.saveInfo.type,
-            payload: {
-                coins: {},
-                platforms: {},
-                config: {},
-            },
-        },
-        {
-            type: buyThunks.loadInfoThunk.pending.type,
-            payload: undefined,
-            meta: {
-                arg: undefined,
-                requestId: expect.any(String),
-                requestStatus: 'pending',
-            },
-        },
-        {
-            type: buyThunks.loadInfoThunk.fulfilled.type,
-            payload: mockBuyInfo,
-            meta: {
-                arg: undefined,
-                requestId: expect.any(String),
-                requestStatus: 'fulfilled',
-            },
-        },
-        {
-            type: tradingBuyActions.saveBuyInfo.type,
-            payload: mockBuyInfo,
-        },
-        {
-            type: exchangeThunks.loadInfoThunk.pending.type,
-            payload: undefined,
-            meta: {
-                arg: undefined,
-                requestId: expect.any(String),
-                requestStatus: 'pending',
-            },
-        },
-        {
-            type: exchangeThunks.loadInfoThunk.fulfilled.type,
-            payload: mockExchangeInfo,
-            meta: {
-                arg: undefined,
-                requestId: expect.any(String),
-                requestStatus: 'fulfilled',
-            },
-        },
-        {
-            type: tradingExchangeActions.saveExchangeInfo.type,
-            payload: mockExchangeInfo,
-        },
-        {
-            type: sellThunks.loadInfoThunk.pending.type,
-            payload: undefined,
-            meta: {
-                arg: undefined,
-                requestId: expect.any(String),
-                requestStatus: 'pending',
-            },
-        },
-        {
-            type: sellThunks.loadInfoThunk.fulfilled.type,
-            payload: mockSellInfo,
-            meta: {
-                arg: undefined,
-                requestId: expect.any(String),
-                requestStatus: 'fulfilled',
-            },
-        },
-        {
-            type: tradingSellActions.saveSellInfo.type,
-            payload: mockSellInfo,
-        },
-        {
-            payload: {
-                isLoading: false,
-                lastLoadedTimestamp: mockedLastLoadedTimestamp,
-            },
-            type: tradingActions.setLoading.type,
-        },
-        {
-            payload: undefined,
-            meta: {
-                arg: {
-                    activeSection: 'buy',
-                },
-                requestId: expect.any(String),
-                requestStatus: 'fulfilled',
-            },
-            type: `${loadInitialDataThunk.typePrefix}/fulfilled`,
-        },
-    ]);
-    expect(getCurrentAccountDescriptorMock).toHaveBeenCalledTimes(1);
-    expect(setServersEnvironmentMock).toHaveBeenCalledTimes(1);
+    return { ...root, getSelectedAccount };
 };
 
-describe('loadInitialDataThunk', () => {
+const expectCatalogCalls = (count: number) => {
+    expect(tradeApi.getInfo).toHaveBeenCalledTimes(count);
+    expect(tradeApi.getBuyList).toHaveBeenCalledTimes(count);
+    expect(tradeApi.getExchangeList).toHaveBeenCalledTimes(count);
+    expect(tradeApi.getSellList).toHaveBeenCalledTimes(count);
+};
+
+const initLoadedRoot = async () => {
+    const root = initRoot();
+    await root.services.dispatch(loadInitialDataThunk({ activeSection: 'buy' })).unwrap();
+    jest.clearAllMocks();
+
+    return root;
+};
+
+describe('loadInitialDataThunk catalog cache', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+        jest.mocked(tradeApi.getInfo).mockResolvedValue(info);
+        jest.mocked(tradeApi.getExchangeList).mockResolvedValue([]);
+        jest.mocked(tradeApi.getApiServerUrl).mockReturnValue('http://localhost:3330');
+    });
+
     afterEach(() => {
-        jest.clearAllMocks();
+        jest.restoreAllMocks();
     });
 
-    it('should update when account is changed', async () => {
-        await testUpdatedInfoData('account-changed');
-    });
+    it('loads the complete catalog on first use', async () => {
+        const { store, services } = initRoot();
 
-    it('should update when data are outdated data ', async () => {
-        await testUpdatedInfoData('outdated');
-    });
+        await services.dispatch(loadInitialDataThunk({ activeSection: 'buy' })).unwrap();
 
-    it('should keep same version of data without update', async () => {
-        tradeApi.getCurrentAccountDescriptor = () => accountBtc.descriptor;
-
-        const getCurrentAccountDescriptorMock = jest.spyOn(tradeApi, 'getCurrentAccountDescriptor');
-        const setServersEnvironmentMock = jest.spyOn(tradeApi, 'setServersEnvironment');
-
-        const store = initStore({
+        expectCatalogCalls(1);
+        expect(store.getState().wallet.trading).toMatchObject({
+            isLoading: false,
             lastLoadedTimestamp: Date.now(),
         });
-
-        await store.dispatch(loadInitialDataThunk({ activeSection: 'buy' }));
-        expect(store.getActions()).toEqual([
-            {
-                payload: undefined,
-                meta: {
-                    arg: {
-                        activeSection: 'buy',
-                    },
-                    requestId: expect.any(String),
-                    requestStatus: 'pending',
-                },
-                type: `${loadInitialDataThunk.typePrefix}/pending`,
-            },
-            {
-                payload: 'buy',
-                type: tradingActions.setTradingActiveSection.type,
-            },
-            {
-                payload: undefined,
-                meta: {
-                    arg: {
-                        activeSection: 'buy',
-                    },
-                    requestId: expect.any(String),
-                    requestStatus: 'fulfilled',
-                },
-                type: `${loadInitialDataThunk.typePrefix}/fulfilled`,
-            },
-        ]);
-        expect(getCurrentAccountDescriptorMock).toHaveBeenCalledTimes(1);
-        expect(setServersEnvironmentMock).toHaveBeenCalledTimes(0);
+        expect(tradeApi.setServersEnvironment).toHaveBeenCalledWith('localhost');
+        expect(tradeApi.createApiKey).toHaveBeenCalledWith(TRADING_FALLBACK_API_KEY);
     });
 
-    it('should reload with the fallback api key when the account disconnects while cached data is fresh', async () => {
-        tradeApi.getCurrentAccountDescriptor = () => accountBtc.descriptor;
-        tradeApi.getInfo = () =>
-            Promise.resolve({
-                coins: {},
-                platforms: {},
-                config: {},
-            });
+    it.each(['exchange', 'sell', 'buy'] as const)(
+        'reuses the catalog, including empty fallbacks, when opening %s without accounts',
+        async activeSection => {
+            const { store, services } = await initLoadedRoot();
+            const timestamp = store.getState().wallet.trading.lastLoadedTimestamp;
+            jest.spyOn(Date, 'now').mockReturnValue(timestamp + 1);
 
-        const createApiKeyMock = jest.spyOn(tradeApi, 'createApiKey');
+            await services.dispatch(loadInitialDataThunk({ activeSection })).unwrap();
 
-        const mockedLastLoadedTimestamp = new Date().getTime();
-        jest.spyOn(Date, 'now').mockImplementation(() => mockedLastLoadedTimestamp);
+            expect(store.getState().wallet.trading.activeSection).toBe(activeSection);
+            expectCatalogCalls(0);
+            expect(store.getState().wallet.trading.lastLoadedTimestamp).toBe(timestamp);
+            expect(services.getActions().filter(tradingActions.setLoading.match)).toHaveLength(2);
+        },
+    );
 
-        const store = initStore(
-            { info: {}, lastLoadedTimestamp: mockedLastLoadedTimestamp },
-            { status: 'none', account: undefined },
+    it.each([
+        { scenario: 'selection', previousAccount: undefined, selectedAccount: account },
+        { scenario: 'change', previousAccount: account, selectedAccount: otherAccount },
+        { scenario: 'disconnect', previousAccount: account, selectedAccount: undefined },
+    ])(
+        'updates API identity on account $scenario without reloading',
+        async ({ previousAccount, selectedAccount }) => {
+            const { services } = await initLoadedRoot();
+            services.dispatch(tradingBuyActions.setTradingAccountKey(previousAccount?.key));
+            await services.dispatch(loadInitialDataThunk({ activeSection: 'buy' })).unwrap();
+            jest.mocked(tradeApi.createApiKey).mockClear();
+
+            services.dispatch(tradingBuyActions.setTradingAccountKey(selectedAccount?.key));
+            await services.dispatch(loadInitialDataThunk({ activeSection: 'buy' })).unwrap();
+
+            expect(tradeApi.createApiKey).toHaveBeenCalledWith(
+                selectedAccount?.descriptor || TRADING_FALLBACK_API_KEY,
+            );
+            expectCatalogCalls(0);
+        },
+    );
+
+    it('preserves desktop selected-account and forced-key precedence on cache hits', async () => {
+        const { services, getSelectedAccount } = await initLoadedRoot();
+        const selectedAccount: SelectedAccountStatus = {
+            status: 'loaded',
+            account,
+            network: getNetwork(account.symbol),
+            params: undefined,
+        };
+        getSelectedAccount.mockReturnValue(selectedAccount);
+        await services
+            .dispatch(loadInitialDataThunk({ activeSection: 'buy', forcedApiKey: 'forced' }))
+            .unwrap();
+        expect(tradeApi.createApiKey).toHaveBeenLastCalledWith(account.descriptor);
+
+        getSelectedAccount.mockReturnValue({
+            status: 'none',
+            account: undefined,
+        });
+        await services
+            .dispatch(loadInitialDataThunk({ activeSection: 'buy', forcedApiKey: 'forced' }))
+            .unwrap();
+        expect(tradeApi.createApiKey).toHaveBeenLastCalledWith('forced');
+        await services
+            .dispatch(loadInitialDataThunk({ activeSection: 'buy', forcedApiKey: '' }))
+            .unwrap();
+        expect(tradeApi.createApiKey).toHaveBeenLastCalledWith(TRADING_FALLBACK_API_KEY);
+        expectCatalogCalls(0);
+    });
+
+    it.each([
+        TRADE_API_RELOAD_DATA_AFTER_MS - 1,
+        TRADE_API_RELOAD_DATA_AFTER_MS,
+        TRADE_API_RELOAD_DATA_AFTER_MS + 1,
+    ])('honors the expiry boundary at an age of %i ms with populated cache entries', async age => {
+        const { store, services } = await initLoadedRoot();
+        const timestamp = store.getState().wallet.trading.lastLoadedTimestamp;
+        jest.spyOn(Date, 'now').mockReturnValue(timestamp + age);
+
+        await services.dispatch(loadInitialDataThunk({ activeSection: 'buy' })).unwrap();
+
+        const isExpired = age >= TRADE_API_RELOAD_DATA_AFTER_MS;
+        expectCatalogCalls(isExpired ? 1 : 0);
+        expect(store.getState().wallet.trading.lastLoadedTimestamp).toBe(
+            isExpired ? Date.now() : timestamp,
         );
-
-        await store.dispatch(loadInitialDataThunk({ activeSection: 'buy' }));
-
-        const dispatchedTypes = store.getActions().map(action => action.type);
-        expect(dispatchedTypes).toContain(tradingActions.setLoading.type);
-        expect(createApiKeyMock).toHaveBeenCalledWith(TRADING_FALLBACK_API_KEY);
     });
 
-    it('should update active section', async () => {
-        const store = initStore({
-            lastLoadedTimestamp: Date.now(),
-            exchange: {
-                ...exchangeInitialState,
-                tradingAccountKey: accountEth.key,
-            },
-        });
+    it.each(['info', 'buy', 'exchange', 'sell'] as const)(
+        'fetches only missing %s data without extending the shared lifetime',
+        async missing => {
+            const loaded = await initLoadedRoot();
+            const cached = loaded.store.getState().wallet.trading;
+            const { store, services } = initRoot({
+                ...cached,
+                info: missing === 'info' ? {} : cached.info,
+                buy: { ...cached.buy, buyInfo: missing === 'buy' ? undefined : cached.buy.buyInfo },
+                exchange: {
+                    ...cached.exchange,
+                    exchangeInfo: missing === 'exchange' ? undefined : cached.exchange.exchangeInfo,
+                },
+                sell: {
+                    ...cached.sell,
+                    sellInfo: missing === 'sell' ? undefined : cached.sell.sellInfo,
+                },
+            });
+            jest.spyOn(Date, 'now').mockReturnValue(cached.lastLoadedTimestamp + 100);
 
-        await store.dispatch(loadInitialDataThunk({ activeSection: 'exchange' })).unwrap();
+            await services.dispatch(loadInitialDataThunk({ activeSection: 'buy' })).unwrap();
 
+            expect(tradeApi.getInfo).toHaveBeenCalledTimes(missing === 'info' ? 1 : 0);
+            expect(tradeApi.getBuyList).toHaveBeenCalledTimes(missing === 'buy' ? 1 : 0);
+            expect(tradeApi.getExchangeList).toHaveBeenCalledTimes(missing === 'exchange' ? 1 : 0);
+            expect(tradeApi.getSellList).toHaveBeenCalledTimes(missing === 'sell' ? 1 : 0);
+            expect(store.getState().wallet.trading.lastLoadedTimestamp).toBe(
+                cached.lastLoadedTimestamp,
+            );
+        },
+    );
+
+    it('explicit Retry refreshes all fresh entries, including empty fallback results', async () => {
+        const { store, services } = await initLoadedRoot();
+        jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 100);
+
+        await services
+            .dispatch(loadInitialDataThunk({ activeSection: 'sell', forceReload: true }))
+            .unwrap();
+
+        expectCatalogCalls(1);
+        expect(store.getState().wallet.trading.lastLoadedTimestamp).toBe(Date.now());
+    });
+
+    it.each(['first use', 'expiry', 'retry'] as const)(
+        'loads all catalog resources in parallel on %s',
+        async scenario => {
+            const { store, services } =
+                scenario === 'first use' ? initRoot() : await initLoadedRoot();
+            const timestamp = store.getState().wallet.trading.lastLoadedTimestamp;
+            if (scenario === 'expiry') {
+                jest.spyOn(Date, 'now').mockReturnValue(timestamp + TRADE_API_RELOAD_DATA_AFTER_MS);
+            }
+            const pendingInfo = createDeferred<typeof info>();
+            jest.mocked(tradeApi.getInfo).mockReturnValueOnce(pendingInfo.promise);
+
+            const load = services.dispatch(
+                loadInitialDataThunk({ activeSection: 'buy', forceReload: scenario === 'retry' }),
+            );
+
+            try {
+                expectCatalogCalls(1);
+                expect(store.getState().wallet.trading).toMatchObject({
+                    isLoading: true,
+                    lastLoadedTimestamp: timestamp,
+                });
+            } finally {
+                pendingInfo.resolve(info);
+                await load.unwrap();
+            }
+
+            expect(store.getState().wallet.trading).toMatchObject({
+                isLoading: false,
+                lastLoadedTimestamp: Date.now(),
+            });
+        },
+    );
+
+    it('deduplicates overlapping loads while updating the latest section and API identity', async () => {
+        const { store, services } = initRoot();
+        const pendingInfo = createDeferred<typeof info>();
+        jest.mocked(tradeApi.getInfo).mockReturnValueOnce(pendingInfo.promise);
+        const firstLoad = services.dispatch(loadInitialDataThunk({ activeSection: 'buy' }));
+        services.dispatch(tradingExchangeActions.setTradingAccountKey(otherAccount.key));
+
+        await services
+            .dispatch(loadInitialDataThunk({ activeSection: 'exchange', forceReload: true }))
+            .unwrap();
+
+        expect(store.getState().wallet.trading.isLoading).toBe(true);
         expect(store.getState().wallet.trading.activeSection).toBe('exchange');
+        expect(tradeApi.createApiKey).toHaveBeenLastCalledWith(otherAccount.descriptor);
+        expect(tradeApi.getInfo).toHaveBeenCalledTimes(1);
+        pendingInfo.resolve(info);
+        await firstLoad.unwrap();
+        expectCatalogCalls(1);
     });
 
-    it('should keep existing coins when getInfo fails after account change', async () => {
-        tradeApi.getCurrentAccountDescriptor = () => 'FakeDescriptor';
-        const getInfoMock = jest.fn(() => Promise.resolve(undefined));
-        tradeApi.getInfo = getInfoMock;
+    it.each(['getInfo', 'getBuyList', 'getExchangeList', 'getSellList'] as const)(
+        'releases loading after an unexpected %s rejection without advancing freshness',
+        async request => {
+            const { store, services } = await initLoadedRoot();
+            const timestamp = store.getState().wallet.trading.lastLoadedTimestamp;
+            jest.spyOn(Date, 'now').mockReturnValue(timestamp + 100);
+            jest.mocked(tradeApi[request]).mockRejectedValueOnce(new Error('Unexpected failure'));
 
-        const mockedLastLoadedTimestamp = new Date().getTime();
-        jest.spyOn(Date, 'now').mockImplementation(() => mockedLastLoadedTimestamp);
+            await expect(
+                services
+                    .dispatch(loadInitialDataThunk({ activeSection: 'buy', forceReload: true }))
+                    .unwrap(),
+            ).rejects.toMatchObject({ message: 'Unexpected failure' });
 
-        const store = initStore({
-            info: {
-                coins: coinsFixture,
-                platforms: platformsFixture,
-            },
-            lastLoadedTimestamp: mockedLastLoadedTimestamp,
+            expect(store.getState().wallet.trading).toMatchObject({
+                isLoading: false,
+                lastLoadedTimestamp: timestamp,
+            });
+            await services
+                .dispatch(loadInitialDataThunk({ activeSection: 'buy', forceReload: true }))
+                .unwrap();
+            expect(store.getState().wallet.trading.lastLoadedTimestamp).toBe(Date.now());
+        },
+    );
+
+    it('refreshes the catalog after debug server invalidation', async () => {
+        const { store, services } = await initLoadedRoot();
+        services.dispatch(tradingActions.invalidateCatalog());
+        expect(store.getState().wallet.trading.lastLoadedTimestamp).toBe(0);
+
+        await services.dispatch(loadInitialDataThunk({ activeSection: 'sell' })).unwrap();
+
+        expectCatalogCalls(1);
+    });
+
+    it('does not mark a load fresh if the debug server changes while it is running', async () => {
+        const { store, services } = await initLoadedRoot();
+        const pendingInfo = createDeferred<typeof info>();
+        jest.mocked(tradeApi.getInfo).mockReturnValueOnce(pendingInfo.promise);
+        const load = services.dispatch(
+            loadInitialDataThunk({ activeSection: 'buy', forceReload: true }),
+        );
+        services.dispatch(tradingActions.invalidateCatalog());
+        jest.mocked(tradeApi.getApiServerUrl).mockReturnValue('https://staging-exchange.trezor.io');
+        pendingInfo.resolve(info);
+        await load.unwrap();
+
+        expect(store.getState().wallet.trading).toMatchObject({
+            isLoading: false,
+            lastLoadedTimestamp: 0,
         });
-
-        await store.dispatch(loadInitialDataThunk({ activeSection: 'buy' }));
-
-        expect(getInfoMock).toHaveBeenCalledTimes(1);
-        expect(store.getState().wallet.trading.info.coins).toEqual(coinsFixture);
-        expect(store.getState().wallet.trading.info.platforms).toEqual(platformsFixture);
-        expect(
-            store.getActions().some(action => action.type === tradingActions.saveInfo.type),
-        ).toBe(false);
     });
+
+    it.each(['retry', 'expiry'] as const)(
+        'keeps existing coins and platforms when getInfo fails during %s',
+        async scenario => {
+            const timestamp = Date.now();
+            const { store, services } = initRoot({
+                info: {
+                    coins: coinsFixture,
+                    platforms: platformsFixture,
+                },
+                lastLoadedTimestamp: timestamp,
+            });
+            jest.mocked(tradeApi.getInfo).mockResolvedValueOnce(undefined);
+            if (scenario === 'expiry') {
+                jest.spyOn(Date, 'now').mockReturnValue(timestamp + TRADE_API_RELOAD_DATA_AFTER_MS);
+            }
+
+            await services
+                .dispatch(
+                    loadInitialDataThunk({
+                        activeSection: 'buy',
+                        forceReload: scenario === 'retry',
+                    }),
+                )
+                .unwrap();
+
+            expect(tradeApi.getInfo).toHaveBeenCalledTimes(1);
+            expect(store.getState().wallet.trading.info.coins).toEqual(coinsFixture);
+            expect(store.getState().wallet.trading.info.platforms).toEqual(platformsFixture);
+            expect(services.getActions().filter(tradingActions.saveInfo.match)).toHaveLength(0);
+        },
+    );
 });

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -28,6 +28,7 @@ import { loadSellInfoThunk } from '../sell/loadSellInfoThunk';
 export interface LoadInitialDataThunkProps {
     activeSection: TradingType;
     forcedApiKey?: string;
+    forceReload?: boolean;
 }
 
 type LoadInitialDataThunkState = TradingRootStateWithAccounts;
@@ -45,7 +46,7 @@ export const loadInitialDataThunk = createThunk<
     { state: LoadInitialDataThunkState; extra: LoadInitialDataThunkDeps }
 >(
     `${TRADING_THUNK_PREFIX}/loadInitialData`,
-    async ({ activeSection, forcedApiKey }, { dispatch, getState, extra }) => {
+    async ({ activeSection, forcedApiKey, forceReload = false }, { dispatch, getState, extra }) => {
         const selectedAccount = extra.services.getSelectedAccount();
         const account = selectTradingAccountAccordingActiveSection(
             getState(),
@@ -58,24 +59,52 @@ export const loadInitialDataThunk = createThunk<
         const { isLoading, lastLoadedTimestamp } = selectTradingLoadingAndTimestamp(getState());
         const { platforms, coins } = selectTradingInfo(getState());
 
-        const currentAccountDescriptor = tradeApi.getCurrentAccountDescriptor();
-        const isDifferentAccount = currentAccountDescriptor !== account?.descriptor;
-        const areDataOutdated = lastLoadedTimestamp + TRADE_API_RELOAD_DATA_AFTER_MS < Date.now();
-
         dispatch(tradingActions.setTradingActiveSection(activeSection));
 
-        if (!isLoading && (isDifferentAccount || areDataOutdated)) {
-            dispatch(tradingActions.setLoading({ isLoading: true }));
+        const apiKey = account?.descriptor || forcedApiKey || TRADING_FALLBACK_API_KEY;
+        tradeApi.createApiKey(apiKey);
 
-            const tradeServerEnvironment = extra.services.getTradingEnvironment();
-            if (tradeServerEnvironment) {
-                tradeApi.setServersEnvironment(tradeServerEnvironment);
+        const tradeServerEnvironment = extra.services.getTradingEnvironment();
+        if (tradeServerEnvironment) {
+            tradeApi.setServersEnvironment(tradeServerEnvironment);
+        }
+
+        const areDataOutdated =
+            lastLoadedTimestamp === 0 ||
+            Date.now() - lastLoadedTimestamp >= TRADE_API_RELOAD_DATA_AFTER_MS;
+        const shouldReloadAll = forceReload || areDataOutdated;
+        const isInfoMissing = !platforms || !coins;
+        const isAnythingMissing = isInfoMissing || !buyInfo || !exchangeInfo || !sellInfo;
+
+        if (isLoading || (!shouldReloadAll && !isAnythingMissing)) {
+            return;
+        }
+
+        const serverUrl = tradeApi.getApiServerUrl();
+        let updatedTimestamp = lastLoadedTimestamp;
+        dispatch(tradingActions.setLoading({ isLoading: true, lastLoadedTimestamp }));
+
+        try {
+            if (shouldReloadAll) {
+                const [info, buyInfoData, exchangeInfoData, sellInfoData] = await Promise.all([
+                    tradeApi.getInfo(),
+                    dispatch(loadBuyInfoThunk()).unwrap(),
+                    dispatch(loadExchangeInfoThunk()).unwrap(),
+                    dispatch(loadSellInfoThunk()).unwrap(),
+                ]);
+
+                if (info) {
+                    dispatch(tradingActions.saveInfo(info));
+                }
+                dispatch(tradingBuyActions.saveBuyInfo(buyInfoData));
+                dispatch(tradingExchangeActions.saveExchangeInfo(exchangeInfoData));
+                dispatch(tradingSellActions.saveSellInfo(sellInfoData));
+                updatedTimestamp = Date.now();
+
+                return;
             }
 
-            const apiKey = account?.descriptor || forcedApiKey || TRADING_FALLBACK_API_KEY;
-            tradeApi.createApiKey(apiKey);
-
-            if (isDifferentAccount || !platforms || !coins) {
+            if (isInfoMissing) {
                 const info = await tradeApi.getInfo();
 
                 // Skip saveInfo on failure so we never replace an existing catalog with empty data.
@@ -84,27 +113,33 @@ export const loadInitialDataThunk = createThunk<
                 }
             }
 
-            if (isDifferentAccount || !buyInfo) {
+            if (!buyInfo) {
                 const buyInfoData = await dispatch(loadBuyInfoThunk()).unwrap();
                 dispatch(tradingBuyActions.saveBuyInfo(buyInfoData));
             }
 
-            if (isDifferentAccount || !exchangeInfo) {
+            if (!exchangeInfo) {
                 const exchangeInfoData = await dispatch(loadExchangeInfoThunk()).unwrap();
 
                 dispatch(tradingExchangeActions.saveExchangeInfo(exchangeInfoData));
             }
 
-            if (isDifferentAccount || !sellInfo) {
+            if (!sellInfo) {
                 const sellInfoData = await dispatch(loadSellInfoThunk()).unwrap();
 
                 dispatch(tradingSellActions.saveSellInfo(sellInfoData));
             }
+        } finally {
+            const currentTimestamp =
+                selectTradingLoadingAndTimestamp(getState()).lastLoadedTimestamp;
+            const wasInvalidated =
+                currentTimestamp !== lastLoadedTimestamp ||
+                tradeApi.getApiServerUrl() !== serverUrl;
 
             dispatch(
                 tradingActions.setLoading({
                     isLoading: false,
-                    lastLoadedTimestamp: Date.now(),
+                    lastLoadedTimestamp: wasInvalidated ? 0 : updatedTimestamp,
                 }),
             );
         }

--- a/suite-native/module-trading/src/components/buy/BuyTab.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTab.test.tsx
@@ -114,17 +114,13 @@ describe('BuyTab', () => {
     });
 
     it('should reload data when server error info is displayed and user presses "Try again" button', async () => {
-        mockUseTradingBuyData
-            .mockReturnValueOnce({
-                isLoading: false,
-                lastLoadedTimestamp: 1,
-                isFullyLoaded: false,
-            })
-            .mockReturnValue({
-                isLoading: false,
-                lastLoadedTimestamp: 1,
-                isFullyLoaded: true,
-            });
+        const refetch = jest.fn();
+        mockUseTradingBuyData.mockReturnValue({
+            isLoading: false,
+            lastLoadedTimestamp: 1,
+            isFullyLoaded: false,
+            refetch,
+        });
 
         const { getByText } = await renderBuyTab();
 
@@ -134,10 +130,7 @@ describe('BuyTab', () => {
             await userEvent.press(reloadButton);
         });
 
-        expectBuyForm();
-        expect(mockUseTradingBuyData).toHaveBeenCalledTimes(2);
-        expect(mockUseTradingBuyData).toHaveBeenCalledWith(0);
-        expect(mockUseTradingBuyData).toHaveBeenCalledWith(1);
+        expect(refetch).toHaveBeenCalledTimes(1);
     });
 
     it('should render disabled info when buy is disabled by FFs', async () => {

--- a/suite-native/module-trading/src/components/buy/BuyTab.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTab.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import { ServerOffline } from '@suite-native/trading-atoms';
@@ -11,13 +11,12 @@ import { useBuyData } from '../../hooks/buy/useBuyData';
 import { TradingTypeDisabled } from '../general/Error/TradingTypeDisabled';
 
 const BuyTabEnabled = () => {
-    const [reloadOrdinal, setReloadOrdinal] = useState(0);
-    const { isLoading, lastLoadedTimestamp, isFullyLoaded } = useBuyData(reloadOrdinal);
+    const { isLoading, lastLoadedTimestamp, isFullyLoaded, refetch } = useBuyData();
     const isLoadingFinished = !isLoading && lastLoadedTimestamp > 0;
     const wasSkeletonDisplayed = useRef(!isLoadingFinished);
 
     if (isLoadingFinished && !isFullyLoaded) {
-        return <ServerOffline onRetryPress={() => setReloadOrdinal(n => n + 1)} />;
+        return <ServerOffline onRetryPress={refetch} />;
     }
 
     if (!isFullyLoaded) {

--- a/suite-native/module-trading/src/components/exchange/ExchangeTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeTabContent.test.tsx
@@ -110,17 +110,13 @@ describe('ExchangeTab', () => {
     });
 
     it('should reload data when server error info is displayed and user presses "Try again" button', async () => {
-        mockUseTradingExchangeData
-            .mockReturnValueOnce({
-                isLoading: false,
-                lastLoadedTimestamp: 1,
-                isFullyLoaded: false,
-            })
-            .mockReturnValue({
-                isLoading: false,
-                lastLoadedTimestamp: 1,
-                isFullyLoaded: true,
-            });
+        const refetch = jest.fn();
+        mockUseTradingExchangeData.mockReturnValue({
+            isLoading: false,
+            lastLoadedTimestamp: 1,
+            isFullyLoaded: false,
+            refetch,
+        });
 
         const { getByText } = await renderExchangeTab();
 
@@ -130,9 +126,6 @@ describe('ExchangeTab', () => {
             await userEvent.press(reloadButton);
         });
 
-        expectExchangeForm();
-        expect(mockUseTradingExchangeData).toHaveBeenCalledTimes(2);
-        expect(mockUseTradingExchangeData).toHaveBeenCalledWith(0);
-        expect(mockUseTradingExchangeData).toHaveBeenCalledWith(1);
+        expect(refetch).toHaveBeenCalledTimes(1);
     });
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangeTabContent.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeTabContent.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { ServerOffline } from '@suite-native/trading-atoms';
 
 import { ExchangeForm } from './ExchangeForm';
@@ -8,12 +6,11 @@ import { ExchangeFormSkeleton } from './ExchangeFormSkeleton';
 import { useExchangeData } from '../../hooks/exchange/useExchangeData';
 
 export const ExchangeTabContent = () => {
-    const [reloadOrdinal, setReloadOrdinal] = useState(0);
-    const { isLoading, lastLoadedTimestamp, isFullyLoaded } = useExchangeData(reloadOrdinal);
+    const { isLoading, lastLoadedTimestamp, isFullyLoaded, refetch } = useExchangeData();
     const isLoadingFinished = !isLoading && lastLoadedTimestamp > 0;
 
     if (isLoadingFinished && !isFullyLoaded) {
-        return <ServerOffline onRetryPress={() => setReloadOrdinal(n => n + 1)} />;
+        return <ServerOffline onRetryPress={refetch} />;
     }
 
     if (!isFullyLoaded) {

--- a/suite-native/module-trading/src/components/sell/SellTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellTabContent.test.tsx
@@ -108,17 +108,13 @@ describe('SellTabContent', () => {
     });
 
     it('should reload data when server error info is displayed and user presses "Try again" button', async () => {
-        mockUseSellData
-            .mockReturnValueOnce({
-                isLoading: false,
-                lastLoadedTimestamp: 1,
-                isFullyLoaded: false,
-            })
-            .mockReturnValue({
-                isLoading: false,
-                lastLoadedTimestamp: 1,
-                isFullyLoaded: true,
-            });
+        const refetch = jest.fn();
+        mockUseSellData.mockReturnValue({
+            isLoading: false,
+            lastLoadedTimestamp: 1,
+            isFullyLoaded: false,
+            refetch,
+        });
 
         const { getByText } = await renderSellTabContent();
 
@@ -128,9 +124,6 @@ describe('SellTabContent', () => {
             await userEvent.press(reloadButton);
         });
 
-        expectSellForm();
-        expect(mockUseSellData).toHaveBeenCalledTimes(2);
-        expect(mockUseSellData).toHaveBeenCalledWith(0);
-        expect(mockUseSellData).toHaveBeenCalledWith(1);
+        expect(refetch).toHaveBeenCalledTimes(1);
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellTabContent.tsx
+++ b/suite-native/module-trading/src/components/sell/SellTabContent.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { ServerOffline } from '@suite-native/trading-atoms';
 
 import { SellForm } from './SellForm';
@@ -8,12 +6,11 @@ import { SellFormSkeleton } from './SellFormSkeleton';
 import { useSellData } from '../../hooks/sell/useSellData';
 
 export const SellTabContent = () => {
-    const [reloadOrdinal, setReloadOrdinal] = useState(0);
-    const { isLoading, lastLoadedTimestamp, isFullyLoaded } = useSellData(reloadOrdinal);
+    const { isLoading, lastLoadedTimestamp, isFullyLoaded, refetch } = useSellData();
     const isLoadingFinished = !isLoading && lastLoadedTimestamp > 0;
 
     if (isLoadingFinished && !isFullyLoaded) {
-        return <ServerOffline onRetryPress={() => setReloadOrdinal(n => n + 1)} />;
+        return <ServerOffline onRetryPress={refetch} />;
     }
 
     if (!isFullyLoaded) {

--- a/suite-native/module-trading/src/hooks/buy/useBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/useBuyData.test.tsx
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { createTestStore } from '@suite-common/test-utils';
+import { createTestCompositionRoot } from '@suite-common/test-utils';
 import { tradingBuyActions, tradingThunks } from '@suite-common/trading';
 import { mockGetSelectedAccount, mockGetTradingEnvironment } from '@suite-common/trading/mocks';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
@@ -17,11 +17,8 @@ import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading
 import { tradingSlice } from '@suite-native/trading-state';
 
 import { useBuyData } from './useBuyData';
-
-jest.mock('@suite-common/trading', () => ({
-    ...jest.requireActual('@suite-common/trading'),
-    getRandomAccountDescriptor: () => 'random_string',
-}));
+import { useExchangeData } from '../exchange/useExchangeData';
+import { useSellData } from '../sell/useSellData';
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount2') });
@@ -60,17 +57,13 @@ describe('useBuyData', () => {
         };
         preloadedState.wallet.trading.buy.tradingAccountKey = tradingAccountKey;
 
-        return createTestStore({ extra, reducer, preloadedState });
+        return createTestCompositionRoot({ extra, reducer, preloadedState }).store;
     };
 
-    const renderUseBuyData = async (reloadRequestOrdinalInitialValue: number, store: TestStore) => {
-        const ret = await renderHookWithStoreProvider(
-            ({ reloadRequestOrdinal }) => useBuyData(reloadRequestOrdinal),
-            {
-                initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
-                store,
-            },
-        );
+    const renderUseBuyData = async (store: TestStore) => {
+        const ret = await renderHookWithStoreProvider(useBuyData, {
+            store,
+        });
 
         await act(() => Promise.resolve()); // Wait for all effects to run
 
@@ -78,10 +71,11 @@ describe('useBuyData', () => {
     };
 
     beforeEach(() => {
+        jest.restoreAllMocks();
         jest.clearAllMocks();
         global.fetch = jest.fn().mockImplementation(() =>
             Promise.resolve({
-                json: () => Promise.resolve({}),
+                json: () => Promise.resolve({ coins: {}, platforms: {}, config: {} }),
                 ok: true,
             }),
         );
@@ -93,49 +87,108 @@ describe('useBuyData', () => {
                 new Promise(resolve => {
                     setTimeout(() => {
                         resolve({
-                            json: () => Promise.resolve({}),
+                            json: () => Promise.resolve({ coins: {}, platforms: {}, config: {} }),
                             ok: true,
                         });
                     }, 100);
                 }),
         );
-        const store = createTestStore({ extra, reducer });
-        const { result } = await renderUseBuyData(0, store);
+        const { store } = createTestCompositionRoot({ extra, reducer });
+        const { result } = await renderUseBuyData(store);
 
         expect(result.current.isLoading).toBe(true);
         expect(result.current.lastLoadedTimestamp).toBe(0);
     });
 
     it('should settle after API queries are resolved', async () => {
-        const store = createTestStore({ extra, reducer });
-        const { result } = await renderUseBuyData(0, store);
+        const { store } = createTestCompositionRoot({ extra, reducer });
+        const { result } = await renderUseBuyData(store);
 
         expect(result.current.isLoading).toBe(false);
         expect(result.current.lastLoadedTimestamp).toBeGreaterThan(0);
     });
+
+    it.each([
+        { section: 'exchange', useData: useExchangeData },
+        { section: 'sell', useData: useSellData },
+        { section: 'buy', useData: useBuyData },
+    ])(
+        'reuses the catalog when remounting $section and refetches on Retry',
+        async ({ useData }) => {
+            const { store } = createTestCompositionRoot({ extra, reducer });
+            const buy = await renderUseBuyData(store);
+            await buy.unmount();
+            expect(global.fetch).toHaveBeenCalledTimes(4);
+
+            const tab = await renderHookWithStoreProvider(useData, { store });
+            expect(global.fetch).toHaveBeenCalledTimes(4);
+            await tab.unmount();
+
+            const retry = await renderHookWithStoreProvider(useData, { store });
+            expect(global.fetch).toHaveBeenCalledTimes(4);
+            await act(async () => {
+                await retry.result.current.refetch();
+            });
+            expect(global.fetch).toHaveBeenCalledTimes(8);
+            expect(jest.mocked(global.fetch).mock.calls.map(([url]) => url)).toEqual(
+                [
+                    ...[
+                        '/api/info',
+                        '/api/v3/buy/list',
+                        '/api/v3/exchange/list',
+                        '/api/v3/sell/list',
+                    ],
+                    ...[
+                        '/api/info',
+                        '/api/v3/buy/list',
+                        '/api/v3/exchange/list',
+                        '/api/v3/sell/list',
+                    ],
+                ].map(path => expect.stringContaining(path)),
+            );
+        },
+    );
 
     it('should dispatch loadInitialDataThunk only once', async () => {
         const initialThunkLoadActionSpy = jest
             .spyOn(tradingThunks, 'loadInitialDataThunk')
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
-        const store = createTestStore({ extra, reducer });
-        const { rerender } = await renderUseBuyData(0, store);
-        await rerender({ reloadRequestOrdinal: 0 });
+        const { store } = createTestCompositionRoot({ extra, reducer });
+        const { rerender } = await renderUseBuyData(store);
+        await rerender({});
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should dispatch loadInitialDataThunk when reloadRequestOrdinal changes', async () => {
+    it('should force reload on refetch and respect the cache on subsequent account changes', async () => {
         const initialThunkLoadActionSpy = jest
             .spyOn(tradingThunks, 'loadInitialDataThunk')
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
-        const store = createTestStore({ extra, reducer });
-        const { rerender } = await renderUseBuyData(0, store);
-        await rerender({ reloadRequestOrdinal: 1 });
+        const { store } = createTestCompositionRoot({ extra, reducer });
+        const { result } = await renderUseBuyData(store);
+        await act(async () => {
+            await result.current.refetch();
+        });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(2);
+        expect(initialThunkLoadActionSpy).toHaveBeenNthCalledWith(1, {
+            activeSection: 'buy',
+            forceReload: false,
+        });
+        expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
+            activeSection: 'buy',
+            forceReload: true,
+        });
+
+        await act(() => {
+            store.dispatch(tradingBuyActions.setTradingAccountKey(btc2Account.key));
+        });
+        expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
+            activeSection: 'buy',
+            forceReload: false,
+        });
     });
 
     describe('on receive account descriptor change', () => {
@@ -149,7 +202,7 @@ describe('useBuyData', () => {
 
         it('should dispatch loadInitialDataThunk when account is changed with descriptor', async () => {
             const store = getInitializedStore(undefined);
-            await renderUseBuyData(0, store);
+            await renderUseBuyData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -165,13 +218,13 @@ describe('useBuyData', () => {
 
             expect(initialThunkLoadActionSpy).toHaveBeenCalledWith({
                 activeSection: 'buy',
-                forcedApiKey: undefined,
+                forceReload: false,
             });
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
             const store = getInitializedStore(btc2Account.key);
-            await renderUseBuyData(0, store);
+            await renderUseBuyData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -188,9 +241,9 @@ describe('useBuyData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(0);
         });
 
-        it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
+        it('should dispatch loadInitialDataThunk without a forced API key when descriptor is empty string', async () => {
             const store = getInitializedStore(btc1Account.key);
-            await renderUseBuyData(0, store);
+            await renderUseBuyData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -207,13 +260,13 @@ describe('useBuyData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
             expect(initialThunkLoadActionSpy).toHaveBeenCalledWith({
                 activeSection: 'buy',
-                forcedApiKey: 'random_string',
+                forceReload: false,
             });
         });
 
-        it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
+        it('should dispatch loadInitialDataThunk without a forced API key when descriptor is undefined', async () => {
             const store = getInitializedStore(btc1Account.key);
-            await renderUseBuyData(0, store);
+            await renderUseBuyData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -230,7 +283,7 @@ describe('useBuyData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
             expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
                 activeSection: 'buy',
-                forcedApiKey: 'random_string',
+                forceReload: false,
             });
         });
     });

--- a/suite-native/module-trading/src/hooks/buy/useBuyData.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyData.ts
@@ -1,28 +1,32 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useDispatch } from '@suite-common/redux-utils';
-import {
-    getRandomAccountDescriptor,
-    selectTradingBuyLoadingTimestampAndStatus,
-    tradingThunks,
-} from '@suite-common/trading';
+import { selectTradingBuyLoadingTimestampAndStatus, tradingThunks } from '@suite-common/trading';
 import { selectBuySelectedReceiveAccount } from '@suite-native/trading-state';
 
-export const useBuyData = (reloadRequestOrdinal: number) => {
+export const useBuyData = () => {
     const dispatch = useDispatch();
     const selectedReceiveAccount = useSelector(selectBuySelectedReceiveAccount);
 
     const descriptor = selectedReceiveAccount?.account?.descriptor;
 
-    useEffect(() => {
-        dispatch(
-            tradingThunks.loadInitialDataThunk({
-                activeSection: 'buy',
-                forcedApiKey: !descriptor ? getRandomAccountDescriptor() : undefined,
-            }),
-        );
-    }, [descriptor, dispatch, reloadRequestOrdinal]);
+    const loadData = useCallback(
+        (forceReload = true) =>
+            dispatch(
+                tradingThunks.loadInitialDataThunk({
+                    activeSection: 'buy',
+                    forceReload,
+                }),
+            ),
+        [dispatch],
+    );
 
-    return useSelector(selectTradingBuyLoadingTimestampAndStatus);
+    useEffect(() => {
+        loadData(false);
+    }, [descriptor, loadData]);
+
+    const loadingStatus = useSelector(selectTradingBuyLoadingTimestampAndStatus);
+
+    return { ...loadingStatus, refetch: loadData };
 };

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeData.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeData.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { createTestStore } from '@suite-common/test-utils';
+import { createTestCompositionRoot } from '@suite-common/test-utils';
 import { tradingExchangeActions, tradingThunks } from '@suite-common/trading';
 import { mockGetSelectedAccount, mockGetTradingEnvironment } from '@suite-common/trading/mocks';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
@@ -17,11 +17,6 @@ import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading
 import { tradingSlice } from '@suite-native/trading-state';
 
 import { useExchangeData } from './useExchangeData';
-
-jest.mock('@suite-common/trading', () => ({
-    ...jest.requireActual('@suite-common/trading'),
-    getRandomAccountDescriptor: () => 'random_string',
-}));
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount2') });
@@ -56,7 +51,7 @@ describe('useExchangeData', () => {
         const tradingState = getInitializedTradingState('exchange');
         tradingState.exchange.tradingAccountKey = tradingAccountKey as any;
 
-        return createTestStore({
+        return createTestCompositionRoot({
             extra,
             reducer,
             preloadedState: {
@@ -64,22 +59,15 @@ describe('useExchangeData', () => {
                     trading: tradingState,
                 },
             },
-        });
+        }).store;
     };
 
-    const renderUseExchangeData = async (
-        reloadRequestOrdinalInitialValue: number = 0,
-        store?: TestStore,
-    ) => {
-        const effectiveStore = store ?? createTestStore({ extra, reducer });
+    const renderUseExchangeData = async (store?: TestStore) => {
+        const effectiveStore = store ?? createTestCompositionRoot({ extra, reducer }).store;
 
-        const ret = await renderHookWithStoreProvider(
-            ({ reloadRequestOrdinal }) => useExchangeData(reloadRequestOrdinal),
-            {
-                initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
-                store: effectiveStore,
-            },
-        );
+        const ret = await renderHookWithStoreProvider(useExchangeData, {
+            store: effectiveStore,
+        });
 
         await act(() => Promise.resolve()); // Wait for all effects to run
 
@@ -87,6 +75,7 @@ describe('useExchangeData', () => {
     };
 
     beforeEach(() => {
+        jest.restoreAllMocks();
         jest.clearAllMocks();
         global.fetch = jest.fn().mockImplementation(() =>
             Promise.resolve({
@@ -127,20 +116,39 @@ describe('useExchangeData', () => {
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
         const { rerender } = await renderUseExchangeData();
-        await rerender({ reloadRequestOrdinal: 0 });
+        await rerender({});
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should dispatch loadInitialDataThunk when reloadRequestOrdinal changes', async () => {
+    it('should force reload on refetch and respect the cache on subsequent account changes', async () => {
         const initialThunkLoadActionSpy = jest
             .spyOn(tradingThunks, 'loadInitialDataThunk')
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
-        const { rerender } = await renderUseExchangeData();
-        await rerender({ reloadRequestOrdinal: 1 });
+        const { store } = createTestCompositionRoot({ extra, reducer });
+        const { result } = await renderUseExchangeData(store);
+        await act(async () => {
+            await result.current.refetch();
+        });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(2);
+        expect(initialThunkLoadActionSpy).toHaveBeenNthCalledWith(1, {
+            activeSection: 'exchange',
+            forceReload: false,
+        });
+        expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
+            activeSection: 'exchange',
+            forceReload: true,
+        });
+
+        await act(() => {
+            store.dispatch(tradingExchangeActions.setTradingAccountKey(btc2Account.key));
+        });
+        expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
+            activeSection: 'exchange',
+            forceReload: false,
+        });
     });
 
     describe('on send account descriptor change', () => {
@@ -154,7 +162,7 @@ describe('useExchangeData', () => {
 
         it('should dispatch loadInitialDataThunk when account is changed with descriptor', async () => {
             const store = getInitializedStore(undefined);
-            await renderUseExchangeData(0, store);
+            await renderUseExchangeData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -170,13 +178,13 @@ describe('useExchangeData', () => {
 
             expect(initialThunkLoadActionSpy).toHaveBeenCalledWith({
                 activeSection: 'exchange',
-                forcedApiKey: undefined,
+                forceReload: false,
             });
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
             const store = getInitializedStore(btc2Account.key);
-            await renderUseExchangeData(0, store);
+            await renderUseExchangeData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -193,9 +201,9 @@ describe('useExchangeData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(0);
         });
 
-        it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
+        it('should dispatch loadInitialDataThunk without a forced API key when descriptor is empty string', async () => {
             const store = getInitializedStore(btc1Account.key);
-            await renderUseExchangeData(0, store);
+            await renderUseExchangeData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -212,13 +220,13 @@ describe('useExchangeData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
             expect(initialThunkLoadActionSpy).toHaveBeenCalledWith({
                 activeSection: 'exchange',
-                forcedApiKey: 'random_string',
+                forceReload: false,
             });
         });
 
-        it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
+        it('should dispatch loadInitialDataThunk without a forced API key when descriptor is undefined', async () => {
             const store = getInitializedStore(btc1Account.key);
-            await renderUseExchangeData(0, store);
+            await renderUseExchangeData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -235,7 +243,7 @@ describe('useExchangeData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
             expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
                 activeSection: 'exchange',
-                forcedApiKey: 'random_string',
+                forceReload: false,
             });
         });
     });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeData.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeData.ts
@@ -1,28 +1,35 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useDispatch } from '@suite-common/redux-utils';
 import {
-    getRandomAccountDescriptor,
     selectTradingExchangeLoadingTimestampAndStatus,
     tradingThunks,
 } from '@suite-common/trading';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
-export const useExchangeData = (reloadRequestOrdinal: number) => {
+export const useExchangeData = () => {
     const dispatch = useDispatch();
     const account = useSelector(selectExchangeSelectedSendAccount);
 
     const descriptor = account?.descriptor;
 
-    useEffect(() => {
-        dispatch(
-            tradingThunks.loadInitialDataThunk({
-                activeSection: 'exchange',
-                forcedApiKey: descriptor ? undefined : getRandomAccountDescriptor(),
-            }),
-        );
-    }, [descriptor, dispatch, reloadRequestOrdinal]);
+    const loadData = useCallback(
+        (forceReload = true) =>
+            dispatch(
+                tradingThunks.loadInitialDataThunk({
+                    activeSection: 'exchange',
+                    forceReload,
+                }),
+            ),
+        [dispatch],
+    );
 
-    return useSelector(selectTradingExchangeLoadingTimestampAndStatus);
+    useEffect(() => {
+        loadData(false);
+    }, [descriptor, loadData]);
+
+    const loadingStatus = useSelector(selectTradingExchangeLoadingTimestampAndStatus);
+
+    return { ...loadingStatus, refetch: loadData };
 };

--- a/suite-native/module-trading/src/hooks/sell/useSellData.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/useSellData.test.tsx
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { createTestStore } from '@suite-common/test-utils';
+import { createTestCompositionRoot } from '@suite-common/test-utils';
 import { tradingSellActions, tradingThunks } from '@suite-common/trading';
 import { mockGetSelectedAccount, mockGetTradingEnvironment } from '@suite-common/trading/mocks';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
@@ -17,11 +17,6 @@ import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading
 import { tradingSlice } from '@suite-native/trading-state';
 
 import { useSellData } from './useSellData';
-
-jest.mock('@suite-common/trading', () => ({
-    ...jest.requireActual('@suite-common/trading'),
-    getRandomAccountDescriptor: () => 'random_string',
-}));
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount2') });
@@ -56,7 +51,7 @@ describe('useSellData', () => {
         const tradingState = getInitializedTradingState('sell');
         tradingState.sell!.tradingAccountKey = tradingAccountKey;
 
-        return createTestStore({
+        return createTestCompositionRoot({
             extra,
             reducer,
             preloadedState: {
@@ -64,22 +59,15 @@ describe('useSellData', () => {
                     trading: tradingState,
                 },
             },
-        });
+        }).store;
     };
 
-    const getDefaultStore = () => createTestStore({ extra, reducer });
+    const getDefaultStore = () => createTestCompositionRoot({ extra, reducer }).store;
 
-    const renderUseSellData = async (
-        reloadRequestOrdinalInitialValue: number = 0,
-        store?: TestStore,
-    ) => {
-        const ret = await renderHookWithStoreProvider(
-            ({ reloadRequestOrdinal }) => useSellData(reloadRequestOrdinal),
-            {
-                initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
-                store: store ?? getDefaultStore(),
-            },
-        );
+    const renderUseSellData = async (store?: TestStore) => {
+        const ret = await renderHookWithStoreProvider(useSellData, {
+            store: store ?? getDefaultStore(),
+        });
 
         await act(() => Promise.resolve()); // Wait for all effects to run
 
@@ -87,6 +75,7 @@ describe('useSellData', () => {
     };
 
     beforeEach(() => {
+        jest.restoreAllMocks();
         jest.clearAllMocks();
         global.fetch = jest.fn().mockImplementation(() =>
             Promise.resolve({
@@ -127,20 +116,39 @@ describe('useSellData', () => {
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
         const { rerender } = await renderUseSellData();
-        await rerender({ reloadRequestOrdinal: 0 });
+        await rerender({});
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should dispatch loadInitialDataThunk when reloadRequestOrdinal changes', async () => {
+    it('should force reload on refetch and respect the cache on subsequent account changes', async () => {
         const initialThunkLoadActionSpy = jest
             .spyOn(tradingThunks, 'loadInitialDataThunk')
             .mockImplementation((() => ({ type: 'TEST_ACTION' })) as () => any);
 
-        const { rerender } = await renderUseSellData();
-        await rerender({ reloadRequestOrdinal: 1 });
+        const { store } = createTestCompositionRoot({ extra, reducer });
+        const { result } = await renderUseSellData(store);
+        await act(async () => {
+            await result.current.refetch();
+        });
 
         expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(2);
+        expect(initialThunkLoadActionSpy).toHaveBeenNthCalledWith(1, {
+            activeSection: 'sell',
+            forceReload: false,
+        });
+        expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
+            activeSection: 'sell',
+            forceReload: true,
+        });
+
+        await act(() => {
+            store.dispatch(tradingSellActions.setTradingAccountKey(btc2Account.key));
+        });
+        expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
+            activeSection: 'sell',
+            forceReload: false,
+        });
     });
 
     describe('on send account descriptor change', () => {
@@ -154,7 +162,7 @@ describe('useSellData', () => {
 
         it('should dispatch loadInitialDataThunk when account is changed with descriptor', async () => {
             const store = getInitializedStore(undefined);
-            await renderUseSellData(0, store);
+            await renderUseSellData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -170,13 +178,13 @@ describe('useSellData', () => {
 
             expect(initialThunkLoadActionSpy).toHaveBeenCalledWith({
                 activeSection: 'sell',
-                forcedApiKey: undefined,
+                forceReload: false,
             });
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
             const store = getInitializedStore(btc2Account.key);
-            await renderUseSellData(0, store);
+            await renderUseSellData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -193,9 +201,9 @@ describe('useSellData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(0);
         });
 
-        it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
+        it('should dispatch loadInitialDataThunk without a forced API key when descriptor is empty string', async () => {
             const store = getInitializedStore(btc1Account.key);
-            await renderUseSellData(0, store);
+            await renderUseSellData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -212,13 +220,13 @@ describe('useSellData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
             expect(initialThunkLoadActionSpy).toHaveBeenCalledWith({
                 activeSection: 'sell',
-                forcedApiKey: 'random_string',
+                forceReload: false,
             });
         });
 
-        it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
+        it('should dispatch loadInitialDataThunk without a forced API key when descriptor is undefined', async () => {
             const store = getInitializedStore(btc1Account.key);
-            await renderUseSellData(0, store);
+            await renderUseSellData(store);
 
             // Clear the initial call
             initialThunkLoadActionSpy.mockClear();
@@ -235,7 +243,7 @@ describe('useSellData', () => {
             expect(initialThunkLoadActionSpy).toHaveBeenCalledTimes(1);
             expect(initialThunkLoadActionSpy).toHaveBeenLastCalledWith({
                 activeSection: 'sell',
-                forcedApiKey: 'random_string',
+                forceReload: false,
             });
         });
     });

--- a/suite-native/module-trading/src/hooks/sell/useSellData.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellData.ts
@@ -1,28 +1,32 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useDispatch } from '@suite-common/redux-utils';
-import {
-    getRandomAccountDescriptor,
-    selectTradingSellLoadingTimestampAndStatus,
-    tradingThunks,
-} from '@suite-common/trading';
+import { selectTradingSellLoadingTimestampAndStatus, tradingThunks } from '@suite-common/trading';
 import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
 
-export const useSellData = (reloadRequestOrdinal: number) => {
+export const useSellData = () => {
     const dispatch = useDispatch();
     const account = useSelector(selectSellSelectedSendAccount);
 
     const descriptor = account?.descriptor;
 
-    useEffect(() => {
-        dispatch(
-            tradingThunks.loadInitialDataThunk({
-                activeSection: 'sell',
-                forcedApiKey: descriptor ? undefined : getRandomAccountDescriptor(),
-            }),
-        );
-    }, [descriptor, dispatch, reloadRequestOrdinal]);
+    const loadData = useCallback(
+        (forceReload = true) =>
+            dispatch(
+                tradingThunks.loadInitialDataThunk({
+                    activeSection: 'sell',
+                    forceReload,
+                }),
+            ),
+        [dispatch],
+    );
 
-    return useSelector(selectTradingSellLoadingTimestampAndStatus);
+    useEffect(() => {
+        loadData(false);
+    }, [descriptor, loadData]);
+
+    const loadingStatus = useSelector(selectTradingSellLoadingTimestampAndStatus);
+
+    return { ...loadingStatus, refetch: loadData };
 };

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -247,7 +247,9 @@ export class TradingPage {
         await this.inputs.selectCountryOfResidence(country);
         await this.inputs.selectFiatCurrency(fiatCurrencyCode);
         const isFiatRateLoadingFlag = `wallet.fiat.current.${networkSymbolOrTokenId}-${fiatCurrencyCode}.isLoading`;
-        await this.page.expectReduxObjectToEqual(isFiatRateLoadingFlag, false);
+        await this.page.expectReduxObjectToEqual(isFiatRateLoadingFlag, false, {
+            timeout: 30_000,
+        });
         await this.inputs.cryptoAmount.fill(cryptoAmount);
         await expect(
             this.page.getByText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage),

--- a/suite/e2e/tests/trading/sell-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/sell-bitcoin.test.ts
@@ -29,6 +29,7 @@ test.describe('Trading - Sell BTC', { tag: ['@T3W1', '@T3T1'] }, () => {
             walletPage,
             tradingPage,
             tradingMockNew,
+            tradingResponses,
         }) => {
             tradingMockNew.setTradeFlow('sell');
             await tradingMockNew.rewriteProviderRedirect();
@@ -47,6 +48,7 @@ test.describe('Trading - Sell BTC', { tag: ['@T3W1', '@T3T1'] }, () => {
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openTrading({ symbol: 'btc' });
             await tradingPage.sellTabButton.click();
+            await tradingResponses.sell.list();
         },
     );
 


### PR DESCRIPTION
## Description

- Reduce redundant network requests triggered by trade form data loading.
- Update shared trading state and initial data loading for buy, sell, and exchange flows.

## Notes for QA

- Verify buy, sell, and exchange flows load correctly without unnecessary repeated requests.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/32158

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/32158-heavy-network-requests-in-trade-form/web/](https://dev.suite.sldev.cz/suite-web/fix/32158-heavy-network-requests-in-trade-form/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/32158-heavy-network-requests-in-trade-form&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/32158-heavy-network-requests-in-trade-form&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/32158-heavy-network-requests-in-trade-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T13:06:15.405Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T13:05:38.850Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->