### PR TITLE
fix(suite-native): use compact/exact formatters in earn deposit amounts

### DIFF
--- a/suite-native/module-earn/src/components/yield/YieldDepositApprovedAmountCard.tsx
+++ b/suite-native/module-earn/src/components/yield/YieldDepositApprovedAmountCard.tsx
@@ -1,10 +1,9 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type TokenSymbol } from '@suite-common/wallet-types';
+import { type TokenSymbol, toTokenSymbol } from '@suite-common/wallet-types';
 import { Card, HStack, PressableOpacity, Text } from '@suite-native/atoms';
+import { ExactTokenAmountFormatter, asDecimalTokenAmount } from '@suite-native/formatters';
 import { Icon, TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-
-import { YieldFormattedAmount } from './YieldFormattedAmount';
 
 type YieldDepositApprovedAmountCardProps = {
     actionType?: 'edit' | 'revoke';
@@ -40,12 +39,10 @@ export const YieldDepositApprovedAmountCard = ({
                     </Text>
                 ) : null}
                 {!isApprovedAmountUnlimited && approvedAmount ? (
-                    <YieldFormattedAmount
-                        value={approvedAmount}
-                        networkSymbol={networkSymbol}
-                        tokenContract={tokenContract}
-                        tokenDecimals={tokenDecimals}
-                        tokenSymbol={tokenSymbol}
+                    <ExactTokenAmountFormatter
+                        value={asDecimalTokenAmount(approvedAmount)}
+                        tokenSymbol={toTokenSymbol(tokenSymbol)}
+                        maxDisplayedDecimals={tokenDecimals}
                         variant="body-sm-strong"
                         color="contentPrimary"
                         numberOfLines={1}

--- a/suite-native/module-earn/src/components/yield/YieldDepositFlowScreenHeader.tsx
+++ b/suite-native/module-earn/src/components/yield/YieldDepositFlowScreenHeader.tsx
@@ -1,12 +1,10 @@
 import { type ReactNode } from 'react';
-import { useSelector } from 'react-redux';
 
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetwork } from '@suite-common/wallet-config';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
-import { formatCoinBalance } from '@suite-common/wallet-utils';
-import { Box, DiscreetText, HStack, IconButton, Text, VStack } from '@suite-native/atoms';
+import { Box, HStack, IconButton, Text, VStack } from '@suite-native/atoms';
+import { CompactCryptoAmountFormatter } from '@suite-native/formatters';
 import { TokenIcon } from '@suite-native/icons';
-import { selectSupportedLanguageLocale } from '@suite-native/intl';
 import { type CloseActionType, ScreenHeader } from '@suite-native/navigation';
 
 type YieldDepositFlowScreenHeaderProps = {
@@ -26,11 +24,7 @@ export const YieldDepositFlowScreenHeader = ({
     title,
     tokenContract,
 }: YieldDepositFlowScreenHeaderProps) => {
-    const locale = useSelector(selectSupportedLanguageLocale);
     const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
-    // Same format as the desktop yield page header: `formatCoinBalance` keeps the leading
-    // significant digits and appends an ellipsis (…) once the fractional part gets too long.
-    const formattedBalance = `${formatCoinBalance(account.formattedBalance, locale)} ${getNetworkDisplaySymbol(account.symbol)}`;
 
     return (
         <ScreenHeader
@@ -60,14 +54,14 @@ export const YieldDepositFlowScreenHeader = ({
                                     {accountLabel}
                                 </Text>
                             </Box>
-                            <DiscreetText
+                            <CompactCryptoAmountFormatter
+                                value={account.formattedBalance}
+                                symbol={account.symbol}
                                 variant="body-xs"
                                 color="contentSecondary"
                                 numberOfLines={1}
                                 testID="@yield/flow-header/balance"
-                            >
-                                {formattedBalance}
-                            </DiscreetText>
+                            />
                         </HStack>
                     </VStack>
                 </HStack>


### PR DESCRIPTION
## Description

Aligns the earn deposit screen with the shared crypto-amount formatting policy (#31420):

- Header top-bar balance: now compact (`CompactCryptoAmountFormatter`) instead of truncated-exact `formatCoinBalance`.
- Approved amount: now exact/full-precision (`ExactTokenAmountFormatter`) instead of compact.

## Notes for QA

On the earn deposit screen: header balance shows compact, approved amount shows the exact value, and discreet mode hides both.

## Related Issue

Resolve #32170

## Screenshots:

<img width="434" height="889" alt="Screenshot 2026-09-07 at 15 17 50" src="https://github.com/user-attachments/assets/df5e8a5d-62f6-4d9a-a032-8bd6df807bd3" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-earn-deposit-amount-formatting&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->