### PR TITLE
fix(suite-desktop-core): defensive code conditions for undefined browserWindow

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -16,6 +16,7 @@ import { isAutoStartEnabled, promptForAutoStartBeforeQuit } from './libs/auto-st
 import { APP_NAME } from './libs/constants';
 import { createElectronSessionInterceptor } from './libs/create-electron-session-interceptor';
 import { getBuildInfo, getComputerInfo } from './libs/info';
+import { isMainWindowUsable } from './libs/isMainWindowUsable';
 import { loadIndex } from './libs/loadIndex';
 import { Logger } from './libs/logger';
 import { MainWindowProxy } from './libs/main-window-proxy';
@@ -52,9 +53,6 @@ type CreateMainWindowParams = {
     store: Store;
     cspNonce: string;
 };
-
-const isMainWindowUsable = (mainWindow: BrowserWindow | undefined): mainWindow is BrowserWindow =>
-    !!mainWindow && !mainWindow.isDestroyed();
 
 const createMainWindow = ({ winBounds, cspNonce, store }: CreateMainWindowParams) => {
     const darkTheme =
@@ -409,7 +407,12 @@ const init = async () => {
                 // https://source.chromium.org/chromium/chromium/src/+/main:net/base/net_error_list.h
                 if (!isMainFrame || errorCode === -3) return;
                 // Delay retry to avoid a busy loop if the failure persists.
-                setTimeout(() => loadIndex(mainWindow), 1000);
+                setTimeout(() => {
+                    // Main Suite window was closed, no point in loading index.
+                    if (!isMainWindowUsable(mainWindow)) return;
+
+                    loadIndex(mainWindow);
+                }, 1000);
             },
         );
 

--- a/packages/suite-desktop-core/src/handshake-and-hang-detect.ts
+++ b/packages/suite-desktop-core/src/handshake-and-hang-detect.ts
@@ -3,6 +3,7 @@ import { type BrowserWindow, dialog } from 'electron';
 import { type TimerId } from '@trezor/type-utils';
 
 import { ipcMain } from './ipcMain';
+import { isMainWindowUsable } from './libs/isMainWindowUsable';
 import { loadIndex } from './libs/loadIndex';
 
 const HANG_WAIT = 30000;
@@ -40,7 +41,7 @@ export const handshakeAndHangDetect = ({
     const handshake = new Promise<HandshakeResult>(resolve => {
         const timeoutCallback = async () => {
             // if renderer process was killed during timeout, then do not invoke any renderer api
-            if (mainWindow.isDestroyed()) return {};
+            if (!isMainWindowUsable(mainWindow)) return {};
 
             // TODO: what happen if handshake will be fired up after timeout?
             const result = await showDialog(mainWindow);

--- a/packages/suite-desktop-core/src/libs/auto-start.ts
+++ b/packages/suite-desktop-core/src/libs/auto-start.ts
@@ -7,10 +7,8 @@ import { createDeferred } from '@trezor/utils';
 
 import { ipcMain } from '../ipcMain';
 import { app } from '../typed-electron';
+import { isMainWindowUsable } from './isMainWindowUsable';
 import { type Store } from './store';
-
-const canUseWindowForAutoStartPrompt = (mainWindow: BrowserWindow) =>
-    !mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed();
 
 // Linux autostart desktop file
 const getLinuxExecutable = () => {
@@ -89,7 +87,7 @@ export const promptForAutoStartBeforeQuit = async (mainWindow: BrowserWindow, st
         isAutoStartEnabled() ||
         store.getConnectSettings().autoStartDontAskAgain ||
         !store.getConnectSettings().hasUsedConnectWs ||
-        !canUseWindowForAutoStartPrompt(mainWindow)
+        !isMainWindowUsable(mainWindow)
     ) {
         return true;
     }

--- a/packages/suite-desktop-core/src/libs/isMainWindowUsable.test.ts
+++ b/packages/suite-desktop-core/src/libs/isMainWindowUsable.test.ts
@@ -1,0 +1,44 @@
+import { type BrowserWindow } from 'electron';
+
+import { isMainWindowUsable } from './isMainWindowUsable';
+
+type CreateMainWindowMockParams = {
+    isDestroyed?: boolean;
+    isWebContentsDestroyed?: boolean;
+};
+
+type MainWindowMock = Pick<BrowserWindow, 'isDestroyed' | 'webContents'>;
+
+const createMainWindowMock = ({
+    isDestroyed = false,
+    isWebContentsDestroyed = false,
+}: CreateMainWindowMockParams = {}): MainWindowMock => ({
+    isDestroyed: () => isDestroyed,
+    webContents: {
+        isDestroyed: () => isWebContentsDestroyed,
+    } as BrowserWindow['webContents'],
+});
+
+describe('isMainWindowUsable', () => {
+    it('returns false for undefined window', () => {
+        expect(isMainWindowUsable(undefined)).toBe(false);
+    });
+
+    it('returns false for destroyed window', () => {
+        const mainWindow = createMainWindowMock({ isDestroyed: true });
+
+        expect(isMainWindowUsable(mainWindow as BrowserWindow)).toBe(false);
+    });
+
+    it('returns false for destroyed webContents', () => {
+        const mainWindow = createMainWindowMock({ isWebContentsDestroyed: true });
+
+        expect(isMainWindowUsable(mainWindow as BrowserWindow)).toBe(false);
+    });
+
+    it('returns true for usable window', () => {
+        const mainWindow = createMainWindowMock();
+
+        expect(isMainWindowUsable(mainWindow as BrowserWindow)).toBe(true);
+    });
+});

--- a/packages/suite-desktop-core/src/libs/isMainWindowUsable.ts
+++ b/packages/suite-desktop-core/src/libs/isMainWindowUsable.ts
@@ -1,0 +1,6 @@
+import { type BrowserWindow } from 'electron';
+
+export const isMainWindowUsable = (
+    mainWindow: BrowserWindow | undefined,
+): mainWindow is BrowserWindow =>
+    !!mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed();

--- a/packages/suite-desktop-core/src/libs/main-window-proxy.ts
+++ b/packages/suite-desktop-core/src/libs/main-window-proxy.ts
@@ -1,6 +1,7 @@
 import { TypedEmitter } from '@trezor/utils';
 
 import { type StrictBrowserWindow } from '../typed-electron';
+import { isMainWindowUsable } from './isMainWindowUsable';
 
 interface MainWindowProxyEvents {
     init: StrictBrowserWindow;
@@ -24,7 +25,7 @@ export class MainWindowProxy extends TypedEmitter<MainWindowProxyEvents> {
     }
 
     getInstance() {
-        if (this.instance?.isDestroyed()) {
+        if (!isMainWindowUsable(this.instance)) {
             this.destroyInstance();
         }
 

--- a/packages/suite-desktop-core/src/modules/bioAuthModule.ts
+++ b/packages/suite-desktop-core/src/modules/bioAuthModule.ts
@@ -6,6 +6,7 @@ import { TypedEmitter, serializeError } from '@trezor/utils';
 
 import { ipcMain } from '../ipcMain';
 import { type Dependencies } from './module';
+import { isMainWindowUsable } from '../libs/isMainWindowUsable';
 
 const PROMPT_REASON = 'Trezor Suite: validation BIO authentication to access the Suite UI';
 const BLUR_LOCK_TIMEOUT_MS = 5 * 60 * 1000;
@@ -319,9 +320,12 @@ export const initBioAuthModule = ({
                     if (prevAvailable === value) return;
                     prevAvailable = value;
                     logger.info('bioAuth', `Availability changed: ${value}`);
-                    mainWindowProxy
-                        .getInstance()
-                        ?.webContents.send('bio-auth/bio-auth-availability-changed', value);
+                    const mainWindow = mainWindowProxy.getInstance();
+
+                    // Main Suite window was closed, no point in responding with IPC event.
+                    if (!isMainWindowUsable(mainWindow)) return;
+
+                    mainWindow.webContents.send('bio-auth/bio-auth-availability-changed', value);
                 });
             }, 10_000);
         });

--- a/packages/suite-desktop-core/src/modules/bridge.ts
+++ b/packages/suite-desktop-core/src/modules/bridge.ts
@@ -7,6 +7,7 @@ import { scheduleAction } from '@trezor/utils';
 
 import { ipcMain } from '../ipcMain';
 import type { Dependencies } from './module';
+import { isMainWindowUsable } from '../libs/isMainWindowUsable';
 import { hasSwitch } from '../libs/process-switches';
 import { ThreadProxy } from '../libs/thread-proxy';
 import { b2t } from '../libs/utils';
@@ -93,7 +94,12 @@ const handleBridgeStatus = async ({
     const status = await bridge.status();
     logger.info('bridge', `Toggling bridge. Status: ${JSON.stringify(status)}`);
 
-    mainWindowProxy.getInstance()?.webContents.send('bridge/status', status);
+    // Respond with IPC event only if the main Suite window is open, but Suite can also run in daemon mode → then just continue.
+    const mainWindow = mainWindowProxy.getInstance();
+    if (isMainWindowUsable(mainWindow)) {
+        mainWindow.webContents.send('bridge/status', status);
+    }
+
     mainThreadEmitter.emit('module/bridge/status', status);
 
     return status;

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -12,6 +12,7 @@ import { type BootstrapEvent } from '@trezor/request-manager';
 import { type BootstrapTorEvent, type HandshakeTorModule } from '@trezor/suite-desktop-api';
 
 import { ipcMain } from '../ipcMain';
+import { isMainWindowUsable } from '../libs/isMainWindowUsable';
 import { hasSwitch } from '../libs/process-switches';
 import { TorExternalProcess } from '../libs/processes/TorExternalProcess';
 import { TorProcess, type TorProcessStatus } from '../libs/processes/TorProcess';
@@ -108,8 +109,13 @@ const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies)
     };
 
     const handleBootstrapEvent = (bootstrapEvent: BootstrapEvent) => {
+        const mainWindow = mainWindowProxy.getInstance();
+
+        // Main Suite window was closed, no point in responding with IPC event.
+        if (!isMainWindowUsable(mainWindow)) return;
+
         if (bootstrapEvent.type === 'slow') {
-            mainWindowProxy.getInstance()?.webContents.send('tor/bootstrap', {
+            mainWindow.webContents.send('tor/bootstrap', {
                 type: 'slow',
             });
         }
@@ -128,7 +134,7 @@ const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies)
                 },
             };
 
-            mainWindowProxy.getInstance()?.webContents.send('tor/bootstrap', event);
+            mainWindow.webContents.send('tor/bootstrap', event);
         }
     };
 


### PR DESCRIPTION
## Description

Add or complete defensive code conditions to early return in `suite-desktop-core` when browser window is gone.
Attempt to fix sentry errors [like this one](https://satoshilabs.sentry.io/issues/7703594634/?project=5193825&seerDrawer=true).

We should check `BrowserWindow.isDestroyed()` **as well as** `BrowserWindow.webContents.isDestroyed()`.
The former is the window itself (for resizing, moving handles), the other for web contents, i.e. JS execution, i.e. IPC.
Supposedly they can close at different times, creating time window for race conditions?
Idk, might help. 

## Notes for QA

Shouldn't direclty affect much, only fix theoretical race conditions edgecases.
→ Just regular RC checks – nothing in Suite Desktop is broken.

## Related Issue

Resolve https://satoshilabs.sentry.io/issues/7703594634/?project=5193825

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all in the Electron main process, touching app startup, bridge lifecycle, main-window proxy, hang detection, auto-start, Tor, and bio-auth. Only the bridge-spawning behavior has clear E2E coverage in this test corpus, so those tests are the highest priority. A single desktop smoke test for window-focus behavior provides secondary confidence in main-process changes. Several changed modules have no matching E2E coverage and should be validated manually or with lower-level tests.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite-desktop-core/src/app.ts`
- `packages/suite-desktop-core/src/handshake-and-hang-detect.ts`
- `packages/suite-desktop-core/src/libs/auto-start.ts`
- `packages/suite-desktop-core/src/libs/isMainWindowUsable.test.ts`
- `packages/suite-desktop-core/src/libs/isMainWindowUsable.ts`
- `packages/suite-desktop-core/src/libs/main-window-proxy.ts`
- `packages/suite-desktop-core/src/modules/bioAuthModule.ts`
- `packages/suite-desktop-core/src/modules/bridge.ts`
- `packages/suite-desktop-core/src/modules/tor.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test launches the Electron app in bridge-daemon mode and as a normal UI instance, directly exercising the app startup logic and the bridge module's spawn/lifecycle behavior that are being changed.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — It verifies the desktop app spawns and stops the bundled bridge on launch/quit, bridge API responses, and device reconnection after an external bridge restart — all code paths affected by the bridge module and main app lifecycle changes.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This desktop-only test asserts that TrezorConnect calls do or do not bring the Suite window to the foreground, which depends on the main process app/focus and main-window handling that changed files influence.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite-desktop-core/src/handshake-and-hang-detect.ts`
- `packages/suite-desktop-core/src/libs/auto-start.ts`
- `packages/suite-desktop-core/src/libs/isMainWindowUsable.test.ts`
- `packages/suite-desktop-core/src/libs/isMainWindowUsable.ts`
- `packages/suite-desktop-core/src/modules/bioAuthModule.ts`
- `packages/suite-desktop-core/src/modules/tor.ts`

_Updated: 2026-09-08T11:06:01.828Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/win-is-not-defined/web/](https://dev.suite.sldev.cz/suite-web/fix/win-is-not-defined/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/win-is-not-defined&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/win-is-not-defined&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T11:08:38.267Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T11:07:49.021Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->