### PR TITLE
feat(suite-native): replace max button with toggle in yield flows

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
@@ -8,6 +8,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { useYieldOpportunity } from '@suite-common/earn-stablecoin-api';
 import { parseCryptoId, toTokenCryptoId } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
+import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { isWrappedNativeToken } from '@trezor/network-ethereum-suite-common';
 import { exhaustive } from '@trezor/type-utils';
@@ -65,7 +66,9 @@ export const YieldApproveModal = ({
               }
             : getAssetLogoUrl({
                   coingeckoId: networkId,
-                  contractAddress: parsedContract,
+                  contractAddress: parsedContract
+                      ? getContractAddressForNetworkSymbol(account.symbol, parsedContract)
+                      : undefined,
                   size: 80,
               }),
         label: 'TR_EARN_YIELD_VAULT',

--- a/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.test.ts
+++ b/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.test.ts
@@ -9,10 +9,6 @@ const underlyingTokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 const receiptTokenAddress = '0xde6c23e561f3e55846207ec45a91b777e0f7c889';
 const yieldId = 'ethereum-usdc-steakusdc';
 
-// Blockbook returns EVM token contracts checksummed rather than lowercased. The exact
-// checksum does not matter here, only that the casing differs from the normalized form.
-const toBackendContractCasing = (address: string) => `0x${address.slice(2).toUpperCase()}`;
-
 const account = {
     key: accountKey,
     symbol: 'eth',
@@ -122,27 +118,6 @@ describe('getResolvedYieldFlowData', () => {
 
         expect(result.flowKey).toBe(`${accountKey}:${yieldId}:${receiptTokenAddress}`);
         expect(result.depositedSharesAmount).toBe('1.5');
-    });
-
-    it('normalizes the contract casing the backend returns for held tokens', () => {
-        const checksummedAccount = {
-            ...account,
-            tokens: account.tokens?.map(accountToken => ({
-                ...accountToken,
-                contract: toBackendContractCasing(accountToken.contract),
-            })),
-        } as unknown as Account;
-
-        const result = getResolvedYieldFlowData({ account: checksummedAccount, vault });
-
-        // The tokens must still be matched and their balances kept ...
-        expect(result.token?.balance).toBe('25');
-        expect(result.depositedSharesAmount).toBe('1.5');
-        // ... while the exposed contracts stay normalized, so that the derived asset logo URLs
-        // and fiat rate tickers keep resolving.
-        expect(result.token?.contractAddress).toBe(underlyingTokenAddress);
-        expect(result.receiptToken?.contractAddress).toBe(receiptTokenAddress);
-        expect(result.flowKey).toBe(`${accountKey}:${yieldId}:${underlyingTokenAddress}`);
     });
 
     it('falls back to the vault token data when the account does not hold the token', () => {

--- a/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts
+++ b/suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts
@@ -193,19 +193,12 @@ export const getResolvedYieldFlowData = ({
         token: vault.outputToken,
     });
 
-    const matchedTokenContract = matchedToken
-        ? getContractAddressForNetworkSymbol(account.symbol, matchedToken.contract)
-        : null;
-    const matchedReceiptTokenContract = matchedReceiptToken
-        ? getContractAddressForNetworkSymbol(account.symbol, matchedReceiptToken.contract)
-        : null;
-
     const token: YieldFlowToken = {
         networkSymbol: account.symbol,
         symbol:
             matchedToken?.symbol ?? vault.token.symbol ?? getNetworkDisplaySymbol(account.symbol),
         decimals: matchedToken?.decimals ?? vault.token.decimals,
-        contractAddress: matchedTokenContract ?? underlyingTokenContract,
+        contractAddress: matchedToken?.contract ?? underlyingTokenContract,
         balance: matchedToken?.balance ?? '0',
     };
 
@@ -213,7 +206,7 @@ export const getResolvedYieldFlowData = ({
         networkSymbol: account.symbol,
         symbol: matchedReceiptToken?.symbol ?? vault.outputToken.symbol,
         decimals: matchedReceiptToken?.decimals ?? vault.outputToken.decimals,
-        contractAddress: matchedReceiptTokenContract ?? receiptTokenContract,
+        contractAddress: matchedReceiptToken?.contract ?? receiptTokenContract,
     };
 
     const flowData: YieldFlowResolvedData = { account, vault, token, receiptToken };

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2671,6 +2671,7 @@ export const messages = {
         staking: 'Staking',
         defiYield: 'DeFi Yield',
         poweredBy: 'Powered by',
+        max: 'Max',
         feeEstimationFailed:
             "The network fee couldn't be estimated, so the transaction can't be prepared. Try again later.",
         stakingOperatedByProviders: 'Staking is operated by independent providers',
@@ -3319,7 +3320,6 @@ export const messages = {
                 },
             },
             depositCompleteStepTitle: 'Deposit complete',
-            depositMax: 'Deposit max',
         },
         yieldDepositRevokeScreen: {
             title: 'Revoke {tokenSymbol} spending',
@@ -3359,7 +3359,6 @@ export const messages = {
                 amountIsZero: 'Amount must be greater than 0.',
                 tooManyDecimals: 'Too many decimal places.',
             },
-            withdrawMax: 'Withdraw max',
         },
         yieldClaimFlowScreen: {
             title: 'Claim rewards',

--- a/suite-native/module-earn/src/components/earn/EarnMaxSwitch.tsx
+++ b/suite-native/module-earn/src/components/earn/EarnMaxSwitch.tsx
@@ -1,0 +1,17 @@
+import { HStack, Switch, Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+type EarnMaxSwitchProps = {
+    isChecked: boolean;
+    onChange: (value: boolean) => void;
+    testID?: string;
+};
+
+export const EarnMaxSwitch = ({ isChecked, onChange, testID }: EarnMaxSwitchProps) => (
+    <HStack alignItems="center" spacing="sp8">
+        <Text variant="body-sm">
+            <Translation id="earn.max" />
+        </Text>
+        <Switch isChecked={isChecked} onChange={onChange} testID={testID} />
+    </HStack>
+);

--- a/suite-native/module-earn/src/components/earn/WrappedNativeTokenAmountInputCard.tsx
+++ b/suite-native/module-earn/src/components/earn/WrappedNativeTokenAmountInputCard.tsx
@@ -1,19 +1,11 @@
-import { type ReactNode, useCallback, useEffect, useRef } from 'react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectIsBaseCurrencyInSats } from '@suite-common/wallet-core';
 import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
 import { getDecimalsForBaseCurrency } from '@suite-common/wallet-utils';
-import {
-    type ActiveView,
-    BaseAmountInputs,
-    Button,
-    Card,
-    HStack,
-    Text,
-    VStack,
-} from '@suite-native/atoms';
+import { type ActiveView, BaseAmountInputs, Card, HStack, Text, VStack } from '@suite-native/atoms';
 import {
     CompactTokenAmountFormatter,
     asDecimalTokenAmount,
@@ -26,6 +18,7 @@ import { BigNumber } from '@trezor/utils';
 import { EarnAmountErrorMessage } from './EarnAmountErrorMessage';
 import { EarnCryptoAmountInput } from './EarnCryptoAmountInput';
 import { EarnFiatAmountInput } from './EarnFiatAmountInput';
+import { EarnMaxSwitch } from './EarnMaxSwitch';
 import { AMOUNT_INPUT_UNFOCUSED_OFFSET, AMOUNT_INPUT_WRAPPER_HEIGHT } from '../../constants';
 import { type YieldDepositFormValues } from '../../utils/yield/yieldDepositFormSchema';
 
@@ -55,6 +48,7 @@ export const WrappedNativeTokenAmountInputCard = ({
     tokenSymbol,
 }: WrappedNativeTokenAmountInputCardProps) => {
     const { setValue, trigger } = useFormContext<YieldDepositFormValues>();
+    const [isMaxSelected, setIsMaxSelected] = useState(false);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
     const converters = useCryptoFiatConverters({ symbol, tokenContract });
@@ -93,7 +87,16 @@ export const WrappedNativeTokenAmountInputCard = ({
         setAmountWithFiat(defaultAmount);
     }, [defaultAmount, setAmountWithFiat]);
 
-    const handleMaxPress = () => {
+    const handleMaxChange = (value: boolean) => {
+        setIsMaxSelected(value);
+
+        if (!value) {
+            setValue('amount', '', { shouldValidate: false });
+            setValue('fiat', '', { shouldValidate: false });
+
+            return;
+        }
+
         onMaxPress?.();
         setAmountWithFiat(maxAmount ?? balance);
     };
@@ -106,7 +109,16 @@ export const WrappedNativeTokenAmountInputCard = ({
                     onInputSwitch={onCurrencyChange}
                     unfocusedOffset={AMOUNT_INPUT_UNFOCUSED_OFFSET}
                     wrapperHeight={AMOUNT_INPUT_WRAPPER_HEIGHT}
-                    renderTopRow={() => <Text variant="body-sm">{amountLabel}</Text>}
+                    renderTopRow={() => (
+                        <>
+                            <Text variant="body-sm">{amountLabel}</Text>
+                            <EarnMaxSwitch
+                                isChecked={isMaxSelected}
+                                onChange={handleMaxChange}
+                                testID="@wrapped-native-token/max-switch"
+                            />
+                        </>
+                    )}
                     renderCryptoInput={({ onPress, isDisabled, inputRef }) => (
                         <EarnCryptoAmountInput
                             symbol={symbol}
@@ -115,7 +127,7 @@ export const WrappedNativeTokenAmountInputCard = ({
                             displaySymbol={tokenSymbol}
                             accessibilityLabel="amount input"
                             inputRef={inputRef}
-                            isDisabled={isDisabled}
+                            isDisabled={isMaxSelected || isDisabled}
                             onPress={onPress}
                         />
                     )}
@@ -126,7 +138,7 @@ export const WrappedNativeTokenAmountInputCard = ({
                             tokenDecimals={tokenDecimals}
                             accessibilityLabel="fiat amount input"
                             inputRef={inputRef}
-                            isDisabled={isDisabled}
+                            isDisabled={isMaxSelected || isDisabled}
                             onPress={onPress}
                         />
                     )}
@@ -134,28 +146,17 @@ export const WrappedNativeTokenAmountInputCard = ({
                         <EarnAmountErrorMessage isFiatDisplayed={isFiatDisplayed} />
                     )}
                 />
-                <HStack spacing="sp8" alignItems="center">
-                    <HStack spacing="sp4" alignItems="center">
-                        <Text variant="body-sm" color="contentSecondary">
-                            <Translation id="earn.yieldDepositFlowScreen.balance" />
-                        </Text>
-                        <CompactTokenAmountFormatter
-                            value={asDecimalTokenAmount(balance)}
-                            tokenSymbol={tokenSymbol}
-                            tokenDecimals={tokenDecimals}
-                            variant="body-sm"
-                            color="contentSecondary"
-                        />
-                    </HStack>
-                    <Button
-                        size="medium"
-                        intent="neutral"
-                        priority="secondary"
-                        onPress={handleMaxPress}
-                        testID="@wrapped-native-token/max-button"
-                    >
-                        <Translation id="earn.wrappedNativeToken.maxButton" />
-                    </Button>
+                <HStack spacing="sp4" alignItems="center">
+                    <Text variant="body-sm" color="contentSecondary">
+                        <Translation id="earn.yieldDepositFlowScreen.balance" />
+                    </Text>
+                    <CompactTokenAmountFormatter
+                        value={asDecimalTokenAmount(balance)}
+                        tokenSymbol={tokenSymbol}
+                        tokenDecimals={tokenDecimals}
+                        variant="body-sm"
+                        color="contentSecondary"
+                    />
                 </HStack>
             </VStack>
         </Card>

--- a/suite-native/module-earn/src/components/yield/YieldAmountInputCard.tsx
+++ b/suite-native/module-earn/src/components/yield/YieldAmountInputCard.tsx
@@ -1,11 +1,10 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
 import {
     type ActiveView,
     BaseAmountInputs,
-    Button,
     Card,
     Divider,
     HStack,
@@ -14,13 +13,16 @@ import {
     VStack,
 } from '@suite-native/atoms';
 import { CompactTokenAmountFormatter, asDecimalTokenAmount } from '@suite-native/formatters';
+import { useFormContext } from '@suite-native/forms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 
 import { AMOUNT_INPUT_UNFOCUSED_OFFSET, AMOUNT_INPUT_WRAPPER_HEIGHT } from '../../constants';
+import { type YieldDepositFormValues } from '../../utils/yield/yieldDepositFormSchema';
 import { EarnAmountErrorMessage } from '../earn/EarnAmountErrorMessage';
 import { EarnCryptoAmountInput } from '../earn/EarnCryptoAmountInput';
 import { EarnFiatAmountInput } from '../earn/EarnFiatAmountInput';
+import { EarnMaxSwitch } from '../earn/EarnMaxSwitch';
 
 type YieldAmountInputCardProps = {
     amountLabel: ReactNode;
@@ -49,8 +51,25 @@ export const YieldAmountInputCard = ({
     tokenDecimals,
     tokenSymbol,
 }: YieldAmountInputCardProps) => {
+    const { setValue } = useFormContext<YieldDepositFormValues>();
+    const [isMaxSelected, setIsMaxSelected] = useState(false);
+
     const hasBalance = balance !== undefined;
     const shouldShowApprovalLimit = !!approvalLimitTitle && !!onApprovalLimitPress;
+
+    const handleMaxChange = (value: boolean) => {
+        setIsMaxSelected(value);
+
+        if (!value) {
+            setValue('amount', '', { shouldValidate: false });
+            setValue('fiat', '', { shouldValidate: false });
+
+            return;
+        }
+
+        onMaxPress();
+    };
+
     const approvalLimitRow = (
         <HStack
             justifyContent="space-between"
@@ -78,7 +97,16 @@ export const YieldAmountInputCard = ({
                     onInputSwitch={onCurrencyChange}
                     unfocusedOffset={AMOUNT_INPUT_UNFOCUSED_OFFSET}
                     wrapperHeight={AMOUNT_INPUT_WRAPPER_HEIGHT}
-                    renderTopRow={() => <Text variant="body-sm">{amountLabel}</Text>}
+                    renderTopRow={() => (
+                        <>
+                            <Text variant="body-sm">{amountLabel}</Text>
+                            <EarnMaxSwitch
+                                isChecked={isMaxSelected}
+                                onChange={handleMaxChange}
+                                testID="@yield-deposit/max-switch"
+                            />
+                        </>
+                    )}
                     renderCryptoInput={({ onPress, isDisabled, inputRef }) => (
                         <EarnCryptoAmountInput
                             symbol={symbol}
@@ -87,7 +115,7 @@ export const YieldAmountInputCard = ({
                             displaySymbol={tokenSymbol}
                             accessibilityLabel="amount to deposit input"
                             inputRef={inputRef}
-                            isDisabled={isDisabled}
+                            isDisabled={isMaxSelected || isDisabled}
                             onPress={onPress}
                         />
                     )}
@@ -98,7 +126,7 @@ export const YieldAmountInputCard = ({
                             tokenDecimals={tokenDecimals}
                             accessibilityLabel="fiat amount to deposit input"
                             inputRef={inputRef}
-                            isDisabled={isDisabled}
+                            isDisabled={isMaxSelected || isDisabled}
                             onPress={onPress}
                         />
                     )}
@@ -107,28 +135,17 @@ export const YieldAmountInputCard = ({
                     )}
                 />
                 {hasBalance && (
-                    <HStack spacing="sp8" alignItems="center">
-                        <HStack spacing="sp4" alignItems="center">
-                            <Text variant="body-sm" color="contentSecondary">
-                                <Translation id="earn.yieldDepositFlowScreen.balance" />
-                            </Text>
-                            <CompactTokenAmountFormatter
-                                value={asDecimalTokenAmount(balance)}
-                                tokenSymbol={tokenSymbol}
-                                tokenDecimals={tokenDecimals}
-                                variant="body-sm"
-                                color="contentSecondary"
-                            />
-                        </HStack>
-                        <Button
-                            size="medium"
-                            intent="neutral"
-                            priority="secondary"
-                            onPress={onMaxPress}
-                            testID="@yield-deposit/max-button"
-                        >
-                            <Translation id="earn.yieldDepositFlowScreen.maxButton" />
-                        </Button>
+                    <HStack spacing="sp4" alignItems="center">
+                        <Text variant="body-sm" color="contentSecondary">
+                            <Translation id="earn.yieldDepositFlowScreen.balance" />
+                        </Text>
+                        <CompactTokenAmountFormatter
+                            value={asDecimalTokenAmount(balance)}
+                            tokenSymbol={tokenSymbol}
+                            tokenDecimals={tokenDecimals}
+                            variant="body-sm"
+                            color="contentSecondary"
+                        />
                     </HStack>
                 )}
             </VStack>

--- a/suite-native/module-earn/src/screens/yield/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/yield/YieldWithdrawScreen.tsx
@@ -48,6 +48,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { BigNumber } from '@trezor/utils';
 
 import { EarnApproximateFiatAmount } from '../../components/earn/EarnApproximateFiatAmount';
+import { EarnMaxSwitch } from '../../components/earn/EarnMaxSwitch';
 import { YieldDepositFlowScreenHeader } from '../../components/yield/YieldDepositFlowScreenHeader';
 import { YieldDepositInfoBottomSheet } from '../../components/yield/YieldDepositInfoBottomSheet';
 import { YieldDisabledAlert } from '../../components/yield/YieldDisabledAlert';
@@ -109,6 +110,7 @@ export const YieldWithdrawScreen = () => {
     const [assetAmount, setAssetAmount] = useState('');
     const [sharesAmount, setSharesAmount] = useState('');
     const [isMaxWithdrawInfoVisible, setIsMaxWithdrawInfoVisible] = useState(false);
+    const [isMaxSelected, setIsMaxSelected] = useState(false);
     const [flowType, setFlowType] = useState<YieldWithdrawFlowType>(
         route.params.withdrawFlowType ?? 'withdraw',
     );
@@ -357,10 +359,21 @@ export const YieldWithdrawScreen = () => {
         [account, resolutionStatus, vault],
     );
 
-    const handleMaxPress = () => {
+    const handleMaxChange = (value: boolean) => {
+        if (!value) {
+            setIsMaxSelected(false);
+            setAssetAmount('');
+            setSharesAmount('');
+            setIsMaxWithdrawInfoVisible(false);
+
+            return;
+        }
+
         if (!depositedAmount || !depositedSharesAmount) {
             return;
         }
+
+        setIsMaxSelected(true);
 
         analytics.report({
             type: events.yieldInteractionEvent.name,
@@ -581,9 +594,18 @@ export const YieldWithdrawScreen = () => {
                     )}
                     <Card style={applyStyle(withdrawFormCardStyle)}>
                         <VStack spacing="sp12">
-                            <Text variant="body-sm">
-                                <Translation id="earn.yieldWithdrawFlowScreen.withdrawalAmount" />
-                            </Text>
+                            <HStack justifyContent="space-between" alignItems="center">
+                                <Text variant="body-sm">
+                                    <Translation id="earn.yieldWithdrawFlowScreen.withdrawalAmount" />
+                                </Text>
+                                {!!maxAmount && (
+                                    <EarnMaxSwitch
+                                        isChecked={isMaxSelected}
+                                        onChange={handleMaxChange}
+                                        testID="@yield-withdraw/max-switch"
+                                    />
+                                )}
+                            </HStack>
 
                             <AnimatedDoubleInput
                                 activeView={isSharesInput ? 'secondary' : 'primary'}
@@ -598,7 +620,7 @@ export const YieldWithdrawScreen = () => {
                                         placeholder="0"
                                         keyboardType="numeric"
                                         maxLength={AMOUNT_INPUT_MAX_LENGTH}
-                                        editable={!isDisabled}
+                                        editable={!isDisabled && !isMaxSelected}
                                         onChangeText={handleAmountChange}
                                         onPress={onPress}
                                         hasError={!isDisabled && isAmountValidationErrorDisplayed}
@@ -627,7 +649,7 @@ export const YieldWithdrawScreen = () => {
                                         placeholder="0"
                                         keyboardType="numeric"
                                         maxLength={AMOUNT_INPUT_MAX_LENGTH}
-                                        editable={!isDisabled}
+                                        editable={!isDisabled && !isMaxSelected}
                                         onChangeText={handleAmountChange}
                                         onPress={onPress}
                                         style={applyStyle(withdrawOutputAmountInputStyle)}
@@ -662,34 +684,23 @@ export const YieldWithdrawScreen = () => {
                                     justifyContent="space-between"
                                     alignItems="center"
                                 >
-                                    <HStack spacing="sp8" alignItems="center" flexShrink={1}>
-                                        <HStack spacing="sp4" alignItems="center" flexShrink={1}>
-                                            <Text variant="body-sm" color="contentSecondary">
-                                                <Translation id="earn.yieldWithdrawFlowScreen.deposited" />
-                                            </Text>
-                                            <Box flexShrink={1}>
-                                                <YieldFormattedAmount
-                                                    value={maxAmount}
-                                                    networkSymbol={account.symbol}
-                                                    tokenContract={activeUnitTokenContract}
-                                                    tokenDecimals={activeInputToken.decimals}
-                                                    tokenSymbol={activeUnitSymbol}
-                                                    variant="body-sm"
-                                                    color="contentSecondary"
-                                                    numberOfLines={1}
-                                                    ellipsizeMode="tail"
-                                                />
-                                            </Box>
-                                        </HStack>
-                                        <Button
-                                            size="medium"
-                                            intent="neutral"
-                                            priority="secondary"
-                                            onPress={handleMaxPress}
-                                            testID="@yield-withdraw/max-button"
-                                        >
-                                            <Translation id="earn.yieldWithdrawFlowScreen.maxButton" />
-                                        </Button>
+                                    <HStack spacing="sp4" alignItems="center" flexShrink={1}>
+                                        <Text variant="body-sm" color="contentSecondary">
+                                            <Translation id="earn.yieldWithdrawFlowScreen.deposited" />
+                                        </Text>
+                                        <Box flexShrink={1}>
+                                            <YieldFormattedAmount
+                                                value={maxAmount}
+                                                networkSymbol={account.symbol}
+                                                tokenContract={activeUnitTokenContract}
+                                                tokenDecimals={activeInputToken.decimals}
+                                                tokenSymbol={activeUnitSymbol}
+                                                variant="body-sm"
+                                                color="contentSecondary"
+                                                numberOfLines={1}
+                                                ellipsizeMode="tail"
+                                            />
+                                        </Box>
                                     </HStack>
                                     <EarnApproximateFiatAmount
                                         amount={assetAmount || (depositedAmount ?? '')}


### PR DESCRIPTION
## Description

Replace `Max` button with a toggle in yield flows.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31297

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-09-07 at 15 49 49" src="https://github.com/user-attachments/assets/5cf1a8c5-e3ae-4d9d-a86a-3a7e9ecd8938" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-09-07 at 15 50 41" src="https://github.com/user-attachments/assets/b8a0821d-0f29-4a23-b6a2-ed4fc94714a1" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-09-07 at 15 51 16" src="https://github.com/user-attachments/assets/593bc0b4-9383-4041-b803-a1fe62d2c1a1" />
</td>
</tr>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-09-07 at 15 52 01" src="https://github.com/user-attachments/assets/a8ed1018-61ae-4ecb-844d-f3258c16e8ff" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-09-07 at 15 52 32" src="https://github.com/user-attachments/assets/ecbf534c-3500-4ac6-9231-b73776a2bb1a" />
</td>
<td>

</td>
</tr>
</table>

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in the earn/yield approval and amount-resolution logic. The primary regression risk is in web Suite yield withdrawal and redeem flows, so the two yield E2E tests are the highest-value coverage. The remaining changed files are suite-native mobile components or unit-test files that are not exercised by the suite-web E2E suite and have no inferred E2E coverage.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx`
- `suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.test.ts`
- `suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/earn/EarnMaxSwitch.tsx`
- `suite-native/module-earn/src/components/earn/WrappedNativeTokenAmountInputCard.tsx`
- `suite-native/module-earn/src/components/yield/YieldAmountInputCard.tsx`
- `suite-native/module-earn/src/screens/yield/YieldWithdrawScreen.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — This test walks through the USDC Prime Vault redeem flow, including the approval/redeem modal and amount resolution. Changes to YieldApproveModal and getResolvedYieldFlowData directly affect how the vault share amount, price-per-share conversion, and fee are computed and presented in this flow.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test exercises the yield withdrawal flow from the earn dashboard through device confirmation. getResolvedYieldFlowData is used to resolve withdrawal amounts and asset conversions, so a regression here would be visible in the amount, fee, and summary values the test asserts.

</details>

⚠️ **Changes with no test coverage (6)**
- `suite-common/wallet-core/src/yield/utils/getResolvedYieldFlowData.test.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/earn/EarnMaxSwitch.tsx`
- `suite-native/module-earn/src/components/earn/WrappedNativeTokenAmountInputCard.tsx`
- `suite-native/module-earn/src/components/yield/YieldAmountInputCard.tsx`
- `suite-native/module-earn/src/screens/yield/YieldWithdrawScreen.tsx`

_Updated: 2026-09-08T08:06:25.644Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/yield-max-toggle/web/](https://dev.suite.sldev.cz/suite-web/feat/native/yield-max-toggle/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/yield-max-toggle&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/yield-max-toggle&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/yield-max-toggle&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T08:08:21.407Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T08:09:28.275Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->