### PR TITLE
fix(suite): compact amount format in activity notifications

### DIFF
--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1487,7 +1487,7 @@ export const signAndPush: SignAndPush[] = [
             actions: [
                 {
                     type: notificationsActions.addToast.type,
-                    payload: { type: 'tx-sent', formattedAmount: '1 ETH' }, // BUG ?
+                    payload: { type: 'tx-sent', formattedAmount: '1.00 ETH' }, // BUG ?
                 },
                 {
                     type: 'mock-redirect',
@@ -1542,7 +1542,7 @@ export const signAndPush: SignAndPush[] = [
             actions: [
                 {
                     type: notificationsActions.addToast.type,
-                    payload: { type: 'tx-sent', formattedAmount: '1 XRP' },
+                    payload: { type: 'tx-sent', formattedAmount: '1.00 XRP' },
                 },
                 {
                     type: 'mock-redirect',
@@ -1644,7 +1644,7 @@ export const signAndPush: SignAndPush[] = [
             actions: [
                 {
                     type: notificationsActions.addToast.type,
-                    payload: { type: 'tx-sent', formattedAmount: '24.999999 BTC' },
+                    payload: { type: 'tx-sent', formattedAmount: '24.99 BTC' },
                 },
                 {
                     type: accountsActions.updateAccount.type,

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -30,7 +30,7 @@ export type CryptoAmountFormatterFormatStyle = 'exact' | 'compact-balance';
 
 // Tokens with this many decimals (e.g. stablecoins like USDC/USDT) are rendered money-like
 // (two decimals) in the compact format.
-const MONEY_LIKE_TOKEN_DECIMALS = 6;
+export const MONEY_LIKE_TOKEN_DECIMALS = 6;
 
 export type CryptoAmountFormatterDataContext = {
     symbol: NetworkSymbol | TokenSymbol;

--- a/suite-common/formatters/src/index.ts
+++ b/suite-common/formatters/src/index.ts
@@ -10,4 +10,8 @@ export {
     type CryptoAmountFormatterFormatStyle,
 } from './formatters/prepareCryptoAmountFormatter';
 export { getCompactAmount } from './utils/getCompactAmount';
+export {
+    formatCompactNotificationNetworkAmount,
+    formatCompactNotificationTokenAmount,
+} from './utils/formatCompactNotificationAmount';
 export { AddressFormatter, type AddressFormat } from './formatters/AddressFormatter';

--- a/suite-common/formatters/src/utils/formatCompactNotificationAmount.test.ts
+++ b/suite-common/formatters/src/utils/formatCompactNotificationAmount.test.ts
@@ -1,0 +1,34 @@
+import {
+    formatCompactNotificationNetworkAmount,
+    formatCompactNotificationTokenAmount,
+} from './formatCompactNotificationAmount';
+
+describe(formatCompactNotificationNetworkAmount.name, () => {
+    it.each([
+        // [amount (subunits), symbol, isSatoshis, expected]
+        ['2500000000000000000', 'eth', undefined, '2.50 ETH'],
+        // below one keeps up to five decimals
+        ['123456000000000000', 'eth', undefined, '0.12345 ETH'],
+        // dust is collapsed behind the minimum
+        ['5000000000000', 'eth', undefined, '<0.00001 ETH'],
+        // satoshis stay as an integer subunit count and are not compacted
+        ['123456', 'btc', true, '123456 sat BTC'],
+    ] as const)('formats %s %s', (amount, symbol, isSatoshis, expected) => {
+        expect(formatCompactNotificationNetworkAmount(amount, symbol, isSatoshis)).toBe(expected);
+    });
+});
+
+describe(formatCompactNotificationTokenAmount.name, () => {
+    it.each([
+        // money-like (6 decimals) renders with two decimals
+        [{ amount: '12500000', decimals: 6, symbol: 'USDC' }, '12.50 USDC'],
+        // money-like dust uses the higher <0.01 threshold
+        [{ amount: '4000', decimals: 6, symbol: 'USDC' }, '<0.01 USDC'],
+        // non-money tokens compact to two decimals above one
+        [{ amount: '3999900000000000000', decimals: 18, symbol: 'SHIB' }, '3.99 SHIB'],
+        // a missing symbol yields the bare amount
+        [{ amount: '2500000000000000000', decimals: 18, symbol: '' }, '2.50'],
+    ] as const)('formats %o', (tokenTransfer, expected) => {
+        expect(formatCompactNotificationTokenAmount(tokenTransfer)).toBe(expected);
+    });
+});

--- a/suite-common/formatters/src/utils/formatCompactNotificationAmount.ts
+++ b/suite-common/formatters/src/utils/formatCompactNotificationAmount.ts
@@ -1,0 +1,46 @@
+import { type Locale } from '@suite-common/suite-types';
+import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { convertAmountSubunitsToUnits, getAccountDecimals } from '@suite-common/wallet-utils';
+import { type TokenTransfer } from '@trezor/connect';
+
+import { formatCompactCryptoAmount } from './formatCompactCryptoAmount';
+import { MONEY_LIKE_TOKEN_DECIMALS } from '../formatters/prepareCryptoAmountFormatter';
+
+// FIXME: Transaction notifications bake their amount into a display string at dispatch time, so there is no
+// locale in scope; keep the historical (non-localized) behavior by formatting in `en-US`.
+const NOTIFICATION_LOCALE: Locale = 'en-US';
+
+export const formatCompactNotificationNetworkAmount = (
+    amount: string,
+    symbol: NetworkSymbol,
+    isSatoshis?: boolean,
+) => {
+    const decimals = getAccountDecimals(symbol);
+
+    if (!decimals) return amount;
+
+    // Satoshis are integer subunit counts with no fractional precision to overflow, so keep them
+    // as-is rather than compacting (mirrors `formatNetworkAmount`).
+    if (isSatoshis) {
+        return `${amount || '0'} sat ${getNetworkDisplaySymbol(symbol)}`;
+    }
+
+    const formattedAmount = formatCompactCryptoAmount({
+        value: convertAmountSubunitsToUnits(amount, decimals),
+        locale: NOTIFICATION_LOCALE,
+    });
+
+    return `${formattedAmount} ${getNetworkDisplaySymbol(symbol)}`;
+};
+
+export const formatCompactNotificationTokenAmount = (
+    tokenTransfer: Pick<TokenTransfer, 'amount' | 'decimals' | 'symbol'>,
+) => {
+    const formattedAmount = formatCompactCryptoAmount({
+        value: convertAmountSubunitsToUnits(tokenTransfer.amount, tokenTransfer.decimals),
+        locale: NOTIFICATION_LOCALE,
+        isMoneyLike: tokenTransfer.decimals === MONEY_LIKE_TOKEN_DECIMALS,
+    });
+
+    return tokenTransfer.symbol ? `${formattedAmount} ${tokenTransfer.symbol}` : formattedAmount;
+};

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -25,6 +25,7 @@
         "@suite-common/earn-staking-api": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/firmware": "workspace:*",
+        "@suite-common/formatters": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/networks": "workspace:*",
         "@suite-common/react-query": "workspace:*",

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -1,5 +1,9 @@
 import { type AnalyticsDep, events } from '@suite-common/analytics';
 import { type DeviceRootState, selectDevices } from '@suite-common/device';
+import {
+    formatCompactNotificationNetworkAmount,
+    formatCompactNotificationTokenAmount,
+} from '@suite-common/formatters';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -16,8 +20,6 @@ import {
 import {
     analyzeTransactions,
     findAccountDevice,
-    formatNetworkAmount,
-    formatTokenAmount,
     getAccountTransactions,
     getAreSatoshisUsed,
     isAccountOutdated,
@@ -278,8 +280,12 @@ export const fetchAndUpdateAccountThunk = createThunk<
                 const areSatoshisUsed = getAreSatoshisUsed(bitcoinAmountUnit, account);
 
                 const formattedAmount = token
-                    ? formatTokenAmount(token)
-                    : formatNetworkAmount(tx.amount, account.symbol, true, areSatoshisUsed);
+                    ? formatCompactNotificationTokenAmount(token)
+                    : formatCompactNotificationNetworkAmount(
+                          tx.amount,
+                          account.symbol,
+                          areSatoshisUsed,
+                      );
 
                 dispatch(
                     notificationsActions.addEvent({

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -1,5 +1,9 @@
 import { type AnalyticsDep } from '@suite-common/analytics';
 import { type DeviceRootState, selectDevices } from '@suite-common/device';
+import {
+    formatCompactNotificationNetworkAmount,
+    formatCompactNotificationTokenAmount,
+} from '@suite-common/formatters';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import { type GetIsWindowVisibleDep } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -14,8 +18,6 @@ import {
     findAccountDevice,
     findAccountsByDescriptor,
     findAccountsByNetwork,
-    formatNetworkAmount,
-    formatTokenAmount,
     getAccountIdentity,
     getAreSatoshisUsed,
     getBackendFromSettings,
@@ -435,8 +437,8 @@ export const onBlockchainNotificationThunk = createThunk<
         const areSatoshisUsed = getAreSatoshisUsed(selectBitcoinAmountUnit(getState()), account);
 
         const formattedAmount = token
-            ? formatTokenAmount(token)
-            : formatNetworkAmount(tx.amount, account.symbol, true, areSatoshisUsed);
+            ? formatCompactNotificationTokenAmount(token)
+            : formatCompactNotificationNetworkAmount(tx.amount, account.symbol, areSatoshisUsed);
 
         dispatch(
             notificationsActions.addEvent({

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -5,6 +5,10 @@ import { type AnalyticsDep } from '@suite-common/analytics';
 import { Calldata } from '@suite-common/calldata';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import {
+    formatCompactNotificationNetworkAmount,
+    formatCompactNotificationTokenAmount,
+} from '@suite-common/formatters';
+import {
     type ActionsFromAsyncThunk,
     type WithServices,
     createThunk,
@@ -27,10 +31,8 @@ import {
     type PrecomposedTransactionFinalCardano,
 } from '@suite-common/wallet-types';
 import {
-    asAmountSubunit,
     convertAmountSubunitsToUnits,
     convertAmountUnitsToSubunits,
-    formatNetworkAmount,
     getAccountDecimals,
     getAreSatoshisUsed,
     getEvmTransactionTextSignature,
@@ -43,7 +45,6 @@ import {
     isEvmYieldTxByTextSignature,
     isExchangeTradingForm,
     isRbfCancelTransaction,
-    subunitsToUnits,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
 import { type BlockbookTransaction } from '@trezor/blockchain-link-types';
@@ -480,10 +481,13 @@ export const pushSendFormTransactionThunk = createThunk<
                     decimals: token.decimals,
                     isSubunit: true,
                 });
-                const amount = subunitsToUnits({
-                    value: asAmountSubunit(new BigNumber(amountString)),
+                // Bare amount (no symbol): the approval toast renderer appends the token symbol
+                // itself, so the tested "missing symbol yields the bare amount" path is used here.
+                const amount = formatCompactNotificationTokenAmount({
+                    amount: amountString,
                     decimals: token.decimals,
-                }).toString();
+                    symbol: '',
+                });
 
                 dispatch(
                     notificationsActions.addToast({
@@ -512,23 +516,18 @@ export const pushSendFormTransactionThunk = createThunk<
                     }),
                 );
             } else {
-                const amount = token
-                    ? subunitsToUnits({
-                          value: asAmountSubunit(new BigNumber(precomposedTransaction.totalSpent)),
-                          decimals: token.decimals,
-                      })
-                    : null;
-
                 // get total amount without fee OR token amount
-                const formattedAmount =
-                    token && amount
-                        ? `${amount} ${token.symbol}`
-                        : formatNetworkAmount(
-                              spentWithoutFee,
-                              selectedAccount.symbol,
-                              true,
-                              areSatoshisUsed,
-                          );
+                const formattedAmount = token
+                    ? formatCompactNotificationTokenAmount({
+                          amount: precomposedTransaction.totalSpent,
+                          decimals: token.decimals,
+                          symbol: token.symbol,
+                      })
+                    : formatCompactNotificationNetworkAmount(
+                          spentWithoutFee,
+                          selectedAccount.symbol,
+                          areSatoshisUsed,
+                      );
                 dispatch(
                     notificationsActions.addToast({
                         type: 'tx-sent',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11667,6 +11667,7 @@ __metadata:
     "@suite-common/earn-staking-api": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/firmware": "workspace:*"
+    "@suite-common/formatters": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/networks": "workspace:*"
     "@suite-common/react-query": "workspace:*"


### PR DESCRIPTION
## Description

  Use compact formatting for transaction notification amounts.

## Notes for QA

- Check Activity/notifications (mobile) and toasts (desktop) for incoming, sent, and approval transactions — amounts should be compact and no longer overflow the row.
- Verify money-like tokens (6 decimals, e.g. USDC/USDT) show two decimals, small amounts collapse to `<0.00001` / `<0.01`, and large amounts abbreviate with `M`/`B`.
- Satoshi display (BTC in sats) is unchanged.
- this PR is changing the shared code, so the change should be reflected on desktop as well

## Related Issue

Resolve #32172

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files touch send form logic (sendFormThunks and useSendForm fixtures), crypto amount formatting (prepareCryptoAmountFormatter and formatCompactNotificationAmount), and account/blockchain synchronization (accountsThunks and blockchainThunks). The recommended set focuses on send flows across the main networks (BTC regtest, EVM, Solana, Doge, LTC), account discovery/creation, custom backend handling, and a staking flow that validates formatted notification amounts. Broad-utility files are not used as a blanket reason to run all mapped tests; only tests that exercise the affected behaviors are selected.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts`
- `suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts`
- `suite-common/formatters/src/index.ts`
- `suite-common/formatters/src/utils/formatCompactNotificationAmount.test.ts`
- `suite-common/formatters/src/utils/formatCompactNotificationAmount.ts`
- `suite-common/wallet-core/package.json`
- `suite-common/wallet-core/src/accounts/accountsThunks.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-common/wallet-core/src/send/sendFormThunks.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly exercises custom backend configuration, WebSocket client connections, discovery completion, and account loading. Changes to blockchainThunks and accountsThunks can affect backend sync and discovery state, making this a strong end-to-end check.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Asserts formatted staking amounts in device prompts, dashboard pending amounts, and the success toast amount. Changes to prepareCryptoAmountFormatter or formatCompactNotificationAmount could alter these displayed values and the toast notification.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Creates accounts for multiple coins (BTC, LTC, ETH, Base, ADA) and verifies account creation analytics with derivation paths. The accountsThunks changes are directly on the account creation path.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates eight coins, verifies discovery completes, and checks resilience after a page reload. blockchainThunks and accountsThunks are central to discovery and account state, so regressions here would be visible.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Broadcasts multi-output Bitcoin regtest transactions and validates pending/confirmed transaction grouping. sendFormThunks and the useSendForm fixtures affect how outputs are built and broadcast.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Fills the send form with a large DOGE amount and verifies device prompt amount formatting plus the sign-tx error toast. sendFormThunks, the amount formatter, and the send-form fixture changes all directly influence this flow.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Uses custom Ethereum fees and verifies send amount, max fee, and fee breakdown formatting in device prompts. sendFormThunks and prepareCryptoAmountFormatter are core to this path.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Exercises add/remove outputs, locktime, OP_RETURN, and BTC/sat unit switching in the send form. This is the most direct coverage of sendFormThunks and the changed useSendForm fixtures.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests Solana Send Max calculation, rent/reserve handling, and amount/fee formatting. sendFormThunks and crypto amount formatter changes can affect the computed max amount and displayed fees.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Discovers accounts using custom Blockbook backends for BTC and LTC. Relevant to blockchainThunks backend/discovery changes, though partially overlapped by coins-custom-backend.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Populates send form outputs from a CSV file, including amount and label fields. sendFormThunks and the send-form fixture changes could affect output parsing and rendering.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Sends LTC spending a MimbleWimble peg-out output via a custom blockbook backend. Covers both send form logic and blockchain backend integration without duplicating the BTC/EVM/SOL high-priority set.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/formatters/src/index.ts`
- `suite-common/formatters/src/utils/formatCompactNotificationAmount.test.ts`
- `suite-common/wallet-core/package.json`

_Updated: 2026-09-07T15:26:48.749Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/activity-compact-amount-32172/web/](https://dev.suite.sldev.cz/suite-web/fix/activity-compact-amount-32172/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/activity-compact-amount-32172&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/activity-compact-amount-32172&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T15:27:58.276Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->