### PR TITLE
test(suite): update suite sync address label expectation

### DIFF
--- a/suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts
@@ -167,7 +167,7 @@ test.describe('Suite Sync - Update and Remove Labels', { tag: ['@T3W1', '@T3T1']
                 await metadataPage.address.removeLabel({ address: addressSeed.address });
                 await expect
                     .soft(metadataPage.address.addressHoverContainer(addressSeed.address))
-                    .toHaveText('bc1q kkr2 ... qfxy fa');
+                    .toHaveText('bc1q kkr2 uvry 034t sj4p 52za 2pg4 2ug4 pxg5 qfxy fa');
             });
 
             await test.step('Remove wallet label', async () => {


### PR DESCRIPTION
## Description

Updates the Suite Sync e2e expectation after address labels are removed. The address fallback is now rendered as the full grouped BTC address instead of the previously truncated value.


## Related Issue

Follow-up to https://github.com/trezor/trezor-suite/pull/32171


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/fix-removed-test/web/](https://dev.suite.sldev.cz/suite-web/juriczech/fix-removed-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/fix-removed-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/fix-removed-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T07:48:32.167Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T07:48:29.473Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->