### PR TITLE
refactor(blockchain-link): log only message type in worker onmessage

### DIFF
--- a/packages/blockchain-link/src/workers/baseWorker.ts
+++ b/packages/blockchain-link/src/workers/baseWorker.ts
@@ -140,7 +140,7 @@ export abstract class BaseWorker<API> {
         const { data } = event;
         const { id } = data;
 
-        this.debug('onmessage', data);
+        this.debug('onmessage', data.type);
 
         if (data.type === MESSAGES.HANDSHAKE) {
             this.settings = data.settings;


### PR DESCRIPTION
## Description

The worker `onmessage` handler logged the full message payload via `this.debug('onmessage', data)`, which spammed the logs. This logs only `data.type` instead, keeping message-type visibility without dumping the entire payload.

## Notes for QA

No functional change — only debug log verbosity is reduced. Nothing to test beyond confirming blockchain-link workers still behave normally.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** packages/blockchain-link/src/workers/baseWorker.ts is a foundational blockchain communication file, so it statically maps to many E2E tests. Following the broad-utility heuristic, only tests that directly depend on blockchain worker behavior are recommended. The selected wallet and Solana staking tests cover address derivation, transaction sending, and Solana backend state management—the areas most likely to regress from a base worker change. Trading and device settings tests are omitted because they rely more heavily on trading-specific mocks and UI flows with weaker direct coupling to baseWorker.

<details><summary><b>Changed files (1)</b></summary>

- `packages/blockchain-link/src/workers/baseWorker.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — Directly exercises address generation and verification across BTC, ETH, SOL, and TRX. These flows rely on blockchain-link workers to derive and validate addresses, so a regression in baseWorker would be immediately visible here.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Covers the full Solana send flow including fee estimation, transaction construction, and device signing. baseWorker changes affecting Solana backend message handling or worker initialization would likely break this test.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Creates stake accounts, simulates transactions, and advances epochs via the Solana backend mock. If baseWorker changes alter how Solana worker messages are routed or subscriptions handled, this end-to-end staking flow would catch it.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Fetches and caches Solana staking rewards, which depends on backend worker responses and reward endpoint polling. A baseWorker regression in request/response handling could corrupt rewards display.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Builds additional stake transactions and verifies dashboard state transitions after epoch advancement. This test is sensitive to Solana worker behavior around transaction simulation and account state updates.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Exercises unstaking, epoch advancement, and claim flows through the Solana backend mock. baseWorker changes affecting worker lifecycle or message passing would surface here.

</details>

_Updated: 2026-09-08T09:18:45.628Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/remove-onmessage-debug-log/web/](https://dev.suite.sldev.cz/suite-web/remove-onmessage-debug-log/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-onmessage-debug-log&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-onmessage-debug-log&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T09:21:21.831Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T09:21:15.655Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->