### PR TITLE
fix(suite-native): adjust receive QR actions

### DIFF
--- a/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
@@ -45,14 +45,18 @@ describe('ReceiveAddressActions', () => {
     const addressPath = "m/84'/0'/0'/0/0";
     const mockUseNavigation = jest.mocked(useNavigation);
 
-    const renderActions = async () =>
+    const renderActions = async (isDeviceVerificationEnabled = true) =>
         await renderWithBasicProvider(
             <ReceiveAddressInteractionsProvider
                 accountKey={accountKey}
                 address={address}
                 addressPath={addressPath}
+                isDeviceVerificationEnabled={isDeviceVerificationEnabled}
             >
-                <ReceiveAddressActions address={address} />
+                <ReceiveAddressActions
+                    address={address}
+                    isDeviceVerificationEnabled={isDeviceVerificationEnabled}
+                />
             </ReceiveAddressInteractionsProvider>,
             { services },
         );
@@ -125,6 +129,28 @@ describe('ReceiveAddressActions', () => {
         });
     });
 
+    it('does not display address verification for portfolio tracker', async () => {
+        const { queryByText } = await renderActions(false);
+
+        expect(queryByText(getTranslation('moduleReceive.addressActions.verify'))).toBeNull();
+    });
+
+    it('does not open the verification sheet after copying portfolio tracker address', async () => {
+        const { getByText } = await renderActions(false);
+
+        await userEvent.press(getByText(getTranslation('qrCode.copyButton')));
+
+        await waitFor(() => {
+            expect(mockCopyToClipboard).toHaveBeenCalledWith(address, undefined, {
+                shouldShowToast: true,
+            });
+            expect(mockOpenCopiedAddressBottomSheet).not.toHaveBeenCalled();
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.receiveCopyAddressEvent.name,
+            });
+        });
+    });
+
     it('opens shared address verification after sharing', async () => {
         const { getByText, getByTestId } = await renderActions();
 
@@ -144,6 +170,20 @@ describe('ReceiveAddressActions', () => {
         });
         expect(mockAnalyticsReport).toHaveBeenCalledWith({
             type: events.receiveStartVerificationEvent.name,
+        });
+    });
+
+    it('does not open shared address verification after sharing portfolio tracker address', async () => {
+        const { getByText } = await renderActions(false);
+
+        await userEvent.press(getByText(getTranslation('qrCode.shareButton')));
+
+        await waitFor(() => {
+            expect(mockShare).toHaveBeenCalledWith({ message: address });
+            expect(mockOpenSharedAddressBottomSheet).not.toHaveBeenCalled();
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.receiveShareAddressEvent.name,
+            });
         });
     });
 

--- a/suite-native/module-receive/src/components/ReceiveAddressActions.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressActions.tsx
@@ -8,16 +8,24 @@ import { useReceiveAddressSharing } from '../hooks/useReceiveAddressSharing';
 
 type ReceiveAddressActionsProps = {
     address: string;
+    isDeviceVerificationEnabled: boolean;
 };
 
-export const ReceiveAddressActions = ({ address }: ReceiveAddressActionsProps) => {
+export const ReceiveAddressActions = ({
+    address,
+    isDeviceVerificationEnabled,
+}: ReceiveAddressActionsProps) => {
     const { handleCopyAddress, handleVerifyAddress } = useReceiveAddressInteractions();
     const {
         sharedAddressBottomSheetRef,
         closeSharedAddressBottomSheet,
         handleShareAddress,
         handleVerifySharedAddress,
-    } = useReceiveAddressSharing({ address, onVerifyAddress: handleVerifyAddress });
+    } = useReceiveAddressSharing({
+        address,
+        isDeviceVerificationEnabled,
+        onVerifyAddress: handleVerifyAddress,
+    });
 
     return (
         <>
@@ -35,25 +43,29 @@ export const ReceiveAddressActions = ({ address }: ReceiveAddressActionsProps) =
                     >
                         <Translation id="qrCode.shareButton" />
                     </Button>
-                    <Button
-                        iconLeft="trezorDevices"
-                        intent="neutral"
-                        priority="secondary"
-                        onPress={() =>
-                            handleVerifyAddress(ReceiveAddressVerificationSource.Verified)
-                        }
-                        flex={1}
-                    >
-                        <Translation id="moduleReceive.addressActions.verify" />
-                    </Button>
+                    {isDeviceVerificationEnabled && (
+                        <Button
+                            iconLeft="trezorDevices"
+                            intent="neutral"
+                            priority="secondary"
+                            onPress={() =>
+                                handleVerifyAddress(ReceiveAddressVerificationSource.Verified)
+                            }
+                            flex={1}
+                        >
+                            <Translation id="moduleReceive.addressActions.verify" />
+                        </Button>
+                    )}
                 </HStack>
             </VStack>
-            <ReceiveAddressVerificationBottomSheet
-                ref={sharedAddressBottomSheetRef}
-                source={ReceiveAddressVerificationSource.Shared}
-                onVerifyAddress={handleVerifySharedAddress}
-                onSkipVerification={closeSharedAddressBottomSheet}
-            />
+            {isDeviceVerificationEnabled && (
+                <ReceiveAddressVerificationBottomSheet
+                    ref={sharedAddressBottomSheetRef}
+                    source={ReceiveAddressVerificationSource.Shared}
+                    onVerifyAddress={handleVerifySharedAddress}
+                    onSkipVerification={closeSharedAddressBottomSheet}
+                />
+            )}
         </>
     );
 };

--- a/suite-native/module-receive/src/components/ReceiveAddressContent.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressContent.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useFocusEffect } from '@react-navigation/native';
 
+import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import { selectCurrentFreshAddress } from '@suite-common/receive';
 import { useDispatch } from '@suite-common/redux-utils';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
@@ -53,6 +54,7 @@ export const ReceiveAddressContent = ({
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
         selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const hasInitializedCurrentFreshAddress = initializedAccountKey === accountKey;
 
     if (hasFirmwareAuthenticityCheckHardFailed) {
@@ -74,6 +76,7 @@ export const ReceiveAddressContent = ({
             accountKey={accountKey}
             address={currentFreshAddress.address}
             addressPath={currentFreshAddress.path}
+            isDeviceVerificationEnabled={!isPortfolioTrackerDevice}
         >
             <Screen
                 header={
@@ -87,7 +90,10 @@ export const ReceiveAddressContent = ({
                     <>
                         <ScreenFooterGradient />
                         <VStack paddingHorizontal="sp16" paddingTop="sp8" paddingBottom="sp16">
-                            <ReceiveAddressActions address={currentFreshAddress.address} />
+                            <ReceiveAddressActions
+                                address={currentFreshAddress.address}
+                                isDeviceVerificationEnabled={!isPortfolioTrackerDevice}
+                            />
                         </VStack>
                     </>
                 }

--- a/suite-native/module-receive/src/components/ReceiveAddressInteractionsProvider.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressInteractionsProvider.tsx
@@ -29,6 +29,7 @@ type ReceiveAddressInteractionsProviderProps = {
     address: string;
     addressPath: string;
     children: ReactNode;
+    isDeviceVerificationEnabled: boolean;
 };
 
 type NavigationProp = StackNavigationProps<ReceiveStackParamList, ReceiveStackRoutes>;
@@ -38,12 +39,17 @@ export const ReceiveAddressInteractionsProvider = ({
     address,
     addressPath,
     children,
+    isDeviceVerificationEnabled,
 }: ReceiveAddressInteractionsProviderProps) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const navigation = useNavigation<NavigationProp>();
 
     const handleVerifyAddress = (source: ReceiveAddressVerificationSource) => {
+        if (!isDeviceVerificationEnabled) {
+            return;
+        }
+
         analytics.report({ type: events.receiveStartVerificationEvent.name });
         navigation.navigate(ReceiveStackRoutes.ReceiveAddressVerification, {
             accountKey,
@@ -57,19 +63,25 @@ export const ReceiveAddressInteractionsProvider = ({
         closeCopiedAddressBottomSheet,
         handleCopyAddress,
         handleVerifyCopiedAddress,
-    } = useReceiveAddressCopy({ address, onVerifyAddress: handleVerifyAddress });
+    } = useReceiveAddressCopy({
+        address,
+        isDeviceVerificationEnabled,
+        onVerifyAddress: handleVerifyAddress,
+    });
 
     const contextValue = { handleCopyAddress, handleVerifyAddress };
 
     return (
         <ReceiveAddressInteractionsContext.Provider value={contextValue}>
             {children}
-            <ReceiveAddressVerificationBottomSheet
-                ref={copiedAddressBottomSheetRef}
-                source={ReceiveAddressVerificationSource.Pasted}
-                onVerifyAddress={handleVerifyCopiedAddress}
-                onSkipVerification={closeCopiedAddressBottomSheet}
-            />
+            {isDeviceVerificationEnabled && (
+                <ReceiveAddressVerificationBottomSheet
+                    ref={copiedAddressBottomSheetRef}
+                    source={ReceiveAddressVerificationSource.Pasted}
+                    onVerifyAddress={handleVerifyCopiedAddress}
+                    onSkipVerification={closeCopiedAddressBottomSheet}
+                />
+            )}
         </ReceiveAddressInteractionsContext.Provider>
     );
 };

--- a/suite-native/module-receive/src/components/ReceiveQRCodeCard.styles.ts
+++ b/suite-native/module-receive/src/components/ReceiveQRCodeCard.styles.ts
@@ -4,6 +4,7 @@ import type { NativeSpacing } from '@trezor/theme';
 export const RECEIVE_QR_CODE_PADDING = 'sp16' satisfies NativeSpacing;
 
 export const receiveQRCodeCardStyle = prepareNativeStyle(() => ({
+    alignSelf: 'center',
     overflow: 'hidden',
 }));
 
@@ -14,5 +15,7 @@ export const receiveQRCodeContainerStyle = prepareNativeStyle<{
 }>((utils, { qrCodeSize, paddingHorizontal, paddingVertical }) => ({
     width: qrCodeSize + paddingHorizontal,
     height: qrCodeSize + paddingVertical,
+    alignItems: 'center',
+    justifyContent: 'center',
     backgroundColor: utils.colors.surfaceFillRaised,
 }));

--- a/suite-native/module-receive/src/hooks/useReceiveAddressCopy.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveAddressCopy.ts
@@ -8,11 +8,13 @@ import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
 
 type UseReceiveAddressCopyParams = {
     address: string;
+    isDeviceVerificationEnabled: boolean;
     onVerifyAddress: (source: ReceiveAddressVerificationSource) => void;
 };
 
 export const useReceiveAddressCopy = ({
     address,
+    isDeviceVerificationEnabled,
     onVerifyAddress,
 }: UseReceiveAddressCopyParams) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
@@ -24,10 +26,21 @@ export const useReceiveAddressCopy = ({
     } = useBottomSheetModal();
 
     const handleCopyAddress = useCallback(async () => {
-        await copyToClipboard(address, undefined, { shouldShowToast: false });
+        await copyToClipboard(address, undefined, {
+            shouldShowToast: !isDeviceVerificationEnabled,
+        });
         analytics.report({ type: events.receiveCopyAddressEvent.name });
-        openCopiedAddressBottomSheet();
-    }, [address, analytics, copyToClipboard, openCopiedAddressBottomSheet]);
+
+        if (isDeviceVerificationEnabled) {
+            openCopiedAddressBottomSheet();
+        }
+    }, [
+        address,
+        analytics,
+        copyToClipboard,
+        isDeviceVerificationEnabled,
+        openCopiedAddressBottomSheet,
+    ]);
 
     const handleVerifyCopiedAddress = useCallback(() => {
         closeCopiedAddressBottomSheet();

--- a/suite-native/module-receive/src/hooks/useReceiveAddressSharing.test.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveAddressSharing.test.ts
@@ -30,11 +30,12 @@ jest.mock('@suite-native/alerts', () => ({
 describe('useReceiveAddressSharing', () => {
     const address = 'bc1qreceiveaddress';
 
-    const renderUseReceiveAddressSharing = async () =>
+    const renderUseReceiveAddressSharing = async (isDeviceVerificationEnabled = true) =>
         await renderHookWithBasicProvider(
             () =>
                 useReceiveAddressSharing({
                     address,
+                    isDeviceVerificationEnabled,
                     onVerifyAddress: mockVerifyAddress,
                 }),
             { services },
@@ -57,6 +58,18 @@ describe('useReceiveAddressSharing', () => {
 
         expect(mockShare).toHaveBeenCalledWith({ message: address });
         expect(mockOpenSharedAddressBottomSheet).toHaveBeenCalledTimes(1);
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.receiveShareAddressEvent.name,
+        });
+    });
+
+    it('does not open shared address verification when verification is disabled', async () => {
+        const { result } = await renderUseReceiveAddressSharing(false);
+
+        await act(() => result.current.handleShareAddress());
+
+        expect(mockShare).toHaveBeenCalledWith({ message: address });
+        expect(mockOpenSharedAddressBottomSheet).not.toHaveBeenCalled();
         expect(mockAnalyticsReport).toHaveBeenCalledWith({
             type: events.receiveShareAddressEvent.name,
         });

--- a/suite-native/module-receive/src/hooks/useReceiveAddressSharing.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveAddressSharing.ts
@@ -10,11 +10,13 @@ import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
 
 type UseReceiveAddressSharingParams = {
     address: string;
+    isDeviceVerificationEnabled: boolean;
     onVerifyAddress: (source: ReceiveAddressVerificationSource) => void;
 };
 
 export const useReceiveAddressSharing = ({
     address,
+    isDeviceVerificationEnabled,
     onVerifyAddress,
 }: UseReceiveAddressSharingParams) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
@@ -40,7 +42,10 @@ export const useReceiveAddressSharing = ({
             }
 
             analytics.report({ type: events.receiveShareAddressEvent.name });
-            openSharedAddressBottomSheet();
+
+            if (isDeviceVerificationEnabled) {
+                openSharedAddressBottomSheet();
+            }
         } catch {
             showAlert({
                 title: translate('generic.unknownError'),
@@ -48,7 +53,14 @@ export const useReceiveAddressSharing = ({
                 primaryButtonTitle: translate('generic.buttons.close'),
             });
         }
-    }, [address, analytics, openSharedAddressBottomSheet, showAlert, translate]);
+    }, [
+        address,
+        analytics,
+        isDeviceVerificationEnabled,
+        openSharedAddressBottomSheet,
+        showAlert,
+        translate,
+    ]);
 
     return {
         sharedAddressBottomSheetRef,

--- a/suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { type RouteProp, useRoute } from '@react-navigation/native';
 
+import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import { parseAccountKey } from '@suite-common/wallet-utils';
 import { ErrorMessage, ScreenFooterGradient, VStack } from '@suite-native/atoms';
 import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
@@ -33,6 +34,7 @@ export const ReceiveAddressDetailScreen = () => {
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
         selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
     if (hasFirmwareAuthenticityCheckHardFailed) {
         return <ReceiveBlockedDeviceCompromisedScreen />;
@@ -60,6 +62,7 @@ export const ReceiveAddressDetailScreen = () => {
             accountKey={accountKey}
             address={address.address}
             addressPath={addressPath}
+            isDeviceVerificationEnabled={!isPortfolioTrackerDevice}
         >
             <Screen
                 header={<ReceiveAddressDetailHeader address={address} symbol={networkSymbol} />}
@@ -67,7 +70,10 @@ export const ReceiveAddressDetailScreen = () => {
                     <>
                         <ScreenFooterGradient />
                         <VStack paddingHorizontal="sp16" paddingTop="sp8" paddingBottom="sp16">
-                            <ReceiveAddressActions address={address.address} />
+                            <ReceiveAddressActions
+                                address={address.address}
+                                isDeviceVerificationEnabled={!isPortfolioTrackerDevice}
+                            />
                         </VStack>
                     </>
                 }


### PR DESCRIPTION
## Description

- Center and size the receive QR card to its QR content so it stays responsive on narrow and foldable layouts.
- Disable receive address device verification for Portfolio Tracker wallets.
- Keep copy/share actions available for Portfolio Tracker while skipping the copied/shared verification bottom sheets.

## Notes for QA

- Check the Receive address screen on narrow Android emulator sizes and foldable/tablet widths. The QR should remain square, centered, and unclipped.
- With a connected Trezor wallet, Copy and Share should still offer address verification and the Verify button should remain visible.
- With Portfolio Tracker selected, Copy and Share should not open verification prompts and the Verify button should not be shown.
- On iOS, QR image actions from the QR long-press menu should remain available.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31466

## Screenshots:
<img width="445" height="580" alt="image" src="https://github.com/user-attachments/assets/2898de13-ee80-40e5-9e24-da0e62230860" />

https://github.com/user-attachments/assets/42846b14-51e2-4b9a-b50e-14de0bd3565f


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/responsive-qr-code&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->