### PR TITLE
Fix/connect mock

### DIFF
--- a/packages/connect-common/src/data/connectSettings.test.ts
+++ b/packages/connect-common/src/data/connectSettings.test.ts
@@ -1,4 +1,4 @@
-import { corsValidator, parseConnectSettings } from './connectSettings';
+import { corsValidator, parseConnectSettings, parseManifest } from './connectSettings';
 
 describe('data/connectSettings', () => {
     describe('parseConnectSettings enabledNetworks', () => {
@@ -18,6 +18,108 @@ describe('data/connectSettings', () => {
                 // @ts-expect-error intentionally malformed input
                 parseConnectSettings({ enabledNetworks: 'ada' }).enabledNetworks,
             ).toBeUndefined();
+        });
+    });
+
+    describe('parseManifest', () => {
+        const baseManifest = {
+            email: 'test@test.com',
+            appUrl: 'https://test.com',
+            appName: 'Test App',
+        };
+
+        it('returns undefined when manifest is undefined', () => {
+            expect(parseManifest(undefined)).toBeUndefined();
+        });
+
+        it('returns undefined when email is not a string', () => {
+            // @ts-expect-error intentionally malformed input
+            expect(parseManifest({ ...baseManifest, email: 123 })).toBeUndefined();
+        });
+
+        it('returns undefined when appUrl is not a string', () => {
+            // @ts-expect-error intentionally malformed input
+            expect(parseManifest({ ...baseManifest, appUrl: null })).toBeUndefined();
+        });
+
+        it('returns undefined when appName is not a string', () => {
+            // @ts-expect-error intentionally malformed input
+            expect(parseManifest({ ...baseManifest, appName: 42 })).toBeUndefined();
+        });
+
+        it('returns undefined when appIcon is not a string or undefined', () => {
+            // @ts-expect-error intentionally malformed input
+            expect(parseManifest({ ...baseManifest, appIcon: 123 })).toBeUndefined();
+        });
+
+        it('accepts appIcon as undefined', () => {
+            expect(parseManifest({ ...baseManifest, appIcon: undefined })).toEqual({
+                ...baseManifest,
+                appIcon: undefined,
+            });
+        });
+
+        it('accepts appIcon as a string', () => {
+            expect(parseManifest({ ...baseManifest, appIcon: 'icon.png' })).toEqual({
+                ...baseManifest,
+                appIcon: 'icon.png',
+            });
+        });
+
+        it('returns a valid manifest with all fields', () => {
+            expect(parseManifest(baseManifest)).toEqual({
+                email: 'test@test.com',
+                appUrl: 'https://test.com',
+                appName: 'Test App',
+                appIcon: undefined,
+            });
+        });
+
+        it('trims leading whitespace from appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: '  Test App' })?.appName).toBe(
+                'Test App',
+            );
+        });
+
+        it('trims trailing whitespace from appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: 'Test App  ' })?.appName).toBe(
+                'Test App',
+            );
+        });
+
+        it('collapses multiple spaces in the middle of appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: 'Test   App' })?.appName).toBe(
+                'Test App',
+            );
+        });
+
+        it('handles combined leading, trailing, and multiple middle spaces in appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: '  Test   App  ' })?.appName).toBe(
+                'Test App',
+            );
+        });
+
+        it('returns undefined when appName is an empty string', () => {
+            expect(parseManifest({ ...baseManifest, appName: '' })).toBeUndefined();
+        });
+
+        it('returns undefined when appName is only whitespace', () => {
+            expect(parseManifest({ ...baseManifest, appName: '   ' })).toBeUndefined();
+        });
+
+        it('strips control characters from appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: 'Test\x00App\x1F' })?.appName).toBe(
+                'TestApp',
+            );
+        });
+
+        it('returns undefined when appName is only control characters', () => {
+            expect(parseManifest({ ...baseManifest, appName: '\x00\x1F\x7F' })).toBeUndefined();
+        });
+
+        it('accepts long appName without length limit', () => {
+            const longName = 'A'.repeat(200);
+            expect(parseManifest({ ...baseManifest, appName: longName })?.appName).toBe(longName);
         });
     });
 

--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -1,5 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/ConnectSettings.js
 
+import { sanitizeName } from './sanitizeName';
 import { parseThpSettings } from './thpSettings';
 import { VERSION } from './version';
 import { DEFINITIONS_CHANNELS } from '../types/definitions';
@@ -25,10 +26,13 @@ export const parseManifest = (manifest?: Manifest) => {
     if (typeof manifest.appName !== 'string') return;
     if (typeof manifest.appIcon !== 'undefined' && typeof manifest.appIcon !== 'string') return;
 
+    const appName = sanitizeName(manifest.appName);
+    if (!appName) return;
+
     return {
         email: manifest.email,
         appUrl: manifest.appUrl,
-        appName: manifest.appName,
+        appName,
         appIcon: manifest.appIcon,
     };
 };

--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -22,8 +22,7 @@ export const parseManifest = (manifest?: Manifest) => {
     if (!manifest) return;
     if (typeof manifest.email !== 'string') return;
     if (typeof manifest.appUrl !== 'string') return;
-    // todo [connect10]: appName should become required
-    if (typeof manifest.appName !== 'undefined' && typeof manifest.appName !== 'string') return;
+    if (typeof manifest.appName !== 'string') return;
     if (typeof manifest.appIcon !== 'undefined' && typeof manifest.appIcon !== 'string') return;
 
     return {

--- a/packages/connect-common/src/data/sanitizeName.ts
+++ b/packages/connect-common/src/data/sanitizeName.ts
@@ -1,0 +1,18 @@
+export const MAX_NAME_LENGTH = 100;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS_REGEX = /[\x00-\x1F\x7F]/g;
+
+export const sanitizeName = (name: string, maxLength?: number): string | undefined => {
+    const sanitized = name.replace(CONTROL_CHARS_REGEX, '').replace(/\s+/g, ' ').trim();
+
+    if (sanitized.length === 0) {
+        return undefined;
+    }
+
+    if (maxLength !== undefined && sanitized.length > maxLength) {
+        return undefined;
+    }
+
+    return sanitized;
+};

--- a/packages/connect-common/src/data/thpSettings.test.ts
+++ b/packages/connect-common/src/data/thpSettings.test.ts
@@ -98,4 +98,86 @@ describe('data/thpSettings', () => {
         });
         expect(result).toEqual({ appName, pairingMethods, knownCredentials: [] });
     });
+
+    describe('trims whitespace from name fields', () => {
+        const pairingMethods = ['CodeEntry' as const];
+
+        it('trims appName from thp settings', () => {
+            const result = parseThpSettings({
+                thp: { appName: '  My  App  ', pairingMethods },
+            });
+            expect(result.appName).toBe('My App');
+        });
+
+        it('trims appName when falling back to manifest', () => {
+            const result = parseThpSettings({
+                manifest: {
+                    appName: '  Manifest  App  ',
+                    appUrl: 'https://test.com',
+                    email: 'test@test.com',
+                },
+            });
+            expect(result.appName).toBe('Manifest App');
+        });
+
+        it('trims hostName', () => {
+            const result = parseThpSettings({
+                thp: { hostName: '  My  Host  ', pairingMethods },
+            });
+            expect(result.hostName).toBe('My Host');
+        });
+    });
+
+    describe('rejects invalid name fields', () => {
+        const pairingMethods = ['CodeEntry' as const];
+
+        it('drops empty appName from thp settings', () => {
+            const result = parseThpSettings({
+                thp: { appName: '', pairingMethods },
+            });
+            expect(result.appName).toBeUndefined();
+        });
+
+        it('drops whitespace-only appName from thp settings', () => {
+            const result = parseThpSettings({
+                thp: { appName: '   ', pairingMethods },
+            });
+            expect(result.appName).toBeUndefined();
+        });
+
+        it('drops appName with only control characters', () => {
+            const result = parseThpSettings({
+                thp: { appName: '\x00\x1F', pairingMethods },
+            });
+            expect(result.appName).toBeUndefined();
+        });
+
+        it('strips control characters from appName', () => {
+            const result = parseThpSettings({
+                thp: { appName: 'My\x00App', pairingMethods },
+            });
+            expect(result.appName).toBe('MyApp');
+        });
+
+        it('drops appName exceeding 100 characters', () => {
+            const result = parseThpSettings({
+                thp: { appName: 'A'.repeat(101), pairingMethods },
+            });
+            expect(result.appName).toBeUndefined();
+        });
+
+        it('drops empty hostName', () => {
+            const result = parseThpSettings({
+                thp: { hostName: '   ', pairingMethods },
+            });
+            expect(result.hostName).toBeUndefined();
+        });
+
+        it('strips control characters from hostName', () => {
+            const result = parseThpSettings({
+                thp: { hostName: 'My\x00Host', pairingMethods },
+            });
+            expect(result.hostName).toBe('MyHost');
+        });
+    });
 });

--- a/packages/connect-common/src/data/thpSettings.ts
+++ b/packages/connect-common/src/data/thpSettings.ts
@@ -1,3 +1,4 @@
+import { MAX_NAME_LENGTH, sanitizeName } from './sanitizeName';
 import type { ConnectSettings, ThpSettings } from '../types/settings';
 
 export const parseThpSettings = ({ manifest, thp }: Partial<ConnectSettings>): ThpSettings => {
@@ -12,13 +13,13 @@ export const parseThpSettings = ({ manifest, thp }: Partial<ConnectSettings>): T
     }
 
     if (typeof thp?.hostName === 'string') {
-        settings.hostName = thp.hostName;
+        settings.hostName = sanitizeName(thp.hostName, MAX_NAME_LENGTH);
     }
 
     if (typeof thp?.appName === 'string') {
-        settings.appName = thp.appName;
+        settings.appName = sanitizeName(thp.appName, MAX_NAME_LENGTH);
     } else if (typeof manifest?.appName === 'string') {
-        settings.appName = manifest?.appName;
+        settings.appName = sanitizeName(manifest.appName, MAX_NAME_LENGTH);
     }
 
     if (Array.isArray(thp?.knownCredentials)) {

--- a/suite-common/test-utils/__mocks__/@trezor/connect.ts
+++ b/suite-common/test-utils/__mocks__/@trezor/connect.ts
@@ -70,7 +70,13 @@ const init = (params: any): Promise<void> => mockResponse('init', params);
 
 const call = (params: CallMethodPayload) => {
     if (params?.__info) {
-        connect.default.init({ manifest: { email: '', appUrl: '' } });
+        connect.default.init({
+            manifest: {
+                email: 'email@trezor.io',
+                appUrl: 'https://trezor.io',
+                appName: 'Test App',
+            },
+        });
 
         // call actual implementation
         return connect.default[params.method](params).finally(() => {

--- a/suite-common/test-utils/__mocks__/@trezor/connect.ts
+++ b/suite-common/test-utils/__mocks__/@trezor/connect.ts
@@ -68,9 +68,9 @@ const mockResponse = (method: string, params: any) =>
 
 const init = (params: any): Promise<void> => mockResponse('init', params);
 
-const call = (params: CallMethodPayload) => {
+const call = async (params: CallMethodPayload) => {
     if (params?.__info) {
-        connect.default.init({
+        await connect.default.init({
             manifest: {
                 email: 'email@trezor.io',
                 appUrl: 'https://trezor.io',

--- a/suite/coinjoin/src/__fixtures__/mockCoinjoinService.ts
+++ b/suite/coinjoin/src/__fixtures__/mockCoinjoinService.ts
@@ -46,7 +46,7 @@ export const mockCoinjoinService = () => {
                     changeCount: 20,
                 },
             })),
-            getAccountInfo: jest.fn(() => ({
+            getAccountInfo: jest.fn(descriptor => ({
                 history: {
                     transactions: [],
                 },
@@ -55,6 +55,7 @@ export const mockCoinjoinService = () => {
                     unused: [],
                     change: [],
                 },
+                descriptor,
             })),
             getAccountCheckpoint: jest.fn(() => undefined),
         };

--- a/suite/coinjoin/src/coinjoinAccountActions.ts
+++ b/suite/coinjoin/src/coinjoinAccountActions.ts
@@ -863,7 +863,7 @@ type RestorePausedCoinjoinSessionsThunkState = CoinjoinRootState &
 
 // check for blocking conditions of interrupted sessions and restore those eligible
 export const restorePausedCoinjoinSessionsThunk =
-    () => (dispatch: Dispatch, getState: () => RestorePausedCoinjoinSessionsThunkState) => {
+    () => async (dispatch: Dispatch, getState: () => RestorePausedCoinjoinSessionsThunkState) => {
         const state = getState();
         const coinjoinAccounts = selectCoinjoinAccounts(state);
         const eligibleAccounts = coinjoinAccounts.filter(({ key, session }) => {
@@ -875,13 +875,18 @@ export const restorePausedCoinjoinSessionsThunk =
             return !hasSendFormOpen && !blocker && session?.paused;
         });
 
-        eligibleAccounts.forEach(account => dispatch(restoreCoinjoinSessionThunk(account.key)));
+        for (const account of eligibleAccounts) {
+            await dispatch(restoreCoinjoinSessionThunk(account.key));
+        }
+
+        // eligibleAccounts.forEach(account => dispatch(restoreCoinjoinSessionThunk(account.key)));
     };
 
 type StopCoinjoinAccountThunkState = CoinjoinRootState;
 
 export const stopCoinjoinAccountThunk =
-    (account: Account) => (dispatch: Dispatch, getState: () => StopCoinjoinAccountThunkState) => {
+    (account: Account) =>
+    async (dispatch: Dispatch, getState: () => StopCoinjoinAccountThunkState) => {
         const cjAccount = selectCoinjoinAccountByKey(getState(), account.key);
 
         if (cjAccount?.session) {
@@ -892,7 +897,7 @@ export const stopCoinjoinAccountThunk =
                     }),
                 );
             }
-            dispatch(coinjoinClientActions.stopCoinjoinSessionThunk(cjAccount.key));
+            await dispatch(coinjoinClientActions.stopCoinjoinSessionThunk(cjAccount.key));
         }
     };
 
@@ -902,7 +907,7 @@ type StopCoinjoinSessionByDeviceIdThunkState = AccountsRootState &
 
 export const stopCoinjoinSessionByDeviceIdThunk =
     (deviceID: string) =>
-    (dispatch: Dispatch, getState: () => StopCoinjoinSessionByDeviceIdThunkState) => {
+    async (dispatch: Dispatch, getState: () => StopCoinjoinSessionByDeviceIdThunkState) => {
         const state = getState();
 
         const devices = selectDevices(state);
@@ -913,7 +918,7 @@ export const stopCoinjoinSessionByDeviceIdThunk =
             ),
         );
 
-        affectedAccounts.forEach(account => {
+        for (const account of affectedAccounts) {
             const isAccountWithSession = selectIsAccountWithSessionByAccountKey(state, account.key);
 
             if (isAccountWithSession) {
@@ -929,9 +934,9 @@ export const stopCoinjoinSessionByDeviceIdThunk =
                     );
                 }
 
-                dispatch(coinjoinClientActions.stopCoinjoinSessionThunk(account.key));
+                await dispatch(coinjoinClientActions.stopCoinjoinSessionThunk(account.key));
             }
-        });
+        }
     };
 
 type RestoreCoinjoinAccountsThunkState = CoinjoinRootState;

--- a/suite/coinjoin/src/coinjoinClientActions.test.ts
+++ b/suite/coinjoin/src/coinjoinClientActions.test.ts
@@ -416,7 +416,7 @@ describe('coinjoinClientActions', () => {
 
         await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
 
-        store.dispatch(stopCoinjoinSessionThunk(accountAKey));
+        await store.dispatch(stopCoinjoinSessionThunk(accountAKey));
     });
 
     it('stopCoinjoinSessionThunk with error from Trezor', async () => {
@@ -437,7 +437,7 @@ describe('coinjoinClientActions', () => {
 
         await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
 
-        store.dispatch(stopCoinjoinSessionThunk(accountAKey));
+        await store.dispatch(stopCoinjoinSessionThunk(accountAKey));
 
         expect(TrezorConnect.cancelCoinjoinAuthorization).toHaveBeenCalledTimes(1);
     });
@@ -480,7 +480,7 @@ describe('coinjoinClientActions', () => {
 
         await store.dispatch(initCoinjoinServiceThunk(btcSymbol));
 
-        store.dispatch(stopCoinjoinSessionThunk(accountAKey));
+        await store.dispatch(stopCoinjoinSessionThunk(accountAKey));
 
         expect(TrezorConnect.cancelCoinjoinAuthorization).toHaveBeenCalledTimes(0);
     });

--- a/suite/coinjoin/src/coinjoinClientActions.ts
+++ b/suite/coinjoin/src/coinjoinClientActions.ts
@@ -418,9 +418,9 @@ export const onCoinjoinRoundChangedThunk =
                         session?.isAutoStopEnabled,
                 );
 
-                accountsWithAutostop.forEach(({ account: { key } }) => {
-                    dispatch(stopCoinjoinSessionThunk(key));
-                });
+                for (const { account } of accountsWithAutostop) {
+                    await dispatch(stopCoinjoinSessionThunk(account.key));
+                }
             } else if (
                 round.phase > RoundPhase.InputRegistration &&
                 !dispatch(hasCriticalPhaseModalThunk())

--- a/suite/coinjoin/src/coinjoinMiddleware.test.ts
+++ b/suite/coinjoin/src/coinjoinMiddleware.test.ts
@@ -116,6 +116,7 @@ describe('coinjoinMiddleware', () => {
             }
 
             store.dispatch(f.action);
+            await new Promise(resolve => setTimeout(resolve, 1)); // wait for async actions to finish
             expect(await store.getActions()).toEqual([f.action, ...f.expectedActions]);
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is split between low-level TrezorConnect/THP configuration utilities and Coinjoin internals. connectSettings.ts and thpSettings.ts are global dependencies referenced by many tests, but only the TrezorConnect E2E tests and the onboarding/device-pairing flows directly exercise their behavior. sanitizeName.ts is best covered by device settings rename tests. The Coinjoin files have no corresponding E2E tests in the suite, so they remain uncovered at the E2E level. Run the high-priority tests unconditionally and the medium-priority tests as a targeted second line.

<details><summary><b>Changed files (11)</b></summary>

- `packages/connect-common/src/data/connectSettings.test.ts`
- `packages/connect-common/src/data/connectSettings.ts`
- `packages/connect-common/src/data/sanitizeName.ts`
- `packages/connect-common/src/data/thpSettings.test.ts`
- `packages/connect-common/src/data/thpSettings.ts`
- `suite-common/test-utils/__mocks__/@trezor/connect.ts`
- `suite/coinjoin/src/__fixtures__/mockCoinjoinService.ts`
- `suite/coinjoin/src/coinjoinAccountActions.ts`
- `suite/coinjoin/src/coinjoinClientActions.test.ts`
- `suite/coinjoin/src/coinjoinClientActions.ts`
- `suite/coinjoin/src/coinjoinMiddleware.test.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test explicitly handles the THP pairing code flow during onboarding, so changes to thpSettings.ts could directly affect device pairing behavior in this path.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — The T3W1 onboarding flow performs THP device pairing, which is governed by thpSettings.ts; regressions here would block wallet creation on this device model.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test changes the device name to 'TREVOR!' and verifies it is applied; sanitizeName.ts likely normalizes the name before the ApplySettings message is sent.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Directly exercises TrezorConnect popup initialization and multiple API calls; connectSettings.ts defines the default Connect configuration consumed by these flows.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests Connect permissions UI and remembered app state; changes to connectSettings.ts could alter how permissions are requested, persisted, or displayed.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Connect flow through the webextension entry point shares the same Connect initialization path as the web popup, so connectSettings.ts changes could affect it.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Core Connect address export flow; would catch regressions in Connect initialization from connectSettings.ts, though it is less permission-focused than the high-priority Connect tests.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Also tests device renaming on T3B1, providing secondary coverage for sanitizeName.ts on a different device model and firmware path.
- `suite/e2e/tests/suite/initial-run.test.ts` — THP pairing can be triggered during the first-run onboarding sequence, sharing THP infrastructure with thpSettings.ts.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/connect-common/src/data/sanitizeName.ts`
- `suite-common/test-utils/__mocks__/@trezor/connect.ts`
- `suite/coinjoin/src/__fixtures__/mockCoinjoinService.ts`
- `suite/coinjoin/src/coinjoinAccountActions.ts`
- `suite/coinjoin/src/coinjoinClientActions.ts`

_Updated: 2026-09-08T10:51:10.742Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-mock/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-mock/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-mock&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-mock&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-mock&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T10:52:05.425Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T10:51:56.741Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->