### PR TITLE
Remove __info calls mock

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/connectInitThunks.test.ts
@@ -355,35 +355,4 @@ describe('TrezorConnect Actions', () => {
         expect(onInvalidPinDepleted).toHaveBeenCalledTimes(1);
         expect(onRequestWord).toHaveBeenCalledTimes(1);
     });
-
-    // 10s timeout — `__info: true` calls the real Connect implementation through the mock,
-    // which spins up an actual Core (init + getFeatures + getAccountInfo + dispose). On
-    // busy CI runners this routinely hovers around 4–5s and tripped the 5s default.
-    it('Test that connect mock works with __info parameter', async () => {
-        const { dispatch, getState, extra } = createThunkDeps();
-        await connectInitThunk()(dispatch, getState, extra);
-
-        const res1 = await testMocks.getTrezorConnectMock().getFeatures({ __info: true });
-        expect(res1).toMatchObject({
-            success: true,
-            payload: expect.objectContaining({
-                name: 'getFeatures',
-                useDevice: true,
-            }),
-        });
-
-        const res2 = await testMocks.getTrezorConnectMock().getAccountInfo({
-            coin: 'btc',
-            descriptor: 'xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiK9w',
-            __info: true,
-        });
-
-        expect(res2).toMatchObject({
-            success: true,
-            payload: expect.objectContaining({
-                name: 'getAccountInfo',
-                useDevice: false,
-            }),
-        });
-    }, 10_000);
 });

--- a/suite-common/test-utils/__mocks__/@trezor/connect.ts
+++ b/suite-common/test-utils/__mocks__/@trezor/connect.ts
@@ -68,25 +68,7 @@ const mockResponse = (method: string, params: any) =>
 
 const init = (params: any): Promise<void> => mockResponse('init', params);
 
-const call = (params: CallMethodPayload) => {
-    if (params?.__info) {
-        connect.default.init({
-            manifest: {
-                email: 'email@trezor.io',
-                appUrl: 'https://trezor.io',
-                appName: 'Test App',
-            },
-        });
-
-        // call actual implementation
-        return connect.default[params.method](params).finally(() => {
-            // I needed to call dispose to get rid of 'Jest did not exit one second after the test run has completed.' warning
-            connect.default.dispose();
-        });
-    }
-
-    return mockResponse(params.method, params);
-};
+const call = (params: CallMethodPayload) => mockResponse(params.method, params);
 
 const on = jest.fn((event: string, cb) => (listeners[event] = cb));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to a connect-init thunk test and a Jest mock for @trezor/connect, so the primary risk is in TrezorConnect initialization and handshake behavior rather than app features. A small set of connect-focused E2E tests covering both suite-web popup and suite-desktop core-mode init flows provides high confidence with minimal runtime. The Jest mock file has no direct E2E coverage and is not exercised by these tests.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/connect-init/src/connectInitThunks.test.ts`
- `suite-common/test-utils/__mocks__/@trezor/connect.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Directly exercises TrezorConnect popup initialization and call lifecycle (getAddress/cardanoGetAddress) in suite-web core mode, which relies on the connect-init handshake and initialization path touched by connectInitThunks.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect.init with coreMode 'suite-desktop' and the resulting error modal flow, making it a focused regression check for desktop connect initialization behavior.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Covers TrezorConnect.init in suite-desktop followed by address export, device confirmation, and permissions handling — all downstream of the connect-init setup.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Validates permission grant/remember during TrezorConnect.init and Connect settings, which is part of the connect-init flow that the changed thunk tests exercise.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Specifically tests TrezorConnect.init with requestedPermissions and how declared permissions are granted upfront, a connect-init feature closely related to the changed thunk unit tests.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Uses the same suite-web connect-init/popup machinery as the web popup test but through a webextension service-worker context; a useful variant to catch init-specific regressions.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Exercises the desktop connect-init handshake before a signing flow, sharing the TrezorConnect.init and permission path with the changed code.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Combines TrezorConnect.init with remembered permissions and silent-mode focus behavior, relying on the same connect-init setup and permission state.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/test-utils/__mocks__/@trezor/connect.ts`

_Updated: 2026-09-08T12:40:57.787Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/info-calls-mock/web/](https://dev.suite.sldev.cz/suite-web/test/info-calls-mock/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T12:44:34.444Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T12:43:24.848Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/info-calls-mock&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/info-calls-mock&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/info-calls-mock&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->