### PR TITLE
fix(suite-native-31462): add trade info card and feedback

### DIFF
--- a/suite-common/formatters/src/FormatterProvider.tsx
+++ b/suite-common/formatters/src/FormatterProvider.tsx
@@ -20,7 +20,10 @@ import {
     prepareCryptoAmountFormatter,
 } from './formatters/prepareCryptoAmountFormatter';
 import { prepareDateFormatter } from './formatters/prepareDateFormatter';
-import { prepareDateTimeFormatter } from './formatters/prepareDateTimeFormatter';
+import {
+    type DateTimeFormatterDataContext,
+    prepareDateTimeFormatter,
+} from './formatters/prepareDateTimeFormatter';
 import {
     type DisplaySymbolFormatterDataContext,
     prepareDisplaySymbolFormatter,
@@ -52,7 +55,7 @@ export type Formatters = {
     >;
     DateFormatter: Formatter<Date | number, string>;
     TimeFormatter: Formatter<Date | number, string>;
-    DateTimeFormatter: Formatter<Date | number | null, string | null>;
+    DateTimeFormatter: Formatter<Date | number | null, string | null, DateTimeFormatterDataContext>;
     MonthNameFormatter: Formatter<Date, string>;
 };
 

--- a/suite-common/formatters/src/formatters/prepareDateTimeFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareDateTimeFormatter.ts
@@ -2,16 +2,25 @@ import { makeFormatter } from '../makeFormatter';
 import { type FormatterConfig } from '../types';
 import { dateFormatterOptions } from './prepareDateFormatter';
 
+export type DateTimeFormatterDataContext = {
+    dateStyle?: 'short' | 'long';
+};
+
 export const prepareDateTimeFormatter = (config: FormatterConfig) =>
-    makeFormatter<Date | number | null, string | null>(value => {
-        if (!value) return null;
+    makeFormatter<Date | number | null, string | null, DateTimeFormatterDataContext>(
+        (value, { dateStyle }) => {
+            if (!value) return null;
 
-        const options: Intl.DateTimeFormatOptions = {
-            ...dateFormatterOptions,
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: !config.is24HourFormat,
-        };
+            const options: Intl.DateTimeFormatOptions = {
+                ...dateFormatterOptions,
+                month: dateStyle === 'long' ? 'long' : '2-digit',
+                day: dateStyle === 'long' ? 'numeric' : '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: !config.is24HourFormat,
+            };
 
-        return new Intl.DateTimeFormat(undefined, options).format(value);
-    }, 'DateTimeFormatter');
+            return new Intl.DateTimeFormat(undefined, options).format(value);
+        },
+        'DateTimeFormatter',
+    );

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -4174,7 +4174,7 @@ export const messages = {
             transactionId: 'Trans. ID: {orderId}',
             detail: {
                 info: {
-                    youPay: 'You pay',
+                    youPayLabel: 'You pay',
                     youGet: 'You get',
                     fromAccount: 'from {accountLabel}',
                     toAccount: 'to {accountLabel}',

--- a/suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusProviderLink.tsx
+++ b/suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusProviderLink.tsx
@@ -10,12 +10,14 @@ type TradeStatusProviderLinkProps = {
     logo?: string;
     statusUrl?: string;
     providerName: string;
+    isActive?: boolean;
 };
 
 export const TradeStatusProviderLink = ({
     logo,
     providerName,
     statusUrl,
+    isActive = true,
 }: TradeStatusProviderLinkProps) => {
     const openLink = useOpenLink();
     const isStatusUrlAvailable = !!statusUrl;
@@ -26,13 +28,7 @@ export const TradeStatusProviderLink = ({
                 label={
                     <Translation id="moduleTrading.tradeHistory.detail.statusStepper.provider.label" />
                 }
-                value={
-                    <ProviderDisplay
-                        color="contentSecondary"
-                        logo={logo}
-                        providerName={providerName}
-                    />
-                }
+                value={<ProviderDisplay logo={logo} providerName={providerName} />}
             />
         );
     }
@@ -43,7 +39,8 @@ export const TradeStatusProviderLink = ({
             <Box flexShrink={1}>
                 <TextButton
                     size="small"
-                    intent="brand"
+                    intent={isActive ? 'brand' : 'neutral'}
+                    priority={isActive ? 'primary' : 'secondary'}
                     isUnderlined
                     iconRight="arrowSquareOut"
                     onPress={() => openLink(statusUrl)}

--- a/suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusSubItem.tsx
+++ b/suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusSubItem.tsx
@@ -18,6 +18,7 @@ export type TradeStatusSubItemProps = {
     onPress?: () => void;
     textVariant?: NativeTypographyStyle;
     color?: Color;
+    isActive?: boolean;
 };
 
 export const TradeStatusSubItem = ({
@@ -26,6 +27,7 @@ export const TradeStatusSubItem = ({
     onPress,
     textVariant = 'body-sm',
     color = 'contentSecondary',
+    isActive = true,
 }: TradeStatusSubItemProps) => {
     const { applyStyle } = useNativeStyles();
     const isValueText = typeof value === 'string' || typeof value === 'number';
@@ -51,13 +53,21 @@ export const TradeStatusSubItem = ({
                                 ellipsizeMode="middle"
                                 isUnderlined
                                 textVariant="body-sm"
+                                textColor={isActive ? 'contentBrand' : 'contentSecondary'}
+                                textPressedColor={
+                                    isActive ? 'contentBrandPressed' : 'contentSecondaryPressed'
+                                }
                                 label={value}
                                 onPress={onPress}
                                 numberOfLines={1}
                                 style={applyStyle(shrinkableStyle)}
                             />
                         </Box>
-                        <Icon name="caretRight" size={20} />
+                        <Icon
+                            name="caretRight"
+                            size={20}
+                            color={isActive ? 'contentPrimary' : 'contentSecondary'}
+                        />
                     </HStack>
                 ) : (
                     renderValue

--- a/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetail.test.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetail.test.tsx
@@ -49,30 +49,42 @@ describe('TradingHistoryDetail', () => {
         ).toBeOnTheScreen();
     });
 
-    it('should render a payment interruption banner for a buy without a status link while waiting for payment', async () => {
-        const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-        const trade = {
-            ...buyTrade,
-            data: { ...buyTrade.data, partnerData: undefined, statusUrl: null },
-        };
-        const { getByText } = await renderDetail(trade);
+    it.each([
+        ['with a status link', getBuyTrade({ status: 'SUBMITTED' })],
+        [
+            'without a status link',
+            {
+                ...getBuyTrade({ status: 'SUBMITTED' }),
+                data: {
+                    ...getBuyTrade({ status: 'SUBMITTED' }).data,
+                    partnerData: undefined,
+                    statusUrl: null,
+                },
+            },
+        ],
+    ] as const)(
+        'should render a payment interruption banner for a buy %s while waiting for payment',
+        async (_, trade) => {
+            const { getByText } = await renderDetail(trade);
 
-        expect(
-            getByText(
-                getTranslation('moduleTrading.tradeHistory.detail.paymentInterruptionBanner.title'),
-            ),
-        ).toBeOnTheScreen();
-        expect(
-            getByText(
-                getTranslation(
-                    'moduleTrading.tradeHistory.detail.paymentInterruptionBanner.description',
+            expect(
+                getByText(
+                    getTranslation(
+                        'moduleTrading.tradeHistory.detail.paymentInterruptionBanner.title',
+                    ),
                 ),
-            ),
-        ).toBeOnTheScreen();
-    });
+            ).toBeOnTheScreen();
+            expect(
+                getByText(
+                    getTranslation(
+                        'moduleTrading.tradeHistory.detail.paymentInterruptionBanner.description',
+                    ),
+                ),
+            ).toBeOnTheScreen();
+        },
+    );
 
     it.each([
-        ['a status link is available', getBuyTrade({ status: 'SUBMITTED' })],
         [
             'the waiting-for-payment step is completed',
             {

--- a/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailAssetRow.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailAssetRow.tsx
@@ -125,7 +125,7 @@ export const TradingHistoryDetailAssetRow = ({
                         <Translation
                             id={
                                 side === 'pay'
-                                    ? 'moduleTrading.tradeHistory.detail.info.youPay'
+                                    ? 'moduleTrading.tradeHistory.detail.info.youPayLabel'
                                     : 'moduleTrading.tradeHistory.detail.info.youGet'
                             }
                         />

--- a/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailBuyPaymentBanner.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailBuyPaymentBanner.tsx
@@ -2,7 +2,7 @@ import { type TradingTransactionBuy } from '@suite-common/trading';
 import { BannerFull } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
-import { getBuyTradeProgress, getTradeStatusUrl } from '../../utils/tradeStatusUtils';
+import { getBuyTradeProgress } from '../../utils/tradeStatusUtils';
 
 type TradingHistoryDetailBuyPaymentBannerProps = {
     trade: TradingTransactionBuy;
@@ -12,9 +12,8 @@ export const TradingHistoryDetailBuyPaymentBanner = ({
     trade,
 }: TradingHistoryDetailBuyPaymentBannerProps) => {
     const isWaitingForPayment = getBuyTradeProgress(trade.data.status) === 'customerAction';
-    const isStatusLinkAvailable = !!getTradeStatusUrl(trade);
 
-    if (!isWaitingForPayment || isStatusLinkAvailable) {
+    if (!isWaitingForPayment) {
         return null;
     }
 

--- a/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailInfo.test.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailInfo.test.tsx
@@ -61,7 +61,7 @@ describe('TradingHistoryDetailInfo', () => {
         );
 
         expect(
-            getByText(getTranslation('moduleTrading.tradeHistory.detail.info.youPay')),
+            getByText(getTranslation('moduleTrading.tradeHistory.detail.info.youPayLabel')),
         ).toBeOnTheScreen();
         expect(
             getByText(getTranslation('moduleTrading.tradeHistory.detail.info.youGet')),

--- a/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailPlacedAtRow.test.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailPlacedAtRow.test.tsx
@@ -6,12 +6,12 @@ import { TradingHistoryDetailPlacedAtRow } from './TradingHistoryDetailPlacedAtR
 describe('TradingHistoryDetailPlacedAtRow', () => {
     it('renders the placement date', async () => {
         const { getByText } = await renderWithBasicProvider(
-            <TradingHistoryDetailPlacedAtRow placedAt={new Date('2025-01-15T10:00:00Z')} />,
+            <TradingHistoryDetailPlacedAtRow placedAt={new Date(2026, 2, 13, 12, 15)} />,
         );
 
         expect(
             getByText(getTranslation('moduleTrading.tradeHistory.detail.info.placed')),
         ).toBeOnTheScreen();
-        expect(getByText(/2025/)).toBeOnTheScreen();
+        expect(getByText('March 13, 2026 at 12:15')).toBeOnTheScreen();
     });
 });

--- a/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailPlacedAtRow.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailPlacedAtRow.tsx
@@ -18,7 +18,7 @@ export const TradingHistoryDetailPlacedAtRow = ({
                 <Translation id="moduleTrading.tradeHistory.detail.info.placed" />
             </Text>
             <Text variant="body-sm">
-                <DateTimeFormatter value={placedAt} />
+                <DateTimeFormatter value={placedAt} dateStyle="long" />
             </Text>
         </TradeInfoRow>
     );

--- a/suite-native/trading-history/src/hooks/useBuyTradeStatusSteps.tsx
+++ b/suite-native/trading-history/src/hooks/useBuyTradeStatusSteps.tsx
@@ -34,6 +34,7 @@ export const useBuyTradeStatusSteps = (trade: TradingTransactionBuy) => {
             statusUrl={statusUrl}
             key="provider"
             logo={provider?.logo}
+            isActive={progressId === 'providerProcessing'}
         />
     );
 

--- a/suite-native/trading-history/src/hooks/useExchangeTradeStatusSteps.tsx
+++ b/suite-native/trading-history/src/hooks/useExchangeTradeStatusSteps.tsx
@@ -48,6 +48,7 @@ export const useExchangeTradeStatusSteps = (trade: TradingTransactionExchange) =
             statusUrl={statusUrl}
             key="provider"
             logo={provider?.logo}
+            isActive={progressId === (isDex ? 'customerAction' : 'providerProcessing')}
         />
     );
 
@@ -59,6 +60,7 @@ export const useExchangeTradeStatusSteps = (trade: TradingTransactionExchange) =
             value={trade.data.receiveTxHash}
             onPress={handleTxIdPress}
             key="transaction-id"
+            isActive={progressId === 'customerAction'}
         />
     );
 
@@ -114,6 +116,7 @@ export const useExchangeTradeStatusSteps = (trade: TradingTransactionExchange) =
                             value={trade.data.receiveTxHash}
                             textVariant="body-md"
                             onPress={handleTxIdPress}
+                            isActive={false}
                         />
                     ),
                 },

--- a/suite-native/trading-history/src/hooks/useSellTradeStatusSteps.tsx
+++ b/suite-native/trading-history/src/hooks/useSellTradeStatusSteps.tsx
@@ -43,6 +43,7 @@ export const useSellTradeStatusSteps = (trade: TradingTransactionSell) => {
             statusUrl={statusUrl}
             key="provider"
             logo={provider?.logo}
+            isActive={progressId === 'providerProcessing'}
         />
     );
 
@@ -67,6 +68,7 @@ export const useSellTradeStatusSteps = (trade: TradingTransactionSell) => {
                             value={trade.data.txid}
                             textVariant="body-md"
                             onPress={handleTxIdPress}
+                            isActive={false}
                         />
                     ),
                 },

--- a/suite-native/trading-history/src/hooks/useTradingHistoryDetailInfo.ts
+++ b/suite-native/trading-history/src/hooks/useTradingHistoryDetailInfo.ts
@@ -107,7 +107,7 @@ const getTradingHistoryDetailAsset = ({
         type: 'crypto',
         accountLabel: accountLabel ?? cryptoAsset.networkName,
         amount,
-        contractAddress: cryptoAsset.contractAddress ?? undefined,
+        contractAddress: cryptoAsset.isNativeToken ? undefined : cryptoAsset.contractAddress,
         cryptoId,
         displaySymbol: cryptoAsset.displaySymbol,
         name: cryptoAsset.name,


### PR DESCRIPTION
## Description
* Long Date format
* Fix TradingAsset Icon not rendering eth on different networks
* Color adjustments of active links 


## Notes for QA
- Just UI adjustments no QA

## Related Issue

Resolve: #31462

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is dominated by suite-native (mobile) trading history components that are not exercised by the desktop/web E2E suite, plus two broadly-shared formatter utilities. Only the swap-history E2E test has explicit, concrete assertions on formatted dates that would catch regressions in the shared date-time/formatter infrastructure. The native files should be validated through the mobile/native test pipeline rather than the Suite E2E suite.

<details><summary><b>Changed files (15)</b></summary>

- `suite-common/formatters/src/FormatterProvider.tsx`
- `suite-common/formatters/src/formatters/prepareDateTimeFormatter.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusProviderLink.tsx`
- `suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusSubItem.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetail.test.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailAssetRow.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailBuyPaymentBanner.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailInfo.test.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailPlacedAtRow.test.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailPlacedAtRow.tsx`
- `suite-native/trading-history/src/hooks/useBuyTradeStatusSteps.tsx`
- `suite-native/trading-history/src/hooks/useExchangeTradeStatusSteps.tsx`
- `suite-native/trading-history/src/hooks/useSellTradeStatusSteps.tsx`
- `suite-native/trading-history/src/hooks/useTradingHistoryDetailInfo.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — This test explicitly asserts that each swap trade row displays a 'formatted date' and validates transaction history ordering. A change to prepareDateTimeFormatter.ts or FormatterProvider.tsx would directly surface here as visible date-formatting regressions in the trading history list.

</details>

⚠️ **Changes with no test coverage (13)**
- `suite-native/intl/src/messages.ts`
- `suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusProviderLink.tsx`
- `suite-native/trading-atoms/src/components/TradeStatusStepper/TradeStatusSubItem.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetail.test.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailAssetRow.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailBuyPaymentBanner.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailInfo.test.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailPlacedAtRow.test.tsx`
- `suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailPlacedAtRow.tsx`
- `suite-native/trading-history/src/hooks/useBuyTradeStatusSteps.tsx`
- `suite-native/trading-history/src/hooks/useExchangeTradeStatusSteps.tsx`
- `suite-native/trading-history/src/hooks/useSellTradeStatusSteps.tsx`
- `suite-native/trading-history/src/hooks/useTradingHistoryDetailInfo.ts`

_Updated: 2026-09-08T12:13:09.127Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31462-post-trade---add-trade-info-card-and-feedback/web/](https://dev.suite.sldev.cz/suite-web/fix/31462-post-trade---add-trade-info-card-and-feedback/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31462-post-trade---add-trade-info-card-and-feedback&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31462-post-trade---add-trade-info-card-and-feedback&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31462-post-trade---add-trade-info-card-and-feedback&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T12:15:26.271Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T12:15:11.867Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->