### PR TITLE
fix(suite-common-30368): merge provider quote updates from watchTrade response

### DIFF
--- a/suite-common/trading/src/thunks/common/watchTradeThunk.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.ts
@@ -57,7 +57,6 @@ const watchTradeData = async <T extends TradingType>({
     const updates = {
         ...getDefinedWatchUpdates(response),
         // always apply, even if undefined
-        status: response.status,
         error: response.error,
     };
     const updateKeys = typedObjectKeys(updates);


### PR DESCRIPTION
## Description

- Summary: Merge provider quote updates from the `watchTrade` response while preserving the existing trade status.

## Notes for QA
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

- Verify that statuses are being updated in post trade or in trade history list

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/30368

## Screenshots:
<!--- Keep just title, empty for later add -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared Redux thunk for watching/polling trade status across buy, sell, and swap flows. Although it maps broadly to 134 tests, only a small subset directly exercises watch status polling. The recommended tests focus on those that explicitly assert watch endpoint behavior or status-phase transitions driven by the watch thunk, providing targeted regression coverage without over-broadening the run.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/trading/src/thunks/common/watchTradeThunk.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test explicitly exercises the buy watch endpoint: it verifies the transaction detail status transitions from 'Waiting for user' to 'Success' after a watch refresh polling interval and asserts on the buy watch API request payload. Changes to watchTradeThunk would directly affect this behavior.
- `suite/e2e/tests/trading/sell-solana.test.ts` — The test directly asserts that after watch polling returns SUCCESS, the transaction status changes to 'TR_TRADING_DETAIL_PROCESSING' and a provider support link appears. This is a direct test of the sell watch polling path that watchTradeThunk implements.
- `suite/e2e/tests/trading/swap-history.test.ts` — This test explicitly mocks the swap watch endpoint to keep CONFIRMING trade statuses stable and verifies status translations in the swap history. Any change to the swap watch thunk logic would directly impact this test's core assertions.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell trade progresses through multiple status phases (e.g., SEND_CRYPTO and subsequent statuses) with correct status translations, which relies on the underlying watch/polling mechanism to advance trade state.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — The test verifies swap transaction status progresses through a defined status flow after broadcast. This status progression depends on the watch thunk polling for updates, making it a meaningful shared-infrastructure regression check.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — The test checks that transaction detail status updates through multiple swap status stages with correct translations. These updates are driven by the watch polling loop, so this test covers the ETH→SOL swap watch path.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — The test asserts status transitions through swap phases (SENDING, CONVERTING, etc.) and support banner behavior during the CONVERTING phase, both of which depend on the watch thunk updating trade status.

</details>

_Updated: 2026-09-08T12:17:18.750Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/30368-trading-merge-provider-quote-updates-from-watchtrade-response/web/](https://dev.suite.sldev.cz/suite-web/fix/30368-trading-merge-provider-quote-updates-from-watchtrade-response/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/30368-trading-merge-provider-quote-updates-from-watchtrade-response&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/30368-trading-merge-provider-quote-updates-from-watchtrade-response&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/30368-trading-merge-provider-quote-updates-from-watchtrade-response&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T12:20:56.745Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T12:20:15.202Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->