### PR TITLE
chore(suite-native): start tracking ENS resolution

### DIFF
--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -103,6 +103,7 @@ export enum EventType {
     SendAddressFilled = 'send/address_filled',
     // eslint-disable-next-line local-rules/analytics-event-name
     SendAmountInputSwitched = 'send/amount_input_switched',
+    SendEnsResolution = 'send/ens-resolution',
     // eslint-disable-next-line local-rules/analytics-event-name
     SendFeeLevelChanged = 'send/fee_level_changed',
     // eslint-disable-next-line local-rules/analytics-event-name

--- a/suite-native/analytics/src/events/index.ts
+++ b/suite-native/analytics/src/events/index.ts
@@ -56,6 +56,7 @@ export { referralButtonPressEvent } from './referralButtonPressEvent';
 export { screenChangeEvent } from './screenChangeEvent';
 export { sendAddressFilledEvent } from './sendAddressFilledEvent';
 export { sendAmountInputSwitchedEvent } from './sendAmountInputSwitchedEvent';
+export { sendEnsResolutionEvent } from './sendEnsResolutionEvent';
 export { sendFeeLevelChangedEvent } from './sendFeeLevelChangedEvent';
 export { sendFlowEnteredEvent } from './sendFlowEnteredEvent';
 export { sendFlowExitedEvent } from './sendFlowExitedEvent';

--- a/suite-native/analytics/src/events/sendEnsResolutionEvent.ts
+++ b/suite-native/analytics/src/events/sendEnsResolutionEvent.ts
@@ -1,0 +1,30 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+
+import { EventType } from '../constants';
+
+export type SendEnsResolutionDirection = 'direct' | 'reverse';
+
+type Attributes = {
+    assetSymbol: AttributeDef<NetworkSymbol>;
+    direction: AttributeDef<SendEnsResolutionDirection>;
+};
+
+export const sendEnsResolutionEvent: EventDef<Attributes, EventType.SendEnsResolution> = {
+    name: EventType.SendEnsResolution,
+    descriptionTrigger:
+        'The send form recipient field resolves a name for the first time in a given direction. Reported once per direction per recipient input, and carries nothing about what was resolved or whether the lookup found anything',
+    changelog: [{ version: '26.9.1', notes: 'added' }],
+    attributes: {
+        assetSymbol: {
+            description:
+                'The blockchain network symbol the resolution ran on (e.g., `eth`, `tsep`)',
+            changelog: [{ version: '26.9.1', notes: 'added' }],
+        },
+        direction: {
+            description:
+                'Which way the recipient field resolved: `direct` for a name the user typed being resolved to an address, `reverse` for the primary name of an address the user typed',
+            changelog: [{ version: '26.9.1', notes: 'added' }],
+        },
+    },
+};

--- a/suite-native/analytics/src/index.ts
+++ b/suite-native/analytics/src/index.ts
@@ -20,6 +20,7 @@ export type {
     TradingSellAction,
     TradingSellStep,
 } from './definitions';
+export type { SendEnsResolutionDirection } from './events/sendEnsResolutionEvent';
 export type { TradingExchangeIssue } from './events/tradingExchangeIssueEvent';
 export type {
     DemoAccountQuestionnaireQuestion,

--- a/suite-native/module-send/src/hooks/useReportEnsResolutionToAnalytics.test.ts
+++ b/suite-native/module-send/src/hooks/useReportEnsResolutionToAnalytics.test.ts
@@ -1,0 +1,122 @@
+import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+
+import { useReportEnsResolutionToAnalytics } from './useReportEnsResolutionToAnalytics';
+
+type ReportingHookProps = Parameters<typeof useReportEnsResolutionToAnalytics>[0];
+
+const renderReportingHook = async (props: ReportingHookProps) => {
+    const services: NativeAnalyticsDep = {
+        analytics: mockNativeAnalytics(jest.fn()),
+    };
+
+    const view = await renderHookWithBasicProvider(useReportEnsResolutionToAnalytics, {
+        initialProps: props,
+        services,
+    });
+
+    return { ...view, analytics: services.analytics };
+};
+
+const settledNameLookup = {
+    symbol: 'eth',
+    mode: 'forward',
+    isFetching: false,
+    isSuccess: true,
+    isError: false,
+} as const satisfies ReportingHookProps;
+
+const settledAddressLookup = { ...settledNameLookup, mode: 'reverse' } as const;
+
+describe(useReportEnsResolutionToAnalytics.name, () => {
+    it('reports a name the user typed as a direct resolution', async () => {
+        const { analytics } = await renderReportingHook(settledNameLookup);
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'send/ens-resolution',
+            payload: { assetSymbol: 'eth', direction: 'direct' },
+        });
+    });
+
+    it('reports an address the user typed as a reverse resolution', async () => {
+        const { analytics } = await renderReportingHook(settledAddressLookup);
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'send/ens-resolution',
+            payload: { assetSymbol: 'eth', direction: 'reverse' },
+        });
+    });
+
+    it('reports a lookup that failed, since it ran all the same', async () => {
+        const { analytics } = await renderReportingHook({
+            ...settledNameLookup,
+            isSuccess: false,
+            isError: true,
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'send/ens-resolution',
+            payload: { assetSymbol: 'eth', direction: 'direct' },
+        });
+    });
+
+    it('reports nothing while a lookup is in flight', async () => {
+        const { analytics } = await renderReportingHook({
+            ...settledNameLookup,
+            isFetching: true,
+        });
+
+        expect(analytics.report).not.toHaveBeenCalled();
+    });
+
+    it('reports nothing before a lookup settles', async () => {
+        const { analytics } = await renderReportingHook({
+            ...settledNameLookup,
+            isSuccess: false,
+        });
+
+        expect(analytics.report).not.toHaveBeenCalled();
+    });
+
+    it('reports nothing when there is nothing to resolve', async () => {
+        const { analytics } = await renderReportingHook({ ...settledNameLookup, mode: 'idle' });
+
+        expect(analytics.report).not.toHaveBeenCalled();
+    });
+
+    it('reports nothing without a network to attribute the resolution to', async () => {
+        const { analytics } = await renderReportingHook({ ...settledNameLookup, symbol: null });
+
+        expect(analytics.report).not.toHaveBeenCalled();
+    });
+
+    it('reports a direction once, however many lookups run in it', async () => {
+        const { rerender, analytics } = await renderReportingHook(settledNameLookup);
+
+        await act(async () => {
+            await rerender({ ...settledNameLookup, isFetching: true });
+        });
+
+        await act(async () => {
+            await rerender(settledNameLookup);
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports both directions when the user uses both', async () => {
+        const { rerender, analytics } = await renderReportingHook(settledNameLookup);
+
+        await act(async () => {
+            await rerender(settledAddressLookup);
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(2);
+        expect(analytics.report).toHaveBeenLastCalledWith({
+            type: 'send/ens-resolution',
+            payload: { assetSymbol: 'eth', direction: 'reverse' },
+        });
+    });
+});

--- a/suite-native/module-send/src/hooks/useReportEnsResolutionToAnalytics.ts
+++ b/suite-native/module-send/src/hooks/useReportEnsResolutionToAnalytics.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type ResolveMode } from '@suite-common/wallet-core';
+import {
+    type SendEnsResolutionDirection,
+    events,
+    selectNativeAnalyticsDep,
+} from '@suite-native/analytics';
+
+type ResolutionState = {
+    mode: ResolveMode;
+    isFetching: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+};
+
+type UseReportEnsResolutionToAnalyticsParams = ResolutionState & {
+    symbol: NetworkSymbol | null | undefined;
+};
+
+/**
+ * Names the direction of a resolution that has actually run. Stays `null` until a lookup settles,
+ * so a value the user abandoned mid-typing is never counted, and it deliberately ignores what came
+ * back — only that the field resolved something.
+ */
+const getResolutionDirection = ({
+    mode,
+    isFetching,
+    isSuccess,
+    isError,
+}: ResolutionState): SendEnsResolutionDirection | null => {
+    if (isFetching || !(isSuccess || isError)) return null;
+    if (mode === 'forward') return 'direct';
+    if (mode === 'reverse') return 'reverse';
+
+    return null;
+};
+
+/**
+ * Reports that the recipient field resolved a name, and in which direction. Never the name, the
+ * address, or whether the lookup found anything — and only once per direction per recipient input,
+ * so the report cannot be tied back to an individual lookup.
+ */
+export const useReportEnsResolutionToAnalytics = ({
+    symbol,
+    mode,
+    isFetching,
+    isSuccess,
+    isError,
+}: UseReportEnsResolutionToAnalyticsParams) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+    const reportedDirectionsRef = useRef<SendEnsResolutionDirection[]>([]);
+    const direction = getResolutionDirection({ mode, isFetching, isSuccess, isError });
+
+    useEffect(() => {
+        if (!symbol || !direction) return;
+        if (reportedDirectionsRef.current.includes(direction)) return;
+
+        reportedDirectionsRef.current = [...reportedDirectionsRef.current, direction];
+        analytics.report({
+            type: events.sendEnsResolutionEvent.name,
+            payload: { assetSymbol: symbol, direction },
+        });
+    }, [analytics, direction, symbol]);
+};

--- a/suite-native/module-send/src/hooks/useResolvedAddress.ts
+++ b/suite-native/module-send/src/hooks/useResolvedAddress.ts
@@ -11,6 +11,7 @@ import { useFormContext, useWatch } from '@suite-native/forms';
 
 import { type SendOutputsFormValues } from '../sendOutputsFormSchema';
 import { getOutputFieldName } from '../utils';
+import { useReportEnsResolutionToAnalytics } from './useReportEnsResolutionToAnalytics';
 
 type UseResolvedAddressArgs = {
     inputIndex: number;
@@ -42,6 +43,8 @@ export const useResolvedAddress = ({ inputIndex, accountKey }: UseResolvedAddres
         resolvedAddress,
         reverseResolvedName,
     } = useResolveNamedAddress(addressValue, symbol);
+
+    useReportEnsResolutionToAnalytics({ symbol, mode, isFetching, isSuccess, isError });
 
     useEffect(() => {
         const nextResolvedAddress = (() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Report analytic events of ENS resolution.

## Notes for QA

Check that after submitting a send on Mainnet with ENS resolved the relevant event is dispatched. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/32229

## Events

```
LOG  [Analytics] 'send/ens-resolution' {"payload": {"assetSymbol": "eth", "direction": "reverse"}, "retry": true, "type": "send/ens-resolution", "url": "https://data.trezor.io/suite/log/mobile/develop.log?c_v=26.9.1&c_type=send%2Fens-resolution&c_commit=3110ad7f75&c_instance_id=vFwfWtPqZ2&c_session_id=Jw8Boyfkrb&c_timestamp=1788871085629&c_message_id=U0Y4ASCf7s&assetSymbol=eth&direction=reverse"}

LOG  [Analytics] 'send/ens-resolution' {"payload": {"assetSymbol": "eth", "direction": "direct"}, "retry": true, "type": "send/ens-resolution", "url": "https://data.trezor.io/suite/log/mobile/develop.log?c_v=26.9.1&c_type=send%2Fens-resolution&c_commit=3110ad7f75&c_instance_id=vFwfWtPqZ2&c_session_id=Jw8Boyfkrb&c_timestamp=1788871137484&c_message_id=rBnhvxTz7O&assetSymbol=eth&direction=direct"}

```

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=53gur0/ens-native-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->