### PR TITLE
refactor(suite-native): rework WalletBackupRecapListItem to use IconCircle

### DIFF
--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapListItem.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/WalletBackupRecapListItem.tsx
@@ -1,26 +1,34 @@
 import { LinearGradient } from 'expo-linear-gradient';
 
-import { HStack, OrderedListIcon, Text, VStack } from '@suite-native/atoms';
+import { HStack, IconCircle, Text, VStack } from '@suite-native/atoms';
 import { type IconName } from '@suite-native/icons';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-import { type ColorVariant, connectorColorsMap, iconColorsMap } from './presets';
+import { type ItemIntent, connectorColorsMap } from './presets';
 
 type WalletBackupRecapListItemProps = {
     labelId: TxKeyPath;
     iconName: IconName;
+    iconIntent: ItemIntent;
+    connectorIntent: ItemIntent;
     isLast: boolean;
-    iconVariant?: ColorVariant;
-    connectorVariant?: ColorVariant;
 };
 
+const ICON_SIZE = 40;
+
+const itemStyle = prepareNativeStyle(utils => ({
+    minHeight: ICON_SIZE + utils.spacings.sp8,
+    gap: utils.spacings.sp16,
+    alignItems: 'center',
+}));
+
 const connectorStyle = prepareNativeStyle(utils => ({
-    width: utils.spacings.sp2,
-    height: utils.spacings.sp36,
+    width: utils.borders.widths.large,
+    height: ICON_SIZE,
     backgroundColor: utils.colors.elementFillNeutralSofter,
     position: 'absolute',
-    bottom: -utils.spacings.sp36,
+    bottom: -ICON_SIZE,
 }));
 
 const textStyle = prepareNativeStyle(() => ({
@@ -30,24 +38,19 @@ const textStyle = prepareNativeStyle(() => ({
 export const WalletBackupRecapListItem = ({
     labelId,
     iconName,
+    iconIntent,
+    connectorIntent,
     isLast,
-    iconVariant = 'default',
-    connectorVariant = 'default',
 }: WalletBackupRecapListItemProps) => {
     const { applyStyle, utils } = useNativeStyles();
 
-    const connectorColor1 = utils.colors[connectorColorsMap[connectorVariant][0]];
-    const connectorColor2 = utils.colors[connectorColorsMap[connectorVariant][1]];
+    const connectorColor1 = utils.colors[connectorColorsMap[connectorIntent][0]];
+    const connectorColor2 = utils.colors[connectorColorsMap[connectorIntent][1]];
 
     return (
-        <HStack spacing="sp16" alignItems="center">
+        <HStack style={applyStyle(itemStyle)}>
             <VStack alignItems="center">
-                <OrderedListIcon
-                    iconBorderRadius="round"
-                    iconName={iconName}
-                    iconSize="large"
-                    {...iconColorsMap[iconVariant]}
-                />
+                <IconCircle name={iconName} intent={iconIntent} size={ICON_SIZE} />
                 {!isLast && (
                     <LinearGradient
                         colors={[connectorColor1, connectorColor2]}

--- a/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/presets.ts
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupRecap/create/presets.ts
@@ -4,62 +4,42 @@ import { type Color } from '@trezor/theme';
 
 export const WALLET_BACKUP_RECAP_STEPS = 4;
 
-export type ColorVariant = 'default' | 'warning' | 'primary';
-
-type IconColors = {
-    iconColor: Color;
-    iconBorderColor: Color;
-    iconBackgroundColor: Color;
-};
+export type ItemIntent = 'neutral' | 'warning' | 'brand';
 
 export const walletBackupSecuritySteps = [
     {
         iconName: 'warning',
         labelId: 'moduleDeviceOnboarding.walletBackupRecapScreen.step1.step1',
-        iconVariant: 'warning',
-        connectorVariant: 'warning',
+        iconIntent: 'warning',
+        connectorIntent: 'warning',
     },
     {
         iconName: 'trezorSafe5',
         labelId: 'moduleDeviceOnboarding.walletBackupRecapScreen.step1.step2',
+        iconIntent: 'neutral',
+        connectorIntent: 'neutral',
     },
     {
         iconName: 'textAa',
         labelId: 'moduleDeviceOnboarding.walletBackupRecapScreen.step1.step3',
-        connectorVariant: 'primary',
+        iconIntent: 'neutral',
+        connectorIntent: 'brand',
     },
     {
         iconName: 'check',
         labelId: 'moduleDeviceOnboarding.walletBackupRecapScreen.step1.step4',
-        iconVariant: 'primary',
+        iconIntent: 'brand',
+        connectorIntent: 'brand',
     },
 ] as const satisfies {
     iconName: IconName;
     labelId: TxKeyPath;
-    iconVariant?: ColorVariant;
-    connectorVariant?: ColorVariant;
+    iconIntent: ItemIntent;
+    connectorIntent: ItemIntent;
 }[];
 
-export const iconColorsMap = {
-    default: {
-        iconColor: 'contentPrimary',
-        iconBorderColor: 'borderNeutral',
-        iconBackgroundColor: 'elementFillNeutralSofter',
-    },
-    warning: {
-        iconColor: 'contentWarning',
-        iconBorderColor: 'elementBorderWarningSofter',
-        iconBackgroundColor: 'elementFillWarningSofter',
-    },
-    primary: {
-        iconColor: 'contentButtonBrandPrimary',
-        iconBorderColor: 'elementFillBrandBold',
-        iconBackgroundColor: 'elementFillBrandBold',
-    },
-} as const satisfies Record<ColorVariant, IconColors>;
-
 export const connectorColorsMap = {
-    default: ['elementFillNeutralSofter', 'elementFillNeutralSofter'],
+    neutral: ['elementFillNeutralSofter', 'elementFillNeutralSofter'],
     warning: ['elementFillWarningSofter', 'elementFillNeutralSofter'],
-    primary: ['elementFillNeutralSofter', 'elementFillBrandBold'],
-} as const satisfies Record<ColorVariant, [Color, Color]>;
+    brand: ['elementFillNeutralSofter', 'elementFillBrandSoft'],
+} as const satisfies Record<ItemIntent, [Color, Color]>;


### PR DESCRIPTION
## Description

`WalletBackupRecapListItem` is the only place that uses `OrderedListIcon` with `iconBorderRadius="round"`. Since `OrderedListIcon` is supposed to be rounded square, the usage may be replaced with `IconCircle`.

Also the connectors were fixed to not overlap the icons.

## Screenshots:

| Before | After |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/48c87faf-a2b9-4b34-8224-25ec42eb5c5f" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/ee7567f4-d837-4531-af53-ee60c044f2f0" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/wallet-backup-recap-list-item&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->