### PR TITLE
chore(suite-native): bump version to 26.10.1

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@suite-native/app",
     "version": "1.0.0",
-    "suiteNativeVersion": "26.9.1",
+    "suiteNativeVersion": "26.10.1",
     "main": "index.js",
     "expo": {
         "autolinking": {


### PR DESCRIPTION
Version bump to follow YY.MM.MINOR convention

Updates version in package.json to 26.10.1

## Notes for QA

Check that suite native version is updated.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/manual-bump-version-to-26.10.1&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->