### PR TITLE
fix(suite): Fix chart

### DIFF
--- a/suite/discreet-mode/src/HiddenPlaceholder.tsx
+++ b/suite/discreet-mode/src/HiddenPlaceholder.tsx
@@ -18,9 +18,7 @@ type WrapperProps = {
 
 const Wrapper = styled.span<WrapperProps>`
     font-variant-numeric: tabular-nums;
-    display: inline-block;
-    width: fit-content;
-    max-width: 100%;
+    display: inline;
 
     ${({ $intensity, $discreetMode }: WrapperProps) =>
         $discreetMode &&
@@ -36,6 +34,7 @@ const Wrapper = styled.span<WrapperProps>`
     ${({ $minWidth }: WrapperProps) =>
         !!$minWidth &&
         css`
+            display: inline-block;
             min-width: ${$minWidth}px;
         `}
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes bug with chart
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before 
<img width="3130" height="2122" alt="image" src="https://github.com/user-attachments/assets/ea2a8abe-dc89-46c5-a4d2-c9ed03441573" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a single discreet-mode rendering component, so the risk surface is narrow and limited to balance-obfuscation UI. The dedicated discreet-mode E2E test provides complete coverage of the affected behavior and should be run unconditionally. No other tests in the candidate set plausibly exercise this component's rendering path.

<details><summary><b>Changed files (1)</b></summary>

- `suite/discreet-mode/src/HiddenPlaceholder.tsx`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test directly exercises the discreet-mode UI behavior that HiddenPlaceholder.tsx implements: it verifies that balances are masked with '###'/$### placeholders across dashboard contexts and revealed on hover. A change to HiddenPlaceholder would most directly affect these assertions.

</details>

_Updated: 2026-09-08T14:46:55.762Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-chart/web/](https://dev.suite.sldev.cz/suite-web/fix-chart/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-chart&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-chart&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |

</details>

_Updated: 2026-09-08T14:50:43.953Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T14:49:57.578Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->