### PR TITLE
chore(suite-native): unify Android NDK versions

### DIFF
--- a/.nix/android.nix
+++ b/.nix/android.nix
@@ -11,8 +11,8 @@ let
     systemImageTypes = [ "google_apis" ];
     abiVersions = [ "x86_64" ];
     includeNDK = true;
-    # 27.1 is RN's default; 27.0 is still requested by expo-sqlite.
-    ndkVersions = [ "27.1.12297006" "27.0.12077973" ];
+    # All Android modules inherit the React Native NDK version.
+    ndkVersions = [ "27.1.12297006" ];
     cmakeVersions = [ "3.22.1" ];
   };
 in

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -136,7 +136,6 @@ const getPlugins = (): ExpoPlugins => {
                     minSdkVersion: 28,
                     // this fixes expo-updates build error
                     kotlinVersion: '2.1.20',
-                    ndkVersion: '27.0.12077973',
                     // react-native-quick-crypto (since v1) and expo-sqlite both bundle their
                     // own OpenSSL libcrypto.so, which collides during mergeDebugNativeLibs.
                     // pickFirst resolves the duplicate-.so packaging conflict.
@@ -157,6 +156,7 @@ const getPlugins = (): ExpoPlugins => {
             },
         ],
         './plugins/withGradleProperties.js',
+        './plugins/withAndroidNDKVersion.js',
         [
             '@config-plugins/detox',
             {

--- a/suite-native/app/plugins/androidNDKVersion.gradle
+++ b/suite-native/app/plugins/androidNDKVersion.gradle
@@ -1,0 +1,6 @@
+// Expo SQLite, Expo Updates and Sentry otherwise fall back to the Android Gradle plugin's NDK.
+subprojects { subproject ->
+    subproject.plugins.withId('com.android.library') {
+        subproject.android.ndkVersion = rootProject.ext.ndkVersion
+    }
+}

--- a/suite-native/app/plugins/withAndroidNDKVersion.js
+++ b/suite-native/app/plugins/withAndroidNDKVersion.js
@@ -1,0 +1,12 @@
+const { withProjectBuildGradle } = require('expo/config-plugins');
+
+const gradleConfiguration = "apply from: new File(rootDir, '../plugins/androidNDKVersion.gradle')";
+
+module.exports = config =>
+    withProjectBuildGradle(config, config2 => {
+        if (!config2.modResults.contents.includes(gradleConfiguration)) {
+            config2.modResults.contents += `\n${gradleConfiguration}\n`;
+        }
+
+        return config2;
+    });


### PR DESCRIPTION
## Description

It saves ~2.5 GB of disk space required for the build.

Make every Android library module inherit React Native's `ndkVersion` through an Expo config plugin. SQLite, Expo Updates and Sentry otherwise fall back to the Android Gradle plugin's NDK 27.0, while React Native uses 27.1.

Remove the ignored `expo-build-properties.android.ndkVersion` option and drop NDK 27.0 from the Nix SDK. Dependency versions stay unchanged.

## Notes for QA

Check Android startup, Suite Sync and access to existing encrypted databases after an upgrade.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are mobile-native configuration/build tooling (suite-native/app/app.config.ts and withAndroidNDKVersion.js), which are outside the scope of the provided suite-web/desktop E2E tests. None of the 107 candidate tests exercise the native mobile app build or NDK configuration, so there are no inferred E2E recommendations. Coverage should be provided by native/mobile-specific tests or manual validation instead.

<details><summary><b>Changed files (2)</b></summary>

- `suite-native/app/app.config.ts`
- `suite-native/app/plugins/withAndroidNDKVersion.js`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `suite-native/app/app.config.ts`
- `suite-native/app/plugins/withAndroidNDKVersion.js`

_Updated: 2026-09-08T16:29:41.563Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/codex/native-unify-ndk/web/](https://dev.suite.sldev.cz/suite-web/codex/native-unify-ndk/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=codex/native-unify-ndk&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=codex/native-unify-ndk&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T16:33:15.784Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->