### PR TITLE
Revalidate sell/swap amounts after account switch

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.test.ts
@@ -5,6 +5,8 @@ import {
     selectTradingProviderMetadata,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { getTranslation } from '@suite-native/intl';
 import {
     type TestStore,
     act,
@@ -20,6 +22,7 @@ import {
     ethAsset,
     exchangeCexdirect,
     exchangeQuotes,
+    getBtcAccount,
     invityDexQuote,
     mercuryoFixedBestQuote,
     mercuryoFixedWorstQuote,
@@ -552,6 +555,64 @@ describe('useExchangeForm', () => {
             const { invalid } = result.current.getFieldState('sendCryptoAmount');
 
             expect(invalid).toBe(true);
+        });
+
+        it('should revalidate send amount against balance after switching send accounts', async () => {
+            const richBtcAccount = getBtcAccount({
+                descriptor: asAccountDescriptor('btc1normal'),
+                balance: '100000000',
+                availableBalance: '100000000',
+                formattedBalance: '1',
+            });
+            const poorBtcAccount = getBtcAccount({
+                descriptor: asAccountDescriptor('btc2legacy'),
+                balance: '10000',
+                availableBalance: '10000',
+                formattedBalance: '0.0001',
+            });
+
+            store = createTradingLightStore({
+                tradeType: 'exchange',
+                overrides: {
+                    device: {
+                        selectedDevice: {
+                            state: {
+                                staticSessionId: accountDeviceState,
+                            },
+                        },
+                    },
+                    wallet: {
+                        accounts: [richBtcAccount, poorBtcAccount],
+                    },
+                },
+            });
+
+            const { result } = await renderUseExchangeForm();
+
+            await act(() => {
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(richBtcAccount.key));
+                result.current.setValue('sendAsset', btcAsset);
+                result.current.setValue('sendCryptoAmount', '0.005');
+            });
+
+            await act(() => result.current.trigger('sendCryptoAmount'));
+
+            expect(result.current.getFieldState('sendCryptoAmount').invalid).toBe(false);
+
+            await act(() => {
+                store.dispatch(tradingExchangeActions.setTradingAccountKey(poorBtcAccount.key));
+            });
+
+            await waitFor(() => {
+                const { invalid, error } = result.current.getFieldState('sendCryptoAmount');
+                expect(invalid).toBe(true);
+                expect(error).toEqual(
+                    expect.objectContaining({
+                        message: getTranslation('moduleTrading.validators.insufficientBalance'),
+                        type: 'insufficient-balance',
+                    }),
+                );
+            });
         });
 
         describe('generalAlert', () => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -186,10 +186,19 @@ const useDexQuoteApprovalInfoChangeEffect = ({
     }, [dispatch, getValues, quote, sendAccount, setValue]);
 };
 
-const useValidations = (
-    { trigger, setValue }: ExchangeFormType,
-    limits: TradingExchangeAmountLimitProps | undefined,
-) => {
+type UseValidationsParams = {
+    form: ExchangeFormType;
+    limits: TradingExchangeAmountLimitProps | undefined;
+    balance: string | undefined;
+    maxSpendableAmount: string | undefined;
+};
+
+const useValidations = ({
+    form: { trigger, setValue },
+    limits,
+    balance,
+    maxSpendableAmount,
+}: UseValidationsParams) => {
     const { translate } = useTranslate();
     const quotes = useSelector(selectExchangeQuotes);
     const quoteRequest = useSelector(selectTradingExchangeQuotesRequest);
@@ -201,7 +210,7 @@ const useValidations = (
 
     useEffect(() => {
         trigger(['sendCryptoAmount']);
-    }, [limits, trigger]);
+    }, [limits, balance, maxSpendableAmount, trigger]);
 
     useEffect(() => {
         setValue('generalAlert', generalAlertMsg);
@@ -251,7 +260,12 @@ export const useExchangeForm = () => {
         setContractAddress,
         setAccountKey,
     });
-    useValidations(form, limits);
+    useValidations({
+        form,
+        limits,
+        balance: context.balance,
+        maxSpendableAmount: context.maxSpendableAmount,
+    });
     useProviderMetadataChangeEffect(control, 'exchange');
 
     return form;

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.test.tsx
@@ -2,6 +2,7 @@ import type { SellFiatTrade } from 'invity-api';
 
 import { tradingSellActions } from '@suite-common/trading';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { getTranslation } from '@suite-native/intl';
 import {
     type TestStore,
     act,
@@ -225,6 +226,56 @@ describe('useSellForm', () => {
             await waitFor(() => {
                 const { invalid } = result.current.getFieldState('cryptoStringAmount');
                 expect(invalid).toBe(true);
+            });
+        });
+
+        it('should revalidate crypto amount against balance after switching send accounts', async () => {
+            const richBtcAccount = getBtcAccount({
+                descriptor: asAccountDescriptor('btc1normal'),
+                balance: '100000000',
+                availableBalance: '100000000',
+                formattedBalance: '1',
+            });
+            const poorBtcAccount = getBtcAccount({
+                descriptor: asAccountDescriptor('btc2legacy'),
+                balance: '10000',
+                availableBalance: '10000',
+                formattedBalance: '0.0001',
+            });
+
+            store = createTradingLightStore({
+                tradeType: 'sell',
+                overrides: {
+                    wallet: { accounts: [richBtcAccount, poorBtcAccount] },
+                },
+            });
+
+            const { result } = await renderUseSellForm();
+
+            await act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey(richBtcAccount.key));
+                result.current.setValue('amountInCrypto', true);
+                result.current.setValue('sendAsset', btcAsset);
+                result.current.setValue('cryptoStringAmount', '0.5');
+            });
+
+            await act(() => result.current.trigger('cryptoStringAmount'));
+
+            expect(result.current.getFieldState('cryptoStringAmount').invalid).toBe(false);
+
+            await act(() => {
+                store.dispatch(tradingSellActions.setTradingAccountKey(poorBtcAccount.key));
+            });
+
+            await waitFor(() => {
+                const { invalid, error } = result.current.getFieldState('cryptoStringAmount');
+                expect(invalid).toBe(true);
+                expect(error).toEqual(
+                    expect.objectContaining({
+                        message: getTranslation('moduleTrading.validators.insufficientBalance'),
+                        type: 'insufficient-balance',
+                    }),
+                );
             });
         });
 

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -111,10 +111,19 @@ const useSellQuoteChangeEffect = ({ control, getValues, setValue }: SellFormType
     }, [quote, isAmountInSats, symbol, getValues, setValue]);
 };
 
-const useValidations = (
-    { trigger, setValue }: SellFormType,
-    limits: TradingAmountLimitProps | undefined,
-) => {
+type UseValidationsParams = {
+    form: SellFormType;
+    limits: TradingAmountLimitProps | undefined;
+    balance: string | undefined;
+    maxSpendableAmount: string | undefined;
+};
+
+const useValidations = ({
+    form: { trigger, setValue },
+    limits,
+    balance,
+    maxSpendableAmount,
+}: UseValidationsParams) => {
     const { translate } = useTranslate();
     const quotes = useSelector(selectValidTradingSellQuotes);
     const quoteRequest = useSelector(selectTradingSellQuotesRequest);
@@ -126,7 +135,7 @@ const useValidations = (
 
     useEffect(() => {
         trigger(['cryptoStringAmount', 'fiatStringAmount']);
-    }, [limits, trigger]);
+    }, [limits, balance, maxSpendableAmount, trigger]);
 
     useEffect(() => {
         setValue('generalAlert', generalAlertMsg);
@@ -170,7 +179,12 @@ export const useSellForm = (): SellFormType => {
     });
     useSellQuotesChangeEffect(form);
     useSellQuoteChangeEffect(form);
-    useValidations(form, limits);
+    useValidations({
+        form,
+        limits,
+        balance: context.balance,
+        maxSpendableAmount: context.maxSpendableAmount,
+    });
     useCountryChangeEffect(control);
     useProviderMetadataChangeEffect(control, 'sell');
 


### PR DESCRIPTION
Closes #32246

<!--- Provide a general summary of your changes in the Title above -->

## Description

revalidates form on account change

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #32246

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=32246-fix-amount-not-revalidated-against-balance-after-switching-accounts-in-sell-and-swap&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->