### PR TITLE
test(suite-native): verify settings persist after app restart

### DIFF
--- a/suite-native/app/e2e/tests/appSettings.test.ts
+++ b/suite-native/app/e2e/tests/appSettings.test.ts
@@ -47,6 +47,31 @@ describe('App Settings - without device interactions [@noDevice]', () => {
         await detoxExpect(element(by.text('0 sat'))).toBeVisible();
     });
 
+    it('Localization settings persist after restarting the app', async () => {
+        const fiatInCZKRegex = /^.*CZK.*$/i;
+        await waitForVisible(by.text(/^.*\$.*$/i));
+        await detoxExpect(element(by.text('0 BTC'))).toBeVisible();
+
+        await onTabBar.navigateToSettings();
+        await onSettings.openSection('preferences');
+        await onSettings.changeLocalizationCurrency('czk');
+        await onSettings.changeBitcoinUnits(PROTO.AmountUnit.SATOSHI);
+        await onTabBar.tapBackButton();
+        await onTabBar.navigateToHome();
+
+        await waitForVisible(by.text(fiatInCZKRegex));
+        await detoxExpect(element(by.text('0 sat'))).toBeVisible();
+
+        await device.terminateApp();
+        // Rehydrate saved state without wiping storage or injecting the initial fixture again.
+        await openApp({ newInstance: true, wipeData: false });
+        await onHome.assertIsPortfolioGraphVisible();
+        await onHome.scrollScreenToBottom();
+
+        await waitForVisible(by.text(fiatInCZKRegex));
+        await detoxExpect(element(by.text('0 sat'))).toBeVisible();
+    });
+
     it('Localization - Language', async () => {
         await onTabBar.assertHomeTabBarItemTitle(EN_TRANSLATIONS['navigation.tabs.home']);
         await onTabBar.navigateToSettings();


### PR DESCRIPTION
## Description

The settings E2E tests currently check changes only within one app session. Add a test that changes fiat currency and Bitcoin units, terminates the app, then relaunches with storage preserved and no preloaded state to verify both settings are restored.

Local validation: the persistence test passed on the Pixel_6_API_34 Android emulator using the repository’s Nix Android shell (1 passed; the other 4 tests were skipped by the test-name filter). The first attempt was blocked by Expo’s developer menu; after disabling its automatic display in the generated local Android manifest, the unchanged test passed and verified that CZK currency and satoshi units survived app termination and relaunch.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-settings-persistence&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->