### PR TITLE
fix(suite-native-32210): prevent minimum received amount text overflow

### DIFF
--- a/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailMinimumReceivedRow.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryDetail/TradingHistoryDetailMinimumReceivedRow.tsx
@@ -1,6 +1,12 @@
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoRow } from '@suite-native/trading-atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+const amountStyle = prepareNativeStyle(() => ({
+    flexGrow: 1,
+    flexShrink: 1,
+}));
 
 type TradingHistoryDetailMinimumReceivedRowProps = {
     formattedMinimumReceived: string;
@@ -8,11 +14,22 @@ type TradingHistoryDetailMinimumReceivedRowProps = {
 
 export const TradingHistoryDetailMinimumReceivedRow = ({
     formattedMinimumReceived,
-}: TradingHistoryDetailMinimumReceivedRowProps) => (
-    <TradeInfoRow>
-        <Text color="contentSecondary" variant="body-sm">
-            <Translation id="moduleTrading.tradeHistory.detail.info.minimumReceivedAmount" />
-        </Text>
-        <Text variant="body-sm">{formattedMinimumReceived}</Text>
-    </TradeInfoRow>
-);
+}: TradingHistoryDetailMinimumReceivedRowProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <TradeInfoRow flexWrap="wrap">
+            <Text color="contentSecondary" variant="body-sm">
+                <Translation id="moduleTrading.tradeHistory.detail.info.minimumReceivedAmount" />
+            </Text>
+            <Text
+                variant="body-sm"
+                textAlign="right"
+
+                style={applyStyle(amountStyle)}
+            >
+                {formattedMinimumReceived}
+            </Text>
+        </TradeInfoRow>
+    );
+};


### PR DESCRIPTION
## Description

- Summary: Allow the minimum received amount value to shrink and wrap within the trade history detail row.

## Notes for QA

- Verify long minimum received amounts wrap correctly without overflowing.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/32210

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/32210-post-trade---overflowing-text-in-minimum-received-amount-field&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->