### PR TITLE
fix(receive): explain the shared address in the receive heading

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5027,6 +5027,14 @@ export const messages = defineMessages({
         id: 'RECEIVE_TITLE',
         defaultMessage: 'Receive {networkDisplaySymbol}',
     },
+    RECEIVE_TITLE_ASSETS: {
+        id: 'RECEIVE_TITLE_ASSETS',
+        defaultMessage: 'Receive assets on {network}',
+    },
+    RECEIVE_ASSETS_TOOLTIP: {
+        id: 'RECEIVE_ASSETS_TOOLTIP',
+        defaultMessage: 'Receive {networkDisplaySymbol} and any {network} token on this address.',
+    },
     RECEIVE_DESC_BITCOIN: {
         id: 'RECEIVE_DESC_BITCOIN',
         defaultMessage:

--- a/suite/receive/src/ReceiveContent.tsx
+++ b/suite/receive/src/ReceiveContent.tsx
@@ -8,7 +8,8 @@ import {
     getNetworkFeatures,
 } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { Banner, Column, H2, Text } from '@trezor/components';
+import { Banner, Column, H2, Icon, Row, Tooltip } from '@trezor/components';
+import { InfoIcon } from '@trezor/icons';
 
 import { AddressHistory } from './AddressHistory';
 import { NewestAddressCard } from './NewestAddressCard';
@@ -79,19 +80,38 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
                 />
             )}
 
-            <Column gap={4} alignItems="stretch">
+            <Row gap={4} alignItems="flex-start">
                 <H2>
-                    <Translation
-                        id="RECEIVE_TITLE"
-                        values={{ networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol) }}
-                    />
+                    {supportsTokens ? (
+                        <Translation
+                            id="RECEIVE_TITLE_ASSETS"
+                            values={{ network: getNetwork(account.symbol).name }}
+                        />
+                    ) : (
+                        <Translation
+                            id="RECEIVE_TITLE"
+                            values={{
+                                networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                            }}
+                        />
+                    )}
                 </H2>
                 {supportsTokens && (
-                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                        <Translation id="TR_INCLUDING_TOKENS" />
-                    </Text>
+                    <Tooltip
+                        content={
+                            <Translation
+                                id="RECEIVE_ASSETS_TOOLTIP"
+                                values={{
+                                    networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                    network: getNetwork(account.symbol).name,
+                                }}
+                            />
+                        }
+                    >
+                        <Icon as={InfoIcon} size={16} intent="neutral" priority="secondary" />
+                    </Tooltip>
                 )}
-            </Column>
+            </Row>
 
             <NewestAddressCard
                 accountKey={account.key}

--- a/suite/receive/src/ReceiveContent.tsx
+++ b/suite/receive/src/ReceiveContent.tsx
@@ -43,6 +43,9 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
         [account.symbol],
     );
 
+    const networkName = getNetwork(account.symbol).name;
+    const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
+
     const handleVerifyAddress = async (path: string) => {
         if (verifyingAddressPath !== undefined) {
             return;
@@ -68,13 +71,13 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
                     title={
                         <Translation
                             id="TR_EVM_EXPLANATION_TITLE"
-                            values={{ network: getNetwork(account.symbol).name }}
+                            values={{ network: networkName }}
                         />
                     }
                     description={
                         <Translation
                             id="TR_EVM_EXPLANATION_RECEIVE_DESCRIPTION"
-                            values={{ network: getNetwork(account.symbol).name }}
+                            values={{ network: networkName }}
                         />
                     }
                 />
@@ -83,17 +86,9 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
             <Row gap={4} alignItems="flex-start">
                 <H2>
                     {supportsTokens ? (
-                        <Translation
-                            id="RECEIVE_TITLE_ASSETS"
-                            values={{ network: getNetwork(account.symbol).name }}
-                        />
+                        <Translation id="RECEIVE_TITLE_ASSETS" values={{ network: networkName }} />
                     ) : (
-                        <Translation
-                            id="RECEIVE_TITLE"
-                            values={{
-                                networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
-                            }}
-                        />
+                        <Translation id="RECEIVE_TITLE" values={{ networkDisplaySymbol }} />
                     )}
                 </H2>
                 {supportsTokens && (
@@ -102,8 +97,8 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
                             <Translation
                                 id="RECEIVE_ASSETS_TOOLTIP"
                                 values={{
-                                    networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
-                                    network: getNetwork(account.symbol).name,
+                                    networkDisplaySymbol,
+                                    network: networkName,
                                 }}
                             />
                         }


### PR DESCRIPTION
The "Including tokens" line restored in 8b6993c6a1 says the least it could: it names no network, sits under a heading that names only the coin, and reads as a caption rather than an explanation. The heading now carries the network — "Receive assets on Ethereum" — and an info tooltip beside it spells out what the address takes: "Receive ETH and any Ethereum token on this address."

The copy is generic over the network rather than naming example tokens, so one string serves Ethereum, Solana, Tron and every other token-bearing network, and nothing has to be revisited as token popularity shifts.

Networks without tokens have nothing to explain, so they keep "Receive BTC" and show no icon. The `tokens` feature already decides this, which is what made the restored line cover Solana and Tron as the reporter asked.

Follow-up to #31277.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

- Check please if the copy is correct per-network in the tooltip


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31277

## Screenshots:

<img width="2070" height="956" alt="image (8)" src="https://github.com/user-attachments/assets/810e0e99-93c6-49d7-ac86-35a3f8fc8985" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The pull request changes the receive UI component and its translation messages, so the primary regression risk is in receive-address display, copying, QR-code rendering, and device verification. The recommended strategy is to run the focused receive test at high priority and a small set of related receive-path tests (global receive, Cardano receive, passphrase receive, address labeling) at medium priority. No changed files are left without inferred coverage.

<details><summary><b>Changed files (2)</b></summary>

- `suite/intl/src/messages.ts`
- `suite/receive/src/ReceiveContent.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — Directly exercises ReceiveContent.tsx functionality: opening the receive tab, displaying addresses, copying to clipboard, showing the address-copied modal, verifying the address on device, and matching the QR code to the address. Changes to the receive component or its translation messages are very likely to affect this test.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/metadata/legacy/address-metadata.test.ts` — Tests labeling of Bitcoin receive addresses. Address labels are rendered inside the receive view, so changes to ReceiveContent.tsx or the messages used for labels/placeholders could alter what this test sees when editing or saving an address label.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Covers displaying and verifying receive addresses on a passphrase-protected wallet, including the used-address table and copy-address button. This flows through the same receive component but with a different wallet state, so it is a meaningful regression check for ReceiveContent.tsx.
- `suite/e2e/tests/wallet/cardano.test.ts` — Includes the Cardano receive flow: opening receive, verifying the address on device, and copying it. The coin-specific receive rendering path may exercise ReceiveContent.tsx branch logic or translation keys that changed.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Tests the global receive modal from the wallet menu, including address display, device verification, and copy button. This uses the receive flow through a different entry point and is a good check that ReceiveContent.tsx still works outside the account-specific receive tab.

</details>

_Updated: 2026-09-10T07:57:20.776Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31277-receive-shared-address-copy/web/](https://dev.suite.sldev.cz/suite-web/fix/31277-receive-shared-address-copy/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31277-receive-shared-address-copy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31277-receive-shared-address-copy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T07:59:35.927Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T07:59:34.757Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->