### PR TITLE
fix: Unify init banner intent

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -65,8 +65,9 @@ const getDeviceNeedsAttentionMessage = (
 
 const getDeviceStatusWarningIntent = (deviceStatus: ReturnType<typeof getStatus>): BannerIntent => {
     switch (deviceStatus) {
-        case 'bootloader':
         case 'initialize':
+            return 'brand';
+        case 'bootloader':
         case 'was-used-in-other-window':
         case 'used-in-other-window':
         case 'unacquired':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

unifying intents for same action from wallet switcher and welcome screen to green

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26741

## Screenshots:

before
<img width="446" height="365" alt="image" src="https://github.com/user-attachments/assets/c0118924-58e5-4dc0-bc3f-c46f5752c5d9" />

<img width="860" height="625" alt="image" src="https://github.com/user-attachments/assets/c8ebba98-5d31-4e2a-adcb-84bf01b0b626" />

after


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a banner component inside the SwitchDevice view. Although static coverage maps this file to 136 tests (indicating it is a broadly-referenced shared component), only device-switcher-centric flows are likely to render or be affected by NeedsAttentionBanner. The recommended subset verifies session status, reconnection, and wallet management in the switcher without running the full suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises the device switching panel and session status transitions (Connected/Use here). Since NeedsAttentionBanner lives in the SwitchDevice view, session-state changes in the switcher are the most likely code path to render or interact with it.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — The test opens the device switcher after device disconnect/reconnect and verifies wallet visibility. Reconnection attention states are a plausible trigger for NeedsAttentionBanner inside SwitchDevice.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Ejecting and re-adding a standard wallet via the device switcher renders the SwitchDevice view, which is where NeedsAttentionBanner is mounted.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Repeatedly adding and ejecting wallets through the device switcher exercises wallet list rendering in SwitchDevice, the component area affected by the changed banner.

</details>

_Updated: 2026-09-09T09:35:45.737Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/unify-init-banner/web/](https://dev.suite.sldev.cz/suite-web/unify-init-banner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=unify-init-banner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=unify-init-banner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T09:37:59.999Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T09:37:14.369Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->