### PR TITLE
fix(suite-native): prevent navigating back during FW installation

### DIFF
--- a/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
+++ b/suite-native/firmware/src/components/FirmwareInstallationScreenContent.tsx
@@ -13,7 +13,11 @@ import {
 } from '@suite-native/confirm-on-trezor';
 import { Translation } from '@suite-native/intl';
 import { SUITE_MOBILE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
-import { DynamicScreenHeader } from '@suite-native/navigation';
+import {
+    DynamicScreenHeader,
+    useDisableIOSGesture,
+    useNavigationRemoveActionInterceptor,
+} from '@suite-native/navigation';
 import { reportSecurityCheck } from '@suite-native/sentry';
 import TrezorConnect from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -42,7 +46,6 @@ type FirmwareInstallationScreenContentProps = {
     isRetryAllowed?: boolean;
     isTemporaryRememeberAllowed?: boolean;
     navigationLocation: 'settings' | 'onboarding';
-    customHeader?: React.ReactNode;
     onCancelAction?: () => void;
 };
 
@@ -52,7 +55,6 @@ export const FirmwareInstallationScreenContent = ({
     onFirmwareInstallationSuccess,
     onFirmwareInstallationFailure,
     onCancelAction,
-    customHeader,
     isRetryAllowed = true,
     isTemporaryRememeberAllowed = true,
     navigationLocation,
@@ -249,6 +251,9 @@ export const FirmwareInstallationScreenContent = ({
 
     const buttonStyle = applyStyle(bottomButtonsContainerStyle);
 
+    useDisableIOSGesture();
+    useNavigationRemoveActionInterceptor({ isEnabled: !isError });
+
     useEffect(() => {
         if (isSheetOpen && !showConfirmOnDevice) {
             closeSheet();
@@ -259,10 +264,6 @@ export const FirmwareInstallationScreenContent = ({
         if (showConfirmOnDevice) revealConfirmOnTrezorSheet();
     }, [closeSheet, isSheetOpen, showConfirmOnDevice, revealConfirmOnTrezorSheet]);
 
-    const CancelButton = customHeader ?? (
-        <DynamicScreenHeader closeActionType="close" closeAction={handleCancel} />
-    );
-
     const isDontCloseAppAlertDisplayed =
         indicatorStatus === 'inProgress' && !isSheetOpen && !mayBeStuck && !isDone;
 
@@ -272,7 +273,11 @@ export const FirmwareInstallationScreenContent = ({
             controlRef={confirmOnTrezorRef}
             closeAction={onCancelAction ?? handleCancel}
             closeActionType="close"
-            defaultHeader={isError && CancelButton}
+            defaultHeader={
+                isError && (
+                    <DynamicScreenHeader closeActionType="close" closeAction={handleCancel} />
+                )
+            }
             isCloseButtonDisabled
         >
             <Box flex={1}>

--- a/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/FirmwareInstallationScreen.tsx
@@ -1,25 +1,15 @@
 import { FirmwareInstallationScreenContent } from '@suite-native/firmware';
-import { ScreenHeader, useOverrideBackNavigation } from '@suite-native/navigation';
 
 import { useExitAlert } from '../hooks/useExitAlert';
 import { useNavigateToNextScreenAfterFirmwareInstallation } from '../hooks/useNavigateToNextScreenAfterFirmwareInstallation';
-
-const FirmwareInstallationScreenHeader = () => {
-    const { handleExitButtonPress } = useExitAlert();
-    useOverrideBackNavigation({ onNavigateBack: handleExitButtonPress });
-
-    return <ScreenHeader closeActionType="close" closeAction={handleExitButtonPress} />;
-};
 
 export const FirmwareInstallationScreen = () => {
     const { handleExitButtonPress } = useExitAlert();
     const { navigateToNextScreenAfterFirmwareInstallation } =
         useNavigateToNextScreenAfterFirmwareInstallation();
-    useOverrideBackNavigation();
 
     return (
         <FirmwareInstallationScreenContent
-            customHeader={<FirmwareInstallationScreenHeader />}
             onCancelAction={handleExitButtonPress}
             onFirmwareInstallationSuccess={navigateToNextScreenAfterFirmwareInstallation}
             isTemporaryRememeberAllowed={false}


### PR DESCRIPTION
## Description

- Navigation prevention logic moved to `FirmwareInstallationScreenContent`.
- Deprecated and dead code removed.

## Notes for QA

I tested both clean installation and update on both platforms.
Don't be nice and try to break it.

## Related Issue

Resolve #31197

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/firmware-installation-navigation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->