### PR TITLE
refactor(suite): access Redux store through services

### DIFF
--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -18,6 +18,7 @@
     "dependencies": {
         "@sentry/browser": "10.69.0",
         "@suite-common/dependency-injection": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite/debug": "workspace:*",
         "@suite/platform-encryption-webauthn": "workspace:*",

--- a/packages/suite-web/src/support/usePlaywright.ts
+++ b/packages/suite-web/src/support/usePlaywright.ts
@@ -1,15 +1,15 @@
 import { useEffect } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectStore } from '@suite-common/redux-utils';
 import TrezorConnect from '@trezor/connect';
-
-import { useStore } from 'src/hooks/suite/useStore';
 
 /**
  * Utility for running tests in Playwright.
  * Used to augment window object with redux store and TrezorConnect instance to make it accessible in tests
  */
 export const usePlaywright = () => {
-    const store = useStore();
+    const { store } = useServices(selectStore);
 
     useEffect(() => {
         if (typeof window !== 'undefined' && window.Playwright) {

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -10,6 +10,9 @@
             "path": "../../suite-common/dependency-injection"
         },
         {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
             "path": "../../suite-common/suite-utils"
         },
         { "path": "../../suite/debug" },

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -5,7 +5,7 @@ import { Translation } from '@suite/intl';
 import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { useDispatch } from '@suite-common/redux-utils';
+import { selectDispatch, selectGetState } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { TrezorBodyIcon } from '@trezor/icons';
@@ -16,12 +16,13 @@ import {
     updateAnalytics,
 } from 'src/actions/onboarding/onboardingActions';
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
-import { useStore } from 'src/hooks/suite/useStore';
 
 export const DeviceInitialize = () => {
-    const dispatch = useDispatch();
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const { getState } = useStore();
+    const { analytics, dispatch, getState } = useServices(
+        selectDesktopAnalyticsDep,
+        selectDispatch,
+        selectGetState,
+    );
 
     const handleCtaClick = (e: MouseEvent) => {
         e.stopPropagation();

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
@@ -5,18 +5,19 @@ import { Translation } from '@suite/intl';
 import { gotoThunk } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { useDispatch } from '@suite-common/redux-utils';
+import { selectDispatch, selectGetState } from '@suite-common/redux-utils';
 import { Banner } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { CpuIcon } from '@trezor/icons';
 
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
-import { useStore } from 'src/hooks/suite/useStore';
 
 export const DeviceNoFirmware = () => {
-    const dispatch = useDispatch();
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const { getState } = useStore();
+    const { analytics, dispatch, getState } = useServices(
+        selectDesktopAnalyticsDep,
+        selectDispatch,
+        selectGetState,
+    );
 
     const handleClick: MouseEventHandler = e => {
         e.stopPropagation();

--- a/packages/suite/src/hooks/suite/useStore.ts
+++ b/packages/suite/src/hooks/suite/useStore.ts
@@ -1,5 +1,0 @@
-import { useStore as useReduxStore } from 'react-redux';
-
-import { type Store } from 'src/types/suite';
-
-export const useStore: () => Store = useReduxStore;

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.ts
@@ -2,7 +2,7 @@ import { type UseFormReturn } from 'react-hook-form';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { useDispatch } from '@suite-common/redux-utils';
+import { selectDispatch, selectGetState } from '@suite-common/redux-utils';
 import {
     TRADING_BUY_RECEIVE_ADDRESS,
     TRADING_FORM_COUNTRY_SELECT,
@@ -19,7 +19,6 @@ import {
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
 
-import { useStore } from 'src/hooks/suite/useStore';
 import { isBuyQuotesFetchAllowed } from 'src/utils/wallet/trading/buyQuotesRequestUtils';
 
 import { useTradingQuoteRequest } from '../common/useTradingQuoteRequest';
@@ -41,9 +40,11 @@ const BUY_IMMEDIATE_FIELDS = [
 const BUY_DEBOUNCED_FIELDS = [TRADING_FORM_FIAT_INPUT, TRADING_FORM_CRYPTO_INPUT] as const;
 
 export const useBuyQuotes = ({ methods, network, shouldSendInSats }: UseBuyQuotesProps) => {
-    const dispatch = useDispatch();
-    const store = useStore();
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const { analytics, dispatch, getState } = useServices(
+        selectDesktopAnalyticsDep,
+        selectDispatch,
+        selectGetState,
+    );
 
     const { isScheduledQuotesRefresh } = useTradingQuoteRequest({
         methods,
@@ -66,7 +67,7 @@ export const useBuyQuotes = ({ methods, network, shouldSendInSats }: UseBuyQuote
 
             const selectedPaymentMethod = values.paymentMethod?.value;
             const paymentMethodOption = selectTradingSelectedPaymentMethodByType(
-                store.getState(),
+                getState(),
                 'buy',
                 selectedPaymentMethod,
             );

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.ts
@@ -3,7 +3,7 @@ import { type UseFormReturn } from 'react-hook-form';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { useDispatch } from '@suite-common/redux-utils';
+import { selectDispatch, selectGetState } from '@suite-common/redux-utils';
 import {
     TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_COUNTRY_SUBDIVISION_SELECT,
@@ -19,7 +19,6 @@ import {
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
 
-import { useStore } from 'src/hooks/suite/useStore';
 import { isSellQuotesFetchAllowed } from 'src/utils/wallet/trading/sellQuotesRequestUtils';
 
 import { useTradingQuoteRequest } from '../common/useTradingQuoteRequest';
@@ -46,9 +45,11 @@ export const useSellQuotes = ({
     shouldSendInSats,
     composeRequestCallback,
 }: UseSellQuotesProps) => {
-    const dispatch = useDispatch();
-    const store = useStore();
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const { analytics, dispatch, getState } = useServices(
+        selectDesktopAnalyticsDep,
+        selectDispatch,
+        selectGetState,
+    );
 
     const { isScheduledQuotesRefresh } = useTradingQuoteRequest({
         methods,
@@ -78,7 +79,7 @@ export const useSellQuotes = ({
 
             const selectedPaymentMethod = values.paymentMethod?.value;
             const paymentMethodOption = selectTradingSelectedPaymentMethodByType(
-                store.getState(),
+                getState(),
                 'sell',
                 selectedPaymentMethod,
             );

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -6,8 +6,9 @@ import { Labeling } from '@suite/labeling';
 import { selectIsLegacyLabelingVisible, selectLabelingValueBeingEdited } from '@suite/metadata';
 import { SuiteSyncWalletDebug } from '@suite/suite-sync';
 import { useWalletLabel } from '@suite/wallet';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectDeviceThunk } from '@suite-common/device';
-import { useDispatch } from '@suite-common/redux-utils';
+import { selectDispatch, selectGetState } from '@suite-common/redux-utils';
 import {
     getAccountsByDeviceState,
     selectAccounts,
@@ -35,7 +36,6 @@ import { redirectAfterWalletSelectedThunk } from 'src/actions/wallet/addWalletTh
 import { WalletLabeling } from 'src/components/suite/labeling/WalletLabeling';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useSelector } from 'src/hooks/suite';
-import { useStore } from 'src/hooks/suite/useStore';
 import { useTotalFiatBalance } from 'src/hooks/wallet/useTotalFiatBalance';
 import { type AcquiredDevice, type ForegroundAppProps } from 'src/types/suite';
 
@@ -61,8 +61,7 @@ export const WalletInstance = ({
     const currentFiatRates = useSelector(selectCurrentFiatRates);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const editing = useSelector(selectLabelingValueBeingEdited);
-    const dispatch = useDispatch();
-    const store = useStore();
+    const { dispatch, getState } = useServices(selectDispatch, selectGetState);
     const { translationString } = useTranslation();
     const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
     const { defaultLabel, label } = useWalletLabel({ device: instance });
@@ -89,7 +88,7 @@ export const WalletInstance = ({
 
             // NOTE: to determine which account is the first one, we need to filter out empty accounts
             // that are currently displayed in the UI
-            const unfilteredUIAccountGroups = selectAllAccountsToList(store.getState());
+            const unfilteredUIAccountGroups = selectAllAccountsToList(getState());
             const currentFirstAccount = unfilteredUIAccountGroups[0];
             // NOTE: attempt to determine, if the currently selected account
             // has a corresponding account in the next wallet accounts

--- a/suite-common/redux-utils/src/index.ts
+++ b/suite-common/redux-utils/src/index.ts
@@ -7,5 +7,6 @@ export * from './createSingleInstanceThunk';
 export * from './hooks/useSelectorDeepComparison';
 export * from './hooks/useDispatch';
 export * from './selectorsUtils';
+export * from './storeSelectors';
 export * from './extraWithStoreThunkMiddleware';
 export { createReduxExtra, type ReduxStoreWithThunk } from './createReduxExtra';

--- a/suite-common/redux-utils/src/storeSelectors.ts
+++ b/suite-common/redux-utils/src/storeSelectors.ts
@@ -1,0 +1,24 @@
+import { type ReduxStoreWithThunk } from './createReduxExtra';
+import { type Dispatch } from './hooks/useDispatch';
+
+export type StoreDep = {
+    store: ReduxStoreWithThunk<any, any>;
+};
+
+export type DispatchDep = {
+    dispatch: Dispatch;
+};
+
+export type GetStateDep = {
+    getState: () => any;
+};
+
+export const selectStore = (services: StoreDep): StoreDep => ({ store: services.store });
+
+export const selectDispatch = (services: { store: DispatchDep }): DispatchDep => ({
+    dispatch: services.store.dispatch,
+});
+
+export const selectGetState = (services: { store: GetStateDep }): GetStateDep => ({
+    getState: services.store.getState,
+});

--- a/suite-common/test-utils/src/createTestCompositionRoot.ts
+++ b/suite-common/test-utils/src/createTestCompositionRoot.ts
@@ -36,6 +36,7 @@ export const createTestCompositionRoot = <
         store,
         services: {
             ...extra.services,
+            store,
             dispatch: store.dispatch,
             getActions,
             clearActions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17903,6 +17903,7 @@ __metadata:
   dependencies:
     "@sentry/browser": "npm:10.69.0"
     "@suite-common/dependency-injection": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite/debug": "workspace:*"
     "@suite/platform-encryption-webauthn": "workspace:*"


### PR DESCRIPTION
## Description

Replace Suite's useStore hook with shared selectStore, selectDispatch and selectGetState service selectors. Migrate all callers, including the web Playwright helper, using the store already exposed by the native, web and desktop composition roots, and expose that store in the test composition root.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is dominated by two targeted functional areas: trading buy/sell quote hooks and device-switcher wallet instance rendering, plus onboarding prerequisite components. The highest-risk regressions are in quote fetching/selection and wallet instance display, so the strategy prioritizes those specific E2E paths. Broadly-shared files (usePlaywright, useStore, redux-utils, tsconfig/package.json) lack concrete evidence of direct behavioral impact, so they are left uncovered rather than inflating the run list.

<details><summary><b>Changed files (12)</b></summary>

- `packages/suite-web/package.json`
- `packages/suite-web/src/support/usePlaywright.ts`
- `packages/suite-web/tsconfig.json`
- `packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx`
- `packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx`
- `packages/suite/src/hooks/suite/useStore.ts`
- `packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.ts`
- `packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.ts`
- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx`
- `suite-common/redux-utils/src/index.ts`
- `suite-common/redux-utils/src/storeSelectors.ts`
- `suite-common/test-utils/src/createTestCompositionRoot.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Directly exercises the buy quote flow including best offer selection, provider display, and trade confirmation—core behaviors implemented in useBuyQuotes.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests ETH buy quote fetching and confirmation flow, covering asset selection and quote display logic from useBuyQuotes.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Validates buy quote error states, empty quotes, and min/max limits—edge cases directly handled by useBuyQuotes.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Tests Solana SPL token buy quotes and trade execution, exercising token-specific paths in useBuyQuotes.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Validates sell form input handling and quote synchronization, which is driven by useSellQuotes.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Tests Solana sell quote selection, confirmation, and trade status flow, directly relying on useSellQuotes.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Specifically verifies wallet instance numbering, labels, and ordering in the device switcher—WalletInstance's core responsibility.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Exercises hidden wallet instance display, selection, and address verification in the device switcher, directly touching WalletInstance behavior.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Tests the firmware readiness prerequisite state during onboarding, which is exactly the UI surface rendered by DeviceNoFirmware and DeviceInitialize.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy/wallet-metadata.test.ts` — Edits and persists wallet labels via the device switcher, exercising WalletInstance label rendering and state.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Tests wallet labels and Suite Sync interactions across multiple wallets in the device switcher.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Verifies cached passphrase wallets remain visible and functional in the device switcher after device reconnection.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests device switcher session status indicators, which are rendered within wallet instances.
- `suite/e2e/tests/trading/navigation.test.ts` — Navigates to buy/sell/swap forms and shares the trading quote/form infrastructure, though it does not deeply test quote logic.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite-web/package.json`
- `packages/suite-web/tsconfig.json`
- `suite-common/redux-utils/src/index.ts`
- `suite-common/redux-utils/src/storeSelectors.ts`
- `suite-common/test-utils/src/createTestCompositionRoot.ts`

_Updated: 2026-09-09T12:37:41.632Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/store-services/web/](https://dev.suite.sldev.cz/suite-web/refactor/store-services/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/store-services&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/store-services&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/store-services&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T12:39:16.777Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T12:38:54.693Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->