### PR TITLE
fix(suite-native): improve text alignment and layout in trading tab

### DIFF
--- a/suite-native/atoms/src/IconListItem.tsx
+++ b/suite-native/atoms/src/IconListItem.tsx
@@ -66,6 +66,7 @@ export type IconListItemProps = {
     variant?: IconListItemVariant;
     verticalAlign?: FlexAlignType;
     spacing?: NativeSpacing | number;
+    isContentFullWidth?: boolean;
 };
 
 export type IconListTextItemProps = IconListItemProps & {
@@ -80,13 +81,16 @@ export const IconListItem = ({
     variant = 'neutral',
     verticalAlign = 'center',
     spacing = 'sp12',
+    isContentFullWidth = false,
 }: IconListItemProps) => {
     const iconColors = iconColorsMap[variant];
 
     return (
         <HStack spacing={spacing} alignItems={verticalAlign}>
             <IconSquare iconName={icon} iconSize={iconSize} {...iconColors} />
-            <Box flexShrink={1}>{children}</Box>
+            <Box flexShrink={1} flex={isContentFullWidth ? 1 : undefined}>
+                {children}
+            </Box>
         </HStack>
     );
 };

--- a/suite-native/trading-provider-utils/src/components/Footer.tsx
+++ b/suite-native/trading-provider-utils/src/components/Footer.tsx
@@ -49,6 +49,8 @@ const FooterProviderContent = ({ provider }: FooterProviderContentProps) => {
 
 const linkStyle = prepareNativeStyle(({ spacings }) => ({
     paddingVertical: spacings.sp10,
+    alignSelf: 'stretch',
+    textAlign: 'center',
 }));
 
 const stackStyle = prepareNativeStyle(() => ({

--- a/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.tsx
+++ b/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.tsx
@@ -6,7 +6,12 @@ import { BottomSheetModal, Button, HStack, IconListItem, Text, VStack } from '@s
 import { Icon, type IconName } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { TREZOR_SUITE_TOS_URL, TREZOR_SUPPORT_UNDERSTANDING_FEES } from '@trezor/urls';
+
+const linkStyle = prepareNativeStyle(() => ({
+    flex: 1,
+}));
 
 type ListItemProps = {
     icon: IconName;
@@ -14,24 +19,29 @@ type ListItemProps = {
     href?: string;
 };
 
-const ListItem = ({ icon, children, href }: ListItemProps) => (
-    <IconListItem icon={icon} variant="brand" iconSize="large">
-        {href ? (
-            <HStack spacing="sp2" alignItems="center">
-                <Link
-                    textColor="contentPrimary"
-                    textVariant="body-md-strong"
-                    href={href}
-                    isUnderlined
-                    label={children}
-                />
-                <Icon name="arrowSquareOut" size="mediumLarge" />
-            </HStack>
-        ) : (
-            <Text variant="body-md-strong">{children}</Text>
-        )}
-    </IconListItem>
-);
+const ListItem = ({ icon, children, href }: ListItemProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <IconListItem icon={icon} variant="brand" iconSize="large" isContentFullWidth>
+            {href ? (
+                <HStack spacing="sp2" alignItems="center">
+                    <Link
+                        textColor="contentPrimary"
+                        textVariant="body-md-strong"
+                        href={href}
+                        isUnderlined
+                        label={children}
+                        style={applyStyle(linkStyle)}
+                    />
+                    <Icon name="arrowSquareOut" size="mediumLarge" />
+                </HStack>
+            ) : (
+                <Text variant="body-md-strong">{children}</Text>
+            )}
+        </IconListItem>
+    );
+};
 
 type HowTradingWorksSheetProps = {
     ref: Ref<BottomSheetModalMethods>;


### PR DESCRIPTION
## Description

On the Trading tab, longer translations break two links: the text wraps onto a second line even though it comfortably fits, and the wrapped lines stay left aligned. Visible in Czech on the footer link ("Jak funguje obchodování") and in the How trading works sheet ("Jak se počítají poplatky"), but it comes down to sub-pixel rounding per string, so any locale can hit it.

## Cause

Both links are a bare `Animated.Text` sized by its own text measurement — in the footer as a shrink-to-fit child of a centered `VStack`, in the sheet as a row child inside the `IconListItem` content column (`Box flexShrink={1}`). The node ends up exactly as wide as the measured max-content width and the text re-wraps inside it. `Link` never sets `textAlign`, so those wrapped lines fall back to left.

## Fix

- **Footer link** — `alignSelf: 'stretch'` + `textAlign: 'center'`: full container width, so no wrap, and centered like the disclaimer above it.
- **Sheet links** — `flex: 1`, so the row sizes the link instead of its own measurement.
- **`IconListItem`** — new opt-in `isContentFullWidth` prop (defaults to `false`, so no change for the ~35 existing usages) that stretches the content column. The sheet links need it, otherwise they have no room to grow into.

Before
<img width="386" height="201" alt="image" src="https://github.com/user-attachments/assets/049f00b9-a9b2-4491-9974-27f131dcf657" />  <img width="386" height="547" alt="image" src="https://github.com/user-attachments/assets/9fd8161d-dc01-49bd-bf2b-8b0f772a4f32" />

After
<img width="371" height="186" alt="image" src="https://github.com/user-attachments/assets/baacdd72-b288-44b7-8240-b50e668ddf20" />  <img width="374" height="521" alt="image" src="https://github.com/user-attachments/assets/6769acb1-287a-421a-9ef2-c87a332a74c5" />

## Worth a look in review

The ↗ icon in the sheet now sits at the right edge of the row instead of directly after the label. Unavoidable here — the link has to be wider than its own measurement and the icon follows it. Same shape as `DemoAccountQuestionnaireLink`. It is still not tappable, same as before, which is more noticeable now that it sits further from the text.

## Notes for QA

Unit tests pass in `@suite-native/atoms` (42) and `@suite-native/trading-provider-utils` (19). Worth a visual pass in cs and en on both the Trading tab footer and the sheet.


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-native-text-alignment&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->