### PR TITLE
fix(enhancePage): optimize getReduxObject method for better performance

### DIFF
--- a/suite/e2e/support/testExtends/enhancePage.ts
+++ b/suite/e2e/support/testExtends/enhancePage.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect, test } from '@playwright/test';
 import { writeFileSync } from 'fs';
-import { get, isMatch, set } from 'lodash';
+import { isMatch, set, toPath } from 'lodash';
 import { join } from 'path';
 
 import {
@@ -108,14 +108,15 @@ export const enhancePage = (page: Page): Page => {
         }).toPass({ timeout: 5000 });
     };
 
-    page.getReduxObject = async (objectPath?: string) => {
-        const state = await page.evaluate(() => window.store.getState());
-
+    page.getReduxObject = (objectPath?: string) => {
         if (!objectPath) {
-            return state;
+            return page.evaluate(() => window.store.getState());
         }
 
-        return get(state, objectPath);
+        return page.evaluate(
+            keys => keys.reduce((node, key) => node?.[key], window.store.getState()),
+            toPath(objectPath),
+        );
     };
 
     page.expectReduxObjectNotToBeEmpty = async function (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Optimize redux getter to not fetch whole store which in trade flows can have large size.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-test-redux-asserting/web/](https://dev.suite.sldev.cz/suite-web/fix-test-redux-asserting/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-test-redux-asserting&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-test-redux-asserting&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH to SOL | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T06:52:13.234Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH to SOL | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T06:51:42.278Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->