### PR TITLE
fix(suite): treat missing tx-simulation decision as cancel in yield thunks

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts
@@ -172,6 +172,15 @@ describe('claimMerklRewardsThunk', () => {
         expect(TrezorConnect.pushTransaction).not.toHaveBeenCalled();
     });
 
+    it('aborts without reporting when the simulation modal is torn down', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve(undefined));
+
+        await dispatchClaim(report);
+
+        expect(report).not.toHaveBeenCalled();
+    });
+
     it('stores the pending claim with its fee and submission time', async () => {
         const { store, result } = await dispatchClaim(jest.fn());
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -187,24 +187,28 @@ export const claimMerklRewardsThunk = createThunk<
                 }),
             );
 
+            if (userAcceptedTxSimulation === undefined) {
+                return;
+            }
+
             extra.services.analytics.report({
                 type: events.yieldClaimEvent.name,
                 payload: {
                     type: 'tx-simulation-modal',
-                    action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                    action: userAcceptedTxSimulation.value === false ? 'cancel' : 'continue',
                     networkSymbol: account.symbol,
                     rewardCount: rewards.length,
                 },
             });
 
-            if (userAcceptedTxSimulation?.value === false) {
+            if (userAcceptedTxSimulation.value === false) {
                 return;
             }
 
             const { formState, precomposedTransaction, availableRewards, transactionForSigning } =
                 buildClaimTransactionReview({
                     unsignedTransaction: unsignedClaimTx,
-                    selectedFee: userAcceptedTxSimulation?.selectedFee,
+                    selectedFee: userAcceptedTxSimulation.selectedFee,
                     rewards,
                 });
 
@@ -251,7 +255,7 @@ export const claimMerklRewardsThunk = createThunk<
                     chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
                 });
 
-                userAcceptedTxSimulation?.resolve();
+                userAcceptedTxSimulation.resolve();
 
                 if (!signingResponse.success) {
                     dispatch(closeModal());

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts
@@ -114,6 +114,16 @@ describe('submitYieldDepositThunk', () => {
         ).toHaveLength(0);
     });
 
+    it('aborts without reporting when the simulation modal is torn down', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve(undefined));
+
+        await dispatchDeposit(report);
+
+        expect(mockSendYieldTransaction).not.toHaveBeenCalled();
+        expect(report).not.toHaveBeenCalled();
+    });
+
     it('stores the broadcast transaction with its fee and submission time', async () => {
         const store = await dispatchDeposit(jest.fn());
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -97,21 +97,25 @@ export const submitYieldDepositThunk = createThunk<
                 }),
             );
 
+            if (userAcceptedTxSimulation === undefined) {
+                return;
+            }
+
             extra.services.analytics.report({
                 type: events.yieldDepositEvent.name,
                 payload: {
                     type: 'tx-simulation-modal',
-                    action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                    action: userAcceptedTxSimulation.value === false ? 'cancel' : 'continue',
                     networkSymbol: flowData.account.symbol,
                     vaultId: flowData.vault.id,
                 },
             });
 
-            if (userAcceptedTxSimulation?.value === false) {
+            if (userAcceptedTxSimulation.value === false) {
                 return;
             }
 
-            const selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
+            const { selectedFee } = userAcceptedTxSimulation;
 
             const sendResult = await sendYieldTransaction({
                 account: flowData.account,
@@ -125,7 +129,7 @@ export const submitYieldDepositThunk = createThunk<
                 selectedFee,
             });
 
-            userAcceptedTxSimulation?.resolve();
+            userAcceptedTxSimulation.resolve();
 
             // A deliberate user cancel — not reported as a failure.
             if (sendResult.status === 'cancelled') {

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts
@@ -120,6 +120,16 @@ describe('submitYieldWithdrawThunk', () => {
         ).toHaveLength(0);
     });
 
+    it('aborts without reporting when the simulation modal is torn down', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve(undefined));
+
+        await dispatchWithdraw(report);
+
+        expect(mockSendYieldTransaction).not.toHaveBeenCalled();
+        expect(report).not.toHaveBeenCalled();
+    });
+
     it('stores the broadcast transaction with its fee and submission time', async () => {
         const store = await dispatchWithdraw(jest.fn());
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -99,22 +99,26 @@ export const submitYieldWithdrawThunk = createThunk<
                 }),
             );
 
+            if (userAcceptedTxSimulation === undefined) {
+                return;
+            }
+
             extra.services.analytics.report({
                 type: events.yieldWithdrawEvent.name,
                 payload: {
                     type: 'tx-simulation-modal',
                     operation: flowType,
-                    action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                    action: userAcceptedTxSimulation.value === false ? 'cancel' : 'continue',
                     networkSymbol: account.symbol,
                     vaultId: flowData.vault.id,
                 },
             });
 
-            if (userAcceptedTxSimulation?.value === false) {
+            if (userAcceptedTxSimulation.value === false) {
                 return;
             }
 
-            const selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
+            const { selectedFee } = userAcceptedTxSimulation;
             const reviewToken = flowType === 'redeem' ? flowData.receiptToken : flowData.token;
 
             const result = await sendYieldTransaction({
@@ -129,7 +133,7 @@ export const submitYieldWithdrawThunk = createThunk<
                 selectedFee,
             });
 
-            userAcceptedTxSimulation?.resolve();
+            userAcceptedTxSimulation.resolve();
 
             // A deliberate user cancel — not reported as a failure.
             if (result.status === 'cancelled') {

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
@@ -290,6 +290,16 @@ describe('submitUnwrapNativeTokenThunk', () => {
         );
     });
 
+    it('aborts without reporting when the simulation modal is torn down', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve(undefined));
+
+        await dispatchUnwrap(report);
+
+        expect(mockSendYieldTransaction).not.toHaveBeenCalled();
+        expect(report).not.toHaveBeenCalled();
+    });
+
     it('reports an error carrying the compose reason when composition fails', async () => {
         const report = jest.fn();
         mockComposeYieldUnwrapTransactionThunk.mockImplementation(() => () => ({

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -107,18 +107,22 @@ export const submitUnwrapNativeTokenThunk = createThunk<
                 }),
             );
 
+            if (userAcceptedTxSimulation === undefined) {
+                return undefined;
+            }
+
             if (!yieldFlow) {
                 extra.services.analytics.report({
                     type: events.yieldUnwrapEvent.name,
                     payload: {
                         type: 'tx-simulation-modal',
-                        action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                        action: userAcceptedTxSimulation.value === false ? 'cancel' : 'continue',
                         networkSymbol: account.symbol,
                     },
                 });
             }
 
-            if (userAcceptedTxSimulation?.value === false) {
+            if (userAcceptedTxSimulation.value === false) {
                 return undefined;
             }
 
@@ -131,10 +135,10 @@ export const submitUnwrapNativeTokenThunk = createThunk<
                 flowType: yieldFlow?.flowType ?? 'withdraw',
                 dispatch,
                 getState,
-                selectedFee: userAcceptedTxSimulation?.selectedFee ?? null,
+                selectedFee: userAcceptedTxSimulation.selectedFee,
             });
 
-            userAcceptedTxSimulation?.resolve();
+            userAcceptedTxSimulation.resolve();
 
             // Unlike the main yield transactions, a cancelled unwrap is reported: the unwrap-step
             // failure values documented on the withdraw event include user rejections.

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -449,6 +449,16 @@ describe('submitWrapNativeTokenThunk', () => {
         );
     });
 
+    it('aborts without reporting when the simulation modal is torn down', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve(undefined));
+
+        await dispatchWrap(report);
+
+        expect(mockSendYieldTransaction).not.toHaveBeenCalled();
+        expect(report).not.toHaveBeenCalled();
+    });
+
     it('reports an error carrying the compose reason when composition fails', async () => {
         const report = jest.fn();
         mockComposeYieldWrapTransactionThunk.mockImplementation(() => () => ({

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -115,18 +115,22 @@ export const submitWrapNativeTokenThunk = createThunk<
                 }),
             );
 
+            if (userAcceptedTxSimulation === undefined) {
+                return undefined;
+            }
+
             if (!yieldFlow) {
                 extra.services.analytics.report({
                     type: events.yieldWrapEvent.name,
                     payload: {
                         type: 'tx-simulation-modal',
-                        action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                        action: userAcceptedTxSimulation.value === false ? 'cancel' : 'continue',
                         networkSymbol: account.symbol,
                     },
                 });
             }
 
-            if (userAcceptedTxSimulation?.value === false) {
+            if (userAcceptedTxSimulation.value === false) {
                 return undefined;
             }
 
@@ -146,10 +150,10 @@ export const submitWrapNativeTokenThunk = createThunk<
                 flowType: yieldFlow?.flowType ?? 'deposit',
                 dispatch,
                 getState,
-                selectedFee: userAcceptedTxSimulation?.selectedFee ?? null,
+                selectedFee: userAcceptedTxSimulation.selectedFee,
             });
 
-            userAcceptedTxSimulation?.resolve();
+            userAcceptedTxSimulation.resolve();
 
             // Unlike the main yield transactions, a cancelled wrap is reported: the wrap-step
             // failure values documented on the deposit event include user rejections.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Yield thunks treated an `undefined` tx-simulation modal result as acceptance - a modal torn down without a decision reported `continue` and proceeded into device signing. All five thunks (deposit, withdraw, claim, wrap, unwrap) now abort silently on a missing decision; explicit confirm/decline is unchanged. Adds a teardown test per thunk.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #30907

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-tx-simulation-teardown&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-tx-simulation-teardown&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies stablecoin-yield action thunks (deposit, withdraw, claim Merkl rewards) and native token wrap/unwrap thunks. The only E2E tests that directly exercise the changed yield paths are the yield redeem and withdrawal tests. Wrap/unwrap thunks and yield deposit/claim reward thunks have no direct E2E coverage and are validated by their unit tests; the broad static mappings to 136 tests are transitive imports and not actionable for targeted E2E validation.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — This test exercises the yield vault redeem/withdraw flow for a USDC Prime Vault, directly invoking submitYieldWithdrawThunk and related stablecoin-yield transaction composition logic changed in this PR.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test covers withdrawing from a USDC yield vault through transaction simulation, device confirmation, and completion, directly exercising the stablecoin-yield withdraw thunk paths modified here.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`

_Updated: 2026-09-09T14:20:59.752Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T14:22:24.894Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap BTC to ETH USDC token | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T14:21:06.576Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-tx-simulation-teardown/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-tx-simulation-teardown/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->