### PR TITLE
feat(suite-native): cardano signing WIP

### DIFF
--- a/networks/cardano/network-cardano/.depcheckrc.json
+++ b/networks/cardano/network-cardano/.depcheckrc.json
@@ -1,0 +1,3 @@
+{
+    "ignores": ["@emurgo/cardano-serialization-lib-asmjs"]
+}

--- a/networks/cardano/network-cardano/jest.config.asmjs.cjs
+++ b/networks/cardano/network-cardano/jest.config.asmjs.cjs
@@ -1,0 +1,18 @@
+/**
+ * Runs the unit tests against the asm.js build of Cardano Serialization Lib, the build the
+ * mobile app uses instead of WASM. The SWC transformer is required because Babel cannot
+ * transform the ~37 MB asm.js source within a default Node heap.
+ */
+const baseConfig = require('../../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+    testMatch: ['**/coinSelectionParity.test.ts'],
+    globals: { ...baseConfig.globals, CARDANO_SERIALIZATION_LIB_BUILD: 'asmjs' },
+    transformIgnorePatterns: ['node_modules/(?!@emurgo/cardano-serialization-lib-asmjs/)'],
+    moduleNameMapper: {
+        ...baseConfig.moduleNameMapper,
+        '^@emurgo/cardano-serialization-lib-(nodejs|browser)$':
+            '@emurgo/cardano-serialization-lib-asmjs/cardano_serialization_lib.js',
+    },
+};

--- a/networks/cardano/network-cardano/package.json
+++ b/networks/cardano/network-cardano/package.json
@@ -44,7 +44,8 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "yarn g:jest --passWithNoTests",
+        "test:unit": "yarn g:jest --passWithNoTests && yarn test:unit:asmjs",
+        "test:unit:asmjs": "yarn g:jest -c jest.config.asmjs.cjs --passWithNoTests",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../../scripts/publish/replace-imports.sh ./lib"
     },
@@ -52,5 +53,8 @@
         "@fivebinaries/coin-selection": "3.0.0",
         "@trezor/utils": "workspace:*",
         "cbor": "^10.0.12"
+    },
+    "devDependencies": {
+        "@emurgo/cardano-serialization-lib-asmjs": "13.2.0"
     }
 }

--- a/networks/cardano/network-cardano/src/runtime/__fixtures__/coinSelectionParity.fixture.ts
+++ b/networks/cardano/network-cardano/src/runtime/__fixtures__/coinSelectionParity.fixture.ts
@@ -1,0 +1,122 @@
+// Deterministic coin-selection inputs used to verify that every Cardano Serialization Lib build
+// (WASM on desktop/web, asm.js on mobile) produces identical transactions.
+// Only cases that take the largest-first path are included; random-improve is not deterministic.
+import type { types } from '@fivebinaries/coin-selection';
+
+const BASE_ADDRESS =
+    'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r';
+const RECIPIENT =
+    'addr1z90z7zqwhya6mpk5q929ur897g3pp9kkgalpreny8y304r2dcrtx0sf3dluyu4erzr3xtmdnzvcyfzekkuteu2xagx0qeva0pr';
+const ACCOUNT_XPUB =
+    'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a';
+const STAKE_ADDRESS = 'stake1uya87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygwx45el';
+const POOL = 'f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973';
+const POLICY_A = '95a427e384527065f2f8946f5e86320d0117839a5e98ea2c0b55fb00';
+const POLICY_B = 'd894897411707efa755a76deb66d26dfd50593f2e70863e1661e98a0';
+const TOKEN_B = `${POLICY_B}746f6b656e`;
+const TTL = 150_000_000;
+
+const hex = (value: number, length: number) => value.toString(16).padStart(length, '0');
+
+const buildUtxos = (count: number): types.Utxo[] =>
+    Array.from({ length: count }, (_, index) => {
+        const amount: types.Asset[] = [
+            { unit: 'lovelace', quantity: String(1_500_000 + index * 731_000) },
+        ];
+        if (index % 5 === 0) {
+            amount.push({ unit: `${POLICY_A}${hex(index, 4)}`, quantity: String(10 + index) });
+        }
+        if (index % 7 === 0) {
+            amount.push({ unit: TOKEN_B, quantity: String(1_000 * (index + 1)) });
+        }
+
+        return {
+            address: BASE_ADDRESS,
+            txHash: hex(index + 1, 8).repeat(8),
+            outputIndex: index % 3,
+            amount,
+        };
+    });
+
+const baseParams = {
+    utxos: buildUtxos(50),
+    changeAddress: BASE_ADDRESS,
+    certificates: [],
+    withdrawals: [],
+    accountPubKey: ACCOUNT_XPUB,
+    ttl: TTL,
+} satisfies Partial<types.CoinSelectionParams>;
+
+export interface ParityCase {
+    params: types.CoinSelectionParams;
+    options: types.Options;
+    expected: {
+        fee: string;
+        totalSpent: string;
+        hash: string;
+        size: number;
+        serializedTxHash: string;
+    };
+}
+
+export const witnesses = [
+    {
+        type: 1,
+        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+        signature:
+            '9d0abbf8a4b5e7f6c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8',
+    },
+];
+
+export const parityCases: Record<string, ParityCase> = {
+    delegationWithTokensAndWithdrawal: {
+        params: {
+            ...baseParams,
+            outputs: [
+                {
+                    address: RECIPIENT,
+                    amount: '3000000',
+                    assets: [{ unit: TOKEN_B, quantity: '1500' }],
+                },
+            ],
+            certificates: [{ type: 0 }, { type: 2, pool: POOL }, { type: 9, dRep: { type: 2 } }],
+            withdrawals: [{ stakeAddress: STAKE_ADDRESS, amount: '1234567' }],
+        },
+        options: {},
+        expected: {
+            fee: '188953',
+            totalSpent: '5188953',
+            hash: '85c398493e69e9632c5e46e13bbe1fc6bdb4d3c5fb1ae696bdf0e51d5652ca4f',
+            size: 759,
+            serializedTxHash: 'b205004f25206cb8d7d634964cee6ee88224787f29442e64d98868fb92c5e98b',
+        },
+    },
+    plainSend: {
+        params: {
+            ...baseParams,
+            outputs: [{ address: RECIPIENT, amount: '12345678', assets: [] }],
+        },
+        options: { forceLargestFirstSelection: true },
+        expected: {
+            fee: '170429',
+            totalSpent: '12516107',
+            hash: '8873131e7e46331e2bef32ec4f8ebd3edde1635c02d95f684705b9be4ff8ff56',
+            size: 338,
+            serializedTxHash: '19be2111ac264e482b8395a42afc1bf36560bd613152d5eb790852a69a4ef3cd',
+        },
+    },
+    sendMax: {
+        params: {
+            ...baseParams,
+            outputs: [{ address: RECIPIENT, amount: undefined, assets: [], setMax: true }],
+        },
+        options: {},
+        expected: {
+            fee: '251609',
+            totalSpent: '968979430',
+            hash: '4dfac9e046d8481866b1fbec22fb83819b64df64ad9a8491ee7e4810ce182bb5',
+            size: 2183,
+            serializedTxHash: '6da4f1422969629ea4306dce5818da30db8220f41a830cab68888d283a233170',
+        },
+    },
+};

--- a/networks/cardano/network-cardano/src/runtime/coinSelectionParity.test.ts
+++ b/networks/cardano/network-cardano/src/runtime/coinSelectionParity.test.ts
@@ -1,0 +1,45 @@
+import { coinSelection, trezorUtils } from '@fivebinaries/coin-selection';
+import { createHash } from 'crypto';
+
+import { parityCases, witnesses } from './__fixtures__/coinSelectionParity.fixture';
+
+// The expected values were produced by the WASM build of Cardano Serialization Lib. The same
+// test runs against the asm.js build used by the mobile app (see jest.config.asmjs.cjs), which
+// guarantees both platforms compose byte-identical transactions from identical inputs.
+// Set by jest.config.asmjs.cjs; undefined under the default config, which uses the WASM build.
+declare const CARDANO_SERIALIZATION_LIB_BUILD: string | undefined;
+
+describe('coin selection parity across Cardano Serialization Lib builds', () => {
+    it('runs against the Cardano Serialization Lib build selected by the Jest config', () => {
+        const expectedBuild =
+            typeof CARDANO_SERIALIZATION_LIB_BUILD === 'undefined'
+                ? 'nodejs'
+                : CARDANO_SERIALIZATION_LIB_BUILD;
+
+        expect(require.resolve('@emurgo/cardano-serialization-lib-nodejs')).toContain(
+            `cardano-serialization-lib-${expectedBuild}`,
+        );
+    });
+
+    it.each(Object.entries(parityCases))(
+        'composes and serializes the expected transaction: %s',
+        (_name, { params, options, expected }) => {
+            const result = coinSelection(params, options);
+
+            expect(result.type).toBe('final');
+            if (result.type !== 'final') return;
+
+            expect(result.fee).toBe(expected.fee);
+            expect(result.totalSpent).toBe(expected.totalSpent);
+            expect(result.tx.hash).toBe(expected.hash);
+            expect(result.tx.size).toBe(expected.size);
+
+            const serializedTx = trezorUtils.signTransaction(result.tx.body, witnesses, {
+                testnet: false,
+            });
+            const serializedTxHash = createHash('sha256').update(serializedTx, 'hex').digest('hex');
+
+            expect(serializedTxHash).toBe(expected.serializedTxHash);
+        },
+    );
+});

--- a/suite-native/app/.depcheckrc.json
+++ b/suite-native/app/.depcheckrc.json
@@ -1,6 +1,7 @@
 {
     "ignore-patterns": ["libDev", "lib"],
     "ignores": [
+        "@emurgo/cardano-serialization-lib-asmjs",
         "@rozenite/redux-devtools-plugin",
         "@react-native-async-storage/async-storage",
         "@react-native-community/netinfo",

--- a/suite-native/app/cardanoPolyfills.js
+++ b/suite-native/app/cardanoPolyfills.js
@@ -1,2 +1,0 @@
-/* eslint-disable import/no-default-export */
-export default {};

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -59,8 +59,18 @@ const isModuleFrom = (packageNames, moduleName) =>
  *
  * @type {import('metro-config').MetroConfig}
  */
+// The asm.js build of Cardano Serialization Lib is a single ~37 MB source file. Transforming it
+// exceeds the default V8 heap of a Metro worker (release bundling peaked at ~8.5 GB), so workers
+// run as child processes (instead of worker threads, which cannot get their own heap limit) with
+// a larger heap. The value is a cap, not an allocation; only the worker handling that file uses it.
+const METRO_WORKER_NODE_OPTIONS = '--max-old-space-size=12288';
+process.env.NODE_OPTIONS = [process.env.NODE_OPTIONS, METRO_WORKER_NODE_OPTIONS]
+    .filter(Boolean)
+    .join(' ');
+
 const config = {
     transformer: {
+        unstable_workerThreads: false,
         getTransformOptions: async () => ({
             transform: {
                 experimentalImportSupport: false,
@@ -110,11 +120,15 @@ const config = {
                 type: 'sourceFile',
             });
 
-            if (moduleName.startsWith('@emurgo/cardano')) {
-                // Cardano libs doesn't have main field in package.json which will cause error in metro
-                // Also they use WASM which doesn't work in RN so we polyfill it with empty file to build errors
-                // In future we will need JS implementation of Cardano libs or C++ implementation
-                return getSourceFile('./cardanoPolyfills.js');
+            if (moduleName.startsWith('@emurgo/cardano-serialization-lib')) {
+                // Cardano coin selection (`@fivebinaries/coin-selection`) imports the WASM build of
+                // Cardano Serialization Lib, which Hermes cannot execute. Route every variant
+                // (nodejs/browser) to the pure-JS asm.js build of the same CSL version instead.
+                // The asm.js package has no `main` field, so the entry file is resolved explicitly.
+                // It needs a global `TextDecoder`, which the Expo runtime polyfills.
+                return getSourceFile(
+                    '@emurgo/cardano-serialization-lib-asmjs/cardano_serialization_lib.js',
+                );
             }
 
             if (process.env.EXPO_PUBLIC_IS_DETOX_BUILD && moduleName === '@trezor/connect') {

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -36,6 +36,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
+        "@emurgo/cardano-serialization-lib-asmjs": "13.2.0",
         "@evolu/common": "8.0.0-next.5",
         "@evolu/react-native": "15.0.0-next.2",
         "@exodus/patch-broken-hermes-typed-arrays": "^1.0.0-alpha.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2896,6 +2896,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emurgo/cardano-serialization-lib-asmjs@npm:13.2.0":
+  version: 13.2.0
+  resolution: "@emurgo/cardano-serialization-lib-asmjs@npm:13.2.0"
+  checksum: 10/28a20ce492e57d5fd820b9603806bd2cddc4ed7f67ff1bc3f4c6ede71055341201ae6913f6473f66b91356ff6ca8efa5cb3a32da8ef9d69f60d22a0dcb608242
+  languageName: node
+  linkType: hard
+
 "@emurgo/cardano-serialization-lib-browser@npm:^13.2.0":
   version: 13.2.0
   resolution: "@emurgo/cardano-serialization-lib-browser@npm:13.2.0"
@@ -12003,6 +12010,7 @@ __metadata:
     "@babel/core": "npm:7.29.7"
     "@config-plugins/detox": "npm:^11.0.0"
     "@currents/cmd": "npm:1.9.7"
+    "@emurgo/cardano-serialization-lib-asmjs": "npm:13.2.0"
     "@evolu/common": "npm:8.0.0-next.5"
     "@evolu/react-native": "npm:15.0.0-next.2"
     "@exodus/patch-broken-hermes-typed-arrays": "npm:^1.0.0-alpha.1"
@@ -17282,6 +17290,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/network-cardano@workspace:networks/cardano/network-cardano"
   dependencies:
+    "@emurgo/cardano-serialization-lib-asmjs": "npm:13.2.0"
     "@fivebinaries/coin-selection": "npm:3.0.0"
     "@trezor/utils": "workspace:*"
     cbor: "npm:^10.0.12"


### PR DESCRIPTION
## Description

- Enables Cardano transaction composing and serialization on mobile. Hermes (RN) cannot run the WASM build of Cardano Serialization Lib (CSL) that desktop uses, so the mobile Metro config now routes CSL imports to Emurgo's pure-JS asm.js build of the same version (13.2.0) instead of the previous empty stub.
- Selection logic (`@fivebinaries/coin-selection`), connect, and the shared send flow are untouched, so mobile produces byte-identical transactions to desktop.
- New parity test in `@trezor/network-cardano` runs the same fixtures against the WASM and asm.js builds; `test:unit` executes both, so CI verifies platform parity on every change.
- Measured on an arm64 phone: +4.2 MB download, +13.5 MB on device, no cold-start change, compose 15–230 ms. Release JS bundling takes 3–6 minutes longer.

For more details, see this [Notion page](https://app.notion.com/p/satoshilabs/Cardano-signing-technical-analysis-3d7dc5260606804b976dce19efaf12b7).

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
