### PR TITLE
test(suite): inject services and simplify test utilities

### DIFF
--- a/docs/tests/suite-common-test-utils.md
+++ b/docs/tests/suite-common-test-utils.md
@@ -68,10 +68,16 @@ Use `createTestCompositionRoot` when Redux integration is part of what the test 
 creates a test application root containing the Redux store and the injected services used by that
 store.
 
+Omit `extra` when the tested code has no injected dependencies; it defaults to `{ services: {} }`.
+When dependencies are required, pass them explicitly through `extra`.
+
 ```ts
 import { createTestCompositionRoot } from '@suite-common/test-utils';
 
-const root = createTestCompositionRoot({
+const {
+    store: { getState },
+    services: { dispatch, getActions },
+} = createTestCompositionRoot({
     extra: {
         services: {
             analytics: mockAnalytics(),
@@ -85,10 +91,10 @@ const root = createTestCompositionRoot({
     },
 });
 
-root.services.dispatch(incrementCounter());
+dispatch(incrementCounter());
 
-expect(root.store.getState().counter.value).toBe(1);
-expect(root.services.getActions()).toContainEqual(incrementCounter());
+expect(getState().counter.value).toBe(1);
+expect(getActions()).toContainEqual(incrementCounter());
 ```
 
 Declare only the services and state needed by the tested application slice. The composition root

--- a/docs/tests/suite-native-test-utils.md
+++ b/docs/tests/suite-native-test-utils.md
@@ -113,22 +113,18 @@ For example, you want to check if some action was dispatched or if the state was
 You have also possibility to dispatch an action by yourself.
 
 ```tsx
-import {
-    type TestStore,
-    act,
-    initStore,
-    renderWithStoreProvider,
-    userEvent,
-} from '@suite-native/test-utils';
+import { type Store } from '@reduxjs/toolkit';
+
+import { act, initStore, renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 
 describe('Counter', () => {
-    let store: TestStore;
+    let store: Store<{ counter: { value: number } }>;
 
     beforeEach(() => {
         ({ store } = initStore({ counter: { value: 0 } }));
     });
 
-    const renderCounter = () => renderWithStoreProvider(<Counter />, { store });
+    const renderCounter = () => renderWithStoreProvider(<Counter />, { services: { store } });
 
     it('should react to state changes', () => {
         const { getByLabelText } = renderCounter();
@@ -159,7 +155,7 @@ To inject custom provider, you can use `wrapper` option of either `render`, `ren
 
 ```tsx
 const renderCounterA = () =>
-    renderWithStoreProvider(<Counter />, { store, wrapper: MyCustomProvider });
+    renderWithStoreProvider(<Counter />, { services: { store }, wrapper: MyCustomProvider });
 
 const renderCounterB = () =>
     renderWithBasicProvider(<Counter />, {
@@ -235,8 +231,8 @@ import {
 } from '@suite-native/test-utils';
 
 describe('useCounter', () => {
-    const renderUseCounter = (store: PreloadedState) =>
-        renderHookWithStoreProvider(() => useCounter(), { store });
+    const renderUseCounter = (preloadedState: PreloadedState) =>
+        renderHookWithStoreProvider(() => useCounter(), { preloadedState });
 
     it('should initialize with count from store', () => {
         const { result } = renderUseCounter({
@@ -251,11 +247,13 @@ describe('useCounter', () => {
 #### Usage example with store access
 
 ```ts
+import { type Store } from '@reduxjs/toolkit';
+
 import { act, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 describe('useCounter', () => {
-    const renderUseCounter = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useCounter(), { store });
+    const renderUseCounter = (store: Store<{ counter: { value: number } }>) =>
+        renderHookWithStoreProvider(() => useCounter(), { services: { store } });
 
     it('should increment count and update store', () => {
         const store = initStore({ counter: { value: 0 } });
@@ -279,7 +277,10 @@ To inject custom provider, you can use `wrapper` option of either `renderHook`, 
 
 ```tsx
 const renderUseCounterA = () =>
-    renderHookWithStoreProvider(() => useCounter(), { store, wrapper: MyCustomProvider });
+    renderHookWithStoreProvider(() => useCounter(), {
+        services: { store },
+        wrapper: MyCustomProvider,
+    });
 
 const renderUseCounterB = () =>
     renderHookWithBasicProvider(() => useCounter(), {

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.test.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.test.ts
@@ -1,7 +1,9 @@
 import { type CryptoId, type SellFiatTrade, type SellFiatTradeQuoteRequest } from 'invity-api';
 
 import { type DesktopAnalyticsDep } from '@suite/analytics';
-import { type GotoThunkDeps } from '@suite/router';
+import { locksReducer } from '@suite/locks';
+import { modalReducer } from '@suite/modal';
+import { type GotoThunkDeps, routerLocationChange, routerReducer } from '@suite/router';
 import { type WithServices } from '@suite-common/redux-utils';
 import { createTestStore } from '@suite-common/test-utils';
 import { initialState as tradingInitialState } from '@suite-common/trading';
@@ -12,11 +14,6 @@ import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { selectSellQuoteThunk } from './selectSellQuoteThunk';
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
-}));
 
 const mockRequestSellTradeThunk = jest.fn((args: unknown) =>
     Object.assign(
@@ -76,6 +73,9 @@ const buildStore = (
     createTestStore({
         extra: createExtra(report),
         preloadedState: {
+            locks: locksReducer(undefined, { type: 'test-init' }),
+            modal: modalReducer(undefined, { type: 'test-init' }),
+            router: routerReducer(undefined, { type: 'test-init' }),
             device: { selectedDevice: { state: { staticSessionId: DEVICE_STATE } } },
             tokenDefinitions: {},
             wallet: {
@@ -154,14 +154,19 @@ describe('selectSellQuoteThunk', () => {
         expect(mockRequestSellTradeThunk).toHaveBeenCalledTimes(1);
         expect(store.getActions()).toEqual(
             expect.arrayContaining([
-                { type: '@router/goto', payload: { routeName: 'wallet-trading-sell-confirm' } },
+                expect.objectContaining({
+                    type: routerLocationChange.type,
+                    payload: expect.objectContaining({
+                        pathname: '/accounts/coinmarket/sell/confirm',
+                    }),
+                }),
                 { type: '@test/request-sell-trade' },
             ]),
         );
 
         const gotoActionIndex = store
             .getActions()
-            .findIndex(action => action.type === '@router/goto');
+            .findIndex(action => action.type === routerLocationChange.type);
         const requestActionIndex = store
             .getActions()
             .findIndex(action => action.type === '@test/request-sell-trade');

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx
@@ -42,14 +42,16 @@ const renderVotingDelegations = (account: Account) => {
 
     renderWithProviders(root, <VotingDelegations account={account} />);
 
-    return root;
+    const { getActions } = root.services;
+
+    return { getActions };
 };
 
 describe('VotingDelegations', () => {
     it('keeps a custom DRep the account already votes for instead of resetting it to Everstake', () => {
-        const root = renderVotingDelegations(createCardanoAccount(CUSTOM_DREP_ID));
+        const { getActions } = renderVotingDelegations(createCardanoAccount(CUSTOM_DREP_ID));
 
-        expect(root.services.getActions()).toContainEqual(
+        expect(getActions()).toContainEqual(
             stakeActions.setAccountVotingDelegation({
                 accountKey: ACCOUNT_KEY,
                 option: { type: 'current' },
@@ -58,9 +60,11 @@ describe('VotingDelegations', () => {
     });
 
     it('keeps the Everstake DRep without re-delegating to it', () => {
-        const root = renderVotingDelegations(createCardanoAccount(CARDANO_EVERSTAKE_DREP.bech32));
+        const { getActions } = renderVotingDelegations(
+            createCardanoAccount(CARDANO_EVERSTAKE_DREP.bech32),
+        );
 
-        expect(root.services.getActions()).toContainEqual(
+        expect(getActions()).toContainEqual(
             stakeActions.setAccountVotingDelegation({
                 accountKey: ACCOUNT_KEY,
                 option: { type: 'current' },
@@ -69,9 +73,9 @@ describe('VotingDelegations', () => {
     });
 
     it('keeps a predefined DRep, which no vote delegation certificate can express', () => {
-        const root = renderVotingDelegations(createCardanoAccount(PREDEFINED_DREP_ID));
+        const { getActions } = renderVotingDelegations(createCardanoAccount(PREDEFINED_DREP_ID));
 
-        expect(root.services.getActions()).toContainEqual(
+        expect(getActions()).toContainEqual(
             stakeActions.setAccountVotingDelegation({
                 accountKey: ACCOUNT_KEY,
                 option: { type: 'current' },
@@ -80,9 +84,9 @@ describe('VotingDelegations', () => {
     });
 
     it('offers Everstake to an account with no vote delegation', () => {
-        const root = renderVotingDelegations(createCardanoAccount(null));
+        const { getActions } = renderVotingDelegations(createCardanoAccount(null));
 
-        expect(root.services.getActions()).toContainEqual(
+        expect(getActions()).toContainEqual(
             stakeActions.setAccountVotingDelegation({
                 accountKey: ACCOUNT_KEY,
                 option: DEFAULT_VOTING_OPTION,

--- a/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.test.tsx
+++ b/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.test.tsx
@@ -1,19 +1,14 @@
+import { type PropsWithChildren } from 'react';
+
 import { act, renderHook } from '@testing-library/react';
 
+import { mockDesktopAnalytics } from '@suite/analytics/mocks';
 import { events } from '@suite-common/analytics';
+import { ServicesProvider } from '@suite-common/dependency-injection';
 
 import { useWrappedNativeFlowAnalytics } from './useWrappedNativeFlowAnalytics';
 
 const mockReport = jest.fn();
-
-// The reference must be stable across renders, or the resolution/leftPending effects re-bind.
-jest.mock('@suite-common/dependency-injection', () => {
-    const analytics = { report: (...args: unknown[]) => mockReport(...args) };
-
-    return { useServices: () => ({ analytics }) };
-});
-
-jest.mock('@suite/analytics', () => ({ selectDesktopAnalyticsDep: () => ({}) }));
 
 type Props = Parameters<typeof useWrappedNativeFlowAnalytics>[0];
 
@@ -24,8 +19,16 @@ const pendingWrap: Props = {
     networkSymbol: 'eth',
 };
 
-const renderFlowAnalytics = (initialProps: Props) =>
-    renderHook((props: Props) => useWrappedNativeFlowAnalytics(props), { initialProps });
+const renderFlowAnalytics = (initialProps: Props) => {
+    const services = { analytics: mockDesktopAnalytics(mockReport) };
+
+    return renderHook((props: Props) => useWrappedNativeFlowAnalytics(props), {
+        initialProps,
+        wrapper: ({ children }: PropsWithChildren) => (
+            <ServicesProvider services={services}>{children}</ServicesProvider>
+        ),
+    });
+};
 
 describe('useWrappedNativeFlowAnalytics', () => {
     beforeEach(() => {

--- a/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.test.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.test.tsx
@@ -8,10 +8,6 @@ jest.mock('@suite/intl', () => ({
     Translation: ({ id }: any) => id,
 }));
 
-jest.mock('@suite/router', () => ({
-    gotoThunk: () => ({ type: 'goto' }),
-}));
-
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),
     isWeb: jest.fn(() => false),

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx
@@ -5,7 +5,7 @@ import { type UnknownAction } from '@reduxjs/toolkit';
 import { QueryClient, QueryClientProvider } from '@suite-common/react-query';
 import {
     act,
-    createTestStore,
+    createTestCompositionRoot,
     renderHookWithStoreProvider,
     testMocks,
     waitFor,
@@ -63,8 +63,10 @@ const renderTransactionGraphUpdater = ({
     transactions?: WalletAccountTransaction[];
     hasAccount?: boolean;
 } = {}) => {
-    const store = createTestStore({ extra: undefined, reducer: { wallet: walletReducer } });
-    store.dispatch(setTransactions(transactions));
+    const root = createTestCompositionRoot({
+        reducer: { wallet: walletReducer },
+    });
+    root.store.dispatch(setTransactions(transactions));
 
     const abortSignals: AbortSignal[] = [];
     const onRequestGraphUpdate = jest.fn((abortSignal: AbortSignal) => {
@@ -84,14 +86,14 @@ const renderTransactionGraphUpdater = ({
                 onRequestGraphUpdate,
             }),
         {
-            store,
+            root,
             wrapper: ({ children }: PropsWithChildren) => (
                 <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
             ),
         },
     );
 
-    return { store, onRequestGraphUpdate, abortSignals, unmount };
+    return { root, onRequestGraphUpdate, abortSignals, unmount };
 };
 
 describe('useTransactionGraphUpdater', () => {
@@ -116,14 +118,14 @@ describe('useTransactionGraphUpdater', () => {
     });
 
     it('requests another update once a transaction is confirmed and aborts the outdated one', async () => {
-        const { store, onRequestGraphUpdate, abortSignals } = renderTransactionGraphUpdater({
+        const { root, onRequestGraphUpdate, abortSignals } = renderTransactionGraphUpdater({
             transactions: [pendingTransaction('txid2'), confirmedTransaction('txid1')],
         });
 
         await waitFor(() => expect(onRequestGraphUpdate).toHaveBeenCalledTimes(1));
 
         act(() => {
-            store.dispatch(
+            root.store.dispatch(
                 setTransactions([confirmedTransaction('txid2'), confirmedTransaction('txid1')]),
             );
         });
@@ -134,14 +136,14 @@ describe('useTransactionGraphUpdater', () => {
     });
 
     it('requests no update for an incoming pending transaction', async () => {
-        const { store, onRequestGraphUpdate, abortSignals } = renderTransactionGraphUpdater({
+        const { root, onRequestGraphUpdate, abortSignals } = renderTransactionGraphUpdater({
             transactions: [confirmedTransaction('txid1')],
         });
 
         await waitFor(() => expect(onRequestGraphUpdate).toHaveBeenCalledTimes(1));
 
         act(() => {
-            store.dispatch(
+            root.store.dispatch(
                 setTransactions([pendingTransaction('txid2'), confirmedTransaction('txid1')]),
             );
         });

--- a/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts
+++ b/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts
@@ -132,13 +132,15 @@ describe('useSeededCardanoVotingDelegation', () => {
             { initialProps: { account } },
         );
 
-        return { root, rerender };
+        const { getActions, dispatch } = root.services;
+
+        return { getActions, dispatch, rerender };
     };
 
     it('seeds the selection with the delegation the account already has', () => {
-        const { root } = renderSeededHook(createCardanoAccount(CUSTOM_DREP_ID));
+        const { getActions } = renderSeededHook(createCardanoAccount(CUSTOM_DREP_ID));
 
-        expect(root.services.getActions()).toEqual([
+        expect(getActions()).toEqual([
             stakeActions.setAccountVotingDelegation({
                 accountKey: ACCOUNT_KEY,
                 option: { type: 'current' },
@@ -147,11 +149,11 @@ describe('useSeededCardanoVotingDelegation', () => {
     });
 
     it('seeds an account only once, so a later backend update cannot overwrite a user selection', () => {
-        const { root, rerender } = renderSeededHook(createCardanoAccount(null));
+        const { getActions, rerender } = renderSeededHook(createCardanoAccount(null));
 
         rerender({ account: createCardanoAccount(CUSTOM_DREP_ID) });
 
-        expect(root.services.getActions()).toHaveLength(1);
+        expect(getActions()).toHaveLength(1);
     });
 
     it('seeds again once the selection is cleared while still mounted', () => {
@@ -159,13 +161,13 @@ describe('useSeededCardanoVotingDelegation', () => {
             accountKey: ACCOUNT_KEY,
             option: { type: 'current' },
         });
-        const { root } = renderSeededHook(createCardanoAccount(CUSTOM_DREP_ID));
+        const { getActions, dispatch } = renderSeededHook(createCardanoAccount(CUSTOM_DREP_ID));
 
         act(() => {
-            root.store.dispatch(stakeActions.clearAccountVotingDelegation());
+            dispatch(stakeActions.clearAccountVotingDelegation());
         });
 
-        expect(root.services.getActions()).toEqual([
+        expect(getActions()).toEqual([
             seedCurrent,
             stakeActions.clearAccountVotingDelegation(),
             seedCurrent,
@@ -173,11 +175,11 @@ describe('useSeededCardanoVotingDelegation', () => {
     });
 
     it('seeds again for a different account', () => {
-        const { root, rerender } = renderSeededHook(createCardanoAccount(null));
+        const { getActions, rerender } = renderSeededHook(createCardanoAccount(null));
 
         rerender({ account: createCardanoAccount(CUSTOM_DREP_ID, true, OTHER_ACCOUNT_KEY) });
 
-        expect(root.services.getActions()).toEqual([
+        expect(getActions()).toEqual([
             stakeActions.setAccountVotingDelegation({
                 accountKey: ACCOUNT_KEY,
                 option: DEFAULT_VOTING_OPTION,

--- a/packages/suite/src/hooks/settings/useGapLimitForm.test.tsx
+++ b/packages/suite/src/hooks/settings/useGapLimitForm.test.tsx
@@ -1,6 +1,7 @@
+import { type UnknownAction } from '@reduxjs/toolkit';
 import { act } from '@testing-library/react';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { blockchainActions } from '@suite-common/wallet-core';
 
@@ -9,8 +10,7 @@ import { useGapLimitForm } from './useGapLimitForm';
 const SYMBOL = asNetworkSymbol('btc');
 
 const renderGapLimitForm = (savedGapLimit?: number) => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: {
             wallet: {
                 blockchain: {
@@ -19,28 +19,30 @@ const renderGapLimitForm = (savedGapLimit?: number) => {
             },
         },
     });
-    const { result } = renderHookWithStoreProvider(() => useGapLimitForm(SYMBOL), { store });
+    const { result } = renderHookWithStoreProvider(() => useGapLimitForm(SYMBOL), { root });
 
-    return { store, result };
+    const { getActions } = root.services;
+
+    return { getActions, result };
 };
 
-const gapLimitActions = (store: ReturnType<typeof renderGapLimitForm>['store']) =>
-    store.getActions().filter(action => action.type === blockchainActions.setBackendGapLimit.type);
+const gapLimitActions = (actions: UnknownAction[]) =>
+    actions.filter(action => action.type === blockchainActions.setBackendGapLimit.type);
 
 describe('useGapLimitForm', () => {
     it('persists a valid gap limit', () => {
-        const { store, result } = renderGapLimitForm();
+        const { getActions, result } = renderGapLimitForm();
 
         act(() => result.current.setValue('30'));
         act(() => result.current.save());
 
-        expect(gapLimitActions(store)).toEqual([
+        expect(gapLimitActions(getActions())).toEqual([
             blockchainActions.setBackendGapLimit({ symbol: SYMBOL, gapLimit: 30 }),
         ]);
     });
 
     it('does not persist a gap limit below the minimum despite the button click', () => {
-        const { store, result } = renderGapLimitForm();
+        const { getActions, result } = renderGapLimitForm();
 
         act(() => result.current.setValue('5'));
 
@@ -48,11 +50,11 @@ describe('useGapLimitForm', () => {
 
         act(() => result.current.save());
 
-        expect(gapLimitActions(store)).toEqual([]);
+        expect(gapLimitActions(getActions())).toEqual([]);
     });
 
     it('does not persist an empty or non-positive gap limit', () => {
-        const { store, result } = renderGapLimitForm();
+        const { getActions, result } = renderGapLimitForm();
 
         act(() => result.current.setValue(''));
         act(() => result.current.save());
@@ -60,6 +62,6 @@ describe('useGapLimitForm', () => {
         act(() => result.current.setValue('0'));
         act(() => result.current.save());
 
-        expect(gapLimitActions(store)).toEqual([]);
+        expect(gapLimitActions(getActions())).toEqual([]);
     });
 });

--- a/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
+++ b/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
@@ -1,5 +1,6 @@
-import { type TransportName, type TransportsDep } from '@suite-common/connect-init';
+import { type TransportName } from '@suite-common/connect-init';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectTransportsDep } from '@suite-common/suite-types';
 import TrezorConnect from '@trezor/connect';
 import { useWindowFocus } from '@trezor/react-utils';
 import { SUITE_BRIDGE_DEEPLINK, SUITE_URL } from '@trezor/urls';
@@ -14,9 +15,7 @@ export const useOpenSuiteDesktop = () => {
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
     const activeTransports = useSelector(selectActiveTransports);
     const windowFocused = useWindowFocus();
-    const { createTransports } = useServices((services): TransportsDep => ({
-        createTransports: services.createTransports,
-    }));
+    const { createTransports } = useServices(selectTransportsDep);
 
     const handleOpenSuite = () => {
         const iframe = document.createElement('iframe');

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -2,6 +2,8 @@ import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
 import { debugInitialState } from '@suite/debug';
 import { locksReducer } from '@suite/locks';
+import { modalReducer } from '@suite/modal';
+import { routerLocationChange, routerReducer } from '@suite/router';
 import { suiteSettingsInitialState } from '@suite/settings';
 import { torReducer } from '@suite/tor';
 import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
@@ -440,8 +442,8 @@ export const getRootReducer: any = (selectedAccount = BTC_ACCOUNT, fees = DEFAUL
             { enabled: false, providers: [], selectedProvider: {} },
             () => ({}),
         ),
-        router: createReducer({}, () => ({})),
-        modal: createReducer({}, () => ({})),
+        router: (state = routerReducer(undefined, { type: 'test-init' })) => state,
+        modal: modalReducer,
         suiteSyncData: createReducer(
             {
                 wallets: {},
@@ -1490,7 +1492,8 @@ export const signAndPush: SignAndPush[] = [
                     payload: { type: 'tx-sent', formattedAmount: '1 ETH' }, // BUG ?
                 },
                 {
-                    type: 'mock-redirect',
+                    type: routerLocationChange.type,
+                    payload: { pathname: '/accounts' },
                 },
             ],
         },
@@ -1545,7 +1548,8 @@ export const signAndPush: SignAndPush[] = [
                     payload: { type: 'tx-sent', formattedAmount: '1 XRP' },
                 },
                 {
-                    type: 'mock-redirect',
+                    type: routerLocationChange.type,
+                    payload: { pathname: '/accounts' },
                 },
             ],
         },
@@ -1702,7 +1706,8 @@ export const signAndPush: SignAndPush[] = [
                     },
                 },
                 {
-                    type: 'mock-redirect',
+                    type: routerLocationChange.type,
+                    payload: { pathname: '/accounts' },
                 },
             ],
         },

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyFlow.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyFlow.test.tsx
@@ -1,11 +1,10 @@
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { locksReducer } from '@suite/locks';
+import { modalReducer } from '@suite/modal';
+import { routerReducer } from '@suite/router';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 
 import { useBuyFlow } from './useBuyFlow';
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
-}));
 
 jest.mock('@suite-common/trading', () => {
     const actual = jest.requireActual('@suite-common/trading');
@@ -30,8 +29,17 @@ const renderBuyFlow = ({
     quotesRequest = undefined,
     isAmountEmpty = false,
 }: Props = {}) => {
-    const store = createTestStore({
-        extra: undefined,
+    const suiteRouterHistory = { ...mockSuiteRouterHistory(), navigate: jest.fn() };
+    const root = createTestCompositionRoot({
+        extra: {
+            services: { suiteRouterHistory },
+        },
+        reducer: {
+            router: routerReducer,
+            locks: locksReducer,
+            modal: modalReducer,
+            wallet: (wallet = { trading: { buy: { quotes: [] } } }) => wallet,
+        },
         preloadedState: {
             wallet: { trading: { buy: { quotes: [] } } },
         },
@@ -44,39 +52,50 @@ const renderBuyFlow = ({
                 quotesRequest: quotesRequest as never,
                 isAmountEmpty,
             }),
-        { store },
+        { root },
     );
 
-    return store;
-};
+    const { getActions } = root.services;
 
-const actionTypes = (store: ReturnType<typeof renderBuyFlow>) =>
-    store.getActions().map(action => action.type);
+    return { getActions, suiteRouterHistory };
+};
 
 describe('useBuyFlow', () => {
     it('dispatches the initial data load once on mount', () => {
-        const store = renderBuyFlow();
+        const { getActions } = renderBuyFlow();
 
         expect(
-            store.getActions().filter(action => action.type === 'trading/loadInitialData'),
+            getActions().filter(action => action.type === 'trading/loadInitialData'),
         ).toHaveLength(1);
     });
 
     it('navigates to the confirm page when both the redirect flag and quotes request are present', () => {
-        const store = renderBuyFlow({ isFromRedirect: true, quotesRequest: { some: 'request' } });
+        const { suiteRouterHistory } = renderBuyFlow({
+            isFromRedirect: true,
+            quotesRequest: { some: 'request' },
+        });
 
-        expect(actionTypes(store)).toContain('@router/goto');
+        expect(suiteRouterHistory.navigate).toHaveBeenCalledWith({
+            pathname: '/accounts/coinmarket/buy/confirm',
+            hash: '',
+        });
     });
 
     it('does not navigate when the redirect flag is not set', () => {
-        const store = renderBuyFlow({ isFromRedirect: false, quotesRequest: { some: 'request' } });
+        const { suiteRouterHistory } = renderBuyFlow({
+            isFromRedirect: false,
+            quotesRequest: { some: 'request' },
+        });
 
-        expect(actionTypes(store)).not.toContain('@router/goto');
+        expect(suiteRouterHistory.navigate).not.toHaveBeenCalled();
     });
 
     it('does not navigate when there is no quotes request', () => {
-        const store = renderBuyFlow({ isFromRedirect: true, quotesRequest: undefined });
+        const { suiteRouterHistory } = renderBuyFlow({
+            isFromRedirect: true,
+            quotesRequest: undefined,
+        });
 
-        expect(actionTypes(store)).not.toContain('@router/goto');
+        expect(suiteRouterHistory.navigate).not.toHaveBeenCalled();
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useSelectedTradingAsset.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useSelectedTradingAsset.test.tsx
@@ -1,6 +1,6 @@
 import { type CryptoId } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -47,24 +47,22 @@ const buildState = (
 
 describe('useSelectedTradingAsset', () => {
     it('returns undefined when no eligible account is selected', () => {
-        const store = createTestStore({
-            extra: undefined,
+        const root = createTestCompositionRoot({
             preloadedState: buildState([INELIGIBLE_ACCOUNT]),
         });
         const { result } = renderHookWithStoreProvider(() => useSelectedTradingAsset('sell'), {
-            store,
+            root,
         });
 
         expect(result.current).toBeUndefined();
     });
 
     it('returns the native asset view-model when a native account is selected', () => {
-        const store = createTestStore({
-            extra: undefined,
+        const root = createTestCompositionRoot({
             preloadedState: buildState([ELIGIBLE_ACCOUNT], ELIGIBLE_ACCOUNT.key),
         });
         const { result } = renderHookWithStoreProvider(() => useSelectedTradingAsset('sell'), {
-            store,
+            root,
         });
 
         expect(result.current).toEqual({
@@ -79,15 +77,14 @@ describe('useSelectedTradingAsset', () => {
     });
 
     it('flags a prefilled token as a token asset', () => {
-        const store = createTestStore({
-            extra: undefined,
+        const root = createTestCompositionRoot({
             preloadedState: buildState([ELIGIBLE_ACCOUNT], ELIGIBLE_ACCOUNT.key, {
                 key: ELIGIBLE_ACCOUNT.key,
                 cryptoId: TOKEN_CRYPTO_ID,
             }),
         });
         const { result } = renderHookWithStoreProvider(() => useSelectedTradingAsset('buy'), {
-            store,
+            root,
         });
 
         expect(result.current?.cryptoId).toBe(TOKEN_CRYPTO_ID);

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingClearStaleQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingClearStaleQuotes.test.tsx
@@ -1,8 +1,10 @@
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import {
+    type TradingRootState,
     type TradingType,
     tradingBuyActions,
     tradingExchangeActions,
+    initialState as tradingInitialState,
     tradingSellActions,
 } from '@suite-common/trading';
 
@@ -14,28 +16,39 @@ const clearQuotesActionTypeByType = {
     exchange: tradingExchangeActions.clearQuotes.type,
 } satisfies Record<TradingType, string>;
 
-const getState = (type: TradingType, hasQuotes: boolean) => ({
+const getState = (type: TradingType, hasQuotes: boolean): TradingRootState => ({
     wallet: {
         trading: {
-            buy: { quotes: type === 'buy' && hasQuotes ? [{ id: '1' }] : [] },
-            sell: { quotes: type === 'sell' && hasQuotes ? [{ id: '1' }] : [] },
-            exchange: { quotes: type === 'exchange' && hasQuotes ? [{ id: '1' }] : [] },
+            ...tradingInitialState,
+            buy: {
+                ...tradingInitialState.buy,
+                quotes: type === 'buy' && hasQuotes ? [{ quoteId: '1' }] : [],
+            },
+            sell: {
+                ...tradingInitialState.sell,
+                quotes: type === 'sell' && hasQuotes ? [{ quoteId: '1' }] : [],
+            },
+            exchange: {
+                ...tradingInitialState.exchange,
+                quotes: type === 'exchange' && hasQuotes ? [{ quoteId: '1' }] : [],
+            },
         },
     },
 });
 
 const renderClearStaleQuotes = (
-    state: ReturnType<typeof getState>,
+    state: TradingRootState,
     props: { type: TradingType; isAmountEmpty: boolean },
 ) => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: state,
     });
 
-    renderHookWithStoreProvider(() => useTradingClearStaleQuotes(props), { store });
+    renderHookWithStoreProvider(() => useTradingClearStaleQuotes(props), { root });
 
-    return store;
+    const { getActions } = root.services;
+
+    return { getActions };
 };
 
 const tradingTypes: TradingType[] = ['buy', 'sell', 'exchange'];
@@ -44,30 +57,30 @@ describe('useTradingClearStaleQuotes', () => {
     it.each(tradingTypes)(
         'dispatches %s clearQuotes when amount is empty and quotes exist',
         type => {
-            const store = renderClearStaleQuotes(getState(type, true), {
+            const { getActions } = renderClearStaleQuotes(getState(type, true), {
                 type,
                 isAmountEmpty: true,
             });
 
-            expect(store.getActions()).toEqual([{ type: clearQuotesActionTypeByType[type] }]);
+            expect(getActions()).toEqual([{ type: clearQuotesActionTypeByType[type] }]);
         },
     );
 
     it('does not dispatch when amount is not empty', () => {
-        const store = renderClearStaleQuotes(getState('buy', true), {
+        const { getActions } = renderClearStaleQuotes(getState('buy', true), {
             type: 'buy',
             isAmountEmpty: false,
         });
 
-        expect(store.getActions()).toEqual([]);
+        expect(getActions()).toEqual([]);
     });
 
     it('does not dispatch when there are no quotes to clear', () => {
-        const store = renderClearStaleQuotes(getState('buy', false), {
+        const { getActions } = renderClearStaleQuotes(getState('buy', false), {
             type: 'buy',
             isAmountEmpty: true,
         });
 
-        expect(store.getActions()).toEqual([]);
+        expect(getActions()).toEqual([]);
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx
@@ -2,7 +2,7 @@ import { useForm } from 'react-hook-form';
 
 import { act, waitFor } from '@testing-library/react';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingSellFormProps } from '@suite-common/trading';
 import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
@@ -78,8 +78,7 @@ const buildDefaults = (): TradingSellFormProps =>
     }) as unknown as TradingSellFormProps;
 
 const renderComposeTransaction = () => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: {
             wallet: {
                 accounts: [BTC_ACCOUNT, SOL_ACCOUNT],
@@ -109,7 +108,7 @@ const renderComposeTransaction = () => {
 
             return { methods, compose };
         },
-        { store, initialProps: { account: BTC_ACCOUNT } },
+        { root, initialProps: { account: BTC_ACCOUNT } },
     );
 };
 

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSendAssetBalance.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSendAssetBalance.test.tsx
@@ -1,6 +1,6 @@
 import { type CryptoId } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingAssetSellOption } from '@suite-common/trading';
 import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { type BaseCurrencyOption } from '@suite-common/wallet-types';
@@ -55,8 +55,7 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
 const OUTPUT_CURRENCY: BaseCurrencyOption = { value: 'usd', label: 'USD' };
 
 const renderSendAssetBalance = (account = ACCOUNT, tokenAddress: string | null = null) => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: { wallet: { accounts: [account] } },
     });
 
@@ -70,7 +69,7 @@ const renderSendAssetBalance = (account = ACCOUNT, tokenAddress: string | null =
                 composedLevels: undefined,
                 composedTransactionInfo: { selectedFee: undefined },
             }),
-        { store },
+        { root },
     );
 };
 

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeApproval.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeApproval.test.tsx
@@ -1,7 +1,7 @@
 import { act } from '@testing-library/react';
 import { type ExchangeTrade } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { tradingExchangeActions } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -38,14 +38,16 @@ const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('eth'), formattedBal
 const TRADE: ExchangeTrade = { exchange: 'provider-1', status: 'CONFIRM' };
 
 const renderExchangeApproval = (receiveAddress?: string) => {
-    const store = createTestStore({ extra: undefined });
+    const root = createTestCompositionRoot({});
 
     const utils = renderHookWithStoreProvider(
         () => useExchangeApproval({ account: ACCOUNT, receiveAddress, extraField: undefined }),
-        { store },
+        { root },
     );
 
-    return { ...utils, store };
+    const { getActions } = root.services;
+
+    return { ...utils, getActions };
 };
 
 describe('useExchangeApproval', () => {
@@ -84,7 +86,7 @@ describe('useExchangeApproval', () => {
     });
 
     it('revokeApproval saves a ZERO-approval quote before confirming', async () => {
-        const { result, store } = renderExchangeApproval('0xreceive');
+        const { result, getActions } = renderExchangeApproval('0xreceive');
 
         let outcome: boolean | undefined;
         await act(async () => {
@@ -92,7 +94,7 @@ describe('useExchangeApproval', () => {
         });
 
         expect(outcome).toBe(true);
-        expect(store.getActions().map(action => action.type)).toContain(
+        expect(getActions().map(action => action.type)).toContain(
             tradingExchangeActions.saveSelectedQuote.type,
         );
         expect(mockConfirmApproval).toHaveBeenCalledWith(

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { act, waitFor } from '@testing-library/react';
 import { type CryptoId, type ExchangeTrade } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import {
     TRADING_EXCHANGE_FORM_CEX,
     TRADING_EXCHANGE_FORM_DEX,
@@ -106,7 +106,7 @@ const renderExchangeDexQuote = ({
     isFormLoading?: boolean;
     isLoadingQuote?: boolean;
 }) => {
-    const store = createTestStore({ extra: undefined });
+    const root = createTestCompositionRoot({});
 
     return renderHookWithStoreProvider(
         () => {
@@ -128,7 +128,7 @@ const renderExchangeDexQuote = ({
 
             return { dex, methods };
         },
-        { store },
+        { root },
     );
 };
 

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFlow.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFlow.test.tsx
@@ -1,6 +1,7 @@
+import { type UnknownAction } from '@reduxjs/toolkit';
 import { type CryptoId } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingTransactionExchange, tradingExchangeActions } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
@@ -41,8 +42,7 @@ const renderExchangeFlow = ({
     transactionId = undefined,
     isAmountEmpty = false,
 }: Props = {}) => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: {
             wallet: { trading: { exchange: { quotes: [] } } },
         },
@@ -50,32 +50,33 @@ const renderExchangeFlow = ({
 
     renderHookWithStoreProvider(
         () => useExchangeFlow({ isFromRedirect, trade, transactionId, isAmountEmpty }),
-        { store },
+        { root },
     );
 
-    return store;
+    const { getActions } = root.services;
+
+    return { getActions };
 };
 
-const actionTypes = (store: ReturnType<typeof renderExchangeFlow>) =>
-    store.getActions().map(action => action.type);
+const actionTypes = (actions: UnknownAction[]) => actions.map(action => action.type);
 
 describe('useExchangeFlow', () => {
     it('dispatches the initial data load once on mount', () => {
-        const store = renderExchangeFlow();
+        const { getActions } = renderExchangeFlow();
 
         expect(
-            store.getActions().filter(action => action.type === 'trading/loadInitialData'),
+            getActions().filter(action => action.type === 'trading/loadInitialData'),
         ).toHaveLength(1);
     });
 
     it('restores the selected quote, form step and send account on redirect', () => {
-        const store = renderExchangeFlow({
+        const { getActions } = renderExchangeFlow({
             isFromRedirect: true,
             trade: TRADE,
             transactionId: 'tx-1',
         });
 
-        const types = actionTypes(store);
+        const types = actionTypes(getActions());
 
         expect(types).toContain(tradingExchangeActions.saveSelectedQuote.type);
         expect(types).toContain(tradingExchangeActions.setFormStep.type);
@@ -84,9 +85,9 @@ describe('useExchangeFlow', () => {
     });
 
     it('clears the redirect flag without restoring a trade when the transaction id is missing', () => {
-        const store = renderExchangeFlow({ isFromRedirect: true, trade: TRADE });
+        const { getActions } = renderExchangeFlow({ isFromRedirect: true, trade: TRADE });
 
-        const types = actionTypes(store);
+        const types = actionTypes(getActions());
 
         expect(types).not.toContain(tradingExchangeActions.saveSelectedQuote.type);
         expect(types).not.toContain(tradingExchangeActions.setFormStep.type);
@@ -94,9 +95,9 @@ describe('useExchangeFlow', () => {
     });
 
     it('does not restore anything when the redirect flag is not set', () => {
-        const store = renderExchangeFlow({ trade: TRADE, transactionId: 'tx-1' });
+        const { getActions } = renderExchangeFlow({ trade: TRADE, transactionId: 'tx-1' });
 
-        const types = actionTypes(store);
+        const types = actionTypes(getActions());
 
         expect(types).not.toContain(tradingExchangeActions.saveSelectedQuote.type);
         expect(types).not.toContain(tradingExchangeActions.setIsFromRedirect.type);

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFormInputs.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFormInputs.test.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { act } from '@testing-library/react';
 import { type CryptoId } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import {
     type TradingAssetOption,
     type TradingAssetSellOption,
@@ -106,8 +106,7 @@ const DEFAULTS: TradingExchangeFormProps = {
 const mockComposeRequest = jest.fn();
 
 const renderExchangeFormInputs = () => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: {
             wallet: { accounts: [ACCOUNT] },
         },
@@ -134,10 +133,12 @@ const renderExchangeFormInputs = () => {
 
             return { inputs, methods };
         },
-        { store },
+        { root },
     );
 
-    return { ...utils, store };
+    const { getActions } = root.services;
+
+    return { ...utils, getActions };
 };
 
 describe('useExchangeFormInputs', () => {
@@ -157,7 +158,7 @@ describe('useExchangeFormInputs', () => {
     });
 
     it('setAllAmount marks the max output, triggers a compose and invalidates the selected quote', () => {
-        const { result, store } = renderExchangeFormInputs();
+        const { result, getActions } = renderExchangeFormInputs();
 
         act(() => {
             result.current.inputs.setAllAmount();
@@ -167,7 +168,7 @@ describe('useExchangeFormInputs', () => {
         expect(result.current.methods.getValues('outputs.0.fiat')).toBe('');
         expect(result.current.inputs.fractionButton).toBe(1);
         expect(mockComposeRequest).toHaveBeenCalledWith('outputs.0.amount');
-        expect(store.getActions().map(action => action.type)).toContain(
+        expect(getActions().map(action => action.type)).toContain(
             tradingExchangeActions.saveSelectedQuote.type,
         );
     });

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellFlow.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellFlow.test.tsx
@@ -1,4 +1,6 @@
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { type UnknownAction } from '@reduxjs/toolkit';
+
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingTransactionSell, tradingSellActions } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
@@ -39,8 +41,7 @@ const renderSellFlow = ({
     transactionId = undefined,
     isAmountEmpty = false,
 }: Props = {}) => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: {
             wallet: { trading: { sell: { quotes: [] } } },
         },
@@ -48,32 +49,33 @@ const renderSellFlow = ({
 
     renderHookWithStoreProvider(
         () => useSellFlow({ isFromRedirect, trade, transactionId, isAmountEmpty }),
-        { store },
+        { root },
     );
 
-    return store;
+    const { getActions } = root.services;
+
+    return { getActions };
 };
 
-const actionTypes = (store: ReturnType<typeof renderSellFlow>) =>
-    store.getActions().map(action => action.type);
+const actionTypes = (actions: UnknownAction[]) => actions.map(action => action.type);
 
 describe('useSellFlow', () => {
     it('dispatches the initial data load once on mount', () => {
-        const store = renderSellFlow();
+        const { getActions } = renderSellFlow();
 
         expect(
-            store.getActions().filter(action => action.type === 'trading/loadInitialData'),
+            getActions().filter(action => action.type === 'trading/loadInitialData'),
         ).toHaveLength(1);
     });
 
     it('restores the selected quote, form step and send account on redirect', () => {
-        const store = renderSellFlow({
+        const { getActions } = renderSellFlow({
             isFromRedirect: true,
             trade: TRADE,
             transactionId: 'tx-1',
         });
 
-        const types = actionTypes(store);
+        const types = actionTypes(getActions());
 
         expect(types).toContain(tradingSellActions.saveSelectedQuote.type);
         expect(types).toContain(tradingSellActions.setFormStep.type);
@@ -82,9 +84,9 @@ describe('useSellFlow', () => {
     });
 
     it('clears the redirect flag without restoring a trade when the transaction id is missing', () => {
-        const store = renderSellFlow({ isFromRedirect: true, trade: TRADE });
+        const { getActions } = renderSellFlow({ isFromRedirect: true, trade: TRADE });
 
-        const types = actionTypes(store);
+        const types = actionTypes(getActions());
 
         expect(types).not.toContain(tradingSellActions.saveSelectedQuote.type);
         expect(types).not.toContain(tradingSellActions.setFormStep.type);
@@ -92,9 +94,9 @@ describe('useSellFlow', () => {
     });
 
     it('does not restore anything when the redirect flag is not set', () => {
-        const store = renderSellFlow({ trade: TRADE, transactionId: 'tx-1' });
+        const { getActions } = renderSellFlow({ trade: TRADE, transactionId: 'tx-1' });
 
-        const types = actionTypes(store);
+        const types = actionTypes(getActions());
 
         expect(types).not.toContain(tradingSellActions.saveSelectedQuote.type);
         expect(types).not.toContain(tradingSellActions.setIsFromRedirect.type);

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellFormInputs.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellFormInputs.test.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { act, waitFor } from '@testing-library/react';
 import { type CryptoId } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingAssetSellOption, type TradingSellFormProps } from '@suite-common/trading';
 import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { mockAccountKey, mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -93,8 +93,7 @@ const DEFAULTS: TradingSellFormProps = {
 const mockComposeRequest = jest.fn();
 
 const renderSellFormInputs = () => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: {
             wallet: {
                 accounts: [ACCOUNT],
@@ -123,7 +122,7 @@ const renderSellFormInputs = () => {
 
             return { inputs, methods };
         },
-        { store },
+        { root },
     );
 };
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.test.tsx
@@ -1,4 +1,4 @@
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -45,11 +45,10 @@ const renderForSell = (
     sellTradingAccountKey?: string,
     accounts: Account[] = [FIRST_ELIGIBLE_ACCOUNT, TRADE_ACCOUNT],
 ) => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         preloadedState: buildState(accounts, sellTradingAccountKey),
     });
-    const { result } = renderHookWithStoreProvider(() => useTradingFormAccount('sell'), { store });
+    const { result } = renderHookWithStoreProvider(() => useTradingFormAccount('sell'), { root });
 
     return result;
 };

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
@@ -1,17 +1,16 @@
 import type { BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { locksReducer } from '@suite/locks';
+import { modalReducer } from '@suite/modal';
+import { routerReducer } from '@suite/router';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
 import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { useTradingBuyConfirm } from './useTradingBuyConfirm';
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
-}));
 
 const mockConfirmTradeThunk = jest.fn((args: unknown) => {
     const thunk = () => ({ unwrap: () => Promise.resolve({ paymentId: 'payment-1' }) });
@@ -100,20 +99,28 @@ const buildState = (overrides: StateOverrides = {}) => {
 };
 
 const renderConfirm = (overrides?: StateOverrides) => {
-    const services = { analytics: mockDesktopAnalytics() };
+    const state = buildState(overrides);
+    const suiteRouterHistory = { ...mockSuiteRouterHistory(), navigate: jest.fn() };
+    const services = {
+        analytics: mockDesktopAnalytics(),
+        suiteRouterHistory,
+    };
     const root = createTestCompositionRoot({
         extra: { services },
-        preloadedState: buildState(overrides),
+        preloadedState: state,
+        reducer: {
+            router: routerReducer,
+            locks: locksReducer,
+            modal: modalReducer,
+            wallet: (wallet = state.wallet) => wallet,
+        },
     });
     const { result } = renderHookWithStoreProvider(() => useTradingBuyConfirm(), {
         root,
     });
 
-    return { root, result };
+    return { root, result, suiteRouterHistory };
 };
-
-const gotoActions = (root: ReturnType<typeof renderConfirm>['root']) =>
-    root.services.getActions().filter(action => action.type === '@router/goto');
 
 describe('useTradingBuyConfirm', () => {
     beforeEach(() => {
@@ -146,17 +153,18 @@ describe('useTradingBuyConfirm', () => {
 
     describe('readiness guard', () => {
         it('does not redirect when every requirement is satisfied', () => {
-            const { root } = renderConfirm();
+            const { suiteRouterHistory } = renderConfirm();
 
-            expect(gotoActions(root)).toHaveLength(0);
+            expect(suiteRouterHistory.navigate).not.toHaveBeenCalled();
         });
 
         it('redirects to the buy form when a requirement is missing', () => {
-            const { root } = renderConfirm({ selectedQuote: undefined });
+            const { suiteRouterHistory } = renderConfirm({ selectedQuote: undefined });
 
-            expect(gotoActions(root)).toEqual([
-                { type: '@router/goto', payload: { routeName: 'wallet-trading-buy' } },
-            ]);
+            expect(suiteRouterHistory.navigate).toHaveBeenCalledWith({
+                pathname: '/accounts/coinmarket/buy',
+                hash: '',
+            });
         });
     });
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingDetailStatusAnalytics.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingDetailStatusAnalytics.test.tsx
@@ -1,26 +1,27 @@
+import { type PropsWithChildren } from 'react';
+
 import { renderHook } from '@testing-library/react';
 
 import { events } from '@suite/analytics';
+import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { ServicesProvider } from '@suite-common/dependency-injection';
 
 import { useTradingDetailStatusAnalytics } from './useTradingDetailStatusAnalytics';
 
 const mockReport = jest.fn();
 
-jest.mock('@suite-common/dependency-injection', () => {
-    const analytics = { report: (...args: unknown[]) => mockReport(...args) };
-
-    return { useServices: () => ({ analytics }) };
-});
-
-jest.mock('@suite/analytics', () => ({
-    ...jest.requireActual('@suite/analytics'),
-    selectDesktopAnalyticsDep: () => ({}),
-}));
-
 type Props = Parameters<typeof useTradingDetailStatusAnalytics>[0];
 
-const renderStatusAnalytics = (initialProps: Props) =>
-    renderHook((props: Props) => useTradingDetailStatusAnalytics(props), { initialProps });
+const renderStatusAnalytics = (initialProps: Props) => {
+    const services = { analytics: mockDesktopAnalytics(mockReport) };
+
+    return renderHook((props: Props) => useTradingDetailStatusAnalytics(props), {
+        initialProps,
+        wrapper: ({ children }: PropsWithChildren) => (
+            <ServicesProvider services={services}>{children}</ServicesProvider>
+        ),
+    });
+};
 
 describe('useTradingDetailStatusAnalytics', () => {
     beforeEach(() => {

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeConfirm.test.tsx
@@ -1,17 +1,17 @@
+import { type UnknownAction } from '@reduxjs/toolkit';
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { locksReducer } from '@suite/locks';
+import { modalReducer } from '@suite/modal';
+import { routerReducer } from '@suite/router';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { exchangeInitialState, initialState as tradingInitialState } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { useTradingExchangeConfirm } from './useTradingExchangeConfirm';
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
-}));
 
 const mockLoadInitialDataThunk = jest.fn((args: unknown) =>
     Object.assign(() => Promise.resolve(), { type: '@trading/loadInitialData', args }),
@@ -101,17 +101,28 @@ const buildState = (overrides: StateOverrides = {}) => {
 const renderConfirm = (overrides?: StateOverrides) => {
     const state = buildState(overrides);
 
-    const store = createTestStore({ extra: undefined, preloadedState: state });
-    const { result } = renderHookWithStoreProvider(() => useTradingExchangeConfirm(), { store });
+    const suiteRouterHistory = { ...mockSuiteRouterHistory(), navigate: jest.fn() };
+    const root = createTestCompositionRoot({
+        extra: {
+            services: { suiteRouterHistory },
+        },
+        preloadedState: state,
+        reducer: {
+            router: routerReducer,
+            locks: locksReducer,
+            modal: modalReducer,
+            wallet: (wallet = state.wallet) => wallet,
+        },
+    });
+    const { result } = renderHookWithStoreProvider(() => useTradingExchangeConfirm(), { root });
 
-    return { store, result };
+    const { getActions } = root.services;
+
+    return { getActions, result, suiteRouterHistory };
 };
 
-const gotoActions = (store: ReturnType<typeof renderConfirm>['store']) =>
-    store.getActions().filter(action => action.type === '@router/goto');
-
-const exchangeActions = (store: ReturnType<typeof renderConfirm>['store']) =>
-    store.getActions().filter(action => action.type?.startsWith('@trading-exchange/'));
+const exchangeActions = (actions: UnknownAction[]) =>
+    actions.filter(action => action.type?.startsWith('@trading-exchange/'));
 
 describe('useTradingExchangeConfirm', () => {
     beforeEach(() => {
@@ -128,29 +139,30 @@ describe('useTradingExchangeConfirm', () => {
 
     describe('readiness guard', () => {
         it('does not redirect when the quotes request is present', () => {
-            const { store } = renderConfirm();
+            const { suiteRouterHistory } = renderConfirm();
 
-            expect(gotoActions(store)).toHaveLength(0);
+            expect(suiteRouterHistory.navigate).not.toHaveBeenCalled();
         });
 
         it('redirects to the exchange form when the quotes request is missing', () => {
-            const { store } = renderConfirm({ quotesRequest: undefined });
+            const { suiteRouterHistory } = renderConfirm({ quotesRequest: undefined });
 
-            expect(gotoActions(store)).toEqual([
-                { type: '@router/goto', payload: { routeName: 'wallet-trading-exchange' } },
-            ]);
+            expect(suiteRouterHistory.navigate).toHaveBeenCalledWith({
+                pathname: '/accounts/coinmarket/exchange',
+                hash: '',
+            });
         });
     });
 
     describe('redirect restoration', () => {
         it('restores the quote, step and account and clears the redirect flag on return', () => {
-            const { store } = renderConfirm({
+            const { getActions } = renderConfirm({
                 isFromRedirect: true,
                 transactionId: REDIRECT_ORDER_ID,
                 trades: [REDIRECT_TRADE],
             });
 
-            expect(exchangeActions(store)).toEqual([
+            expect(exchangeActions(getActions())).toEqual([
                 tradingExchangeActions.saveSelectedQuote(REDIRECT_TRADE.data),
                 tradingExchangeActions.setFormStep('SEND_TRANSACTION'),
                 tradingExchangeActions.setTradingAccountKey(REDIRECT_TRADE.sendAccountKey),
@@ -159,20 +171,20 @@ describe('useTradingExchangeConfirm', () => {
         });
 
         it('only clears the redirect flag when no active trade is resolved', () => {
-            const { store } = renderConfirm({ isFromRedirect: true });
+            const { getActions } = renderConfirm({ isFromRedirect: true });
 
-            expect(exchangeActions(store)).toEqual([
+            expect(exchangeActions(getActions())).toEqual([
                 tradingExchangeActions.setIsFromRedirect(false),
             ]);
         });
 
         it('does not dispatch redirect actions when not returning from a redirect', () => {
-            const { store } = renderConfirm({
+            const { getActions } = renderConfirm({
                 transactionId: REDIRECT_ORDER_ID,
                 trades: [REDIRECT_TRADE],
             });
 
-            expect(exchangeActions(store)).toHaveLength(0);
+            expect(exchangeActions(getActions())).toHaveLength(0);
         });
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.cancelledSigning.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.cancelledSigning.test.tsx
@@ -1,7 +1,7 @@
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { exchangeInitialState, initialState as tradingInitialState } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
@@ -183,14 +183,14 @@ describe('cancelling a swap on the device', () => {
     });
 
     it('reports the cancellation once and nothing else', async () => {
-        const store = createTestStore({ extra: undefined, preloadedState });
+        const root = createTestCompositionRoot({ preloadedState });
         const { result } = renderHookWithStoreProvider(() => useTradingExchangeTradeActions(), {
-            store,
+            root,
         });
 
         const success = await result.current.sendTransaction();
 
-        const toasts = store
+        const toasts = root.services
             .getActions()
             .filter(action => action.type === notificationsActions.addToast.type);
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.test.tsx
@@ -1,6 +1,6 @@
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { exchangeInitialState, initialState as tradingInitialState } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
@@ -135,12 +135,14 @@ const renderActions = (overrides?: StateOverrides) => {
         cryptoId: ETHEREUM_CRYPTO_ID,
     });
 
-    const store = createTestStore({ extra: undefined, preloadedState: state });
+    const root = createTestCompositionRoot({ preloadedState: state });
     const { result } = renderHookWithStoreProvider(() => useTradingExchangeTradeActions(), {
-        store,
+        root,
     });
 
-    return { store, result };
+    const { getActions } = root.services;
+
+    return { getActions, result };
 };
 
 describe('useTradingExchangeTradeActions', () => {
@@ -153,9 +155,9 @@ describe('useTradingExchangeTradeActions', () => {
 
     describe('mount is side-effect free', () => {
         it('does not dispatch anything on mount', () => {
-            const { store } = renderActions();
+            const { getActions } = renderActions();
 
-            expect(store.getActions()).toHaveLength(0);
+            expect(getActions()).toHaveLength(0);
         });
     });
 
@@ -188,12 +190,12 @@ describe('useTradingExchangeTradeActions', () => {
                 type: 'sign-cancelled',
                 error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
             });
-            const { store, result } = renderActions();
+            const { getActions, result } = renderActions();
 
             const success = await result.current.sendTransaction();
 
             expect(success).toBe(false);
-            expect(toastsOf(store.getActions())).toHaveLength(0);
+            expect(toastsOf(getActions())).toHaveLength(0);
         });
 
         it('reports an error nothing else has reported', async () => {
@@ -201,12 +203,12 @@ describe('useTradingExchangeTradeActions', () => {
                 type: 'sign-tx-error',
                 error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
             });
-            const { store, result } = renderActions();
+            const { getActions, result } = renderActions();
 
             const success = await result.current.sendTransaction();
 
             expect(success).toBe(false);
-            expect(toastsOf(store.getActions())).toHaveLength(1);
+            expect(toastsOf(getActions())).toHaveLength(1);
         });
 
         it('returns false without dispatching when the account is missing', async () => {

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.test.tsx
@@ -1,17 +1,16 @@
 import type { CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
 
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { locksReducer } from '@suite/locks';
+import { modalReducer } from '@suite/modal';
+import { routerReducer } from '@suite/router';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { sellInitialState, initialState as tradingInitialState } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { useTradingSellConfirm } from './useTradingSellConfirm';
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
-}));
 
 jest.mock('src/hooks/wallet/trading/useServerEnviroment', () => ({
     useServerEnvironment: jest.fn(),
@@ -86,14 +85,23 @@ const buildState = (overrides: StateOverrides = {}) => {
 const renderConfirm = (overrides?: StateOverrides) => {
     const state = buildState(overrides);
 
-    const store = createTestStore({ extra: undefined, preloadedState: state });
-    const { result } = renderHookWithStoreProvider(() => useTradingSellConfirm(), { store });
+    const suiteRouterHistory = { ...mockSuiteRouterHistory(), navigate: jest.fn() };
+    const root = createTestCompositionRoot({
+        extra: {
+            services: { suiteRouterHistory },
+        },
+        preloadedState: state,
+        reducer: {
+            router: routerReducer,
+            locks: locksReducer,
+            modal: modalReducer,
+            wallet: (wallet = state.wallet) => wallet,
+        },
+    });
+    const { result } = renderHookWithStoreProvider(() => useTradingSellConfirm(), { root });
 
-    return { store, result };
+    return { root, result, suiteRouterHistory };
 };
-
-const gotoActions = (store: ReturnType<typeof renderConfirm>['store']) =>
-    store.getActions().filter(action => action.type === '@router/goto');
 
 describe('useTradingSellConfirm', () => {
     beforeEach(() => {
@@ -110,17 +118,18 @@ describe('useTradingSellConfirm', () => {
 
     describe('readiness guard', () => {
         it('does not redirect when the quotes request is present', () => {
-            const { store } = renderConfirm();
+            const { suiteRouterHistory } = renderConfirm();
 
-            expect(gotoActions(store)).toHaveLength(0);
+            expect(suiteRouterHistory.navigate).not.toHaveBeenCalled();
         });
 
         it('redirects to the sell form when the quotes request is missing', () => {
-            const { store } = renderConfirm({ quotesRequest: undefined });
+            const { suiteRouterHistory } = renderConfirm({ quotesRequest: undefined });
 
-            expect(gotoActions(store)).toEqual([
-                { type: '@router/goto', payload: { routeName: 'wallet-trading-sell' } },
-            ]);
+            expect(suiteRouterHistory.navigate).toHaveBeenCalledWith({
+                pathname: '/accounts/coinmarket/sell',
+                hash: '',
+            });
         });
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.test.tsx
@@ -1,17 +1,13 @@
 import type { BankAccount, CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
 
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
 import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { useTradingSellTradeActions } from './useTradingSellTradeActions';
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: jest.fn((payload: unknown) => ({ type: '@router/goto', payload })),
-}));
 
 const mockLoadInitialDataThunk = jest.fn((args: unknown) =>
     Object.assign(() => Promise.resolve(), { type: '@trading/loadInitialData', args }),
@@ -156,7 +152,10 @@ const renderActions = (overrides?: StateOverrides) => {
         cryptoId: BITCOIN_CRYPTO_ID,
     });
 
-    const services = { analytics: mockDesktopAnalytics() };
+    const services = {
+        analytics: mockDesktopAnalytics(),
+        suiteRouterHistory: { ...mockSuiteRouterHistory(), navigate: jest.fn() },
+    };
     const root = createTestCompositionRoot({
         extra: { services },
         preloadedState: state,
@@ -165,7 +164,9 @@ const renderActions = (overrides?: StateOverrides) => {
         root,
     });
 
-    return { root, result };
+    const { getActions } = root.services;
+
+    return { getActions, result };
 };
 
 describe('useTradingSellTradeActions', () => {
@@ -179,15 +180,15 @@ describe('useTradingSellTradeActions', () => {
 
     describe('mount is side-effect free', () => {
         it('does not dispatch anything on mount', () => {
-            const { root } = renderActions();
+            const { getActions } = renderActions();
 
-            expect(root.services.getActions()).toHaveLength(0);
+            expect(getActions()).toHaveLength(0);
         });
 
         it('does not redirect nor initialize even when the quotes request is missing', () => {
-            const { root } = renderActions({ quotesRequest: undefined });
+            const { getActions } = renderActions({ quotesRequest: undefined });
 
-            expect(root.services.getActions()).toHaveLength(0);
+            expect(getActions()).toHaveLength(0);
         });
     });
 

--- a/packages/suite/src/hooks/wallet/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/useRbfForm.test.tsx
@@ -3,6 +3,7 @@ import '@suite-common/test-utils/globalOverrides';
 import { screen } from '@testing-library/react';
 
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
 import { createTestCompositionRoot, initPreloadedState } from '@suite-common/test-utils';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { type ServerInfo } from '@trezor/blockchain-link-types';
@@ -28,11 +29,6 @@ global.ResizeObserver = class MockedResizeObserver {
 
 // do not mock
 jest.unmock('@trezor/connect');
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: () => ({ type: 'mock-redirect' }),
-}));
 
 // !!! Must be a stable reference, else it will break some hooks / memoization and causes inf. re-renders
 const translationStringMock = (id: string) => id;
@@ -146,7 +142,12 @@ describe('useRbfForm hook', () => {
         it(`composeAndSign: ${f.description}`, async () => {
             const rootReducer = fixtures.getRootReducer(f.store.selectedAccount, f.store.fees);
             const root = createTestCompositionRoot({
-                extra: { services: { analytics: mockDesktopAnalytics() } },
+                extra: {
+                    services: {
+                        analytics: mockDesktopAnalytics(),
+                        suiteRouterHistory: { ...mockSuiteRouterHistory(), navigate: jest.fn() },
+                    },
+                },
                 reducer: rootReducer,
                 preloadedState: initPreloadedState({
                     rootReducer,

--- a/packages/suite/src/hooks/wallet/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/useSendForm.test.tsx
@@ -9,6 +9,8 @@ import { type DesktopAnalyticsDep } from '@suite/analytics';
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
 import { debugInitialState } from '@suite/debug';
 import { closeModal, openModal } from '@suite/modal';
+import { type SuiteRouterHistoryDep } from '@suite/router';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
 import { suiteSettingsInitialState } from '@suite/settings';
 import { type AddressValidatorDep, type GetNamedAddressSupportDep } from '@suite-common/address';
 import { mockAddressValidator, mockGetNamedAddressSupport } from '@suite-common/address/mocks';
@@ -34,11 +36,13 @@ import {
     testMocks,
 } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type SendState } from '@suite-common/wallet-core';
 import { type FormState, type GetTradedAccountKeysDep } from '@suite-common/wallet-types';
 import { mockGetTradedAccountKeys } from '@suite-common/wallet-types/mocks';
 import { type PROTO } from '@trezor/connect';
 import { asProtocol } from '@trezor/network-module-suite-common-types';
 
+import { type ProtocolState } from 'src/reducers/suite/protocolReducer';
 import {
     type UserAction,
     actionSequence,
@@ -70,11 +74,6 @@ jest.mock('cross-fetch', () => ({
     default: () => Promise.resolve({ ok: false }),
 }));
 
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: () => ({ type: 'mock-redirect' }),
-}));
-
 // !!! Must be a stable reference, else it will break some hooks / memoization and causes inf. re-renders
 const translationStringMock = (id: string) => id;
 
@@ -86,18 +85,18 @@ jest.mock('@suite/intl', () => ({
 
 jest.mock('@suite-common/tx-simulation', () => ({}));
 
-type RootReducerState = ReturnType<ReturnType<typeof fixtures.getRootReducer>>;
 interface Args {
-    send?: Partial<RootReducerState['wallet']['send']>;
+    send?: Partial<SendState>;
     fees?: any;
     selectedAccount?: any;
     coinjoin?: any;
     bitcoinAmountUnit?: PROTO.AmountUnit;
-    protocol?: Partial<RootReducerState['protocol']>;
+    protocol?: Partial<ProtocolState>;
 }
 
 const TrezorConnect = testMocks.getTrezorConnectMock();
-type SendFormTestServices = AddressValidatorDep &
+type SendFormTestServices = SuiteRouterHistoryDep &
+    AddressValidatorDep &
     DesktopAnalyticsDep &
     FindNetworkSymbolForProtocolDep &
     GetIsWindowVisibleDep &
@@ -108,6 +107,7 @@ type SendFormTestServices = AddressValidatorDep &
     SuiteSyncDep;
 
 const services: SendFormTestServices = {
+    suiteRouterHistory: mockSuiteRouterHistory(),
     addressValidator: mockAddressValidator({
         isAddressValid: address => address !== '' && address !== 'X' && address !== 'FOO',
     }),
@@ -312,7 +312,7 @@ describe('useSendForm hook', () => {
                     protocol: {
                         sendForm: {
                             shouldFill: true,
-                            scheme: 'bitcoin',
+                            scheme: asProtocol('bitcoin'),
                             address: protocolAddress,
                             amount: protocolAmount,
                             label: protocolLabel,
@@ -462,6 +462,8 @@ describe('useSendForm hook', () => {
             async () => {
                 testMocks.setTrezorConnectFixtures(f.connect);
                 const root = createTestCompositionRoot(buildTestCompositionRootParams(f.store));
+                const { subscribe } = root.store;
+                const { getActions } = root.services;
                 const callback: TestCallback = {};
                 const { unmount } = renderWithProviders(
                     root,
@@ -472,8 +474,8 @@ describe('useSendForm hook', () => {
 
                 // wait for first render
                 await waitForLoader();
-                root.store.subscribe(() => {
-                    const actions = filterThunkActionTypes(root.services.getActions());
+                subscribe(() => {
+                    const actions = filterThunkActionTypes(getActions());
                     const lastAction = actions[actions.length - 1];
                     if (
                         openModal.match(lastAction) &&
@@ -486,7 +488,7 @@ describe('useSendForm hook', () => {
                 });
 
                 await actionSequence([{ type: 'click', element: '@send/review-button' }], () => {
-                    const actions = root.services.getActions();
+                    const actions = getActions();
                     f.result.actions.forEach((action: any) => {
                         expect(actions.find(a => a.type === action.type)).toMatchObject(action);
                     });

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.test.ts
@@ -1,10 +1,23 @@
 import { type UnknownAction } from '@reduxjs/toolkit';
 
-import { locksInitialState, locksReducer } from '@suite/locks';
-import { modalReducer } from '@suite/modal';
-import { gotoThunk, routerReducer } from '@suite/router';
-import { type RouterStateOverrides, createRouterStateMock } from '@suite/router/mocks';
-import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
+import { type LocksRootState, locksInitialState, locksReducer } from '@suite/locks';
+import { type State as ModalReducerState, type ModalRootState, modalReducer } from '@suite/modal';
+import { type RouterRootState, routerReducer } from '@suite/router';
+import {
+    type RouterStateOverrides,
+    createRouterStateMock,
+    mockSuiteRouterHistory,
+} from '@suite/router/mocks';
+import {
+    type DeviceReducerState,
+    type DeviceRootState,
+    deviceActions,
+    prepareDeviceReducer,
+} from '@suite-common/device';
+import {
+    type MessageSystemRootState,
+    messageSystemInitialState,
+} from '@suite-common/message-system';
 import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
 import { mockSuiteSync } from '@suite-common/suite-sync/mocks';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
@@ -13,14 +26,12 @@ import { DEVICE } from '@trezor/connect';
 
 import redirectMiddleware from 'src/middlewares/suite/redirectMiddleware';
 import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
-import suiteReducer from 'src/reducers/suite/suiteReducer';
+import suiteReducer, {
+    type SuiteRootState,
+    type SuiteState,
+} from 'src/reducers/suite/suiteReducer';
 
 jest.mock('src/actions/suite/storageActions', () => ({ __esModule: true }));
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: jest.fn(() => ({ type: '@router/goto/mocked' })),
-}));
-
 const deviceReducer = prepareDeviceReducer({
     actionTypes: {
         setDeviceMetadata: mockActionType('setDeviceMetadata'),
@@ -34,16 +45,19 @@ const deviceReducer = prepareDeviceReducer({
     },
 });
 
-type SuiteState = ReturnType<typeof suiteReducer>;
-type DevicesState = ReturnType<typeof deviceReducer>;
-type ModalState = ReturnType<typeof modalReducer>;
+type State = SuiteRootState &
+    DeviceRootState &
+    LocksRootState &
+    RouterRootState &
+    ModalRootState &
+    MessageSystemRootState;
 
 const getInitialState = (
     suite?: Partial<SuiteState>,
-    device?: Partial<DevicesState>,
+    device?: Partial<DeviceReducerState>,
     router?: RouterStateOverrides,
-    modal?: Partial<ModalState>,
-) => ({
+    modal?: ModalReducerState,
+): State => ({
     suite: {
         ...suiteReducer(undefined, { type: 'foo' } as any),
         ...suite,
@@ -54,24 +68,21 @@ const getInitialState = (
         ...device,
     },
     router: createRouterStateMock(router),
-    modal: {
-        ...modalReducer(undefined, { type: 'foo' } as any),
-        ...modal,
-    },
-    messageSystem: {},
+    modal: modal ?? modalReducer(undefined, { type: 'foo' }),
+    messageSystem: messageSystemInitialState,
 });
 
-type State = ReturnType<typeof getInitialState>;
 const middlewares = [
     redirectMiddleware,
     prepareSuiteMiddleware(() => ({ services: { suiteSync: mockSuiteSync() } })),
 ];
 
 const initStore = (state: State) => {
-    const store = createTestStore<void, State, UnknownAction>({
-        extra: undefined,
+    const extra = { services: { suiteRouterHistory: mockSuiteRouterHistory() } };
+    const store = createTestStore<typeof extra, State, UnknownAction>({
+        extra,
         middleware: middlewares,
-        reducer: (currentState = state, action) => {
+        reducer: (currentState = state, action: UnknownAction) => {
             const typedState = currentState as State;
 
             return {
@@ -90,12 +101,6 @@ const initStore = (state: State) => {
 
 describe('redirectMiddleware', () => {
     describe('redirects on DEVICE.CONNECT event', () => {
-        const gotoMock = jest.mocked(gotoThunk);
-
-        afterEach(() => {
-            gotoMock.mockClear();
-        });
-
         it('DEVICE.CONNECT mode=initialize', () => {
             const store = initStore(getInitialState());
 
@@ -105,7 +110,7 @@ describe('redirectMiddleware', () => {
             const device = store.getState().device.devices.find(d => d.id === connectDevice.id);
             store.dispatch({ type: deviceActions.selectDevice.type, payload: device });
 
-            expect(gotoMock).toHaveBeenNthCalledWith(1, { routeName: 'suite-start' });
+            expect(store.getState().router.route?.name).toBe('suite-start');
         });
 
         it('DEVICE.CONNECT firmware=required', () => {
@@ -117,7 +122,7 @@ describe('redirectMiddleware', () => {
             const device = store.getState().device.devices.find(d => d.id === connectDevice.id);
             store.dispatch({ type: deviceActions.selectDevice.type, payload: device });
 
-            expect(gotoMock).toHaveBeenNthCalledWith(1, { routeName: 'firmware-index' });
+            expect(store.getState().router.route?.name).toBe('firmware-index');
         });
 
         it('SUITE.SELECT_DEVICE reset wallet params', () => {
@@ -160,7 +165,7 @@ describe('redirectMiddleware', () => {
                 type: deviceActions.selectDevice.type,
                 payload: mockSuiteDevice(),
             });
-            expect(gotoMock).toHaveBeenNthCalledWith(1, { routeName: 'wallet-index' });
+            expect(store.getState().router.route?.name).toBe('wallet-index');
         });
     });
 });

--- a/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
@@ -5,9 +5,9 @@ import {
     selectDebugTransports,
     suiteSettingsActions,
 } from '@suite/settings';
-import { type TransportsDep } from '@suite-common/connect-init';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectDispatch } from '@suite-common/redux-utils';
+import { selectTransportsDep } from '@suite-common/suite-types';
 import { Checkbox } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
@@ -56,12 +56,7 @@ const useTransportItems = (transports: readonly Transport[]): TransportMenuItem[
 export const Transport = () => {
     const transports = isDesktop() ? TRANSPORTS_DESKTOP : TRANSPORTS_WEB;
     const items = useTransportItems(transports);
-    const { createTransports, dispatch } = useServices(
-        (services): TransportsDep => ({
-            createTransports: services.createTransports,
-        }),
-        selectDispatch,
-    );
+    const { createTransports, dispatch } = useServices(selectTransportsDep, selectDispatch);
 
     return (
         <>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailTxId.test.tsx
@@ -50,6 +50,7 @@ describe('TradingDetailTxId', () => {
             extra: { services },
             preloadedState: getInitialState(),
         });
+        const { getActions } = root.services;
 
         const { container } = renderWithProviders(
             root,
@@ -65,7 +66,7 @@ describe('TradingDetailTxId', () => {
 
         await userEvent.click(link);
 
-        expect(root.services.getActions()).toContainEqual(
+        expect(getActions()).toContainEqual(
             openModal({
                 type: 'transaction-detail',
                 txid: payoutTxid,
@@ -83,6 +84,7 @@ describe('TradingDetailTxId', () => {
             extra: { services },
             preloadedState: getInitialState(),
         });
+        const { getActions } = root.services;
 
         const { container } = renderWithProviders(
             root,
@@ -98,7 +100,7 @@ describe('TradingDetailTxId', () => {
 
         await userEvent.click(link);
 
-        expect(root.services.getActions()).toContainEqual(
+        expect(getActions()).toContainEqual(
             openModal({
                 type: 'transaction-detail',
                 txid: 'signedSendTxid',

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
@@ -6,6 +6,8 @@ import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { type SuiteRouterHistoryDep } from '@suite/router';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
 import { createTestCompositionRoot } from '@suite-common/test-utils';
 import {
     type ExchangeIssue,
@@ -27,7 +29,6 @@ import { mockInitialAppState } from '../../../../../../../mocks/mockInitialAppSt
 
 const mockSendTransaction = jest.fn(() => Promise.resolve(true));
 const mockSignDataAndConfirm = jest.fn(() => Promise.resolve());
-const mockGoto = jest.fn((payload: unknown) => ({ type: 'test/goto', payload }));
 
 jest.mock('@suite/device', () => ({
     ...jest.requireActual('@suite/device'),
@@ -37,11 +38,6 @@ jest.mock('@suite/device', () => ({
 jest.mock('@suite/intl', () => ({
     ...jest.requireActual('@suite/intl'),
     Translation: ({ id }: { id: string }) => <span>{id}</span>,
-}));
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: (payload: unknown) => mockGoto(payload),
 }));
 
 jest.mock('@suite-common/trading', () => ({
@@ -147,11 +143,16 @@ const renderOfferExchange = ({
     mockGetSimulatedReceiveAmount.mockReturnValue(simulatedReceiveAmount);
 
     const report = jest.fn();
-    const services: DesktopAnalyticsDep = { analytics: mockDesktopAnalytics(report) };
+    const navigate = jest.fn();
+    const services: DesktopAnalyticsDep & SuiteRouterHistoryDep = {
+        analytics: mockDesktopAnalytics(report),
+        suiteRouterHistory: { ...mockSuiteRouterHistory(), navigate },
+    };
     const root = createTestCompositionRoot({
         extra: { services },
         preloadedState: {
             ...mockInitialAppState,
+            router: { ...mockInitialAppState.router, hash: '#eth/0/normal' },
             wallet: {
                 ...mockInitialAppState.wallet,
                 trading: {
@@ -163,7 +164,7 @@ const renderOfferExchange = ({
     });
     renderWithProviders(root, <TradingOfferExchange />);
 
-    return { report };
+    return { report, navigate };
 };
 
 describe('TradingOfferExchange', () => {
@@ -226,7 +227,7 @@ describe('TradingOfferExchange', () => {
     });
 
     it('replaces the confirmation button with back to trade form on an issue', async () => {
-        renderOfferExchange({ issue: PRICE_IMPACT_ISSUE });
+        const { navigate } = renderOfferExchange({ issue: PRICE_IMPACT_ISSUE });
 
         expect(
             screen.queryByTestId('@trading/offer/confirm-on-trezor-and-send'),
@@ -234,9 +235,9 @@ describe('TradingOfferExchange', () => {
 
         await userEvent.click(screen.getByTestId('@trading/offer/back-to-trade-form'));
 
-        expect(mockGoto).toHaveBeenCalledWith({
-            routeName: 'wallet-trading-exchange',
-            preserveParams: true,
+        expect(navigate).toHaveBeenCalledWith({
+            pathname: '/accounts/coinmarket/exchange',
+            hash: '#eth/0/normal',
         });
     });
 

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { type Coins, type CryptoId } from 'invity-api';
 
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { createTestCompositionRoot } from '@suite-common/test-utils';
 import {
@@ -23,11 +24,6 @@ import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
 
 import { TradingTransactionsList } from './TradingTransactionsList';
 import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: (payload: unknown) => ({ type: '@router/goto', payload }),
-}));
 
 const BITCOIN = 'bitcoin' as CryptoId;
 const ETHEREUM = 'ethereum' as CryptoId;
@@ -123,7 +119,12 @@ const buildState = (trades: TradingTransaction[]): AppState => ({
 
 const renderList = (trades: TradingTransaction[]) => {
     const root = createTestCompositionRoot({
-        extra: { services: { analytics: mockDesktopAnalytics() } },
+        extra: {
+            services: {
+                analytics: mockDesktopAnalytics(),
+                suiteRouterHistory: { ...mockSuiteRouterHistory(), navigate: jest.fn() },
+            },
+        },
         preloadedState: buildState(trades),
     });
 

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/useTradingTransactionClick.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/useTradingTransactionClick.test.tsx
@@ -1,6 +1,7 @@
 import { type CryptoId } from 'invity-api';
 
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { mockSuiteRouterHistory } from '@suite/router/mocks';
 import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import {
     type TradingTransaction,
@@ -20,13 +21,6 @@ import { type AppState } from 'src/reducers/store';
 
 import { useTradingTransactionClick } from './useTradingTransactionClick';
 import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
-
-jest.mock('@suite/router', () => ({
-    ...jest.requireActual('@suite/router'),
-    gotoThunk: (payload: unknown) => ({ type: '@router/goto', payload }),
-}));
-
-const goto = (routeName: string) => ({ type: '@router/goto', payload: { routeName } });
 
 const BITCOIN = 'bitcoin' as CryptoId;
 
@@ -88,54 +82,70 @@ const buildState = (): AppState => ({
 });
 
 const renderClickHandler = () => {
+    const suiteRouterHistory = { ...mockSuiteRouterHistory(), navigate: jest.fn() };
     const root = createTestCompositionRoot({
-        extra: { services: { analytics: mockDesktopAnalytics() } },
+        extra: {
+            services: {
+                analytics: mockDesktopAnalytics(),
+                suiteRouterHistory,
+            },
+        },
         preloadedState: buildState(),
     });
     const { result } = renderHookWithStoreProvider(() => useTradingTransactionClick(), { root });
 
     return {
         click: (trade: TradingTransaction) => result.current(trade),
-        getActions: () => root.services.getActions(),
+        getActions: () =>
+            root.services
+                .getActions()
+                .filter(
+                    action =>
+                        !action.type.startsWith('@router/') && !action.type.startsWith('router/'),
+                ),
+        navigate: suiteRouterHistory.navigate,
     };
 };
 
 describe('useTradingTransactionClick', () => {
     it('opens the buy detail', () => {
-        const { click, getActions } = renderClickHandler();
+        const { click, getActions, navigate } = renderClickHandler();
 
         click(buy);
 
-        expect(getActions()).toEqual([
-            tradingBuyActions.saveTransactionId('buy-key'),
-            goto('wallet-trading-buy-detail'),
-        ]);
+        expect(getActions()).toEqual([tradingBuyActions.saveTransactionId('buy-key')]);
+        expect(navigate).toHaveBeenCalledWith({
+            pathname: '/accounts/coinmarket/buy/detail',
+            hash: '',
+        });
     });
 
     it('opens the exchange detail', () => {
-        const { click, getActions } = renderClickHandler();
+        const { click, getActions, navigate } = renderClickHandler();
 
         click(exchange);
 
-        expect(getActions()).toEqual([
-            tradingExchangeActions.saveTransactionId('exchange-key'),
-            goto('wallet-trading-exchange-detail'),
-        ]);
+        expect(getActions()).toEqual([tradingExchangeActions.saveTransactionId('exchange-key')]);
+        expect(navigate).toHaveBeenCalledWith({
+            pathname: '/accounts/coinmarket/exchange/detail',
+            hash: '',
+        });
     });
 
     it('opens the sell detail for a finished sell', () => {
-        const { click, getActions } = renderClickHandler();
+        const { click, getActions, navigate } = renderClickHandler();
 
         click(sell);
 
-        expect(getActions()).toEqual([
-            tradingSellActions.saveTransactionId('sell-key'),
-            goto('wallet-trading-sell-detail'),
-        ]);
+        expect(getActions()).toEqual([tradingSellActions.saveTransactionId('sell-key')]);
+        expect(navigate).toHaveBeenCalledWith({
+            pathname: '/accounts/coinmarket/sell/detail',
+            hash: '',
+        });
     });
 
     it('resumes an interrupted sell with a default fee, not the one left in the slot', () => {
-        const { click, getActions } = renderClickHandler();
+        const { click, getActions, navigate } = renderClickHandler();
 
         click(submittedSell);
 
@@ -151,18 +161,22 @@ describe('useTradingTransactionClick', () => {
                 selectedFee: 'normal',
                 composed: { feePerByte: '', fee: '' },
             }),
-            goto('wallet-trading-sell-confirm'),
         ]);
+        expect(navigate).toHaveBeenCalledWith({
+            pathname: '/accounts/coinmarket/sell/confirm',
+            hash: '',
+        });
     });
 
     it('opens the sell detail when an interrupted sell has no crypto currency', () => {
-        const { click, getActions } = renderClickHandler();
+        const { click, getActions, navigate } = renderClickHandler();
 
         click({ ...submittedSell, data: { ...submittedSell.data, cryptoCurrency: undefined } });
 
-        expect(getActions()).toEqual([
-            tradingSellActions.saveTransactionId('sell-key'),
-            goto('wallet-trading-sell-detail'),
-        ]);
+        expect(getActions()).toEqual([tradingSellActions.saveTransactionId('sell-key')]);
+        expect(navigate).toHaveBeenCalledWith({
+            pathname: '/accounts/coinmarket/sell/detail',
+            hash: '',
+        });
     });
 });

--- a/skills/tests-native/SKILL.md
+++ b/skills/tests-native/SKILL.md
@@ -28,7 +28,7 @@ helper or when the testing-library API requires a `wrapper` component rather tha
 
 Extends `@suite-native/test-utils` with Redux support. Provides `renderWithStoreProvider` and
 `renderHookWithStoreProvider` — both accept the same options: `preloadedState?: Record<string, unknown>` or a
-pre-built `store?: TestStore`. Plus store factory helpers:
+pre-built store passed as `services: { store }`. Plus store factory helpers:
 
 - `createStoreFromPreloadedState(preloadedState?)` — static (no-op) reducers; use when the test only reads state.
 - `createLightStore({ reducer, preloadedState })` — real reducers; use when the test dispatches actions that must mutate

--- a/suite-common/message-system/src/useExperiment.test.ts
+++ b/suite-common/message-system/src/useExperiment.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { getIntegerInRangeFromString } from '@trezor/utils';
 
 jest.mock('@trezor/utils', () => ({
@@ -20,7 +20,7 @@ const messageSystemReducer = prepareMessageSystemReducer({
     actionTypes: { storageLoad: mockActionType('storageLoad') },
 });
 
-const createStore = (
+const createRoot = (
     overrides: {
         messageSystem?: MessageSystemState;
         instanceId?: string | undefined;
@@ -30,8 +30,7 @@ const createStore = (
     // distinguish an explicit `instanceId: undefined` from an absent key
     const instanceId = 'instanceId' in overrides ? overrides.instanceId : 'test-instance-id';
 
-    return createTestStore({
-        extra: undefined,
+    return createTestCompositionRoot({
         reducer: combineReducers({
             messageSystem: messageSystemReducer,
             analytics: (state = { instanceId }) => state,
@@ -40,33 +39,33 @@ const createStore = (
     });
 };
 
-const renderUseExperiment = (store = createStore()) =>
-    renderHookWithStoreProvider(() => useExperiment(ExperimentId.tradingFeedbackForm), { store });
+const renderUseExperiment = (root = createRoot()) =>
+    renderHookWithStoreProvider(() => useExperiment(ExperimentId.tradingFeedbackForm), { root });
 
 describe('useExperiment', () => {
     it('returns undefined experiment and variant when experiment is not valid', () => {
-        const store = createStore({ messageSystem: messageSystemInitialState });
-        const { result } = renderUseExperiment(store);
+        const root = createRoot({ messageSystem: messageSystemInitialState });
+        const { result } = renderUseExperiment(root);
 
         expect(result.current.experiment).toBeUndefined();
         expect(result.current.activeExperimentVariant).toBeUndefined();
     });
 
     it('returns undefined variant when instanceId is missing', () => {
-        const store = createStore({ instanceId: undefined });
-        const { result } = renderUseExperiment(store);
+        const root = createRoot({ instanceId: undefined });
+        const { result } = renderUseExperiment(root);
 
         expect(result.current.experiment).toBeDefined();
         expect(result.current.activeExperimentVariant).toBeUndefined();
     });
 
     it('assigns the only group when it covers 100 %', () => {
-        const store = createStore({
+        const root = createRoot({
             messageSystem: createMessageSystemState({
                 groups: [{ variant: 'A', percentage: 100 }],
             }),
         });
-        const { result } = renderUseExperiment(store);
+        const { result } = renderUseExperiment(root);
 
         expect(result.current.activeExperimentVariant?.variant).toBe('A');
     });
@@ -83,7 +82,7 @@ describe('useExperiment', () => {
         ({ inclusion, expectedVariant }) => {
             jest.mocked(getIntegerInRangeFromString).mockReturnValueOnce(inclusion);
 
-            const store = createStore({
+            const root = createRoot({
                 messageSystem: createMessageSystemState({
                     groups: [
                         { variant: 'A', percentage: 30 },
@@ -92,7 +91,7 @@ describe('useExperiment', () => {
                     ],
                 }),
             });
-            const { result } = renderUseExperiment(store);
+            const { result } = renderUseExperiment(root);
 
             expect(result.current.activeExperimentVariant?.variant).toBe(expectedVariant);
         },
@@ -106,10 +105,10 @@ describe('useExperiment', () => {
     ])(
         'assigns variant $expectedVariant for inclusion override $inclusionOverride',
         ({ inclusionOverride, expectedVariant }) => {
-            const store = createStore({
+            const root = createRoot({
                 messageSystem: createMessageSystemState({ inclusionOverride }),
             });
-            const { result } = renderUseExperiment(store);
+            const { result } = renderUseExperiment(root);
 
             expect(result.current.activeExperimentVariant?.variant).toBe(expectedVariant);
         },

--- a/suite-common/message-system/src/useMessageSystemEarnDashboard.test.ts
+++ b/suite-common/message-system/src/useMessageSystemEarnDashboard.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 
 import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
 import { type MessageSystemState } from './messageSystemTypes';
@@ -51,16 +51,15 @@ const stateWithMessages = {
     },
 } as unknown as MessageSystemState;
 
-const createStore = (state: MessageSystemState = stateWithMessages) =>
-    createTestStore({
-        extra: undefined,
+const createRoot = (state: MessageSystemState = stateWithMessages) =>
+    createTestCompositionRoot({
         reducer: combineReducers({ messageSystem: messageSystemReducer }),
         preloadedState: { messageSystem: state } as { messageSystem: MessageSystemState },
     });
 
 const renderHook = (props: Parameters<typeof useMessageSystemEarnDashboard>[0]) =>
     renderHookWithStoreProvider(() => useMessageSystemEarnDashboard(props), {
-        store: createStore(),
+        root: createRoot(),
     });
 
 describe('useMessageSystemEarnDashboard', () => {
@@ -91,10 +90,10 @@ describe('useMessageSystemEarnDashboard', () => {
     });
 
     it('returns not disabled without content when no messages are configured', () => {
-        const store = createStore(messageSystemInitialState);
+        const root = createRoot(messageSystemInitialState);
         const { result } = renderHookWithStoreProvider(
             () => useMessageSystemEarnDashboard({ type: 'yield', locale: 'en' }),
-            { store },
+            { root },
         );
 
         expect(result.current).toMatchObject({

--- a/suite-common/message-system/src/useMessageSystemMessageForm.test.ts
+++ b/suite-common/message-system/src/useMessageSystemMessageForm.test.ts
@@ -2,7 +2,11 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { type Action } from '@suite-common/suite-types';
-import { act, createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import {
+    act,
+    createTestCompositionRoot,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
 
 import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
 import { type MessageSystemState } from './messageSystemTypes';
@@ -21,9 +25,8 @@ const messageSystemReducer = prepareMessageSystemReducer({
     actionTypes: { storageLoad: mockActionType('storageLoad') },
 });
 
-const createStore = (actions: Action[] = []) =>
-    createTestStore({
-        extra: undefined,
+const createRoot = (actions: Action[] = []) =>
+    createTestCompositionRoot({
         reducer: combineReducers({ messageSystem: messageSystemReducer }),
         preloadedState: {
             messageSystem: {
@@ -39,8 +42,8 @@ const createStore = (actions: Action[] = []) =>
         },
     });
 
-const renderForm = (store = createStore()) =>
-    renderHookWithStoreProvider(() => useMessageSystemMessageForm(), { store });
+const renderForm = (root = createRoot()) =>
+    renderHookWithStoreProvider(() => useMessageSystemMessageForm(), { root });
 
 describe('useMessageSystemMessageForm', () => {
     it('initializes with a valid banner preset', () => {
@@ -89,7 +92,7 @@ describe('useMessageSystemMessageForm', () => {
 
     it('rejects a duplicate message id', () => {
         const existing = getDefaultActionByCategory('banner');
-        const { result } = renderForm(createStore([existing]));
+        const { result } = renderForm(createRoot([existing]));
 
         const duplicate = getDefaultActionByCategory('banner');
         duplicate.message.id = existing.message.id;

--- a/suite-common/message-system/src/useMessageSystemStaking.test.ts
+++ b/suite-common/message-system/src/useMessageSystemStaking.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
@@ -66,9 +66,8 @@ const stateWithDisabledFeatures = {
     },
 } as unknown as MessageSystemState;
 
-const createStore = (state: MessageSystemState = stateWithDisabledFeatures) =>
-    createTestStore({
-        extra: undefined,
+const createRoot = (state: MessageSystemState = stateWithDisabledFeatures) =>
+    createTestCompositionRoot({
         reducer: combineReducers({ messageSystem: messageSystemReducer }),
         preloadedState: { messageSystem: state } as { messageSystem: MessageSystemState },
     });
@@ -78,7 +77,7 @@ const renderHook = (
     locale = 'en',
 ) =>
     renderHookWithStoreProvider(() => useMessageSystemStaking({ networkSymbol, locale }), {
-        store: createStore(),
+        root: createRoot(),
     });
 
 describe('useMessageSystemStaking', () => {
@@ -129,14 +128,14 @@ describe('useMessageSystemStaking', () => {
     );
 
     it('returns not disabled when no feature messages configured', () => {
-        const store = createStore(messageSystemInitialState);
+        const root = createRoot(messageSystemInitialState);
         const { result } = renderHookWithStoreProvider(
             () =>
                 useMessageSystemStaking({
                     networkSymbol: ethSymbol,
                     locale: 'en',
                 }),
-            { store },
+            { root },
         );
 
         expect(result.current).toMatchObject({

--- a/suite-common/message-system/src/useMessageSystemWrappedNative.test.ts
+++ b/suite-common/message-system/src/useMessageSystemWrappedNative.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 
 import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
 import { type MessageSystemState } from './messageSystemTypes';
@@ -40,16 +40,15 @@ const stateWithDisabledWrap = {
     },
 } as unknown as MessageSystemState;
 
-const createStore = (state: MessageSystemState = stateWithDisabledWrap) =>
-    createTestStore({
-        extra: undefined,
+const createRoot = (state: MessageSystemState = stateWithDisabledWrap) =>
+    createTestCompositionRoot({
         reducer: combineReducers({ messageSystem: messageSystemReducer }),
         preloadedState: { messageSystem: state } as { messageSystem: MessageSystemState },
     });
 
 const renderHook = (props: Parameters<typeof useMessageSystemWrappedNative>[0]) =>
     renderHookWithStoreProvider(() => useMessageSystemWrappedNative(props), {
-        store: createStore(),
+        root: createRoot(),
     });
 
 describe('useMessageSystemWrappedNative', () => {
@@ -80,10 +79,10 @@ describe('useMessageSystemWrappedNative', () => {
     });
 
     it('returns not disabled when no feature messages are configured', () => {
-        const store = createStore(messageSystemInitialState);
+        const root = createRoot(messageSystemInitialState);
         const { result } = renderHookWithStoreProvider(
             () => useMessageSystemWrappedNative({ type: 'wrap', locale: 'en' }),
-            { store },
+            { root },
         );
 
         expect(result.current).toMatchObject({

--- a/suite-common/message-system/src/useMessageSystemYield.test.ts
+++ b/suite-common/message-system/src/useMessageSystemYield.test.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { createTestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { createTestCompositionRoot, renderHookWithStoreProvider } from '@suite-common/test-utils';
 
 import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
 import { type MessageSystemState } from './messageSystemTypes';
@@ -58,16 +58,15 @@ const stateWithDisabledFeatures = {
     },
 } as unknown as MessageSystemState;
 
-const createStore = (state: MessageSystemState = stateWithDisabledFeatures) =>
-    createTestStore({
-        extra: undefined,
+const createRoot = (state: MessageSystemState = stateWithDisabledFeatures) =>
+    createTestCompositionRoot({
         reducer: combineReducers({ messageSystem: messageSystemReducer }),
         preloadedState: { messageSystem: state } as { messageSystem: MessageSystemState },
     });
 
 const renderHook = (props: Parameters<typeof useMessageSystemYield>[0]) =>
     renderHookWithStoreProvider(() => useMessageSystemYield(props), {
-        store: createStore(),
+        root: createRoot(),
     });
 
 describe('useMessageSystemYield', () => {
@@ -109,10 +108,10 @@ describe('useMessageSystemYield', () => {
     });
 
     it('returns not disabled when no feature messages are configured', () => {
-        const store = createStore(messageSystemInitialState);
+        const root = createRoot(messageSystemInitialState);
         const { result } = renderHookWithStoreProvider(
             () => useMessageSystemYield({ type: 'deposit', locale: 'en' }),
-            { store },
+            { root },
         );
 
         expect(result.current).toMatchObject({

--- a/suite-common/suite-types/src/connectInit.ts
+++ b/suite-common/suite-types/src/connectInit.ts
@@ -46,3 +46,7 @@ export type TransportName =
 export type CreateTransports = (transports: TransportName[]) => ConnectSettings['transports'];
 
 export type TransportsDep = { createTransports: CreateTransports };
+
+export const selectTransportsDep = (services: TransportsDep): TransportsDep => ({
+    createTransports: services.createTransports,
+});

--- a/suite-common/suite-types/src/index.ts
+++ b/suite-common/suite-types/src/index.ts
@@ -6,7 +6,7 @@ import {
 
 export * from './device';
 export * from './firmware';
-export type * from './connectInit';
+export * from './connectInit';
 export type * from './guide';
 export type * from './messageSystem';
 export type * from './modal';

--- a/suite-common/test-utils/src/createTestCompositionRoot.ts
+++ b/suite-common/test-utils/src/createTestCompositionRoot.ts
@@ -19,14 +19,20 @@ export type TestAppRoot<
     services: TestCompositionRootServices<TStore, TServices>;
 };
 
+type CreateTestCompositionRootParams<S, A extends UnknownAction, Extra> = Omit<
+    CreateTestStoreParams<S, A, Extra>,
+    'extra'
+> &
+    ({ services: object } extends Extra ? { extra?: Extra } : { extra: Extra });
+
 export const createTestCompositionRoot = <
-    Extra extends { services: object },
+    Extra extends { services: object } = { services: object },
     S = any,
     A extends UnknownAction = UnknownAction,
 >({
-    extra,
+    extra = { services: {} } as Extra,
     ...storeParams
-}: CreateTestStoreParams<S, A, Extra>) => {
+}: CreateTestCompositionRootParams<S, A, Extra>) => {
     const { getActions, clearActions, ...store } = createTestStore({
         ...storeParams,
         extra,

--- a/suite-common/test-utils/src/createTestCompositionRoot.type-test.ts
+++ b/suite-common/test-utils/src/createTestCompositionRoot.type-test.ts
@@ -1,0 +1,25 @@
+import { type WithServices } from '@suite-common/redux-utils';
+
+import { createTestCompositionRoot } from './createTestCompositionRoot';
+
+type RequiredExtra = WithServices<{
+    formatValue: (value: number) => string;
+}>;
+
+const formatValue = (value: number) => value.toString();
+
+// Extra can be omitted when no services are required.
+createTestCompositionRoot({});
+
+// Provide the required service.
+createTestCompositionRoot<RequiredExtra>({
+    extra: { services: { formatValue } },
+});
+
+// @ts-expect-error Required dependencies cannot be omitted.
+createTestCompositionRoot<RequiredExtra>({});
+
+createTestCompositionRoot<RequiredExtra>({
+    // @ts-expect-error Empty services do not include the required service.
+    extra: { services: {} },
+});

--- a/suite-common/test-utils/src/renderWithStore.tsx
+++ b/suite-common/test-utils/src/renderWithStore.tsx
@@ -1,4 +1,3 @@
-import { type ReactNode } from 'react';
 import { Provider } from 'react-redux';
 
 import { type Store } from '@reduxjs/toolkit';
@@ -10,32 +9,19 @@ import { type TestAppRoot } from './createTestCompositionRoot';
 
 export type TestStore = Store;
 
-type RenderHookOptionsExtended<Props> = RenderHookOptions<Props> &
-    ({ root: TestAppRoot; store?: never } | { store: TestStore; root?: never });
+type RenderHookOptionsExtended<Props> = RenderHookOptions<Props> & { root: TestAppRoot };
 
 export const renderHookWithStoreProvider = <Result, Props>(
     callback: (props: Props) => Result,
-    { wrapper: Wrapper, store, root, ...options }: RenderHookOptionsExtended<Props>,
-) => {
-    const reduxStore = root?.store ?? store;
-    if (!reduxStore) {
-        throw new Error('Expected a store or root.');
-    }
-
-    const childrenWithProviders = (children: ReactNode) => {
-        const wrappedChildren = Wrapper ? <Wrapper>{children}</Wrapper> : children;
-
-        return (
-            <ServicesProvider services={{ ...root?.services, store: reduxStore }}>
-                {wrappedChildren}
-            </ServicesProvider>
-        );
-    };
-
-    return renderHook(callback, {
+    { wrapper: Wrapper, root, ...options }: RenderHookOptionsExtended<Props>,
+) =>
+    renderHook(callback, {
         wrapper: ({ children }) => (
-            <Provider store={reduxStore}>{childrenWithProviders(children)}</Provider>
+            <Provider store={root.store}>
+                <ServicesProvider services={root.services}>
+                    {Wrapper ? <Wrapper>{children}</Wrapper> : children}
+                </ServicesProvider>
+            </Provider>
         ),
         ...options,
     });
-};

--- a/suite-common/trading/src/hooks/useAllowanceTxTracking.test.ts
+++ b/suite-common/trading/src/hooks/useAllowanceTxTracking.test.ts
@@ -2,7 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import {
     act,
-    createTestStore,
+    createTestCompositionRoot,
     renderHookWithStoreProvider,
     testMocks,
 } from '@suite-common/test-utils';
@@ -26,8 +26,7 @@ const createPreloadedState = (transactions: WalletAccountTransaction[] = []) => 
 });
 
 const renderUseAllowanceTxTracking = (preloadedState = createPreloadedState()) => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
         reducer: combineReducers({
             wallet: combineReducers({
                 transactions: (state = preloadedState.wallet.transactions) => state,
@@ -39,9 +38,9 @@ const renderUseAllowanceTxTracking = (preloadedState = createPreloadedState()) =
 
     return {
         ...renderHookWithStoreProvider(() => useAllowanceTxTracking({ accountKey: ACCOUNT_KEY }), {
-            store,
+            root,
         }),
-        store,
+        root,
     };
 };
 
@@ -59,7 +58,7 @@ describe('useAllowanceTxTracking', () => {
         });
     });
 
-    describe('when approvalTxid is set but no matching transaction exists in store', () => {
+    describe('when approvalTxid is set but no matching transaction exists in root', () => {
         it('should return idle status', () => {
             const { result } = renderUseAllowanceTxTracking(createPreloadedState([]));
 

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -34,6 +34,7 @@ export * from './reducers/tradingReducer';
 export * from './regional';
 export { buyThunks } from './thunks/buy';
 export { tradingThunks } from './thunks/common';
+export type { LoadInitialDataThunkDeps } from './thunks/common/loadInitialDataThunk';
 export { exchangeThunks } from './thunks/exchange';
 export { sellThunks } from './thunks/sell';
 export * from './selectors/tradingSelectors';

--- a/suite-common/trading/src/test-utils/testUtils.tsx
+++ b/suite-common/trading/src/test-utils/testUtils.tsx
@@ -1,15 +1,12 @@
-import type { PropsWithChildren } from 'react';
-
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { ServicesProvider } from '@suite-common/dependency-injection';
 import {
     createNetworkModuleRepository,
     createNetworksCompositionRoot,
 } from '@suite-common/networks';
 import {
     type RenderHookOptions,
-    createTestStore,
+    createTestCompositionRoot,
     renderHookWithStoreProvider,
 } from '@suite-common/test-utils';
 import {
@@ -193,10 +190,10 @@ export const createSellInfoState = (providerInfos: Record<string, any> = {}): an
  */
 export const renderHookWithTradingStore = <Result, Props = unknown>(
     callback: (props: Props) => Result,
-    { preloadedState, wrapper: Wrapper, ...options }: RenderHookWithTradingStoreOptions<Props> = {},
+    { preloadedState, ...options }: RenderHookWithTradingStoreOptions<Props> = {},
 ) => {
-    const store = createTestStore({
-        extra: undefined,
+    const root = createTestCompositionRoot({
+        extra: { services: { networkModuleRepository } },
         reducer: combineReducers({
             wallet: combineReducers({
                 trading: tradingCommonReducer,
@@ -213,18 +210,11 @@ export const renderHookWithTradingStore = <Result, Props = unknown>(
         preloadedState: preloadedState || createTradingTestState(),
     });
 
-    const TradingServicesProvider = ({ children }: PropsWithChildren) => (
-        <ServicesProvider services={{ networkModuleRepository, store }}>
-            {Wrapper ? <Wrapper>{children}</Wrapper> : children}
-        </ServicesProvider>
-    );
-
     return {
         ...renderHookWithStoreProvider(callback, {
-            store,
-            wrapper: TradingServicesProvider,
+            root,
             ...options,
         }),
-        store,
+        store: root.store,
     };
 };

--- a/suite-native/accounts/src/components/AccountLabel.test.tsx
+++ b/suite-native/accounts/src/components/AccountLabel.test.tsx
@@ -60,15 +60,17 @@ describe('AccountLabel', () => {
 
     const renderAccountLabel = async (props: AccountLabelPropsWithAccount) =>
         await renderWithStoreProvider(<AccountLabel {...props} />, {
-            store: createLightStore({
-                reducer,
-                preloadedState: {
-                    wallet: {
-                        settings: initialWalletSettingsState,
-                        accounts,
-                    },
-                } satisfies PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>>,
-            }),
+            services: {
+                store: createLightStore({
+                    reducer,
+                    preloadedState: {
+                        wallet: {
+                            settings: initialWalletSettingsState,
+                            accounts,
+                        },
+                    } satisfies PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>>,
+                }),
+            },
         });
 
     it('should render account label when account is provided', async () => {

--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -34,6 +34,7 @@
         "react-redux": "9.3.0"
     },
     "devDependencies": {
+        "@reduxjs/toolkit": "2.12.0",
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*"
     }

--- a/suite-native/formatters/src/hooks/useFormattedGraphHeaderValues.test.ts
+++ b/suite-native/formatters/src/hooks/useFormattedGraphHeaderValues.test.ts
@@ -1,7 +1,13 @@
-import { type SupportedLocaleCode } from '@suite-native/intl';
-import { localeReducer } from '@suite-native/intl';
+import { type Store } from '@reduxjs/toolkit';
+
 import {
-    type TestStore,
+    type WalletSettingsRootState,
+    initialWalletSettingsState,
+} from '@suite-common/wallet-core';
+import { type LocaleSliceRootState, type SupportedLocaleCode } from '@suite-native/intl';
+import { localeInitialState, localeReducer } from '@suite-native/intl';
+import {
+    type PreloadedStatePartial,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
@@ -10,16 +16,23 @@ import { AmountUnit } from '@trezor/protobuf/src/definitions';
 
 import { useFormattedGraphHeaderValues } from './useFormattedGraphHeaderValues';
 
-let store: TestStore;
+type State = WalletSettingsRootState & LocaleSliceRootState;
 
-const setNewStoreMockup = (preloadedState: any) => {
+let store: Store<State>;
+
+const setNewStoreMockup = (preloadedState: PreloadedStatePartial<State>) => {
     store = createLightStore({
         reducer: {
             locale: localeReducer,
-            wallet: createStaticReducer(preloadedState.wallet),
+            wallet: createStaticReducer({
+                settings: {
+                    ...initialWalletSettingsState,
+                    ...preloadedState.wallet?.settings,
+                },
+            }),
         },
         preloadedState: {
-            ...preloadedState,
+            locale: { ...localeInitialState, ...preloadedState.locale },
         },
     });
 };
@@ -27,7 +40,7 @@ const setNewStoreMockup = (preloadedState: any) => {
 describe(useFormattedGraphHeaderValues.name, () => {
     const renderUseFormattedGraphHeaderValues = async (value?: string) =>
         await renderHookWithStoreProvider(() => useFormattedGraphHeaderValues(value), {
-            store,
+            services: { store },
         });
 
     beforeEach(() => {

--- a/suite-native/module-earn/src/hooks/earn/usePreparedTxFees.test.ts
+++ b/suite-native/module-earn/src/hooks/earn/usePreparedTxFees.test.ts
@@ -123,7 +123,7 @@ const renderPreparedTxFees = async (initialProps: HookProps) => {
     return {
         store,
         ...(await renderHookWithStoreProvider((props: HookProps) => usePreparedTxFees(props), {
-            store,
+            services: { store },
             initialProps,
         })),
     };

--- a/suite-native/module-earn/src/hooks/yield/useStartYieldDepositFlow.test.ts
+++ b/suite-native/module-earn/src/hooks/yield/useStartYieldDepositFlow.test.ts
@@ -1,7 +1,8 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
+    type AccountsRootState,
     type YieldFlowResolvedData,
     type YieldRootState,
     fetchAllowance,
@@ -14,7 +15,6 @@ import { type Account, type AccountKey, type TokenAddress } from '@suite-common/
 import { asAmountSubunit } from '@suite-common/wallet-utils';
 import { type YieldFlowParams, YieldStackRoutes } from '@suite-native/navigation';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
@@ -23,6 +23,8 @@ import {
 import { BigNumber } from '@trezor/utils';
 
 import { useStartYieldDepositFlow } from './useStartYieldDepositFlow';
+
+type State = YieldRootState & AccountsRootState;
 
 const mockNavigate = jest.fn();
 const mockReplace = jest.fn();
@@ -149,9 +151,12 @@ const wethHookParams: HookParams = {
 };
 
 const renderUseStartYieldDepositFlow = async (
-    store: TestStore,
+    store: Store<State>,
     hookParams: HookParams = defaultHookParams,
-) => await renderHookWithStoreProvider(() => useStartYieldDepositFlow(hookParams), { store });
+) =>
+    await renderHookWithStoreProvider(() => useStartYieldDepositFlow(hookParams), {
+        services: { store },
+    });
 
 describe('useStartYieldDepositFlow', () => {
     beforeEach(() => {

--- a/suite-native/module-earn/src/hooks/yield/useYieldClaimFees.test.ts
+++ b/suite-native/module-earn/src/hooks/yield/useYieldClaimFees.test.ts
@@ -103,7 +103,7 @@ const createTestStore = () =>
 
 const renderYieldClaimFees = (initialProps: HookProps) =>
     renderHookWithStoreProvider((props: HookProps) => useYieldClaimFees(props), {
-        store: createTestStore(),
+        services: { store: createTestStore() },
         initialProps,
     });
 

--- a/suite-native/module-home/src/screens/HomeScreen/selectHomeScreenState.test.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/selectHomeScreenState.test.ts
@@ -1,4 +1,5 @@
 import { PORTFOLIO_TRACKER_DEVICE_ID, PORTFOLIO_TRACKER_DEVICE_STATE } from '@suite-common/device';
+import { type NativeDeviceRootState } from '@suite-native/device';
 import { createStoreFromPreloadedState } from '@suite-native/test-utils-store';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -6,10 +7,8 @@ import { selectHomeScreenState } from './homescreenSelectors';
 
 const TEST_SESSION_ID = 'address@hash:0' as const;
 
-const buildState = (preloadedState: Record<string, unknown>) =>
-    createStoreFromPreloadedState(preloadedState).getState() as Parameters<
-        typeof selectHomeScreenState
-    >[0];
+const buildState = (preloadedState: Record<string, unknown>): NativeDeviceRootState =>
+    createStoreFromPreloadedState(preloadedState as NativeDeviceRootState).getState();
 
 describe('selectHomeScreenState', () => {
     describe('portfolioContent', () => {

--- a/suite-native/module-onboarding/package.json
+++ b/suite-native/module-onboarding/package.json
@@ -41,6 +41,7 @@
         "react-redux": "9.3.0"
     },
     "devDependencies": {
+        "@reduxjs/toolkit": "2.12.0",
         "@suite-common/message-system": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/test-utils-store": "workspace:*",

--- a/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.test.ts
+++ b/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.test.ts
@@ -1,7 +1,12 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { HomeStackRoutes, RootStackRoutes } from '@suite-native/navigation';
-import { appSettingsReducer, setIsOnboardingFinished } from '@suite-native/settings';
 import {
-    type TestStore,
+    type SettingsSliceRootState,
+    appSettingsReducer,
+    setIsOnboardingFinished,
+} from '@suite-native/settings';
+import {
     act,
     createLightStore,
     createStaticReducer,
@@ -27,10 +32,10 @@ jest.mock('@suite-native/app-init', () => ({
 }));
 
 describe('useExitOnboardingFlow', () => {
-    let store: TestStore;
+    let store: Store<SettingsSliceRootState>;
 
     const renderUseExitOnboardingFlow = async () =>
-        await renderHookWithStoreProvider(() => useExitOnboardingFlow(), { store });
+        await renderHookWithStoreProvider(() => useExitOnboardingFlow(), { services: { store } });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/module-onboarding/src/screens/BiometricsScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/BiometricsScreen.test.tsx
@@ -1,9 +1,13 @@
-import { messageSystemInitialState } from '@suite-common/message-system';
-import { featureFlagsReducer } from '@suite-native/feature-flags';
+import { type Store } from '@reduxjs/toolkit';
+
+import {
+    type MessageSystemRootState,
+    messageSystemInitialState,
+} from '@suite-common/message-system';
+import { type FeatureFlagsRootState, featureFlagsReducer } from '@suite-native/feature-flags';
 import { getTranslation } from '@suite-native/intl';
 import { OnboardingStackRoutes } from '@suite-native/navigation';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     renderWithStoreProvider,
@@ -11,6 +15,8 @@ import {
 } from '@suite-native/test-utils-store';
 
 import { BiometricsScreen, type BiometricsScreenProps } from './BiometricsScreen';
+
+type State = FeatureFlagsRootState & MessageSystemRootState;
 
 const mockNavigate = jest.fn();
 const mockNavigationDispatch = jest.fn();
@@ -40,7 +46,7 @@ jest.mock('@suite-native/app-init', () => ({
 }));
 
 describe('BiometricsScreen', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderBiometricsScreen = async () =>
         await renderWithStoreProvider(
@@ -50,7 +56,7 @@ describe('BiometricsScreen', () => {
                 }
                 route={mockRoute}
             />,
-            { store },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.test.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.test.ts
@@ -1,3 +1,7 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type DeviceRootState, deviceInitialState } from '@suite-common/device';
+import { type AccountsRootState, type FormDraftRootState } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import {
@@ -6,16 +10,21 @@ import {
     StellarManageTokenStackRoutes,
 } from '@suite-native/navigation';
 import {
-    type TestStore,
     act,
     createStoreFromPreloadedState,
     renderHookWithStoreProvider,
     waitFor,
 } from '@suite-native/test-utils-store';
+import {
+    type NativeSendRootState,
+    sendFormInitialState,
+} from '@suite-native/transaction-management';
 import { STELLAR_BASE_RESERVE } from '@trezor/network-stellar/constants';
 import { BigNumber } from '@trezor/utils';
 
 import { useStellarFeeScreen } from './useStellarFeeScreen';
+
+type State = AccountsRootState & DeviceRootState & FormDraftRootState & NativeSendRootState;
 
 type UseStellarFeeScreenParams = Parameters<typeof useStellarFeeScreen>[0];
 
@@ -179,7 +188,7 @@ const createDeferred = () => {
 };
 
 describe('useStellarFeeScreen', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const mockThunkAction = jest.fn();
     const mockOnSuccess = jest.fn();
@@ -199,14 +208,22 @@ describe('useStellarFeeScreen', () => {
 
     const renderUseStellarFeeScreen = async (props: UseStellarFeeScreenParams = defaultProps) =>
         await renderHookWithStoreProvider(hookProps => useStellarFeeScreen(hookProps), {
-            store,
+            services: { store },
             initialProps: props,
         });
 
     beforeEach(() => {
         jest.clearAllMocks();
         focusEffectCallback = undefined;
-        store = createStoreFromPreloadedState();
+        const state: State = {
+            device: deviceInitialState,
+            wallet: {
+                accounts: [],
+                formDrafts: {},
+                send: sendFormInitialState,
+            },
+        };
+        store = createStoreFromPreloadedState(state);
 
         mockSelectAccountByKey.mockReturnValue(mockAccount);
         mockSelectDeviceButtonRequestsCodes.mockReturnValue([]);

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -95,8 +95,10 @@
         "react-redux": "9.3.0"
     },
     "devDependencies": {
+        "@suite-common/discreet-mode": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
+        "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/tx-simulation": "workspace:*",
         "@suite-native/bluetooth": "workspace:*",
         "@suite-native/settings": "workspace:*",

--- a/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.test.tsx
@@ -1,22 +1,26 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { type useListDataFilter } from '@suite-common/trading';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     fireEvent,
     renderHookWithStoreProvider,
     renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils-store';
-import { buyActions } from '@suite-native/trading-state';
+import { type TradingRootState, buyActions } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 
 import { BuyFiatCurrencyPicker } from './BuyFiatCurrencyPicker';
 import { useBuyForm } from '../../hooks/buy/useBuyForm';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 let mockUseListDataFilter: typeof useListDataFilter;
 const reportMock = jest.fn();
@@ -32,15 +36,14 @@ jest.mock('@suite-common/trading', () => ({
 
 describe('BuyFiatCurrencyPicker', () => {
     let form: BuyFormType;
-    let store: TestStore;
+    let store: Store<State>;
 
     beforeEach(async () => {
         mockUseListDataFilter = jest.requireActual('@suite-common/trading').useListDataFilter;
         reportMock.mockClear();
-        store = createTradingLightStore({ tradeType: 'buy' });
+        store = createTradingTestStore({ tradeType: 'buy' });
         const { result } = await renderHookWithStoreProvider(() => useBuyForm(), {
-            services,
-            store,
+            services: { ...services, store },
         });
         form = result.current;
     });
@@ -50,10 +53,7 @@ describe('BuyFiatCurrencyPicker', () => {
             <Form form={form}>
                 <BuyFiatCurrencyPicker />
             </Form>,
-            {
-                services,
-                store,
-            },
+            { services: { ...services, store } },
         );
 
     afterEach(async () => {

--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.test.tsx
@@ -67,6 +67,7 @@ describe('BuyPaymentMethodPicker', () => {
             typeof defaultPreloadedState
         > = defaultPreloadedState,
     ) => {
+        const extra = { services: { ...services, store } };
         const mergedFormPreloadedState = mergeDeepObject(defaultPreloadedState, formPreloadedState);
         const mergedComponentPreloadedState = mergeDeepObject(
             defaultPreloadedState,
@@ -75,8 +76,7 @@ describe('BuyPaymentMethodPicker', () => {
 
         const { result } = await renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState: mergedFormPreloadedState,
-            services,
-            store,
+            ...extra,
         });
         form = result.current;
 
@@ -84,7 +84,7 @@ describe('BuyPaymentMethodPicker', () => {
             <Form form={form}>
                 <BuyPaymentMethodPicker />
             </Form>,
-            { preloadedState: mergedComponentPreloadedState, services, store },
+            { ...extra, preloadedState: mergedComponentPreloadedState },
         );
     };
 

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.test.tsx
@@ -1,12 +1,17 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type DeviceRootState } from '@suite-common/device';
 import { type NetworkModuleRepositoryDep } from '@suite-common/networks';
 import { mockNetworkModuleRepository } from '@suite-common/networks/mocks';
 import { tradingBuyActions } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { type FeatureFlagsRootState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils';
-import { type TestStore, fireEvent, screen, waitFor } from '@suite-native/test-utils-store';
+import { fireEvent, screen, waitFor } from '@suite-native/test-utils-store';
 import {
     MOCK_ACCOUNT_DEVICE_SESSION_ID,
     eth1NormalAccount,
@@ -14,17 +19,19 @@ import {
     ethAsset,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
-import { buyActions } from '@suite-native/trading-state';
+import { type TradingRootState, buyActions } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
 
 import { BuyTradeableAssetPicker } from './BuyTradeableAssetPicker';
 import { useBuyForm } from '../../hooks/buy/useBuyForm';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
 } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & FeatureFlagsRootState & DeviceRootState;
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep & NetworkModuleRepositoryDep = {
@@ -61,11 +68,11 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('BuyTradeableAssetPicker', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let form: BuyFormType;
 
     const initPreloadedStore = (firmwareType: FirmwareType) =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'buy',
             overrides: {
                 device: { selectedDevice: { firmwareType } },
@@ -75,7 +82,7 @@ describe('BuyTradeableAssetPicker', () => {
     // Account preselection needs a device session that the mock accounts belong to,
     // otherwise they are not treated as visible device accounts.
     const initPreloadedStoreWithAccounts = () =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'buy',
             overrides: {
                 device: {
@@ -89,8 +96,7 @@ describe('BuyTradeableAssetPicker', () => {
 
     const renderFormHook = async () => {
         const { result } = await renderHookWithTradingProvider(() => useBuyForm(), {
-            services,
-            store,
+            services: { ...services, store },
         });
 
         return result.current;
@@ -101,7 +107,7 @@ describe('BuyTradeableAssetPicker', () => {
             <Form form={form}>
                 <BuyTradeableAssetPicker />
             </Form>,
-            { services, store },
+            { services: { ...services, store } },
         );
         await act(async () => {
             await act(() => Promise.resolve());

--- a/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.test.tsx
@@ -1,11 +1,19 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { tradingExchangeActions } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, renderWithStoreProvider, userEvent } from '@suite-native/test-utils-store';
+import { renderWithStoreProvider, userEvent } from '@suite-native/test-utils-store';
 import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { ApprovalButton, type ApprovalButtonProps } from './ApprovalButton';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 const mockNavigate = jest.fn();
 
@@ -17,28 +25,20 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockAnalyticsReport = jest.fn();
-jest.mock('@suite-native/trading-analytics', () => ({
-    ...jest.requireActual('@suite-native/trading-analytics'),
-    useExchangeAnalyticsStepReport:
-        (action: unknown) =>
-        (...args: unknown[]) =>
-            mockAnalyticsReport(action, ...args),
-}));
-
 const ethAccountKey = mockAccountKey({ symbol: 'eth', descriptor: 'eth1normal' });
 
 describe('ApprovalButton', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderApprovalButton = async (props: Partial<ApprovalButtonProps>) =>
         await renderWithStoreProvider(<ApprovalButton flowType="approve" isReady {...props} />, {
-            store,
+            services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store },
         });
 
     beforeEach(() => {
         jest.clearAllMocks();
 
-        store = createTradingLightStore({
+        store = createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -91,7 +91,10 @@ describe('ApprovalButton', () => {
             getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
         );
 
-        expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-preview', 'continue');
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.tradingExchangeEvent.name,
+            payload: expect.objectContaining({ step: 'approval-preview', action: 'continue' }),
+        });
     });
 
     it('should navigate to TradingExchangeOutputsReview on press for flowType revoke', async () => {
@@ -116,7 +119,10 @@ describe('ApprovalButton', () => {
             getByText(getTranslation('moduleTrading.tradingScreen.buttons.continue')),
         );
 
-        expect(mockAnalyticsReport).toHaveBeenCalledWith('revoke-preview', 'continue');
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.tradingExchangeEvent.name,
+            payload: expect.objectContaining({ step: 'revoke-preview', action: 'continue' }),
+        });
     });
 
     it('should render nothing when no selected quote is provided', async () => {

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.test.tsx
@@ -1,18 +1,18 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { selectTradingExchangeSelectedQuote, tradingExchangeActions } from '@suite-common/trading';
 import { getTranslation } from '@suite-native/intl';
-import {
-    type TestStore,
-    renderWithStoreProvider,
-    userEvent,
-    within,
-} from '@suite-native/test-utils-store';
+import { renderWithStoreProvider, userEvent, within } from '@suite-native/test-utils-store';
 import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { LimitPicker } from './LimitPicker';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 describe('LimitPicker', () => {
-    let store: TestStore;
+    let store: Store<State>;
     const mockOnApprovalTypeChange = jest.fn();
 
     const renderLimitPicker = async () =>
@@ -29,7 +29,7 @@ describe('LimitPicker', () => {
                     );
                 }}
             />,
-            { store },
+            { services: { store } },
         );
 
     beforeEach(() => {
@@ -37,7 +37,7 @@ describe('LimitPicker', () => {
 
         const quote = { ...mercuryoFixedWorstQuote, approvalStringAmount: '100' };
 
-        store = createTradingLightStore({
+        store = createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 wallet: {

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationHeader.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationHeader.test.tsx
@@ -1,26 +1,32 @@
+import { type Store } from '@reduxjs/toolkit';
 import type { ExchangeTrade } from 'invity-api';
 
 import { tradingExchangeActions } from '@suite-common/trading';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { exchangeQuotes } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import {
     ExchangeConfirmationHeader,
     type ExchangeConfirmationHeaderProps,
 } from './ExchangeConfirmationHeader';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 const testQuote = exchangeQuotes[0];
 
 describe('ExchangeConfirmationHeader', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderHeader = async (props: ExchangeConfirmationHeaderProps) =>
-        await renderWithStoreProvider(<ExchangeConfirmationHeader {...props} />, { store });
+        await renderWithStoreProvider(<ExchangeConfirmationHeader {...props} />, {
+            services: { store },
+        });
 
     beforeEach(() => {
-        store = createTradingLightStore({ tradeType: 'exchange' });
+        store = createTradingTestStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
     });
 

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationInfo.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationInfo.test.tsx
@@ -1,27 +1,33 @@
+import { type Store } from '@reduxjs/toolkit';
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { tradingExchangeActions } from '@suite-common/trading';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, renderWithStoreProvider, screen } from '@suite-native/test-utils-store';
+import { renderWithStoreProvider, screen } from '@suite-native/test-utils-store';
 import { mockTransaction } from '@suite-native/tokens';
 import { exchangeQuotes } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import {
     ExchangeConfirmationInfo,
     type ExchangeConfirmationInfoCardProps,
 } from './ExchangeConfirmationInfo';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 const testQuote = exchangeQuotes[0];
 
 describe('ExchangeConfirmationInfo', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderInfo = async (props: ExchangeConfirmationInfoCardProps) =>
-        await renderWithStoreProvider(<ExchangeConfirmationInfo {...props} />, { store });
+        await renderWithStoreProvider(<ExchangeConfirmationInfo {...props} />, {
+            services: { store },
+        });
 
     beforeEach(() => {
-        store = createTradingLightStore({ tradeType: 'exchange' });
+        store = createTradingTestStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
     });
 

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
@@ -1,14 +1,20 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
-import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
+import { fireEvent, screen } from '@suite-native/test-utils-store';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { ExchangeUsdcPresetButton } from './ExchangeUsdcPresetButton';
 import {
-    createTradingLightStore,
     createTradingPreloadedState,
+    createTradingTestStore,
     renderWithTradingProvider,
 } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 const mockSetValue = jest.fn();
 const mockGetValues = jest.fn();
@@ -45,22 +51,22 @@ describe('ExchangeUsdcPresetButton', () => {
     });
 
     it('without a matching account shows an error message', async () => {
-        const store = createTradingLightStore({ tradeType: 'exchange' });
-        await renderWithTradingProvider(<ExchangeUsdcPresetButton />, { store });
+        const store = createTradingTestStore({ tradeType: 'exchange' });
+        await renderWithTradingProvider(<ExchangeUsdcPresetButton />, { services: { store } });
 
         expect(screen.getByText('No account with USDC found.')).toBeOnTheScreen();
     });
 
     describe('with a matching ETH account that has a USDC token', () => {
-        let store: TestStore;
+        let store: Store<State>;
 
         beforeEach(async () => {
-            const preloadedState = createTradingPreloadedState({
+            const preloadedState: State = createTradingPreloadedState({
                 tradeType: 'exchange',
                 overrides: { wallet: { accounts: [ethAccountWithUsdc] } },
             });
-            store = createTradingLightStore({ tradeType: 'exchange', overrides: preloadedState });
-            await renderWithTradingProvider(<ExchangeUsdcPresetButton />, { store });
+            store = createTradingTestStore({ tradeType: 'exchange', overrides: preloadedState });
+            await renderWithTradingProvider(<ExchangeUsdcPresetButton />, { services: { store } });
         });
 
         it('renders the preset button', () => {

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.test.tsx
@@ -1,13 +1,16 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { type NetworkModuleRepositoryDep } from '@suite-common/networks';
 import { mockNetworkModuleRepository } from '@suite-common/networks/mocks';
 import { tradingExchangeActions } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { featureFlagsInitialState } from '@suite-native/feature-flags';
+import { type FeatureFlagsRootState, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils';
-import { type TestStore, fireEvent, screen, waitFor } from '@suite-native/test-utils-store';
+import { fireEvent, screen, waitFor } from '@suite-native/test-utils-store';
 import {
     MOCK_ACCOUNT_DEVICE_SESSION_ID,
     btc1NormalAccount,
@@ -17,17 +20,19 @@ import {
     ethAsset,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
-import { exchangeActions } from '@suite-native/trading-state';
+import { type TradingRootState, exchangeActions } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
 
 import { ExchangeTradeableAssetPicker } from './ExchangeTradeableAssetPicker';
 import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
 } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & FeatureFlagsRootState;
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep & NetworkModuleRepositoryDep = {
@@ -65,11 +70,11 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('ExchangeTradeableAssetPicker', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let form: ExchangeFormType;
 
     const initPreloadedStore = (firmwareType: FirmwareType) =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 device: { selectedDevice: { firmwareType } },
@@ -82,7 +87,7 @@ describe('ExchangeTradeableAssetPicker', () => {
     // Account preselection needs a device session that the mock accounts belong to,
     // otherwise they are not treated as visible device accounts.
     const initPreloadedStoreWithAccounts = () =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 device: {
@@ -99,8 +104,7 @@ describe('ExchangeTradeableAssetPicker', () => {
 
     const renderFormHook = async () => {
         const { result } = await renderHookWithTradingProvider(() => useExchangeForm(), {
-            services,
-            store,
+            services: { ...services, store },
         });
 
         return result.current;
@@ -108,8 +112,7 @@ describe('ExchangeTradeableAssetPicker', () => {
 
     const renderTradeableAssetPicker = async () =>
         await renderWithTradingProvider(<ExchangeTradeableAssetPicker />, {
-            services,
-            store,
+            services: { ...services, store },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.test.tsx
@@ -1,4 +1,4 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 import type { CryptoId } from 'invity-api';
 
 import { deviceInitialState } from '@suite-common/device';
@@ -7,7 +7,11 @@ import { type NetworkModuleRepositoryDep } from '@suite-common/networks';
 import { mockNetworkModuleRepository } from '@suite-common/networks/mocks';
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { initialSuiteSyncDataState, initialSuiteSyncState } from '@suite-common/suite-sync';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import {
+    type AccountsRootState,
+    type WalletSettingsRootState,
+    initialWalletSettingsState,
+} from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
@@ -15,7 +19,7 @@ import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
+    type PreloadedStatePartial,
     createLightStore,
     createStaticReducer,
     fireEvent,
@@ -30,6 +34,7 @@ import {
     getWalletState,
 } from '@suite-native/trading-fixtures';
 import {
+    type TradingRootState,
     exchangeActions,
     selectAccountsWithTokensToSellSectionListByTradingType,
     tradingSlice,
@@ -39,6 +44,8 @@ import { BigNumber } from '@trezor/utils';
 
 import { ExchangeSendAssetPicker } from './ExchangeSendAssetPicker';
 import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 jest.mock('@suite-native/trading-state', () => ({
     ...jest.requireActual('@suite-native/trading-state'),
@@ -72,7 +79,7 @@ jest.mock('@react-navigation/native', () => ({
 
 describe('ExchangeSendAssetPicker', () => {
     let form: ExchangeFormType;
-    let store: TestStore;
+    let store: Store<State>;
 
     const btcAccount = getBtcAccount();
     const ethAccount = getEthAccount();
@@ -101,14 +108,7 @@ describe('ExchangeSendAssetPicker', () => {
         },
     ];
 
-    const getPreloadedState = () => ({
-        device: deviceInitialState,
-        featureFlags: {
-            ...featureFlagsInitialState,
-        },
-        messageSystem: messageSystemInitialState,
-        suiteSync: initialSuiteSyncState,
-        suiteSyncData: initialSuiteSyncDataState,
+    const getPreloadedState = (): PreloadedStatePartial<State> => ({
         wallet: {
             trading: getInitializedTradingState(),
             accounts: [btcAccount, ethAccount],
@@ -116,12 +116,13 @@ describe('ExchangeSendAssetPicker', () => {
     });
 
     const renderExchangeForm = async () =>
-        await renderHookWithStoreProvider(() => useExchangeForm(), { services, store });
+        await renderHookWithStoreProvider(() => useExchangeForm(), {
+            services: { ...services, store },
+        });
 
     const renderExchangeSendAssetPicker = async () =>
         await renderWithStoreProvider(<ExchangeSendAssetPicker />, {
-            services,
-            store,
+            services: { ...services, store },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/components/general/AccountList/AccountList.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountList.test.tsx
@@ -18,7 +18,7 @@ import { AccountList, type AccountsListProps, keyExtractor } from './AccountList
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
-    createTradingLightStore,
+    createTradingTestStore,
 } from '../../../test-utils/tradingTestUtils';
 
 const navigationNavigate = jest.fn();
@@ -47,7 +47,7 @@ describe('AccountList', () => {
         props: Partial<AccountsListProps> = {},
         overrides: PreloadedStatePartial<TradingTestPreloadedState> = defaultOverrides,
     ) => {
-        const store = createTradingLightStore({ overrides });
+        const store = createTradingTestStore({ overrides });
         const symbol = props.symbol ?? 'btc';
         const receiveAccounts = store
             .getState()
@@ -65,7 +65,7 @@ describe('AccountList', () => {
                 {...props}
                 data={props.data ?? data}
             />,
-            { store },
+            { services: { store } },
         );
 
         return { ...result, store };

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
@@ -1,13 +1,24 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type DeviceRootState } from '@suite-common/device';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
+import {
+    type PreloadedStatePartial,
+    fireEvent,
+    renderWithStoreProvider,
+} from '@suite-native/test-utils-store';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { type ReceiveAccount } from '@suite-native/trading-types';
 import { type StaticSessionId } from '@trezor/connect';
 
 import { AccountListItem } from './AccountListItem';
 import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & DeviceRootState;
 
 const DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
 
@@ -19,7 +30,7 @@ const btc10000000Account = mockWalletAccount({
     availableBalance: '10000000',
 });
 
-const defaultOverrides = {
+const defaultOverrides: PreloadedStatePartial<State> = {
     device: {
         devices: [],
         selectedDevice: {
@@ -58,17 +69,17 @@ jest.mock('@suite-common/trading', () => {
 describe('AccountListItem', () => {
     const onPressMock = jest.fn();
 
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderAccountListItem = async (
         receiveAccount: ReceiveAccount,
-        overrides: Record<string, unknown> = defaultOverrides,
+        overrides: PreloadedStatePartial<State> = defaultOverrides,
     ) => {
         store = createTradingTestStore({ overrides });
 
         return await renderWithStoreProvider(
             <AccountListItem onPress={onPressMock} receiveAccount={receiveAccount} />,
-            { store },
+            { services: { store } },
         );
     };
 

--- a/suite-native/module-trading/src/components/general/Error/LastErrorMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/Error/LastErrorMessage.test.tsx
@@ -1,21 +1,22 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { tradingBuyActions } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
-import { tradingSlice } from '@suite-native/trading-state';
+import { type TradingRootState, tradingSlice } from '@suite-native/trading-state';
 
 import { LastErrorMessage, type LastErrorMessageProps } from './LastErrorMessage';
 
+type State = TradingRootState;
+
 describe('LastErrorMessage', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const reducer = {
         locale: localeReducer,
@@ -28,7 +29,7 @@ describe('LastErrorMessage', () => {
     } as const;
 
     const renderLastErrorMessage = async (props: LastErrorMessageProps) =>
-        await renderWithStoreProvider(<LastErrorMessage {...props} />, { store });
+        await renderWithStoreProvider(<LastErrorMessage {...props} />, { services: { store } });
 
     beforeEach(() => {
         store = createLightStore({ reducer });

--- a/suite-native/module-trading/src/components/general/Header/Header.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/Header.test.tsx
@@ -1,17 +1,22 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { mockMessageSystemStateWithFeatureFlags } from '@suite-common/message-system/mocks';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, fireEvent } from '@suite-native/test-utils-store';
+import { fireEvent } from '@suite-native/test-utils-store';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { Header } from './Header';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
-    createTradingLightStore,
+    createTradingTestStore,
     renderWithTradingProvider,
 } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 describe('Header', () => {
     const getFFOverrides = (): PreloadedStatePartial<TradingTestPreloadedState> => ({
@@ -41,13 +46,15 @@ describe('Header', () => {
         };
     };
 
-    const createTestStore = () => createTradingLightStore({ overrides: getFFOverrides() });
+    const createTestStore = () => createTradingTestStore({ overrides: getFFOverrides() });
 
-    const renderHeaderWithStore = async (store: TestStore) => {
+    const renderHeaderWithStore = async (store: Store<State>) => {
         const { reportMock, services } = setupReportMock();
 
         return {
-            renderer: await renderWithTradingProvider(<Header />, { services, store }),
+            renderer: await renderWithTradingProvider(<Header />, {
+                services: { ...services, store },
+            }),
             reportMock,
         };
     };
@@ -100,7 +107,7 @@ describe('Header', () => {
     });
 
     describe('analytics', () => {
-        let store: TestStore;
+        let store: Store<State>;
 
         beforeEach(() => {
             store = createTestStore();

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.test.tsx
@@ -1,11 +1,21 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { type CombinedLabelingState } from '@suite-native/labeling';
+import {
+    type PreloadedStatePartial,
+    fireEvent,
+    renderWithStoreProvider,
+} from '@suite-native/test-utils-store';
 import { btc1NormalAccount } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { ReceiveAccountPicker, type ReceiveAccountPickerProps } from './ReceiveAccountPicker';
 import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
 
-const defaultOverrides = {
+type State = TradingRootState & CombinedLabelingState;
+
+const defaultOverrides: PreloadedStatePartial<State> = {
     device: {
         devices: [],
         selectedDevice: {
@@ -28,11 +38,11 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('ReceiveAccountPicker', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderReceiveAccountPicker = async (
         props: Partial<ReceiveAccountPickerProps>,
-        overrides: Record<string, unknown> = defaultOverrides,
+        overrides: PreloadedStatePartial<State> = defaultOverrides,
     ) => {
         store = createTradingTestStore({ overrides });
 
@@ -46,7 +56,7 @@ describe('ReceiveAccountPicker', () => {
                 }}
                 {...props}
             />,
-            { store },
+            { services: { store } },
         );
     };
 

--- a/suite-native/module-trading/src/components/general/TradingDeviceConnectionGuard.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradingDeviceConnectionGuard.test.tsx
@@ -1,10 +1,16 @@
 import { Text } from 'react-native';
 
+import { type Store } from '@reduxjs/toolkit';
+
+import { type DeviceRootState } from '@suite-common/device';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { TradingDeviceConnectionGuard } from './TradingDeviceConnectionGuard';
 import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & DeviceRootState;
 
 const mockNavigation = {
     popToTop: jest.fn(),
@@ -25,14 +31,14 @@ jest.mock('@suite-common/device', () => ({
 }));
 
 describe('TradingDeviceConnectionGuard', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderTradingDeviceConnectionGuard = async () =>
         await renderWithStoreProvider(
             <TradingDeviceConnectionGuard>
                 <Text>CHILDREN</Text>
             </TradingDeviceConnectionGuard>,
-            { store },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.test.tsx
@@ -1,22 +1,26 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { type useListDataFilter } from '@suite-common/trading';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     fireEvent,
     renderHookWithStoreProvider,
     renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils-store';
-import { sellActions } from '@suite-native/trading-state';
+import { type TradingRootState, sellActions } from '@suite-native/trading-state';
 import { type SellFormType } from '@suite-native/trading-types';
 
 import { SellFiatCurrencyPicker } from './SellFiatCurrencyPicker';
 import { useSellForm } from '../../../hooks/sell/useSellForm';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 let mockUseListDataFilter: typeof useListDataFilter;
 const reportMock = jest.fn();
@@ -32,15 +36,14 @@ jest.mock('@suite-common/trading', () => ({
 
 describe('SellFiatCurrencyPicker', () => {
     let form: SellFormType;
-    let store: TestStore;
+    let store: Store<State>;
 
     beforeEach(async () => {
         mockUseListDataFilter = jest.requireActual('@suite-common/trading').useListDataFilter;
         reportMock.mockClear();
-        store = createTradingLightStore({ tradeType: 'sell' });
+        store = createTradingTestStore({ tradeType: 'sell' });
         const { result } = await renderHookWithStoreProvider(() => useSellForm(), {
-            services,
-            store,
+            services: { ...services, store },
         });
         form = result.current;
     });
@@ -54,10 +57,7 @@ describe('SellFiatCurrencyPicker', () => {
             <Form form={form}>
                 <SellFiatCurrencyPicker />
             </Form>,
-            {
-                services,
-                store,
-            },
+            { services: { ...services, store } },
         );
 
     it('should display selected currency', async () => {

--- a/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.test.tsx
@@ -1,13 +1,14 @@
+import { type Store } from '@reduxjs/toolkit';
 import type { CryptoId } from 'invity-api';
 
 import { type NetworkModuleRepositoryDep } from '@suite-common/networks';
 import { mockNetworkModuleRepository } from '@suite-common/networks/mocks';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { Form } from '@suite-native/forms';
 import {
-    type TestStore,
     renderHookWithStoreProvider,
     renderWithStoreProvider,
     userEvent,
@@ -18,6 +19,7 @@ import {
     getInitializedTradingState,
 } from '@suite-native/trading-fixtures';
 import {
+    type TradingRootState,
     selectAccountsWithTokensToSellSectionListByTradingType,
     sellActions,
 } from '@suite-native/trading-state';
@@ -26,7 +28,9 @@ import { BigNumber } from '@trezor/utils';
 
 import { SellSendAssetPicker } from './SellSendAssetPicker';
 import { useSellForm } from '../../../hooks/sell/useSellForm';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 jest.mock('@suite-native/trading-state', () => ({
     ...jest.requireActual('@suite-native/trading-state'),
@@ -59,7 +63,7 @@ jest.mock('@react-navigation/native', () => ({
 
 describe('SellSendAssetPicker', () => {
     let form: SellFormType;
-    let store: TestStore;
+    let store: Store<State>;
 
     const btcAccount = getBtcAccount();
     const ethAccount = getEthAccount();
@@ -89,12 +93,13 @@ describe('SellSendAssetPicker', () => {
     ];
 
     const renderSellForm = async () =>
-        await renderHookWithStoreProvider(() => useSellForm(), { services, store });
+        await renderHookWithStoreProvider(() => useSellForm(), {
+            services: { ...services, store },
+        });
 
     const renderSellSendAssetPicker = async () =>
         await renderWithStoreProvider(<SellSendAssetPicker />, {
-            services,
-            store,
+            services: { ...services, store },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
@@ -103,7 +108,7 @@ describe('SellSendAssetPicker', () => {
         jest.clearAllMocks();
         mockSelectedMyAssetAccountKey = undefined;
         mockSelectedMyAssetCryptoId = undefined;
-        store = createTradingLightStore({
+        store = createTradingTestStore({
             tradeType: 'sell',
             overrides: {
                 wallet: {

--- a/suite-native/module-trading/src/hooks/buy/useBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/useBuyData.test.tsx
@@ -1,31 +1,39 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
+import { type ReduxStoreWithThunk } from '@suite-common/redux-utils';
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { createTestCompositionRoot } from '@suite-common/test-utils';
-import { tradingBuyActions, tradingThunks } from '@suite-common/trading';
+import {
+    type LoadInitialDataThunkDeps,
+    tradingBuyActions,
+    tradingThunks,
+} from '@suite-common/trading';
 import { mockGetSelectedAccount, mockGetTradingEnvironment } from '@suite-common/trading/mocks';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { type AccountsRootState, initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
+    type PreloadedStatePartial,
     act,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading-fixtures';
-import { tradingSlice } from '@suite-native/trading-state';
+import { type TradingRootState, tradingSlice } from '@suite-native/trading-state';
+import { type TradingState } from '@suite-native/trading-types';
 
 import { useBuyData } from './useBuyData';
 import { useExchangeData } from '../exchange/useExchangeData';
 import { useSellData } from '../sell/useSellData';
+
+type State = TradingRootState & AccountsRootState;
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount2') });
 const btc3Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount3') });
 
 describe('useBuyData', () => {
-    const extra = {
+    const extra: LoadInitialDataThunkDeps = {
         services: {
             getSelectedAccount: mockGetSelectedAccount(),
             getTradingEnvironment: mockGetTradingEnvironment(),
@@ -50,19 +58,23 @@ describe('useBuyData', () => {
     } as const;
 
     const getInitializedStore = (tradingAccountKey: AccountKey | undefined) => {
-        const preloadedState = {
+        const tradingState: TradingState = getInitializedTradingState();
+        tradingState.buy.tradingAccountKey = tradingAccountKey;
+
+        const preloadedState: PreloadedStatePartial<State> = {
             wallet: {
-                trading: getInitializedTradingState(),
+                trading: tradingState,
             },
         };
-        preloadedState.wallet.trading.buy.tradingAccountKey = tradingAccountKey;
 
         return createTestCompositionRoot({ extra, reducer, preloadedState }).store;
     };
 
-    const renderUseBuyData = async (store: TestStore) => {
+    const renderUseBuyData = async (
+        store: ReduxStoreWithThunk<State, LoadInitialDataThunkDeps>,
+    ) => {
         const ret = await renderHookWithStoreProvider(useBuyData, {
-            store,
+            services: { store },
         });
 
         await act(() => Promise.resolve()); // Wait for all effects to run
@@ -120,11 +132,11 @@ describe('useBuyData', () => {
             await buy.unmount();
             expect(global.fetch).toHaveBeenCalledTimes(4);
 
-            const tab = await renderHookWithStoreProvider(useData, { store });
+            const tab = await renderHookWithStoreProvider(useData, { services: { store } });
             expect(global.fetch).toHaveBeenCalledTimes(4);
             await tab.unmount();
 
-            const retry = await renderHookWithStoreProvider(useData, { store });
+            const retry = await renderHookWithStoreProvider(useData, { services: { store } });
             expect(global.fetch).toHaveBeenCalledTimes(4);
             await act(async () => {
                 await retry.result.current.refetch();

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.test.ts
@@ -1,16 +1,22 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     getBtcAccount,
     getInitializedTradingStateWithQuotes,
     invityErrorBuyQuote,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 
 import { useBuyFlow } from './useBuyFlow';
 import { useBuyForm } from './useBuyForm';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 const mockSelectQuoteThunk = jest.fn();
 const services: NativeAnalyticsDep = {
@@ -31,14 +37,14 @@ jest.mock('@suite-common/trading', () => ({
 
 describe('useBuyFlow', () => {
     let buyForm: BuyFormType;
-    let store: TestStore;
+    let store: Store<State>;
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     const getInitializedStore = ({ isLoading }: { isLoading?: boolean }) =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'buy',
             overrides: {
                 wallet: {
@@ -51,10 +57,12 @@ describe('useBuyFlow', () => {
         });
 
     const renderBuyForm = async () =>
-        await renderHookWithStoreProvider(() => useBuyForm(), { store, services });
+        await renderHookWithStoreProvider(() => useBuyForm(), { services: { ...services, store } });
 
     const renderUseTradingBuyFlow = async () =>
-        await renderHookWithStoreProvider(() => useBuyFlow(buyForm), { store, services });
+        await renderHookWithStoreProvider(() => useBuyFlow(buyForm), {
+            services: { ...services, store },
+        });
 
     describe('while loading quotes', () => {
         beforeEach(async () => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.test.ts
@@ -1,16 +1,12 @@
 import { Platform } from 'react-native';
 
-import { type EnhancedStore } from '@reduxjs/toolkit';
+import { type Store } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { selectTradingProviderMetadata, tradingBuyActions } from '@suite-common/trading';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
-import {
-    type TestStore,
-    act,
-    renderHookWithStoreProvider,
-    waitFor,
-} from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 import {
     btc1NormalAccount,
     btc2legacyAccount,
@@ -25,12 +21,14 @@ import {
     mercuryoApplePayBuyQuote,
     mercuryoCreditCardBuyQuote,
 } from '@suite-native/trading-fixtures';
-import { selectTradingResidenceCountry } from '@suite-native/trading-state';
+import { type TradingRootState, selectTradingResidenceCountry } from '@suite-native/trading-state';
 import { type BuyFormType, type TradeableAsset } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
 import { clearBuyFormQuoteData, useBuyForm } from './useBuyForm';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 jest.mock('@trezor/react-utils', () => {
     const originalModule = jest.requireActual('@trezor/react-utils');
@@ -46,14 +44,14 @@ const btc2AccountKey = btc2legacyAccount.key;
 const accountDeviceState = btc1NormalAccount.deviceState;
 
 describe('useBuyForm', () => {
-    const renderUseTradingBuyForm = async (store: TestStore) =>
-        await renderHookWithStoreProvider(() => useBuyForm(), { store });
+    const renderUseTradingBuyForm = async (store: Store<State>) =>
+        await renderHookWithStoreProvider(() => useBuyForm(), { services: { store } });
 
     const getInitializedStore = (amountInSats = false) => {
         const tradingState = getInitializedTradingState();
         tradingState.buy.tradingAccountKey = btc1AccountKey;
 
-        return createTradingLightStore({
+        return createTradingTestStore({
             overrides: {
                 device: {
                     selectedDevice: {
@@ -80,7 +78,7 @@ describe('useBuyForm', () => {
         });
     };
 
-    const initFormAndQuotes = async (form: BuyFormType, store: EnhancedStore) => {
+    const initFormAndQuotes = async (form: BuyFormType, store: Store<State>) => {
         await act(() => {
             form.setValue('fiatValue', '10');
             form.setValue('asset', btcAsset);
@@ -307,7 +305,7 @@ describe('useBuyForm', () => {
         });
 
         describe('when quote is selected and new quotes are fetched', () => {
-            let store: EnhancedStore;
+            let store: Store<State>;
             let form: BuyFormType;
 
             beforeEach(async () => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyPreviewFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyPreviewFlow.test.ts
@@ -1,3 +1,6 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
@@ -6,9 +9,12 @@ import {
     getInitializedTradingState,
     mercuryoApplePayBuyQuote,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useBuyPreviewFlow } from './useBuyPreviewFlow';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 const mockPopToTop = jest.fn();
 
@@ -61,7 +67,7 @@ describe('useBuyPreviewFlow', () => {
     } = {}) => {
         const baseBuyState = getInitializedTradingState().buy;
 
-        return createTradingLightStore({
+        return createTradingTestStore({
             tradeType: 'buy',
             overrides: {
                 wallet: {
@@ -82,8 +88,10 @@ describe('useBuyPreviewFlow', () => {
         });
     };
 
-    const renderHook = async (store: ReturnType<typeof getInitializedStore>) =>
-        await renderHookWithStoreProvider(() => useBuyPreviewFlow(), { store, services });
+    const renderHook = async (store: Store<State>) =>
+        await renderHookWithStoreProvider(() => useBuyPreviewFlow(), {
+            services: { ...services, store },
+        });
 
     const getProcessResponseData = () => {
         const [payload] = mockConfirmTradeThunk.mock.calls[0] as [any];

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.test.ts
@@ -1,9 +1,12 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import {
     TRADE_API_RELOAD_QUOTES_AFTER_SECONDS,
     tradingActions,
     tradingBuyActions,
 } from '@suite-common/trading';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     bnbAsset,
     btc1NormalAccount,
@@ -12,11 +15,14 @@ import {
     getInitializedTradingState,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { type BuyFormValues } from '@suite-native/trading-types';
 
 import { useBuyForm } from './useBuyForm';
 import { useBuyQuotes } from './useBuyQuotes';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 jest.mock('@trezor/react-utils', () => {
     const originalModule = jest.requireActual('@trezor/react-utils');
@@ -42,14 +48,14 @@ describe('useBuyQuotes', () => {
         const tradingState = getInitializedTradingState();
         tradingState.buy.tradingAccountKey = eth1NormalAccount.key;
 
-        return createTradingLightStore({
+        return createTradingTestStore({
             overrides: {
                 wallet: { trading: tradingState, accounts: [eth1NormalAccount] },
             },
         });
     };
 
-    const renderUseBuyQuotes = async (store: TestStore) =>
+    const renderUseBuyQuotes = async (store: Store<State>) =>
         await renderHookWithStoreProvider(
             () => {
                 const form = useBuyForm();
@@ -57,7 +63,7 @@ describe('useBuyQuotes', () => {
 
                 return form;
             },
-            { store },
+            { services: { store } },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.test.ts
@@ -3,7 +3,7 @@ import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store
 import { invityDexQuote } from '@suite-native/trading-fixtures';
 
 import { useApprovalFlow } from './useApprovalFlow';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
 
 const mockConfirmApprovalThunk: any = () => () => ({
     unwrap: () => Promise.resolve({}),
@@ -12,7 +12,7 @@ jest.spyOn(exchangeThunks, 'confirmApprovalThunk').mockImplementation(mockConfir
 
 describe('useApprovalFlow', () => {
     it('should return selected quote from exchange state', async () => {
-        const store = createTradingLightStore({
+        const store = createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -25,14 +25,16 @@ describe('useApprovalFlow', () => {
             },
         });
 
-        const { result } = await renderHookWithStoreProvider(() => useApprovalFlow(), { store });
+        const { result } = await renderHookWithStoreProvider(() => useApprovalFlow(), {
+            services: { store },
+        });
 
         expect(result.current.quote).toEqual(invityDexQuote);
     });
 
     it('should update selected quote approval type', async () => {
         const quote = { ...invityDexQuote, approvalType: 'MINIMAL' as const };
-        const store = createTradingLightStore({
+        const store = createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -44,7 +46,9 @@ describe('useApprovalFlow', () => {
                 },
             },
         });
-        const { result } = await renderHookWithStoreProvider(() => useApprovalFlow(), { store });
+        const { result } = await renderHookWithStoreProvider(() => useApprovalFlow(), {
+            services: { store },
+        });
 
         await act(async () => {
             await result.current.onApprovalTypeChange('INFINITE');

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.test.ts
@@ -1,22 +1,24 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { tradingActions } from '@suite-common/trading';
+import { type AccountsRootState, type FeesRootState } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getFormDraftKey } from '@suite-common/wallet-utils';
 import { getTranslation } from '@suite-native/intl';
-import {
-    type TestStore,
-    renderHookWithStoreProvider,
-    waitFor,
-} from '@suite-native/test-utils-store';
+import { renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 import { invityDexQuote } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { mergeDeepObject } from '@trezor/utils';
 
 import { useEvmApprovalFees } from './useEvmApprovalFees';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
-    createTradingLightStore,
+    createTradingTestStore,
 } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & FeesRootState;
 
 const mockComposeEvmApprovalFeeLevelsThunk = jest.fn();
 
@@ -65,15 +67,18 @@ describe('useEvmApprovalFees', () => {
     };
 
     const createStore = (extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'exchange',
             overrides: mergeDeepObject(baseOverrides, extraOverrides),
         });
 
     const renderUseEvmApprovalFees = async (
-        store: TestStore,
+        store: Store<State>,
         params?: Parameters<typeof useEvmApprovalFees>[0],
-    ) => await renderHookWithStoreProvider(() => useEvmApprovalFees(params), { store });
+    ) =>
+        await renderHookWithStoreProvider(() => useEvmApprovalFees(params), {
+            services: { store },
+        });
 
     beforeEach(() => {
         mockComposeEvmApprovalFeeLevelsThunk.mockReset().mockImplementation(() => ({

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeData.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeData.test.ts
@@ -1,29 +1,35 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
+import { type ReduxStoreWithThunk } from '@suite-common/redux-utils';
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { createTestCompositionRoot } from '@suite-common/test-utils';
-import { tradingExchangeActions, tradingThunks } from '@suite-common/trading';
+import {
+    type LoadInitialDataThunkDeps,
+    tradingExchangeActions,
+    tradingThunks,
+} from '@suite-common/trading';
 import { mockGetSelectedAccount, mockGetTradingEnvironment } from '@suite-common/trading/mocks';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { type AccountsRootState, initialWalletSettingsState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading-fixtures';
-import { tradingSlice } from '@suite-native/trading-state';
+import { type TradingRootState, tradingSlice } from '@suite-native/trading-state';
 
 import { useExchangeData } from './useExchangeData';
+
+type State = TradingRootState & AccountsRootState;
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount2') });
 const btc3Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount3') });
 
 describe('useExchangeData', () => {
-    const extra = {
+    const extra: LoadInitialDataThunkDeps = {
         services: {
             getSelectedAccount: mockGetSelectedAccount(),
             getTradingEnvironment: mockGetTradingEnvironment(),
@@ -62,11 +68,13 @@ describe('useExchangeData', () => {
         }).store;
     };
 
-    const renderUseExchangeData = async (store?: TestStore) => {
+    const renderUseExchangeData = async (
+        store?: ReduxStoreWithThunk<State, LoadInitialDataThunkDeps>,
+    ) => {
         const effectiveStore = store ?? createTestCompositionRoot({ extra, reducer }).store;
 
         const ret = await renderHookWithStoreProvider(useExchangeData, {
-            store: effectiveStore,
+            services: { store: effectiveStore },
         });
 
         await act(() => Promise.resolve()); // Wait for all effects to run

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.test.ts
@@ -1,16 +1,23 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type DeviceRootState } from '@suite-common/device';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { RootStackRoutes } from '@suite-native/navigation';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     getBtcAccount,
     getInitializedTradingStateWithQuotes,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { type UseExchangeFlowProps, useExchangeFlow } from './useExchangeFlow';
 import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & DeviceRootState;
 
 const mockNavigate = jest.fn();
 let mockConfirmTradeThunk: jest.Mock;
@@ -78,7 +85,7 @@ describe('useExchangeFlow', () => {
         store,
         flowType,
     }: {
-        store: TestStore;
+        store: Store<State>;
         flowType?: UseExchangeFlowProps['flowType'];
     }) => {
         const reportMock = jest.fn();
@@ -90,8 +97,7 @@ describe('useExchangeFlow', () => {
             reportMock,
             result: (
                 await renderHookWithStoreProvider(() => useExchangeFlow({ flowType }), {
-                    services,
-                    store,
+                    services: { ...services, store },
                 })
             ).result,
         };

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.test.ts
@@ -1,3 +1,4 @@
+import { type Store } from '@reduxjs/toolkit';
 import type { ExchangeTrade } from 'invity-api';
 
 import {
@@ -5,14 +6,10 @@ import {
     selectTradingProviderMetadata,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { getTranslation } from '@suite-native/intl';
-import {
-    type TestStore,
-    act,
-    renderHookWithStoreProvider,
-    waitFor,
-} from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 import {
     accounts,
     btc1NormalAccount,
@@ -30,11 +27,14 @@ import {
     oneInchFusionQuote,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
 import { clearExchangeFormQuoteData, useExchangeForm } from './useExchangeForm';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 type PrefetchDexQuoteApprovalThunk = typeof exchangeThunks.prefetchDexQuoteApprovalThunk;
 
@@ -81,13 +81,13 @@ const eth1AccountKey = eth1NormalAccount.key;
 const accountDeviceState = btc1NormalAccount.deviceState;
 
 describe('useExchangeForm', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseExchangeForm = async () =>
-        await renderHookWithStoreProvider(() => useExchangeForm(), { store });
+        await renderHookWithStoreProvider(() => useExchangeForm(), { services: { store } });
 
     const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 device: {
@@ -571,7 +571,7 @@ describe('useExchangeForm', () => {
                 formattedBalance: '0.0001',
             });
 
-            store = createTradingLightStore({
+            store = createTradingTestStore({
                 tradeType: 'exchange',
                 overrides: {
                     device: {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.test.ts
@@ -1,3 +1,4 @@
+import { type Store } from '@reduxjs/toolkit';
 import { type CryptoId } from 'invity-api';
 
 import {
@@ -6,9 +7,10 @@ import {
     tradingActions,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 import {
     btc1NormalAccount,
     btcAsset,
@@ -18,12 +20,15 @@ import {
     getInitializedTradingState,
     usdtAsset,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { type ExchangeFormValues, type ReceiveAccount } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
 import { useExchangeForm } from './useExchangeForm';
 import { useExchangeQuotes } from './useExchangeQuotes';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 const mockReport = jest.fn();
 const services: NativeAnalyticsDep = {
@@ -50,8 +55,8 @@ jest.mock('@suite-common/trading', () => ({
 }));
 
 describe('useExchangeQuotes', () => {
-    const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN): TestStore =>
-        createTradingLightStore({
+    const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
+        createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -64,7 +69,7 @@ describe('useExchangeQuotes', () => {
             },
         });
 
-    const renderUseExchangeQuotes = async (store: TestStore) =>
+    const renderUseExchangeQuotes = async (store: Store<State>) =>
         await renderHookWithStoreProvider(
             () => {
                 const form = useExchangeForm();
@@ -72,7 +77,7 @@ describe('useExchangeQuotes', () => {
 
                 return { form };
             },
-            { services, store },
+            { services: { ...services, store } },
         );
 
     beforeEach(() => {
@@ -292,6 +297,7 @@ describe('useExchangeQuotes', () => {
             await Promise.resolve();
         });
 
+        dispatchSpy.mockClear();
         await act(() => {
             store.dispatch(
                 tradingActions.setRefetchQuotesTimestamp(
@@ -299,17 +305,14 @@ describe('useExchangeQuotes', () => {
                 ),
             );
         });
-        dispatchSpy.mockClear();
 
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0));
+        await waitFor(() => {
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'handleRequestThunkMock',
+                }),
+            );
         });
-
-        expect(dispatchSpy).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: 'handleRequestThunkMock',
-            }),
-        );
     });
 
     it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', async () => {
@@ -322,6 +325,7 @@ describe('useExchangeQuotes', () => {
             form.setValue('sendAsset', btcAsset);
         });
 
+        dispatchSpy.mockClear();
         await act(() => {
             store.dispatch(
                 tradingActions.setRefetchQuotesTimestamp(
@@ -329,7 +333,6 @@ describe('useExchangeQuotes', () => {
                 ),
             );
         });
-        dispatchSpy.mockClear();
 
         await act(async () => {
             await new Promise(resolve => setTimeout(resolve, 0));
@@ -423,7 +426,7 @@ describe('useExchangeQuotes', () => {
     });
 
     describe('analytics', () => {
-        const renderUseExchangeQuotesWithFilledForm = async (store: TestStore) => {
+        const renderUseExchangeQuotesWithFilledForm = async (store: Store<State>) => {
             const { result } = await renderUseExchangeQuotes(store);
             const { form } = result.current;
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.test.ts
@@ -1,13 +1,15 @@
 import React from 'react';
 
+import { type Store } from '@reduxjs/toolkit';
 import type { ExchangeTrade } from 'invity-api';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { tradingExchangeActions } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { type NativeAnalyticsDep, events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     btcAsset,
     getBtcAccount,
@@ -16,11 +18,14 @@ import {
     invityDexQuote,
     mercuryoFixedBestQuote,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
 import { useExchangeForm } from './useExchangeForm';
 import { useExchangeSelectQuote } from './useExchangeSelectQuote';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
@@ -65,7 +70,7 @@ const useExchangeSelectQuoteWithReportSpy = (exchangeForm: ExchangeFormType) => 
 
 describe('useExchangeSelectQuote', () => {
     let exchangeForm: ExchangeFormType;
-    let store: TestStore;
+    let store: Store<State>;
 
     const btcAccount = getBtcAccount({ descriptor: asAccountDescriptor('btcAccountKey') });
     const ethAccount = getEthAccount({ descriptor: asAccountDescriptor('ethAccountKey') });
@@ -90,7 +95,7 @@ describe('useExchangeSelectQuote', () => {
         tradingState.exchange.tradingAccountKey = btcAccount.key;
         tradingState.exchange.receiveAccountKey = ethAccount.key;
 
-        return createTradingLightStore({
+        return createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -102,12 +107,14 @@ describe('useExchangeSelectQuote', () => {
     };
 
     const renderExchangeForm = async () =>
-        await renderHookWithStoreProvider(() => useExchangeForm(), { store, services });
+        await renderHookWithStoreProvider(() => useExchangeForm(), {
+            services: { ...services, store },
+        });
 
     const renderUseExchangeSelectQuote = async () => {
         const hook = await renderHookWithStoreProvider(
             () => useExchangeSelectQuoteWithReportSpy(exchangeForm),
-            { store, services },
+            { services: { ...services, store } },
         );
 
         const spy = hook.result.current.reportSpy;

--- a/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.test.tsx
@@ -1,4 +1,4 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import {
@@ -12,18 +12,20 @@ import { useForm } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import {
+    type TradingRootState,
     selectTradingResidenceCountry,
     selectTradingResidenceCountrySubdivision,
     tradingSlice,
 } from '@suite-native/trading-state';
 
 import { useCountryChangeEffect } from './useCountryChangeEffect';
+
+type State = TradingRootState;
 
 type CountryFormValues = {
     country: TradingCountryOption | undefined;
@@ -40,7 +42,7 @@ const buildCountryOption = (value: TradingCountryCode): TradingCountryOption => 
 });
 
 describe('useCountryChangeEffect', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const reducer = {
         locale: localeReducer,
@@ -63,7 +65,7 @@ describe('useCountryChangeEffect', () => {
 
                 return form;
             },
-            { store },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.test.ts
@@ -1,14 +1,18 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { selectTradingProviderMetadata } from '@suite-common/trading';
 import { yup } from '@suite-common/validators';
 import { useForm } from '@suite-native/forms';
-import { type TestStore } from '@suite-native/test-utils-store';
 import { buyMercuryo } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useProviderMetadataChangeEffect } from './useProviderMetadataChangeEffect';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
 } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 type ProviderFormValues = {
     quote: {
@@ -28,7 +32,7 @@ jest.mock('@react-navigation/native', () => {
 });
 
 describe('useProviderMetadataChangeEffect', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseProviderMetadataChangeEffect = async (exchange: string | undefined) =>
         await renderHookWithTradingProvider(
@@ -40,11 +44,11 @@ describe('useProviderMetadataChangeEffect', () => {
 
                 return useProviderMetadataChangeEffect(form.control, 'buy');
             },
-            { store, tradeType: 'buy' },
+            { services: { store }, tradeType: 'buy' },
         );
 
     beforeEach(() => {
-        store = createTradingLightStore({ tradeType: 'buy' });
+        store = createTradingTestStore({ tradeType: 'buy' });
         mockIsFocused = true;
     });
 

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.test.ts
@@ -1,24 +1,29 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { tradingExchangeActions } from '@suite-common/trading';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { type AccountsRootState, initialWalletSettingsState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
-import { selectExchangeSelectedReceiveAccount, tradingSlice } from '@suite-native/trading-state';
+import {
+    type TradingRootState,
+    selectExchangeSelectedReceiveAccount,
+    tradingSlice,
+} from '@suite-native/trading-state';
 
 import { useReceiveAccountChangeEffect } from './useReceiveAccountChangeEffect';
 
+type State = TradingRootState & AccountsRootState;
+
 describe('useReceiveAccountChangeEffect', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let setValue: jest.Mock;
 
     const reducer = {
@@ -35,7 +40,7 @@ describe('useReceiveAccountChangeEffect', () => {
     const renderUseReceiveAccountChangeEffect = async () =>
         await renderHookWithStoreProvider(
             () => useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount),
-            { store },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.test.ts
@@ -1,3 +1,5 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { type AccountKey } from '@suite-common/wallet-types';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
@@ -7,6 +9,8 @@ import {
     btcAsset,
 } from '@suite-native/trading-fixtures';
 import {
+    type CombinedSelectorsRootState,
+    type TradingRootState,
     selectBuySelectedReceiveAccount,
     selectExchangeSelectedReceiveAccount,
     tradingActions,
@@ -14,7 +18,9 @@ import {
 import { type TradeableAsset } from '@suite-native/trading-types';
 
 import { useReceiveAccountPreselectionEffect } from './useReceiveAccountPreselectionEffect';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & CombinedSelectorsRootState;
 
 const btc1AccountKey = btc1NormalAccount.key;
 
@@ -24,7 +30,7 @@ describe('useReceiveAccountPreselectionEffect', () => {
         tradingType = 'buy',
         receiveAsset = btcAsset,
     }: {
-        store: ReturnType<typeof createTradingLightStore>;
+        store: Store<State>;
         tradingType?: 'buy' | 'exchange';
         receiveAsset?: TradeableAsset;
     }) =>
@@ -38,7 +44,7 @@ describe('useReceiveAccountPreselectionEffect', () => {
                             ? selectBuySelectedReceiveAccount
                             : selectExchangeSelectedReceiveAccount,
                 }),
-            { store },
+            { services: { store } },
         );
 
     const createStore = ({
@@ -48,7 +54,7 @@ describe('useReceiveAccountPreselectionEffect', () => {
         selectedReceiveAccountKey?: AccountKey;
         tradeType?: 'buy' | 'exchange';
     } = {}) =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType,
             overrides: {
                 device: {
@@ -73,45 +79,51 @@ describe('useReceiveAccountPreselectionEffect', () => {
 
     it('should dispatch buy actions when account is preselected', async () => {
         const store = createStore();
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
 
         await renderUseReceiveAccountPreselectionEffect({ store });
 
-        expect(store.getActions()).toEqual([
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
+        expect(dispatchSpy).toHaveBeenCalledWith(
             tradingActions.setReceiveAccount({
                 tradingType: 'buy',
                 accountKey: btc1AccountKey,
                 address: 'UNUSED1',
             }),
-        ]);
+        );
     });
 
     it('should dispatch exchange actions when account is preselected', async () => {
         const store = createStore({ tradeType: 'exchange' });
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
 
         await renderUseReceiveAccountPreselectionEffect({ store, tradingType: 'exchange' });
 
-        expect(store.getActions()).toEqual([
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
+        expect(dispatchSpy).toHaveBeenCalledWith(
             tradingActions.setReceiveAccount({
                 tradingType: 'exchange',
                 accountKey: btc1AccountKey,
                 address: 'UNUSED1',
             }),
-        ]);
+        );
     });
 
     it('should not dispatch actions when no preselected account can be found', async () => {
         const store = createStore();
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
 
         await renderUseReceiveAccountPreselectionEffect({ store, receiveAsset: adaAsset });
 
-        expect(store.getActions()).toEqual([]);
+        expect(dispatchSpy).not.toHaveBeenCalled();
     });
 
     it('should not dispatch actions when selectedReceiveAccount already has account set', async () => {
         const store = createStore({ selectedReceiveAccountKey: btc1AccountKey });
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
 
         await renderUseReceiveAccountPreselectionEffect({ store });
 
-        expect(store.getActions()).toEqual([]);
+        expect(dispatchSpy).not.toHaveBeenCalled();
     });
 });

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.test.ts
@@ -1,27 +1,32 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { tradingExchangeActions } from '@suite-common/trading';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { type AccountsRootState, initialWalletSettingsState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
-import { selectExchangeSelectedSendAccount, tradingSlice } from '@suite-native/trading-state';
+import {
+    type TradingRootState,
+    selectExchangeSelectedSendAccount,
+    tradingSlice,
+} from '@suite-native/trading-state';
 
 import { useSendAccountChangeEffect } from './useSendAccountChangeEffect';
+
+type State = TradingRootState & AccountsRootState;
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btc2legacy') });
 
 describe('useSendAccountChangeEffect', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let setValue: jest.Mock;
     let onSendAssetCleared: jest.Mock;
 
@@ -45,7 +50,7 @@ describe('useSendAccountChangeEffect', () => {
                     onSendAssetCleared,
                 );
             },
-            { store },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.test.ts
@@ -1,13 +1,17 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { tradingExchangeActions } from '@suite-common/trading';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { type UseFormReturn } from '@suite-native/forms';
-import { type TestStore, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { btcAsset, ethAsset, getBtcAccount, usdcAsset } from '@suite-native/trading-fixtures';
-import { buyActions, exchangeActions } from '@suite-native/trading-state';
+import { type TradingRootState, buyActions, exchangeActions } from '@suite-native/trading-state';
 
 import { useTradeableAssetChange } from './useTradeableAssetChange';
-import { createTradingLightStore } from '../../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep = {
@@ -27,12 +31,12 @@ const createMockForm = (counterpartAsset?: unknown): MockForm => ({
 });
 
 describe('useTradeableAssetChange', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let setSelectedValue: jest.Mock;
 
     beforeEach(() => {
         reportMock.mockClear();
-        store = createTradingLightStore({ tradeType: 'exchange' });
+        store = createTradingTestStore({ tradeType: 'exchange' });
         setSelectedValue = jest.fn();
     });
 
@@ -52,7 +56,7 @@ describe('useTradeableAssetChange', () => {
                     ...config,
                     form: config.form as unknown as UseFormReturn<never>,
                 }),
-            { store, services },
+            { services: { ...services, store } },
         );
 
         return result.current;

--- a/suite-native/module-trading/src/hooks/general/form/useTradeableAssetValidityEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useTradeableAssetValidityEffect.test.ts
@@ -1,4 +1,4 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 import type { CryptoId } from 'invity-api';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
@@ -6,19 +6,20 @@ import { tradingActions } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { btcAsset, getWalletState, usdcAsset } from '@suite-native/trading-fixtures';
-import { tradingSlice } from '@suite-native/trading-state';
+import { type TradingRootState, tradingSlice } from '@suite-native/trading-state';
 
 import { useTradeableAssetValidityEffect } from './useTradeableAssetValidityEffect';
 
+type State = TradingRootState;
+
 describe('useTradeableAssetValidityEffect', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let setValue: jest.Mock;
 
     const reducer = {
@@ -35,7 +36,7 @@ describe('useTradeableAssetValidityEffect', () => {
     const renderEffect = async (cryptoId: CryptoId | undefined) =>
         await renderHookWithStoreProvider(
             () => useTradeableAssetValidityEffect(setValue, cryptoId),
-            { store },
+            { services: { store } },
         );
 
     beforeEach(() => {
@@ -58,14 +59,14 @@ describe('useTradeableAssetValidityEffect', () => {
 
     it('should clear asset when cryptoId is no longer present in coins', async () => {
         await renderEffect(usdcAsset.cryptoId);
-        setValue.mockClear();
+        expect(setValue).not.toHaveBeenCalled();
 
         await act(() => {
             const { coins, platforms } = store.getState().wallet.trading.info;
             store.dispatch(
                 tradingActions.saveInfo({
                     coins: {
-                        bitcoin: coins!.bitcoin,
+                        bitcoin: coins!.bitcoin!,
                     },
                     platforms: platforms!,
                     config: {},

--- a/suite-native/module-trading/src/hooks/general/useActiveTradingTypeReaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useActiveTradingTypeReaction.test.ts
@@ -1,22 +1,24 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { type TradingType } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import {
+    type TradingRootState,
     selectActiveTradingType,
     selectEnabledTradingTypes,
     tradingSlice,
 } from '@suite-native/trading-state';
 
 import { useActiveTradingTypeReaction } from './useActiveTradingTypeReaction';
+
+type State = TradingRootState;
 
 let mockUseRouteParams: {
     tradingType?: TradingType;
@@ -46,8 +48,10 @@ describe('useActiveTradingTypeReaction', () => {
         }),
     } as const;
 
-    const renderUseActiveTradingTypeReaction = async (store: TestStore) =>
-        await renderHookWithStoreProvider(() => useActiveTradingTypeReaction(), { store });
+    const renderUseActiveTradingTypeReaction = async (store: Store<State>) =>
+        await renderHookWithStoreProvider(() => useActiveTradingTypeReaction(), {
+            services: { store },
+        });
 
     beforeEach(() => {
         castedSelectEnabledTradingTypes.mockReturnValue(['buy', 'exchange', 'sell']);

--- a/suite-native/module-trading/src/hooks/general/useAllTradesReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useAllTradesReloadTimer.test.ts
@@ -1,4 +1,7 @@
-import { type TestStore, act } from '@suite-native/test-utils-store';
+import { type Store } from '@reduxjs/toolkit';
+
+import { type TradingRootStateWithDeviceAndAccounts } from '@suite-common/trading';
+import { act } from '@suite-native/test-utils-store';
 import {
     MOCK_ACCOUNT_DEVICE_SESSION_ID,
     btc1NormalAccount,
@@ -8,12 +11,15 @@ import {
     getSellTrade,
     sol1normalAccount,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useAllTradesReloadTimer } from './useAllTradesReloadTimer';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
 } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & TradingRootStateWithDeviceAndAccounts;
 
 // Mock the useReloadTimer hook
 jest.mock('./useReloadTimer', () => ({
@@ -42,7 +48,7 @@ describe('useAllTradesReloadTimer', () => {
     });
 
     const getInitializedStore = ({ trades = [] }: { trades?: any[] } = {}) =>
-        createTradingLightStore({
+        createTradingTestStore({
             overrides: {
                 wallet: {
                     trading: { trades },
@@ -56,8 +62,10 @@ describe('useAllTradesReloadTimer', () => {
             },
         });
 
-    const renderUseAllTradesReloadTimer = async (store: TestStore) =>
-        await renderHookWithTradingProvider(() => useAllTradesReloadTimer(), { store });
+    const renderUseAllTradesReloadTimer = async (store: Store<State>) =>
+        await renderHookWithTradingProvider(() => useAllTradesReloadTimer(), {
+            services: { store },
+        });
 
     it('should enable reload timer when there are trades to watch', async () => {
         const mockTrades = [

--- a/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.test.ts
@@ -1,15 +1,34 @@
-import { formDraftActions } from '@suite-common/wallet-core';
+import { type Store } from '@reduxjs/toolkit';
+
+import { type DeviceRootState } from '@suite-common/device';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import { type TradingRootStateWithDeviceAndAccounts } from '@suite-common/trading';
+import {
+    type AccountsRootState,
+    type FeesRootState,
+    type FormDraftRootState,
+    formDraftActions,
+} from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
-import { FeatureFlag } from '@suite-native/feature-flags';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { FeatureFlag, type FeatureFlagsRootState } from '@suite-native/feature-flags';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     getBtcAccount,
     getInitializedTradingStateWithQuotes,
 } from '@suite-native/trading-fixtures';
-import { getFormDraftKeyByTradeType } from '@suite-native/trading-state';
+import { type TradingRootState, getFormDraftKeyByTradeType } from '@suite-native/trading-state';
 
 import { useComposeTradingTransaction } from './useComposeTradingTransaction';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState &
+    AccountsRootState &
+    DeviceRootState &
+    TradingRootStateWithDeviceAndAccounts &
+    FeesRootState &
+    FormDraftRootState &
+    MessageSystemRootState &
+    FeatureFlagsRootState;
 
 const mockComposeTradingTransactionThunk = jest.fn(
     (payload: unknown) => () =>
@@ -36,12 +55,12 @@ const btcFeeInfo = {
 };
 
 describe('useComposeTradingTransaction', () => {
-    const getInitializedStore = (): TestStore => {
+    const getInitializedStore = (): Store<State> => {
         const tradingState = getInitializedTradingStateWithQuotes();
         tradingState.exchange.tradingAccountKey = btcAccount.key;
         tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
 
-        return createTradingLightStore({
+        return createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 featureFlags: { [FeatureFlag.IsTradingSlip24Enabled]: true },
@@ -71,12 +90,10 @@ describe('useComposeTradingTransaction', () => {
         });
     };
 
-    const renderUseComposeTradingTransaction = async (store: TestStore) =>
+    const renderUseComposeTradingTransaction = async (store: Store<State>) =>
         await renderHookWithStoreProvider(
             () => useComposeTradingTransaction({ tradeType: 'exchange' }),
-            {
-                store,
-            },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.test.tsx
@@ -1,28 +1,38 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
-import { deviceInitialState } from '@suite-common/device';
+import { type DeviceRootState, deviceInitialState } from '@suite-common/device';
 import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import {
+    type AccountsRootState,
+    type WalletSettingsRootState,
+    initialWalletSettingsState,
+} from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
+    type PreloadedStatePartial,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
-import { selectIsAmountInputActive, tradingSlice } from '@suite-native/trading-state';
+import {
+    type TradingRootState,
+    selectIsAmountInputActive,
+    tradingSlice,
+} from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 
 import { useFocusedValueWatch } from './useFocusedValueWatch';
 import { useBuyForm } from '../buy/useBuyForm';
 
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState & DeviceRootState;
+
 jest.mock('./useFocusedValueWatch', () => jest.requireActual('./useFocusedValueWatch'));
 
 describe('useFocusedValueWatch', () => {
     let form: BuyFormType;
-    let store: TestStore;
+    let store: Store<State>;
 
     const reducer = {
         device: createStaticReducer(deviceInitialState),
@@ -36,7 +46,7 @@ describe('useFocusedValueWatch', () => {
         }),
     } as const;
 
-    const preloadedState = {
+    const preloadedState: PreloadedStatePartial<State> = {
         device: deviceInitialState,
         wallet: {
             trading: getWalletState({ tradeType: 'buy' }).trading,
@@ -51,7 +61,7 @@ describe('useFocusedValueWatch', () => {
     const renderUseFocusedValueWatch = async () =>
         await renderHookWithStoreProvider(({ control }) => useFocusedValueWatch(control), {
             initialProps: { control: form.control },
-            store,
+            services: { store },
         });
 
     beforeEach(async () => {

--- a/suite-native/module-trading/src/hooks/general/useGeolocationCountryCode.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useGeolocationCountryCode.test.ts
@@ -1,6 +1,7 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import {
+    type GeolocationRootState,
     geolocationActions,
     geolocationReducer,
     selectCountryCode,
@@ -8,13 +9,14 @@ import {
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
 import { useGeolocationCountryCode } from './useGeolocationCountryCode';
+
+type State = GeolocationRootState;
 
 jest.mock('@suite-common/geolocation', () => {
     const actual = jest.requireActual('@suite-common/geolocation');
@@ -39,8 +41,10 @@ describe('useGeolocationCountryCode', () => {
             },
         });
 
-    const renderUseGeolocationCountryCode = async (store: TestStore) =>
-        await renderHookWithStoreProvider(() => useGeolocationCountryCode(), { store });
+    const renderUseGeolocationCountryCode = async (store: Store<State>) =>
+        await renderHookWithStoreProvider(() => useGeolocationCountryCode(), {
+            services: { store },
+        });
 
     it('should call geolocation thunk on mount', async () => {
         const store = createGeolocationTestStore();

--- a/suite-native/module-trading/src/hooks/general/useQuotesInvalidator.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useQuotesInvalidator.test.ts
@@ -1,16 +1,18 @@
-import { type ActionCreatorWithoutPayload } from '@reduxjs/toolkit';
+import { type ActionCreatorWithoutPayload, type Store } from '@reduxjs/toolkit';
 
-import { type TestStore } from '@suite-native/test-utils-store';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { type AbortablePromise } from '@suite-native/trading-types';
 
 import { type UseQuotesInvalidatorProps, useQuotesInvalidator } from './useQuotesInvalidator';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
 } from '../../test-utils/tradingTestUtils';
 
+type State = TradingRootState;
+
 describe('useQuotesInvalidator', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseQuotesInvalidator = async ({
         isFormValid = false,
@@ -24,7 +26,7 @@ describe('useQuotesInvalidator', () => {
         getClearStateAction = (() => ({ type: 'clearStateAction' })) as ActionCreatorWithoutPayload,
     }: Partial<UseQuotesInvalidatorProps>) =>
         await renderHookWithTradingProvider(props => useQuotesInvalidator(props), {
-            store,
+            services: { store },
             initialProps: {
                 isFormValid,
                 isLoading,
@@ -37,7 +39,7 @@ describe('useQuotesInvalidator', () => {
         });
 
     beforeEach(() => {
-        store = createTradingLightStore();
+        store = createTradingTestStore();
     });
 
     it('should call debounce with empty method when form is not valid', async () => {

--- a/suite-native/module-trading/src/hooks/general/useTradingReceiveAccountSelection.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingReceiveAccountSelection.test.ts
@@ -1,26 +1,31 @@
+import { createMockDispatch } from '@suite-common/redux-utils/mocks';
+import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { btc1NormalAccount, btc2legacyAccount } from '@suite-native/trading-fixtures';
 import { selectExchangeSelectedReceiveAccount, tradingActions } from '@suite-native/trading-state';
 
 import { useTradingReceiveAccountSelection } from './useTradingReceiveAccountSelection';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
 
 describe('useTradingReceiveAccountSelection', () => {
     it.each(['buy', 'exchange'] as const)(
         'should select the %s receive account with one action',
         async tradingType => {
-            const store = createTradingLightStore({ tradeType: tradingType });
+            const { actions, dispatch } = createMockDispatch({
+                getState: () => undefined,
+                extra: undefined,
+            });
             const address = btc1NormalAccount.addresses?.unused[0];
-            const { result } = await renderHookWithStoreProvider(
+            const { result } = await renderHookWithBasicProvider(
                 () => useTradingReceiveAccountSelection(tradingType),
-                { store },
+                { services: { store: { dispatch } } },
             );
 
             await act(() => {
                 result.current({ account: btc1NormalAccount, address });
             });
 
-            expect(store.getActions()).toEqual([
+            expect(actions).toEqual([
                 tradingActions.setReceiveAccount({
                     tradingType,
                     accountKey: btc1NormalAccount.key,
@@ -31,7 +36,7 @@ describe('useTradingReceiveAccountSelection', () => {
     );
 
     it('should not expose a stale address when switching exchange accounts', async () => {
-        const store = createTradingLightStore({
+        const store = createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -51,7 +56,7 @@ describe('useTradingReceiveAccountSelection', () => {
         const unsubscribe = store.subscribe(selectReceiveAccount);
         const { result } = await renderHookWithStoreProvider(
             () => useTradingReceiveAccountSelection('exchange'),
-            { store },
+            { services: { store } },
         );
 
         expect(async () => {

--- a/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.test.ts
@@ -85,7 +85,7 @@ const renderUseTradingStellarActivateToken = async (options?: {
                 receiveCryptoId: options?.receiveCryptoId,
                 buttonTestId: options?.buttonTestId,
             }),
-        { store },
+        { services: { store } },
     );
 };
 

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.test.ts
@@ -1,16 +1,40 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type DeviceRootState } from '@suite-common/device';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import { type TradingRootStateWithDeviceAndAccounts } from '@suite-common/trading';
+import {
+    type AccountsRootState,
+    type FormDraftRootState,
+    type WalletSettingsRootState,
+} from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
-import { FeatureFlag } from '@suite-native/feature-flags';
-import { type TestStore, act } from '@suite-native/test-utils-store';
+import { FeatureFlag, type FeatureFlagsRootState } from '@suite-native/feature-flags';
+import { act } from '@suite-native/test-utils-store';
+import { type TokensRootState } from '@suite-native/tokens';
 import {
     getBtcAccount,
     getInitializedTradingStateWithQuotes,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
+import { type NativeSendRootState } from '@suite-native/transaction-management';
 
 import { useTradingTransaction } from './useTradingTransaction';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
 } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState &
+    AccountsRootState &
+    DeviceRootState &
+    TradingRootStateWithDeviceAndAccounts &
+    FormDraftRootState &
+    WalletSettingsRootState &
+    TokensRootState &
+    NativeSendRootState &
+    MessageSystemRootState &
+    FeatureFlagsRootState;
 
 const mockComposeTradingTransaction = jest.fn();
 
@@ -73,7 +97,7 @@ describe('useTradingTransaction', () => {
         // Set a selected quote so the hook can access selectedQuote.send
         tradingState.exchange.selectedQuote = tradingState.exchange.quotes[0];
 
-        return createTradingLightStore({
+        return createTradingTestStore({
             tradeType: 'exchange',
             overrides: {
                 wallet: {
@@ -98,12 +122,10 @@ describe('useTradingTransaction', () => {
         });
     };
 
-    const renderUseTradingTransaction = async ({ store }: { store: TestStore }) =>
+    const renderUseTradingTransaction = async ({ store }: { store: Store<State> }) =>
         await renderHookWithTradingProvider(
             () => useTradingTransaction({ tradeType: 'exchange' }),
-            {
-                store,
-            },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/useWatchAllTrades.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchAllTrades.test.ts
@@ -1,4 +1,8 @@
-import { type TestStore } from '@suite-native/test-utils-store';
+import { type Store } from '@reduxjs/toolkit';
+
+import { type TradingRootStateWithDeviceAndAccounts } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import {
     MOCK_ACCOUNT_DEVICE_SESSION_ID,
     btc1NormalAccount,
@@ -8,21 +12,19 @@ import {
     getSellTrade,
     sol1normalAccount,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useWatchAllTrades } from './useWatchAllTrades';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
 } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & TradingRootStateWithDeviceAndAccounts;
 
 // Mock the useAllTradesReloadTimer hook
 jest.mock('./useAllTradesReloadTimer', () => ({
     useAllTradesReloadTimer: jest.fn(),
-}));
-
-// Mock the useTransactionStateChangeAnalyticsReporting hook
-jest.mock('./useTransactionStateChangeAnalyticsReporting', () => ({
-    useTransactionStateChangeAnalyticsReporting: jest.fn(),
 }));
 
 const mockUseAllTradesReloadTimer = require('./useAllTradesReloadTimer').useAllTradesReloadTimer;
@@ -50,7 +52,7 @@ describe('useWatchAllTrades', () => {
     });
 
     const getInitializedStore = ({ trades = [] }: { trades?: any[] } = {}) =>
-        createTradingLightStore({
+        createTradingTestStore({
             overrides: {
                 wallet: {
                     trading: { trades },
@@ -64,8 +66,10 @@ describe('useWatchAllTrades', () => {
             },
         });
 
-    const renderUseWatchAllTrades = async (store: TestStore) =>
-        await renderHookWithTradingProvider(() => useWatchAllTrades(), { store });
+    const renderUseWatchAllTrades = async (store: Store<State>) =>
+        await renderHookWithTradingProvider(() => useWatchAllTrades(), {
+            services: { analytics: mockNativeAnalytics(), store },
+        });
 
     it('should return empty arrays when no trades', async () => {
         const store = getInitializedStore();

--- a/suite-native/module-trading/src/hooks/general/useWatchTrade.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchTrade.test.ts
@@ -1,18 +1,23 @@
 import React from 'react';
 
+import { type Store } from '@reduxjs/toolkit';
+
 import { useServices } from '@suite-common/dependency-injection';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { type NativeAnalyticsDep, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { type TestStore } from '@suite-native/test-utils-store';
 import { getBuyTrade } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useWatchTrade } from './useWatchTrade';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
 } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 jest.mock('./useReloadTimer', () => ({
     useReloadTimer: jest.fn(),
@@ -78,7 +83,7 @@ describe('useWatchTrade', () => {
         trades = [],
         accounts = [],
     }: { trades?: any[]; accounts?: any[] } = {}) =>
-        createTradingLightStore({
+        createTradingTestStore({
             overrides: {
                 wallet: {
                     trading: { trades },
@@ -109,7 +114,7 @@ describe('useWatchTrade', () => {
         });
 
     const renderUseWatchTrade = async (
-        store: TestStore,
+        store: Store<State>,
         props: {
             accountKey?: AccountKey;
             orderId?: string;
@@ -119,8 +124,7 @@ describe('useWatchTrade', () => {
         },
     ) =>
         await renderHookWithTradingProvider(() => useWatchTradeWithReportSpy(props), {
-            store,
-            services,
+            services: { ...services, store },
         });
 
     describe('Trade Watching Behavior', () => {
@@ -230,13 +234,16 @@ describe('useWatchTrade', () => {
                         orderId: buyTrade.data.orderId,
                         isEnabled,
                     }),
-                { store, services },
+                { services: { ...services, store } },
             );
 
             expect(mockWatchTradeThunk).toHaveBeenCalledTimes(1);
 
             isEnabled = false;
             await rerender({});
+
+            expect(mockWatchTradeThunk).toHaveBeenCalledTimes(1);
+
             isEnabled = true;
             await rerender({});
 

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewErrorAlert.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewErrorAlert.test.ts
@@ -1,13 +1,20 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type DeviceRootState } from '@suite-common/device';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
-import { type TestStore, act } from '@suite-native/test-utils-store';
+import { act } from '@suite-native/test-utils-store';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useTradingOutputsReviewErrorAlert } from './useTradingOutputsReviewErrorAlert';
 import {
-    createTradingLightStore,
+    createTradingTestStore,
     renderHookWithTradingProvider,
 } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & DeviceRootState;
 
 const mockShowAlert = jest.fn();
 
@@ -18,16 +25,16 @@ jest.mock('@suite-native/alerts', () => ({
 }));
 
 describe('useTradingOutputsReviewErrorAlert', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseTradingOutputsReviewErrorAlert = async (accountKey: AccountKey) =>
         await renderHookWithTradingProvider(() => useTradingOutputsReviewErrorAlert(accountKey), {
-            store,
+            services: { store },
         });
 
     beforeEach(() => {
         jest.clearAllMocks();
-        store = createTradingLightStore({ tradeType: 'exchange' });
+        store = createTradingTestStore({ tradeType: 'exchange' });
     });
 
     it('should show alert', async () => {

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.test.ts
@@ -1,7 +1,9 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
 import {
+    type AccountsRootState,
+    type SendRootState,
     type SendState,
     initialWalletSettingsState,
     sendFormActions,
@@ -10,20 +12,24 @@ import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { localeReducer } from '@suite-native/intl';
 import { type ExchangeFlowType } from '@suite-native/navigation';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { createPrecomposedTxFinal, getWalletState } from '@suite-native/trading-fixtures';
-import { tradingSlice } from '@suite-native/trading-state';
-import { prepareSendFormReducer } from '@suite-native/transaction-management';
+import { type TradingRootState, tradingSlice } from '@suite-native/trading-state';
+import {
+    type NativeSendRootState,
+    prepareSendFormReducer,
+} from '@suite-native/transaction-management';
 import TrezorConnect from '@trezor/connect';
 
 import { useTradingOutputsReviewScreenControls } from './useTradingOutputsReviewScreenControls';
 import { type TradingExchangeSignAndSendTransactionProps } from '../exchange/useExchangeFlow';
 import { type TradingTransactionSignAndSendProps } from '../general/useTradingTransaction';
+
+type State = TradingRootState & AccountsRootState & SendRootState & NativeSendRootState;
 
 const mockReportToAnalytics = jest.fn();
 const mockResolveTransactionSendConsent = jest.fn();
@@ -105,7 +111,7 @@ jest.mock('@suite-native/alerts', () => ({
 }));
 
 describe('useTradingOutputsReviewScreenControls', () => {
-    let store: TestStore;
+    let store: Store<State>;
     const mockTrezorConnectCancel = TrezorConnect.cancel as jest.Mock;
 
     const reducer = {
@@ -159,9 +165,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
                     reportToAnalytics: mockReportToAnalytics,
                     exchangeFlowType,
                 }),
-            {
-                store,
-            },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/sell/useSellData.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/useSellData.test.tsx
@@ -1,29 +1,35 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
+import { type ReduxStoreWithThunk } from '@suite-common/redux-utils';
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { createTestCompositionRoot } from '@suite-common/test-utils';
-import { tradingSellActions, tradingThunks } from '@suite-common/trading';
+import {
+    type LoadInitialDataThunkDeps,
+    tradingSellActions,
+    tradingThunks,
+} from '@suite-common/trading';
 import { mockGetSelectedAccount, mockGetTradingEnvironment } from '@suite-common/trading/mocks';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { type AccountsRootState, initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading-fixtures';
-import { tradingSlice } from '@suite-native/trading-state';
+import { type TradingRootState, tradingSlice } from '@suite-native/trading-state';
 
 import { useSellData } from './useSellData';
+
+type State = TradingRootState & AccountsRootState;
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount2') });
 const btc3Account = getBtcAccount({ descriptor: asAccountDescriptor('btcAccount3') });
 
 describe('useSellData', () => {
-    const extra = {
+    const extra: LoadInitialDataThunkDeps = {
         services: {
             getSelectedAccount: mockGetSelectedAccount(),
             getTradingEnvironment: mockGetTradingEnvironment(),
@@ -64,9 +70,11 @@ describe('useSellData', () => {
 
     const getDefaultStore = () => createTestCompositionRoot({ extra, reducer }).store;
 
-    const renderUseSellData = async (store?: TestStore) => {
+    const renderUseSellData = async (
+        store?: ReduxStoreWithThunk<State, LoadInitialDataThunkDeps>,
+    ) => {
         const ret = await renderHookWithStoreProvider(useSellData, {
-            store: store ?? getDefaultStore(),
+            services: { store: store ?? getDefaultStore() },
         });
 
         await act(() => Promise.resolve()); // Wait for all effects to run

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.test.ts
@@ -1,21 +1,26 @@
+import { type Store } from '@reduxjs/toolkit';
 import type { SellFiatTrade, SellFiatTradeResponse } from 'invity-api';
 
 import { tradingSellActions } from '@suite-common/trading';
 import type { sellThunks } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { type NativeAnalyticsDep } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     banxaCreditCardSellQuote,
     getBtcAccount,
     verifiedBankAccount,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useSellFlow } from './useSellFlow';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
 
-// Store captured arguments for testing side effects (processResponseData callback)
+type State = TradingRootState & AccountsRootState;
+
+// Store<State> captured arguments for testing side effects (processResponseData callback)
 let capturedHandleTradeArgs: Parameters<typeof sellThunks.handleTradeThunk>[0] | null = null;
 
 jest.mock('@suite-common/trading', () => ({
@@ -72,13 +77,15 @@ const services: NativeAnalyticsDep = {
 };
 
 describe('useSellFlow', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseSellFlow = async () =>
-        await renderHookWithStoreProvider(() => useSellFlow(), { store, services });
+        await renderHookWithStoreProvider(() => useSellFlow(), {
+            services: { ...services, store },
+        });
 
     beforeEach(() => {
-        store = createTradingLightStore({ tradeType: 'sell' });
+        store = createTradingTestStore({ tradeType: 'sell' });
 
         capturedHandleTradeArgs = null;
         jest.clearAllMocks();

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.test.tsx
@@ -1,15 +1,11 @@
+import { type Store } from '@reduxjs/toolkit';
 import type { SellFiatTrade } from 'invity-api';
 
 import { tradingSellActions } from '@suite-common/trading';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { getTranslation } from '@suite-native/intl';
-import {
-    type TestStore,
-    act,
-    renderHookWithStoreProvider,
-    screen,
-    waitFor,
-} from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider, screen, waitFor } from '@suite-native/test-utils-store';
 import {
     banxaBankTransferSellQuote,
     banxaCreditCardSellQuote,
@@ -20,24 +16,26 @@ import {
     sellQuotes,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
-import { selectTradingResidenceCountry } from '@suite-native/trading-state';
+import { type TradingRootState, selectTradingResidenceCountry } from '@suite-native/trading-state';
 import { type SellFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
 import { useSellForm } from './useSellForm';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const eth1Account = getEthAccount({ descriptor: asAccountDescriptor('eth1normal') });
 
 describe('useSellForm', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseSellForm = async () =>
-        await renderHookWithStoreProvider(() => useSellForm(), { store });
+        await renderHookWithStoreProvider(() => useSellForm(), { services: { store } });
 
     const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'sell',
             overrides: {
                 wallet: { settings: { bitcoinAmountUnit } },
@@ -243,7 +241,7 @@ describe('useSellForm', () => {
                 formattedBalance: '0.0001',
             });
 
-            store = createTradingLightStore({
+            store = createTradingTestStore({
                 tradeType: 'sell',
                 overrides: {
                     wallet: { accounts: [richBtcAccount, poorBtcAccount] },

--- a/suite-native/module-trading/src/hooks/sell/useSellPreviewFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellPreviewFlow.test.ts
@@ -4,7 +4,7 @@ import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store
 import { banxaCreditCardSellQuote, eth1NormalAccount } from '@suite-native/trading-fixtures';
 
 import { useSellPreviewFlow } from './useSellPreviewFlow';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
 
 const mockReplace = jest.fn();
 
@@ -24,7 +24,7 @@ describe('useSellPreviewFlow', () => {
     });
 
     it('reports preview continue and replaces the route', async () => {
-        const store = createTradingLightStore({
+        const store = createTradingTestStore({
             tradeType: 'sell',
             overrides: {
                 wallet: {
@@ -38,8 +38,7 @@ describe('useSellPreviewFlow', () => {
             },
         });
         const { result } = await renderHookWithStoreProvider(() => useSellPreviewFlow(), {
-            store,
-            services,
+            services: { ...services, store },
         });
 
         await act(() => result.current.continueToProvider());

--- a/suite-native/module-trading/src/hooks/sell/useSellQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellQuotes.test.ts
@@ -1,10 +1,13 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import {
     TRADE_API_RELOAD_QUOTES_AFTER_SECONDS,
     tradingActions,
     tradingSellActions,
 } from '@suite-common/trading';
+import { type AccountsRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
-import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     banxaCreditCardSellQuote,
     bnbAsset,
@@ -13,11 +16,14 @@ import {
     sellQuotes,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { type SellFormValues } from '@suite-native/trading-types';
 
 import { useSellForm } from './useSellForm';
 import { useSellQuotes } from './useSellQuotes';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState & WalletSettingsRootState;
 
 const mockDebounce = (fn: () => unknown) => fn();
 
@@ -45,7 +51,7 @@ jest.mock('@suite-common/trading', () => ({
 
 describe('useSellQuotes', () => {
     const getInitializedStore = () =>
-        createTradingLightStore({
+        createTradingTestStore({
             tradeType: 'sell',
             overrides: {
                 wallet: {
@@ -54,7 +60,7 @@ describe('useSellQuotes', () => {
             },
         });
 
-    const renderUseSellQuotes = async (store: TestStore) =>
+    const renderUseSellQuotes = async (store: Store<State>) =>
         await renderHookWithStoreProvider(
             () => {
                 const form = useSellForm();
@@ -62,7 +68,7 @@ describe('useSellQuotes', () => {
 
                 return form;
             },
-            { store },
+            { services: { store } },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.test.ts
@@ -1,16 +1,17 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { tradingSellActions } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
-import {
-    type TestStore,
-    act,
-    renderHookWithStoreProvider,
-    waitFor,
-} from '@suite-native/test-utils-store';
+import { act, renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 import { banxaCreditCardSellQuote } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { useSellForm } from './useSellForm';
 import { useSellSelectQuote } from './useSellSelectQuote';
-import { createTradingLightStore } from '../../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
@@ -20,7 +21,7 @@ jest.mock('@suite-common/trading', () => ({
 }));
 
 describe('useSellSelectQuote', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseSellSelectQuote = async () =>
         await renderHookWithStoreProvider(
@@ -29,11 +30,11 @@ describe('useSellSelectQuote', () => {
 
                 return { form, ...useSellSelectQuote(form) };
             },
-            { store },
+            { services: { store } },
         );
 
     beforeEach(() => {
-        store = createTradingLightStore({ tradeType: 'sell' });
+        store = createTradingTestStore({ tradeType: 'sell' });
     });
 
     describe('canProceed', () => {

--- a/suite-native/module-trading/src/navigation/TradingStackNavigator.test.tsx
+++ b/suite-native/module-trading/src/navigation/TradingStackNavigator.test.tsx
@@ -1,25 +1,43 @@
 import { mockMessageSystemStateWithFeatureFlags } from '@suite-common/message-system/mocks';
+import { type NetworkModuleRepositoryDep } from '@suite-common/networks';
+import { mockNetworkModuleRepository } from '@suite-common/networks/mocks';
+import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 
 import { TradingStackNavigator } from './TradingStackNavigator';
 import {
+    type PreloadedStatePartial,
+    type TradingTestPreloadedState,
     createTradingFeatureFlags,
+    createTradingTestStore,
     renderWithTradingProvider,
 } from '../test-utils/tradingTestUtils';
 
-jest.mock('../hooks/buy/useBuyData', () => ({
-    useBuyData: () => ({
-        isLoading: true,
-        lastLoadedTimestamp: 0,
-        isFullyLoaded: false,
-    }),
-}));
+const services: NativeAnalyticsDep & NetworkModuleRepositoryDep = {
+    analytics: mockNativeAnalytics(),
+    networkModuleRepository: mockNetworkModuleRepository(),
+};
+
+const renderTradingStackNavigator = (
+    overrides: PreloadedStatePartial<TradingTestPreloadedState>,
+) => {
+    const store = createTradingTestStore({ overrides });
+
+    return renderWithTradingProvider(<TradingStackNavigator />, {
+        services: { ...services, store: { ...store, dispatch: jest.fn() } },
+    });
+};
 
 describe('TradingStackNavigator', () => {
     it('should render', async () => {
-        const { getByTestId } = await renderWithTradingProvider(<TradingStackNavigator />, {
-            overrides: {
-                featureFlags: createTradingFeatureFlags({}),
-                messageSystem: mockMessageSystemStateWithFeatureFlags({}),
+        const { getByTestId } = await renderTradingStackNavigator({
+            featureFlags: createTradingFeatureFlags({}),
+            messageSystem: mockMessageSystemStateWithFeatureFlags({}),
+            wallet: {
+                trading: {
+                    isLoading: true,
+                    info: { coins: undefined, platforms: undefined },
+                },
             },
         });
 
@@ -27,16 +45,14 @@ describe('TradingStackNavigator', () => {
     });
 
     it('should not render when all feature flags are disabled', async () => {
-        const { queryByTestId } = await renderWithTradingProvider(<TradingStackNavigator />, {
-            overrides: {
-                featureFlags: createTradingFeatureFlags({}),
-                messageSystem: mockMessageSystemStateWithFeatureFlags({
-                    'trading.buy': false,
-                    'trading.exchange': false,
-                    'trading.sell': false,
-                    'trading.concierge': false,
-                }),
-            },
+        const { queryByTestId } = await renderTradingStackNavigator({
+            featureFlags: createTradingFeatureFlags({}),
+            messageSystem: mockMessageSystemStateWithFeatureFlags({
+                'trading.buy': false,
+                'trading.exchange': false,
+                'trading.sell': false,
+                'trading.concierge': false,
+            }),
         });
 
         expect(queryByTestId('@screen/Trading')).toBeFalsy();

--- a/suite-native/module-trading/src/screens/TradingBuyPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingBuyPreviewScreen.test.tsx
@@ -1,5 +1,7 @@
 import type { BuyTrade, ProviderMetadata } from 'invity-api';
 
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
 import {
     buyMercuryo,
@@ -17,14 +19,6 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockAnalyticsReport = jest.fn();
-jest.mock('@suite-native/trading-analytics', () => ({
-    ...jest.requireActual('@suite-native/trading-analytics'),
-    useBuyAnalyticsStepReport:
-        (step: unknown) =>
-        (...args: unknown[]) =>
-            mockAnalyticsReport(step, ...args),
-}));
-
 describe('TradingBuyPreviewScreen', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -43,6 +37,7 @@ describe('TradingBuyPreviewScreen', () => {
 
         return await renderWithTradingProvider(<TradingBuyPreviewScreen />, {
             tradeType: 'buy',
+            services: { analytics: mockNativeAnalytics(mockAnalyticsReport) },
             overrides: { wallet: { trading: tradingState } },
         });
     };
@@ -84,7 +79,10 @@ describe('TradingBuyPreviewScreen', () => {
             providerMetadata: buyMercuryo,
         });
 
-        expect(mockAnalyticsReport).toHaveBeenCalledWith('buy-preview', 'visit');
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.tradingBuyEvent.name,
+            payload: expect.objectContaining({ step: 'buy-preview', action: 'visit' }),
+        });
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
     });
 });

--- a/suite-native/module-trading/src/screens/TradingConfirmingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingConfirmingScreen.test.tsx
@@ -1,21 +1,29 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import type { TransactionStatus } from '@suite-common/trading';
 import {
     selectTradingExchangeSelectedQuote,
     tradingExchangeActions,
     useAllowanceTxTracking,
 } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { type RootStackParamList, RootStackRoutes } from '@suite-native/navigation';
-import { type TestStore, act, renderWithStoreProvider } from '@suite-native/test-utils-store';
+import { act, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { mockTransaction } from '@suite-native/tokens';
 import { exchangeQuotes } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 import {
     useNavigationRemoveInterceptorAlert,
     useTransactionDetails,
 } from '@suite-native/transaction-management';
 
 import { TradingConfirmingScreen } from './TradingConfirmingScreen';
-import { createTradingLightStore } from '../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 const mockOpenInBlockchain = jest.fn();
 
@@ -87,18 +95,10 @@ jest.mock('@suite-common/trading', () => ({
 }));
 
 const mockAnalyticsReport = jest.fn();
-jest.mock('@suite-native/trading-analytics', () => ({
-    ...jest.requireActual('@suite-native/trading-analytics'),
-    useExchangeAnalyticsStepReport:
-        (action: unknown) =>
-        (...args: unknown[]) =>
-            mockAnalyticsReport(action, ...args),
-}));
-
 const mockUseAllowanceTxTracking = useAllowanceTxTracking as jest.Mock;
 
 describe('TradingConfirmingScreen', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderScreen = async (
         routeProps: Partial<RootStackParamList[RootStackRoutes.TradingConfirming]> = {},
@@ -110,13 +110,13 @@ describe('TradingConfirmingScreen', () => {
 
         return await renderWithStoreProvider(
             <TradingConfirmingScreen navigation={mockNavigation} route={mockUseRoute()} />,
-            { store },
+            { services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store } },
         );
     };
 
     beforeEach(() => {
         jest.clearAllMocks();
-        store = createTradingLightStore({ tradeType: 'exchange' });
+        store = createTradingTestStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         mockUseAllowanceTxTracking.mockReturnValue({
             status: mockAllowanceTxStatus,
@@ -324,7 +324,10 @@ describe('TradingConfirmingScreen', () => {
         it('should report approval-confirming visit ', async () => {
             await renderScreen();
 
-            expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-confirming', 'visit');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingExchangeEvent.name,
+                payload: expect.objectContaining({ step: 'approval-confirming', action: 'visit' }),
+            });
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
@@ -345,14 +348,20 @@ describe('TradingConfirmingScreen', () => {
                 onRemoveConfirmed();
             });
 
-            expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-confirming', 'cancel');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingExchangeEvent.name,
+                payload: expect.objectContaining({ step: 'approval-confirming', action: 'cancel' }),
+            });
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(2);
         });
 
         it('should report revoke-confirming visit for revoke', async () => {
             await renderScreen({ flowType: 'revoke' });
 
-            expect(mockAnalyticsReport).toHaveBeenCalledWith('revoke-confirming', 'visit');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingExchangeEvent.name,
+                payload: expect.objectContaining({ step: 'revoke-confirming', action: 'visit' }),
+            });
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
@@ -367,7 +376,13 @@ describe('TradingConfirmingScreen', () => {
                 );
             });
 
-            expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-confirming', 'continue');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingExchangeEvent.name,
+                payload: expect.objectContaining({
+                    step: 'approval-confirming',
+                    action: 'continue',
+                }),
+            });
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(2);
         });
     });

--- a/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.test.tsx
@@ -1,17 +1,23 @@
 import { type NavigationAction, type RouteProp } from '@react-navigation/native';
+import { type Store } from '@reduxjs/toolkit';
 
 import { selectTradingExchangeSelectedQuote, tradingExchangeActions } from '@suite-common/trading';
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
 import {
     type RootStackParamList,
     RootStackRoutes,
     useNavigationRemoveActionInterceptor,
 } from '@suite-native/navigation';
-import { type TestStore, fireEvent } from '@suite-native/test-utils-store';
+import { fireEvent } from '@suite-native/test-utils-store';
 import { eth1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { TradingExchangeApprovalScreen } from './TradingExchangeApprovalScreen';
-import { createTradingLightStore, renderWithTradingProvider } from '../test-utils/tradingTestUtils';
+import { createTradingTestStore, renderWithTradingProvider } from '../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 const mockShowSheet = jest.fn();
 const mockHideSheet = jest.fn();
@@ -68,14 +74,6 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockAnalyticsReport = jest.fn();
-jest.mock('@suite-native/trading-analytics', () => ({
-    ...jest.requireActual('@suite-native/trading-analytics'),
-    useExchangeAnalyticsStepReport:
-        (action: unknown) =>
-        (...args: unknown[]) =>
-            mockAnalyticsReport(action, ...args),
-}));
-
 jest.mock('@suite-native/atoms', () => ({
     ...jest.requireActual('@suite-native/atoms'),
     useBottomSheetControls: () => ({
@@ -94,7 +92,7 @@ jest.mock('@suite-common/device', () => ({
 const testQuote = mercuryoFixedWorstQuote;
 
 describe('TradingExchangeApprovalScreen', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let unmount: (() => void) | undefined;
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -105,7 +103,10 @@ describe('TradingExchangeApprovalScreen', () => {
                 route={{ params } as any}
                 navigation={{ dispatch: mockNavigationDispatch } as any}
             />,
-            { store, tradeType: 'exchange' },
+            {
+                services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store },
+                tradeType: 'exchange',
+            },
         );
 
         ({ unmount } = result);
@@ -118,7 +119,7 @@ describe('TradingExchangeApprovalScreen', () => {
 
         mockIsDeviceConnected = true;
 
-        store = createTradingLightStore({ tradeType: 'exchange' });
+        store = createTradingTestStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1NormalAccount.key));
     });
@@ -222,7 +223,10 @@ describe('TradingExchangeApprovalScreen', () => {
         it('should report approval-preview visit ', async () => {
             await renderScreen();
 
-            expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-preview', 'visit');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingExchangeEvent.name,
+                payload: expect.objectContaining({ step: 'approval-preview', action: 'visit' }),
+            });
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
@@ -232,7 +236,10 @@ describe('TradingExchangeApprovalScreen', () => {
 
             triggerPreventNavigationRemove({ type: 'GO_BACK' });
 
-            expect(mockAnalyticsReport).toHaveBeenCalledWith('approval-preview', 'cancel');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingExchangeEvent.name,
+                payload: expect.objectContaining({ step: 'approval-preview', action: 'cancel' }),
+            });
         });
     });
 });

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx
@@ -1,17 +1,14 @@
 import { type RouteProp } from '@react-navigation/native';
+import { type Store } from '@reduxjs/toolkit';
 import type { ExchangeTrade } from 'invity-api';
 
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { type RootStackParamList, RootStackRoutes } from '@suite-native/navigation';
-import {
-    type TestStore,
-    renderWithStoreProvider,
-    userEvent,
-    waitFor,
-} from '@suite-native/test-utils-store';
+import { renderWithStoreProvider, userEvent, waitFor } from '@suite-native/test-utils-store';
 import {
     createPrecomposedTxFinal,
     exchangeQuotes,
@@ -21,6 +18,7 @@ import {
     mercuryoFixedWorstQuote,
     oneInchFusionPlusWithEip712SignDataQuote,
 } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import {
     TradingExchangePreviewScreen,
@@ -28,7 +26,9 @@ import {
 } from './TradingExchangePreviewScreen';
 import { useDexExchangeTxSimulation } from '../hooks/exchange/useDexExchangeTxSimulation';
 import { useExchangeIssue } from '../hooks/exchange/useExchangeIssue';
-import { createTradingLightStore } from '../test-utils/tradingTestUtils';
+import { createTradingTestStore } from '../test-utils/tradingTestUtils';
+
+type State = TradingRootState & AccountsRootState;
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const eth1Account = getEthAccount({ descriptor: asAccountDescriptor('eth1normal') });
@@ -113,7 +113,7 @@ const mockPopToTop = jest.fn();
 const mockNavigate = jest.fn();
 
 const createStore = (quote?: ExchangeTrade) =>
-    createTradingLightStore({
+    createTradingTestStore({
         tradeType: 'exchange',
         overrides: {
             wallet: {
@@ -148,13 +148,13 @@ const createRouteProps = (isApproved: boolean = false) =>
     ({ params: { isApproved } }) as TradingExchangePreviewScreenProps['route'];
 
 describe('TradingExchangePreviewScreen', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let consoleErrorSpy: jest.SpyInstance;
     let unmount: (() => void) | undefined;
 
     const renderTradingExchangePreviewScreen = async (
         isApproved: boolean = false,
-        customStore?: TestStore,
+        customStore?: Store<State>,
     ) => {
         const testStore = customStore ?? store;
         const reportMock = jest.fn();
@@ -168,7 +168,7 @@ describe('TradingExchangePreviewScreen', () => {
                 navigation={createNavigationProps()}
                 route={createRouteProps(isApproved)}
             />,
-            { services, store: testStore },
+            { services: { ...services, store: testStore } },
         );
 
         ({ unmount } = result);

--- a/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.test.tsx
@@ -1,17 +1,22 @@
 import { type NavigationAction, type RouteProp } from '@react-navigation/native';
+import { type Store } from '@reduxjs/toolkit';
 
 import { selectTradingExchangeSelectedQuote, tradingExchangeActions } from '@suite-common/trading';
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
 import {
     type RootStackParamList,
     RootStackRoutes,
     useNavigationRemoveActionInterceptor,
 } from '@suite-native/navigation';
-import { type TestStore } from '@suite-native/test-utils-store';
 import { eth1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import { TradingExchangeRevokeScreen } from './TradingExchangeRevokeScreen';
-import { createTradingLightStore, renderWithTradingProvider } from '../test-utils/tradingTestUtils';
+import { createTradingTestStore, renderWithTradingProvider } from '../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 const mockShowSheet = jest.fn();
 const mockHideSheet = jest.fn();
@@ -81,18 +86,10 @@ jest.mock('@suite-common/device', () => ({
 }));
 
 const mockAnalyticsReport = jest.fn();
-jest.mock('@suite-native/trading-analytics', () => ({
-    ...jest.requireActual('@suite-native/trading-analytics'),
-    useExchangeAnalyticsStepReport:
-        (action: unknown) =>
-        (...args: unknown[]) =>
-            mockAnalyticsReport(action, ...args),
-}));
-
 const testQuote = mercuryoFixedWorstQuote;
 
 describe('TradingExchangeRevokeScreen', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let unmount: (() => void) | undefined;
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -103,7 +100,10 @@ describe('TradingExchangeRevokeScreen', () => {
                 route={{ params } as any}
                 navigation={{ dispatch: mockNavigationDispatch } as any}
             />,
-            { store, tradeType: 'exchange' },
+            {
+                services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store },
+                tradeType: 'exchange',
+            },
         );
 
         ({ unmount } = result);
@@ -116,7 +116,7 @@ describe('TradingExchangeRevokeScreen', () => {
 
         mockIsDeviceConnected = true;
 
-        store = createTradingLightStore({ tradeType: 'exchange' });
+        store = createTradingTestStore({ tradeType: 'exchange' });
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         store.dispatch(tradingExchangeActions.setTradingAccountKey(eth1NormalAccount.key));
     });
@@ -207,7 +207,10 @@ describe('TradingExchangeRevokeScreen', () => {
         it('should report revoke-preview visit ', async () => {
             await renderScreen();
 
-            expect(mockAnalyticsReport).toHaveBeenCalledWith('revoke-preview', 'visit');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingExchangeEvent.name,
+                payload: expect.objectContaining({ step: 'revoke-preview', action: 'visit' }),
+            });
             expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
         });
 
@@ -217,7 +220,10 @@ describe('TradingExchangeRevokeScreen', () => {
 
             triggerPreventNavigationRemove({ type: 'GO_BACK' });
 
-            expect(mockAnalyticsReport).toHaveBeenCalledWith('revoke-preview', 'cancel');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingExchangeEvent.name,
+                payload: expect.objectContaining({ step: 'revoke-preview', action: 'cancel' }),
+            });
         });
     });
 });

--- a/suite-native/module-trading/src/screens/TradingOutputsReviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingOutputsReviewScreen.test.tsx
@@ -1,19 +1,23 @@
 import { type RouteProp } from '@react-navigation/native';
+import { type Store } from '@reduxjs/toolkit';
 
 import { type TokenAddress } from '@suite-common/wallet-types';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import type {
     ExchangeFlowType,
     RootStackParamList,
     RootStackRoutes,
     StackProps,
 } from '@suite-native/navigation';
-import { type TestStore } from '@suite-native/test-utils-store';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 import {
     TradingExchangeOutputsReviewScreen,
     TradingSellOutputsReviewScreen,
 } from './TradingOutputsReviewScreen';
-import { createTradingLightStore, renderWithTradingProvider } from '../test-utils/tradingTestUtils';
+import { createTradingTestStore, renderWithTradingProvider } from '../test-utils/tradingTestUtils';
+
+type State = TradingRootState;
 
 const mockSignAndSendTransaction = jest.fn();
 const mockSignDataAndConfirm = jest.fn();
@@ -30,15 +34,6 @@ const mockUseSellFlow = {
     isTransactionSendConsentRequested: false,
     resolveTransactionSendConsent: mockResolveTransactionSendConsent,
 };
-
-const mockReportToAnalyticsExchange = jest.fn();
-const mockReportToAnalyticsSell = jest.fn();
-
-jest.mock('@suite-native/trading-analytics', () => ({
-    ...jest.requireActual('@suite-native/trading-analytics'),
-    useExchangeAnalyticReportCallback: () => mockReportToAnalyticsExchange,
-    useSellAnalyticReportCallback: () => mockReportToAnalyticsSell,
-}));
 
 const mockNavigation = {
     navigate: jest.fn(),
@@ -124,7 +119,7 @@ const createExchangeRoute = (params: ReturnType<typeof createExchangeRouteParams
     }) as RouteProp<RootStackParamList, RootStackRoutes.TradingExchangeOutputsReview>;
 
 describe('TradingSellOutputsReviewScreen', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let unmount: (() => void) | undefined;
 
     afterEach(async () => {
@@ -143,7 +138,7 @@ describe('TradingSellOutputsReviewScreen', () => {
         ) => {
             const result = await renderWithTradingProvider(
                 <TradingSellOutputsReviewScreen route={route} navigation={mockNavigation} />,
-                { store },
+                { services: { analytics: mockNativeAnalytics(), store } },
             );
 
             ({ unmount } = result);
@@ -153,7 +148,7 @@ describe('TradingSellOutputsReviewScreen', () => {
 
         beforeEach(() => {
             jest.clearAllMocks();
-            store = createTradingLightStore({ tradeType: 'sell' });
+            store = createTradingTestStore({ tradeType: 'sell' });
             mockNavigation.navigate.mockClear();
             mockNavigation.goBack.mockClear();
             mockNavigation.popToTop.mockClear();
@@ -171,7 +166,7 @@ describe('TradingSellOutputsReviewScreen', () => {
                 expect.objectContaining({
                     orderId: TEST_ORDER_ID,
                     accountKey: TEST_ACCOUNT_KEY,
-                    reportToAnalytics: mockReportToAnalyticsSell,
+                    reportToAnalytics: expect.any(Function),
                 }),
             );
         });
@@ -186,7 +181,7 @@ describe('TradingSellOutputsReviewScreen', () => {
         ) => {
             const result = await renderWithTradingProvider(
                 <TradingExchangeOutputsReviewScreen route={route} navigation={mockNavigation} />,
-                { store },
+                { services: { analytics: mockNativeAnalytics(), store } },
             );
 
             ({ unmount } = result);
@@ -196,7 +191,7 @@ describe('TradingSellOutputsReviewScreen', () => {
 
         beforeEach(() => {
             jest.clearAllMocks();
-            store = createTradingLightStore({ tradeType: 'exchange' });
+            store = createTradingTestStore({ tradeType: 'exchange' });
             mockNavigation.navigate.mockClear();
             mockNavigation.goBack.mockClear();
             mockNavigation.popToTop.mockClear();
@@ -214,7 +209,7 @@ describe('TradingSellOutputsReviewScreen', () => {
                 expect.objectContaining({
                     orderId: TEST_ORDER_ID,
                     accountKey: TEST_ACCOUNT_KEY,
-                    reportToAnalytics: mockReportToAnalyticsExchange,
+                    reportToAnalytics: expect.any(Function),
                 }),
             );
         });

--- a/suite-native/module-trading/src/screens/TradingReceiveAddressPickerScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingReceiveAddressPickerScreen.test.tsx
@@ -14,7 +14,7 @@ import { TradingReceiveAddressPickerScreen } from './TradingReceiveAddressPicker
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
-    createTradingLightStore,
+    createTradingTestStore,
 } from '../test-utils/tradingTestUtils';
 
 const navigationPopToTop = jest.fn();
@@ -53,12 +53,12 @@ describe('TradingReceiveAddressPickerScreen', () => {
     };
 
     const renderScreen = async () => {
-        const store = createTradingLightStore({
+        const store = createTradingTestStore({
             tradeType: mockRouteParams.tradingType,
             overrides,
         });
         const result = await renderWithStoreProvider(<TradingReceiveAddressPickerScreen />, {
-            store,
+            services: { store },
         });
 
         return { ...result, store };

--- a/suite-native/module-trading/src/screens/TradingSellPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/TradingSellPreviewScreen.test.tsx
@@ -1,3 +1,5 @@
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
 import {
     eth1NormalAccount,
@@ -16,11 +18,6 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockAnalyticsReport = jest.fn();
-jest.mock('@suite-native/trading-analytics', () => ({
-    ...jest.requireActual('@suite-native/trading-analytics'),
-    useSellAnalyticReportCallback: () => mockAnalyticsReport,
-}));
-
 describe('TradingSellPreviewScreen', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -34,6 +31,7 @@ describe('TradingSellPreviewScreen', () => {
 
         return await renderWithTradingProvider(<TradingSellPreviewScreen />, {
             tradeType: 'sell',
+            services: { analytics: mockNativeAnalytics(mockAnalyticsReport) },
             overrides: { wallet: { trading: tradingState } },
         });
     };
@@ -68,7 +66,10 @@ describe('TradingSellPreviewScreen', () => {
     it('reports a transaction-preview visit', async () => {
         await renderScreen();
 
-        expect(mockAnalyticsReport).toHaveBeenCalledWith('transaction-preview', 'visit');
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.tradingSellEvent.name,
+            payload: expect.objectContaining({ step: 'transaction-preview', action: 'visit' }),
+        });
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
     });
 });

--- a/suite-native/module-trading/src/test-utils/tradingTestUtils.ts
+++ b/suite-native/module-trading/src/test-utils/tradingTestUtils.ts
@@ -1,83 +1,134 @@
 import { type ReactElement } from 'react';
 
-import { type UnknownAction, combineReducers } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
 import { deviceInitialState } from '@suite-common/device';
-import { geolocationInitialState } from '@suite-common/geolocation';
-import { messageSystemInitialState } from '@suite-common/message-system';
-import { mockActionType } from '@suite-common/redux-utils/mocks';
-import { initialSuiteSyncDataState, initialSuiteSyncState } from '@suite-common/suite-sync';
-import { createTestStore } from '@suite-common/test-utils';
-import { tokenDefinitionsInitialState } from '@suite-common/token-definitions';
+import { type DiscreetModeRootState } from '@suite-common/discreet-mode';
+import { type GeolocationRootState, geolocationInitialState } from '@suite-common/geolocation';
 import {
+    type MessageSystemRootState,
+    messageSystemInitialState,
+} from '@suite-common/message-system';
+import { type ReduxStoreWithThunk } from '@suite-common/redux-utils';
+import { mockActionType } from '@suite-common/redux-utils/mocks';
+import {
+    type SuiteSyncDataRootState,
+    type WithSuiteSyncState,
+    initialSuiteSyncDataState,
+    initialSuiteSyncState,
+} from '@suite-common/suite-sync';
+import { type NotificationsRootState } from '@suite-common/toast-notifications';
+import {
+    type TokenDefinitionsRootState,
+    tokenDefinitionsInitialState,
+} from '@suite-common/token-definitions';
+import {
+    type TradingRootStateWithDeviceAndAccounts,
+    type TradingType,
+} from '@suite-common/trading';
+import {
+    type FeesRootState,
+    type FiatRatesRootState,
+    type FormDraftRootState,
+    type PhishingRootState,
+    type TransactionsRootState,
+    type WalletSettingsRootState,
     formDraftReducer,
     initialWalletSettingsState,
     phishingInitialState,
     transactionsInitialState,
 } from '@suite-common/wallet-core';
-import { bluetoothInitialState } from '@suite-native/bluetooth';
-import { deviceAuthorizationInitialState } from '@suite-native/device-authorization';
-import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
-import { localeInitialState } from '@suite-native/intl';
-import { appSettingsInitialState } from '@suite-native/settings';
+import { type NativeBluetoothRootState, bluetoothInitialState } from '@suite-native/bluetooth';
+import {
+    type DeviceAuthorizationRootState,
+    deviceAuthorizationInitialState,
+} from '@suite-native/device-authorization';
+import {
+    FeatureFlag,
+    type FeatureFlagsRootState,
+    type FeatureFlagsState,
+    featureFlagsInitialState,
+} from '@suite-native/feature-flags';
+import { type LocaleSliceRootState, localeInitialState } from '@suite-native/intl';
+import { type SettingsSliceRootState, appSettingsInitialState } from '@suite-native/settings';
 import {
     type PreloadedStatePartial,
     type RenderHookOptionsExtended,
-    type RenderHookResult,
     type RenderOptionsExtended,
-    type RenderResult,
     createStaticReducer,
-    createStoreFromPreloadedState,
     mergePreloadedState,
     renderHookWithStoreProvider,
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
-import { tradingSlice } from '@suite-native/trading-state';
+import { type TradingRootState, tradingSlice } from '@suite-native/trading-state';
+import {
+    type NativeSendRootState,
+    sendFormInitialState,
+} from '@suite-native/transaction-management';
 
 export type { PreloadedStatePartial } from '@suite-native/test-utils-store';
 
-export type TradingTestTradeType = 'buy' | 'sell' | 'exchange';
+const createBaseTradingPreloadedState = (tradeType: TradingType): TradingTestPreloadedState => {
+    const wallet = getWalletState({ tradeType });
 
-const createBaseTradingPreloadedState = (tradeType: TradingTestTradeType) => ({
-    appSettings: appSettingsInitialState,
-    bluetooth: bluetoothInitialState,
-    device: deviceInitialState,
-    discreetMode: { isActive: false },
-    deviceAuthorization: deviceAuthorizationInitialState,
-    geolocation: geolocationInitialState,
-    featureFlags: featureFlagsInitialState,
-    locale: localeInitialState,
-    messageSystem: messageSystemInitialState,
-    suiteSync: initialSuiteSyncState,
-    suiteSyncData: initialSuiteSyncDataState,
-    notifications: [],
-    tokenDefinitions: tokenDefinitionsInitialState,
-    wallet: {
-        ...getWalletState({ tradeType }),
-        fees: {},
-        formDrafts: {},
-        phishing: phishingInitialState,
-        transactions: transactionsInitialState,
-    },
-});
-
-export type TradingTestPreloadedState = ReturnType<typeof createBaseTradingPreloadedState>;
-
-type TradingLightStoreState = Omit<TradingTestPreloadedState, 'wallet'> & {
-    wallet: Omit<TradingTestPreloadedState['wallet'], 'formDrafts'> & {
-        formDrafts: ReturnType<typeof formDraftReducer>;
-        transactions: typeof transactionsInitialState;
+    return {
+        appSettings: appSettingsInitialState,
+        bluetooth: bluetoothInitialState,
+        device: deviceInitialState,
+        discreetMode: { isActive: false },
+        deviceAuthorization: deviceAuthorizationInitialState,
+        geolocation: geolocationInitialState,
+        featureFlags: featureFlagsInitialState,
+        locale: localeInitialState,
+        messageSystem: messageSystemInitialState,
+        suiteSync: initialSuiteSyncState,
+        suiteSyncData: initialSuiteSyncDataState,
+        notifications: [],
+        tokenDefinitions: tokenDefinitionsInitialState,
+        wallet: {
+            ...wallet,
+            settings: { ...initialWalletSettingsState, ...wallet.settings },
+            selectedAccount: { status: 'none' },
+            send: { ...sendFormInitialState, ...wallet.send },
+            fees: {},
+            formDrafts: {},
+            phishing: phishingInitialState,
+            transactions: transactionsInitialState,
+        },
     };
 };
 
-type TradingLightStore = ReturnType<
-    typeof createTestStore<void, TradingLightStoreState, UnknownAction>
->;
+export type TradingTestPreloadedState = TradingRootState &
+    TradingRootStateWithDeviceAndAccounts &
+    WalletSettingsRootState &
+    FiatRatesRootState &
+    FeesRootState &
+    FormDraftRootState &
+    PhishingRootState &
+    TransactionsRootState &
+    NativeSendRootState &
+    NativeBluetoothRootState &
+    DeviceAuthorizationRootState &
+    SettingsSliceRootState &
+    FeatureFlagsRootState &
+    LocaleSliceRootState &
+    GeolocationRootState &
+    MessageSystemRootState &
+    WithSuiteSyncState &
+    SuiteSyncDataRootState &
+    TokenDefinitionsRootState &
+    DiscreetModeRootState &
+    NotificationsRootState;
+
+type TradingProviderOptions = {
+    overrides?: PreloadedStatePartial<TradingTestPreloadedState>;
+    tradeType?: TradingType;
+};
 
 export const createTradingFeatureFlags = (
-    overrides: Partial<typeof featureFlagsInitialState> = {},
-) => ({
+    overrides: Partial<FeatureFlagsState> = {},
+): FeatureFlagsState => ({
     ...featureFlagsInitialState,
     [FeatureFlag.IsTradingResidenceCheckEnabled]: false,
     ...overrides,
@@ -86,26 +137,12 @@ export const createTradingFeatureFlags = (
 export const createTradingPreloadedState = ({
     overrides = {},
     tradeType = 'buy',
-}: {
-    overrides?: PreloadedStatePartial<TradingTestPreloadedState>;
-    tradeType?: TradingTestTradeType;
-} = {}): TradingTestPreloadedState =>
+}: TradingProviderOptions = {}): TradingTestPreloadedState =>
     mergePreloadedState(createBaseTradingPreloadedState(tradeType), overrides);
 
-export const createTradingTestStore = (args?: {
-    overrides?: PreloadedStatePartial<TradingTestPreloadedState>;
-    tradeType?: TradingTestTradeType;
-}) => createStoreFromPreloadedState(createTradingPreloadedState(args));
-
-/**
- * Creates a store with a real trading reducer (responds to dispatched actions)
- * plus static reducers for all other slices.
- * Use this for tests that dispatch trading actions and assert on state changes.
- */
-export const createTradingLightStore = (args?: {
-    overrides?: PreloadedStatePartial<TradingTestPreloadedState>;
-    tradeType?: TradingTestTradeType;
-}): TradingLightStore => {
+export const createTradingTestStore = (
+    args: TradingProviderOptions = {},
+): ReduxStoreWithThunk<TradingTestPreloadedState, Record<never, never>> => {
     const preloadedState = createTradingPreloadedState(args);
 
     const reducer = {
@@ -123,59 +160,64 @@ export const createTradingLightStore = (args?: {
         suiteSyncData: createStaticReducer(preloadedState.suiteSyncData),
         tokenDefinitions: createStaticReducer(preloadedState.tokenDefinitions),
         wallet: combineReducers({
-            settings: createStaticReducer(
-                preloadedState.wallet.settings ?? initialWalletSettingsState,
-            ),
-            accounts: createStaticReducer(preloadedState.wallet.accounts ?? []),
-            fiat: createStaticReducer(preloadedState.wallet.fiat ?? {}),
-            fees: createStaticReducer(preloadedState.wallet.fees ?? {}),
+            selectedAccount: createStaticReducer(preloadedState.wallet.selectedAccount),
+            settings: createStaticReducer(preloadedState.wallet.settings),
+            accounts: createStaticReducer(preloadedState.wallet.accounts),
+            fiat: createStaticReducer(preloadedState.wallet.fiat),
+            fees: createStaticReducer(preloadedState.wallet.fees),
             formDrafts: formDraftReducer,
             phishing: createStaticReducer(preloadedState.wallet.phishing),
-            send: createStaticReducer(preloadedState.wallet.send ?? {}),
-            transactions: createStaticReducer(transactionsInitialState),
+            send: createStaticReducer(preloadedState.wallet.send),
+            transactions: createStaticReducer(preloadedState.wallet.transactions),
             trading: tradingSlice.prepareReducer({
                 actionTypes: { storageLoad: mockActionType('storageLoad') },
             }),
         }),
     } as const;
 
-    return createTestStore({
-        extra: undefined,
+    return configureStore({
         reducer,
-        preloadedState: {
-            wallet: {
-                trading: preloadedState.wallet.trading,
-                formDrafts: preloadedState.wallet.formDrafts ?? {},
-            },
+        preloadedState,
+        middleware: getDefaultMiddleware =>
+            getDefaultMiddleware({
+                thunk: { extraArgument: {} },
+                serializableCheck: false,
+                immutableCheck: false,
+            }),
+    });
+};
+
+export const renderWithTradingProvider = <TServices extends object>(
+    element: ReactElement,
+    {
+        overrides,
+        tradeType,
+        services,
+        ...options
+    }: TradingProviderOptions & Omit<RenderOptionsExtended<TServices>, 'preloadedState'> = {},
+) =>
+    renderWithStoreProvider(element, {
+        ...options,
+        services: {
+            ...services,
+            store: services?.store ?? createTradingTestStore({ overrides, tradeType }),
         },
     });
-};
 
-type TradingProviderOptions = {
-    overrides?: PreloadedStatePartial<TradingTestPreloadedState>;
-    tradeType?: TradingTestTradeType;
-};
-
-type RenderWithTradingProviderOptions = TradingProviderOptions &
-    Omit<RenderOptionsExtended, 'preloadedState'>;
-
-type RenderHookWithTradingProviderOptions<Props> = TradingProviderOptions &
-    Omit<RenderHookOptionsExtended<Props>, 'preloadedState'>;
-
-export const renderWithTradingProvider = (
-    element: ReactElement,
-    { overrides, tradeType, ...options }: RenderWithTradingProviderOptions = {},
-): Promise<RenderResult> =>
-    renderWithStoreProvider(element, {
-        preloadedState: createTradingPreloadedState({ overrides, tradeType }),
-        ...options,
-    });
-
-export const renderHookWithTradingProvider = <Result, Props>(
+export const renderHookWithTradingProvider = <Result, Props, TServices extends object>(
     callback: (props: Props) => Result,
-    { overrides, tradeType, ...options }: RenderHookWithTradingProviderOptions<Props> = {},
-): Promise<RenderHookResult<Result, Props>> =>
-    renderHookWithStoreProvider<Result, Props>(callback, {
-        preloadedState: createTradingPreloadedState({ overrides, tradeType }),
+    {
+        overrides,
+        tradeType,
+        services,
+        ...options
+    }: TradingProviderOptions &
+        Omit<RenderHookOptionsExtended<Props, TServices>, 'preloadedState'> = {},
+) =>
+    renderHookWithStoreProvider(callback, {
         ...options,
+        services: {
+            ...services,
+            store: services?.store ?? createTradingTestStore({ overrides, tradeType }),
+        },
     });

--- a/suite-native/module-trading/src/thunks.test.ts
+++ b/suite-native/module-trading/src/thunks.test.ts
@@ -1,5 +1,6 @@
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
+import { type ReduxStoreWithThunk } from '@suite-common/redux-utils';
 import {
     tradingBuyActions,
     tradingExchangeActions,
@@ -7,12 +8,15 @@ import {
 } from '@suite-common/trading';
 import { type Account, type TokenAddress, type TokenInfoBranded } from '@suite-common/wallet-types';
 import { getFormDraftKey } from '@suite-common/wallet-utils';
-import { type TestStore } from '@suite-native/test-utils-store';
 import { selectAccountTokenInfo } from '@suite-native/tokens';
 import { eth1NormalAccount, invityDexQuote } from '@suite-native/trading-fixtures';
 
-import { createTradingLightStore } from './test-utils/tradingTestUtils';
-import { clearTradingStateThunk, composeEvmApprovalFeeLevelsThunk } from './thunks';
+import { createTradingTestStore } from './test-utils/tradingTestUtils';
+import {
+    type ComposeEvmApprovalFeeLevelsThunkState,
+    clearTradingStateThunk,
+    composeEvmApprovalFeeLevelsThunk,
+} from './thunks';
 
 jest.mock('@trezor/connect', () => ({
     ...jest.requireActual('@trezor/connect'),
@@ -127,7 +131,7 @@ describe('thunks', () => {
     });
 
     describe('composeEvmApprovalFeeLevelsThunk', () => {
-        let store: TestStore;
+        let store: ReduxStoreWithThunk<ComposeEvmApprovalFeeLevelsThunkState, Record<never, never>>;
 
         const dexQuoteWithApprovalData: ExchangeTrade = {
             ...invityDexQuote,
@@ -153,7 +157,7 @@ describe('thunks', () => {
         };
 
         beforeEach(() => {
-            store = createTradingLightStore({
+            store = createTradingTestStore({
                 tradeType: 'exchange',
                 overrides: {
                     wallet: {
@@ -212,7 +216,7 @@ describe('thunks', () => {
         it('should merge composed approval fees into existing exchange form draft without dropping fields', async () => {
             const formDraftKey = getFormDraftKey('trading-exchange', '');
 
-            const localStore = createTradingLightStore({
+            const localStore = createTradingTestStore({
                 tradeType: 'exchange',
                 overrides: {
                     wallet: {
@@ -269,7 +273,7 @@ describe('thunks', () => {
         it('should add default payment output with token when exchange form draft has no outputs', async () => {
             const formDraftKey = getFormDraftKey('trading-exchange', '');
 
-            const localStore = createTradingLightStore({
+            const localStore = createTradingTestStore({
                 tradeType: 'exchange',
                 overrides: {
                     wallet: {

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -104,10 +104,16 @@
         { "path": "../../packages/urls" },
         { "path": "../../packages/utils" },
         {
+            "path": "../../suite-common/discreet-mode"
+        },
+        {
             "path": "../../suite-common/suite-constants"
         },
         {
             "path": "../../suite-common/test-utils"
+        },
+        {
+            "path": "../../suite-common/toast-notifications"
         },
         {
             "path": "../../suite-common/tx-simulation"

--- a/suite-native/test-utils-store/README.md
+++ b/suite-native/test-utils-store/README.md
@@ -30,10 +30,13 @@ const { result } = renderHookWithStoreProvider(() => useMyHook());
 
 Both helpers accept the standard `@testing-library/react-native` options plus:
 
-- `preloadedState?: Record<string, unknown>` — initial state merged over defaults.
-- `services?: Record<string, unknown>` — overrides injected into the shared `ServicesProvider`; useful for tests that need custom service mocks.
-- `store?: EnhancedStore` — inject a pre-built store (see `createLightStore` below); takes precedence over `preloadedState`.
+- `preloadedState?: object` — initial state merged over defaults.
+- `services` (optional) — services supplied to the test composition, including an optional pre-built `store` that takes precedence over `preloadedState`.
 - `wrapper?: ComponentType` — additional inner wrapper (e.g. a form provider).
+
+Each test declares the state slices and service dependencies its subject needs. The render helpers infer the supplied services through generics, preserving the store state and dispatch types.
+
+The helpers create services once per render call. Both the Redux provider and the services provider use that same store, which is preserved across rerenders.
 
 ## Store factories
 
@@ -48,11 +51,11 @@ Two factories with different trade-offs. Pick by what your test needs to do:
 
 ### `createStoreFromPreloadedState(preloadedState?)`
 
-Called internally by `renderWithStoreProvider` when no `store` is injected. Each top-level slice becomes a static reducer that ignores every action. This is the fast path used by most render tests.
+Called internally by `renderWithStoreProvider` when no `services.store` is supplied. The inferred state is preserved by a static reducer that ignores every action. This is the fast path used by most render tests.
 
 ### `createLightStore({ reducer, preloadedState })`
 
-Thin wrapper over `configureStore` with `serializableCheck` and `immutableCheck` disabled and typed `preloadedState` via `PreloadedStatePartial`. Use this to build a store with selected real reducers, then pass it to `renderWithStoreProvider` via the `store` option.
+Thin wrapper over `configureStore` with `serializableCheck` and `immutableCheck` disabled and typed `preloadedState` via `PreloadedStatePartial`. Use this to build a store with selected real reducers, then pass it to `renderWithStoreProvider` via `services.store`.
 
 ```tsx
 import {
@@ -71,7 +74,7 @@ const store = createLightStore({
     preloadedState: { wallet: { trading: initialTradingState } },
 });
 
-renderWithStoreProvider(<MyComponent />, { store });
+renderWithStoreProvider(<MyComponent />, { services: { store } });
 ```
 
 ### `createStaticReducer(initialState)`
@@ -82,4 +85,3 @@ Helper for building a reducer map for `createLightStore` when you want most slic
 
 - `PreloadedStatePartial<T>` — deep-partial of state that preserves functions and arrays as-is (unlike a naive `DeepPartial`). Used by `createLightStore` and re-exported for test-side preloaded-state typing.
 - `RenderOptionsExtended` / `RenderHookOptionsExtended<Props>` — the option types accepted by the render helpers.
-- `TestStore` — alias for the `EnhancedStore` returned by the factories.

--- a/suite-native/test-utils-store/src/StoreProviderForTests.tsx
+++ b/suite-native/test-utils-store/src/StoreProviderForTests.tsx
@@ -1,31 +1,20 @@
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode } from 'react';
 import { Provider } from 'react-redux';
 
-import { type EnhancedStore, type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
+import { type Store } from '@reduxjs/toolkit';
 
 import { useFormattersConfig } from '@suite-native/formatters-config';
 import { BasicProviderForTests } from '@suite-native/test-utils';
 
-import { createStoreFromPreloadedState } from './createStoreFromPreloadedState';
-
-export type TestStore = Omit<EnhancedStore, 'dispatch'> & {
-    dispatch: ThunkDispatch<any, any, UnknownAction>;
-};
-
-type ReduxProviderProps = {
+type ReduxProviderProps<TServices extends { store: Store }> = {
     children: ReactNode;
-    preloadedState?: Record<string, unknown>;
-    injectedStore?: TestStore;
-    services?: Record<string, unknown>;
+    services: TServices;
 };
 
-const BasicProviderWithFormattingConfig = ({
+const BasicProviderWithFormattingConfig = <TServices extends { store: Store }>({
     children,
     services,
-}: {
-    children: ReactNode;
-    services?: Record<string, unknown>;
-}) => {
+}: ReduxProviderProps<TServices>) => {
     const formattersConfig = useFormattersConfig();
 
     return (
@@ -35,30 +24,13 @@ const BasicProviderWithFormattingConfig = ({
     );
 };
 
-/*
-Simplified synchronous (= no async warming up) version of `StoreProvider.tsx` from `suite-native/state` but without async logic
-for persisted state or Sentry. Allows to specify `preloadedState` of store or even inject precomposed
-store with `injectedStore`.
- */
-export const StoreProviderForTests = ({
+export const StoreProviderForTests = <TServices extends { store: Store }>({
     children,
-    injectedStore,
-    preloadedState,
     services,
-}: ReduxProviderProps) => {
-    const store = useMemo(() => {
-        if (injectedStore) {
-            return injectedStore;
-        }
-
-        return createStoreFromPreloadedState(preloadedState);
-    }, [injectedStore, preloadedState]);
-
-    return (
-        <Provider store={store}>
-            <BasicProviderWithFormattingConfig services={{ ...services, store }}>
-                {children}
-            </BasicProviderWithFormattingConfig>
-        </Provider>
-    );
-};
+}: ReduxProviderProps<TServices>) => (
+    <Provider store={services.store}>
+        <BasicProviderWithFormattingConfig services={services}>
+            {children}
+        </BasicProviderWithFormattingConfig>
+    </Provider>
+);

--- a/suite-native/test-utils-store/src/createStoreFromPreloadedState.ts
+++ b/suite-native/test-utils-store/src/createStoreFromPreloadedState.ts
@@ -1,20 +1,21 @@
-import { type Reducer, configureStore } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 
-import { mergeDeepObject, typedObjectEntries } from '@trezor/utils';
+import { mergeDeepObject } from '@trezor/utils';
 
 import { createStaticReducer } from './createStaticReducer';
 
 /**
- * Creates a Redux store with identity reducers inferred from the shape of
- * `preloadedState`. Each leaf value becomes the initial state of a no-op
- * reducer that ignores every action and always returns its initial state.
+ * Creates a Redux store whose state is inferred from `preloadedState` and the
+ * default provider state. Its no-op reducer preserves that state on every action.
  *
  * This is useful for tests that only *read* from the store (most render
  * and hook tests). Tests that *dispatch* actions that should mutate state
  * must use `createLightStore` with real reducers instead.
  */
-export const createStoreFromPreloadedState = (preloadedState: Record<string, unknown> = {}) => {
-    const defaultState: Record<string, unknown> = {
+export const createStoreFromPreloadedState = <TState extends object = object>(
+    preloadedState?: TState,
+) => {
+    const defaultState = {
         discreetMode: { isActive: false },
         wallet: {
             settings: { localCurrency: 'usd', bitcoinAmountUnit: 0, addressDisplayType: 'chunked' },
@@ -22,17 +23,12 @@ export const createStoreFromPreloadedState = (preloadedState: Record<string, unk
         locale: { systemLocaleCode: 'en', appLocaleCode: 'system' },
     };
 
-    const merged = mergeDeepObject(defaultState, preloadedState);
+    // Preserve discriminated unions from the input; mergeDeepObject otherwise merges their variants.
+    const merged = mergeDeepObject(defaultState, preloadedState ?? {}) as TState &
+        typeof defaultState;
 
-    const reducer: Record<string, Reducer> = {};
-
-    for (const [key, value] of typedObjectEntries(merged)) {
-        reducer[key] = createStaticReducer(value);
-    }
-
-    return configureStore({
-        reducer,
-        preloadedState: merged,
+    return configureStore<typeof merged>({
+        reducer: createStaticReducer(merged),
         middleware: getDefaultMiddleware =>
             getDefaultMiddleware({ serializableCheck: false, immutableCheck: false }),
     });

--- a/suite-native/test-utils-store/src/mergePreloadedState.ts
+++ b/suite-native/test-utils-store/src/mergePreloadedState.ts
@@ -8,7 +8,7 @@ import { type PreloadedStatePartial } from './createLightStore';
  * merged return type narrows back to `T` instead of the loose `TMerged<T[number]>`
  * that the underlying utility produces.
  */
-export const mergePreloadedState = <T extends Record<string, unknown>>(
+export const mergePreloadedState = <T extends object>(
     base: T,
     overrides: PreloadedStatePartial<NoInfer<T>>,
 ): T => mergeDeepObject.withOptions({ mergeArrays: false }, base, overrides) as T;

--- a/suite-native/test-utils-store/src/renderWithStore.tsx
+++ b/suite-native/test-utils-store/src/renderWithStore.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement } from 'react';
 
+import { type Store } from '@reduxjs/toolkit';
 import {
     type RenderHookOptions,
     type RenderHookResult,
@@ -9,56 +10,70 @@ import {
     renderHook,
 } from '@testing-library/react-native';
 
-import { StoreProviderForTests, type TestStore } from './StoreProviderForTests';
+import { StoreProviderForTests } from './StoreProviderForTests';
+import { createStoreFromPreloadedState } from './createStoreFromPreloadedState';
 
-export type RenderOptionsExtended = RenderOptions & {
-    preloadedState?: Record<string, unknown>;
-    services?: Record<string, unknown>;
-    store?: TestStore;
+export type RenderOptionsExtended<TServices extends object = object> = RenderOptions & {
+    preloadedState?: object;
+    services?: TServices & { store?: Store };
 };
 
-export type RenderHookOptionsExtended<Props> = RenderHookOptions<Props> & {
-    preloadedState?: Record<string, unknown>;
-    services?: Record<string, unknown>;
-    store?: TestStore;
+export type RenderHookOptionsExtended<
+    Props,
+    TServices extends object = object,
+> = RenderHookOptions<Props> & {
+    preloadedState?: object;
+    services?: TServices & { store?: Store };
 };
 
-export const renderWithStoreProvider = async (
+export const renderWithStoreProvider = async <TServices extends object>(
     element: ReactElement,
-    { preloadedState, services, wrapper: Wrapper, store, ...options }: RenderOptionsExtended = {},
-): Promise<RenderResult> =>
-    await render(element, {
+    {
+        preloadedState,
+        services,
+        wrapper: Wrapper,
+        ...options
+    }: RenderOptionsExtended<TServices> = {},
+): Promise<RenderResult> => {
+    const resolvedServices = {
+        ...services,
+        store: services?.store ?? createStoreFromPreloadedState(preloadedState),
+    };
+
+    return await render(element, {
         wrapper: ({ children }) => (
-            <StoreProviderForTests
-                preloadedState={preloadedState}
-                injectedStore={store}
-                services={services}
-            >
+            <StoreProviderForTests services={resolvedServices}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
             </StoreProviderForTests>
         ),
         ...options,
     });
+};
 
-export const renderHookWithStoreProvider = async <Result = unknown, Props = unknown>(
+export const renderHookWithStoreProvider = async <
+    Result = unknown,
+    Props = unknown,
+    TServices extends object = object,
+>(
     callback: (props: Props) => Result,
     {
         preloadedState,
         services,
         wrapper: Wrapper,
-        store,
         ...options
-    }: RenderHookOptionsExtended<Props> = {},
-): Promise<RenderHookResult<Result, Props>> =>
-    await renderHook(callback, {
+    }: RenderHookOptionsExtended<Props, TServices> = {},
+): Promise<RenderHookResult<Result, Props>> => {
+    const resolvedServices = {
+        ...services,
+        store: services?.store ?? createStoreFromPreloadedState(preloadedState),
+    };
+
+    return await renderHook(callback, {
         wrapper: ({ children }) => (
-            <StoreProviderForTests
-                preloadedState={preloadedState}
-                injectedStore={store}
-                services={services}
-            >
+            <StoreProviderForTests services={resolvedServices}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
             </StoreProviderForTests>
         ),
         ...options,
     });
+};

--- a/suite-native/trading-analytics/src/hooks/useBuyAnalyticsStepReport.test.ts
+++ b/suite-native/trading-analytics/src/hooks/useBuyAnalyticsStepReport.test.ts
@@ -1,12 +1,11 @@
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { useBuyAnalyticsStepReport } from './useBuyAnalyticsStepReport';
 
 const reportToAnalyticsMock = jest.fn();
-
-jest.mock('./useBuyAnalyticReportCallback', () => ({
-    useBuyAnalyticReportCallback: jest.fn(() => reportToAnalyticsMock),
-}));
 
 describe('useBuyAnalyticsStepReport', () => {
     beforeEach(() => {
@@ -14,8 +13,12 @@ describe('useBuyAnalyticsStepReport', () => {
     });
 
     it('should pass the step and action to the underlying callback', async () => {
-        const { result } = await renderHookWithBasicProvider(() =>
-            useBuyAnalyticsStepReport('buy-preview'),
+        const { result } = await renderHookWithStoreProvider(
+            () => useBuyAnalyticsStepReport('buy-preview'),
+            {
+                preloadedState: { wallet: getWalletState({ tradeType: 'buy' }) },
+                services: { analytics: mockNativeAnalytics(reportToAnalyticsMock) },
+            },
         );
 
         result.current('visit');
@@ -23,8 +26,17 @@ describe('useBuyAnalyticsStepReport', () => {
         result.current('visit');
 
         expect(reportToAnalyticsMock).toHaveBeenCalledTimes(3);
-        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(1, 'buy-preview', 'visit');
-        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(2, 'buy-preview', 'continue');
-        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(3, 'buy-preview', 'visit');
+        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(1, {
+            type: events.tradingBuyEvent.name,
+            payload: expect.objectContaining({ step: 'buy-preview', action: 'visit' }),
+        });
+        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(2, {
+            type: events.tradingBuyEvent.name,
+            payload: expect.objectContaining({ step: 'buy-preview', action: 'continue' }),
+        });
+        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(3, {
+            type: events.tradingBuyEvent.name,
+            payload: expect.objectContaining({ step: 'buy-preview', action: 'visit' }),
+        });
     });
 });

--- a/suite-native/trading-analytics/src/hooks/useExchangeAnalyticsStepReport.test.ts
+++ b/suite-native/trading-analytics/src/hooks/useExchangeAnalyticsStepReport.test.ts
@@ -1,13 +1,11 @@
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { useExchangeAnalyticsStepReport } from './useExchangeAnalyticsStepReport';
 
 const reportToAnalyticsMock = jest.fn();
-
-jest.mock('./useExchangeAnalyticReportCallback', () => ({
-    useExchangeAnalyticReportCallback: jest.fn(() => reportToAnalyticsMock),
-}));
 
 describe('useExchangeAnalyticsStepReport', () => {
     const preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
@@ -19,7 +17,7 @@ describe('useExchangeAnalyticsStepReport', () => {
     it('should report correct data on callback execution', async () => {
         const { result } = await renderHookWithStoreProvider(
             () => useExchangeAnalyticsStepReport('exchange-form'),
-            { preloadedState },
+            { preloadedState, services: { analytics: mockNativeAnalytics(reportToAnalyticsMock) } },
         );
 
         result.current('visit');
@@ -27,8 +25,17 @@ describe('useExchangeAnalyticsStepReport', () => {
         result.current('visit');
 
         expect(reportToAnalyticsMock).toHaveBeenCalledTimes(3);
-        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(1, 'exchange-form', 'visit');
-        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(2, 'exchange-form', 'retry');
-        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(3, 'exchange-form', 'visit');
+        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(1, {
+            type: events.tradingExchangeEvent.name,
+            payload: expect.objectContaining({ step: 'exchange-form', action: 'visit' }),
+        });
+        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(2, {
+            type: events.tradingExchangeEvent.name,
+            payload: expect.objectContaining({ step: 'exchange-form', action: 'retry' }),
+        });
+        expect(reportToAnalyticsMock).toHaveBeenNthCalledWith(3, {
+            type: events.tradingExchangeEvent.name,
+            payload: expect.objectContaining({ step: 'exchange-form', action: 'visit' }),
+        });
     });
 });

--- a/suite-native/trading-atoms/src/components/TradeInfo/NetworkAndAccountCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/NetworkAndAccountCard.test.tsx
@@ -33,14 +33,16 @@ describe('NetworkAndAccountCard', () => {
         await renderWithStoreProvider(
             <NetworkAndAccountCard title="TITLE" account={btc1NormalAccount} {...props} />,
             {
-                store: createLightStore({
-                    reducer,
-                    preloadedState: {
-                        wallet: {
-                            accounts: [btc1NormalAccount],
+                services: {
+                    store: createLightStore({
+                        reducer,
+                        preloadedState: {
+                            wallet: {
+                                accounts: [btc1NormalAccount],
+                            },
                         },
-                    },
-                }),
+                    }),
+                },
             },
         );
 

--- a/suite-native/trading-atoms/src/components/TradeInfo/TradeSideCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/TradeSideCard.test.tsx
@@ -40,14 +40,18 @@ describe('TradeSideCard', () => {
                 {...props}
             />,
             {
-                store: createLightStore({
-                    reducer,
-                    preloadedState: {
-                        wallet: {
-                            accounts: [btc1NormalAccount],
-                        },
-                    } satisfies PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>>,
-                }),
+                services: {
+                    store: createLightStore({
+                        reducer,
+                        preloadedState: {
+                            wallet: {
+                                accounts: [btc1NormalAccount],
+                            },
+                        } satisfies PreloadedStatePartial<
+                            StateFromReducersMapObject<typeof reducer>
+                        >,
+                    }),
+                },
             },
         );
 

--- a/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.test.tsx
@@ -1,25 +1,30 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { FeatureFlag, featureFlagsReducer, toggleFeatureFlag } from '@suite-native/feature-flags';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils-store';
-import { selectTradingProviderConfirmationStatus, tradingSlice } from '@suite-native/trading-state';
+import {
+    type TradingRootState,
+    selectTradingProviderConfirmationStatus,
+    tradingSlice,
+} from '@suite-native/trading-state';
 
 import { ProviderStatusDevButtons } from './ProviderStatusDevButtons';
 
+type State = TradingRootState;
+
 describe('ProviderStatusDevButtons', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderProviderStatusDevButtons = async () =>
-        await renderWithStoreProvider(<ProviderStatusDevButtons />, { store });
+        await renderWithStoreProvider(<ProviderStatusDevButtons />, { services: { store } });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.test.ts
@@ -1,4 +1,4 @@
-import { type StateFromReducersMapObject, combineReducers } from '@reduxjs/toolkit';
+import { type StateFromReducersMapObject, type Store, combineReducers } from '@reduxjs/toolkit';
 import { WebBrowserResultType } from 'expo-web-browser';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
@@ -9,7 +9,6 @@ import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation, localeReducer } from '@suite-native/intl';
 import {
     type PreloadedStatePartial,
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
@@ -17,6 +16,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 import {
+    type TradingRootState,
     selectTradingProviderConfirmationStatus,
     tradingActions,
     tradingSlice,
@@ -24,6 +24,8 @@ import {
 
 import { TRADING_URL_DEFAULT_BACK } from '../consts';
 import { useBrowserAuth } from './useBrowserAuth';
+
+type State = TradingRootState;
 
 const mockOpenBrowserAsync = jest.fn();
 const mockDismissBrowser = jest.fn();
@@ -60,10 +62,12 @@ jest.mock('./useOnForegroundCallback', () => ({
 }));
 
 describe('useBrowserAuth', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseBrowserAuth = async (tradingType: TradingType = 'sell') =>
-        await renderHookWithStoreProvider(() => useBrowserAuth(tradingType), { services, store });
+        await renderHookWithStoreProvider(() => useBrowserAuth(tradingType), {
+            services: { ...services, store },
+        });
 
     const defaultWalletState = getWalletState();
 
@@ -108,8 +112,7 @@ describe('useBrowserAuth', () => {
             const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
             const { result } = await renderHookWithStoreProvider(() => useBrowserAuth(undefined), {
-                services,
-                store,
+                services: { ...services, store },
             });
 
             await act(async () => {

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserStateChangeCallbacks.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserStateChangeCallbacks.test.ts
@@ -1,33 +1,35 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { type TradingType } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
-import { selectTradingProviderConfirmationStatus, tradingSlice } from '@suite-native/trading-state';
+import {
+    type TradingRootState,
+    selectTradingProviderConfirmationStatus,
+    tradingSlice,
+} from '@suite-native/trading-state';
 
 import { useBrowserStateChangeCallbacks } from './useBrowserStateChangeCallbacks';
 
-const mockReportToAnalytics = jest.fn();
+type State = TradingRootState;
 
-jest.mock('@suite-native/trading-analytics', () => ({
-    ...jest.requireActual('@suite-native/trading-analytics'),
-    useTradingAnalyticReportCallback: () => mockReportToAnalytics,
-}));
+const mockAnalyticsReport = jest.fn();
 
 describe('useBrowserStateChangeCallbacks', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseBrowserwStateChangeCallbacks = async (tradingType: TradingType | undefined) =>
         await renderHookWithStoreProvider(() => useBrowserStateChangeCallbacks(tradingType), {
-            store,
+            services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store },
         });
 
     beforeEach(() => {
@@ -63,7 +65,10 @@ describe('useBrowserStateChangeCallbacks', () => {
                 result.current.handleBrowserOpened();
             });
 
-            expect(mockReportToAnalytics).toHaveBeenCalledWith('webview', 'visit');
+            expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                type: events.tradingSellEvent.name,
+                payload: expect.objectContaining({ step: 'webview', action: 'visit' }),
+            });
         });
     });
 
@@ -112,8 +117,14 @@ describe('useBrowserStateChangeCallbacks', () => {
 
             expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
             expect(dispatchSpy).not.toHaveBeenCalled();
-            // note that analytics event should be still reported
-            expect(mockReportToAnalytics).toHaveBeenCalledWith('webview', 'visit');
+            if (tradingType === 'exchange') {
+                expect(mockAnalyticsReport).toHaveBeenCalledWith({
+                    type: events.tradingExchangeEvent.name,
+                    payload: expect.objectContaining({ step: 'webview', action: 'visit' }),
+                });
+            } else {
+                expect(mockAnalyticsReport).not.toHaveBeenCalled();
+            }
         },
     );
 
@@ -130,6 +141,6 @@ describe('useBrowserStateChangeCallbacks', () => {
 
         expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
         expect(dispatchSpy).not.toHaveBeenCalled();
-        expect(mockReportToAnalytics).not.toHaveBeenCalled();
+        expect(mockAnalyticsReport).not.toHaveBeenCalled();
     });
 });

--- a/suite-native/trading-browser-auth/src/hooks/useDispatchProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useDispatchProviderConfirmationStatus.test.ts
@@ -1,24 +1,31 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
-import { selectTradingProviderConfirmationStatus, tradingSlice } from '@suite-native/trading-state';
+import {
+    type TradingRootState,
+    selectTradingProviderConfirmationStatus,
+    tradingSlice,
+} from '@suite-native/trading-state';
 
 import { useDispatchProviderConfirmationStatus } from './useDispatchProviderConfirmationStatus';
 
+type State = TradingRootState;
+
 describe('useDispatchProviderConfirmationStatus', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseDispatchProviderConfirmationStatus = async () =>
-        await renderHookWithStoreProvider(() => useDispatchProviderConfirmationStatus(), { store });
+        await renderHookWithStoreProvider(() => useDispatchProviderConfirmationStatus(), {
+            services: { store },
+        });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/trading-browser-auth/src/hooks/useProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useProviderConfirmationStatus.test.ts
@@ -1,16 +1,20 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
-import { initialWalletSettingsState, sendFormActions } from '@suite-common/wallet-core';
+import {
+    type SendRootState,
+    initialWalletSettingsState,
+    sendFormActions,
+} from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import {
+    type TradingRootState,
     selectTradingProviderConfirmationStatus,
     tradingActions,
     tradingSlice,
@@ -19,12 +23,14 @@ import { prepareSendFormReducer } from '@suite-native/transaction-management';
 
 import { useProviderConfirmationStatus } from './useProviderConfirmationStatus';
 
+type State = TradingRootState & SendRootState;
+
 describe('useProviderConfirmationStatus', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseProviderConfirmationStatus = async () =>
         await renderHookWithStoreProvider(() => useProviderConfirmationStatus(), {
-            store,
+            services: { store },
         });
 
     beforeEach(() => {

--- a/suite-native/trading-debug/src/components/TradingEnvironmentWarning.test.tsx
+++ b/suite-native/trading-debug/src/components/TradingEnvironmentWarning.test.tsx
@@ -26,17 +26,19 @@ describe('TradingEnvironmentWarning', () => {
         tradingEnvironment: TradingState['tradingEnvironment'],
     ) =>
         await renderWithStoreProvider(<TradingEnvironmentWarning />, {
-            store: createLightStore({
-                reducer,
-                preloadedState: {
-                    wallet: {
-                        trading: {
-                            ...tradingInitialState,
-                            tradingEnvironment,
+            services: {
+                store: createLightStore({
+                    reducer,
+                    preloadedState: {
+                        wallet: {
+                            trading: {
+                                ...tradingInitialState,
+                                tradingEnvironment,
+                            },
                         },
-                    },
-                } satisfies PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>>,
-            }),
+                    } satisfies PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>>,
+                }),
+            },
         });
 
     it('should render nothing when tradingEnvironment is [production]', async () => {

--- a/suite-native/trading-history/src/test-utils/tradingHistoryTestUtils.ts
+++ b/suite-native/trading-history/src/test-utils/tradingHistoryTestUtils.ts
@@ -1,12 +1,21 @@
 import { type ReactElement } from 'react';
 
-import { analyticsInitialState } from '@suite-common/analytics-redux';
-import { deviceInitialState } from '@suite-common/device';
-import { geolocationInitialState } from '@suite-common/geolocation';
-import { messageSystemInitialState } from '@suite-common/message-system';
-import { initialSuiteSyncDataState } from '@suite-common/suite-sync';
-import { featureFlagsInitialState } from '@suite-native/feature-flags';
-import { localeInitialState } from '@suite-native/intl';
+import { type AnalyticsRootState, analyticsInitialState } from '@suite-common/analytics-redux';
+import { type DeviceRootState, deviceInitialState } from '@suite-common/device';
+import { type GeolocationRootState, geolocationInitialState } from '@suite-common/geolocation';
+import {
+    type MessageSystemRootState,
+    messageSystemInitialState,
+} from '@suite-common/message-system';
+import { type SuiteSyncDataRootState, initialSuiteSyncDataState } from '@suite-common/suite-sync';
+import {
+    type AccountsRootState,
+    type FiatRatesRootState,
+    type SendRootState,
+    type WalletSettingsRootState,
+} from '@suite-common/wallet-core';
+import { type FeatureFlagsRootState, featureFlagsInitialState } from '@suite-native/feature-flags';
+import { type LocaleSliceRootState, localeInitialState } from '@suite-native/intl';
 import {
     type PreloadedStatePartial,
     type RenderOptionsExtended,
@@ -15,10 +24,11 @@ import {
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
+import { type TradingRootState } from '@suite-native/trading-state';
 
 export type { PreloadedStatePartial } from '@suite-native/test-utils-store';
 
-const createBaseTradingPreloadedState = () => ({
+const createBaseTradingPreloadedState = (): TradingTestPreloadedState => ({
     analytics: analyticsInitialState,
     device: deviceInitialState,
     featureFlags: featureFlagsInitialState,
@@ -31,7 +41,18 @@ const createBaseTradingPreloadedState = () => ({
     },
 });
 
-export type TradingTestPreloadedState = ReturnType<typeof createBaseTradingPreloadedState>;
+export type TradingTestPreloadedState = AnalyticsRootState &
+    DeviceRootState &
+    FeatureFlagsRootState &
+    GeolocationRootState &
+    LocaleSliceRootState &
+    MessageSystemRootState &
+    SuiteSyncDataRootState &
+    TradingRootState &
+    AccountsRootState &
+    WalletSettingsRootState &
+    FiatRatesRootState &
+    SendRootState;
 
 export const createTradingPreloadedState = ({
     overrides = {},
@@ -44,12 +65,12 @@ type TradingProviderOptions = {
     overrides?: PreloadedStatePartial<TradingTestPreloadedState>;
 };
 
-type RenderWithTradingProviderOptions = TradingProviderOptions &
-    Omit<RenderOptionsExtended, 'preloadedState'>;
+type RenderWithTradingProviderOptions<TServices extends object> = TradingProviderOptions &
+    Omit<RenderOptionsExtended<TServices>, 'preloadedState'>;
 
-export const renderWithTradingHistoryProvider = (
+export const renderWithTradingHistoryProvider = <TServices extends object>(
     element: ReactElement,
-    { overrides, ...options }: RenderWithTradingProviderOptions = {},
+    { overrides, ...options }: RenderWithTradingProviderOptions<TServices> = {},
 ): Promise<RenderResult> =>
     renderWithStoreProvider(element, {
         preloadedState: createTradingPreloadedState({ overrides }),

--- a/suite-native/trading-residence/package.json
+++ b/suite-native/trading-residence/package.json
@@ -43,6 +43,7 @@
         "@suite-common/message-system": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/test-utils": "workspace:*",
-        "@suite-native/test-utils-store": "workspace:*"
+        "@suite-native/test-utils-store": "workspace:*",
+        "@suite-native/trading-types": "workspace:*"
     }
 }

--- a/suite-native/trading-residence/src/components/ConfirmLocationButton.test.tsx
+++ b/suite-native/trading-residence/src/components/ConfirmLocationButton.test.tsx
@@ -1,12 +1,13 @@
 import { type ReactNode, useEffect, useState } from 'react';
 
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { useFormContext } from '@suite-native/forms';
 import { getTranslation, localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     fireEvent,
@@ -18,6 +19,7 @@ import {
     selectTradingResidenceCountry,
     selectTradingResidenceCountrySubdivision,
 } from '@suite-native/trading-state';
+import { type TradingResidenceRootState } from '@suite-native/trading-types';
 
 import { ConfirmLocationButton, type ConfirmLocationButtonProps } from './ConfirmLocationButton';
 import { type TradingLocationFormValues } from '../types/tradingLocationForm';
@@ -25,11 +27,9 @@ import { CountrySubdivisionPicker } from './CountrySheet/CountrySubdivisionPicke
 import { CountrySubdivisionPickerControlsContext } from './CountrySheet/CountrySubdivisionPickerControlsContext';
 import { LocationForm } from './LocationForm';
 
-const mockAnalyticsReport = jest.fn();
+type State = TradingResidenceRootState;
 
-jest.mock('../hooks/useCountrySelectionAnalyticsReport', () => ({
-    useCountrySelectionAnalyticsReport: () => mockAnalyticsReport,
-}));
+const mockAnalyticsReport = jest.fn();
 
 const ConfirmLocationButtonWithChangedCountry = () => {
     const { setValue } = useFormContext<TradingLocationFormValues>();
@@ -101,12 +101,12 @@ const LocationFormWithCountrySubdivisionPickerControls = ({
 };
 
 describe('ConfirmLocationButton', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderConfirmLocationButton = async (props: Partial<ConfirmLocationButtonProps>) =>
         await renderWithStoreProvider(<ConfirmLocationButton afterConfirm={jest.fn} {...props} />, {
             wrapper: LocationForm,
-            store,
+            services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store },
         });
 
     beforeEach(() => {
@@ -145,7 +145,10 @@ describe('ConfirmLocationButton', () => {
         );
 
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
-        expect(mockAnalyticsReport).toHaveBeenCalledWith('submitDefault');
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.tradingCountrySelectionEvent.name,
+            payload: expect.objectContaining({ action: 'submitDefault' }),
+        });
     });
 
     it('should log submitCustom when selected value does not match the default one', async () => {
@@ -153,7 +156,7 @@ describe('ConfirmLocationButton', () => {
             <ConfirmLocationButtonWithChangedCountry />,
             {
                 wrapper: LocationForm,
-                store,
+                services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store },
             },
         );
 
@@ -162,7 +165,10 @@ describe('ConfirmLocationButton', () => {
         );
 
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
-        expect(mockAnalyticsReport).toHaveBeenCalledWith('submitCustom');
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.tradingCountrySelectionEvent.name,
+            payload: expect.objectContaining({ action: 'submitCustom' }),
+        });
     });
 
     it('should open subdivision picker and not confirm when subdivision is required but missing', async () => {
@@ -171,7 +177,7 @@ describe('ConfirmLocationButton', () => {
             <ConfirmLocationButtonWithUSCountry afterConfirm={afterConfirmMock} />,
             {
                 wrapper: LocationFormWithCountrySubdivisionPickerControls,
-                store,
+                services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store },
             },
         );
 
@@ -205,7 +211,7 @@ describe('ConfirmLocationButton', () => {
             />,
             {
                 wrapper: LocationFormWithCountrySubdivisionPickerControls,
-                store,
+                services: { analytics: mockNativeAnalytics(mockAnalyticsReport), store },
             },
         );
 

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.test.tsx
@@ -73,8 +73,7 @@ describe('CountryOfResidencePicker', () => {
         props: Partial<CountryOfResidencePickerProps> = {},
     ) => {
         const { result } = await renderHookWithStoreProvider(() => useLocationForm(), {
-            services,
-            store: createTradingResidenceStore(),
+            services: { ...services, store: createTradingResidenceStore() },
         });
 
         return await renderWithBasicProvider(

--- a/suite-native/trading-residence/src/components/OnboardingButtons.test.tsx
+++ b/suite-native/trading-residence/src/components/OnboardingButtons.test.tsx
@@ -1,11 +1,10 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type NativeAnalyticsDep } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation, localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     fireEvent,
@@ -16,19 +15,21 @@ import {
     selectTradingResidenceCountry,
     selectWasTradingResidenceOnboardingVisited,
 } from '@suite-native/trading-state';
+import { type TradingResidenceRootState } from '@suite-native/trading-types';
 
 import { LocationForm } from './LocationForm';
 import { OnboardingButtons, type OnboardingButtonsProps } from './OnboardingButtons';
 
+type State = TradingResidenceRootState;
+
 describe('OnboardingButtons', () => {
-    let store: TestStore;
+    let store: Store<State>;
     const services: NativeAnalyticsDep = { analytics: mockNativeAnalytics() };
 
     const renderOnboardingButtons = async (props: OnboardingButtonsProps) =>
         await renderWithStoreProvider(<OnboardingButtons {...props} />, {
             wrapper: LocationForm,
-            services,
-            store,
+            services: { ...services, store },
         });
 
     beforeEach(() => {

--- a/suite-native/trading-residence/src/components/SkipButton.test.tsx
+++ b/suite-native/trading-residence/src/components/SkipButton.test.tsx
@@ -1,3 +1,5 @@
+import { events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
@@ -5,13 +7,11 @@ import { SkipButton, type SkipButtonProps } from './SkipButton';
 
 const mockAnalyticsReport = jest.fn();
 
-jest.mock('../hooks/useCountrySelectionAnalyticsReport', () => ({
-    useCountrySelectionAnalyticsReport: () => mockAnalyticsReport,
-}));
-
 describe('SkipButton', () => {
     const renderSkipButton = async (props: Partial<SkipButtonProps>) =>
-        await renderWithBasicProvider(<SkipButton onPress={jest.fn()} {...props} />);
+        await renderWithBasicProvider(<SkipButton onPress={jest.fn()} {...props} />, {
+            services: { analytics: mockNativeAnalytics(mockAnalyticsReport) },
+        });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -35,6 +35,9 @@ describe('SkipButton', () => {
         );
 
         expect(mockAnalyticsReport).toHaveBeenCalledTimes(1);
-        expect(mockAnalyticsReport).toHaveBeenCalledWith('cancel');
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.tradingCountrySelectionEvent.name,
+            payload: expect.objectContaining({ action: 'cancel' }),
+        });
     });
 });

--- a/suite-native/trading-residence/src/components/TradingLocationSettings.test.tsx
+++ b/suite-native/trading-residence/src/components/TradingLocationSettings.test.tsx
@@ -1,24 +1,26 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { Text } from '@suite-native/atoms';
 import { getTranslation, localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils-store';
 import { residenceReducer } from '@suite-native/trading-state';
+import { type TradingResidenceRootState } from '@suite-native/trading-types';
 
 import {
     TradingLocationSettings,
     type TradingLocationSettingsProps,
 } from './TradingLocationSettings';
 
+type State = TradingResidenceRootState;
+
 describe('TradingLocationSettings', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const createStore = (preloadedResidenceState = {}) =>
         createLightStore({
@@ -41,7 +43,9 @@ describe('TradingLocationSettings', () => {
         });
 
     const renderTradingLocationSettings = async (props: TradingLocationSettingsProps) =>
-        await renderWithStoreProvider(<TradingLocationSettings {...props} />, { store });
+        await renderWithStoreProvider(<TradingLocationSettings {...props} />, {
+            services: { store },
+        });
 
     beforeEach(() => {
         store = createStore();

--- a/suite-native/trading-residence/src/hooks/useFormCountryCode.test.tsx
+++ b/suite-native/trading-residence/src/hooks/useFormCountryCode.test.tsx
@@ -20,17 +20,19 @@ import { type TradingLocationFormType } from '../types/tradingLocationForm';
 describe('useFormCountryCode', () => {
     const renderLocationForm = async () =>
         await renderHookWithStoreProvider(() => useLocationForm(), {
-            store: createLightStore({
-                reducer: {
-                    locale: localeReducer,
-                    wallet: combineReducers({
-                        settings: createStaticReducer(initialWalletSettingsState),
-                        trading: combineReducers({
-                            residence: residenceReducer,
+            services: {
+                store: createLightStore({
+                    reducer: {
+                        locale: localeReducer,
+                        wallet: combineReducers({
+                            settings: createStaticReducer(initialWalletSettingsState),
+                            trading: combineReducers({
+                                residence: residenceReducer,
+                            }),
                         }),
-                    }),
-                },
-            }),
+                    },
+                }),
+            },
         });
 
     const renderUseFormCountryCode = async (locationForm: TradingLocationFormType) =>

--- a/suite-native/trading-residence/src/hooks/useLocationForm.test.ts
+++ b/suite-native/trading-residence/src/hooks/useLocationForm.test.ts
@@ -1,24 +1,26 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 import Localization, { type Locale } from 'expo-localization';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     act,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { residenceActions, residenceReducer } from '@suite-native/trading-state';
+import { type TradingResidenceRootState } from '@suite-native/trading-types';
 
 import { useLocationForm } from './useLocationForm';
 
+type State = TradingResidenceRootState;
+
 describe('useLocationForm', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const renderUseLocationForm = async () =>
-        await renderHookWithStoreProvider(() => useLocationForm(), { store });
+        await renderHookWithStoreProvider(() => useLocationForm(), { services: { store } });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/trading-residence/src/screens/SettingsTradingLocationScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/SettingsTradingLocationScreen.test.tsx
@@ -39,19 +39,21 @@ jest.mock('@react-navigation/native', () => ({
 describe('TradingLocationSettingsScreen', () => {
     const renderTradingLocationSettingsScreen = async () =>
         await renderWithStoreProvider(<SettingsTradingLocationScreen />, {
-            services,
-            store: createLightStore({
-                reducer: {
-                    locale: localeReducer,
-                    messageSystem: createStaticReducer(messageSystemInitialState),
-                    wallet: combineReducers({
-                        settings: createStaticReducer(initialWalletSettingsState),
-                        trading: combineReducers({
-                            residence: residenceReducer,
+            services: {
+                ...services,
+                store: createLightStore({
+                    reducer: {
+                        locale: localeReducer,
+                        messageSystem: createStaticReducer(messageSystemInitialState),
+                        wallet: combineReducers({
+                            settings: createStaticReducer(initialWalletSettingsState),
+                            trading: combineReducers({
+                                residence: residenceReducer,
+                            }),
                         }),
-                    }),
-                },
-            }),
+                    },
+                }),
+            },
         });
 
     beforeEach(() => {

--- a/suite-native/trading-residence/src/screens/TradingLocationModalScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/TradingLocationModalScreen.test.tsx
@@ -56,19 +56,21 @@ describe('TradingLocationModalScreen', () => {
                 route={mockRoute}
             />,
             {
-                store: createLightStore({
-                    reducer: {
-                        locale: localeReducer,
-                        messageSystem: createStaticReducer(messageSystemInitialState),
-                        wallet: combineReducers({
-                            settings: createStaticReducer(initialWalletSettingsState),
-                            trading: combineReducers({
-                                residence: residenceReducer,
+                services: {
+                    ...services,
+                    store: createLightStore({
+                        reducer: {
+                            locale: localeReducer,
+                            messageSystem: createStaticReducer(messageSystemInitialState),
+                            wallet: combineReducers({
+                                settings: createStaticReducer(initialWalletSettingsState),
+                                trading: combineReducers({
+                                    residence: residenceReducer,
+                                }),
                             }),
-                        }),
-                    },
-                }),
-                services,
+                        },
+                    }),
+                },
             },
         );
 

--- a/suite-native/trading-residence/tsconfig.json
+++ b/suite-native/trading-residence/tsconfig.json
@@ -32,6 +32,7 @@
             "path": "../../suite-common/wallet-core"
         },
         { "path": "../test-utils" },
-        { "path": "../test-utils-store" }
+        { "path": "../test-utils-store" },
+        { "path": "../trading-types" }
     ]
 }

--- a/suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx
@@ -1,11 +1,16 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { selectTradingExchangeSelectedQuoteSwapSlippage } from '@suite-common/trading';
-import { getTranslation } from '@suite-native/intl';
+import { type LocaleSliceRootState, getTranslation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
-import { type TestStore, act, userEvent } from '@suite-native/test-utils-store';
+import { act, userEvent } from '@suite-native/test-utils-store';
+import { type TradingRootState } from '@suite-native/trading-state';
 import { TREZOR_TRADING_DEX_SLIPPAGE_URL } from '@trezor/urls';
 
 import { SlippageBottomSheet } from './SlippageBottomSheet';
 import { createSlippageTestStore, renderWithSlippageTestProvider } from '../test-utils/testUtils';
+
+type State = TradingRootState & LocaleSliceRootState;
 
 jest.mock('@suite-native/link', () => ({
     useOpenLink: jest.fn(),
@@ -18,7 +23,7 @@ const mockOnClose = jest.fn();
 const mockOnSlippageConfirmed = jest.fn();
 
 describe('SlippageBottomSheet', () => {
-    const renderSlippageBottomSheet = async (store: TestStore) => {
+    const renderSlippageBottomSheet = async (store: Store<State>) => {
         const result = await renderWithSlippageTestProvider(
             <SlippageBottomSheet
                 isVisible={false}

--- a/suite-native/trading-slippage/src/test-utils/testUtils.ts
+++ b/suite-native/trading-slippage/src/test-utils/testUtils.ts
@@ -1,11 +1,11 @@
 import type { ReactElement } from 'react';
 
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 import type { ExchangeTrade } from 'invity-api';
 
 import { mockActionType } from '@suite-common/redux-utils/mocks';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
-import { localeInitialState, localeReducer } from '@suite-native/intl';
+import { type LocaleSliceRootState, localeInitialState, localeReducer } from '@suite-native/intl';
 import {
     type RenderHookResult,
     type RenderResult,
@@ -15,10 +15,12 @@ import {
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
 import { getInitializedTradingState, mercuryoDexQuote } from '@suite-native/trading-fixtures';
-import { tradingSlice } from '@suite-native/trading-state';
+import { type TradingRootState, tradingSlice } from '@suite-native/trading-state';
+
+type State = TradingRootState & LocaleSliceRootState;
 
 type SlippageTestOptions = {
-    store?: ReturnType<typeof createLightStore>;
+    store?: Store<State>;
     quote?: ExchangeTrade;
 };
 
@@ -34,7 +36,7 @@ const reducer = {
 
 export const getSlippageTestPreloadedState = (
     quote: ExchangeTrade | undefined = mercuryoDexQuote,
-) => {
+): State => {
     const trading = getInitializedTradingState();
     trading.exchange.selectedQuote = quote;
 
@@ -56,7 +58,7 @@ export const renderWithSlippageTestProvider = (
 ): Promise<RenderResult> => {
     const preloadedState = store ? undefined : getSlippageTestPreloadedState(quote);
 
-    return renderWithStoreProvider(element, { preloadedState, store });
+    return renderWithStoreProvider(element, { preloadedState, services: { store } });
 };
 
 export const renderHookWithSlippageTestProvider = <Result>(
@@ -65,5 +67,5 @@ export const renderHookWithSlippageTestProvider = <Result>(
 ): Promise<RenderHookResult<Result, unknown>> => {
     const preloadedState = store ? undefined : getSlippageTestPreloadedState(quote);
 
-    return renderHookWithStoreProvider(callback, { preloadedState, store });
+    return renderHookWithStoreProvider(callback, { preloadedState, services: { store } });
 };

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.test.tsx
@@ -1,9 +1,11 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type FeesRootState } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import {
-    type TestStore,
     createStoreFromPreloadedState,
     renderHookWithStoreProvider,
     renderWithStoreProvider,
@@ -13,6 +15,8 @@ import { CustomFeeInputs, type CustomFeeInputsProps } from './CustomFeeInputs';
 import { type FeesFormType } from '../../..';
 import { ETH_ACCOUNT_KEY, getWalletState } from '../../../__fixtures__/walletState';
 import { useFeesForm } from '../../../hooks';
+
+type State = FeesRootState;
 
 // Mock the selectors
 jest.mock('@suite-common/wallet-core', () => ({
@@ -28,12 +32,12 @@ const btcSymbol = asNetworkSymbol('btc');
 const ethSymbol = asNetworkSymbol('eth');
 
 describe('CustomFeeInputs', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     const defaultProps = {
         symbol: btcSymbol,
     };
-    const defaultState = {
+    const defaultState: State = {
         wallet: getWalletState(),
     };
 
@@ -44,10 +48,7 @@ describe('CustomFeeInputs', () => {
                     accountKey,
                     defaultFeePerUnit: '1',
                 }),
-            {
-                store,
-                preloadedState: defaultState,
-            },
+            { services: { store }, preloadedState: defaultState },
         );
 
         return result.current;
@@ -64,7 +65,7 @@ describe('CustomFeeInputs', () => {
 
         return await renderWithStoreProvider(<CustomFeeInputs {...finalProps} />, {
             preloadedState: defaultState,
-            store,
+            services: { store },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
     };

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.test.tsx
@@ -1,8 +1,10 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { yup } from '@suite-common/validators';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type FeesRootState } from '@suite-common/wallet-core';
 import { Form, useForm } from '@suite-native/forms';
 import {
-    type TestStore,
     createStoreFromPreloadedState,
     renderWithStoreProvider,
     userEvent,
@@ -12,6 +14,8 @@ import { FeeOption } from './FeeOption';
 import { createFeeLevel } from '../../../__fixtures__/feeLevels';
 import { getWalletState } from '../../../__fixtures__/walletState';
 import { type NativeSupportedPredefinedFeeLevel } from '../../../types';
+
+type State = FeesRootState;
 
 // Create a simple validation schema for testing
 const testValidationSchema = yup.object({
@@ -49,7 +53,7 @@ const mockSelectConvertedNetworkFeeLevelFeePerUnit = jest.requireMock(
 ).selectConvertedNetworkFeeLevelFeePerUnit;
 
 describe('FeeOption', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let mockOnSelectedFeeLevel: jest.Mock;
 
     const defaultProps = {
@@ -67,7 +71,7 @@ describe('FeeOption', () => {
         onSelectedFeeLevel: jest.fn(),
     };
 
-    const getPreloadedState = () => ({
+    const getPreloadedState = (): State => ({
         wallet: getWalletState(),
     });
 
@@ -79,10 +83,7 @@ describe('FeeOption', () => {
             <TestFormWrapper>
                 <FeeOption {...finalProps} />
             </TestFormWrapper>,
-            {
-                store,
-                preloadedState: getPreloadedState(),
-            },
+            { services: { store }, preloadedState: getPreloadedState() },
         );
     };
 

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.test.tsx
@@ -1,11 +1,18 @@
-import { type StateFromReducersMapObject, combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import {
+    type AccountsRootState,
+    type FeesRootState,
+    type FiatRatesRootState,
+    type WalletSettingsRootState,
+    initialWalletSettingsState,
+} from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
-import { localeReducer } from '@suite-native/intl';
+import { type LocaleSliceRootState, localeReducer } from '@suite-native/intl';
 import {
+    type PreloadedStatePartial,
     act,
     createLightStore,
     createStaticReducer,
@@ -18,6 +25,14 @@ import { FeeOptionsList, type FeeOptionsListProps } from './FeeOptionsList';
 import { createFeeLevel, createFeeLevels } from '../../../__fixtures__/feeLevels';
 import { ETH_ACCOUNT_KEY, getWalletState } from '../../../__fixtures__/walletState';
 import { useFeesForm } from '../../../hooks/fees/useFeesForm';
+import { type NativeSendRootState, sendFormInitialState } from '../../../sendFormSlice';
+
+type State = AccountsRootState &
+    FeesRootState &
+    WalletSettingsRootState &
+    FiatRatesRootState &
+    LocaleSliceRootState &
+    NativeSendRootState;
 
 // Mock the fee-related selectors
 jest.mock('@suite-common/wallet-core', () => ({
@@ -62,21 +77,19 @@ describe('FeeOptionsList', () => {
             settings: createStaticReducer(initialWalletSettingsState),
             accounts: createStaticReducer(defaultWalletState.accounts),
             fiat: createStaticReducer(defaultWalletState.fiat),
-            send: createStaticReducer(defaultWalletState.send),
+            send: createStaticReducer({ ...sendFormInitialState, ...defaultWalletState.send }),
             fees: createStaticReducer(defaultWalletState.fees),
         }),
     } as const;
 
-    const createFeeOptionsStore = (
-        preloadedState?: Partial<StateFromReducersMapObject<typeof reducer>>,
-    ) =>
+    const createFeeOptionsStore = (preloadedState?: PreloadedStatePartial<State>): Store<State> =>
         createLightStore({
             reducer,
             preloadedState,
         });
 
     const renderUseFeesForm = async (
-        store: ReturnType<typeof createFeeOptionsStore>,
+        store: Store<State>,
         accountKey: AccountKey = ETH_ACCOUNT_KEY,
         defaultFeePerUnit?: string,
     ) => {
@@ -86,9 +99,7 @@ describe('FeeOptionsList', () => {
                     accountKey,
                     defaultFeePerUnit: defaultFeePerUnit || '1',
                 }),
-            {
-                store,
-            },
+            { services: { store } },
         );
 
         return result.current;
@@ -98,7 +109,7 @@ describe('FeeOptionsList', () => {
         preloadedState,
         props,
     }: {
-        preloadedState?: Partial<StateFromReducersMapObject<typeof reducer>>;
+        preloadedState?: PreloadedStatePartial<State>;
         props?: Partial<FeeOptionsListProps>;
     }) => {
         const finalProps = { ...defaultProps, ...props };
@@ -106,7 +117,7 @@ describe('FeeOptionsList', () => {
         const form = await renderUseFeesForm(store);
 
         const view = await renderWithStoreProvider(<FeeOptionsList {...finalProps} />, {
-            store,
+            services: { store },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/transaction-management/src/components/fees/FeesFooter.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesFooter.test.tsx
@@ -1,11 +1,13 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { yup } from '@suite-common/validators';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type FiatRatesRootState, type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { Form, useForm } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import {
-    type TestStore,
     createStoreFromPreloadedState,
     renderWithStoreProvider,
     userEvent,
@@ -13,6 +15,8 @@ import {
 
 import { FeesFooter } from './FeesFooter';
 import { getWalletState } from '../../__fixtures__/walletState';
+
+type State = WalletSettingsRootState & FiatRatesRootState;
 
 // Create a simple validation schema for testing
 const testValidationSchema = yup.object({
@@ -54,7 +58,7 @@ const mockSelectAccountTokenDecimals =
     jest.requireMock('@suite-native/tokens').selectAccountTokenDecimals;
 
 describe('FeesFooter', () => {
-    let store: TestStore;
+    let store: Store<State>;
     let mockOnSubmit: jest.Mock;
 
     const defaultProps = {
@@ -68,7 +72,7 @@ describe('FeesFooter', () => {
         withSubmitButton: true,
     };
 
-    const getPreloadedState = () => ({
+    const getPreloadedState = (): State => ({
         wallet: getWalletState(),
     });
 
@@ -85,10 +89,7 @@ describe('FeesFooter', () => {
                 */}
                 <FeesFooter {...(finalProps as React.ComponentProps<typeof FeesFooter>)} />
             </TestFormWrapper>,
-            {
-                store,
-                preloadedState: getPreloadedState(),
-            },
+            { services: { store }, preloadedState: getPreloadedState() },
         );
     };
 

--- a/suite-native/transaction-management/src/hooks/fees/useFeesFetching.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesFetching.test.ts
@@ -1,13 +1,16 @@
+import { type Store } from '@reduxjs/toolkit';
+
 import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
-import { type FeesStatus } from '@suite-common/wallet-types';
+import { type FeesRootState } from '@suite-common/wallet-core';
 import {
-    type TestStore,
     createStoreFromPreloadedState,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
 import { useFeesFetching } from './useFeesFetching';
 import { getWalletState } from '../../__fixtures__/walletState';
+
+type State = FeesRootState;
 
 // Mock the fee hooks since they have side effects and we want to test the hook's logic
 jest.mock('@suite-common/wallet-core', () => ({
@@ -23,22 +26,15 @@ const mockUseRefetchFees = jest.requireMock('@suite-common/wallet-core').useRefe
 const mockSelectAreFeesLoading = jest.requireMock('@suite-common/wallet-core').selectAreFeesLoading;
 const btcSymbol = asNetworkSymbol('btc');
 
-// Add fees to the wallet state for testing
-const getWalletStateWithFees = () => ({
-    ...getWalletState(),
-    fees: {
-        btc: {
-            status: 'loaded' as FeesStatus,
-        },
-        eth: {
-            status: 'loaded' as FeesStatus,
-        },
-    },
-});
-
 describe('useFeesFetching', () => {
-    const createMockState = (overrides: Record<string, unknown> = {}) => ({
-        wallet: getWalletStateWithFees(),
+    const createMockState = (overrides: Partial<State> = {}): State => ({
+        wallet: {
+            ...getWalletState(),
+            fees: {
+                btc: { status: 'loaded' },
+                eth: { status: 'loaded' },
+            },
+        },
         ...overrides,
     });
 
@@ -47,15 +43,13 @@ describe('useFeesFetching', () => {
         networkSymbol,
         isRefetchDisabled = false,
     }: {
-        store: TestStore;
+        store: Store<State>;
         networkSymbol?: NetworkSymbol;
         isRefetchDisabled?: boolean;
     }) =>
         await renderHookWithStoreProvider(
             () => useFeesFetching({ networkSymbol, isRefetchDisabled }),
-            {
-                store,
-            },
+            { services: { store } },
         );
 
     beforeEach(() => {

--- a/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.test.ts
+++ b/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.test.ts
@@ -1,10 +1,12 @@
-import { combineReducers } from '@reduxjs/toolkit';
+import { type Store, combineReducers } from '@reduxjs/toolkit';
 
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import {
+    type WalletSettingsRootState,
+    initialWalletSettingsState,
+} from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
-    type TestStore,
     createLightStore,
     createStaticReducer,
     renderHookWithStoreProvider,
@@ -12,13 +14,15 @@ import {
 
 import { useIsNetworkReserveBannerVisible } from './useIsNetworkReserveBannerVisible';
 
+type State = WalletSettingsRootState;
+
 const solSymbol = asNetworkSymbol('sol');
 const btcSymbol = asNetworkSymbol('btc');
 const baseSymbol = asNetworkSymbol('base');
 
 // SOL nativeTokenReserve: "0.003"; base: "0.0002"
 describe('useIsNetworkReserveBannerVisible', () => {
-    let store: TestStore;
+    let store: Store<State>;
 
     beforeEach(() => {
         store = createLightStore({
@@ -36,7 +40,7 @@ describe('useIsNetworkReserveBannerVisible', () => {
 
     const renderHook = async (params: Parameters<typeof useIsNetworkReserveBannerVisible>[0]) =>
         await renderHookWithStoreProvider(() => useIsNetworkReserveBannerVisible(params), {
-            store,
+            services: { store },
         });
 
     it('returns false for null symbol, null amount, null balance, or no-reserve network', async () => {

--- a/suite-native/transaction-management/src/hooks/useShowReviewCancellationAlert.test.ts
+++ b/suite-native/transaction-management/src/hooks/useShowReviewCancellationAlert.test.ts
@@ -1,5 +1,7 @@
+import { type Store } from '@reduxjs/toolkit';
+
+import { type CancelSignSendFormTransactionThunkState } from '@suite-common/wallet-core';
 import {
-    type TestStore,
     createStoreFromPreloadedState,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
@@ -22,14 +24,19 @@ jest.mock('@suite-common/wallet-core', () => ({
 }));
 
 describe('useShowReviewCancellationAlert', () => {
-    let store: TestStore;
+    let store: Store<CancelSignSendFormTransactionThunkState>;
 
     const renderUseShowReviewCancellationAlert = async () =>
-        await renderHookWithStoreProvider(() => useShowReviewCancellationAlert(), { store });
+        await renderHookWithStoreProvider(() => useShowReviewCancellationAlert(), {
+            services: { store },
+        });
 
     beforeEach(() => {
         mockShowAlert.mockClear();
-        store = createStoreFromPreloadedState();
+        const state: CancelSignSendFormTransactionThunkState = {
+            wallet: { send: { drafts: {} } },
+        };
+        store = createStoreFromPreloadedState(state);
     });
 
     it('should return stable callback', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12808,6 +12808,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/formatters@workspace:suite-native/formatters"
   dependencies:
+    "@reduxjs/toolkit": "npm:2.12.0"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -13687,6 +13688,7 @@ __metadata:
   dependencies:
     "@react-navigation/native": "npm:7.1.31"
     "@react-navigation/native-stack": "npm:7.12.0"
+    "@reduxjs/toolkit": "npm:2.12.0"
     "@suite-common/analytics": "workspace:*"
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/message-system": "workspace:*"
@@ -13986,6 +13988,7 @@ __metadata:
     "@suite-common/calldata": "workspace:*"
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
+    "@suite-common/discreet-mode": "workspace:*"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/geolocation": "workspace:*"
     "@suite-common/message-system": "workspace:*"
@@ -13996,6 +13999,7 @@ __metadata:
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
+    "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/trading": "workspace:*"
     "@suite-common/tx-simulation": "workspace:*"
@@ -14869,6 +14873,7 @@ __metadata:
     "@suite-native/trading-atoms": "workspace:*"
     "@suite-native/trading-consts": "workspace:*"
     "@suite-native/trading-state": "workspace:*"
+    "@suite-native/trading-types": "workspace:*"
     "@trezor/analytics-uploader": "workspace:*"
     expo-localization: "npm:~57.0.1"
     react: "npm:19.2.3"


### PR DESCRIPTION
## Description

Refactor tests to inject dependencies through `extra` or `services`, with the store in `services.store`, instead of mocking injectable imports. Simplify rendering and trading test utilities, allow `createTestCompositionRoot` to omit empty `extra`, and preserve explicit state and dependency contracts. Use per-test `createMockDispatch` action collections for dispatch assertions.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/dispatch-services-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/dispatch-services-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/dispatch-services-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/dispatch-services-tests/web/](https://dev.suite.sldev.cz/suite-web/refactor/dispatch-services-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T13:25:05.194Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T13:25:23.417Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->