### PR TITLE
fix(redux-utils): make mock dispatch extra optional

### DIFF
--- a/suite-common/redux-utils/mocks/createMockDispatch.test.ts
+++ b/suite-common/redux-utils/mocks/createMockDispatch.test.ts
@@ -4,16 +4,14 @@ import { createMockDispatch, failOnUnobservedSubscriptions } from './createMockD
 
 type State = { value: number };
 type Extra = { value: string };
-type TestThunk = ThunkAction<Promise<void>, State, Extra, UnknownAction>;
+type TestThunk<TExtra = unknown> = ThunkAction<Promise<void>, State, TExtra, UnknownAction>;
 
-const createTestMockDispatch = () =>
-    createMockDispatch({ getState: () => ({ value: 1 }), extra: { value: 'extra' } });
+const createTestMockDispatch = () => createMockDispatch({ getState: () => ({ value: 1 }) });
 
 describe(createMockDispatch.name, () => {
     it('stores plain actions', () => {
         const { actions, dispatch } = createMockDispatch({
             getState: () => ({ value: 1 }),
-            extra: { value: 'extra' },
         });
         const action = { type: 'test/action', payload: 42 };
 
@@ -30,11 +28,11 @@ describe(createMockDispatch.name, () => {
             getState: () => state,
             extra,
         });
-        const childThunk: TestThunk = async (childDispatch, getState, injectedExtra) => {
+        const childThunk: TestThunk<Extra> = async (childDispatch, getState, injectedExtra) => {
             await Promise.resolve();
             childDispatch({ type: 'test/child', payload: { state: getState(), injectedExtra } });
         };
-        const parentThunk: TestThunk = async parentDispatch => {
+        const parentThunk: TestThunk<Extra> = async parentDispatch => {
             await Promise.resolve();
             parentDispatch(childThunk);
             parentDispatch({ type: 'test/parent' });

--- a/suite-common/redux-utils/mocks/createMockDispatch.ts
+++ b/suite-common/redux-utils/mocks/createMockDispatch.ts
@@ -2,7 +2,7 @@ import { type Action, type ThunkDispatch, type UnknownAction } from '@reduxjs/to
 
 type CreateMockDispatchParams<TState, TExtra> = {
     getState: () => TState;
-    extra: TExtra;
+    extra?: TExtra;
 };
 
 /**

--- a/suite-common/wallet-core/src/yield/thunks/yieldWrapThunks.test.ts
+++ b/suite-common/wallet-core/src/yield/thunks/yieldWrapThunks.test.ts
@@ -46,7 +46,7 @@ const runThunk = async (
         accountKey: ethereumAccount.key,
     },
 ) => {
-    const { actions, dispatch } = createMockDispatch({ getState, extra: {} });
+    const { actions, dispatch } = createMockDispatch({ getState });
     const balance = await trackWrappedNativeTokenThunk(payload)(dispatch, getState, {}).unwrap();
     const addTokensActions = actions.filter(action =>
         accountsActions.addAccountTokens.match(action),


### PR DESCRIPTION
## Description

Make createMockDispatch extra optional so tests without injected dependencies can call createMockDispatch({ getState }). Remove unnecessary extra arguments from mock dispatch call sites and test helpers while preserving direct invocation of the yield thunk under test.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All three changed files are unit-test-level artifacts: two are `.test.ts` files and one is a narrow redux mock utility (`createMockDispatch.ts`). None of them are application source files that drive E2E behavior, and the static coverage mapper found no E2E references. The yield thunk test relates to the same functional domain as the yield E2E tests, but because it is itself a test file and does not modify production code, running the yield E2E suite would not provide meaningful regression signal. Therefore, no E2E tests are recommended for this changeset; rely on the existing unit-test suite and CI linting instead.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/redux-utils/mocks/createMockDispatch.test.ts`
- `suite-common/redux-utils/mocks/createMockDispatch.ts`
- `suite-common/wallet-core/src/yield/thunks/yieldWrapThunks.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-common/redux-utils/mocks/createMockDispatch.test.ts`
- `suite-common/redux-utils/mocks/createMockDispatch.ts`
- `suite-common/wallet-core/src/yield/thunks/yieldWrapThunks.test.ts`

_Updated: 2026-09-10T04:52:31.185Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/codex/mock-dispatch-optional-extra/web/](https://dev.suite.sldev.cz/suite-web/codex/mock-dispatch-optional-extra/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=codex/mock-dispatch-optional-extra&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=codex/mock-dispatch-optional-extra&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=codex/mock-dispatch-optional-extra&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T04:56:05.616Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T04:55:50.586Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->