### PR TITLE
fix(eslint): bound recursive contract type comparisons

### DIFF
--- a/eslint-local-rules/no-unused-intersection-members/README.md
+++ b/eslint-local-rules/no-unused-intersection-members/README.md
@@ -123,6 +123,10 @@ The complete alias is kept when the implementation contains an ambiguous use, in
 Contracts with no observed runtime usages are also ignored. Other tooling is better suited to finding
 entirely unused declarations.
 
+Structural comparisons stop after 32 levels. Recursive generics can produce a different type at every
+level, so detecting repeated types alone does not prevent a stack overflow. When the depth limit is
+reached, the comparison cannot prove that a member is removable and the rule keeps it.
+
 ### Type-aware execution
 
 The rule requires TypeScript parser services and reuses their existing `Program` and `TypeChecker`. It

--- a/eslint-local-rules/no-unused-intersection-members/rule.test.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.test.ts
@@ -23,6 +23,23 @@ const typeAwareTestFilename = path.join(__dirname, '../..', 'unused-intersection
 typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMembersRule, {
     valid: [
         {
+            name: 'preserves members when recursive generic arguments keep growing',
+            filename: typeAwareTestFilename,
+            code: `
+                    type Left<T> = { left: T; next: Left<T[]> };
+                    type Right<T> = { right: T; next: Right<T[]> };
+                    type Both<T> = { left: T; right: T; next: Both<T[]> };
+                    type LeftDep = { root: Left<number> };
+                    type RightDep = { root: Right<number> };
+                    type UnusedDep = { unused: boolean };
+                    type RunDeps = LeftDep & RightDep & UnusedDep;
+
+                    declare function consume(value: Both<number>): void;
+
+                    const run = (deps: RunDeps) => consume(deps.root);
+                `,
+        },
+        {
             name: 'accepts when every direct intersection member is used',
             filename: typeAwareTestFilename,
             code: `
@@ -345,6 +362,50 @@ typeAwareRuleTester.run('no-unused-intersection-members', noUnusedIntersectionMe
         },
     ],
     invalid: [
+        {
+            name: 'reports unused members alongside recursive types with stable arguments',
+            filename: typeAwareTestFilename,
+            code: `
+                    type Left<T> = { left: T; next: Left<T> };
+                    type Right<T> = { right: T; next: Right<T> };
+                    type Both<T> = { left: T; right: T; next: Both<T> };
+                    type LeftDep = { root: Left<number> };
+                    type RightDep = { root: Right<number> };
+                    type UnusedDep = { unused: boolean };
+                    type RunDeps = LeftDep & RightDep & UnusedDep;
+
+                    declare function consume(value: Both<number>): void;
+
+                    const run = (deps: RunDeps) => consume(deps.root);
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'UnusedDep', typeName: 'RunDeps' },
+                },
+            ],
+        },
+        {
+            name: 'reports unused members when finite nested requirements are split across members',
+            filename: typeAwareTestFilename,
+            code: `
+                    type Branch<T> = { next: { next: T } };
+                    type LeftDep = { root: Branch<{ left: number }> };
+                    type RightDep = { root: Branch<{ right: number }> };
+                    type UnusedDep = { unused: boolean };
+                    type RunDeps = LeftDep & RightDep & UnusedDep;
+
+                    declare function consume(value: Branch<{ left: number; right: number }>): void;
+
+                    const run = (deps: RunDeps) => consume(deps.root);
+                `,
+            errors: [
+                {
+                    messageId: 'unusedIntersectionMember',
+                    data: { memberName: 'UnusedDep', typeName: 'RunDeps' },
+                },
+            ],
+        },
         {
             name: 'reports an unused direct intersection member',
             filename: typeAwareTestFilename,

--- a/eslint-local-rules/no-unused-intersection-members/rule.ts
+++ b/eslint-local-rules/no-unused-intersection-members/rule.ts
@@ -48,6 +48,7 @@ type RuleOptions = {
 };
 
 const defaultTypeNameSuffixes = ['State', 'Deps'];
+const maxTypeComparisonDepth = 32;
 
 const isInsideTypeNode = (node: ts.Node) => {
     let currentNode: ts.Node | undefined = node.parent;
@@ -455,6 +456,12 @@ const areTypesCollectivelyAssignable = (
     checker: ts.TypeChecker,
     visitedTypes = new Set<ts.Type>(),
 ): boolean => {
+    if (visitedTypes.size >= maxTypeComparisonDepth) {
+        // Recursive generics can create a new type at every level, bypassing cycle detection.
+        // Stop before further checker calls and keep the member when this proof is too deep.
+        return false;
+    }
+
     if (
         (targetType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0 ||
         sourceTypes.some(sourceType => checker.isTypeAssignableTo(sourceType, targetType))


### PR DESCRIPTION
## Description

The local no-unused-intersection-members rule overflows the stack when recursive generic arguments keep growing, because each level creates a new type that bypasses cycle detection. Bound structural comparisons to 32 levels and conservatively retain members when the comparison cannot prove they are removable.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are an ESLint local rule (`no-unused-intersection-members`) and its unit test. These only affect static linting and do not change any runtime application behavior exercised by the Playwright E2E suite. None of the 36 candidate E2E tests cover ESLint rule logic, so no E2E tests are required. The appropriate validation is the rule's own unit test suite, which is already included as a changed file.

<details><summary><b>Changed files (2)</b></summary>

- `eslint-local-rules/no-unused-intersection-members/rule.test.ts`
- `eslint-local-rules/no-unused-intersection-members/rule.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `eslint-local-rules/no-unused-intersection-members/rule.test.ts`
- `eslint-local-rules/no-unused-intersection-members/rule.ts`

_Updated: 2026-09-10T07:29:05.769Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/eslint-recursive-contracts/web/](https://dev.suite.sldev.cz/suite-web/fix/eslint-recursive-contracts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/eslint-recursive-contracts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/eslint-recursive-contracts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T07:32:33.528Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T07:31:54.507Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->