### PR TITLE
chore(connect): restrict dependency consumers

### DIFF
--- a/packages/connect-cli/forbiddenDeps.config.ts
+++ b/packages/connect-cli/forbiddenDeps.config.ts
@@ -1,0 +1,8 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: [],
+        reason: 'Connect CLI is an application and must not be a workspace dependency.',
+    },
+};

--- a/packages/connect-cli/package.json
+++ b/packages/connect-cli/package.json
@@ -22,6 +22,7 @@
         "@trezor/transport-common": "workspace:*"
     },
     "devDependencies": {
+        "@trezor/requirements": "workspace:*",
         "tsx": "^4.21.0"
     }
 }

--- a/packages/connect-cli/tsconfig.json
+++ b/packages/connect-cli/tsconfig.json
@@ -5,6 +5,7 @@
         { "path": "../connect" },
         { "path": "../transport" },
         { "path": "../transport-bluetooth" },
-        { "path": "../transport-common" }
+        { "path": "../transport-common" },
+        { "path": "../requirements" }
     ]
 }

--- a/packages/connect-data/forbiddenDeps.config.ts
+++ b/packages/connect-data/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: ['@trezor/connect', '@trezor/connect-explorer'],
+        reason: 'Connect data is internal to Connect, with an exception for the Explorer coin table.',
+    },
+    'forbidden-in': {
+        packageNamePattern: '^@trezor/network-',
+        reason:
+            'Network modules must receive Connect through dependency injection. ' +
+            'Import contracts from @trezor/connect-common.',
+    },
+};

--- a/packages/connect-data/forbiddenDeps.config.ts
+++ b/packages/connect-data/forbiddenDeps.config.ts
@@ -5,10 +5,4 @@ export const forbiddenDepsConfig: ForbiddenDepsConfig = {
         packages: ['@trezor/connect', '@trezor/connect-explorer'],
         reason: 'Connect data is internal to Connect, with an exception for the Explorer coin table.',
     },
-    'forbidden-in': {
-        packageNamePattern: '^@trezor/network-',
-        reason:
-            'Network modules must receive Connect through dependency injection. ' +
-            'Import contracts from @trezor/connect-common.',
-    },
 };

--- a/packages/connect-data/package.json
+++ b/packages/connect-data/package.json
@@ -48,6 +48,7 @@
         "tslib": "^2.6.2"
     },
     "devDependencies": {
+        "@trezor/requirements": "workspace:*",
         "@types/chrome": "^0.2.2",
         "@types/jest": "30.0.0",
         "@types/node": "22.13.10"

--- a/packages/connect-data/tsconfig.json
+++ b/packages/connect-data/tsconfig.json
@@ -5,5 +5,5 @@
         "types": ["node", "chrome", "jest"]
     },
     "include": [".", "./files/**/*.json"],
-    "references": []
+    "references": [{ "path": "../requirements" }]
 }

--- a/packages/connect-data/tsconfig.lib.json
+++ b/packages/connect-data/tsconfig.lib.json
@@ -6,5 +6,5 @@
         "rootDir": "./src",
         "types": ["node", "chrome", "jest"]
     },
-    "references": []
+    "references": [{ "path": "../requirements" }]
 }

--- a/packages/connect-electron/forbiddenDeps.config.ts
+++ b/packages/connect-electron/forbiddenDeps.config.ts
@@ -1,0 +1,10 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-in': {
+        packageNamePattern: '^@trezor/network-',
+        reason:
+            'Network modules must receive Connect through dependency injection. ' +
+            'Import contracts from @trezor/connect-common.',
+    },
+};

--- a/packages/connect-electron/package.json
+++ b/packages/connect-electron/package.json
@@ -16,5 +16,8 @@
         "@trezor/connect-common": "workspace:*",
         "@trezor/ipc-proxy": "workspace:*",
         "@trezor/utils": "workspace:*"
+    },
+    "devDependencies": {
+        "@trezor/requirements": "workspace:*"
     }
 }

--- a/packages/connect-electron/tsconfig.json
+++ b/packages/connect-electron/tsconfig.json
@@ -5,6 +5,7 @@
         { "path": "../connect" },
         { "path": "../connect-common" },
         { "path": "../ipc-proxy" },
-        { "path": "../utils" }
+        { "path": "../utils" },
+        { "path": "../requirements" }
     ]
 }

--- a/packages/connect-explorer-theme/forbiddenDeps.config.ts
+++ b/packages/connect-explorer-theme/forbiddenDeps.config.ts
@@ -5,10 +5,4 @@ export const forbiddenDepsConfig: ForbiddenDepsConfig = {
         packages: ['@trezor/connect-explorer'],
         reason: 'The Explorer theme is internal to Connect Explorer.',
     },
-    'forbidden-in': {
-        packageNamePattern: '^@trezor/network-',
-        reason:
-            'Network modules must receive Connect through dependency injection. ' +
-            'Import contracts from @trezor/connect-common.',
-    },
 };

--- a/packages/connect-explorer-theme/forbiddenDeps.config.ts
+++ b/packages/connect-explorer-theme/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: ['@trezor/connect-explorer'],
+        reason: 'The Explorer theme is internal to Connect Explorer.',
+    },
+    'forbidden-in': {
+        packageNamePattern: '^@trezor/network-',
+        reason:
+            'Network modules must receive Connect through dependency injection. ' +
+            'Import contracts from @trezor/connect-common.',
+    },
+};

--- a/packages/connect-explorer-theme/package.json
+++ b/packages/connect-explorer-theme/package.json
@@ -47,6 +47,7 @@
         "zod": "4.3.6"
     },
     "devDependencies": {
+        "@trezor/requirements": "workspace:*",
         "@types/react": "19.2.14",
         "concurrently": "^10.0.3",
         "next": "15.5.21",

--- a/packages/connect-explorer-theme/tsconfig.json
+++ b/packages/connect-explorer-theme/tsconfig.json
@@ -11,6 +11,7 @@
         { "path": "../product-components" },
         { "path": "../theme" },
         { "path": "../type-utils" },
-        { "path": "../utils" }
+        { "path": "../utils" },
+        { "path": "../requirements" }
     ]
 }

--- a/packages/connect-explorer/forbiddenDeps.config.ts
+++ b/packages/connect-explorer/forbiddenDeps.config.ts
@@ -1,0 +1,8 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: [],
+        reason: 'Connect Explorer is an application and must not be a workspace dependency.',
+    },
+};

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -55,6 +55,7 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
+        "@trezor/requirements": "workspace:*",
         "@types/chrome": "^0.2.2",
         "@types/node": "22.13.10",
         "@types/redux-logger": "^3.0.13",

--- a/packages/connect-explorer/tsconfig.json
+++ b/packages/connect-explorer/tsconfig.json
@@ -34,6 +34,7 @@
         { "path": "../theme" },
         { "path": "../urls" },
         { "path": "../utils" },
-        { "path": "../eslint" }
+        { "path": "../eslint" },
+        { "path": "../requirements" }
     ]
 }

--- a/packages/connect-mobile/forbiddenDeps.config.ts
+++ b/packages/connect-mobile/forbiddenDeps.config.ts
@@ -5,10 +5,4 @@ export const forbiddenDepsConfig: ForbiddenDepsConfig = {
         packages: ['@suite-native/app', '@trezor/connect-explorer', 'connect-mobile-example'],
         reason: 'The mobile client is restricted to Explorer, the mobile example and Suite Native E2E tests.',
     },
-    'forbidden-in': {
-        packageNamePattern: '^@trezor/network-',
-        reason:
-            'Network modules must receive Connect through dependency injection. ' +
-            'Import contracts from @trezor/connect-common.',
-    },
 };

--- a/packages/connect-mobile/forbiddenDeps.config.ts
+++ b/packages/connect-mobile/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: ['@suite-native/app', '@trezor/connect-explorer', 'connect-mobile-example'],
+        reason: 'The mobile client is restricted to Explorer, the mobile example and Suite Native E2E tests.',
+    },
+    'forbidden-in': {
+        packageNamePattern: '^@trezor/network-',
+        reason:
+            'Network modules must receive Connect through dependency injection. ' +
+            'Import contracts from @trezor/connect-common.',
+    },
+};

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -35,5 +35,8 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
+    },
+    "devDependencies": {
+        "@trezor/requirements": "workspace:*"
     }
 }

--- a/packages/connect-mobile/tsconfig.json
+++ b/packages/connect-mobile/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../connect-common" },
-        { "path": "../utils" }
+        { "path": "../utils" },
+        { "path": "../requirements" }
     ]
 }

--- a/packages/connect-mobile/tsconfig.lib.json
+++ b/packages/connect-mobile/tsconfig.lib.json
@@ -7,6 +7,7 @@
     },
     "references": [
         { "path": "../connect-common" },
-        { "path": "../utils" }
+        { "path": "../utils" },
+        { "path": "../requirements" }
     ]
 }

--- a/packages/connect-plugin-ethereum/forbiddenDeps.config.ts
+++ b/packages/connect-plugin-ethereum/forbiddenDeps.config.ts
@@ -1,0 +1,8 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: [],
+        reason: 'The deprecated Ethereum plugin must not be a workspace dependency.',
+    },
+};

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -42,5 +42,8 @@
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib",
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
+    },
+    "devDependencies": {
+        "@trezor/requirements": "workspace:*"
     }
 }

--- a/packages/connect-plugin-ethereum/tsconfig.json
+++ b/packages/connect-plugin-ethereum/tsconfig.json
@@ -5,5 +5,5 @@
         "outDir": "./libDev"
     },
     "include": ["."],
-    "references": []
+    "references": [{ "path": "../requirements" }]
 }

--- a/packages/connect-plugin-ethereum/tsconfig.lib.json
+++ b/packages/connect-plugin-ethereum/tsconfig.lib.json
@@ -5,5 +5,5 @@
         "outDir": "./lib",
         "rootDir": "./src"
     },
-    "references": []
+    "references": [{ "path": "../requirements" }]
 }

--- a/packages/connect-plugin-stellar/forbiddenDeps.config.ts
+++ b/packages/connect-plugin-stellar/forbiddenDeps.config.ts
@@ -1,0 +1,8 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: [],
+        reason: 'The deprecated Stellar plugin must not be a workspace dependency.',
+    },
+};

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -42,5 +42,8 @@
         "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib",
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
+    },
+    "devDependencies": {
+        "@trezor/requirements": "workspace:*"
     }
 }

--- a/packages/connect-plugin-stellar/tsconfig.json
+++ b/packages/connect-plugin-stellar/tsconfig.json
@@ -2,5 +2,5 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "./libDev" },
     "include": ["."],
-    "references": []
+    "references": [{ "path": "../requirements" }]
 }

--- a/packages/connect-plugin-stellar/tsconfig.lib.json
+++ b/packages/connect-plugin-stellar/tsconfig.lib.json
@@ -5,5 +5,5 @@
         "outDir": "./lib",
         "rootDir": "./src"
     },
-    "references": []
+    "references": [{ "path": "../requirements" }]
 }

--- a/packages/connect-web/forbiddenDeps.config.ts
+++ b/packages/connect-web/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: ['@trezor/connect-explorer', '@trezor/connect-webextension', '@trezor/suite-e2e'],
+        reason: 'The web client is restricted to Explorer, webextension implementation reuse and Suite E2E tests.',
+    },
+    'forbidden-in': {
+        packageNamePattern: '^@trezor/network-',
+        reason:
+            'Network modules must receive Connect through dependency injection. ' +
+            'Import contracts from @trezor/connect-common.',
+    },
+};

--- a/packages/connect-web/forbiddenDeps.config.ts
+++ b/packages/connect-web/forbiddenDeps.config.ts
@@ -5,10 +5,4 @@ export const forbiddenDepsConfig: ForbiddenDepsConfig = {
         packages: ['@trezor/connect-explorer', '@trezor/connect-webextension', '@trezor/suite-e2e'],
         reason: 'The web client is restricted to Explorer, webextension implementation reuse and Suite E2E tests.',
     },
-    'forbidden-in': {
-        packageNamePattern: '^@trezor/network-',
-        reason:
-            'Network modules must receive Connect through dependency injection. ' +
-            'Import contracts from @trezor/connect-common.',
-    },
 };

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -52,6 +52,7 @@
     "devDependencies": {
         "@playwright/test": "1.62.1",
         "@trezor/eslint": "workspace:*",
+        "@trezor/requirements": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/chrome": "^0.2.2",
         "@types/jest": "30.0.0",

--- a/packages/connect-web/tsconfig.json
+++ b/packages/connect-web/tsconfig.json
@@ -16,6 +16,7 @@
         { "path": "../utils" },
         { "path": "../websocket-client" },
         { "path": "../eslint" },
+        { "path": "../requirements" },
         { "path": "../type-utils" }
     ]
 }

--- a/packages/connect-web/tsconfig.lib.json
+++ b/packages/connect-web/tsconfig.lib.json
@@ -11,6 +11,7 @@
         { "path": "../utils" },
         { "path": "../websocket-client" },
         { "path": "../eslint" },
+        { "path": "../requirements" },
         { "path": "../type-utils" }
     ]
 }

--- a/packages/connect-webextension/forbiddenDeps.config.ts
+++ b/packages/connect-webextension/forbiddenDeps.config.ts
@@ -1,0 +1,14 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'allowed-only-in': {
+        packages: ['@trezor/connect-explorer', '@trezor/webextension-mv3-sw-ts'],
+        reason: 'The webextension client is restricted to Explorer and the webextension example.',
+    },
+    'forbidden-in': {
+        packageNamePattern: '^@trezor/network-',
+        reason:
+            'Network modules must receive Connect through dependency injection. ' +
+            'Import contracts from @trezor/connect-common.',
+    },
+};

--- a/packages/connect-webextension/forbiddenDeps.config.ts
+++ b/packages/connect-webextension/forbiddenDeps.config.ts
@@ -5,10 +5,4 @@ export const forbiddenDepsConfig: ForbiddenDepsConfig = {
         packages: ['@trezor/connect-explorer', '@trezor/webextension-mv3-sw-ts'],
         reason: 'The webextension client is restricted to Explorer and the webextension example.',
     },
-    'forbidden-in': {
-        packageNamePattern: '^@trezor/network-',
-        reason:
-            'Network modules must receive Connect through dependency injection. ' +
-            'Import contracts from @trezor/connect-common.',
-    },
 };

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -51,6 +51,7 @@
     "devDependencies": {
         "@babel/preset-typescript": "^7.29.7",
         "@trezor/eslint": "workspace:*",
+        "@trezor/requirements": "workspace:*",
         "@types/chrome": "^0.2.2",
         "@types/w3c-web-usb": "^1.0.14",
         "babel-loader": "^10.1.1",

--- a/packages/connect-webextension/tsconfig.json
+++ b/packages/connect-webextension/tsconfig.json
@@ -9,6 +9,7 @@
     "references": [
         { "path": "../connect-common" },
         { "path": "../connect-web" },
-        { "path": "../eslint" }
+        { "path": "../eslint" },
+        { "path": "../requirements" }
     ]
 }

--- a/packages/connect-webextension/tsconfig.lib.json
+++ b/packages/connect-webextension/tsconfig.lib.json
@@ -9,6 +9,7 @@
     "references": [
         { "path": "../connect-common" },
         { "path": "../connect-web" },
-        { "path": "../eslint" }
+        { "path": "../eslint" },
+        { "path": "../requirements" }
     ]
 }

--- a/packages/connect/forbiddenDeps.config.ts
+++ b/packages/connect/forbiddenDeps.config.ts
@@ -1,0 +1,10 @@
+import type { ForbiddenDepsConfig } from '@trezor/requirements';
+
+export const forbiddenDepsConfig: ForbiddenDepsConfig = {
+    'forbidden-in': {
+        packageNamePattern: '^@trezor/network-',
+        reason:
+            'Network modules must receive Connect through dependency injection. ' +
+            'Import contracts from @trezor/connect-common.',
+    },
+};

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -111,6 +111,7 @@
     "devDependencies": {
         "@babel/preset-typescript": "^7.29.7",
         "@trezor/eslint": "workspace:*",
+        "@trezor/requirements": "workspace:*",
         "@trezor/trezor-user-env-link": "workspace:*",
         "@types/jws": "^3.2.11",
         "@types/node": "22.13.10",

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -38,6 +38,7 @@
         { "path": "../utils" },
         { "path": "../utxo-lib" },
         { "path": "../eslint" },
+        { "path": "../requirements" },
         { "path": "../trezor-user-env-link" }
     ]
 }

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -35,6 +35,7 @@
         { "path": "../utils" },
         { "path": "../utxo-lib" },
         { "path": "../eslint" },
+        { "path": "../requirements" },
         { "path": "../trezor-user-env-link" }
     ]
 }

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -119,6 +119,32 @@ export const typescriptConfig = [
         },
     },
     {
+        files: ['networks/**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+        rules: {
+            '@typescript-eslint/no-restricted-imports': [
+                'error',
+                {
+                    paths: [
+                        { name: '.' },
+                        { name: '..' },
+                        { name: '../..' },
+                        electronIpcMainRestrictedImport,
+                    ],
+                    patterns: [
+                        buildArtifactPatterns,
+                        networksPackagePattern,
+                        ...connectDeepImportPatterns,
+                        {
+                            regex: '^@trezor/connect(?!-common(?:/|$))',
+                            message:
+                                'Network modules must receive Connect through dependency injection. Import contracts from @trezor/connect-common.',
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    {
         // restrict import of suite-common and suite-native packages outside of suite
         files: ['packages/**/*.{js,mjs,cjs,ts,jsx,tsx}'],
         ignores: ['packages/suite*/**/*'],

--- a/packages/requirements/src/requirements/forbidden-deps/forbiddenDepsTypes.ts
+++ b/packages/requirements/src/requirements/forbidden-deps/forbiddenDepsTypes.ts
@@ -19,7 +19,14 @@ export type AllowedOnlyInRule = {
     readonly reason: string;
 };
 
+export type ForbiddenInRule = {
+    /** Regular expression matching consumer workspace names. */
+    readonly packageNamePattern: string;
+    readonly reason: string;
+};
+
 export type ForbiddenDepsConfig = {
     readonly 'forbidden-deps'?: ReadonlyArray<ForbiddenDependency>;
     readonly 'allowed-only-in'?: AllowedOnlyInRule;
+    readonly 'forbidden-in'?: ForbiddenInRule;
 };

--- a/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.test.ts
+++ b/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.test.ts
@@ -1,4 +1,5 @@
-import { getForbiddenDependencyErrors } from './requireForbiddenDeps';
+import type { ForbiddenDepsConfig } from './forbiddenDepsTypes';
+import { getDependencyConsumerErrors, getForbiddenDependencyErrors } from './requireForbiddenDeps';
 
 describe(getForbiddenDependencyErrors.name, () => {
     it('rejects an exact forbidden dependency', () => {
@@ -44,6 +45,119 @@ describe(getForbiddenDependencyErrors.name, () => {
             }),
         ).toEqual([
             '@suite-common/redux-utils: "@suite-common/wallet-core" is forbidden in dependencies. Reason: Redux utilities must stay domain-independent.',
+        ]);
+    });
+});
+
+describe(getDependencyConsumerErrors.name, () => {
+    const connectConfig: ForbiddenDepsConfig = {
+        'forbidden-in': {
+            packageNamePattern: '^@trezor/network-',
+            reason: 'Inject the client.',
+        },
+    };
+
+    it.each([
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    ] as const)(
+        'rejects a network consumer in %s using the dependency-owned config',
+        async field => {
+            const errors = await getDependencyConsumerErrors({
+                dependencyOccurrences: [{ field, name: '@trezor/connect' }],
+                workspaceName: '@trezor/network-future',
+                repoRoot: '/repo',
+                getWorkspaceDirByName: () => '/repo/packages/connect',
+                loadConfig: () => Promise.resolve(connectConfig),
+            });
+
+            expect(errors).toEqual([
+                `@trezor/network-future: "@trezor/connect" is forbidden in ${field} by its "forbidden-in" rule. Reason: Inject the client.`,
+            ]);
+        },
+    );
+
+    it('allows applications to depend on Connect', async () => {
+        const errors = await getDependencyConsumerErrors({
+            dependencyOccurrences: [{ field: 'dependencies', name: '@trezor/connect' }],
+            workspaceName: '@trezor/suite',
+            repoRoot: '/repo',
+            getWorkspaceDirByName: () => '/repo/packages/connect',
+            loadConfig: () => Promise.resolve(connectConfig),
+        });
+
+        expect(errors).toEqual([]);
+    });
+
+    it('allows dependencies without consumer restrictions', async () => {
+        const errors = await getDependencyConsumerErrors({
+            dependencyOccurrences: [{ field: 'dependencies', name: '@trezor/connect-common' }],
+            workspaceName: '@trezor/network-ethereum',
+            repoRoot: '/repo',
+            getWorkspaceDirByName: () => '/repo/packages/connect-common',
+            loadConfig: () => Promise.resolve(undefined),
+        });
+
+        expect(errors).toEqual([]);
+    });
+
+    it('preserves allowed-only-in restrictions', async () => {
+        const errors = await getDependencyConsumerErrors({
+            dependencyOccurrences: [{ field: 'dependencies', name: '@trezor/example' }],
+            workspaceName: '@trezor/suite',
+            repoRoot: '/repo',
+            getWorkspaceDirByName: () => '/repo/packages/example',
+            loadConfig: () =>
+                Promise.resolve({
+                    'allowed-only-in': {
+                        packages: ['@trezor/another-app'],
+                        reason: 'Internal implementation.',
+                    },
+                }),
+        });
+
+        expect(errors).toEqual([
+            '@trezor/suite: "@trezor/example" is allowed only in "@trezor/another-app" and must not be listed in dependencies. Reason: Internal implementation.',
+        ]);
+    });
+
+    it('does not let allowed-only-in bypass forbidden-in', async () => {
+        const errors = await getDependencyConsumerErrors({
+            dependencyOccurrences: [{ field: 'dependencies', name: '@trezor/connect' }],
+            workspaceName: '@trezor/network-ethereum',
+            repoRoot: '/repo',
+            getWorkspaceDirByName: () => '/repo/packages/connect',
+            loadConfig: () =>
+                Promise.resolve({
+                    ...connectConfig,
+                    'allowed-only-in': {
+                        packages: ['@trezor/network-ethereum'],
+                        reason: 'Internal implementation.',
+                    },
+                }),
+        });
+
+        expect(errors).toEqual([
+            '@trezor/network-ethereum: "@trezor/connect" is forbidden in dependencies by its "forbidden-in" rule. Reason: Inject the client.',
+        ]);
+    });
+
+    it('reports an invalid consumer pattern against the dependency owning it', async () => {
+        const errors = await getDependencyConsumerErrors({
+            dependencyOccurrences: [{ field: 'dependencies', name: '@trezor/connect' }],
+            workspaceName: '@trezor/network-ethereum',
+            repoRoot: '/repo',
+            getWorkspaceDirByName: () => '/repo/packages/connect',
+            loadConfig: () =>
+                Promise.resolve({
+                    'forbidden-in': { packageNamePattern: '[', reason: 'Invalid configuration.' },
+                }),
+        });
+
+        expect(errors).toEqual([
+            '@trezor/connect: "[" in "forbidden-in" is not a valid packageNamePattern regular expression.',
         ]);
     });
 });

--- a/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts
+++ b/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from 'node:url';
 import { type PackageJson, readPackageJson } from '@trezor/node-utils';
 import { typedObjectKeys } from '@trezor/utils';
 
-import type { AllowedOnlyInRule, ForbiddenDepsConfig } from './forbiddenDepsTypes';
+import type { AllowedOnlyInRule, ForbiddenDepsConfig, ForbiddenInRule } from './forbiddenDepsTypes';
 import { getWorkspaceDirectoryMap } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
@@ -95,6 +95,17 @@ const getWorkspaceDirectoryResolver = (repoRoot: string): WorkspaceDirectories =
 const getWorkspaceDirectoryByName: WorkspaceDirectoryResolver = ({ repoRoot, workspaceName }) =>
     getWorkspaceDirectoryResolver(repoRoot).get(workspaceName);
 
+const parseForbiddenInPattern = (rule: ForbiddenInRule) => {
+    try {
+        return { pattern: new RegExp(rule.packageNamePattern), error: null };
+    } catch {
+        return {
+            pattern: null,
+            error: `${JSON.stringify(rule.packageNamePattern)} in "forbidden-in" is not a valid packageNamePattern regular expression.`,
+        };
+    }
+};
+
 type InvalidConfiguredPackagesErrorsParams = {
     readonly dependencyRule: ForbiddenDepsConfig | undefined;
     readonly workspaceDirectories: WorkspaceDirectories;
@@ -107,6 +118,14 @@ const getInvalidConfiguredPackagesErrors = ({
     workspaceName,
 }: InvalidConfiguredPackagesErrorsParams): ReadonlyArray<string> => {
     const errors: string[] = [];
+
+    const forbiddenIn = dependencyRule?.['forbidden-in'];
+    if (forbiddenIn !== undefined) {
+        const { error } = parseForbiddenInPattern(forbiddenIn);
+        if (error !== null) {
+            errors.push(`${workspaceName}: ${error}`);
+        }
+    }
 
     for (const forbiddenDependency of dependencyRule?.['forbidden-deps'] ?? []) {
         if (forbiddenDependency.packageName === undefined) {
@@ -168,7 +187,7 @@ export const getForbiddenDependencyErrors = ({
     });
 };
 
-type AllowedOnlyErrorsParams = {
+type DependencyConsumerErrorsParams = {
     readonly dependencyOccurrences: ReadonlyArray<DependencyOccurrence>;
     readonly getWorkspaceDirByName: WorkspaceDirectoryResolver;
     readonly loadConfig: ForbiddenDepsConfigLoader;
@@ -176,13 +195,13 @@ type AllowedOnlyErrorsParams = {
     readonly workspaceName: string;
 };
 
-const getAllowedOnlyErrors = async ({
+export const getDependencyConsumerErrors = async ({
     dependencyOccurrences,
     getWorkspaceDirByName,
     loadConfig,
     repoRoot,
     workspaceName,
-}: AllowedOnlyErrorsParams): Promise<ReadonlyArray<string>> => {
+}: DependencyConsumerErrorsParams): Promise<ReadonlyArray<string>> => {
     const errors: string[] = [];
 
     for (const dependencyOccurrence of dependencyOccurrences) {
@@ -198,13 +217,25 @@ const getAllowedOnlyErrors = async ({
         const dependencyRule = await loadConfig(dependencyWorkspaceDir);
         const allowedOnlyIn = dependencyRule?.['allowed-only-in'];
 
-        if (allowedOnlyIn === undefined || allowedOnlyIn.packages.includes(workspaceName)) {
+        if (allowedOnlyIn !== undefined && !allowedOnlyIn.packages.includes(workspaceName)) {
+            errors.push(
+                `${workspaceName}: ${JSON.stringify(dependencyOccurrence.name)} is allowed only in ${formatAllowedOnlyInPackages(allowedOnlyIn)} and must not be listed in ${dependencyOccurrence.field}. Reason: ${allowedOnlyIn.reason}`,
+            );
+        }
+
+        const forbiddenIn = dependencyRule?.['forbidden-in'];
+        if (forbiddenIn === undefined) {
             continue;
         }
 
-        errors.push(
-            `${workspaceName}: ${JSON.stringify(dependencyOccurrence.name)} is allowed only in ${formatAllowedOnlyInPackages(allowedOnlyIn)} and must not be listed in ${dependencyOccurrence.field}. Reason: ${allowedOnlyIn.reason}`,
-        );
+        const { pattern, error } = parseForbiddenInPattern(forbiddenIn);
+        if (error !== null) {
+            errors.push(`${dependencyOccurrence.name}: ${error}`);
+        } else if (pattern.test(workspaceName)) {
+            errors.push(
+                `${workspaceName}: ${JSON.stringify(dependencyOccurrence.name)} is forbidden in ${dependencyOccurrence.field} by its "forbidden-in" rule. Reason: ${forbiddenIn.reason}`,
+            );
+        }
     }
 
     return errors;
@@ -239,7 +270,7 @@ export const requireForbiddenDeps: Requirement<'workspace'> = {
                 dependencyRule: localRule,
                 workspaceName: context.workspaceName,
             }),
-            ...(await getAllowedOnlyErrors({
+            ...(await getDependencyConsumerErrors({
                 dependencyOccurrences,
                 getWorkspaceDirByName: getWorkspaceDirectoryByName,
                 loadConfig: loadForbiddenDepsConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16856,6 +16856,7 @@ __metadata:
   resolution: "@trezor/connect-cli@workspace:packages/connect-cli"
   dependencies:
     "@trezor/connect": "workspace:*"
+    "@trezor/requirements": "workspace:*"
     "@trezor/transport": "workspace:*"
     "@trezor/transport-bluetooth": "workspace:*"
     "@trezor/transport-common": "workspace:*"
@@ -16892,6 +16893,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-data@workspace:packages/connect-data"
   dependencies:
+    "@trezor/requirements": "workspace:*"
     "@types/chrome": "npm:^0.2.2"
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:22.13.10"
@@ -16908,6 +16910,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     "@trezor/ipc-proxy": "workspace:*"
+    "@trezor/requirements": "workspace:*"
     "@trezor/utils": "workspace:*"
   languageName: unknown
   linkType: soft
@@ -16920,6 +16923,7 @@ __metadata:
     "@trezor/components": "workspace:*"
     "@trezor/icons": "workspace:*"
     "@trezor/product-components": "workspace:*"
+    "@trezor/requirements": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -16972,6 +16976,7 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     "@trezor/icons": "workspace:*"
     "@trezor/protobuf": "workspace:^"
+    "@trezor/requirements": "workspace:*"
     "@trezor/schema-utils": "workspace:^"
     "@trezor/theme": "workspace:^"
     "@trezor/urls": "workspace:^"
@@ -17019,6 +17024,7 @@ __metadata:
   resolution: "@trezor/connect-mobile@workspace:packages/connect-mobile"
   dependencies:
     "@trezor/connect-common": "workspace:^"
+    "@trezor/requirements": "workspace:*"
     "@trezor/utils": "workspace:^"
   peerDependencies:
     tslib: ^2.6.2
@@ -17028,6 +17034,8 @@ __metadata:
 "@trezor/connect-plugin-ethereum@workspace:packages/connect-plugin-ethereum":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-plugin-ethereum@workspace:packages/connect-plugin-ethereum"
+  dependencies:
+    "@trezor/requirements": "workspace:*"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -17036,6 +17044,8 @@ __metadata:
 "@trezor/connect-plugin-stellar@workspace:packages/connect-plugin-stellar":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-plugin-stellar@workspace:packages/connect-plugin-stellar"
+  dependencies:
+    "@trezor/requirements": "workspace:*"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -17048,6 +17058,7 @@ __metadata:
     "@playwright/test": "npm:1.62.1"
     "@trezor/connect-common": "workspace:*"
     "@trezor/eslint": "workspace:*"
+    "@trezor/requirements": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/websocket-client": "workspace:*"
@@ -17069,6 +17080,7 @@ __metadata:
     "@trezor/connect-common": "workspace:*"
     "@trezor/connect-web": "workspace:*"
     "@trezor/eslint": "workspace:*"
+    "@trezor/requirements": "workspace:*"
     "@types/chrome": "npm:^0.2.2"
     "@types/w3c-web-usb": "npm:^1.0.14"
     babel-loader: "npm:^10.1.1"
@@ -17102,6 +17114,7 @@ __metadata:
     "@trezor/network-tron": "workspace:*"
     "@trezor/protobuf": "workspace:*"
     "@trezor/protocol": "workspace:*"
+    "@trezor/requirements": "workspace:*"
     "@trezor/schema-utils": "workspace:*"
     "@trezor/transport-common": "workspace:*"
     "@trezor/transport-web": "workspace:*"


### PR DESCRIPTION
## Description

Add dependency-owned rules and ESLint enforcement so network modules receive Connect through dependency injection while connect-common remains available. Use allowed-only-in for Connect data, the Explorer theme, platform clients, applications and deprecated plugins; keep network-specific forbidden-in rules only for Connect and Connect Electron.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set consists entirely of configuration files (package.json, tsconfig.json) across Trezor Connect packages plus requirements forbidden-deps tooling. The main risk is build-time or bundling regressions that propagate to the Connect web popup, webextension popup, and suite-desktop core integrations. The recommended strategy is to run a focused set of Connect E2E tests that cover each major entry point and a representative sample of desktop APIs, rather than the full Suite suite. The requirements forbidden-deps changes and packages without Connect E2E coverage (connect-cli, connect-mobile, connect-plugin-stellar, connect-explorer-theme) have no known runtime E2E tests to run.

<details><summary><b>Changed files (32)</b></summary>

- `packages/connect-cli/package.json`
- `packages/connect-cli/tsconfig.json`
- `packages/connect-data/package.json`
- `packages/connect-data/tsconfig.json`
- `packages/connect-data/tsconfig.lib.json`
- `packages/connect-electron/package.json`
- `packages/connect-electron/tsconfig.json`
- `packages/connect-explorer-theme/package.json`
- `packages/connect-explorer-theme/tsconfig.json`
- `packages/connect-explorer/package.json`
- `packages/connect-explorer/tsconfig.json`
- `packages/connect-mobile/package.json`
- `packages/connect-mobile/tsconfig.json`
- `packages/connect-mobile/tsconfig.lib.json`
- `packages/connect-plugin-ethereum/package.json`
- `packages/connect-plugin-ethereum/tsconfig.json`
- `packages/connect-plugin-ethereum/tsconfig.lib.json`
- `packages/connect-plugin-stellar/package.json`
- `packages/connect-plugin-stellar/tsconfig.json`
- `packages/connect-plugin-stellar/tsconfig.lib.json`
- `packages/connect-web/package.json`
- `packages/connect-web/tsconfig.json`
- `packages/connect-web/tsconfig.lib.json`
- `packages/connect-webextension/package.json`
- `packages/connect-webextension/tsconfig.json`
- `packages/connect-webextension/tsconfig.lib.json`
- `packages/connect/package.json`
- `packages/connect/tsconfig.json`
- `packages/connect/tsconfig.lib.json`
- `packages/requirements/src/requirements/forbidden-deps/forbiddenDepsTypes.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.test.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the Connect web popup flow through Connect Explorer, relying on @trezor/connect-web and connect-explorer builds. Changes to package.json/tsconfig in connect-web, connect-explorer, or connect-data could break bundling, module resolution, or runtime exports used by this path.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test covers the webextension popup path, which depends on @trezor/connect-webextension, @trezor/connect-web, and the connect-explorer webextension build. Config changes in these packages can directly break the webextension bundle or its integration.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test validates the desktop Ethereum transaction signing flow using @trezor/connect-web in suite-desktop core mode and the ethereum plugin. It is a direct end-to-end check that connect, connect-electron, and connect-plugin-ethereum still compile and expose the right APIs after config changes.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This is a foundational Connect desktop test that verifies address export via @trezor/connect-web in suite-desktop core mode. Passing this gives confidence that the core connect package, connect-web, and connect-electron integration are still healthy after the config churn.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test exercises the Bitcoin transaction signing path in desktop core mode. It is representative of the core connect signing API and can catch regressions in connect/connect-web/connect-electron build output or module resolution.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test covers Connect permissions/session management in desktop mode. It shares the same connect-web/connect-electron runtime as the high-priority desktop tests, and config changes that alter how permissions are persisted or exposed could affect it.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test validates the silent-mode setting and Electron focus IPC behavior across the Connect desktop integration. It is a good canary for connect-electron and connect-web packaging because it relies on the desktop API surface remaining stable.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test exercises Ethereum message signing in desktop core mode, using connect-plugin-ethereum. It provides additional coverage for the ethereum plugin and connect-web beyond the transaction signing test.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test covers the getAccountInfo API and account selection modal in desktop mode. It is another representative Connect desktop flow that can surface regressions in connect/connect-data build output or module resolution.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — This test validates the selectAccount API with multi/single selection and unsupported coin handling in desktop mode. It exercises a different Connect API surface and is a useful regression check for connect/connect-web compilation.

</details>

⚠️ **Changes with no test coverage (13)**
- `packages/connect-cli/package.json`
- `packages/connect-cli/tsconfig.json`
- `packages/connect-mobile/package.json`
- `packages/connect-mobile/tsconfig.json`
- `packages/connect-mobile/tsconfig.lib.json`
- `packages/connect-plugin-stellar/package.json`
- `packages/connect-plugin-stellar/tsconfig.json`
- `packages/connect-plugin-stellar/tsconfig.lib.json`
- `packages/connect-explorer-theme/package.json`
- `packages/connect-explorer-theme/tsconfig.json`
- `packages/requirements/src/requirements/forbidden-deps/forbiddenDepsTypes.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.test.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts`

_Updated: 2026-09-11T12:18:15.236Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/network-connect-dependency-guardrails/web/](https://dev.suite.sldev.cz/suite-web/chore/network-connect-dependency-guardrails/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/network-connect-dependency-guardrails&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/network-connect-dependency-guardrails&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T12:20:16.910Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T12:19:42.501Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->