### PR TITLE
refactor(suite-native): replace IconSquare color props with intent

### DIFF
--- a/suite-native/atoms/src/Icon/IconSquare.tsx
+++ b/suite-native/atoms/src/Icon/IconSquare.tsx
@@ -7,29 +7,64 @@ import { type Color } from '@trezor/theme';
 import { Box } from '../Box';
 import { Text } from '../Text';
 
+export const ICON_SQUARE_INTENTS = ['brand', 'neutral', 'info', 'warning', 'critical'] as const;
+export type IconSquareIntent = (typeof ICON_SQUARE_INTENTS)[number];
+
+type IconSquareColors = {
+    borderColor: Color;
+    backgroundColor: Color;
+    iconColor: Color;
+};
+
+const intentToColorsMap = {
+    brand: {
+        borderColor: 'elementBorderBrandSofter',
+        backgroundColor: 'elementFillBrandSofter',
+        iconColor: 'contentBrand',
+    },
+    neutral: {
+        borderColor: 'elementBorderNeutralSofter',
+        backgroundColor: 'elementFillNeutralSofter',
+        iconColor: 'contentPrimary',
+    },
+    info: {
+        borderColor: 'elementBorderInfoSofter',
+        backgroundColor: 'elementFillInfoSofter',
+        iconColor: 'contentInfo',
+    },
+    warning: {
+        borderColor: 'elementBorderWarningSofter',
+        backgroundColor: 'elementFillWarningSofter',
+        iconColor: 'contentWarning',
+    },
+    critical: {
+        borderColor: 'elementBorderCriticalSofter',
+        backgroundColor: 'elementFillCriticalSofter',
+        iconColor: 'contentCritical',
+    },
+} as const satisfies Record<IconSquareIntent, IconSquareColors>;
+
 const iconSquareStyle = prepareNativeStyle<{
     iconSize: number;
-    backgroundColor: Color;
     borderColor: Color;
-}>((utils, { iconSize, backgroundColor, borderColor }) => ({
+    backgroundColor: Color;
+}>((utils, { iconSize, borderColor, backgroundColor }) => ({
     width: iconSize + 2 * utils.spacings.sp8,
+    borderWidth: utils.borders.widths.small,
+    borderRadius: utils.borders.radii.r12,
+    borderColor: utils.colors[borderColor],
+    backgroundColor: utils.colors[backgroundColor],
     aspectRatio: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: utils.colors[backgroundColor],
-    borderRadius: utils.borders.radii.r12,
-    borderWidth: utils.borders.widths.small,
-    borderColor: utils.colors[borderColor],
 }));
 
 export type IconSquareProps = RequireExactlyOne<
     {
         iconName: IconName;
         iconNumber: number;
-        iconBackgroundColor?: Color;
-        iconColor?: Color;
+        intent?: IconSquareIntent;
         iconSize?: IconSize;
-        iconBorderColor?: Color;
     },
     'iconName' | 'iconNumber'
 >;
@@ -37,19 +72,19 @@ export type IconSquareProps = RequireExactlyOne<
 export const IconSquare = ({
     iconName,
     iconNumber,
-    iconColor,
+    intent = 'neutral',
     iconSize = 'mediumLarge',
-    iconBackgroundColor = 'elementFillNeutralSofter',
-    iconBorderColor = 'elementBorderNeutralSofter',
 }: IconSquareProps) => {
     const { applyStyle } = useNativeStyles();
+
+    const { borderColor, backgroundColor, iconColor } = intentToColorsMap[intent];
 
     return (
         <Box
             style={applyStyle(iconSquareStyle, {
                 iconSize: getIconSize(iconSize),
-                backgroundColor: iconBackgroundColor,
-                borderColor: iconBorderColor,
+                borderColor,
+                backgroundColor,
             })}
         >
             {iconNumber && <Text color={iconColor}>{iconNumber}</Text>}

--- a/suite-native/atoms/src/Icon/IconSquare.tsx
+++ b/suite-native/atoms/src/Icon/IconSquare.tsx
@@ -2,7 +2,7 @@ import { type RequireExactlyOne } from 'type-fest';
 
 import { Icon, type IconName, type IconSize, getIconSize } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
-import { type Color, type NativeRadius } from '@trezor/theme';
+import { type Color } from '@trezor/theme';
 
 import { Box } from '../Box';
 import { Text } from '../Text';
@@ -11,14 +11,13 @@ const iconSquareStyle = prepareNativeStyle<{
     iconSize: number;
     backgroundColor: Color;
     borderColor: Color;
-    borderRadius: NativeRadius;
-}>((utils, { iconSize, backgroundColor, borderColor, borderRadius }) => ({
+}>((utils, { iconSize, backgroundColor, borderColor }) => ({
     width: iconSize + 2 * utils.spacings.sp8,
     aspectRatio: 1,
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: utils.colors[backgroundColor],
-    borderRadius: utils.borders.radii[borderRadius],
+    borderRadius: utils.borders.radii.r12,
     borderWidth: utils.borders.widths.small,
     borderColor: utils.colors[borderColor],
 }));
@@ -31,7 +30,6 @@ export type IconSquareProps = RequireExactlyOne<
         iconColor?: Color;
         iconSize?: IconSize;
         iconBorderColor?: Color;
-        iconBorderRadius?: NativeRadius;
     },
     'iconName' | 'iconNumber'
 >;
@@ -43,7 +41,6 @@ export const IconSquare = ({
     iconSize = 'mediumLarge',
     iconBackgroundColor = 'elementFillNeutralSofter',
     iconBorderColor = 'elementBorderNeutralSofter',
-    iconBorderRadius = 'r12',
 }: IconSquareProps) => {
     const { applyStyle } = useNativeStyles();
 
@@ -53,7 +50,6 @@ export const IconSquare = ({
                 iconSize: getIconSize(iconSize),
                 backgroundColor: iconBackgroundColor,
                 borderColor: iconBorderColor,
-                borderRadius: iconBorderRadius,
             })}
         >
             {iconNumber && <Text color={iconColor}>{iconNumber}</Text>}

--- a/suite-native/atoms/src/IconListItem.tsx
+++ b/suite-native/atoms/src/IconListItem.tsx
@@ -9,56 +9,10 @@ import { IconSquare } from './Icon/IconSquare';
 import { HStack } from './Stack';
 import { Text } from './Text';
 
-export const ICON_LIST_ITEM_VARIANTS = [
-    'neutral',
-    'info',
-    'critical',
-    'warning',
-    'primary',
-    'brand',
-] as const;
+export const ICON_LIST_ITEM_VARIANTS = ['neutral', 'info', 'critical', 'warning', 'brand'] as const;
 
 export type IconListItemVariant = (typeof ICON_LIST_ITEM_VARIANTS)[number];
 
-type IconColors = {
-    iconColor: Color;
-    iconBorderColor: Color;
-    iconBackgroundColor: Color;
-};
-
-const iconColorsMap = {
-    neutral: {
-        iconColor: 'contentPrimary',
-        iconBorderColor: 'elementBorderNeutralSofter',
-        iconBackgroundColor: 'elementFillNeutralSofter',
-    },
-    info: {
-        iconColor: 'contentInfo',
-        iconBorderColor: 'elementBorderInfoSofter',
-        iconBackgroundColor: 'elementFillInfoSofter',
-    },
-    critical: {
-        iconColor: 'contentCritical',
-        iconBorderColor: 'elementBorderCriticalSofter',
-        iconBackgroundColor: 'elementFillCriticalSofter',
-    },
-    warning: {
-        iconColor: 'contentWarning',
-        iconBorderColor: 'elementBorderWarningSofter',
-        iconBackgroundColor: 'elementFillWarningSofter',
-    },
-    primary: {
-        iconColor: 'contentPrimaryInverse',
-        // `elementFillFieldSelected` has no matching border token, so this variant is borderless.
-        iconBorderColor: 'transparent',
-        iconBackgroundColor: 'elementFillFieldSelected',
-    },
-    brand: {
-        iconColor: 'contentBrand',
-        iconBorderColor: 'elementBorderBrandSofter',
-        iconBackgroundColor: 'elementFillBrandSofter',
-    },
-} as const satisfies Record<IconListItemVariant, IconColors>;
 export type IconListItemProps = {
     children: ReactNode;
     icon: IconName;
@@ -80,16 +34,12 @@ export const IconListItem = ({
     variant = 'neutral',
     verticalAlign = 'center',
     spacing = 'sp12',
-}: IconListItemProps) => {
-    const iconColors = iconColorsMap[variant];
-
-    return (
-        <HStack spacing={spacing} alignItems={verticalAlign}>
-            <IconSquare iconName={icon} iconSize={iconSize} {...iconColors} />
-            <Box flexShrink={1}>{children}</Box>
-        </HStack>
-    );
-};
+}: IconListItemProps) => (
+    <HStack spacing={spacing} alignItems={verticalAlign}>
+        <IconSquare iconName={icon} intent={variant} iconSize={iconSize} />
+        <Box flexShrink={1}>{children}</Box>
+    </HStack>
+);
 
 export const IconListTextItem = ({
     children,

--- a/suite-native/atoms/src/stories/Icon/IconSquare.stories.tsx
+++ b/suite-native/atoms/src/stories/Icon/IconSquare.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-native';
 
 import { ICON_SIZES } from '@suite-native/icons';
-import { COLOR_TOKENS, nativeBorders } from '@trezor/theme';
+import { COLOR_TOKENS } from '@trezor/theme';
 
 import { IconSquare as IconSquareComponent, type IconSquareProps } from '../../Icon/IconSquare';
 
@@ -18,7 +18,6 @@ export const IconSquare: IconSquareStory = {
     name: 'IconSquare',
     args: {
         iconNumber: 1,
-        iconBorderRadius: 'r12',
         iconColor: 'contentPrimary',
         iconSize: 'mediumLarge',
     },
@@ -33,10 +32,6 @@ export const IconSquare: IconSquareStory = {
         iconBorderColor: {
             control: { type: 'select' },
             options: COLOR_TOKENS,
-        },
-        iconBorderRadius: {
-            control: { type: 'select' },
-            options: Object.keys(nativeBorders.radii),
         },
         iconColor: {
             control: { type: 'select' },

--- a/suite-native/atoms/src/stories/Icon/IconSquare.stories.tsx
+++ b/suite-native/atoms/src/stories/Icon/IconSquare.stories.tsx
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-native';
 
 import { ICON_SIZES } from '@suite-native/icons';
-import { COLOR_TOKENS } from '@trezor/theme';
 
-import { IconSquare as IconSquareComponent, type IconSquareProps } from '../../Icon/IconSquare';
+import {
+    ICON_SQUARE_INTENTS,
+    IconSquare as IconSquareComponent,
+    type IconSquareProps,
+} from '../../Icon/IconSquare';
 
 type IconSquareStory = StoryObj<IconSquareProps>;
 
@@ -18,24 +21,16 @@ export const IconSquare: IconSquareStory = {
     name: 'IconSquare',
     args: {
         iconNumber: 1,
-        iconColor: 'contentPrimary',
+        intent: 'neutral',
         iconSize: 'mediumLarge',
     },
     argTypes: {
         iconNumber: {
             control: { type: 'number' },
         },
-        iconBackgroundColor: {
+        intent: {
             control: { type: 'select' },
-            options: COLOR_TOKENS,
-        },
-        iconBorderColor: {
-            control: { type: 'select' },
-            options: COLOR_TOKENS,
-        },
-        iconColor: {
-            control: { type: 'select' },
-            options: COLOR_TOKENS,
+            options: ICON_SQUARE_INTENTS,
         },
         iconSize: {
             control: { type: 'select' },

--- a/suite-native/device/src/components/UninitializedDeviceModalAppendix.tsx
+++ b/suite-native/device/src/components/UninitializedDeviceModalAppendix.tsx
@@ -11,17 +11,13 @@ export const UninitializedDeviceModalAppendix = () => (
                 iconNumber={1}
                 translationKey="moduleDevice.noSeedModal.appendix.lines.1"
             />
-
             <BottomSheetListItem
                 iconNumber={2}
                 translationKey="moduleDevice.noSeedModal.appendix.lines.2"
             />
-
             <BottomSheetListItem
                 iconName="checkCircle"
-                iconColor="contentBrand"
-                iconBorderColor="elementBorderBrandSofter"
-                iconBackgroundColor="elementFillBrandSofter"
+                intent="brand"
                 translationKey="moduleDevice.noSeedModal.appendix.lines.3"
             />
         </VStack>

--- a/suite-native/module-check-backup/src/screens/DeviceCheckBackupUnsupportedModelScreen.tsx
+++ b/suite-native/module-check-backup/src/screens/DeviceCheckBackupUnsupportedModelScreen.tsx
@@ -73,7 +73,7 @@ export const DeviceCheckBackupUnsupportedModelScreen = () => {
                     <IconListTextItem
                         textVariant="body-md-strong"
                         iconSize="large"
-                        variant="primary"
+                        variant="brand"
                         icon="checkCircle"
                     >
                         <Translation id="moduleCheckBackup.checkBackupUnsupportedModelScreen.step3" />

--- a/suite-native/module-earn/src/components/earn/EarnConsentsItem.tsx
+++ b/suite-native/module-earn/src/components/earn/EarnConsentsItem.tsx
@@ -24,13 +24,7 @@ export const EarnConsentsItem = ({
 
     return (
         <HStack spacing="sp12" alignItems="center">
-            <IconSquare
-                iconName={iconName}
-                iconSize="large"
-                iconColor="contentInfo"
-                iconBackgroundColor="elementFillInfoSofter"
-                iconBorderColor="elementBorderInfoSofter"
-            />
+            <IconSquare iconName={iconName} intent="info" iconSize="large" />
             <Text variant="body-sm-strong" color={color} style={applyStyle(textStyle)}>
                 {children}
             </Text>

--- a/suite-native/module-earn/src/components/earn/HowEarnWorks/HowEarnWorksBenefitsSection.tsx
+++ b/suite-native/module-earn/src/components/earn/HowEarnWorks/HowEarnWorksBenefitsSection.tsx
@@ -40,13 +40,7 @@ export const HowEarnWorksBenefitsSection = ({ items }: HowEarnWorksBenefitsSecti
         <VStack spacing="sp16">
             {items.map(item => (
                 <HStack key={item.id} spacing="sp12" style={applyStyle(benefitRowStyle)}>
-                    <IconSquare
-                        iconName={item.icon}
-                        iconSize="large"
-                        iconColor="contentBrand"
-                        iconBackgroundColor="elementFillBrandSofter"
-                        iconBorderColor="elementBorderBrandSofter"
-                    />
+                    <IconSquare iconName={item.icon} intent="brand" iconSize="large" />
                     <VStack spacing={0} style={applyStyle(benefitTextContainerStyle)}>
                         <Text variant="body-md-strong" style={applyStyle(benefitTitleStyle)}>
                             {item.title}

--- a/suite-native/module-send/src/components/AddressReviewStep.tsx
+++ b/suite-native/module-send/src/components/AddressReviewStep.tsx
@@ -14,30 +14,13 @@ type AddressReviewStepProps = {
 
 const getIconProps = (stepNumber: AddressReviewStepProps['stepNumber']): IconSquareProps =>
     stepNumber
-        ? {
-              iconNumber: stepNumber,
-              iconBackgroundColor: 'elementFillNeutralSofter',
-              iconBorderColor: 'elementBorderNeutralSofter',
-          }
-        : {
-              iconName: 'flagCheckered',
-              iconBackgroundColor: 'elementFillBrandBold',
-              iconColor: 'contentBrand',
-          };
+        ? { iconNumber: stepNumber, intent: 'neutral' }
+        : { iconName: 'flagCheckered', intent: 'brand' };
 
-const cardStyle = prepareNativeStyle<{ isFinalStep: boolean }>((utils, { isFinalStep }) => ({
+const cardStyle = prepareNativeStyle(utils => ({
     borderWidth: utils.borders.widths.small,
     borderColor: utils.colors.borderNeutral,
     maxWidth: '100%',
-
-    extend: {
-        condition: isFinalStep,
-        style: {
-            backgroundColor: utils.colors.elementFillBrandSofter,
-            borderColor: utils.colors.elementBorderBrandSofter,
-            ...utils.boxShadows.none,
-        },
-    },
 }));
 
 export const AddressReviewStep = ({
@@ -50,7 +33,7 @@ export const AddressReviewStep = ({
 
     return (
         <View onLayout={onLayout}>
-            <Card style={applyStyle(cardStyle, { isFinalStep: !stepNumber })}>
+            <Card style={applyStyle(cardStyle)}>
                 <HStack spacing="sp12" flexDirection="row" alignItems="center">
                     <IconSquare {...getIconProps(stepNumber)} />
                     <Box flexShrink={1}>

--- a/suite-native/passphrase/src/components/EmptyWalletInfoSheet.tsx
+++ b/suite-native/passphrase/src/components/EmptyWalletInfoSheet.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 
 import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import { useNavigation } from '@react-navigation/native';
@@ -69,23 +69,20 @@ export const EmptyWalletInfoSheet = forwardRef<BottomSheetModalMethods, EmptyWal
                     <BottomSheetListItem
                         iconName="pencilSimpleLine"
                         translationKey="modulePassphrase.emptyPassphraseWallet.confirmEmptyWalletSheet.list.backup"
+                        intent="neutral"
                         iconSize="medium"
-                        iconBackgroundColor="elementFillNeutralSofter"
-                        iconBorderColor="elementBorderNeutralSofter"
                     />
                     <BottomSheetListItem
                         iconName="copy"
                         translationKey="modulePassphrase.emptyPassphraseWallet.confirmEmptyWalletSheet.list.store"
+                        intent="neutral"
                         iconSize="medium"
-                        iconBackgroundColor="elementFillNeutralSofter"
-                        iconBorderColor="elementBorderNeutralSofter"
                     />
                     <BottomSheetListItem
                         iconName="eyeSlash"
                         translationKey="modulePassphrase.emptyPassphraseWallet.confirmEmptyWalletSheet.list.neverShare"
+                        intent="neutral"
                         iconSize="medium"
-                        iconBackgroundColor="elementFillNeutralSofter"
-                        iconBorderColor="elementBorderNeutralSofter"
                     />
                 </VStack>
                 <VStack style={applyStyle(bottomSheetBottomStyle)}>


### PR DESCRIPTION
## Description

- Unused properties removed from `IconSquare` atom.
- `IconSquare` color props replaced with `intent`.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/icon-square-props&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->