### PR TITLE
chore(analytics): document the ts-only property payloadType

### DIFF
--- a/suite-common/analytics/src/eventDefinition.ts
+++ b/suite-common/analytics/src/eventDefinition.ts
@@ -23,8 +23,8 @@ type Domain = string;
 type EventName = `${Domain}/${string}` | `${string}`;
 
 // An event can describe its data in two ways:
-// 1. List every field separately in `attributes`, for example `amount: AttributeDef<number>`.
-// 2. Describe the whole payload with one type in `payloadType`.
+// 1. List every field separately in `attributes` with a prescribed structure, e.g. `amount: AttributeDef<number>` (real example: `createBackupEvent`).
+// 2. Arbitrary object payload with no per-field documentation, via `payloadType` (real example: `accountsNonZeroBalanceEvent`).
 // `HasKeys` checks whether the attributes list is empty. `IsAttributeMap` tells these two kinds of
 // event apart.
 type HasKeys<T> = keyof T extends never ? false : true;
@@ -52,7 +52,6 @@ type AttributeEventInstance<A, N> =
         : {
               type: N;
           };
-
 type PayloadEventInstance<A, N> = {
     type: N;
     payload: A;
@@ -64,8 +63,10 @@ export type EventDef<A, N extends EventName = EventName> =
               name: N;
               attributes: A;
           }
-        : AnalyticsBaseEvent & {
+        : // This is effectively a fallback for events that don't conform to Attribute Map (events with more arbitrary data that are assignable to this).
+          AnalyticsBaseEvent & {
               name: N;
+              // Never used at runtime, it's only to give `EventInstance` something to `infer A` from, so it can recover the payload type below.
               payloadType?: A;
           };
 

--- a/suite-common/analytics/src/eventDefinition.type-test.ts
+++ b/suite-common/analytics/src/eventDefinition.type-test.ts
@@ -12,6 +12,12 @@ type EmptyAttributeEventDefinition = EventDef<Record<never, never>, 'test/empty-
 
 type PayloadEventDefinition = EventDef<boolean, 'test/payload-event'>;
 
+// Arbitrary payload with dynamic keys that are not listed as individual attributes.
+type ArbitraryRecordPayloadEventDefinition = EventDef<
+    Record<string, number>,
+    'test/record-payload-event'
+>;
+
 const attributeEvent: EventInstance<AttributeEventDefinition> = {
     type: 'test/attribute-event',
     payload: { requiredAttribute: 'value' },
@@ -53,6 +59,27 @@ const payloadEventWithoutPayload: EventInstance<PayloadEventDefinition> = {
     type: 'test/payload-event',
 };
 
+const recordPayloadEvent: EventInstance<ArbitraryRecordPayloadEventDefinition> = {
+    type: 'test/record-payload-event',
+    payload: { btc_normal: 3, eth_normal: 1 },
+};
+
+// @ts-expect-error Record payload events require their direct payload type.
+const recordPayloadEventWithoutPayload: EventInstance<ArbitraryRecordPayloadEventDefinition> = {
+    type: 'test/record-payload-event',
+};
+
+const recordPayloadEventWithEmptyPayload: EventInstance<ArbitraryRecordPayloadEventDefinition> = {
+    type: 'test/record-payload-event',
+    payload: {},
+};
+
+const recordPayloadEventWithWrongValueType: EventInstance<ArbitraryRecordPayloadEventDefinition> = {
+    type: 'test/record-payload-event',
+    // @ts-expect-error Record payload values must match the declared value type.
+    payload: { btc_normal: 'not-a-number' },
+};
+
 type EventDefinitionUnion =
     AttributeEventDefinition | EmptyAttributeEventDefinition | PayloadEventDefinition;
 
@@ -75,5 +102,9 @@ void emptyAttributeEvent;
 void emptyAttributeEventWithPayload;
 void payloadEvent;
 void payloadEventWithoutPayload;
+void recordPayloadEvent;
+void recordPayloadEventWithoutPayload;
+void recordPayloadEventWithEmptyPayload;
+void recordPayloadEventWithWrongValueType;
 void eventFromDefinitionUnion;
 void mismatchedEventFromDefinitionUnion;


### PR DESCRIPTION
## Description

Better describe the two type branches of analytics event, incl. the seemingly useless `payloadType` property.
- At first I wanted to remove that, but it has a usecase for typescript inferrence, not to be used directly
- The TS ternary was kinda misleading, looking as if these were the two acceptable structures. But I found out that the else branch is effectively a fallback when the first structure is not matched.

## Notes for QA

N/A. only typescript and commentary

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are central analytics event definition files. The primary risk is that event payload shapes or emitted event types are altered, which would be caught by the core analytics tests. A minimal, high-confidence selection is the two broad analytics tests that validate event payloads and lifecycle behavior.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/analytics/src/eventDefinition.ts`
- `suite-common/analytics/src/eventDefinition.type-test.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test validates the payload structures and values of core analytics events (SuiteReady, DeviceConnect, TransportType, DeviceDisconnect, SettingsAnalytics). Changes to eventDefinition.ts directly affect how these events are defined and what payload fields they emit, so this is the most targeted regression test.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test exercises the analytics lifecycle (suite/ready, settings/analytics, menuToggleDiscreetEvent, routerLocationChangeEvent) and verifies that events are emitted correctly when analytics is enabled or disabled. It directly depends on the event definitions in eventDefinition.ts.

</details>

_Updated: 2026-09-10T11:03:53.153Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-dead-analytics-event-types/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-dead-analytics-event-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-dead-analytics-event-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-dead-analytics-event-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T11:07:04.800Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T11:06:47.624Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->