### PR TITLE
fix(suite): stop defaulting the yield unwrap amount to the full balance

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts
@@ -64,7 +64,10 @@ const flowData = {
     },
 } as unknown as YieldFlowResolvedData;
 
-const dispatchWithdraw = (report: jest.Mock) => {
+const dispatchWithdraw = (
+    report: jest.Mock,
+    overrides: Partial<Parameters<typeof submitYieldWithdrawThunk>[0]> = {},
+) => {
     const store = createTestStore({ extra: createExtra(report), preloadedState: {} });
 
     return store
@@ -74,6 +77,7 @@ const dispatchWithdraw = (report: jest.Mock) => {
                 flowData,
                 amount: '100',
                 flowType: 'withdraw',
+                ...overrides,
             }),
         )
         .unwrap()
@@ -137,6 +141,7 @@ describe('submitYieldWithdrawThunk', () => {
                 fee: '31500000000',
                 submittedAt: expect.any(Number),
             },
+            receiptAmount: '100',
         });
 
         const toast = store
@@ -144,6 +149,34 @@ describe('submitYieldWithdrawThunk', () => {
             .filter(notificationsActions.addToast.match)
             .find(action => action.payload.type === 'tx-yield-withdraw');
         expect(toast?.payload).toMatchObject({ txid: '0xwithdraw' });
+    });
+
+    it('persists the asset output converted at submit for a redeem', async () => {
+        const store = await dispatchWithdraw(jest.fn(), {
+            flowType: 'redeem',
+            flowData: {
+                ...flowData,
+                vault: {
+                    id: 'vault-1',
+                    state: {
+                        pricePerShareState: {
+                            shareToken: { symbol: 'musdc', decimals: 18 },
+                            quoteToken: { symbol: 'usdc', decimals: 6 },
+                            price: '1.05',
+                        },
+                    },
+                },
+            } as unknown as YieldFlowResolvedData,
+        });
+
+        const pendingTxAction = store
+            .getActions()
+            .find(action => action.type === yieldActions.setPendingTx.type);
+
+        expect(pendingTxAction?.payload).toMatchObject({
+            tx: { type: 'redeem', amount: '100' },
+            receiptAmount: '105',
+        });
     });
 
     it('still reports submit-failed when the signing throws', async () => {

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -10,6 +10,7 @@ import {
     type YieldFlowResolvedData,
     type YieldWithdrawFlowType,
     composeYieldWithdrawTransactionThunk,
+    getConvertedOutputTokenBalanceToInputTokenAmount,
     isYieldWithdrawFeeError,
     yieldActions,
 } from '@suite-common/wallet-core';
@@ -145,6 +146,17 @@ export const submitYieldWithdrawThunk = createThunk<
                 }),
             );
 
+            const receiptAmount =
+                flowType === 'redeem'
+                    ? getConvertedOutputTokenBalanceToInputTokenAmount({
+                          networkSymbol: account.symbol,
+                          token: flowData.token,
+                          outputToken: flowData.receiptToken,
+                          outputTokenBalance: amount,
+                          pricePerShareState: flowData.vault.state?.pricePerShareState,
+                      })
+                    : amount;
+
             dispatch(
                 yieldActions.setPendingTx({
                     flowType,
@@ -156,6 +168,7 @@ export const submitYieldWithdrawThunk = createThunk<
                         fee: result.fee,
                         submittedAt: Date.now(),
                     },
+                    receiptAmount,
                 }),
             );
         } catch (error) {

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -58,7 +58,7 @@ type UseYieldFlowProps = {
     flowType: YieldPositionFlowType;
 };
 
-type UseYieldFlowStepsResult = {
+type YieldFlowStepState = {
     currentStep: YieldFlowStepId;
     isWrappedNativeVault: boolean;
 };
@@ -109,7 +109,7 @@ export type UseYieldFlowResult = {
     fiatToggle: YieldAmountCardFiatToggleProps | undefined;
     setMaxAmount: (cryptoMax: string) => void;
     methods: UseFormReturn<YieldFlowFormValues>;
-    flow: UseYieldFlowStepsResult;
+    flow: YieldFlowStepState;
 };
 
 /** Context value type shared by both deposit and withdraw — non-null token/receiptToken/vault. */

--- a/packages/suite/src/components/earn/yield/hooks/useYieldForm.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldForm.ts
@@ -135,7 +135,7 @@ export const useYieldForm = ({
     const pricePerShareState = vault.state?.pricePerShareState;
     const unwrapDefaultAmount = useMemo(() => {
         if (!token || !receiptToken || !isYieldWithdrawFlow(flowType)) {
-            return token?.balance ?? '';
+            return '';
         }
 
         return getYieldUnwrapDefaultAmount({
@@ -144,9 +144,16 @@ export const useYieldForm = ({
             token,
             receiptToken,
             pricePerShareState,
-            fallbackAmount: token.balance,
+            persistedAssetAmount: session.result.completedReceiptAmount,
         });
-    }, [flowType, pricePerShareState, receiptToken, session.result.completedAmount, token]);
+    }, [
+        flowType,
+        pricePerShareState,
+        receiptToken,
+        session.result.completedAmount,
+        session.result.completedReceiptAmount,
+        token,
+    ]);
 
     useEffect(() => {
         const prevStep = prevStepRef.current;

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -69,7 +69,6 @@ const baseUnwrapParams: Parameters<typeof getYieldUnwrapDefaultAmount>[0] = {
         contractAddress: VAULT_ADDRESS,
     },
     pricePerShareState,
-    fallbackAmount: '5',
 };
 
 describe('yieldFlowUtils', () => {
@@ -181,27 +180,61 @@ describe('yieldFlowUtils', () => {
             ).toBe('0.02');
         });
 
-        it('falls back to the balance when the withdrawn amount is zero', () => {
-            expect(
-                getYieldUnwrapDefaultAmount({
-                    ...baseUnwrapParams,
-                    flowType: 'withdraw',
-                    withdrawnAmount: '0',
-                    fallbackAmount: '5',
-                }),
-            ).toBe('5');
-        });
-
-        it('falls back to the balance when shares cannot be converted without a price', () => {
+        it('falls back to the amount persisted at submit when shares cannot be converted', () => {
             expect(
                 getYieldUnwrapDefaultAmount({
                     ...baseUnwrapParams,
                     flowType: 'redeem',
                     withdrawnAmount: '1',
                     pricePerShareState: undefined,
-                    fallbackAmount: '5',
+                    persistedAssetAmount: '0.019',
                 }),
-            ).toBe('5');
+            ).toBe('0.019');
+        });
+
+        it('prefers the live conversion over the persisted amount', () => {
+            expect(
+                getYieldUnwrapDefaultAmount({
+                    ...baseUnwrapParams,
+                    flowType: 'redeem',
+                    withdrawnAmount: '1',
+                    persistedAssetAmount: '0.019',
+                }),
+            ).toBe('0.02');
+        });
+
+        it('ignores a non-positive persisted amount', () => {
+            expect(
+                getYieldUnwrapDefaultAmount({
+                    ...baseUnwrapParams,
+                    flowType: 'redeem',
+                    withdrawnAmount: '1',
+                    pricePerShareState: undefined,
+                    // The reducer's initial `completedReceiptAmount` is '0'.
+                    persistedAssetAmount: '0',
+                }),
+            ).toBe('');
+        });
+
+        it('stays empty when neither the price nor a persisted amount is available', () => {
+            expect(
+                getYieldUnwrapDefaultAmount({
+                    ...baseUnwrapParams,
+                    flowType: 'redeem',
+                    withdrawnAmount: '1',
+                    pricePerShareState: undefined,
+                }),
+            ).toBe('');
+        });
+
+        it('stays empty when the withdrawn amount is zero', () => {
+            expect(
+                getYieldUnwrapDefaultAmount({
+                    ...baseUnwrapParams,
+                    flowType: 'withdraw',
+                    withdrawnAmount: '0',
+                }),
+            ).toBe('');
         });
     });
 

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -95,18 +95,17 @@ type YieldUnwrapDefaultAmountParams = {
     pricePerShareState?: Parameters<
         typeof getConvertedOutputTokenBalanceToInputTokenAmount
     >[0]['pricePerShareState'];
-    /** Fallback used when the withdrawn asset amount can't be resolved (e.g. missing price). */
-    fallbackAmount: string;
+    /** Asset-output amount persisted when the withdraw was submitted. */
+    persistedAssetAmount?: string;
 };
 
 /**
  * Amount to pre-fill in the withdraw flow's unwrap (wrapped-native → native) step.
  *
- * It must default to the asset amount that was just withdrawn — NOT the account's full
- * wrapped-native balance, which would sweep in unrelated WETH the user never meant to unwrap
- * (see trezor/trezor-suite#30559). A `withdraw` yields the asset amount directly; a `redeem`
- * yields shares, so those are converted to their asset (WETH) equivalent via the vault
- * price-per-share. Falls back to the full balance only when the asset amount can't be resolved.
+ * It must default to the asset amount that was just withdrawn — never the account's full
+ * wrapped-native balance, which would sweep in unrelated WETH (trezor/trezor-suite#30559).
+ * When the price can't convert a redeem's shares, the amount persisted at submit is used;
+ * failing that the field stays empty (trezor/trezor-suite#30893).
  */
 export const getYieldUnwrapDefaultAmount = ({
     flowType,
@@ -114,7 +113,7 @@ export const getYieldUnwrapDefaultAmount = ({
     token,
     receiptToken,
     pricePerShareState,
-    fallbackAmount,
+    persistedAssetAmount,
 }: YieldUnwrapDefaultAmountParams): string => {
     const withdrawnAssetAmount =
         flowType === 'redeem'
@@ -127,11 +126,15 @@ export const getYieldUnwrapDefaultAmount = ({
               })
             : withdrawnAmount;
 
-    if (!withdrawnAssetAmount || new BigNumber(withdrawnAssetAmount).lte(0)) {
-        return fallbackAmount;
+    if (withdrawnAssetAmount && new BigNumber(withdrawnAssetAmount).gt(0)) {
+        return withdrawnAssetAmount;
     }
 
-    return withdrawnAssetAmount;
+    if (persistedAssetAmount && new BigNumber(persistedAssetAmount).gt(0)) {
+        return persistedAssetAmount;
+    }
+
+    return '';
 };
 
 type ShouldInitializeYieldAllowanceParams = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The unwrap step pre-fill fell back to the account's entire WETH balance when a redeem's shares couldn't be converted (missing price-per-share). The withdraw thunk now persists the asset output at submit, and the pre-fill uses: live conversion → persisted amount → empty field. Healthy paths unchanged.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #30893

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly scoped to the stablecoin yield withdrawal/redeem flow. Regression risk is concentrated in the yield vault user flows rather than any shared global utilities. The two dedicated yield E2E tests provide direct coverage of the changed hooks, utilities, and thunk. No other tests in the broad static mapping are justified because they do not touch the stablecoin yield flow.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldForm.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/yield/redeem.test.ts` — This test directly exercises the USDC Prime Vault redeem/withdraw flow, including share-token amount input, transaction simulation, device confirmation, and post-redeem dashboard updates. The changed files (submitYieldWithdrawThunk, useYieldFlow, useYieldForm, yieldFlowUtils) are all part of this code path.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This test covers the full stablecoin yield vault withdrawal flow, from amount entry and transaction simulation to device confirmation and dashboard state updates. It is a primary end-to-end consumer of the changed yield hooks and thunk.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.test.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`

_Updated: 2026-09-10T09:08:51.613Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-unwrap-default-sweep/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-unwrap-default-sweep/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-unwrap-default-sweep&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-unwrap-default-sweep&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T09:11:57.532Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T09:11:17.180Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->