### PR TITLE
test(e2e): add e2e test for yield claim rewards

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
@@ -55,7 +55,12 @@ export const EarnYieldClaimRewardsBanner = ({
     const areRewardsLoading = isLoading || isFiatRateLoading || isDiscoveryRunning;
     const amountContent = (
         <HiddenPlaceholder>
-            <Text typographyStyle="body-md-strong" intent="neutral" priority="primary">
+            <Text
+                typographyStyle="body-md-strong"
+                intent="neutral"
+                priority="primary"
+                data-testid="@earn/dashboard/claim-rewards-amount"
+            >
                 {!isClaimDisabled && '≈ '}
                 <BaseCurrencyAmountFormatter value={value} currency={currency} />
             </Text>
@@ -149,6 +154,7 @@ export const EarnYieldClaimRewardsBanner = ({
                         isDisabled={isClaimDisabled || isDiscoveryRunning}
                         iconLeft={claimDisabledTooltip ? InfoIcon : undefined}
                         onClick={handleOnClaim}
+                        data-testid="@earn/dashboard/claim-rewards-button"
                     >
                         <Translation id="TR_EARN_CLAIM_REWARDS_BUTTON" />
                     </Banner.Button>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
@@ -114,7 +114,9 @@ const RewardTokenAmounts = ({ rewardTokenAmounts }: RewardTokenAmountsProps) => 
             content={fullRewardAmounts}
         >
             <RewardAmountsContainer>
-                <RewardAmountsText>{compactRewardAmounts}</RewardAmountsText>
+                <RewardAmountsText data-testid="@earn/claim-select-account/reward-amounts">
+                    {compactRewardAmounts}
+                </RewardAmountsText>
             </RewardAmountsContainer>
         </Tooltip>
     );
@@ -173,6 +175,7 @@ export const EarnYieldClaimSelectAccountModal = ({
             heading={<Translation id="TR_EARN_YIELD_CLAIM_MODAL_TITLE" />}
             description={<Translation id="TR_EARN_YIELD_CLAIM_MODAL_SUBTITLE" />}
             onCancel={handleOnCancel}
+            data-testid="@modal/earn-claim-select-account"
         >
             <CardList>
                 {sortedAccountsRewards.map(accountRewards => {
@@ -182,6 +185,7 @@ export const EarnYieldClaimSelectAccountModal = ({
                         <CardList.Item
                             key={accountRewards.account.key}
                             onClick={() => handleOnSelect(accountRewards)}
+                            data-testid={`@earn/claim-select-account/account/${accountRewards.account.symbol}-${accountRewards.account.accountType}-${accountRewards.account.index}`}
                         >
                             <Row gap={16} flex="1" overflow="hidden">
                                 <TokenIcon symbol={accountRewards.account.symbol} size={32} />
@@ -210,7 +214,11 @@ export const EarnYieldClaimSelectAccountModal = ({
                                     }
                                 >
                                     <HiddenPlaceholder>
-                                        <Text typographyStyle="body-md-strong" isTabular>
+                                        <Text
+                                            typographyStyle="body-md-strong"
+                                            isTabular
+                                            data-testid="@earn/claim-select-account/fiat-amount"
+                                        >
                                             {BaseCurrencyAmountFormatter.format(
                                                 accountRewards.totalClaimableFiatAmount,
                                             )}

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -164,7 +164,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                     <>
                         <ContextMessage context={Context.getEarnYield('claim')} />
 
-                        <Text typographyStyle="headline-md">
+                        <Text typographyStyle="headline-md" data-testid="@yield/claim/heading">
                             <Translation id="TR_EARN_CLAIM_REWARDS" />
                         </Text>
                     </>
@@ -227,6 +227,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                                                 isClaimSubmitting || merklRewardsQuery.isLoading
                                             }
                                             onClick={handleClaim}
+                                            data-testid="@yield/claim/claim-button"
                                         >
                                             <Translation id="TR_EARN_YIELD_CLAIM" />
                                         </Button>

--- a/packages/suite/src/components/earn/yield/claim/YieldRewardsList.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldRewardsList.tsx
@@ -33,7 +33,7 @@ export const YieldRewardsList = ({ accountRewards, isLoading }: YieldRewardsList
     }
 
     return (
-        <Column gap={16}>
+        <Column gap={16} data-testid="@yield/claim/rewards-list">
             {accountRewards.rewards.map((reward, index) => {
                 const claimableUnits = subunitsToUnits({
                     value: asAmountSubunit(new BigNumber(reward.claimable)),

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteClaim.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteClaim.tsx
@@ -26,7 +26,7 @@ export const YieldFlowCompleteClaim = ({ rewards }: YieldFlowCompleteClaimProps)
                     <Translation id="TR_STAKE_REWARDS" />
                 </Text>
 
-                <Column gap={16}>
+                <Column gap={16} data-testid="@yield/flow-complete/rewards-list">
                     {rewards.map((reward, index) => {
                         const formattedAmount = CryptoAmountFormatter.format(reward.value, {
                             symbol: toTokenSymbol(reward.token.symbol),

--- a/packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx
@@ -18,7 +18,12 @@ export const YieldRewardItem = ({
     tokenAddress,
     networkSymbol,
 }: YieldRewardItemProps) => (
-    <Row justifyContent="space-between" alignItems="center" gap={16}>
+    <Row
+        justifyContent="space-between"
+        alignItems="center"
+        gap={16}
+        data-testid={`@yield/rewards/item/${tokenSymbol.toLowerCase()}`}
+    >
         <Row gap={12} alignItems="center" flex="1" overflow="hidden">
             <TokenIcon
                 symbol={networkSymbol}
@@ -28,14 +33,22 @@ export const YieldRewardItem = ({
                 isBordered={false}
             />
             <HiddenPlaceholder>
-                <Text typographyStyle="body-md-strong">
+                <Text
+                    typographyStyle="body-md-strong"
+                    data-testid="@yield/rewards/reward-amount-with-symbol"
+                >
                     {formattedAmount} {tokenSymbol}
                 </Text>
             </HiddenPlaceholder>
         </Row>
 
         <HiddenPlaceholder>
-            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+            <Text
+                typographyStyle="body-md"
+                intent="neutral"
+                priority="secondary"
+                data-testid="@yield/rewards/reward-fiat-amount"
+            >
                 {formattedFiatAmount ? `≈ ${formattedFiatAmount}` : '—'}
             </Text>
         </HiddenPlaceholder>

--- a/suite/e2e/support/mocks/eth-endpoints.ts
+++ b/suite/e2e/support/mocks/eth-endpoints.ts
@@ -89,10 +89,18 @@ export const fixtures = [
         method: 'estimateFee',
         default: true,
         response: ({ params }: any) => {
-            // ERC-4626 vault calls: deposit === 0x6e553f65, withdraw === 0xb460af94,
-            // redeem === 0xba087652
-            const vaultCallSelectors = ['0x6e553f65', '0xb460af94', '0xba087652'];
-            if (vaultCallSelectors.some(selector => params?.specific?.data?.startsWith(selector))) {
+            const CONTRACT_CALL_SELECTORS = {
+                vaultDeposit: '0x6e553f65', // ERC-4626 deposit
+                vaultWithdraw: '0xb460af94', // ERC-4626 withdraw
+                vaultRedeem: '0xba087652', // ERC-4626 redeem
+                merklClaim: '0x71ee95c0', // Merkl distributor claim
+            } as const;
+
+            if (
+                Object.values(CONTRACT_CALL_SELECTORS).some(selector =>
+                    params?.specific?.data?.startsWith(selector),
+                )
+            ) {
                 return {
                     data: [
                         {

--- a/suite/e2e/support/mocks/yieldMock.ts
+++ b/suite/e2e/support/mocks/yieldMock.ts
@@ -46,8 +46,40 @@ export const YIELD_USDC_VAULT_SHARE_TOKEN = {
     transfers: 1,
 } as const;
 
+export const YIELD_NEW_BLOCK = {
+    height: 22881954,
+    hash: '0xa07d0d92b6bb9a5f388d47a10b824b4b09e0b3aeb08d0f61c0e30a25f6c8455f',
+} as const;
+
 // Share token balance converted by pricePerShareState.price (1.005607422297114), as displayed
 export const YIELD_USDC_DEPOSITED_AMOUNT = '10';
+
+// Merkl protocol-incentive reward (MORPHO) claimable by the mocked account.
+const MORPHO_CONTRACT = '0x58D97B57BB95320F9a05dC918Aef65434969c2B2';
+export const YIELD_MERKL_CLAIM_REWARD = {
+    token: {
+        address: MORPHO_CONTRACT,
+        chainId: 1,
+        symbol: 'MORPHO',
+        decimals: 18,
+    },
+    // claimed and pending are 0, so the on-chain cumulative amount equals the claimable amount.
+    amount: '2500000000000000000',
+    claimable: '2500000000000000000',
+    claimableUnits: '2.5',
+} as const;
+
+// MORPHO token entry for the blockbook account state after the claim is confirmed.
+export const YIELD_CLAIMED_MORPHO_TOKEN = {
+    type: 'ERC20',
+    standard: 'ERC20',
+    name: 'Morpho Token',
+    contract: MORPHO_CONTRACT.toLowerCase(),
+    symbol: 'MORPHO',
+    decimals: 18,
+    balance: YIELD_MERKL_CLAIM_REWARD.claimable,
+    transfers: 1,
+} as const;
 const USDC_ASSET = {
     type: 'ERC20',
     address: USDC_CONTRACT,
@@ -64,6 +96,14 @@ const USDC_VAULT_SHARE_ASSET = {
     symbol: 'trSHUSDCp',
 };
 
+const MORPHO_ASSET = {
+    type: 'ERC20',
+    address: MORPHO_CONTRACT,
+    decimals: 18,
+    name: 'Morpho Token',
+    symbol: 'MORPHO',
+};
+
 type BlockaidTransfer = {
     asset: typeof USDC_ASSET;
     rawValue: string;
@@ -76,7 +116,7 @@ const createBlockaidBenignResponse = ({
     sent,
     received,
 }: {
-    sent: BlockaidTransfer;
+    sent?: BlockaidTransfer;
     received: BlockaidTransfer;
 }) => ({
     validation: {
@@ -96,19 +136,23 @@ const createBlockaidBenignResponse = ({
 
         account_summary: {
             assets_diffs: [
-                {
-                    asset_type: 'ERC20',
-                    asset: sent.asset,
-                    in: [],
-                    out: [
-                        {
-                            raw_value: sent.rawValue,
-                            value: sent.value,
-                            usd_price: sent.usdPrice,
-                            summary: sent.summary,
-                        },
-                    ],
-                },
+                ...(sent
+                    ? [
+                          {
+                              asset_type: 'ERC20',
+                              asset: sent.asset,
+                              in: [],
+                              out: [
+                                  {
+                                      raw_value: sent.rawValue,
+                                      value: sent.value,
+                                      usd_price: sent.usdPrice,
+                                      summary: sent.summary,
+                                  },
+                              ],
+                          },
+                      ]
+                    : []),
                 {
                     asset_type: 'ERC20',
                     asset: received.asset,
@@ -126,8 +170,8 @@ const createBlockaidBenignResponse = ({
             exposures: [],
             total_usd_diff: {
                 in: received.usdPrice,
-                out: sent.usdPrice,
-                total: (Number(received.usdPrice) - Number(sent.usdPrice)).toString(),
+                out: sent?.usdPrice ?? '0',
+                total: (Number(received.usdPrice) - Number(sent?.usdPrice ?? '0')).toString(),
             },
             total_usd_exposure: {},
             traces: [],
@@ -189,6 +233,38 @@ const BLOCKAID_REDEEM_RESPONSE = createBlockaidBenignResponse({
         summary: 'Receiving 3.016822 USDC',
     },
 });
+
+// Claiming Merkl rewards only receives tokens; there is no outgoing transfer.
+const BLOCKAID_CLAIM_RESPONSE = createBlockaidBenignResponse({
+    received: {
+        asset: MORPHO_ASSET,
+        rawValue: '0x22b1c8c1227a0000',
+        value: '2.5',
+        usdPrice: '2.5',
+        summary: 'Receiving 2.5 MORPHO',
+    },
+});
+
+const createMerklRewardsResponse = (entries: { chainId: number; address: string }[]) =>
+    entries.map(({ chainId, address }) => ({
+        chainId,
+        address,
+        rewards: [
+            {
+                root: '0xdd919087d979f8b985e53c9c360709d2a751f8c5dabe3834a4552a49e3b836cd',
+                amount: YIELD_MERKL_CLAIM_REWARD.amount,
+                claimed: '0',
+                pending: '0',
+                token: YIELD_MERKL_CLAIM_REWARD.token,
+                proofs: [
+                    '0x8e18f5e7ec457f26c11ed8659eda26b740a0dbe125e1276c675f89b9916cee5a',
+                    '0x6da49a874e58d9268789b2c5d7fda203407321b8f2b985cc31cc83d07e683591',
+                ],
+                claimable: YIELD_MERKL_CLAIM_REWARD.claimable,
+            },
+        ],
+        totalClaimable: YIELD_MERKL_CLAIM_REWARD.claimable,
+    }));
 
 const YIELD_VAULTS_RESPONSE = {
     items: [
@@ -374,6 +450,35 @@ export class YieldMock {
     async mockUsdcRedeem() {
         await this.page.route(BLOCKAID_API_PATTERN, route =>
             route.fulfill({ json: BLOCKAID_REDEEM_RESPONSE }),
+        );
+    }
+
+    // Serves claimable Merkl rewards for every queried account. Once Suite polls with
+    // `reloadChainId` after the claim tx is confirmed (waitForMerklToResolveClaim), the mock
+    // switches to empty rewards for good — the same way real Merkl reports a settled claim.
+    @step()
+    async mockMerklRewards() {
+        let isClaimSettled = false;
+
+        await this.page.route(MERKL_API_PATTERN, route => {
+            const entries: { chainId: number; address: string; reloadChainId?: number }[] = route
+                .request()
+                .postDataJSON();
+
+            if (entries.some(entry => entry.reloadChainId !== undefined)) {
+                isClaimSettled = true;
+            }
+
+            return route.fulfill({
+                json: isClaimSettled ? [] : createMerklRewardsResponse(entries),
+            });
+        });
+    }
+
+    @step()
+    async mockMorphoClaim() {
+        await this.page.route(BLOCKAID_API_PATTERN, route =>
+            route.fulfill({ json: BLOCKAID_CLAIM_RESPONSE }),
         );
     }
 }

--- a/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
@@ -21,12 +21,19 @@ export class YieldFlowSection {
     readonly maxButton: Locator;
     readonly maxWithdrawInfoBanner: Locator;
     readonly withdrawnToast: Locator;
+    // Claim step
+    readonly claimHeading: Locator;
+    readonly claimButton: Locator;
+    readonly claimRewardsList: Locator;
+    readonly claimedToast: Locator;
+    readonly claimedToastMessage: Locator;
     // Flow-complete screen
     readonly flowCompleteHeading: Locator;
     readonly flowCompleteStatus: Locator;
     readonly flowCompleteApy: Locator;
     readonly flowCompleteTransferInputAmount: Locator;
     readonly flowCompleteTransferOutputAmount: Locator;
+    readonly flowCompleteRewardsList: Locator;
     readonly backToOverviewButton: Locator;
 
     constructor(private readonly page: Page) {
@@ -47,6 +54,11 @@ export class YieldFlowSection {
         this.maxButton = this.page.getByTestId('@yield/form/max-button');
         this.maxWithdrawInfoBanner = this.page.getByTestId('@yield/form/max-withdraw-info');
         this.withdrawnToast = this.page.getByTestId('@toast/tx-yield-withdraw');
+        this.claimHeading = this.page.getByTestId('@yield/claim/heading');
+        this.claimButton = this.page.getByTestId('@yield/claim/claim-button');
+        this.claimRewardsList = this.page.getByTestId('@yield/claim/rewards-list');
+        this.claimedToast = this.page.getByTestId('@toast/tx-yield-claim');
+        this.claimedToastMessage = this.page.getByTestId('@toast/tx-yield-claim/message');
         this.flowCompleteHeading = this.page.getByTestId('@yield/flow-complete/heading');
         this.flowCompleteStatus = this.page.getByTestId('@yield/flow-complete/status');
         this.flowCompleteApy = this.page.getByTestId('@earn/dashboard/apy-percentage');
@@ -56,8 +68,44 @@ export class YieldFlowSection {
         this.flowCompleteTransferOutputAmount = this.page.getByTestId(
             '@yield/flow-complete/transfer/output-with-symbol',
         );
+        this.flowCompleteRewardsList = this.page.getByTestId('@yield/flow-complete/rewards-list');
         this.backToOverviewButton = this.page.getByTestId(
             '@yield/flow-complete/back-to-overview-button',
+        );
+    }
+
+    // Token symbol shown in the claim review modal's "Reward tokens" step.
+    claimReviewRewardToken(tokenAddress: string): Locator {
+        return this.page
+            .getByTestId(`@modal/output-reward-${tokenAddress}`)
+            .getByTestId('@modal/output-value');
+    }
+
+    private rewardItem(list: Locator, tokenSymbol: string): Locator {
+        return list.getByTestId(`@yield/rewards/item/${tokenSymbol.toLowerCase()}`);
+    }
+
+    claimRewardAmount(tokenSymbol: string): Locator {
+        return this.rewardItem(this.claimRewardsList, tokenSymbol).getByTestId(
+            '@yield/rewards/reward-amount-with-symbol',
+        );
+    }
+
+    claimRewardFiatAmount(tokenSymbol: string): Locator {
+        return this.rewardItem(this.claimRewardsList, tokenSymbol).getByTestId(
+            '@yield/rewards/reward-fiat-amount',
+        );
+    }
+
+    flowCompleteRewardAmount(tokenSymbol: string): Locator {
+        return this.rewardItem(this.flowCompleteRewardsList, tokenSymbol).getByTestId(
+            '@yield/rewards/reward-amount-with-symbol',
+        );
+    }
+
+    flowCompleteRewardFiatAmount(tokenSymbol: string): Locator {
+        return this.rewardItem(this.flowCompleteRewardsList, tokenSymbol).getByTestId(
+            '@yield/rewards/reward-fiat-amount',
         );
     }
 }

--- a/suite/e2e/support/pageObjects/yield/yieldSection.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldSection.ts
@@ -2,6 +2,12 @@ import { type Locator, type Page } from '@playwright/test';
 
 import { step } from '../../common';
 
+type ClaimAccountParams = {
+    symbol: string;
+    accountType: string;
+    index: number;
+};
+
 export class YieldSection {
     readonly earnMenuButton: Locator;
     readonly dashboardContainer: Locator;
@@ -10,6 +16,10 @@ export class YieldSection {
     readonly apyBreakdownDescriptions: Locator;
     readonly apyBreakdownRates: Locator;
     readonly apyBreakdownFooter: Locator;
+    readonly claimRewardsButton: Locator;
+    readonly claimRewardsAmount: Locator;
+    readonly claimSelectAccountModal: Locator;
+    readonly claimSelectAccountHeading: Locator;
 
     constructor(private readonly page: Page) {
         this.earnMenuButton = this.page.getByTestId('@suite/menu/suite-earn');
@@ -25,6 +35,28 @@ export class YieldSection {
             '@earn/dashboard/apy-breakdown/rate-percent',
         );
         this.apyBreakdownFooter = this.page.getByTestId('@earn/dashboard/apy-breakdown/footer');
+        this.claimRewardsButton = this.page.getByTestId('@earn/dashboard/claim-rewards-button');
+        this.claimRewardsAmount = this.page.getByTestId('@earn/dashboard/claim-rewards-amount');
+        this.claimSelectAccountModal = this.page.getByTestId('@modal/earn-claim-select-account');
+        this.claimSelectAccountHeading = this.claimSelectAccountModal.getByTestId('@modal/header');
+    }
+
+    claimAccountButton({ symbol, accountType, index }: ClaimAccountParams): Locator {
+        return this.claimSelectAccountModal.getByTestId(
+            `@earn/claim-select-account/account/${symbol}-${accountType}-${index}`,
+        );
+    }
+
+    claimAccountRewardAmounts(account: ClaimAccountParams): Locator {
+        return this.claimAccountButton(account).getByTestId(
+            '@earn/claim-select-account/reward-amounts',
+        );
+    }
+
+    claimAccountFiatAmount(account: ClaimAccountParams): Locator {
+        return this.claimAccountButton(account).getByTestId(
+            '@earn/claim-select-account/fiat-amount',
+        );
     }
 
     row(vaultId: string): Locator {

--- a/suite/e2e/tests/yield/claimRewards.test.ts
+++ b/suite/e2e/tests/yield/claimRewards.test.ts
@@ -1,0 +1,189 @@
+import { TestStream } from '@trezor/e2e-utils';
+
+import ETH_BASE_TX from '../../fixtures/staking/eth-base-tx.json';
+import ETH_STAKE_CONFIRMED_TX from '../../fixtures/staking/eth-stake-confirmed-tx.json';
+import { expect, test } from '../../support/fixtures';
+import { ETH_MOCKED_ACCOUNT } from '../../support/mocks/eth-endpoints';
+import {
+    YIELD_CLAIMED_MORPHO_TOKEN,
+    YIELD_MERKL_CLAIM_REWARD,
+    YIELD_NEW_BLOCK,
+    YIELD_USDC_VAULT_SHARE_TOKEN,
+} from '../../support/mocks/yieldMock';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+const CLAIM_REWARD_TOKEN = YIELD_MERKL_CLAIM_REWARD.token.symbol;
+const CLAIM_REWARD_AMOUNT = `${YIELD_MERKL_CLAIM_REWARD.claimableUnits} ${CLAIM_REWARD_TOKEN}`;
+const CLAIM_REWARD_FIAT_AMOUNT = '≈ $2.50';
+const CLAIM_MAX_FEE = '0.00010840280031 ETH';
+
+const buildEthAccountTokens = ({ withClaimedMorpho }: { withClaimedMorpho: boolean }) => [
+    ...ETH_MOCKED_ACCOUNT.tokens.map(token =>
+        token.symbol === 'USDC' ? { ...token, balance: '990000000' } : token,
+    ),
+    YIELD_USDC_VAULT_SHARE_TOKEN,
+    ...(withClaimedMorpho ? [YIELD_CLAIMED_MORPHO_TOKEN] : []),
+];
+
+test.describe('stablecoin yield claim', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({
+        deviceSetup: {
+            mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
+        },
+    });
+
+    test.beforeEach(async ({ onboardingPage, settingsPage, blockbookMock, yieldMock }) => {
+        await onboardingPage.completeOnboarding();
+        await blockbookMock.start('eth');
+        blockbookMock.updateAccountState({
+            txs: 3,
+            nonce: '2',
+            transactions: [ETH_STAKE_CONFIRMED_TX, ETH_BASE_TX],
+            tokens: buildEthAccountTokens({ withClaimedMorpho: false }),
+        });
+        await yieldMock.start();
+        await yieldMock.mockMerklRewards();
+        await settingsPage.changeNetworks({
+            enableNetworks: [
+                { symbol: 'eth', backend: { type: 'blockbook', url: blockbookMock.url } },
+            ],
+        });
+    });
+
+    test(
+        'User can claim yield rewards',
+        { annotation: createTestAnnotation({ stream: TestStream.Earn }) },
+        async ({
+            page,
+            walletPage,
+            yieldSection,
+            yieldFlowSection,
+            txSimulationModal,
+            devicePrompt,
+            device,
+            blockbookMock,
+            yieldMock,
+        }) => {
+            await test.step('Dashboard shows the claim rewards banner', async () => {
+                await yieldSection.earnMenuButton.click();
+
+                await expect(yieldSection.claimRewardsAmount).toHaveText(CLAIM_REWARD_FIAT_AMOUNT);
+                await yieldSection.claimRewardsButton.click();
+            });
+
+            await test.step('Select the account with claimable rewards', async () => {
+                const ethAccount = { symbol: 'eth', accountType: 'normal', index: 0 };
+
+                await expect(yieldSection.claimSelectAccountHeading).toHaveTranslation(
+                    'TR_EARN_YIELD_CLAIM_MODAL_TITLE',
+                );
+                await expect(yieldSection.claimAccountRewardAmounts(ethAccount)).toHaveText(
+                    CLAIM_REWARD_AMOUNT,
+                );
+                await expect(yieldSection.claimAccountFiatAmount(ethAccount)).toHaveText('$2.50');
+                await yieldSection.claimAccountButton(ethAccount).click();
+            });
+
+            await test.step('Claim page lists the claimable rewards', async () => {
+                await expect(yieldFlowSection.claimHeading).toHaveTranslation(
+                    'TR_EARN_CLAIM_REWARDS',
+                );
+                await expect(yieldFlowSection.claimRewardAmount(CLAIM_REWARD_TOKEN)).toHaveText(
+                    CLAIM_REWARD_AMOUNT,
+                );
+                await expect(yieldFlowSection.claimRewardFiatAmount(CLAIM_REWARD_TOKEN)).toHaveText(
+                    CLAIM_REWARD_FIAT_AMOUNT,
+                );
+            });
+
+            await test.step('Claim the rewards', async () => {
+                await yieldMock.mockMorphoClaim();
+                await yieldFlowSection.claimButton.click();
+
+                await expect(txSimulationModal.receivedAsset(0)).toHaveText(
+                    `Receiving ${CLAIM_REWARD_AMOUNT}`,
+                );
+                await expect(txSimulationModal.receivedAssetFiat(0)).toHaveText('+$2.50');
+                await expect(txSimulationModal.maxFeeAmount).toHaveText('0.000108403 ETH');
+                await expect(txSimulationModal.maxFeeFiat).toHaveText('≈ $0.00');
+                await txSimulationModal.confirmButton.click();
+
+                await devicePrompt.confirmOnDevicePromptIsShown();
+
+                const ethAccountName = await walletPage
+                    .accountLabel({ symbol: 'eth', type: 'normal', atIndex: 0 })
+                    .innerText();
+                await expect(devicePrompt.header.accountLabel).toHaveText(ethAccountName);
+
+                await expect(devicePrompt.outputValueOf('data')).toHaveText('Merkl.xyz');
+                await expect(device).toShowOnDisplay({
+                    T3W1: {
+                        header: { title: 'Rewards claim' },
+                        body: [['Claim rewards from', '\n', 'Merkl.xyz']],
+                        actions: { right_button: 'Confirm' },
+                    },
+                });
+                await devicePrompt.waitForPromptAndClick();
+                await expect(
+                    yieldFlowSection.claimReviewRewardToken(YIELD_MERKL_CLAIM_REWARD.token.address),
+                ).toHaveText(CLAIM_REWARD_TOKEN);
+                await expect(device).toShowOnDisplay({
+                    T3W1: {
+                        header: { title: 'Rewards claim' },
+                        body: [['Reward tokens'], [CLAIM_REWARD_TOKEN]],
+                        actions: { right_button: 'Continue' },
+                    },
+                });
+                await device.pressYes();
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
+                    CLAIM_MAX_FEE,
+                );
+                await expect(device).toShowOnDisplay({
+                    T3W1: {
+                        header: { title: 'Rewards claim' },
+                        body: [['Maximum fee'], device.wrapText(CLAIM_MAX_FEE, { isAmount: true })],
+                        actions: { right_button: 'Hold to sign' },
+                    },
+                });
+                await devicePrompt.waitForFinalPromptAndConfirm();
+
+                blockbookMock.updateAccountState({
+                    txs: 4,
+                    nonce: '3',
+                    tokens: buildEthAccountTokens({ withClaimedMorpho: true }),
+                });
+                await devicePrompt.sendButton.click();
+
+                await expect(yieldFlowSection.claimedToast).toBeVisible();
+                await expect(yieldFlowSection.claimedToastMessage).toHaveTranslation(
+                    'TOAST_TX_YIELD_CLAIM',
+                    { values: { account: ethAccountName } },
+                );
+                await expect(yieldFlowSection.flowCompleteHeading).toHaveTranslation(
+                    'TR_EARN_YIELD_CLAIM_COMPLETE',
+                );
+                await expect(yieldFlowSection.flowCompleteStatus).toHaveTranslation(
+                    'TR_EARN_YIELD_COMPLETED',
+                );
+                await expect(
+                    yieldFlowSection.flowCompleteRewardAmount(CLAIM_REWARD_TOKEN),
+                ).toHaveText(CLAIM_REWARD_AMOUNT);
+                await expect(
+                    yieldFlowSection.flowCompleteRewardFiatAmount(CLAIM_REWARD_TOKEN),
+                ).toHaveText(CLAIM_REWARD_FIAT_AMOUNT);
+
+                await blockbookMock.sendNewBlockNotification(YIELD_NEW_BLOCK);
+            });
+
+            await test.step('Dashboard no longer offers rewards to claim', async () => {
+                await page.clock.install();
+                await page.clock.fastForward('01:01');
+                await yieldFlowSection.backToOverviewButton.click();
+
+                await expect(yieldSection.yieldTitle).toHaveTranslation('TR_EARN_DEFI_YIELD_TITLE');
+                await expect(yieldSection.claimRewardsAmount).toHaveText('$0.00');
+                await expect(yieldSection.claimRewardsButton).toBeDisabled();
+            });
+        },
+    );
+});

--- a/suite/e2e/tests/yield/deposit.test.ts
+++ b/suite/e2e/tests/yield/deposit.test.ts
@@ -4,7 +4,11 @@ import ETH_BASE_TX from '../../fixtures/staking/eth-base-tx.json';
 import ETH_STAKE_CONFIRMED_TX from '../../fixtures/staking/eth-stake-confirmed-tx.json';
 import { expect, test } from '../../support/fixtures';
 import { ETH_MOCKED_ACCOUNT } from '../../support/mocks/eth-endpoints';
-import { YIELD_USDC_VAULT_SHARE_TOKEN, YIELD_VAULTS } from '../../support/mocks/yieldMock';
+import {
+    YIELD_NEW_BLOCK,
+    YIELD_USDC_VAULT_SHARE_TOKEN,
+    YIELD_VAULTS,
+} from '../../support/mocks/yieldMock';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const { usdcPrime, usdtPrime } = YIELD_VAULTS;
@@ -268,11 +272,7 @@ test.describe('stablecoin yield', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =>
                     '9.94423845… trSHUSDCp',
                 );
 
-                await blockbookMock.sendNewBlockNotification({
-                    // One block above bestHeight of the getInfo fixture in eth-endpoints.
-                    height: 22881954,
-                    hash: '0xa07d0d92b6bb9a5f388d47a10b824b4b09e0b3aeb08d0f61c0e30a25f6c8455f',
-                });
+                await blockbookMock.sendNewBlockNotification(YIELD_NEW_BLOCK);
             });
 
             await test.step('Returning to the dashboard shows the deposited position', async () => {

--- a/suite/e2e/tests/yield/redeem.test.ts
+++ b/suite/e2e/tests/yield/redeem.test.ts
@@ -4,7 +4,11 @@ import ETH_BASE_TX from '../../fixtures/staking/eth-base-tx.json';
 import ETH_STAKE_CONFIRMED_TX from '../../fixtures/staking/eth-stake-confirmed-tx.json';
 import { expect, test } from '../../support/fixtures';
 import { ETH_MOCKED_ACCOUNT } from '../../support/mocks/eth-endpoints';
-import { YIELD_USDC_VAULT_SHARE_TOKEN, YIELD_VAULTS } from '../../support/mocks/yieldMock';
+import {
+    YIELD_NEW_BLOCK,
+    YIELD_USDC_VAULT_SHARE_TOKEN,
+    YIELD_VAULTS,
+} from '../../support/mocks/yieldMock';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
 const { usdcPrime } = YIELD_VAULTS;
@@ -15,10 +19,6 @@ const REDEEM_PAYOUT_AMOUNT = '3.016822';
 // YIELD_USDC_VAULT_SHARE_TOKEN.balance (18 decimals) converted to units
 const REDEEM_MAX_SHARES_AMOUNT = '9.944238455556494216';
 const REDEEM_MAX_FEE = '0.00010840280031 ETH';
-const NEW_BLOCK = {
-    height: 22881954,
-    hash: '0xa07d0d92b6bb9a5f388d47a10b824b4b09e0b3aeb08d0f61c0e30a25f6c8455f',
-};
 
 const buildEthAccountTokens = ({
     usdcBalance,
@@ -163,7 +163,7 @@ test.describe('stablecoin yield redeem', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
                     `${REDEEM_PAYOUT_AMOUNT} USDC`,
                 );
 
-                await blockbookMock.sendNewBlockNotification(NEW_BLOCK);
+                await blockbookMock.sendNewBlockNotification(YIELD_NEW_BLOCK);
             });
 
             await test.step('Dashboard shows the reduced position', async () => {

--- a/suite/e2e/tests/yield/withdrawal.test.ts
+++ b/suite/e2e/tests/yield/withdrawal.test.ts
@@ -5,6 +5,7 @@ import ETH_STAKE_CONFIRMED_TX from '../../fixtures/staking/eth-stake-confirmed-t
 import { expect, test } from '../../support/fixtures';
 import { ETH_MOCKED_ACCOUNT } from '../../support/mocks/eth-endpoints';
 import {
+    YIELD_NEW_BLOCK,
     YIELD_USDC_DEPOSITED_AMOUNT,
     YIELD_USDC_VAULT_SHARE_TOKEN,
     YIELD_VAULTS,
@@ -15,10 +16,6 @@ const { usdcPrime } = YIELD_VAULTS;
 const YIELD_USDC_VAULT_DISPLAY_NAME = ['Trezor Steakhouse', '\n', 'USDC Prime Vault'];
 const WITHDRAW_AMOUNT = '5';
 const WITHDRAW_MAX_FEE = '0.00010840280031 ETH';
-const NEW_BLOCK = {
-    height: 22881954,
-    hash: '0xa07d0d92b6bb9a5f388d47a10b824b4b09e0b3aeb08d0f61c0e30a25f6c8455f',
-};
 
 const buildEthAccountTokens = ({
     usdcBalance,
@@ -190,7 +187,7 @@ test.describe('stablecoin yield withdrawal', { tag: ['@webOnly', '@T3W1', '@T3T1
                     `${WITHDRAW_AMOUNT} USDC`,
                 );
 
-                await blockbookMock.sendNewBlockNotification(NEW_BLOCK);
+                await blockbookMock.sendNewBlockNotification(YIELD_NEW_BLOCK);
             });
 
             await test.step('Dashboard shows the reduced position', async () => {


### PR DESCRIPTION
## Description

Adds an e2e test for the yield claim rewards flow: dashboard claim banner → account selection → claim page → tx simulation → device confirmation → toast, flow-complete screen, and emptied dashboard.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-yield-claim/web/](https://dev.suite.sldev.cz/suite-web/test-yield-claim/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-yield-claim&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-yield-claim&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T14:30:04.948Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T14:30:52.473Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->