### PR TITLE
fix(connect-popup): reject websocket connections before upgrade

### DIFF
--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -24,6 +24,7 @@ import { type Dependencies } from '../modules';
 const LOG_PREFIX = 'connect-ws';
 const HANDSHAKE_TIMEOUT_MS = 10000;
 const MAX_CONCURRENT_CONNECTIONS = 50;
+const MAX_MESSAGE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 /**
  * allowed message from connect-in-suite-desktop implementation
@@ -87,6 +88,7 @@ export const exposeConnectWs = ({
 
     const wss = new WebSocketServer({
         noServer: true,
+        maxPayload: MAX_MESSAGE_SIZE,
     });
 
     wss.on('listening', () => {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -23,6 +23,7 @@ import { type Dependencies } from '../modules';
 
 const LOG_PREFIX = 'connect-ws';
 const HANDSHAKE_TIMEOUT_MS = 10000;
+const MAX_CONCURRENT_CONNECTIONS = 50;
 
 /**
  * allowed message from connect-in-suite-desktop implementation
@@ -82,6 +83,8 @@ export const exposeConnectWs = ({
 }) => {
     const { logger } = global;
 
+    let activeConnections = 0;
+
     const wss = new WebSocketServer({
         noServer: true,
     });
@@ -100,7 +103,23 @@ export const exposeConnectWs = ({
 
             return;
         }
-        logger.info(LOG_PREFIX, `new connection from ${ip}:${port}`);
+
+        // Enforce connection limit to prevent resource exhaustion
+        if (activeConnections + 1 > MAX_CONCURRENT_CONNECTIONS) {
+            logger.warn(
+                LOG_PREFIX,
+                `connection rejected: limit (${MAX_CONCURRENT_CONNECTIONS}) exceeded`,
+            );
+            ws.close();
+
+            return;
+        }
+        activeConnections += 1;
+
+        logger.info(
+            LOG_PREFIX,
+            `new connection from ${ip}:${port} (${activeConnections}/${MAX_CONCURRENT_CONNECTIONS})`,
+        );
 
         let processOnPort: ProcessInfo | undefined;
         const { origin } = req.headers;
@@ -293,7 +312,11 @@ export const exposeConnectWs = ({
         });
         ws.on('close', () => {
             clearTimeout(handshakeTimeout);
-            logger.info(LOG_PREFIX, 'Connection closed');
+            activeConnections = Math.max(0, activeConnections - 1);
+            logger.info(
+                LOG_PREFIX,
+                `Connection closed (${activeConnections}/${MAX_CONCURRENT_CONNECTIONS})`,
+            );
 
             if (connectionPendingMessages.size > 0) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -22,6 +22,7 @@ import { getProcessIcon } from './process-icon';
 import { type Dependencies } from '../modules';
 
 const LOG_PREFIX = 'connect-ws';
+const HANDSHAKE_TIMEOUT_MS = 10000;
 
 /**
  * allowed message from connect-in-suite-desktop implementation
@@ -109,6 +110,14 @@ export const exposeConnectWs = ({
         let requestedPermissions: PermissionRequest[] | undefined;
         let isHandshakeDone = false;
 
+        // Close connection if handshake is not received within timeout
+        const handshakeTimeout = setTimeout(() => {
+            if (!isHandshakeDone) {
+                logger.warn(LOG_PREFIX, `connection closed: handshake timeout from ${ip}:${port}`);
+                ws.close();
+            }
+        }, HANDSHAKE_TIMEOUT_MS);
+
         logger.info(LOG_PREFIX, `origin: ${origin}`);
 
         ws.on('error', err => {
@@ -149,6 +158,7 @@ export const exposeConnectWs = ({
                 version = parseVersion(message.payload.settings.version);
                 requestedPermissions = message.payload.settings.requestedPermissions;
                 isHandshakeDone = true;
+                clearTimeout(handshakeTimeout);
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
             } else if (message.type === POPUP.CLOSED) {
                 if (!isHandshakeDone) {
@@ -282,6 +292,7 @@ export const exposeConnectWs = ({
             }
         });
         ws.on('close', () => {
+            clearTimeout(handshakeTimeout);
             logger.info(LOG_PREFIX, 'Connection closed');
 
             if (connectionPendingMessages.size > 0) {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -107,6 +107,7 @@ export const exposeConnectWs = ({
         let manifest: Manifest | undefined;
         let version: string | undefined;
         let requestedPermissions: PermissionRequest[] | undefined;
+        let isHandshakeDone = false;
 
         logger.info(LOG_PREFIX, `origin: ${origin}`);
 
@@ -147,18 +148,34 @@ export const exposeConnectWs = ({
                 manifest = parseManifest(message.payload.settings.manifest);
                 version = parseVersion(message.payload.settings.version);
                 requestedPermissions = message.payload.settings.requestedPermissions;
+                isHandshakeDone = true;
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
             } else if (message.type === POPUP.CLOSED) {
+                if (!isHandshakeDone) {
+                    logger.warn(LOG_PREFIX, `${message.type} rejected: handshake not completed`);
+
+                    return;
+                }
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.error,
                     callId: message.payload?.callId,
                 });
             } else if (message.type === CORE_CALL_CANCEL) {
+                if (!isHandshakeDone) {
+                    logger.warn(LOG_PREFIX, `${message.type} rejected: handshake not completed`);
+
+                    return;
+                }
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.reason,
                     callId: message.payload?.callId,
                 });
             } else if (message.type === CORE_CALL) {
+                if (!isHandshakeDone) {
+                    logger.warn(LOG_PREFIX, `${message.type} rejected: handshake not completed`);
+
+                    return;
+                }
                 if (!processOnPort) {
                     // ts check, should be set
                     logger.error(LOG_PREFIX, 'processOnPort result not found');

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -101,7 +101,7 @@ export const exposeConnectWs = ({
         const port = req.socket.remotePort;
         if ((ip !== '127.0.0.1' && ip !== '::1') || !port) {
             logger.error(LOG_PREFIX, `invalid connection attempt from ${ip}:${port}`);
-            ws.close();
+            req.socket.destroy();
 
             return;
         }
@@ -112,7 +112,7 @@ export const exposeConnectWs = ({
                 LOG_PREFIX,
                 `connection rejected: limit (${MAX_CONCURRENT_CONNECTIONS}) exceeded`,
             );
-            ws.close();
+            req.socket.destroy();
 
             return;
         }
@@ -135,7 +135,7 @@ export const exposeConnectWs = ({
         const handshakeTimeout = setTimeout(() => {
             if (!isHandshakeDone) {
                 logger.warn(LOG_PREFIX, `connection closed: handshake timeout from ${ip}:${port}`);
-                ws.close();
+                req.socket.destroy();
             }
         }, HANDSHAKE_TIMEOUT_MS);
 
@@ -337,12 +337,19 @@ export const exposeConnectWs = ({
     });
 
     httpReceiver.server.on('upgrade', (request, socket, head) => {
-        if (!request?.url) return;
+        if (!request?.url) {
+            socket.destroy();
+
+            return;
+        }
+
         const { pathname } = new URL(request.url, 'http://localhost');
         if (pathname === '/connect-ws') {
             wss.handleUpgrade(request, socket, head, ws => {
                 wss.emit('connection', ws, request);
             });
+        } else {
+            socket.destroy();
         }
     });
 };

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -96,23 +96,15 @@ export const exposeConnectWs = ({
     });
 
     wss.on('connection', (ws, req) => {
+        ws.on('error', err => {
+            logger.error(LOG_PREFIX, err.message);
+        });
+
         const connectionPendingMessages = new Set<string>();
         const ip = req.socket.remoteAddress;
         const port = req.socket.remotePort;
-        if ((ip !== '127.0.0.1' && ip !== '::1') || !port) {
-            logger.error(LOG_PREFIX, `invalid connection attempt from ${ip}:${port}`);
-            req.socket.destroy();
-
-            return;
-        }
-
-        // Enforce connection limit to prevent resource exhaustion
-        if (activeConnections + 1 > MAX_CONCURRENT_CONNECTIONS) {
-            logger.warn(
-                LOG_PREFIX,
-                `connection rejected: limit (${MAX_CONCURRENT_CONNECTIONS}) exceeded`,
-            );
-            req.socket.destroy();
+        if (!port) {
+            ws.terminate();
 
             return;
         }
@@ -140,10 +132,6 @@ export const exposeConnectWs = ({
         }, HANDSHAKE_TIMEOUT_MS);
 
         logger.info(LOG_PREFIX, `origin: ${origin}`);
-
-        ws.on('error', err => {
-            logger.error(LOG_PREFIX, err.message);
-        });
 
         ws.on('message', async data => {
             const dataString = data.toString();
@@ -338,6 +326,25 @@ export const exposeConnectWs = ({
 
     httpReceiver.server.on('upgrade', (request, socket, head) => {
         if (!request?.url) {
+            socket.destroy();
+
+            return;
+        }
+
+        const ip = request.socket.remoteAddress;
+        const port = request.socket.remotePort;
+        if ((ip !== '127.0.0.1' && ip !== '::1') || !port) {
+            logger.error(LOG_PREFIX, `invalid connection attempt from ${ip}:${port}`);
+            socket.destroy();
+
+            return;
+        }
+
+        if (activeConnections >= MAX_CONCURRENT_CONNECTIONS) {
+            logger.warn(
+                LOG_PREFIX,
+                `connection rejected: limit (${MAX_CONCURRENT_CONNECTIONS}) exceeded`,
+            );
             socket.destroy();
 
             return;


### PR DESCRIPTION
## Description

When the WebSocket connection limit is reached, the current implementation sends `101 Switching Protocols` before rejecting the connection. A malformed frame pipelined after the upgrade request can also reach the global `uncaughtException` handler because rejection returns before registering the WebSocket error listener.

Move the loopback address, remote port and capacity checks into the HTTP `upgrade` handler, before `handleUpgrade()`, so rejected connections receive no response and never create a WebSocket parser. Register the WebSocket error listener first for accepted connections. Retain the local port guard to narrow the optional port for process lookup, with connection accounting starting only after that guard.

## Validation

Passed an isolated Node regression harness using the modified source and real `ws@8.20.0`, with Electron and process lookup dependencies stubbed:

- 50 connections complete the application handshake.
- A connection above the limit receives zero bytes instead of HTTP 101.
- An above-limit connection carrying a malformed pipelined frame receives zero bytes and causes no uncaught exception. The original PR code reproduced the exception.
- Closing one connection frees capacity; a replacement connects and exchanges ping/pong messages.

Prettier and `git diff --check` pass. The workspace has no installed project dependencies, so the project test suite, ESLint and Electron E2E tests were not run.

## Notes for QA

Verify that a normal Connect call still works in Suite Desktop. With connection capacity exhausted, verify that additional upgrades receive no HTTP response and that closing an accepted connection allows a new client to connect.

## Related Issue

Proposed follow-up to #31227. This PR targets `fix/connect-ws-server` so it can be incorporated into that PR.
