### PR TITLE
fix(connect-popup): reject invalid handshakes and expire idle connections

### DIFF
--- a/packages/suite-desktop-core/src/libs/connect-ws.test.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.test.ts
@@ -1,0 +1,239 @@
+import { EventEmitter } from 'events';
+import { WebSocketServer } from 'ws';
+
+import { CORE_CALL, type Manifest, POPUP, type PopupHandshake } from '@trezor/connect';
+import { findProcessFromIncomingPort } from '@trezor/node-utils';
+import { type Deferred, createDeferred } from '@trezor/utils';
+
+import { addMessage } from './connect-popup-messages';
+import { exposeConnectWs } from './connect-ws';
+
+jest.mock('ws', () => ({
+    WebSocketServer: jest.fn(() => new EventEmitter()),
+}));
+
+jest.mock('@trezor/connect', () => ({
+    ...jest.requireActual('@trezor/connect-common/src/events/core-call'),
+    ...jest.requireActual('@trezor/connect-common/src/events/popup'),
+}));
+
+jest.mock('@trezor/node-utils', () => ({
+    findProcessFromIncomingPort: jest.fn(),
+}));
+
+jest.mock('@trezor/env-utils', () => ({ isLinux: () => true }));
+
+jest.mock('@trezor/utils', () => ({
+    ...jest.requireActual('@trezor/utils/src/createDeferred'),
+    ...jest.requireActual('@trezor/utils/src/resolveAfter'),
+}));
+
+jest.mock('./connect-popup-messages', () => ({
+    addMessage: jest.fn(),
+    deleteMessage: jest.fn(),
+    setAppInit: jest.fn(),
+}));
+
+jest.mock('./process-icon', () => ({ getProcessIcon: jest.fn() }));
+
+const manifest: Manifest = {
+    appName: 'Test app',
+    appUrl: 'https://example.com',
+    email: 'test@example.com',
+};
+
+const handshake: PopupHandshake = {
+    type: POPUP.HANDSHAKE,
+    payload: { settings: { manifest, version: '10.0.0' } },
+};
+
+describe('Connect WebSocket connection lifetime', () => {
+    const originalLogger = global.logger;
+    let server: EventEmitter;
+    let responses: Deferred<{ success: boolean }>[];
+
+    const connect = () => {
+        const ws = Object.assign(new EventEmitter(), { send: jest.fn() });
+        const socket = {
+            remoteAddress: '127.0.0.1',
+            remotePort: 12345,
+            destroyed: false,
+            destroy: jest.fn(() => {
+                socket.destroyed = true;
+                ws.emit('close');
+            }),
+        };
+        server.emit('connection', ws, { socket, headers: { origin: 'https://example.com' } });
+
+        const send = async (message: object, id = '1') => {
+            ws.emit('message', Buffer.from(JSON.stringify({ id, ...message })));
+            await jest.advanceTimersByTimeAsync(0);
+        };
+
+        return { ws, socket, send };
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+        responses = [];
+        jest.mocked(findProcessFromIncomingPort).mockResolvedValue(undefined);
+        jest.mocked(addMessage).mockImplementation(() => {
+            const response = createDeferred<{ success: boolean }>();
+            responses.push(response);
+
+            return response;
+        });
+        global.logger = {
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            debug: jest.fn(),
+            exit: jest.fn(),
+            getLog: () => [],
+            level: 'debug',
+            config: {
+                colors: false,
+                writeToConsole: false,
+                writeToDisk: false,
+                outputFile: '',
+                outputPath: '',
+                logFormat: '',
+                dedupeTimeout: 0,
+                memoryCap: 0,
+            },
+        };
+
+        // The Electron dependencies are only used through these methods in this test.
+        const dependencies = {
+            httpReceiver: { server: new EventEmitter() },
+            mainThreadEmitter: { emit: jest.fn() },
+            mainWindowProxy: { getInstance: () => ({ webContents: { send: jest.fn() } }) },
+            store: { setConnectSettings: jest.fn() },
+        } as unknown as Parameters<typeof exposeConnectWs>[0];
+
+        exposeConnectWs(dependencies);
+        const result = jest.mocked(WebSocketServer).mock.results[0];
+        if (!result) throw new Error('WebSocket server was not created');
+        server = result.value;
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        global.logger = originalLogger;
+    });
+
+    it.each([undefined, {}, { email: manifest.email, appUrl: manifest.appUrl }])(
+        'closes an invalid handshake without acknowledging it or looking up a process: %j',
+        async invalidManifest => {
+            const connection = connect();
+
+            await connection.send({
+                type: POPUP.HANDSHAKE,
+                payload: { settings: { manifest: invalidManifest } },
+            });
+
+            expect(connection.socket.destroyed).toBe(true);
+            expect(connection.ws.send).not.toHaveBeenCalled();
+            expect(findProcessFromIncomingPort).not.toHaveBeenCalled();
+        },
+    );
+
+    it('releases capacity after invalid handshakes', async () => {
+        for (let index = 0; index < 50; index++) {
+            await connect().send({ type: POPUP.HANDSHAKE, payload: { settings: {} } });
+        }
+        const connection = connect();
+        await connection.send(handshake);
+
+        expect(connection.socket.destroyed).toBe(false);
+        expect(connection.ws.send).toHaveBeenCalledWith(
+            JSON.stringify({ id: '1', type: POPUP.HANDSHAKE, payload: 'ok' }),
+        );
+    });
+
+    it('expires idle connections even when pings and repeated handshakes are received', async () => {
+        const connection = connect();
+        await connection.send(handshake);
+        await jest.advanceTimersByTimeAsync(59000);
+        await connection.send({ type: 'ping' });
+        await connection.send(handshake);
+        expect(connection.socket.destroyed).toBe(false);
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(connection.socket.destroyed).toBe(true);
+    });
+
+    it('releases capacity when valid handshakes are followed by no calls', async () => {
+        for (let index = 0; index < 50; index++) {
+            await connect().send(handshake);
+        }
+        await jest.advanceTimersByTimeAsync(60000);
+        const connection = connect();
+        await connection.send(handshake);
+
+        expect(connection.socket.destroyed).toBe(false);
+        expect(connection.ws.send).toHaveBeenCalled();
+    });
+
+    it('keeps pending calls alive and starts a fresh idle timeout after the last response', async () => {
+        const connection = connect();
+        await connection.send(handshake);
+        await jest.advanceTimersByTimeAsync(59000);
+        await connection.send({ type: CORE_CALL, payload: { method: 'getAddress' } }, '2');
+        await connection.send({ type: CORE_CALL, payload: { method: 'getAddress' } }, '3');
+        expect(responses).toHaveLength(2);
+        await jest.advanceTimersByTimeAsync(120000);
+        expect(connection.socket.destroyed).toBe(false);
+
+        responses[0]?.resolve({ success: true });
+        await jest.advanceTimersByTimeAsync(120000);
+        expect(connection.socket.destroyed).toBe(false);
+
+        responses[1]?.resolve({ success: true });
+        await jest.advanceTimersByTimeAsync(59000);
+        expect(connection.socket.destroyed).toBe(false);
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(connection.socket.destroyed).toBe(true);
+    });
+
+    it('starts the idle timeout again after a call fails', async () => {
+        const connection = connect();
+        await connection.send(handshake);
+        await connection.send({ type: CORE_CALL, payload: { method: 'getAddress' } }, '2');
+
+        responses[0]?.reject(new Error('Call failed'));
+        await jest.advanceTimersByTimeAsync(60000);
+
+        expect(connection.socket.destroyed).toBe(true);
+    });
+
+    it('does not restart the idle timeout when a response arrives after disconnecting', async () => {
+        const connection = connect();
+        await connection.send(handshake);
+        await connection.send({ type: CORE_CALL, payload: { method: 'getAddress' } }, '2');
+        connection.socket.destroy();
+
+        responses[0]?.resolve({ success: true });
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('does not start an idle timer if process lookup finishes after the connection closes', async () => {
+        const lookup = createDeferred<undefined>();
+        jest.mocked(findProcessFromIncomingPort).mockReturnValue(lookup.promise);
+        const connection = connect();
+        await connection.send(handshake);
+        await jest.advanceTimersByTimeAsync(10000);
+        expect(connection.socket.destroyed).toBe(true);
+
+        lookup.resolve(undefined);
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(connection.ws.send).not.toHaveBeenCalled();
+        expect(jest.getTimerCount()).toBe(0);
+    });
+});

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -24,6 +24,7 @@ import { type Dependencies } from '../modules';
 const LOG_PREFIX = 'connect-ws';
 const HANDSHAKE_TIMEOUT_MS = 10000;
 const MAX_CONCURRENT_CONNECTIONS = 50;
+const MAX_MESSAGE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 /**
  * allowed message from connect-in-suite-desktop implementation
@@ -87,6 +88,7 @@ export const exposeConnectWs = ({
 
     const wss = new WebSocketServer({
         noServer: true,
+        maxPayload: MAX_MESSAGE_SIZE,
     });
 
     wss.on('listening', () => {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -23,6 +23,7 @@ import { type Dependencies } from '../modules';
 
 const LOG_PREFIX = 'connect-ws';
 const HANDSHAKE_TIMEOUT_MS = 10000;
+const MAX_CONCURRENT_CONNECTIONS = 50;
 
 /**
  * allowed message from connect-in-suite-desktop implementation
@@ -82,6 +83,8 @@ export const exposeConnectWs = ({
 }) => {
     const { logger } = global;
 
+    let activeConnections = 0;
+
     const wss = new WebSocketServer({
         noServer: true,
     });
@@ -100,7 +103,23 @@ export const exposeConnectWs = ({
 
             return;
         }
-        logger.info(LOG_PREFIX, `new connection from ${ip}:${port}`);
+
+        // Enforce connection limit to prevent resource exhaustion
+        if (activeConnections + 1 > MAX_CONCURRENT_CONNECTIONS) {
+            logger.warn(
+                LOG_PREFIX,
+                `connection rejected: limit (${MAX_CONCURRENT_CONNECTIONS}) exceeded`,
+            );
+            ws.close();
+
+            return;
+        }
+        activeConnections += 1;
+
+        logger.info(
+            LOG_PREFIX,
+            `new connection from ${ip}:${port} (${activeConnections}/${MAX_CONCURRENT_CONNECTIONS})`,
+        );
 
         let processOnPort: ProcessInfo | undefined;
         const { origin } = req.headers;
@@ -293,7 +312,11 @@ export const exposeConnectWs = ({
         });
         ws.on('close', () => {
             clearTimeout(handshakeTimeout);
-            logger.info(LOG_PREFIX, 'Connection closed');
+            activeConnections = Math.max(0, activeConnections - 1);
+            logger.info(
+                LOG_PREFIX,
+                `Connection closed (${activeConnections}/${MAX_CONCURRENT_CONNECTIONS})`,
+            );
 
             if (connectionPendingMessages.size > 0) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -22,6 +22,7 @@ import { getProcessIcon } from './process-icon';
 import { type Dependencies } from '../modules';
 
 const LOG_PREFIX = 'connect-ws';
+const HANDSHAKE_TIMEOUT_MS = 10000;
 
 /**
  * allowed message from connect-in-suite-desktop implementation
@@ -109,6 +110,14 @@ export const exposeConnectWs = ({
         let requestedPermissions: PermissionRequest[] | undefined;
         let isHandshakeDone = false;
 
+        // Close connection if handshake is not received within timeout
+        const handshakeTimeout = setTimeout(() => {
+            if (!isHandshakeDone) {
+                logger.warn(LOG_PREFIX, `connection closed: handshake timeout from ${ip}:${port}`);
+                ws.close();
+            }
+        }, HANDSHAKE_TIMEOUT_MS);
+
         logger.info(LOG_PREFIX, `origin: ${origin}`);
 
         ws.on('error', err => {
@@ -149,6 +158,7 @@ export const exposeConnectWs = ({
                 version = parseVersion(message.payload.settings.version);
                 requestedPermissions = message.payload.settings.requestedPermissions;
                 isHandshakeDone = true;
+                clearTimeout(handshakeTimeout);
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
             } else if (message.type === POPUP.CLOSED) {
                 if (!isHandshakeDone) {
@@ -282,6 +292,7 @@ export const exposeConnectWs = ({
             }
         });
         ws.on('close', () => {
+            clearTimeout(handshakeTimeout);
             logger.info(LOG_PREFIX, 'Connection closed');
 
             if (connectionPendingMessages.size > 0) {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -107,6 +107,7 @@ export const exposeConnectWs = ({
         let manifest: Manifest | undefined;
         let version: string | undefined;
         let requestedPermissions: PermissionRequest[] | undefined;
+        let isHandshakeDone = false;
 
         logger.info(LOG_PREFIX, `origin: ${origin}`);
 
@@ -147,18 +148,34 @@ export const exposeConnectWs = ({
                 manifest = parseManifest(message.payload.settings.manifest);
                 version = parseVersion(message.payload.settings.version);
                 requestedPermissions = message.payload.settings.requestedPermissions;
+                isHandshakeDone = true;
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
             } else if (message.type === POPUP.CLOSED) {
+                if (!isHandshakeDone) {
+                    logger.warn(LOG_PREFIX, `${message.type} rejected: handshake not completed`);
+
+                    return;
+                }
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.error,
                     callId: message.payload?.callId,
                 });
             } else if (message.type === CORE_CALL_CANCEL) {
+                if (!isHandshakeDone) {
+                    logger.warn(LOG_PREFIX, `${message.type} rejected: handshake not completed`);
+
+                    return;
+                }
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.reason,
                     callId: message.payload?.callId,
                 });
             } else if (message.type === CORE_CALL) {
+                if (!isHandshakeDone) {
+                    logger.warn(LOG_PREFIX, `${message.type} rejected: handshake not completed`);
+
+                    return;
+                }
                 if (!processOnPort) {
                     // ts check, should be set
                     logger.error(LOG_PREFIX, 'processOnPort result not found');

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -101,7 +101,7 @@ export const exposeConnectWs = ({
         const port = req.socket.remotePort;
         if ((ip !== '127.0.0.1' && ip !== '::1') || !port) {
             logger.error(LOG_PREFIX, `invalid connection attempt from ${ip}:${port}`);
-            ws.close();
+            req.socket.destroy();
 
             return;
         }
@@ -112,7 +112,7 @@ export const exposeConnectWs = ({
                 LOG_PREFIX,
                 `connection rejected: limit (${MAX_CONCURRENT_CONNECTIONS}) exceeded`,
             );
-            ws.close();
+            req.socket.destroy();
 
             return;
         }
@@ -135,7 +135,7 @@ export const exposeConnectWs = ({
         const handshakeTimeout = setTimeout(() => {
             if (!isHandshakeDone) {
                 logger.warn(LOG_PREFIX, `connection closed: handshake timeout from ${ip}:${port}`);
-                ws.close();
+                req.socket.destroy();
             }
         }, HANDSHAKE_TIMEOUT_MS);
 
@@ -337,12 +337,19 @@ export const exposeConnectWs = ({
     });
 
     httpReceiver.server.on('upgrade', (request, socket, head) => {
-        if (!request?.url) return;
+        if (!request?.url) {
+            socket.destroy();
+
+            return;
+        }
+
         const { pathname } = new URL(request.url, 'http://localhost');
         if (pathname === '/connect-ws') {
             wss.handleUpgrade(request, socket, head, ws => {
                 wss.emit('connection', ws, request);
             });
+        } else {
+            socket.destroy();
         }
     });
 };

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -23,6 +23,7 @@ import { type Dependencies } from '../modules';
 
 const LOG_PREFIX = 'connect-ws';
 const HANDSHAKE_TIMEOUT_MS = 10000;
+const IDLE_CONNECTION_TIMEOUT_MS = 60000;
 const MAX_CONCURRENT_CONNECTIONS = 50;
 const MAX_MESSAGE_SIZE = 2 * 1024 * 1024; // 2 MB
 
@@ -130,6 +131,15 @@ export const exposeConnectWs = ({
         let version: string | undefined;
         let requestedPermissions: PermissionRequest[] | undefined;
         let isHandshakeDone = false;
+        let idleTimeout: ReturnType<typeof setTimeout> | undefined;
+
+        const startIdleTimeout = () => {
+            clearTimeout(idleTimeout);
+            idleTimeout = setTimeout(() => {
+                logger.info(LOG_PREFIX, `connection closed: idle timeout from ${ip}:${port}`);
+                req.socket.destroy();
+            }, IDLE_CONNECTION_TIMEOUT_MS);
+        };
 
         // Close connection if handshake is not received within timeout
         const handshakeTimeout = setTimeout(() => {
@@ -169,17 +179,33 @@ export const exposeConnectWs = ({
                 return;
             }
             if (message.type === POPUP.HANDSHAKE) {
+                const parsedManifest = parseManifest(message.payload.settings.manifest);
+                if (!parsedManifest?.appName) {
+                    logger.warn(LOG_PREFIX, 'connection closed: invalid handshake manifest');
+                    req.socket.destroy();
+
+                    return;
+                }
+
                 const filterSelf = !process.env.PLAYWRIGHT_RUN; // ignore own process, unless testing
                 processOnPort = await findProcessFromIncomingPort(port, filterSelf).catch(() => {
                     logger.error(LOG_PREFIX, 'findProcessFromIncomingPort failed');
 
                     return undefined;
                 });
-                manifest = parseManifest(message.payload.settings.manifest);
+                if (req.socket.destroyed) {
+                    return;
+                }
+
+                manifest = parsedManifest;
                 version = parseVersion(message.payload.settings.version);
                 requestedPermissions = message.payload.settings.requestedPermissions;
-                isHandshakeDone = true;
-                clearTimeout(handshakeTimeout);
+                if (!isHandshakeDone) {
+                    isHandshakeDone = true;
+                    clearTimeout(handshakeTimeout);
+                    // Pings and repeated handshakes must not retain idle connection slots.
+                    startIdleTimeout();
+                }
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
             } else if (message.type === POPUP.CLOSED) {
                 if (!isHandshakeDone) {
@@ -237,6 +263,8 @@ export const exposeConnectWs = ({
 
                 const deferred = addMessage(message.id);
                 connectionPendingMessages.add(message.id);
+                // Do not disconnect a caller while it is waiting for device confirmation.
+                clearTimeout(idleTimeout);
 
                 try {
                     // check window exists, if not wait for it to be created
@@ -309,11 +337,15 @@ export const exposeConnectWs = ({
                     logger.error(LOG_PREFIX, 'error handling call: ' + e);
                 } finally {
                     connectionPendingMessages.delete(message.id);
+                    if (connectionPendingMessages.size === 0 && !req.socket.destroyed) {
+                        startIdleTimeout();
+                    }
                 }
             }
         });
         ws.on('close', () => {
             clearTimeout(handshakeTimeout);
+            clearTimeout(idleTimeout);
             activeConnections = Math.max(0, activeConnections - 1);
             logger.info(
                 LOG_PREFIX,


### PR DESCRIPTION
## Description

A handshake with `payload.settings: {}` currently receives an acknowledgement and cancels the handshake timeout even though its manifest is invalid. Fifty connections left in this state can occupy the global limit indefinitely and prevent other clients from connecting. A valid manifest alone does not establish a need to retain an idle connection either.

Close handshakes with an invalid manifest or missing app name before process lookup or acknowledgement. After the first valid handshake, start a 60-second idle timeout. Pings and repeated handshakes do not extend this timeout. Suspend it while Connect calls are pending and restart it after the last call settles, preserving time spent waiting for device confirmation. Clear timers on disconnect and ignore a process lookup that finishes after its connection closes.

The desktop Connect client already reconnects before its next call if the socket has closed.

## Validation

- Added 10 co-located Jest tests covering invalid handshakes, capacity recovery, pings/repeated handshakes, overlapping pending calls, failed calls, disconnect cleanup and late process lookup. All pass with isolated Jest/SWC dependencies and source alias mapping; the initial regression cases failed against the original PR code.
- An additional harness using real `ws@8.20.0` sockets, a controlled server clock and stubbed Electron/process lookup dependencies verified that 50 invalid handshakes release capacity, 50 valid but idle connections expire, and a pending call survives beyond the idle deadline, returns its response and subsequently expires when idle.
- Prettier and `git diff --check` pass.
- Full workspace checks, ESLint and Electron E2E tests were not run because the project dependencies are not installed in this workspace.

## Notes for QA

- Make a successful Suite Desktop Connect call, leave the connection idle for more than 60 seconds, then make another call and verify that it reconnects successfully.
- Leave a call waiting for device confirmation for more than 60 seconds and verify that it is still usable.
- Verify that an invalid handshake closes its connection and that idle slots become available even if the client sends pings or repeats its handshake.

## Related Issue

Proposed follow-up to #31227, targeting `fix/connect-ws-server`. This branch is based directly on that PR and addresses invalid handshakes and idle connection capacity.
