### PR TITLE
fix(suite): Fix sidebar icon alignment

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
-import { Box, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
+import { Box, Column, TOOLTIP_DELAY_NORMAL, Tooltip } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
 import { useGoToWithAnalytics } from 'src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics';
@@ -107,23 +107,25 @@ export const AccountItem = memo(
                     />
                 </ExpandedSidebarOnly>
                 <CollapsedSidebarOnly>
-                    <Tooltip
-                        delayShow={TOOLTIP_DELAY_NORMAL}
-                        cursor="pointer"
-                        content={
-                            <Box padding={4}>
-                                <AccountItemContent {...commonProps} showAccountTypeBadge />
-                            </Box>
-                        }
-                        placement="right"
-                    >
-                        <AccountRow
-                            {...commonProps}
-                            isSelected={isSelected}
-                            handleHeaderClick={handleHeaderClick}
-                            isCollapsed
-                        />
-                    </Tooltip>
+                    <Column alignItems="center" width="100%">
+                        <Tooltip
+                            delayShow={TOOLTIP_DELAY_NORMAL}
+                            cursor="pointer"
+                            content={
+                                <Box padding={4}>
+                                    <AccountItemContent {...commonProps} showAccountTypeBadge />
+                                </Box>
+                            }
+                            placement="right"
+                        >
+                            <AccountRow
+                                {...commonProps}
+                                isSelected={isSelected}
+                                handleHeaderClick={handleHeaderClick}
+                                isCollapsed
+                            />
+                        </Tooltip>
+                    </Column>
                 </CollapsedSidebarOnly>
             </>
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- when sidebar is collapsed (on DESKTOP, not WEB!) icons were misaligned

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before
<img width="282" height="714" alt="image" src="https://github.com/user-attachments/assets/50070ba1-a89b-4c7a-8bf3-f96898c474be" />


after
<img width="273" height="734" alt="image" src="https://github.com/user-attachments/assets/169adcb3-5f72-4df0-8390-a7f87d70933a" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** AccountItem.tsx is a widely used account menu component, but the risk is concentrated in label rendering, account search/filtering, account creation, and discovery visibility. The recommended high-priority tests directly assert account menu items, labels, and search behavior. Medium-priority tests cover broader discovery and balance-display flows that depend on the account list rendering correctly.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Directly edits Bitcoin account labels and asserts the updated text appears in the account menu, that labels can be searched from the sidebar, and that removing a label reverts to the default account name.
- `suite/e2e/tests/metadata/legacy/interval-fetching.test.ts` — Verifies that account menu labels for a BTC account update automatically after remote metadata changes, exercising the AccountItem label rendering and periodic sync path.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Covers updating and removing account labels via Suite Sync, checking the UI shows the new label, reverts to default names, and syncs null values back to the relay.
- `suite/e2e/tests/wallet/account-search.test.ts` — Tests the account search/filter field in the wallet sidebar, asserting that matching and non-matching account buttons are shown or hidden based on the query.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Creates multiple BTC-like and non-BTC accounts and checks that the account list reflects the new accounts with correct types, relying on AccountItem rendering for each entry.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Toggles discreet mode and checks balance display across the dashboard, asset views, and account list, so a regression in AccountItem balance rendering would be visible.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Ejects and re-discovers a standard wallet, then switches BTC accounts; it depends on the account menu being correctly rendered after discovery.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates many coin networks and verifies discovered accounts become visible on the dashboard, which can be affected if AccountItem fails to render account entries after discovery.

</details>

_Updated: 2026-09-10T10:01:16.767Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-sidebar-icons/web/](https://dev.suite.sldev.cz/suite-web/fix-sidebar-icons/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-sidebar-icons&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-sidebar-icons&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T10:03:00.795Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T10:02:26.929Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->