### PR TITLE
fix(suite-native): format native asset sheet balance

### DIFF
--- a/suite-native/module-earn/src/components/earn/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/earn/TokenSettingsBottomSheet.tsx
@@ -40,6 +40,7 @@ import { isDevelopOrDebugEnv } from '@suite-native/config';
 import {
     AddressFormatter,
     CoinToFiatAmountFormatter,
+    ExactCryptoAmountFormatter,
     ExactTokenAmountFormatter,
     TokenToFiatAmountFormatter,
     asDecimalTokenAmount,
@@ -147,7 +148,8 @@ export const TokenSettingsBottomSheet = forwardRef(
 
         const displaySymbol = getDisplaySymbol(account.symbol);
 
-        const balance = token?.balance ?? account.balance;
+        const tokenBalance = token?.balance ?? '0';
+        const tokenSymbol = token?.symbol ? toTokenSymbol(getDisplaySymbol(token.symbol)) : null;
         const networkName = getNetwork(symbol).name;
 
         const isHidden = hiddenTokens.some(
@@ -270,25 +272,32 @@ export const TokenSettingsBottomSheet = forwardRef(
                             >
                                 <Box flex={1} alignItems="flex-end" marginLeft="sp8">
                                     <VStack spacing={0} alignItems="flex-end">
-                                        <ExactTokenAmountFormatter
-                                            value={asDecimalTokenAmount(balance)}
-                                            tokenSymbol={toTokenSymbol(
-                                                getDisplaySymbol(
-                                                    token?.symbol ?? toTokenSymbol(account.symbol),
-                                                ),
-                                            )}
-                                            variant="body-sm"
-                                            color="contentPrimary"
-                                            numberOfLines={1}
-                                            ellipsizeMode="tail"
-                                        />
+                                        {tokenContract ? (
+                                            <ExactTokenAmountFormatter
+                                                value={asDecimalTokenAmount(tokenBalance)}
+                                                tokenSymbol={tokenSymbol}
+                                                variant="body-sm"
+                                                color="contentPrimary"
+                                                numberOfLines={1}
+                                                ellipsizeMode="tail"
+                                            />
+                                        ) : (
+                                            <ExactCryptoAmountFormatter
+                                                value={account.formattedBalance}
+                                                symbol={account.symbol}
+                                                variant="body-sm"
+                                                color="contentPrimary"
+                                                numberOfLines={1}
+                                                ellipsizeMode="tail"
+                                            />
+                                        )}
 
                                         {!isUnrecognized && (
                                             <>
                                                 {tokenContract ? (
                                                     <TokenToFiatAmountFormatter
                                                         symbol={symbol}
-                                                        value={balance}
+                                                        value={tokenBalance}
                                                         contract={tokenContract}
                                                         variant="body-sm"
                                                         color="contentSecondary"
@@ -296,7 +305,7 @@ export const TokenSettingsBottomSheet = forwardRef(
                                                 ) : (
                                                     <CoinToFiatAmountFormatter
                                                         accountKey={accountKey}
-                                                        value={balance}
+                                                        value={account.balance}
                                                         variant="body-sm"
                                                         color="contentSecondary"
                                                     />


### PR DESCRIPTION
## Description

Fixes the native asset settings bottom sheet balance row for native coins such as ETH.

The sheet previously routed both token balances and native account balances through the token amount formatter. Native account balances are stored in base units, so ETH wei could be displayed as ETH. Native coins now use the crypto amount formatter with `account.formattedBalance`, while token rows keep the token amount formatter and only use a token symbol when token metadata is present.

## Notes for QA

Open the mobile app, go to My assets, open an ETH/Ethereum account detail, and tap the gear icon in the top-right. In the bottom sheet titled ETH, verify the Balance row shows the decimal ETH amount matching the account card, not a large wei/base-unit value.

Also verify an ERC-20 token detail bottom sheet still displays its token balance and fiat value correctly.


## Screenshots
<img width="411" height="918" alt="image" src="https://github.com/user-attachments/assets/846d115b-aab3-45bd-bceb-49756d5eb34a" />

Resolve #32330

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/fix-eth-sheet-value&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->