### PR TITLE
fix(suite-native): adapt Trade tab layout to Czech translations

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetHeader.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetHeader.tsx
@@ -4,10 +4,10 @@ import { View, type ViewProps } from 'react-native';
 import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { Box } from '../Box';
 import { IconButton } from '../Button/IconButton';
 import { Text } from '../Text';
 import { BottomSheetGrabber } from './BottomSheetGrabber';
-import { Box } from '../Box';
 
 type BottomSheetHeaderProps = {
     title: ReactNode;
@@ -25,14 +25,13 @@ const sheetHeaderStyle = prepareNativeStyle<{ isCloseDisplayed: boolean }>(
         alignItems: isCloseDisplayed ? 'center' : 'flex-start',
         paddingHorizontal: utils.spacings.sp16,
         paddingBottom: utils.spacings.sp16,
+        gap: utils.spacings.sp16,
     }),
 );
 
-const titlesContainer = prepareNativeStyle<{ isCloseDisplayed: boolean }>(
-    (_, { isCloseDisplayed }) => ({
-        maxWidth: isCloseDisplayed ? '70%' : '100%',
-    }),
-);
+const titlesContainer = prepareNativeStyle(_ => ({
+    flexShrink: 1,
+}));
 
 export const BottomSheetHeader = ({
     title,
@@ -54,7 +53,7 @@ export const BottomSheetHeader = ({
             </Box>
             {isHeaderDisplayed && (
                 <View style={applyStyle(sheetHeaderStyle, { isCloseDisplayed })}>
-                    <View style={applyStyle(titlesContainer, { isCloseDisplayed })}>
+                    <View style={applyStyle(titlesContainer)}>
                         {title && <Text variant="headline-sm">{title}</Text>}
                         {subtitle && (
                             <Text variant="body-sm" color="contentSecondary">

--- a/suite-native/trading-provider-utils/src/components/Footer.tsx
+++ b/suite-native/trading-provider-utils/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import type { ProviderMetadata } from 'invity-api';
 
 import { selectTradingProviderMetadata } from '@suite-common/trading';
-import { AnimatedBox, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
+import { AnimatedBox, Box, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
 import { selectIsAmountInputActive } from '@suite-native/trading-state';
@@ -28,7 +28,7 @@ const FooterProviderContent = ({ provider }: FooterProviderContentProps) => {
     const { companyName, termsUrl } = provider;
 
     return (
-        <VStack alignItems="center" spacing={0}>
+        <Box alignItems="center">
             <Text variant="body-sm" color="contentSecondary" textAlign="center">
                 <Translation
                     id="moduleTrading.tradingScreen.footer.providerDisclaimer"
@@ -43,12 +43,13 @@ const FooterProviderContent = ({ provider }: FooterProviderContentProps) => {
                 label={<Translation id="moduleTrading.tradingScreen.footer.termsApply" />}
                 isUnderlined
             />
-        </VStack>
+        </Box>
     );
 };
 
 const linkStyle = prepareNativeStyle(({ spacings }) => ({
     paddingVertical: spacings.sp10,
+    textAlign: 'center',
 }));
 
 const stackStyle = prepareNativeStyle(() => ({
@@ -69,7 +70,7 @@ export const Footer = () => {
     return (
         <VStack style={applyStyle(stackStyle)}>
             <AnimatedBox entering={FadeInDown}>
-                <VStack alignItems="center" paddingBottom="sp12">
+                <VStack paddingBottom="sp12">
                     <FooterProviderContent provider={providerInfo} />
                     <Link
                         label={

--- a/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.tsx
+++ b/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.tsx
@@ -2,10 +2,17 @@ import { type ReactNode, type Ref } from 'react';
 
 import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 
-import { BottomSheetModal, Button, HStack, IconListItem, Text, VStack } from '@suite-native/atoms';
-import { Icon, type IconName } from '@suite-native/icons';
+import {
+    BottomSheetModal,
+    Button,
+    IconListItem,
+    Text,
+    TextButton,
+    VStack,
+} from '@suite-native/atoms';
+import { type IconName } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { Link } from '@suite-native/link';
+import { useOpenLink } from '@suite-native/link';
 import { TREZOR_SUITE_TOS_URL, TREZOR_SUPPORT_UNDERSTANDING_FEES } from '@trezor/urls';
 
 type ListItemProps = {
@@ -14,24 +21,21 @@ type ListItemProps = {
     href?: string;
 };
 
-const ListItem = ({ icon, children, href }: ListItemProps) => (
-    <IconListItem icon={icon} variant="brand" iconSize="large">
-        {href ? (
-            <HStack spacing="sp2" alignItems="center">
-                <Link
-                    textColor="contentPrimary"
-                    textVariant="body-md-strong"
-                    href={href}
-                    isUnderlined
-                    label={children}
-                />
-                <Icon name="arrowSquareOut" size="mediumLarge" />
-            </HStack>
-        ) : (
-            <Text variant="body-md-strong">{children}</Text>
-        )}
-    </IconListItem>
-);
+const ListItem = ({ icon, children, href }: ListItemProps) => {
+    const openLink = useOpenLink();
+
+    return (
+        <IconListItem icon={icon} variant="brand" iconSize="large">
+            {href ? (
+                <TextButton iconRight="arrowSquareOut" isUnderlined onPress={() => openLink(href)}>
+                    {children}
+                </TextButton>
+            ) : (
+                <Text>{children}</Text>
+            )}
+        </IconListItem>
+    );
+};
 
 type HowTradingWorksSheetProps = {
     ref: Ref<BottomSheetModalMethods>;


### PR DESCRIPTION
## Description

- `BottomSheetHeader` layout styles improved.
- Trade tab layout adapted to Czech translations.

## Related Issue

Resolve #32301

## Screenshots:

| Trade tab | How trading works |
| --- | --- |
| <img width="1080" height="2340" alt="Screenshot_20260910_140313" src="https://github.com/user-attachments/assets/0af83ce0-997d-4cf9-92c8-af56b823c034" /> | <img width="1080" height="2340" alt="Screenshot_20260910_140325" src="https://github.com/user-attachments/assets/a458ba17-47e5-415c-b99e-c0856b26188e" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/how-trading-works&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->