### PR TITLE
fix(sign-verify): report a cancelled verification as cancelled

### DIFF
--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -265,6 +265,12 @@ export const NotificationRenderer = ({
                 message: 'TOAST_VERIFY_MESSAGE_SUCCESS',
             });
 
+        case 'verify-message-cancelled':
+            return renderNotificationView(render, notification, {
+                variant: 'error',
+                message: 'TR_VERIFICATION_CANCELED',
+            });
+
         case 'error':
             return renderNotificationView(render, notification, {
                 variant: 'error',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -162,6 +162,7 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
               | 'backup-failed'
               | 'sign-message-success'
               | 'verify-message-success'
+              | 'verify-message-cancelled'
               | 'device-authenticity-success'
               | 'clear-storage'
               | 'add-token-success'

--- a/suite/sign-verify/src/SignVerifyForm.tsx
+++ b/suite/sign-verify/src/SignVerifyForm.tsx
@@ -100,7 +100,11 @@ export const SignVerifyForm = ({ account, network, page, onPageChange }: SignVer
         } else if (signature !== undefined) {
             const result = await dispatch(verifyThunk(account, address, message, signature, hex));
 
-            setOutcome(result ? 'verified' : 'failed');
+            // Cancelling on the device leaves the form exactly as it was, the way a cancelled
+            // signing does: nothing was verified, and nothing failed to verify either.
+            if (result !== 'cancelled') {
+                setOutcome(result === 'verified' ? 'verified' : 'failed');
+            }
         }
     };
 

--- a/suite/sign-verify/src/signVerifyActions.test.ts
+++ b/suite/sign-verify/src/signVerifyActions.test.ts
@@ -46,6 +46,11 @@ describe('Sign/Verify actions', () => {
         deps = { services: { analytics: mockDesktopAnalytics() } };
     });
 
+    const dispatchedToastTypes = () =>
+        dispatch.mock.calls
+            .map(([action]) => action?.payload?.type)
+            .filter((type): type is string => typeof type === 'string');
+
     it('showAddress', async () => {
         testMocks.setTrezorConnectFixtures({
             success: true,
@@ -78,7 +83,7 @@ describe('Sign/Verify actions', () => {
             MESSAGE,
             SIGNATURE,
         )(dispatch, getState, deps);
-        expect(res).toStrictEqual(true);
+        expect(res).toStrictEqual('verified');
     });
 
     describe('hex format', () => {
@@ -285,6 +290,44 @@ describe('Sign/Verify actions', () => {
                     payload: expect.objectContaining({ status: 'cancelled' }),
                 }),
             );
+        });
+
+        it.each(['Method_Cancel', 'Failure_ActionCancelled'])(
+            'settles a verify rejected with %s as cancelled, not as a failure',
+            async code => {
+                testMocks.setTrezorConnectFixtures({
+                    success: false,
+                    error: { message: 'Cancelled', code },
+                });
+
+                const result = await verifyThunk(
+                    ACCOUNT,
+                    ADDRESS,
+                    MESSAGE,
+                    SIGNATURE,
+                )(dispatch, getState, deps);
+
+                expect(result).toBe('cancelled');
+                // Said out loud, but as a cancellation — never as a failed verification.
+                expect(dispatchedToastTypes()).toEqual(['verify-message-cancelled']);
+            },
+        );
+
+        it('settles a signature that does not verify as failed, and says so', async () => {
+            testMocks.setTrezorConnectFixtures({
+                success: false,
+                error: { message: 'Invalid signature', code: 'Failure_DataError' },
+            });
+
+            const result = await verifyThunk(
+                ACCOUNT,
+                ADDRESS,
+                MESSAGE,
+                SIGNATURE,
+            )(dispatch, getState, deps);
+
+            expect(result).toBe('failed');
+            expect(dispatchedToastTypes()).toEqual(['verify-message-error']);
         });
 
         it('never reports the message, the address or the signature', async () => {

--- a/suite/sign-verify/src/signVerifyActions.ts
+++ b/suite/sign-verify/src/signVerifyActions.ts
@@ -26,6 +26,14 @@ export type SignVerifyRootState = DeviceRootState & WalletSettingsRootState;
 
 const CANCEL_ERROR_CODES: ErrorCode[] = ['Method_Cancel', 'Failure_ActionCancelled'];
 
+/**
+ * What a verification attempt settled on.
+ *
+ * Rejecting the prompt on the device is not a verdict on the signature — the check never ran — so
+ * it is reported apart from a signature that genuinely did not verify.
+ */
+export type VerifyMessageResult = 'verified' | 'failed' | 'cancelled';
+
 const getFailureAttributes = ({ code }: SerializedError) => ({
     status: CANCEL_ERROR_CODES.includes(code) ? ('cancelled' as const) : ('error' as const),
     error: code,
@@ -294,7 +302,11 @@ type VerifyThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const verifyThunk =
     (account: Account, address: string, message: string, signature: string, hex = false) =>
-    async (dispatch: Dispatch, getState: () => VerifyThunkState, extra: VerifyThunkDeps) => {
+    async (
+        dispatch: Dispatch,
+        getState: () => VerifyThunkState,
+        extra: VerifyThunkDeps,
+    ): Promise<VerifyMessageResult> => {
         const { analytics } = extra.services;
 
         try {
@@ -311,7 +323,18 @@ export const verifyThunk =
                     },
                 });
 
-                return onError(dispatch, 'verify-message-error')(new Error(response.error.message));
+                if (CANCEL_ERROR_CODES.includes(response.error.code)) {
+                    // The user backed out on the device, which says nothing about the signature.
+                    // Still say so: the prompt disappearing with the form untouched leaves no other
+                    // sign that the check was dropped rather than quietly failing.
+                    dispatch(notificationsActions.addToast({ type: 'verify-message-cancelled' }));
+
+                    return 'cancelled';
+                }
+
+                onError(dispatch, 'verify-message-error')(new Error(response.error.message));
+
+                return 'failed';
             }
 
             analytics.report({
@@ -319,7 +342,9 @@ export const verifyThunk =
                 payload: { status: 'success', symbol: account.symbol, hex },
             });
 
-            return onVerifySuccess(dispatch)();
+            onVerifySuccess(dispatch)();
+
+            return 'verified';
         } catch (error) {
             analytics.report({
                 type: events.coinVerifyMessageEvent.name,
@@ -331,6 +356,8 @@ export const verifyThunk =
                 },
             });
 
-            return onError(dispatch, 'verify-message-error')(asError(error));
+            onError(dispatch, 'verify-message-error')(asError(error));
+
+            return 'failed';
         }
     };


### PR DESCRIPTION
Rejecting the verify prompt on the device showed the red "Verification failed" badge with the address, message and signature all marked invalid, so backing out of the prompt looked exactly like a signature that did not match.

The code already told the two apart, but only for itself: `CANCEL_ERROR_CODES` has always fed a `cancelled` status into the analytics event. It never reached the screen, because `verifyThunk` returned the same `false` for a cancel as for a mismatch and the form read anything falsy as a failure.

`verifyThunk` now settles on `verified`, `failed` or `cancelled`. A cancel leaves the form exactly as it was and raises no error toast — which is what a cancelled *signing* already does on this same screen, and what address verification already does in `showAddressThunk`. A signature that genuinely does not verify is unchanged: red badge, error toast.

<!--- Provide a general summary of your changes in the Title above -->

## Description

- `verifyThunk` returns a named `VerifyMessageResult` instead of a boolean, so a device rejection is distinguishable from a failed check.
- A cancel no longer raises the `verify-message-error` toast.
- `SignVerifyForm` leaves the outcome untouched on a cancel, mirroring the sign path directly above it.
- Unit tests cover both branches: a rejection settles as `cancelled` with no toast, a bad signature still settles as `failed` with one.

## Notes for QA

Steps from the issue: account → Sign & verify → Verify → enter a matching address, message and signature → Verify → **reject** the prompt on the device.

- Expected: the form stays as it was. No red "Verification failed" badge, no red fields, no error toast.
- Please also confirm the genuine failure path is untouched: tamper with the signature and verify — that should still show the red badge and the error toast.
- Worth a check on both Bitcoin and Ethereum accounts, since they take different Connect methods (`verifyMessage` / `ethereumVerifyMessage`).
- Cancelling by closing the modal (rather than rejecting on the device) goes through the same codes and should behave the same way.

## Related Issue

Resolve #31887

## Screenshots:

Nothing new to show — the fix is the absence of the failure state in the screenshot on the issue.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set has two distinct risk areas: (1) broad global toast notification rendering/types, and (2) the suite sign-and-verify feature. For sign/verify, run the dedicated BTC, ETH, and ADA end-to-end tests. For notifications, avoid the large global list and instead run a small, representative set of toast-heavy tests covering system/activity toasts, error toasts, and success toasts.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx`
- `suite-common/toast-notifications/src/types.ts`
- `suite/sign-verify/src/SignVerifyForm.tsx`
- `suite/sign-verify/src/signVerifyActions.test.ts`
- `suite/sign-verify/src/signVerifyActions.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/activity/activity-page.test.ts` — The changed NotificationRenderer and toast-notification types directly drive how toast notifications are rendered. This test explicitly asserts that system-activity toasts appear, transaction toasts are hidden, and toasts can be dismissed, so it will catch regressions in the toast rendering path.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — This test exercises the Bitcoin sign/verify dialog end-to-end, including signing, verifying, success/error toasts, and outcome badges. It directly covers the changed SignVerifyForm and signVerifyActions code paths (inferred from LLM analysis, not static mapping).
- `suite/e2e/tests/wallet/sign-and-verify-ada.test.ts` — The Cardano sign/verify flow uses the same signVerifyActions and SignVerifyForm infrastructure for COSE signing. This test verifies message signing, stake credential path selection, and the resulting signature/public-key fields, making it a strong direct regression guard.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test covers the Ethereum message signing and verification flow through the wallet's sign-and-verify UI, which is implemented by the changed suite/sign-verify module. It asserts both the signature output and the success toasts produced by the actions.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — The test asserts that a specific error toast ('@toast/backup-failed') appears after a failed backup. This exercises the global NotificationRenderer on an error notification path that is not covered by the activity-page test.
- `suite/e2e/tests/settings/passphrase.test.ts` — This test checks that a success toast ('@toast/settings-applied') is rendered after enabling passphrase protection. It provides a simple, focused verification of the success-notification rendering path affected by the NotificationRenderer/types changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/sign-verify/src/signVerifyActions.test.ts`

_Updated: 2026-09-11T11:36:27.087Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31887-verify-cancel-not-failure/web/](https://dev.suite.sldev.cz/suite-web/fix/31887-verify-cancel-not-failure/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31887-verify-cancel-not-failure&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31887-verify-cancel-not-failure&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31887-verify-cancel-not-failure&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T11:39:21.718Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T11:38:57.429Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->