### PR TITLE
Feat create data fields for better dom navigation

### DIFF
--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -118,7 +118,13 @@ export const Badge = ({
     };
 
     return (
-        <Container data-testid={dataTest} $intent={intent} $isAnimated={isAnimated} {...frameProps}>
+        <Container
+            data-component="Badge"
+            data-testid={dataTest}
+            $intent={intent}
+            $isAnimated={isAnimated}
+            {...frameProps}
+        >
             <Row gap={4} padding={mapSizeToPadding(size)}>
                 {iconLeft && <Icon as={iconLeft} {...iconProps} />}
                 <Text

--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -102,6 +102,7 @@ export const Banner = ({
             borderWidth={1}
             borderOffset={-1}
             borderRadius={8}
+            data-component="Banner"
             data-testid={dataTest}
             overflow="hidden"
             padding={{ vertical: 12, horizontal: 16 }}

--- a/packages/components/src/components/Banner/BannerButton.tsx
+++ b/packages/components/src/components/Banner/BannerButton.tsx
@@ -5,7 +5,7 @@ export const BannerButton = ({ children, intent, size = 'small', ...rest }: Butt
     const { intent: bannerIntent } = useBannerContext();
 
     return (
-        <Button intent={intent ?? bannerIntent} size={size} {...rest}>
+        <Button intent={intent ?? bannerIntent} size={size} {...rest} data-component="BannerButton">
             {children}
         </Button>
     );

--- a/packages/components/src/components/Banner/BannerIconButton.tsx
+++ b/packages/components/src/components/Banner/BannerIconButton.tsx
@@ -4,5 +4,12 @@ import { IconButton, type IconButtonProps } from '../buttons/IconButton/IconButt
 export const BannerIconButton = ({ intent, size = 'small', ...rest }: IconButtonProps) => {
     const { intent: bannerIntent } = useBannerContext();
 
-    return <IconButton intent={intent ?? bannerIntent} size={size} {...rest} />;
+    return (
+        <IconButton
+            intent={intent ?? bannerIntent}
+            size={size}
+            {...rest}
+            data-component="BannerIconButton"
+        />
+    );
 };

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -123,7 +123,7 @@ export const Box = ({
     borderColor,
     shadow,
     'data-testid': dataTestId,
-    'data-component': dataComponent,
+    'data-component': dataComponent = 'Box',
     'aria-hidden': ariaHidden,
     as = 'div',
     onClick,

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -108,6 +108,7 @@ export type BoxProps = Pick<
         borderColor?: Color;
         shadow?: BoxShadow;
         'data-testid'?: string;
+        'data-component'?: string;
         'aria-hidden'?: boolean;
         as?: React.ElementType;
         ref?: React.RefObject<HTMLElement | null>;
@@ -122,6 +123,7 @@ export const Box = ({
     borderColor,
     shadow,
     'data-testid': dataTestId,
+    'data-component': dataComponent,
     'aria-hidden': ariaHidden,
     as = 'div',
     onClick,
@@ -137,6 +139,7 @@ export const Box = ({
         <Container
             as={as}
             data-testid={dataTestId}
+            data-component={dataComponent}
             aria-hidden={ariaHidden}
             $borderWidth={borderWidth}
             $borderOffset={borderOffset}

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -99,6 +99,7 @@ export const Card = ({
             onClick={onClick}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
+            data-component="Card"
             data-testid={dataTest}
             {...frameProps}
             {...withAccessibilityProps({

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -69,6 +69,7 @@ export type CardProps = AccessibilityProps &
         children?: ReactNode;
         isSelected?: boolean;
         'data-testid'?: string;
+        'data-component'?: string;
     };
 
 export const Card = ({
@@ -83,6 +84,7 @@ export const Card = ({
     children,
     isSelected = false,
     'data-testid': dataTest,
+    'data-component': dataComponent = 'Card',
     ...rest
 }: CardProps) => {
     const frameProps = pickAndPrepareFrameProps(
@@ -99,7 +101,7 @@ export const Card = ({
             onClick={onClick}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
-            data-component="Card"
+            data-component={dataComponent}
             data-testid={dataTest}
             {...frameProps}
             {...withAccessibilityProps({

--- a/packages/components/src/components/CardList/CardList.tsx
+++ b/packages/components/src/components/CardList/CardList.tsx
@@ -45,7 +45,7 @@ export type CardListProps = AllowedCardListFrameProps &
     >;
 
 export const CardList = ({ children, typographyStyle = 'body-md', ...rest }: CardListProps) => (
-    <Card paddingType="none" {...rest}>
+    <Card paddingType="none" {...rest} data-component="CardList">
         <Text typographyStyle={typographyStyle} as="div" width="100%">
             <Column gap={0} hasDivider>
                 {children}

--- a/packages/components/src/components/CardList/CardListItem.tsx
+++ b/packages/components/src/components/CardList/CardListItem.tsx
@@ -29,6 +29,7 @@ export const CardListItem = ({
         onClick={onClick}
         isDisabled={!onClick}
         {...rest}
+        data-component="CardListItem"
     >
         <Row justifyContent="space-between" gap={12} overflow="hidden">
             {children}

--- a/packages/components/src/components/Collapsible/Collapsible.tsx
+++ b/packages/components/src/components/Collapsible/Collapsible.tsx
@@ -38,7 +38,7 @@ export const Collapsible = ({
                 gap,
             }}
         >
-            <Container data-testid={dataTest} aria-expanded={isOpen ?? uncontrolledIsOpen}>
+            <Container data-component="Collapsible" data-testid={dataTest} aria-expanded={isOpen ?? uncontrolledIsOpen}>
                 {children}
             </Container>
         </CollapsibleContext.Provider>

--- a/packages/components/src/components/Collapsible/Collapsible.tsx
+++ b/packages/components/src/components/Collapsible/Collapsible.tsx
@@ -38,7 +38,11 @@ export const Collapsible = ({
                 gap,
             }}
         >
-            <Container data-component="Collapsible" data-testid={dataTest} aria-expanded={isOpen ?? uncontrolledIsOpen}>
+            <Container
+                data-component="Collapsible"
+                data-testid={dataTest}
+                aria-expanded={isOpen ?? uncontrolledIsOpen}
+            >
                 {children}
             </Container>
         </CollapsibleContext.Provider>

--- a/packages/components/src/components/Collapsible/CollapsibleContent.tsx
+++ b/packages/components/src/components/Collapsible/CollapsibleContent.tsx
@@ -44,6 +44,7 @@ export const CollapsibleContent = ({
                             ease: isOpen ? motionEasing.exit : motionEasing.enter,
                         },
                     }}
+                    data-component="CollapsibleContent"
                     data-testid={dataTestId}
                     aria-expanded={isOpen}
                     id={contentId}

--- a/packages/components/src/components/Collapsible/CollapsibleToggle.tsx
+++ b/packages/components/src/components/Collapsible/CollapsibleToggle.tsx
@@ -38,6 +38,7 @@ export const CollapsibleToggle = ({
             aria-disabled={disabled}
             aria-expanded={isOpen}
             aria-controls={contentId}
+            data-component="CollapsibleToggle"
             data-testid={dataTestId}
             onClick={clickHandler}
             $disabled={disabled}

--- a/packages/components/src/components/Collapsible/CollapsibleToggleIcon.tsx
+++ b/packages/components/src/components/Collapsible/CollapsibleToggleIcon.tsx
@@ -34,7 +34,7 @@ export const CollapsibleToggleIcon = ({
     const { isOpen } = useCollapsible();
 
     return (
-        <IconWrapper $isCollapsed={!isOpen}>
+        <IconWrapper $isCollapsed={!isOpen} data-component="CollapsibleToggleIcon">
             <Icon
                 as={icon}
                 size={size}

--- a/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
+++ b/packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx
@@ -193,6 +193,7 @@ export const CollapsibleBox = ({
             {...frameProps}
             $paddingType={paddingType}
             $fillType={fillType}
+            data-component="CollapsibleBox"
             data-testid={dataTest}
         >
             <Collapsible isOpen={isOpen}>

--- a/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.tsx
+++ b/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.tsx
@@ -43,7 +43,12 @@ export const ComponentWithSubIcon = ({
     const hasSubIcon = icon !== undefined || subContent !== undefined;
 
     return (
-        <Box width="fit-content" position={{ type: 'relative' }} data-component="ComponentWithSubIcon" {...frameProps}>
+        <Box
+            width="fit-content"
+            position={{ type: 'relative' }}
+            data-component="ComponentWithSubIcon"
+            {...frameProps}
+        >
             {children}
             {hasSubIcon && (
                 <Box

--- a/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.tsx
+++ b/packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.tsx
@@ -43,7 +43,7 @@ export const ComponentWithSubIcon = ({
     const hasSubIcon = icon !== undefined || subContent !== undefined;
 
     return (
-        <Box width="fit-content" position={{ type: 'relative' }} {...frameProps}>
+        <Box width="fit-content" position={{ type: 'relative' }} data-component="ComponentWithSubIcon" {...frameProps}>
             {children}
             {hasSubIcon && (
                 <Box

--- a/packages/components/src/components/Divider/Divider.tsx
+++ b/packages/components/src/components/Divider/Divider.tsx
@@ -107,6 +107,7 @@ export const Divider = ({
 
     const line = (
         <Line
+            data-component={children === undefined ? 'Divider' : undefined}
             $color={color}
             $strokeWidth={strokeWidth}
             $orientation={orientation}
@@ -125,7 +126,7 @@ export const Divider = ({
     );
 
     return orientation === 'horizontal' ? (
-        <Row gap={gap} width="100%" alignItems="center" {...frameProps}>
+        <Row gap={gap} width="100%" alignItems="center" data-component="Divider" {...frameProps}>
             {content}
         </Row>
     ) : (
@@ -134,6 +135,7 @@ export const Divider = ({
             height="100%"
             alignItems="center"
             justifyContent="space-evenly"
+            data-component="Divider"
             {...frameProps}
         >
             {content}

--- a/packages/components/src/components/Dot/Dot.tsx
+++ b/packages/components/src/components/Dot/Dot.tsx
@@ -80,6 +80,7 @@ export const Dot = ({
         $intent={intent}
         $isAnimated={isAnimated}
         className={className}
+        data-component="Dot"
         data-testid={dataTestId}
     />
 );

--- a/packages/components/src/components/DotIndicator/DotIndicator.tsx
+++ b/packages/components/src/components/DotIndicator/DotIndicator.tsx
@@ -20,7 +20,7 @@ export type DotIndicatorProps = {
 };
 
 export const DotIndicator = ({ isActive }: DotIndicatorProps) => (
-    <Box padding={4}>
+    <Box padding={4} data-component="DotIndicator">
         <Circle $isActive={isActive} />
     </Box>
 );

--- a/packages/components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/components/src/components/Dropdown/Dropdown.tsx
@@ -69,6 +69,7 @@ export const Dropdown = forwardRef(
             <Popover
                 ref={popoverRef}
                 placement={placement}
+                data-component="Dropdown"
                 content={
                     <Menu
                         ref={menuRef}

--- a/packages/components/src/components/Flag/Flag.tsx
+++ b/packages/components/src/components/Flag/Flag.tsx
@@ -37,7 +37,7 @@ const FlagImage = styled.img<{ $size: FlagSize }>`
 `;
 
 export const Flag = ({ size = 24, country }: FlagProps) => (
-    <Wrapper $size={size}>
+    <Wrapper $size={size} data-component="Flag">
         <FlagImage $size={size} src={getFlagSource(country)} alt={`flag-${country}`} />
     </Wrapper>
 );

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -140,6 +140,7 @@ export type FlexProps = AllowedFrameProps &
         hasDivider?: boolean;
         dividerColor?: Color;
         'data-testid'?: string;
+        'data-component'?: string;
         as?: string;
         ref?: React.RefObject<HTMLElement | null>;
     };
@@ -158,6 +159,7 @@ export const Flex = ({
     order,
     isReversed = false,
     'data-testid': dataTestId,
+    'data-component': dataComponent,
     as = 'div',
     hasDivider = false,
     dividerColor,
@@ -172,6 +174,7 @@ export const Flex = ({
     return (
         <Container
             data-testid={dataTestId}
+            data-component={dataComponent}
             {...makePropsTransient({
                 rowGap,
                 columnGap,

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -159,7 +159,7 @@ export const Flex = ({
     order,
     isReversed = false,
     'data-testid': dataTestId,
-    'data-component': dataComponent,
+    'data-component': dataComponent = 'Flex',
     as = 'div',
     hasDivider = false,
     dividerColor,
@@ -201,10 +201,15 @@ export const Flex = ({
     );
 };
 
-export const Column = (props: FlexProps) => <Flex {...props} direction="column" />;
-export const Row = (props: FlexProps) => <Flex alignItems="center" {...props} direction="row" />;
+export const Column = (props: FlexProps) => (
+    <Flex data-component="Column" {...props} direction="column" />
+);
+export const Row = (props: FlexProps) => (
+    <Flex data-component="Row" alignItems="center" {...props} direction="row" />
+);
 export const Center = (props: FlexProps) => (
     <Flex
+        data-component="Center"
         alignSelf="center"
         alignItems="center"
         justifyContent="center"

--- a/packages/components/src/components/GhostContainer/GhostContainer.tsx
+++ b/packages/components/src/components/GhostContainer/GhostContainer.tsx
@@ -39,6 +39,7 @@ type GhostContainerProps = AllowedGhostContainerFrameProps &
         backgroundColorOnInteraction?: Color;
         as?: React.ElementType;
         'data-testid'?: string;
+        'data-component'?: string;
     };
 
 export const GhostContainer = ({
@@ -48,6 +49,7 @@ export const GhostContainer = ({
     onClick,
     children,
     'data-testid': dataTestId,
+    'data-component': dataComponent = 'GhostContainer',
     tabIndex,
     as = 'button',
     borderRadius = 10,
@@ -65,6 +67,7 @@ export const GhostContainer = ({
             }
             as={as}
             data-testid={dataTestId}
+            data-component={dataComponent}
             tabIndex={tabIndex}
             {...frameProps}
             borderRadius={borderRadius}

--- a/packages/components/src/components/Grid/Grid.tsx
+++ b/packages/components/src/components/Grid/Grid.tsx
@@ -70,6 +70,7 @@ export const Grid = ({
 
     return (
         <Container
+            data-component="Grid"
             $columns={columns}
             $rowGap={rowGap}
             $columnGap={columnGap}

--- a/packages/components/src/components/Icon/Icon.test.tsx
+++ b/packages/components/src/components/Icon/Icon.test.tsx
@@ -29,6 +29,7 @@ describe('Icon', () => {
             width: '16px',
             height: '16px',
         });
+        expect(screen.getByTestId('@icon/component')).toHaveAttribute('data-icon', 'TestIcon');
         expect(icon).toHaveAttribute('width', '100%');
         expect(icon).toHaveAttribute('height', '100%');
     });

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -133,6 +133,7 @@ export const Icon = ({
             $isInverse={isInverse}
             $isDisabled={isDisabled}
             $color={color}
+            data-component="Icon"
             data-testid={dataTest}
             onClick={onClick && !isDisabled ? handleClick : undefined}
             {...frameProps}

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -24,6 +24,16 @@ export { iconIntents, iconPriorities };
 export type { IconIntent, IconPriority, IconSize };
 export type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
+export const getIconComponentName = (icon: IconComponent) => {
+    const name = icon.displayName ?? icon.name;
+
+    if (!name || name === 'ReactComponent') {
+        return undefined;
+    }
+
+    return name.startsWith('Svg') ? name.slice(3) : name;
+};
+
 export const allowedIconFrameProps = [
     'margin',
     'pointerEvents',
@@ -134,6 +144,7 @@ export const Icon = ({
             $isDisabled={isDisabled}
             $color={color}
             data-component="Icon"
+            data-icon={getIconComponentName(IconComponent)}
             data-testid={dataTest}
             onClick={onClick && !isDisabled ? handleClick : undefined}
             {...frameProps}

--- a/packages/components/src/components/IconCircle/IconCircle.tsx
+++ b/packages/components/src/components/IconCircle/IconCircle.tsx
@@ -49,7 +49,7 @@ export const IconCircle = ({ icon, size = 40, intent = 'brand', ...rest }: IconC
     const frameProps = pickAndPrepareFrameProps(rest, allowedIconCircleFrameProps);
 
     return (
-        <Circle $size={size} $intent={intent} {...frameProps}>
+        <Circle $size={size} $intent={intent} data-component="IconCircle" {...frameProps}>
             <Icon as={icon} size={mapSizeToIconSize(size)} intent={intent} priority="secondary" />
         </Circle>
     );

--- a/packages/components/src/components/Illustration/Illustration.tsx
+++ b/packages/components/src/components/Illustration/Illustration.tsx
@@ -74,7 +74,7 @@ export const Illustration = ({
     const frameProps = pickAndPrepareFrameProps(rest, allowedIllustrationFrameProps);
 
     return (
-        <Container $intent={intent} data-testid={dataTest} {...frameProps}>
+        <Container $intent={intent} data-component="Illustration" data-testid={dataTest} {...frameProps}>
             <SVG src={illustrations[name]} />
         </Container>
     );

--- a/packages/components/src/components/Illustration/Illustration.tsx
+++ b/packages/components/src/components/Illustration/Illustration.tsx
@@ -74,7 +74,12 @@ export const Illustration = ({
     const frameProps = pickAndPrepareFrameProps(rest, allowedIllustrationFrameProps);
 
     return (
-        <Container $intent={intent} data-component="Illustration" data-testid={dataTest} {...frameProps}>
+        <Container
+            $intent={intent}
+            data-component="Illustration"
+            data-testid={dataTest}
+            {...frameProps}
+        >
             <SVG src={illustrations[name]} />
         </Container>
     );

--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -98,11 +98,6 @@ export const Image = ({ image, imageSrc, ...rest }: ImageProps) => {
     const sourceProps = image ? getSourceProps(image) : { src: imageSrc };
 
     return (
-        <StyledImage
-            {...sourceProps}
-            {...imageHTMLProps}
-            {...frameProps}
-            data-component="Image"
-        />
+        <StyledImage {...sourceProps} {...imageHTMLProps} {...frameProps} data-component="Image" />
     );
 };

--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -97,5 +97,12 @@ export const Image = ({ image, imageSrc, ...rest }: ImageProps) => {
     const imageHTMLProps = getImageHTMLProps(rest);
     const sourceProps = image ? getSourceProps(image) : { src: imageSrc };
 
-    return <StyledImage {...sourceProps} {...imageHTMLProps} {...frameProps} />;
+    return (
+        <StyledImage
+            {...sourceProps}
+            {...imageHTMLProps}
+            {...frameProps}
+            data-component="Image"
+        />
+    );
 };

--- a/packages/components/src/components/Image/SvgImage.tsx
+++ b/packages/components/src/components/Image/SvgImage.tsx
@@ -41,7 +41,7 @@ export type SvgImageProps = {
 const getImageSrc = (image: ImageType) => resolveStaticPath(`${IMAGES_PATH}/${IMAGES[image]}`);
 
 export const SvgImage = ({ image, width, height, color }: SvgImageProps) => (
-    <Container $width={width} $height={height} $color={color}>
+    <Container data-component="SvgImage" $width={width} $height={height} $color={color}>
         <StyledReactSVG src={getImageSrc(image)} loading={() => null} />
     </Container>
 );

--- a/packages/components/src/components/InfoItem/InfoItem.tsx
+++ b/packages/components/src/components/InfoItem/InfoItem.tsx
@@ -81,7 +81,7 @@ export const InfoItem = ({
     const isRow = direction === 'row';
 
     return (
-        <Container data-testid={dataTestId} {...frameProps}>
+        <Container data-component="InfoItem" data-testid={dataTestId} {...frameProps}>
             <Flex
                 direction={direction}
                 alignItems={isRow ? mapVerticalAlignmentToAlignItems(verticalAlignment) : 'normal'}

--- a/packages/components/src/components/InfoSegments/InfoSegments.tsx
+++ b/packages/components/src/components/InfoSegments/InfoSegments.tsx
@@ -45,6 +45,7 @@ export const InfoSegments = ({
 
     return (
         <Text
+            data-component="InfoSegments"
             data-testid={dataTestId}
             as="div"
             typographyStyle={typographyStyle}

--- a/packages/components/src/components/List/List.tsx
+++ b/packages/components/src/components/List/List.tsx
@@ -84,7 +84,13 @@ export const List = ({
         <ListContext.Provider
             value={{ bulletGap, bulletAlignment, bulletComponent, listStyleType }}
         >
-            <Text as="div" intent={intent} priority={priority} isDisabled={isDisabled} data-component="List">
+            <Text
+                as="div"
+                intent={intent}
+                priority={priority}
+                isDisabled={isDisabled}
+                data-component="List"
+            >
                 <Container
                     {...makePropsTransient({ gap, listStyleType })}
                     {...frameProps}

--- a/packages/components/src/components/List/List.tsx
+++ b/packages/components/src/components/List/List.tsx
@@ -84,7 +84,7 @@ export const List = ({
         <ListContext.Provider
             value={{ bulletGap, bulletAlignment, bulletComponent, listStyleType }}
         >
-            <Text as="div" intent={intent} priority={priority} isDisabled={isDisabled}>
+            <Text as="div" intent={intent} priority={priority} isDisabled={isDisabled} data-component="List">
                 <Container
                     {...makePropsTransient({ gap, listStyleType })}
                     {...frameProps}

--- a/packages/components/src/components/List/ListItem.tsx
+++ b/packages/components/src/components/List/ListItem.tsx
@@ -67,6 +67,7 @@ export const ListItem = ({
             $bulletAlignment={bulletAlignment}
             $hasListStyleType={!!listStyleType}
             $hasBulletComponent={!!bulletComponent}
+            data-component="ListItem"
             data-testid={dataTestId}
         >
             <BulletWrapper>{bulletComponent ?? listBulletComponent}</BulletWrapper>

--- a/packages/components/src/components/Markdown/Markdown.tsx
+++ b/packages/components/src/components/Markdown/Markdown.tsx
@@ -79,7 +79,7 @@ const StyledMarkdown = styled.div`
 `;
 
 export const Markdown = (options: Readonly<Options>) => (
-    <StyledMarkdown>
+    <StyledMarkdown data-component="Markdown">
         <ReactMarkdown {...options}></ReactMarkdown>
     </StyledMarkdown>
 );

--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -197,6 +197,7 @@ export const Menu = forwardRef<HTMLUListElement, MenuProps>(
 
         return (
             <Container
+                data-component="Menu"
                 tabIndex={content ? 0 : 1} // do not affect tab order when there is no content
                 onClick={e => e.stopPropagation()} // prevent closing the menu when clicking on the menu itself or within the menu
                 {...frameProps}

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -93,7 +93,7 @@ const ModalBase = ({
 
     return (
         <ModalContext.Provider value={{ intent }}>
-            <Box maxWidth="95%" maxHeight={maxHeight} width={width} height={height}>
+            <Box maxWidth="95%" maxHeight={maxHeight} width={width} height={height} data-component="Modal">
                 <Container data-testid={dataTest}>
                     <Column height="100%">
                         {hasHeader && (

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -93,7 +93,13 @@ const ModalBase = ({
 
     return (
         <ModalContext.Provider value={{ intent }}>
-            <Box maxWidth="95%" maxHeight={maxHeight} width={width} height={height} data-component="Modal">
+            <Box
+                maxWidth="95%"
+                maxHeight={maxHeight}
+                width={width}
+                height={height}
+                data-component="Modal"
+            >
                 <Container data-testid={dataTest}>
                     <Column height="100%">
                         {hasHeader && (

--- a/packages/components/src/components/Modal/ModalBackdrop.tsx
+++ b/packages/components/src/components/Modal/ModalBackdrop.tsx
@@ -57,7 +57,12 @@ export const ModalBackdrop = ({
         // eslint-disable-next-line jsx-a11y/no-autofocus
         <FocusLock autoFocus={false}>
             <Box position={{ type: 'absolute', inset: 0 }} zIndex={zIndex}>
-                <Backdrop onMouseDown={onClick} $opaque={opaque} data-testid={dataTest}>
+                <Backdrop
+                    onMouseDown={onClick}
+                    $opaque={opaque}
+                    data-component="ModalBackdrop"
+                    data-testid={dataTest}
+                >
                     <Box padding={padding} height="100%">
                         <Column
                             alignItems={mapAlignmentToAlignItems(alignment)}

--- a/packages/components/src/components/Modal/ModalButton.tsx
+++ b/packages/components/src/components/Modal/ModalButton.tsx
@@ -13,7 +13,13 @@ export const ModalButton = ({
 
     return (
         <ModalContext.Provider value={{ intent: modalIntent }}>
-            <Button intent={resolvedIntent} size={size} minWidth={minWidth} {...rest}>
+            <Button
+                intent={resolvedIntent}
+                size={size}
+                minWidth={minWidth}
+                {...rest}
+                data-component="ModalButton"
+            >
                 {children}
             </Button>
         </ModalContext.Provider>

--- a/packages/components/src/components/Modal/ModalProvider.tsx
+++ b/packages/components/src/components/Modal/ModalProvider.tsx
@@ -41,7 +41,7 @@ export const ModalProvider = ({ isDisabled = false, children }: ModalProviderPro
                 isDisabled: disabled,
             }}
         >
-            <div ref={target} />
+            <div ref={target} data-component="ModalProvider" />
             {children}
         </ModalContext.Provider>
     );

--- a/packages/components/src/components/Note/Note.tsx
+++ b/packages/components/src/components/Note/Note.tsx
@@ -35,7 +35,7 @@ export const Note = ({
     isInverse = false,
     'data-testid': dataTestId,
 }: NoteProps) => (
-    <Row gap={gap} margin={margin} minWidth={minWidth}>
+    <Row gap={gap} margin={margin} minWidth={minWidth} data-component="Note">
         <Icon
             as={icon}
             size={16}

--- a/packages/components/src/components/PinInput/PinInput.tsx
+++ b/packages/components/src/components/PinInput/PinInput.tsx
@@ -232,7 +232,7 @@ export const PinInput = ({
     };
 
     return (
-        <Row gap={8}>
+        <Row gap={8} data-component="PinInput">
             {symbols.map((symbol, index) => (
                 <SymbolInput
                     // eslint-disable-next-line jsx-a11y/no-autofocus

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -40,6 +40,7 @@ export type PopoverProps = {
     popoverOffset?: number;
     zIndex?: number;
     'data-testid'?: string;
+    'data-component'?: string;
 };
 
 export function usePopover({
@@ -116,9 +117,14 @@ export const usePopoverContext = () =>
 type PopoverTriggerProps = {
     children: React.ReactNode;
     'data-testid'?: string;
+    'data-component'?: string;
 };
 
-export const PopoverTrigger = ({ children, 'data-testid': dataTestId }: PopoverTriggerProps) => {
+export const PopoverTrigger = ({
+    children,
+    'data-testid': dataTestId,
+    'data-component': dataComponent,
+}: PopoverTriggerProps) => {
     const context = usePopoverContext();
     const ref = useMergeRefs([context.refs.setReference]);
 
@@ -127,6 +133,7 @@ export const PopoverTrigger = ({ children, 'data-testid': dataTestId }: PopoverT
             ref={ref}
             data-state={context.open ? 'open' : 'closed'}
             data-testid={dataTestId}
+            data-component={dataComponent}
             {...context.getReferenceProps()}
             style={{
                 display: 'flex',
@@ -196,6 +203,7 @@ export const Popover = forwardRef(
             children,
             onOpenChange,
             'data-testid': dataTestId,
+            'data-component': dataComponent = 'Popover',
         }: PopoverProps & { children: React.ReactNode },
         ref,
     ) => {
@@ -214,7 +222,9 @@ export const Popover = forwardRef(
 
         return (
             <PopoverContext.Provider value={popover}>
-                <PopoverTrigger data-testid={dataTestId}>{children}</PopoverTrigger>
+                <PopoverTrigger data-testid={dataTestId} data-component={dataComponent}>
+                    {children}
+                </PopoverTrigger>
                 <PopoverContent style={{ zIndex }}>{content}</PopoverContent>
             </PopoverContext.Provider>
         );

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -123,7 +123,7 @@ type PopoverTriggerProps = {
 export const PopoverTrigger = ({
     children,
     'data-testid': dataTestId,
-    'data-component': dataComponent,
+    'data-component': dataComponent = 'PopoverTrigger',
 }: PopoverTriggerProps) => {
     const context = usePopoverContext();
     const ref = useMergeRefs([context.refs.setReference]);
@@ -133,8 +133,8 @@ export const PopoverTrigger = ({
             ref={ref}
             data-state={context.open ? 'open' : 'closed'}
             data-testid={dataTestId}
-            data-component={dataComponent}
             {...context.getReferenceProps()}
+            data-component={dataComponent}
             style={{
                 display: 'flex',
             }}
@@ -178,6 +178,7 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>((p
                     aria-labelledby={context.labelId}
                     aria-describedby={context.descriptionId}
                     {...context.getFloatingProps()}
+                    data-component="PopoverContent"
                 >
                     {children}
                 </div>

--- a/packages/components/src/components/RadioCard/RadioCard.tsx
+++ b/packages/components/src/components/RadioCard/RadioCard.tsx
@@ -54,6 +54,7 @@ export const RadioCard = ({
             <Card
                 onClick={!isDisabled ? onClick : undefined}
                 isSelected={isSelected}
+                data-component="RadioCard"
                 data-testid={dataTestId}
                 type="contrast"
                 {...frameProps}

--- a/packages/components/src/components/ResizableBox/ResizableBox.tsx
+++ b/packages/components/src/components/ResizableBox/ResizableBox.tsx
@@ -499,6 +499,7 @@ export const ResizableBox = ({
 
     return (
         <Resizers
+            data-component="ResizableBox"
             $width={collapse ? minWidth : effectiveWidth}
             $minWidth={minWidth}
             $maxWidth={maxWidth}

--- a/packages/components/src/components/ShortcutBadge/ShortcutBadge.tsx
+++ b/packages/components/src/components/ShortcutBadge/ShortcutBadge.tsx
@@ -32,7 +32,7 @@ export const ShortcutBadge = ({ shortcut, isInverse = false }: ShortcutBadgeProp
     const isMac = isMacOs();
 
     return (
-        <Wrapper>
+        <Wrapper data-component="ShortcutBadge">
             <Text as="div" typographyStyle="body-xs" case="uppercase">
                 <Row gap={2}>
                     {shortcut.map((key, index) => {

--- a/packages/components/src/components/Skeleton/Skeleton.tsx
+++ b/packages/components/src/components/Skeleton/Skeleton.tsx
@@ -90,5 +90,5 @@ export const Skeleton = ({ type = 'rectangle', animate, ...rest }: SkeletonProps
         allowedSkeletonFrameProps,
     );
 
-    return <StyledSkeleton $animate={animate} {...frameProps} />;
+    return <StyledSkeleton data-component="Skeleton" $animate={animate} {...frameProps} />;
 };

--- a/packages/components/src/components/StatusBadge/StatusBadge.tsx
+++ b/packages/components/src/components/StatusBadge/StatusBadge.tsx
@@ -53,7 +53,7 @@ export const StatusBadge = ({
     const y = offset?.y ?? 0;
 
     return isShown ? (
-        <Box position={{ type: 'relative' }} display="inline-flex">
+        <Box position={{ type: 'relative' }} display="inline-flex" data-component="StatusBadge">
             <MaskedContent $x={x} $y={y}>
                 {children}
             </MaskedContent>

--- a/packages/components/src/components/StepList/StepList.tsx
+++ b/packages/components/src/components/StepList/StepList.tsx
@@ -74,7 +74,7 @@ export const StepList = ({
                 direction,
             }}
         >
-            <Container data-testid={dataTestId} {...frameProps} $direction={direction}>
+            <Container data-component="StepList" data-testid={dataTestId} {...frameProps} $direction={direction}>
                 {children}
             </Container>
         </StepListContext.Provider>

--- a/packages/components/src/components/StepList/StepList.tsx
+++ b/packages/components/src/components/StepList/StepList.tsx
@@ -74,7 +74,12 @@ export const StepList = ({
                 direction,
             }}
         >
-            <Container data-component="StepList" data-testid={dataTestId} {...frameProps} $direction={direction}>
+            <Container
+                data-component="StepList"
+                data-testid={dataTestId}
+                {...frameProps}
+                $direction={direction}
+            >
                 {children}
             </Container>
         </StepListContext.Provider>

--- a/packages/components/src/components/StepList/StepListItem.tsx
+++ b/packages/components/src/components/StepList/StepListItem.tsx
@@ -276,7 +276,7 @@ export const StepListItem = ({
     };
 
     return (
-        <Item $direction={direction} data-testid={dataTestId}>
+        <Item $direction={direction} data-component="StepListItem" data-testid={dataTestId}>
             <ItemLayout
                 $bulletGap={bulletGap}
                 $titleGap={titleGap}

--- a/packages/components/src/components/SubTabs/SubTabs.tsx
+++ b/packages/components/src/components/SubTabs/SubTabs.tsx
@@ -32,7 +32,7 @@ const SubTabs = ({ activeItemId, size = 'medium', children, ...rest }: SubTabsPr
 
     return (
         <SubTabsContext.Provider value={{ activeItemId, size }}>
-            <Container {...frameProps}>
+            <Container data-component="SubTabs" {...frameProps}>
                 <Row alignItems="stretch" gap={4}>
                     {children}
                 </Row>

--- a/packages/components/src/components/SubTabs/SubTabsItem.tsx
+++ b/packages/components/src/components/SubTabs/SubTabsItem.tsx
@@ -51,7 +51,12 @@ export const SubTabsItem = ({
     const isActive = id === activeItemId;
 
     return (
-        <Item $isActive={isActive} onClick={onClick} data-testid={dataTestId}>
+        <Item
+            $isActive={isActive}
+            onClick={onClick}
+            data-component="SubTabsItem"
+            data-testid={dataTestId}
+        >
             <Row gap={8} padding={{ vertical: 8, horizontal: 16 }}>
                 {icon && <Icon as={icon} size={mapSizeToIconSize(size)} />}
                 <Text as="div" typographyStyle={mapSizeToTypography(size)} textWrap="nowrap">

--- a/packages/components/src/components/Table/Table.tsx
+++ b/packages/components/src/components/Table/Table.tsx
@@ -79,7 +79,7 @@ export const Table = ({
                 <ScrollContainer ref={scrollElementRef}>
                     <ScrollContent>
                         <ScrollSentinels />
-                        <Container {...makePropsTransient({ margin })}>
+                        <Container data-component="Table" {...makePropsTransient({ margin })}>
                             {colWidths && (
                                 <colgroup>
                                     {colWidths.map((widths, index) => (

--- a/packages/components/src/components/Table/TableBody.tsx
+++ b/packages/components/src/components/Table/TableBody.tsx
@@ -4,4 +4,6 @@ export interface TableBodyProps {
     children: ReactNode;
 }
 
-export const TableBody = ({ children }: TableBodyProps) => <tbody>{children}</tbody>;
+export const TableBody = ({ children }: TableBodyProps) => (
+    <tbody data-component="TableBody">{children}</tbody>
+);

--- a/packages/components/src/components/Table/TableCell.tsx
+++ b/packages/components/src/components/Table/TableCell.tsx
@@ -83,6 +83,7 @@ export const TableCell = ({
             $padding={padding ?? defaultPadding}
             $maxWidth={maxWidth}
             $hasBorder={hasBorders}
+            data-component="TableCell"
             data-testid={dataTestId}
         >
             <Text

--- a/packages/components/src/components/Table/TableHeader.tsx
+++ b/packages/components/src/components/Table/TableHeader.tsx
@@ -8,7 +8,7 @@ export interface TableHeaderProps {
 
 export const TableHeader = ({ children }: TableHeaderProps) => (
     <HeaderContext.Provider value={true}>
-        <thead>{children}</thead>
+        <thead data-component="TableHeader">{children}</thead>
     </HeaderContext.Provider>
 );
 

--- a/packages/components/src/components/Table/TableRow.tsx
+++ b/packages/components/src/components/Table/TableRow.tsx
@@ -105,6 +105,7 @@ export const TableRow = ({
             onClick={onClick}
             onMouseEnter={() => onHover?.(true)}
             onMouseLeave={() => onHover?.(false)}
+            data-component="TableRow"
             data-testid={dataTestId}
         >
             {children}

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -108,6 +108,7 @@ const Tabs = ({
         <TabsContext.Provider value={{ activeItemId, isDisabled, size, setTabRef }}>
             <Container
                 ref={containerRef}
+                data-component="Tabs"
                 $hasBorder={hasBorder}
                 $indicatorWidth={indicatorWidth}
                 $indicatorPosition={indicatorPosition}

--- a/packages/components/src/components/Tabs/TabsItem.tsx
+++ b/packages/components/src/components/Tabs/TabsItem.tsx
@@ -69,6 +69,7 @@ export const TabsItem = ({ id, onClick, 'data-testid': dataTestId, children }: T
             $size={size}
             ref={setTabRef?.(id)}
             onClick={onClick}
+            data-component="TabsItem"
             data-testid={dataTestId}
         >
             <Title>

--- a/packages/components/src/components/Timerange/Timerange.tsx
+++ b/packages/components/src/components/Timerange/Timerange.tsx
@@ -625,7 +625,7 @@ const Timerange = (props: TimerangeProps) => {
     };
 
     return (
-        <StyledTimerange>
+        <StyledTimerange data-component="Timerange">
             <Calendar>
                 <DateRange
                     editableDateInputs

--- a/packages/components/src/components/Toast/Toast.tsx
+++ b/packages/components/src/components/Toast/Toast.tsx
@@ -56,7 +56,7 @@ export const Toast = ({
     );
 
     return (
-        <div data-testid={dataTestBase} data-toast-intent={intent}>
+        <div data-component="Toast" data-testid={dataTestBase} data-toast-intent={intent}>
             <Box
                 borderRadius={8}
                 backgroundColor={mapToastIntentToBackgroundColor(intent)}

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -117,7 +117,7 @@ export const Tooltip = ({
             disableFlip={disableFlip}
         >
             <TooltipTrigger>
-                <Content as={as} {...frameProps}>
+                <Content as={as} data-component="Tooltip" {...frameProps}>
                     {children}
                     {hasIcon && isActive && <Icon as={QuestionIcon} size={16} />}
                 </Content>

--- a/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/components/src/components/VirtualizedList/VirtualizedList.tsx
@@ -221,6 +221,7 @@ export function VirtualizedListComponent<T extends BaseItemProps>({
     return (
         <Container
             ref={containerRef}
+            data-component="VirtualizedList"
             $height={listHeight}
             $minHeight={listMinHeight}
             {...frameProps}

--- a/packages/components/src/components/animations/AnimationPrimitives.tsx
+++ b/packages/components/src/components/animations/AnimationPrimitives.tsx
@@ -18,7 +18,9 @@ export type AllowedAnimationPrimitiveFrameProps = Pick<
 export const shapes = ['CIRCLE', 'ROUNDED', 'ROUNDED-SMALL'] as const;
 export type Shape = (typeof shapes)[number];
 
-export const AnimationWrapper = styled.div<
+export const AnimationWrapper = styled.div.attrs<{ 'data-component'?: string }>(props => ({
+    'data-component': props['data-component'] ?? 'AnimationWrapper',
+}))<
     TransientProps<AllowedAnimationPrimitiveFrameProps> & {
         shape?: Shape;
     }

--- a/packages/components/src/components/animations/LottieAnimation.tsx
+++ b/packages/components/src/components/animations/LottieAnimation.tsx
@@ -90,7 +90,13 @@ export const LottieAnimation = ({
     );
 
     return (
-        <AnimationWrapper $height={size} $width={size} shape={shape} {...props}>
+        <AnimationWrapper
+            $height={size}
+            $width={size}
+            shape={shape}
+            {...props}
+            data-component="LottieAnimation"
+        >
             <>
                 {animationData && (
                     <StyledLottie

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -69,11 +69,13 @@ export type ButtonProps = CommonButtonProps &
         iconRight?: IconComponent;
         children: React.ReactNode;
         'data-testid'?: string;
+        'data-component'?: string;
         shortcut?: Keys[];
     };
 
 export const Button = ({
     'data-testid': dataTestId,
+    'data-component': dataComponent = 'Button',
     children,
     iconLeft,
     iconRight,
@@ -93,7 +95,7 @@ export const Button = ({
 
     return (
         <Container
-            data-component="Button"
+            data-component={dataComponent}
             data-testid={dataTestId}
             $size={size}
             $priority={priority}

--- a/packages/components/src/components/buttons/Button/Button.tsx
+++ b/packages/components/src/components/buttons/Button/Button.tsx
@@ -93,6 +93,7 @@ export const Button = ({
 
     return (
         <Container
+            data-component="Button"
             data-testid={dataTestId}
             $size={size}
             $priority={priority}

--- a/packages/components/src/components/buttons/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/components/buttons/ButtonGroup/ButtonGroup.tsx
@@ -106,7 +106,7 @@ export const ButtonGroup = ({
     });
 
     return (
-        <Container $size={size} {...frameProps}>
+        <Container data-component="ButtonGroup" $size={size} {...frameProps}>
             {childrenWithProps}
         </Container>
     );

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../utils/frameProps';
 import { type TransientProps } from '../../../utils/transientProps';
 import { Box } from '../../Box/Box';
-import { Icon, type IconComponent } from '../../Icon/Icon';
+import { Icon, type IconComponent, getIconComponentName } from '../../Icon/Icon';
 import { Tooltip, type UnmanagedTooltipProps } from '../../Tooltip/Tooltip';
 import { TOOLTIP_DELAY_NORMAL } from '../../Tooltip/TooltipDelay';
 import { Spinner } from '../../loaders/Spinner/Spinner';
@@ -88,6 +88,7 @@ export const IconButton = ({
     return (
         <Container
             data-component="IconButton"
+            data-icon={getIconComponentName(icon)}
             data-testid={dataTestId}
             aria-label={ariaLabel}
             $size={size}

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -87,6 +87,7 @@ export const IconButton = ({
 
     return (
         <Container
+            data-component="IconButton"
             data-testid={dataTestId}
             aria-label={ariaLabel}
             $size={size}

--- a/packages/components/src/components/buttons/IconButton/IconButton.tsx
+++ b/packages/components/src/components/buttons/IconButton/IconButton.tsx
@@ -64,11 +64,13 @@ export type IconButtonProps = CommonButtonProps &
         icon: IconComponent;
         tooltip: IconButtonTooltipProps;
         'data-testid'?: string;
+        'data-component'?: string;
         'aria-label'?: string;
     };
 
 export const IconButton = ({
     'data-testid': dataTestId,
+    'data-component': dataComponent = 'IconButton',
     'aria-label': ariaLabel,
     icon,
     size = 'medium',
@@ -87,7 +89,7 @@ export const IconButton = ({
 
     return (
         <Container
-            data-component="IconButton"
+            data-component={dataComponent}
             data-icon={getIconComponentName(icon)}
             data-testid={dataTestId}
             aria-label={ariaLabel}

--- a/packages/components/src/components/buttons/TextButton/TextButton.tsx
+++ b/packages/components/src/components/buttons/TextButton/TextButton.tsx
@@ -94,6 +94,7 @@ export const TextButton = ({
             $priority={priority}
             $isInverse={isInverse}
             $isUnderlined={isUnderlined}
+            data-component="TextButton"
             data-testid={dataTestId}
             {...buttonProps}
             {...frameProps}

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -78,6 +78,7 @@ export const Checkbox = ({
         <Row
             gap={12}
             alignItems={verticalAlignment === 'start' ? 'flex-start' : 'center'}
+            data-component="Checkbox"
             data-testid={dataTest}
             isReversed={labelAlignment === 'start'}
             cursor={isDisabled ? 'not-allowed' : 'pointer'}

--- a/packages/components/src/components/form/FormCell/FormCell.tsx
+++ b/packages/components/src/components/form/FormCell/FormCell.tsx
@@ -71,7 +71,7 @@ export const FormCell = ({
     hasError,
     isDisabled,
     'data-testid': dataTestId,
-    'data-component': dataComponent,
+    'data-component': dataComponent = 'FormCell',
     ...rest
 }: FormCellProps) => {
     const [isHovered, setIsHovered] = useState(false);

--- a/packages/components/src/components/form/FormCell/FormCell.tsx
+++ b/packages/components/src/components/form/FormCell/FormCell.tsx
@@ -57,6 +57,7 @@ export type FormCellProps = AllowedFrameProps & {
     isDisabled?: boolean;
     children: ReactNode;
     'data-testid'?: string;
+    'data-component'?: string;
 };
 
 export const FormCell = ({
@@ -70,6 +71,7 @@ export const FormCell = ({
     hasError,
     isDisabled,
     'data-testid': dataTestId,
+    'data-component': dataComponent,
     ...rest
 }: FormCellProps) => {
     const [isHovered, setIsHovered] = useState(false);
@@ -78,6 +80,7 @@ export const FormCell = ({
     return (
         <Wrapper
             {...frameProps}
+            data-component={dataComponent}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >

--- a/packages/components/src/components/form/FractionButton/FractionButton.tsx
+++ b/packages/components/src/components/form/FractionButton/FractionButton.tsx
@@ -18,6 +18,7 @@ export const FractionButton = ({
 }: FractionButtonProps) => (
     <Tooltip key={id} content={tooltip} cursor="pointer">
         <Button
+            data-component="FractionButton"
             intent="neutral"
             type="button"
             size="small"

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -83,7 +83,7 @@ export const Input = ({
     const hasShowClearButton = showClearButton && !!value && value.length > 0;
 
     return (
-        <FormCell {...formCellProps} data-testid={dataTest}>
+        <FormCell {...formCellProps} data-component="Input" data-testid={dataTest}>
             <InputWrapper
                 hasError={hasError}
                 isDisabled={isDisabled ?? false}

--- a/packages/components/src/components/form/Radio/Radio.tsx
+++ b/packages/components/src/components/form/Radio/Radio.tsx
@@ -88,6 +88,7 @@ export const Radio = ({
         <Row
             gap={12}
             alignItems={verticalAlignment === 'start' ? 'flex-start' : 'center'}
+            data-component="Radio"
             data-testid={dataTest}
             data-checked={isChecked}
             isReversed={labelAlignment === 'start'}

--- a/packages/components/src/components/form/Range/Range.tsx
+++ b/packages/components/src/components/form/Range/Range.tsx
@@ -353,7 +353,7 @@ export const Range = ({
     );
 
     return (
-        <StyledRange $fill={fill}>
+        <StyledRange $fill={fill} data-component="Range">
             <Input
                 {...props}
                 type="range"

--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -155,7 +155,7 @@ export const Select = ({
     );
 
     return (
-        <FormCell {...formCellProps}>
+        <FormCell {...formCellProps} data-component="Select">
             <ReactSelect
                 ref={selectRef}
                 openMenuOnFocus={openMenuOnFocus}

--- a/packages/components/src/components/form/SelectBar/SelectBar.tsx
+++ b/packages/components/src/components/form/SelectBar/SelectBar.tsx
@@ -172,6 +172,7 @@ export const SelectBar = <V extends ValueTypes>({
 
     return (
         <Flex
+            data-component="SelectBar"
             data-testid={dataTest}
             direction={isVertical ? 'column' : 'row'}
             margin={margin}

--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -120,6 +120,7 @@ export const Switch = ({
             gap={mapSizeToLabelContainerGap(size)}
             isReversed={labelPosition === 'start'}
             margin={margin}
+            data-component="Switch"
             onClick={handleContainerClick}
         >
             <Container

--- a/packages/components/src/components/form/Textarea/Textarea.tsx
+++ b/packages/components/src/components/form/Textarea/Textarea.tsx
@@ -71,7 +71,7 @@ export const Textarea = ({
     }, {} as TextareaHTMLProps);
 
     return (
-        <FormCell {...formCellProps}>
+        <FormCell {...formCellProps} data-component="Textarea">
             <InputWrapper hasError={hasError} isDisabled={isDisabled}>
                 <StyledTextarea
                     $hasLabel={!!label}

--- a/packages/components/src/components/loaders/LoadingContent/LoadingContent.tsx
+++ b/packages/components/src/components/loaders/LoadingContent/LoadingContent.tsx
@@ -89,7 +89,7 @@ export const LoadingContent = ({
     );
 
     return (
-        <LoadingWrapper>
+        <LoadingWrapper data-component="LoadingContent">
             {!isLoadingPositionReversed && <SpinnerContainer />}
             {slideContent ? (
                 <ContentCell $isLoading={isLoading} $size={size}>

--- a/packages/components/src/components/loaders/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/components/loaders/ProgressBar/ProgressBar.tsx
@@ -40,7 +40,11 @@ export const ProgressBar = ({
     const theme = useTheme();
 
     return (
-        <Wrapper $color={backgroundColor || theme.elementFillNeutralBold} data-testid={dataTestId}>
+        <Wrapper
+            $color={backgroundColor || theme.elementFillNeutralBold}
+            data-component="ProgressBar"
+            data-testid={dataTestId}
+        >
             <Value $max={max} $value={value} $color={foregroundColor || theme.contentBrand} />
         </Wrapper>
     );

--- a/packages/components/src/components/loaders/ProgressPie/ProgressPie.tsx
+++ b/packages/components/src/components/loaders/ProgressPie/ProgressPie.tsx
@@ -57,6 +57,7 @@ export const ProgressPie = ({
 
     return (
         <Container
+            data-component="ProgressPie"
             $size={size}
             $valueInPercents={valueInPercents}
             $backgroundColor={backgroundColor}

--- a/packages/components/src/components/loaders/Spinner/Spinner.tsx
+++ b/packages/components/src/components/loaders/Spinner/Spinner.tsx
@@ -120,6 +120,7 @@ export const Spinner = ({
         <StyledLottie
             key={animationKey}
             size={size}
+            data-component="Spinner"
             data-testid={dataTest ?? '@spinner'}
             {...lottieProps}
             {...frameProps}

--- a/packages/components/src/components/loaders/Stepper/Stepper.tsx
+++ b/packages/components/src/components/loaders/Stepper/Stepper.tsx
@@ -36,5 +36,9 @@ export const Stepper = ({ step, total, maxWidth = 200 }: StepperProps) => {
             return <Step key={`${index}`} $isActive={isActive} />;
         });
 
-    return <Container $maxWidth={maxWidth}>{steps}</Container>;
+    return (
+        <Container data-component="Stepper" $maxWidth={maxWidth}>
+            {steps}
+        </Container>
+    );
 };

--- a/packages/components/src/components/typography/Code/Code.tsx
+++ b/packages/components/src/components/typography/Code/Code.tsx
@@ -15,4 +15,6 @@ const StyledCode = styled.code`
     border-radius: 4px;
 `;
 
-export const Code = ({ children }: { children: ReactNode }) => <StyledCode>{children}</StyledCode>;
+export const Code = ({ children }: { children: ReactNode }) => (
+    <StyledCode data-component="Code">{children}</StyledCode>
+);

--- a/packages/components/src/components/typography/Heading/Heading.tsx
+++ b/packages/components/src/components/typography/Heading/Heading.tsx
@@ -5,7 +5,12 @@ import { Text, type TextProps } from '../Text/Text';
 const createHeading =
     (as: 'h1' | 'h2' | 'h3' | 'h4', defaultTypographyStyle: TypographyStyle) =>
     ({ children, ...rest }: TextProps) => (
-        <Text as={as} typographyStyle={defaultTypographyStyle} {...rest}>
+        <Text
+            as={as}
+            typographyStyle={defaultTypographyStyle}
+            {...rest}
+            data-component={as.toUpperCase()}
+        >
             {children}
         </Text>
     );

--- a/packages/components/src/components/typography/Link/Link.tsx
+++ b/packages/components/src/components/typography/Link/Link.tsx
@@ -46,9 +46,10 @@ export const Link = ({
     onClick,
     'data-testid': dataTest,
     children,
+    typographyStyle,
     ...rest
 }: LinkProps) => {
-    const textProps = pickAndPrepareTextProps(rest, allowedTextTextProps);
+    const textProps = pickAndPrepareTextProps({ ...rest, typographyStyle }, allowedTextTextProps);
 
     return (
         <A
@@ -56,6 +57,7 @@ export const Link = ({
             target={target ?? '_blank'}
             rel="noreferrer noopener"
             data-testid={dataTest}
+            data-typography-style={typographyStyle}
             onClick={(e: MouseEvent<HTMLAnchorElement>) => {
                 if (onClick !== undefined) {
                     e.stopPropagation();

--- a/packages/components/src/components/typography/Link/Link.tsx
+++ b/packages/components/src/components/typography/Link/Link.tsx
@@ -57,6 +57,7 @@ export const Link = ({
             target={target ?? '_blank'}
             rel="noreferrer noopener"
             data-testid={dataTest}
+            data-component="Link"
             data-typography-style={typographyStyle}
             onClick={(e: MouseEvent<HTMLAnchorElement>) => {
                 if (onClick !== undefined) {

--- a/packages/components/src/components/typography/Paragraph/Paragraph.tsx
+++ b/packages/components/src/components/typography/Paragraph/Paragraph.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Text, type TextProps } from '../Text/Text';
 
 export const Paragraph = ({ children, as, role, ...rest }: TextProps) => (
-    <Text {...rest} as={as || 'div'} role={role || 'paragraph'}>
+    <Text {...rest} as={as || 'div'} role={role || 'paragraph'} data-component="Paragraph">
         {children}
     </Text>
 );

--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -152,6 +152,7 @@ export type TextProps = Pick<HTMLProps<HTMLElement>, 'onCopy' | 'onClick'> & {
     isTabular?: boolean;
     as?: string;
     'data-testid'?: string;
+    'data-component'?: string;
     role?: string;
 } & ExclusiveColorOrIntent &
     AllowedFrameProps &
@@ -166,6 +167,7 @@ export const Text = ({
     children,
     as = 'span',
     'data-testid': dataTest,
+    'data-component': dataComponent = 'Text',
     onClick,
     onCopy,
     isMonospaced,
@@ -189,6 +191,7 @@ export const Text = ({
             onClick={onClick}
             onCopy={onCopy}
             data-testid={dataTest}
+            data-component={dataComponent}
             data-typography-style={typographyStyle}
             $isMonospaced={isMonospaced}
             $isHighlighted={isHighlighted}

--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -172,10 +172,11 @@ export const Text = ({
     isHighlighted,
     role,
     isTabular,
+    typographyStyle,
     ...rest
 }: TextProps) => {
     const frameProps = pickAndPrepareFrameProps(rest, allowedTextFrameProps);
-    const textProps = pickAndPrepareTextProps(rest, allowedTextTextProps);
+    const textProps = pickAndPrepareTextProps({ ...rest, typographyStyle }, allowedTextTextProps);
 
     return (
         <StyledText
@@ -188,6 +189,7 @@ export const Text = ({
             onClick={onClick}
             onCopy={onCopy}
             data-testid={dataTest}
+            data-typography-style={typographyStyle}
             $isMonospaced={isMonospaced}
             $isHighlighted={isHighlighted}
             $isTabular={isTabular}

--- a/packages/components/src/components/typography/TruncateWithTooltip/TruncateWithTooltip.tsx
+++ b/packages/components/src/components/typography/TruncateWithTooltip/TruncateWithTooltip.tsx
@@ -44,7 +44,7 @@ export const TruncateWithTooltip = ({ children, delayShow, ...rest }: TruncateWi
     }, [children]);
 
     return (
-        <EllipsisContainer ref={containerRef}>
+        <EllipsisContainer ref={containerRef} data-component="TruncateWithTooltip">
             <Tooltip
                 isActive={Boolean(children) && isEllipsisActive}
                 delayShow={delayShow}

--- a/packages/components/src/support/Story.tsx
+++ b/packages/components/src/support/Story.tsx
@@ -4,7 +4,7 @@ import styled, { ThemeProvider } from 'styled-components';
 
 import { intermediaryTheme } from '../config/colors';
 
-const Wrapper = styled.div`
+const Wrapper = styled.div.attrs({ 'data-component': 'StoryWrapper' })`
     padding: 20px;
     display: flex;
     height: 100%;
@@ -35,7 +35,7 @@ interface StoryColumnProps {
     minWidth?: number;
 }
 
-const Col = styled.div<StoryColumnProps>`
+const Col = styled.div.attrs({ 'data-component': 'StoryColumn' })<StoryColumnProps>`
     padding: 10px;
     flex: 1;
     border-radius: 10px;

--- a/packages/components/src/support/Story.tsx
+++ b/packages/components/src/support/Story.tsx
@@ -4,7 +4,9 @@ import styled, { ThemeProvider } from 'styled-components';
 
 import { intermediaryTheme } from '../config/colors';
 
-const Wrapper = styled.div.attrs({ 'data-component': 'StoryWrapper' })`
+const Wrapper = styled.div.attrs<{ 'data-component'?: string }>(() => ({
+    'data-component': 'StoryWrapper',
+}))`
     padding: 20px;
     display: flex;
     height: 100%;
@@ -35,7 +37,9 @@ interface StoryColumnProps {
     minWidth?: number;
 }
 
-const Col = styled.div.attrs({ 'data-component': 'StoryColumn' })<StoryColumnProps>`
+const Col = styled.div.attrs<{ 'data-component'?: string }>(() => ({
+    'data-component': 'StoryColumn',
+}))<StoryColumnProps>`
     padding: 10px;
     flex: 1;
     border-radius: 10px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- for better debugging in DOM

## Notes for QA

for devs only, shouldnt show anything to user

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="1474" height="605" alt="image" src="https://github.com/user-attachments/assets/aa621611-3a36-4029-8c5e-646fe5ccb6ec" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The PR touches the shared component library in packages/components, which are global UI primitives used by almost every screen. Most static coverage mappings are too broad (120-140 tests) to be actionable, so I selected a short, representative set of E2E tests that exercise the most user-visible surfaces: onboarding, settings, dashboard, activity, modals, forms, and a complex transaction flow. These tests will catch regressions in Button, Switch, Select, Radio, Modal, Toast, Banner, Card, Input, and typography components. No tests specifically cover the changed Stepper or Story support files.

<details><summary><b>Changed files (89)</b></summary>

- `packages/components/src/components/Badge/Badge.tsx`
- `packages/components/src/components/Banner/Banner.tsx`
- `packages/components/src/components/Banner/BannerButton.tsx`
- `packages/components/src/components/Banner/BannerIconButton.tsx`
- `packages/components/src/components/Box/Box.tsx`
- `packages/components/src/components/Card/Card.tsx`
- `packages/components/src/components/CardList/CardList.tsx`
- `packages/components/src/components/CardList/CardListItem.tsx`
- `packages/components/src/components/Collapsible/Collapsible.tsx`
- `packages/components/src/components/Collapsible/CollapsibleContent.tsx`
- `packages/components/src/components/Collapsible/CollapsibleToggle.tsx`
- `packages/components/src/components/Collapsible/CollapsibleToggleIcon.tsx`
- `packages/components/src/components/CollapsibleBox/CollapsibleBox.tsx`
- `packages/components/src/components/ComponentWithSubIcon/ComponentWithSubIcon.tsx`
- `packages/components/src/components/Divider/Divider.tsx`
- `packages/components/src/components/Dot/Dot.tsx`
- `packages/components/src/components/DotIndicator/DotIndicator.tsx`
- `packages/components/src/components/Dropdown/Dropdown.tsx`
- `packages/components/src/components/Flag/Flag.tsx`
- `packages/components/src/components/Flex/Flex.tsx`
- `packages/components/src/components/GhostContainer/GhostContainer.tsx`
- `packages/components/src/components/Grid/Grid.tsx`
- `packages/components/src/components/Icon/Icon.test.tsx`
- `packages/components/src/components/Icon/Icon.tsx`
- `packages/components/src/components/IconCircle/IconCircle.tsx`
- `packages/components/src/components/Illustration/Illustration.tsx`
- `packages/components/src/components/Image/Image.tsx`
- `packages/components/src/components/Image/SvgImage.tsx`
- `packages/components/src/components/InfoItem/InfoItem.tsx`
- `packages/components/src/components/InfoSegments/InfoSegments.tsx`
- `packages/components/src/components/List/List.tsx`
- `packages/components/src/components/List/ListItem.tsx`
- `packages/components/src/components/Markdown/Markdown.tsx`
- `packages/components/src/components/Menu/Menu.tsx`
- `packages/components/src/components/Modal/Modal.tsx`
- `packages/components/src/components/Modal/ModalBackdrop.tsx`
- `packages/components/src/components/Modal/ModalButton.tsx`
- `packages/components/src/components/Modal/ModalProvider.tsx`
- `packages/components/src/components/Note/Note.tsx`
- `packages/components/src/components/PinInput/PinInput.tsx`
- `packages/components/src/components/Popover/Popover.tsx`
- `packages/components/src/components/RadioCard/RadioCard.tsx`
- `packages/components/src/components/ResizableBox/ResizableBox.tsx`
- `packages/components/src/components/ShortcutBadge/ShortcutBadge.tsx`
- `packages/components/src/components/Skeleton/Skeleton.tsx`
- `packages/components/src/components/StatusBadge/StatusBadge.tsx`
- `packages/components/src/components/StepList/StepList.tsx`
- `packages/components/src/components/StepList/StepListItem.tsx`
- `packages/components/src/components/SubTabs/SubTabs.tsx`
- `packages/components/src/components/SubTabs/SubTabsItem.tsx`
- `packages/components/src/components/Table/Table.tsx`
- `packages/components/src/components/Table/TableBody.tsx`
- `packages/components/src/components/Table/TableCell.tsx`
- `packages/components/src/components/Table/TableHeader.tsx`
- `packages/components/src/components/Table/TableRow.tsx`
- `packages/components/src/components/Tabs/Tabs.tsx`
- `packages/components/src/components/Tabs/TabsItem.tsx`
- `packages/components/src/components/Timerange/Timerange.tsx`
- `packages/components/src/components/Toast/Toast.tsx`
- `packages/components/src/components/Tooltip/Tooltip.tsx`
- `packages/components/src/components/VirtualizedList/VirtualizedList.tsx`
- `packages/components/src/components/animations/AnimationPrimitives.tsx`
- `packages/components/src/components/animations/LottieAnimation.tsx`
- `packages/components/src/components/buttons/Button/Button.tsx`
- `packages/components/src/components/buttons/ButtonGroup/ButtonGroup.tsx`
- `packages/components/src/components/buttons/IconButton/IconButton.tsx`
- `packages/components/src/components/buttons/TextButton/TextButton.tsx`
- `packages/components/src/components/form/Checkbox/Checkbox.tsx`
- `packages/components/src/components/form/FormCell/FormCell.tsx`
- `packages/components/src/components/form/FractionButton/FractionButton.tsx`
- `packages/components/src/components/form/Input/Input.tsx`
- `packages/components/src/components/form/Radio/Radio.tsx`
- `packages/components/src/components/form/Range/Range.tsx`
- `packages/components/src/components/form/Select/Select.tsx`
- `packages/components/src/components/form/SelectBar/SelectBar.tsx`
- `packages/components/src/components/form/Switch/Switch.tsx`
- `packages/components/src/components/form/Textarea/Textarea.tsx`
- `packages/components/src/components/loaders/LoadingContent/LoadingContent.tsx`
- `packages/components/src/components/loaders/ProgressBar/ProgressBar.tsx`
- `packages/components/src/components/loaders/ProgressPie/ProgressPie.tsx`
- `packages/components/src/components/loaders/Spinner/Spinner.tsx`
- `packages/components/src/components/loaders/Stepper/Stepper.tsx`
- `packages/components/src/components/typography/Code/Code.tsx`
- `packages/components/src/components/typography/Heading/Heading.tsx`
- `packages/components/src/components/typography/Link/Link.tsx`
- `packages/components/src/components/typography/Paragraph/Paragraph.tsx`
- `packages/components/src/components/typography/Text/Text.tsx`
- `packages/components/src/components/typography/TruncateWithTooltip/TruncateWithTooltip.tsx`
- `packages/components/src/support/Story.tsx`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/activity/activity-page.test.ts` — Directly exercises Toast, Banner, Tabs, and Badge components through unseen indicators, toast notifications, and tab switching. A regression in any of these shared primitives would fail assertions here.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Validates dashboard interactions that rely on Button, Card, Tooltip, and typography components to toggle discreet mode and reveal balances. Component regressions would break visibility assertions.
- `suite/e2e/tests/general/check-links.test.ts` — Crawls nearly every app route and verifies the main layout and onboarding shell render, providing the broadest smoke coverage for shared layout primitives like Box, Flex, Grid, Card, typography, and Modal infrastructure.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Hits the first user-facing screen after launch, which depends on Switch, Button, Modal/dialog, and typography components. Failures here would block all subsequent onboarding tests.
- `suite/e2e/tests/settings/general.test.ts` — Interacts directly with Select, Switch, Button, and settings layout components to change fiat, theme, language, and analytics. These are the exact form primitives being modified.
- `suite/e2e/tests/settings/safety-checks.test.ts` — Opens a settings modal and manipulates Radio buttons, confirm Button, and device prompt UI. Directly exercises Modal, Radio, and Button variants in a real flow.
- `suite/e2e/tests/suite/initial-run.test.ts` — Validates onboarding persistence UI including analytics toggle (Switch), complete button (Button), and device status indicators. Component regressions would prevent reaching the dashboard.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — Opens the Guide panel over modals and uses search input, buttons, and feedback forms. Covers Dropdown/Menu, Input, Button, and Modal overlay behavior in a non-trivial nested UI context.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Flows through staking modals and forms that use Checkbox, Button, Input, Card, progress indicators, and Toast notifications. Exercises several changed form and feedback components together.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Navigates buy quotes, offer comparison modal, confirmation preview, and transaction detail, relying on Input, Select, Button, Modal, Card, and typography components throughout the trading flow.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Uses the send form's output management, header dropdown, locktime input, OP_RETURN controls, and amount unit switch — directly exercising Input, Select/Dropdown, Button, and form layout components.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/components/src/components/Icon/Icon.test.tsx`
- `packages/components/src/components/loaders/Stepper/Stepper.tsx`
- `packages/components/src/support/Story.tsx`

_Updated: 2026-09-10T14:38:40.001Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat-create-data-fields-for-better-dom-navigation/web/](https://dev.suite.sldev.cz/suite-web/feat-create-data-fields-for-better-dom-navigation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-create-data-fields-for-better-dom-navigation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-create-data-fields-for-better-dom-navigation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell BTC > Sell Bitcoin for best offer | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T14:41:29.793Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T14:41:28.527Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->