### PR TITLE
refactor(suite): accept an omitted network protocol

### DIFF
--- a/packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx
@@ -34,7 +34,7 @@ export const AssetsListEmpty = ({
     const device = useSelector(selectSelectedDevice);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
-    const protocolSymbol = protocolScheme ? findNetworkSymbolForProtocol(protocolScheme) : null;
+    const protocolSymbol = findNetworkSymbolForProtocol(protocolScheme);
     const network = protocolSymbol ? getNetworkDisplaySymbolName(protocolSymbol) : undefined;
 
     const openActivateNetworkModal = () => {

--- a/suite-common/networks/mocks/mockFindNetworkSymbolForProtocol.ts
+++ b/suite-common/networks/mocks/mockFindNetworkSymbolForProtocol.ts
@@ -7,4 +7,4 @@ export const mockFindNetworkSymbolForProtocol =
         symbolsByProtocol: Partial<Record<Protocol, NetworkSymbol>> = {},
     ): FindNetworkSymbolForProtocol =>
     protocol =>
-        symbolsByProtocol[protocol] ?? null;
+        protocol ? (symbolsByProtocol[protocol] ?? null) : null;

--- a/suite-common/networks/src/createFindNetworkSymbolForProtocol.ts
+++ b/suite-common/networks/src/createFindNetworkSymbolForProtocol.ts
@@ -4,7 +4,7 @@ import type { NetworkModuleRepositoryDep } from './NetworkModuleRepository';
 import type { NetworkSymbol } from './NetworkModules';
 import type { GetNetworkConfigDep } from './createGetNetworkConfig';
 
-export type FindNetworkSymbolForProtocol = (protocol: Protocol) => NetworkSymbol | null;
+export type FindNetworkSymbolForProtocol = (protocol?: Protocol) => NetworkSymbol | null;
 
 export type FindNetworkSymbolForProtocolDeps = GetNetworkConfigDep & NetworkModuleRepositoryDep;
 
@@ -20,9 +20,14 @@ export const selectFindNetworkSymbolForProtocolDep = (
 
 export const createFindNetworkSymbolForProtocol =
     (deps: FindNetworkSymbolForProtocolDeps): FindNetworkSymbolForProtocol =>
-    protocol =>
-        deps.networkModuleRepository
-            .getSupportedNetworks()
-            .find(networkSymbol =>
-                deps.getNetworkConfig(networkSymbol).protocols.includes(protocol),
-            ) ?? null;
+    protocol => {
+        if (!protocol) return null;
+
+        return (
+            deps.networkModuleRepository
+                .getSupportedNetworks()
+                .find(networkSymbol =>
+                    deps.getNetworkConfig(networkSymbol).protocols.includes(protocol),
+                ) ?? null
+        );
+    };


### PR DESCRIPTION
## Description

Allow findNetworkSymbolForProtocol to accept an omitted protocol and return null, and align its mock with that behavior. AssetsListEmpty can then call the lookup directly without a ternary.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The PR changes the asset picker empty state and a network-symbol-to-protocol utility, so risk is concentrated in asset-picker flows. A small, targeted set of tests that explicitly open the asset picker, filter by network, and search for assets provides good coverage without running the entire suite. The protocol-mapping utility has no dedicated E2E coverage, so the recommended asset-picker tests also act as indirect regression guards for network matching.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx`
- `suite-common/networks/mocks/mockFindNetworkSymbolForProtocol.ts`
- `suite-common/networks/src/createFindNetworkSymbolForProtocol.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test explicitly selects Ethereum as the buy asset through the asset picker using network filtering and search, which directly exercises the changed AssetsListEmpty component and the createFindNetworkSymbolForProtocol mapping that underlies network/protocol filtering.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — The test filters the asset picker by network and searches by token name to select a Solana SPL token, making it a direct consumer of the asset picker list/filter behavior affected by both the empty-state component and the network-symbol-for-protocol utility.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — It opens the swap form and uses the asset picker to select sell/buy assets with search and network filters from a remembered wallet; this path is likely to hit the empty-state rendering and protocol-to-network mapping changed here.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test opens the global receive/send asset picker, filters accounts by network, and adds a new ETH account, directly depending on the asset picker's list state and network-matching logic.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — It selects a Solana token and a disabled-network asset (XLM) in the swap form, relying on the asset picker/network filter and inline network enablement; changes to network protocol mapping could alter whether the disabled network is matched correctly.
- `suite/e2e/tests/trading/navigation.test.ts` — Covers navigation into buy/sell/swap forms from dashboard, accounts, and tokens, which often initialize the asset picker; while it does not deeply exercise search/empty states, it validates that the picker-based forms open with the expected asset.
- `suite/e2e/tests/dashboard/assets.test.ts` — Exercises the dashboard Assets section and the Activate Assets modal, which share the asset list/list-empty rendering components with the asset picker; a regression in empty-state display could affect activation flows.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/networks/mocks/mockFindNetworkSymbolForProtocol.ts`

_Updated: 2026-09-10T14:01:53.233Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/optional-network-protocol/web/](https://dev.suite.sldev.cz/suite-web/refactor/optional-network-protocol/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/optional-network-protocol&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/optional-network-protocol&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/optional-network-protocol&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T14:04:30.344Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH to SOL | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-10T14:03:59.370Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->