### PR TITLE
fix(suite-native): exclude failed accounts from portfolio graph

### DIFF
--- a/suite-native/graph/src/selectors.test.ts
+++ b/suite-native/graph/src/selectors.test.ts
@@ -165,4 +165,33 @@ describe('selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning', () => {
             },
         ]);
     });
+
+    it('should exclude accounts whose discovery failed', () => {
+        const account = mockWalletAccount({
+            symbol: asNetworkSymbol('btc'),
+            descriptor: asAccountDescriptor('descriptor1'),
+        });
+        const failedAccount = mockWalletAccount(
+            {
+                symbol: asNetworkSymbol('btc'),
+                descriptor: asAccountDescriptor('failed:16:btc:normal'),
+            },
+            undefined,
+            { failed: true, error: 'Discovery failed' },
+        );
+
+        mockSelectDeviceMainnetAccounts.mockReturnValue([account, failedAccount]);
+
+        const result = selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning(mockState);
+
+        expect(result).toEqual([
+            {
+                symbol: 'btc',
+                descriptor: 'descriptor1',
+                identity: undefined,
+                accountKey: account.key,
+                tokensFilter: [],
+            },
+        ]);
+    });
 });

--- a/suite-native/graph/src/selectors.ts
+++ b/suite-native/graph/src/selectors.ts
@@ -29,24 +29,26 @@ export const selectPortfolioGraphAccountItems = createMemoizedSelector(
     [selectDeviceMainnetAccounts, selectTokenDefinitions],
     (accounts, tokenDefinitions): AccountItem[] =>
         returnStableArrayIfEmpty(
-            accounts.map(account => {
-                const knownTokens = account.tokens
-                    ? filterKnownTokens(
-                          tokenDefinitions?.[account.symbol]?.coin?.data,
-                          account.symbol,
-                          account.tokens,
-                      )
-                    : undefined;
-                const tokensFilter = knownTokens?.map(token => token.contract as TokenAddress);
+            accounts
+                .filter(account => !account.failed)
+                .map(account => {
+                    const knownTokens = account.tokens
+                        ? filterKnownTokens(
+                              tokenDefinitions?.[account.symbol]?.coin?.data,
+                              account.symbol,
+                              account.tokens,
+                          )
+                        : undefined;
+                    const tokensFilter = knownTokens?.map(token => token.contract as TokenAddress);
 
-                return {
-                    symbol: account.symbol,
-                    descriptor: account.descriptor,
-                    identity: tryGetAccountIdentity(account),
-                    accountKey: account.key,
-                    tokensFilter,
-                };
-            }),
+                    return {
+                        symbol: account.symbol,
+                        descriptor: account.descriptor,
+                        identity: tryGetAccountIdentity(account),
+                        accountKey: account.key,
+                        tokensFilter,
+                    };
+                }),
         ),
     {
         memoizeOptions: {


### PR DESCRIPTION
## Description

When account discovery fails for an individual account, wallet-core creates a failed placeholder account with a synthetic descriptor such as `failed:16:btc:normal`. This preserves the discovery error so the UI can surface it.

The mobile portfolio graph previously converted every mainnet account into a graph request, including these failed placeholders. It then sent the synthetic descriptor to `blockchainGetAccountBalanceHistory`. Blockbook attempted to decode it as an address or account descriptor and returned:

`Invalid address, decoded address is of unknown format`

This change excludes failed accounts when building portfolio graph inputs. Successfully discovered accounts remain in the graph. The Bitcoin asset-row warning remains visible because it correctly represents the underlying discovery failure.

Related to #32337. This PR prevents the downstream mobile graph error; it does not fix the discovery failure described there.

## QA notes

### Reproduction

1. Run a mobile debug build with Bitcoin enabled.
2. Connect a device and add a passphrase wallet containing enough Bitcoin accounts to reproduce #32337 (the reported wallet has more than 16 accounts).
3. Wait for discovery to produce one or more failed Bitcoin accounts.
4. Open the Home screen.

### Expected

- The portfolio graph does not show `Get account balance movement error: Invalid address, decoded address is of unknown format`.
- The React Native red error overlay is not opened by the portfolio graph request.
- The graph is calculated from successfully discovered accounts.
- The Bitcoin asset row still shows its warning icon, indicating that Bitcoin discovery was incomplete.
- Opening the Bitcoin asset list still exposes the failed account state through the existing UI.

### Regression

1. Open a standard or passphrase wallet without failed accounts.
2. Verify the portfolio graph loads and timeframe switching and retry continue to work.
3. Verify portfolio totals and the Bitcoin asset balance are unchanged.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/fix-native-graph-failed-accounts&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->