### PR TITLE
docs(skills): keep injected services under deps

### DIFF
--- a/skills/dependency-injection/SKILL.md
+++ b/skills/dependency-injection/SKILL.md
@@ -49,6 +49,10 @@ export type ServiceNameDeps = {
 
 Do not repeat `ServiceParams` in factory (`(params)` only). It is inferred from `ServiceName`.
 
+Always access injected services through `deps.serviceName`. Do not destructure `deps` in factory
+parameters or function bodies, or alias injected services with `const serviceName = deps.serviceName`.
+The `deps.` prefix makes injected dependencies visible at each use.
+
 Service factory:
 
 File shall be named: `createServiceName.ts`.


### PR DESCRIPTION
## Description

Require service factories to access injected services through deps.serviceName, without destructuring or local aliases, so injected dependencies remain visible at each use.