### PR TITLE
fix(suite-native): do not force default slippage on DEX quote selection

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.test.ts
@@ -3,10 +3,7 @@ import React from 'react';
 import type { ExchangeTrade } from 'invity-api';
 
 import { useServices } from '@suite-common/dependency-injection';
-import {
-    TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
-    tradingExchangeActions,
-} from '@suite-common/trading';
+import { tradingExchangeActions } from '@suite-common/trading';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { type NativeAnalyticsDep, events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
@@ -281,7 +278,7 @@ describe('useExchangeSelectQuote', () => {
             );
         });
 
-        it('should apply default slippage when selecting a DEX quote without slippage', async () => {
+        it('should keep slippage unset when selecting a DEX quote without slippage', async () => {
             const quote = { ...invityDexQuote, swapSlippage: undefined };
             await act(() => {
                 exchangeForm.setValue('quote', quote);
@@ -300,19 +297,14 @@ describe('useExchangeSelectQuote', () => {
                 payload: { nextStep: () => void; quote: ExchangeTrade };
             };
 
-            expect(selectQuoteAction.payload.quote.swapSlippage).toBe(
-                TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
-            );
+            expect(selectQuoteAction.payload.quote.swapSlippage).toBeUndefined();
 
             await act(() => {
                 selectQuoteAction.payload.nextStep();
             });
 
             expect(dispatchSpy).toHaveBeenCalledWith(
-                tradingExchangeActions.saveSelectedQuote({
-                    ...quote,
-                    swapSlippage: TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
-                }),
+                tradingExchangeActions.saveSelectedQuote(quote),
             );
         });
 
@@ -529,13 +521,9 @@ describe('useExchangeSelectQuote', () => {
             });
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangeApproval', {});
-            // The hook persists the normalized quote before navigating to the approval screen.
             expect(dispatchSpy).toHaveBeenCalledWith({
                 type: '@trading-exchange/saveSelectedQuote',
-                payload: {
-                    ...quote,
-                    swapSlippage: TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
-                },
+                payload: quote,
             });
             const dispatchedTypes = dispatchSpy.mock.calls.map(([action]) => (action as any)?.type);
             expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
@@ -575,10 +563,7 @@ describe('useExchangeSelectQuote', () => {
             });
             expect(dispatchSpy).toHaveBeenCalledWith({
                 type: '@trading-exchange/saveSelectedQuote',
-                payload: {
-                    ...quote,
-                    swapSlippage: TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
-                },
+                payload: quote,
             });
             const dispatchedTypes = dispatchSpy.mock.calls.map(([action]) => (action as any)?.type);
             expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');
@@ -620,10 +605,7 @@ describe('useExchangeSelectQuote', () => {
             });
             expect(dispatchSpy).toHaveBeenCalledWith({
                 type: '@trading-exchange/saveSelectedQuote',
-                payload: {
-                    ...quote,
-                    swapSlippage: TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
-                },
+                payload: quote,
             });
         });
 
@@ -660,10 +642,7 @@ describe('useExchangeSelectQuote', () => {
             });
             expect(dispatchSpy).toHaveBeenCalledWith({
                 type: '@trading-exchange/saveSelectedQuote',
-                payload: {
-                    ...quote,
-                    swapSlippage: TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
-                },
+                payload: quote,
             });
             const dispatchedTypes = dispatchSpy.mock.calls.map(([action]) => (action as any)?.type);
             expect(dispatchedTypes).not.toContain('@trading-exchange/savePreselectedQuote');

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -6,7 +6,6 @@ import type { ExchangeTrade } from 'invity-api';
 import { useDispatch } from '@suite-common/redux-utils';
 import {
     type ApprovalStatus,
-    TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
     type TradingRootState,
     exchangeThunks,
     getApprovalStatus,
@@ -93,20 +92,12 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
             return;
         }
 
-        const selectedQuote =
-            candidateQuote.isDex && !candidateQuote.swapSlippage
-                ? {
-                      ...candidateQuote,
-                      swapSlippage: TRADING_SETTINGS_MAX_SLIPPAGE_PERCENTAGE_DEFAULT,
-                  }
-                : candidateQuote;
-
         await dispatch(
             exchangeThunks.selectQuoteThunk({
-                quote: selectedQuote,
+                quote: candidateQuote,
                 nextStep: () => {
                     clearExchangeFormQuoteData(form);
-                    nextStep(getApprovalStatus(selectedQuote), selectedQuote);
+                    nextStep(getApprovalStatus(candidateQuote), candidateQuote);
                 },
             }),
         );


### PR DESCRIPTION
## Description

Selecting a 📱 DEX quote without `swapSlippage` injected a hardcoded 1% default into the quote, which was then sent to the exchange API in `doExchangeTrade`, silently overriding the provider's own slippage default. The quote is now passed through unchanged and slippage is only sent when the quote carries it or the user sets it via the slippage picker, matching desktop behavior. Downstream UI already expects this: the slippage picker and summary render only when slippage is present.

## Notes for QA

- Mobile DEX swap: select a DEX quote and confirm; slippage picker and behavior unchanged for quotes that carry slippage (Invity DEX quotes normally do).
- For a hypothetical DEX quote without slippage, the picker is hidden and no slippage is sent to the API (provider default applies), same as desktop.
- CEX flows unaffected.



## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-native-dex-slippage-default&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->