### PR TITLE
refactor(suite): inject Connect through getTrezorConnect

### DIFF
--- a/networks/ethereum/network-ethereum-suite-common/package.json
+++ b/networks/ethereum/network-ethereum-suite-common/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@noble/hashes": "^2.0.1",
         "@suite-common/calldata": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/network-ethereum": "workspace:*",
         "@trezor/network-module-suite-common-types": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/networks/ethereum/network-ethereum-suite-common/src/namedAddress/createCallEnsUniversalResolver.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/namedAddress/createCallEnsUniversalResolver.ts
@@ -1,7 +1,7 @@
 import type { Hex } from 'viem';
 
+import type { GetTrezorConnectDep } from '@trezor/connect-common';
 import type { EthereumNetworkSymbol } from '@trezor/network-ethereum/constants';
-import type { GetTrezorConnectDep } from '@trezor/network-module-suite-common-types';
 
 import { asHex } from './ensUniversalResolverUtils';
 import { ONCHAIN_CALL_TIMEOUT_MS } from './namedAddressUtils';

--- a/networks/ethereum/network-ethereum-suite-common/src/namedAddress/createResolveNamedAddressViaBlockbook.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/namedAddress/createResolveNamedAddressViaBlockbook.ts
@@ -1,4 +1,4 @@
-import type { GetTrezorConnectDep } from '@trezor/network-module-suite-common-types';
+import type { GetTrezorConnectDep } from '@trezor/connect-common';
 
 import type { ResolveNamedAddress } from './ResolveNamedAddress';
 import { isAddressLike } from './namedAddressUtils';

--- a/networks/ethereum/network-ethereum-suite-common/tsconfig.json
+++ b/networks/ethereum/network-ethereum-suite-common/tsconfig.json
@@ -5,6 +5,9 @@
         {
             "path": "../../../suite-common/calldata"
         },
+        {
+            "path": "../../../packages/connect-common"
+        },
         { "path": "../network-ethereum" },
         {
             "path": "../../network-module/network-module-suite-common-types"

--- a/networks/ethereum/network-ethereum-suite-common/tsconfig.lib.json
+++ b/networks/ethereum/network-ethereum-suite-common/tsconfig.lib.json
@@ -6,6 +6,9 @@
         {
             "path": "../../../suite-common/calldata"
         },
+        {
+            "path": "../../../packages/connect-common"
+        },
         { "path": "../network-ethereum" },
         {
             "path": "../../network-module/network-module-suite-common-types"

--- a/networks/network-module/network-module-suite-common-types/mocks/mockGetTrezorConnect.ts
+++ b/networks/network-module/network-module-suite-common-types/mocks/mockGetTrezorConnect.ts
@@ -1,6 +1,4 @@
-import type { TrezorConnectCallable } from '@trezor/connect-common';
-
-import type { GetTrezorConnect } from '../src/GetTrezorConnect';
+import type { GetTrezorConnect, TrezorConnectCallable } from '@trezor/connect-common';
 
 export const mockGetTrezorConnect: GetTrezorConnect<keyof TrezorConnectCallable> = () => {
     throw new Error('Connect is not mocked for this test.');

--- a/networks/network-module/network-module-suite-common-types/src/NetworkSuiteCommonModuleApi.ts
+++ b/networks/network-module/network-module-suite-common-types/src/NetworkSuiteCommonModuleApi.ts
@@ -1,4 +1,4 @@
-import type { GetTrezorConnectDep } from './GetTrezorConnect';
+import type { GetTrezorConnectDep } from '@trezor/connect-common';
 
 /**
  * Application capabilities injected into suite-common network modules.

--- a/networks/network-module/network-module-suite-common-types/src/index.ts
+++ b/networks/network-module/network-module-suite-common-types/src/index.ts
@@ -2,7 +2,6 @@ export { addressType } from './AddressValidator';
 export type { AddressType, AddressValidator } from './AddressValidator';
 export type { NamedAddressResolver } from './NamedAddressResolver';
 export type { NetworkSuiteCommonModuleApi } from './NetworkSuiteCommonModuleApi';
-export type { GetTrezorConnect, GetTrezorConnectDep } from './GetTrezorConnect';
 export { asProtocol } from './Protocol';
 export type { Protocol } from './Protocol';
 export type {

--- a/packages/connect-common/src/types/getTrezorConnect.ts
+++ b/packages/connect-common/src/types/getTrezorConnect.ts
@@ -1,4 +1,4 @@
-import type { TrezorConnectCallable } from '@trezor/connect-common';
+import type { TrezorConnectCallable, TrezorConnectPrivilegedAPI } from './api';
 
 /**
  * Reads Connect at call time because legacy initialization replaces its methods.
@@ -11,4 +11,10 @@ export type GetTrezorConnect<TMethod extends keyof TrezorConnectCallable> = () =
 
 export type GetTrezorConnectDep<TMethod extends keyof TrezorConnectCallable> = {
     getTrezorConnect: GetTrezorConnect<TMethod>;
+};
+
+export type GetTrezorConnectPrivileged = () => TrezorConnectPrivilegedAPI;
+
+export type GetTrezorConnectPrivilegedDep = {
+    getTrezorConnect: GetTrezorConnectPrivileged;
 };

--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -5,6 +5,12 @@ export * from './definitions';
 export * from './device';
 export * from './fees';
 export type * from './firmware';
+export type {
+    GetTrezorConnect,
+    GetTrezorConnectDep,
+    GetTrezorConnectPrivileged,
+    GetTrezorConnectPrivilegedDep,
+} from './getTrezorConnect';
 export * from './method';
 export * from './params';
 export * from './settings';

--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -2,6 +2,7 @@ import { createMemoryHistory } from 'history';
 
 import { createElectronPlatformEncryption } from '@suite/platform-encryption-electron';
 import { toGetter } from '@suite-common/dependency-injection';
+import TrezorConnect from '@trezor/connect-electron';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { createHydrateReduxStore } from 'src/reducers/createHydrateReduxStore';
@@ -43,6 +44,7 @@ export const createSuiteDesktopCompositionRoot = (): SuiteDesktopCompositionRoot
         reloadApp,
         thpHostName: undefined,
         getTransportsFactories,
+        getTrezorConnect: () => TrezorConnect,
     });
     const hydrateReduxStore = createHydrateReduxStore({ store, reducer: rootReducer });
     const services = { ...suiteServices, store, hydrateReduxStore };

--- a/packages/suite-web/src/createSuiteWebCompositionRoot.ts
+++ b/packages/suite-web/src/createSuiteWebCompositionRoot.ts
@@ -2,6 +2,7 @@ import { createBrowserHistory } from 'history';
 
 import { createWebauthnPlatformEncryption } from '@suite/platform-encryption-webauthn';
 import { asGetter } from '@suite-common/dependency-injection';
+import TrezorConnect from '@trezor/connect';
 import type { CreateLogger } from '@trezor/connect-common';
 import { resolveConnectPath } from '@trezor/env-utils';
 import { BridgeTransport } from '@trezor/transport-common';
@@ -58,6 +59,7 @@ export const createSuiteWebCompositionRoot = (): SuiteWebCompositionRoot => {
         reloadApp,
         thpHostName: getWebThpHostName(),
         getTransportsFactories,
+        getTrezorConnect: () => TrezorConnect,
     });
     const hydrateReduxStore = createHydrateReduxStore({ store, reducer: rootReducer });
     const services = { ...suiteServices, store, hydrateReduxStore };

--- a/packages/suite/src/support/createSuiteCompositionRoot.ts
+++ b/packages/suite/src/support/createSuiteCompositionRoot.ts
@@ -47,7 +47,7 @@ import { type GetBinFilesBaseUrlDep, type ReloadAppDep } from '@suite-common/sui
 import { type ThpHostNameDep } from '@suite-common/thp';
 import { selectTradedAccountKeys } from '@suite-common/trading';
 import { selectAccountsByDeviceState } from '@suite-common/wallet-core';
-import TrezorConnect, { type CreateLoggerDep } from '@trezor/connect';
+import { type CreateLoggerDep, type GetTrezorConnectPrivilegedDep } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 
 import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
@@ -86,7 +86,8 @@ export type SuiteAppDeps = StoreAPIDep &
     GetBinFilesBaseUrlDep &
     ReloadAppDep &
     ThpHostNameDep &
-    GetTransportsFactoriesDep;
+    GetTransportsFactoriesDep &
+    GetTrezorConnectPrivilegedDep;
 
 export const selectSuiteServices = (services: any): SuiteServices => services;
 
@@ -95,7 +96,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         dispatch: deps.dispatch,
         getState: deps.getState,
         platformEncryption: deps.platformEncryption,
-        trezorConnect: TrezorConnect,
+        getTrezorConnect: deps.getTrezorConnect,
     });
 
     const analytics = createAnalytics();
@@ -122,7 +123,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         dispatch: deps.dispatch,
         getState: deps.getState,
         platformEncryption: deps.platformEncryption,
-        trezorConnect: TrezorConnect,
+        getTrezorConnect: deps.getTrezorConnect,
         ensureDelegatedIdentityKey,
         analytics,
         fetch: globalThis.fetch.bind(globalThis),
@@ -141,7 +142,9 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         dispatch: deps.dispatch,
         getState: deps.getState,
     });
-    const networkModules = createNetworksCompositionRoot({ getTrezorConnect: () => TrezorConnect });
+    const networkModules = createNetworksCompositionRoot({
+        getTrezorConnect: deps.getTrezorConnect,
+    });
     const networkModuleRepository = createNetworkModuleRepository({ networkModules });
     const getNetworkConfig = createGetNetworkConfig({ networkModuleRepository });
     const findNetworkSymbolForProtocol = createFindNetworkSymbolForProtocol({

--- a/suite-common/delegated-identity-key/package.json
+++ b/suite-common/delegated-identity-key/package.json
@@ -20,6 +20,7 @@
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
     }

--- a/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
+++ b/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
@@ -15,8 +15,8 @@ import { createSaveDelegatedIdentityKey } from './saveDelegatedIdentityKey';
 type DelegatedIdentityKeyCompositionRootDeps = {
     dispatch: Dispatch;
     getState: () => DeviceRootState;
-    trezorConnect: RetrieveDelegatedIdentityKeyFromDeviceDeps['trezorConnect'];
-} & PlatformEncryptionDep;
+} & PlatformEncryptionDep &
+    RetrieveDelegatedIdentityKeyFromDeviceDeps;
 
 export const delegatedIdentityKeyCompositionRoot = (
     deps: DelegatedIdentityKeyCompositionRootDeps,
@@ -31,7 +31,7 @@ export const delegatedIdentityKeyCompositionRoot = (
             ),
         }),
         retrieveDelegatedIdentityKeyFromDevice: createRetrieveDelegatedIdentityKeyFromDevice({
-            trezorConnect: deps.trezorConnect,
+            getTrezorConnect: deps.getTrezorConnect,
         }),
         saveDelegatedIdentityKey: createSaveDelegatedIdentityKey({
             dispatch: deps.dispatch,

--- a/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.test.ts
+++ b/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.test.ts
@@ -1,7 +1,7 @@
 import { type DeviceIdentity, asDeviceUniquePath } from '@trezor/connect';
+import { type GetTrezorConnect } from '@trezor/connect-common';
 
 import {
-    type RetrieveDelegatedIdentityKeyFromDeviceDeps,
     type RetrieveDelegatedIdentityKeyParams,
     createRetrieveDelegatedIdentityKeyFromDevice,
 } from './retrieveDelegatedIdentityKeyFromDevice';
@@ -12,19 +12,19 @@ const device123: RetrieveDelegatedIdentityKeyParams['device'] = {
     connected: true,
 };
 
-const connectSimple: RetrieveDelegatedIdentityKeyFromDeviceDeps['trezorConnect'] = {
+const mockGetTrezorConnect: GetTrezorConnect<'evoluGetDelegatedIdentityKey'> = () => ({
     evoluGetDelegatedIdentityKey: device =>
         Promise.resolve({
             device: device as DeviceIdentity,
             success: true,
             payload: { private_key: 'delegated-key-123' },
         }),
-};
+});
 
 describe(createRetrieveDelegatedIdentityKeyFromDevice.name, () => {
     it('calls TrezorConnect to get the delegated key', async () => {
         const retrieveDelegatedIdentityKeyFromDevice = createRetrieveDelegatedIdentityKeyFromDevice(
-            { trezorConnect: connectSimple },
+            { getTrezorConnect: mockGetTrezorConnect },
         );
 
         const result = await retrieveDelegatedIdentityKeyFromDevice({
@@ -36,9 +36,9 @@ describe(createRetrieveDelegatedIdentityKeyFromDevice.name, () => {
     });
 
     it('returns DeviceNotConnectedError without calling Connect when device is not connected', async () => {
-        const evoluGetDelegatedIdentityKey = jest.fn();
+        const getTrezorConnect = jest.fn();
         const retrieveDelegatedIdentityKeyFromDevice = createRetrieveDelegatedIdentityKeyFromDevice(
-            { trezorConnect: { evoluGetDelegatedIdentityKey } },
+            { getTrezorConnect },
         );
 
         const result = await retrieveDelegatedIdentityKeyFromDevice({
@@ -47,6 +47,6 @@ describe(createRetrieveDelegatedIdentityKeyFromDevice.name, () => {
 
         expect(result.success).toBe(false);
         expect(!result.success && result.error.type).toBe('DeviceNotConnectedError');
-        expect(evoluGetDelegatedIdentityKey).not.toHaveBeenCalled();
+        expect(getTrezorConnect).not.toHaveBeenCalled();
     });
 });

--- a/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts
+++ b/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts
@@ -12,7 +12,7 @@ import {
     type TrezorDeviceWithState,
     asDelegatedIdentityKey,
 } from '@suite-common/suite-types';
-import type TrezorConnect from '@trezor/connect';
+import { type GetTrezorConnectDep } from '@trezor/connect-common';
 import { type Result, err, ok } from '@trezor/type-utils';
 
 export type RetrieveDelegatedIdentityKeyParams = {
@@ -22,9 +22,8 @@ export type RetrieveDelegatedIdentityKeyParams = {
     >;
 };
 
-export type RetrieveDelegatedIdentityKeyFromDeviceDeps = {
-    trezorConnect: Pick<typeof TrezorConnect, 'evoluGetDelegatedIdentityKey'>;
-};
+export type RetrieveDelegatedIdentityKeyFromDeviceDeps =
+    GetTrezorConnectDep<'evoluGetDelegatedIdentityKey'>;
 
 type RetrieveDelegatedIdentityKeyFromDevice = (
     params: RetrieveDelegatedIdentityKeyParams,
@@ -50,7 +49,7 @@ export const createRetrieveDelegatedIdentityKeyFromDevice =
             );
         }
 
-        const result = await deps.trezorConnect.evoluGetDelegatedIdentityKey({
+        const result = await deps.getTrezorConnect().evoluGetDelegatedIdentityKey({
             device: {
                 path: device.path,
                 state: device.state,

--- a/suite-common/delegated-identity-key/tsconfig.json
+++ b/suite-common/delegated-identity-key/tsconfig.json
@@ -10,6 +10,9 @@
         { "path": "../platform-encryption" },
         { "path": "../suite-types" },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-common/suite-sync-quota-manager/src/createSuiteSyncQuotaManagerCompositionRoot.ts
+++ b/suite-common/suite-sync-quota-manager/src/createSuiteSyncQuotaManagerCompositionRoot.ts
@@ -2,7 +2,7 @@ import { type Dispatch } from '@reduxjs/toolkit';
 
 import { type DeviceRootState } from '@suite-common/device';
 import { type GetIsTorEnabledDep } from '@suite-common/suite-sync-types';
-import { type TrezorConnectCallable } from '@trezor/connect';
+import { type GetTrezorConnectDep } from '@trezor/connect-common';
 
 import { createPrepareChallengeSessionFetch } from './challenge/createPrepareChallengeSessionFetch';
 import { createEnsureQuota } from './createEnsureQuota';
@@ -33,8 +33,8 @@ import { generateSessionId } from './session/generateSessionId';
 type CreateSuiteSyncQuotaManagerCompositionRootDeps = {
     dispatch: Dispatch;
     getState: () => DeviceRootState & WithSuiteSyncQuotaManagerState;
-    trezorConnect: Pick<TrezorConnectCallable, 'evoluSignRegistrationRequest'>;
-} & GetDeviceForStaticSessionIdDep &
+} & GetTrezorConnectDep<'evoluSignRegistrationRequest'> &
+    GetDeviceForStaticSessionIdDep &
     GetIsTorEnabledDep &
     GetIsUsingTrezorRelayDep &
     FetchDep;
@@ -82,7 +82,7 @@ export const createSuiteSyncQuotaManagerCompositionRoot = (
         dispatch: deps.dispatch,
         prepareChallengeSessionFetch,
         registerDeviceFetch,
-        trezorConnect: deps.trezorConnect,
+        getTrezorConnect: deps.getTrezorConnect,
     });
 
     const ensureDeviceHasQuota = createEnsureDeviceHasQuota({

--- a/suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.test.ts
@@ -29,20 +29,20 @@ const deviceWithV2RegistrationRequest = mockSuiteDevice(
 
 describe(createRegisterDevice.name, () => {
     it('registers device using challenge session and Connect signature', async () => {
+        const evoluSignRegistrationRequest = jest.fn(() =>
+            Promise.resolve(
+                ok({
+                    certificate_chain: ['device-cert', 'ca-cert'],
+                    signature: 'device-signature',
+                }),
+            ),
+        );
         const deps = createMockDeps<RegisterDeviceDeps>({
             prepareChallengeSessionFetch: () =>
                 Promise.resolve(ok({ sessionId: 'session-123', challenge: 'aa55' })),
             registerDeviceFetch: () =>
                 Promise.resolve(ok({ totalStorageSize: 5000, unspentStorageSize: 1200 })),
-            trezorConnect: {
-                evoluSignRegistrationRequest: () =>
-                    Promise.resolve(
-                        ok({
-                            certificate_chain: ['device-cert', 'ca-cert'],
-                            signature: 'device-signature',
-                        }),
-                    ),
-            },
+            getTrezorConnect: () => ({ evoluSignRegistrationRequest }),
             dispatch: jest.fn(),
         });
 
@@ -53,7 +53,7 @@ describe(createRegisterDevice.name, () => {
 
         expect(result).toEqual(ok());
         expect(deps.prepareChallengeSessionFetch).toHaveBeenCalledWith();
-        expect(deps.trezorConnect.evoluSignRegistrationRequest).toHaveBeenCalledWith({
+        expect(evoluSignRegistrationRequest).toHaveBeenCalledWith({
             challenge_from_server: 'aa55',
             size_to_acquire: DEFAULT_DEVICE_SIZE_QUOTA,
             proof_of_delegated_identity:
@@ -81,7 +81,7 @@ describe(createRegisterDevice.name, () => {
                 Promise.resolve(ok({ sessionId: 'session-123', challenge: 'aa55' })),
             registerDeviceFetch: () =>
                 Promise.resolve(ok({ totalStorageSize: 5000, unspentStorageSize: 1200 })),
-            trezorConnect: {
+            getTrezorConnect: () => ({
                 evoluSignRegistrationRequest: () =>
                     Promise.resolve(
                         ok({
@@ -90,7 +90,7 @@ describe(createRegisterDevice.name, () => {
                             rotation_index: 42,
                         }),
                     ),
-            },
+            }),
             dispatch: jest.fn(),
         });
 
@@ -113,7 +113,7 @@ describe(createRegisterDevice.name, () => {
                 Promise.resolve(ok({ sessionId: 'session-123', challenge: 'aa55' })),
             registerDeviceFetch: () =>
                 Promise.resolve(ok({ totalStorageSize: 5000, unspentStorageSize: 1200 })),
-            trezorConnect: {
+            getTrezorConnect: () => ({
                 evoluSignRegistrationRequest: () =>
                     Promise.resolve(
                         ok({
@@ -121,7 +121,7 @@ describe(createRegisterDevice.name, () => {
                             signature: 'device-signature',
                         }),
                     ),
-            },
+            }),
             dispatch: jest.fn(),
         });
 
@@ -143,9 +143,7 @@ describe(createRegisterDevice.name, () => {
             prepareChallengeSessionFetch: () =>
                 Promise.resolve(err({ type: 'HttpError', code: 500, message: 'Internal error' })),
             registerDeviceFetch: null,
-            trezorConnect: {
-                evoluSignRegistrationRequest: null,
-            },
+            getTrezorConnect: null,
             dispatch: jest.fn(),
         });
 
@@ -161,5 +159,6 @@ describe(createRegisterDevice.name, () => {
             }),
         );
         expect(deps.registerDeviceFetch).not.toHaveBeenCalled();
+        expect(deps.getTrezorConnect).not.toHaveBeenCalled();
     });
 });

--- a/suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.ts
@@ -11,7 +11,7 @@ import {
     type DeviceErrorType,
     type TrezorDeviceWithState,
 } from '@suite-common/suite-types';
-import { type TrezorConnectCallable } from '@trezor/connect';
+import { type GetTrezorConnectDep } from '@trezor/connect-common';
 import { getFirmwareVersionArray } from '@trezor/device-utils';
 import { type Result, err, ok } from '@trezor/type-utils';
 import { versionUtils } from '@trezor/utils';
@@ -42,8 +42,8 @@ export type RegisterDevice = (
 
 export type RegisterDeviceDeps = {
     dispatch: Dispatch;
-    trezorConnect: Pick<TrezorConnectCallable, 'evoluSignRegistrationRequest'>;
-} & RegisterDeviceFetchDep &
+} & GetTrezorConnectDep<'evoluSignRegistrationRequest'> &
+    RegisterDeviceFetchDep &
     PrepareChallengeSessionFetchDep;
 
 export type RegisterDeviceDep = {
@@ -86,11 +86,13 @@ export const createRegisterDevice =
             return proofOfDelegatedIdentity;
         }
 
-        const registrationRequestResult = await deps.trezorConnect.evoluSignRegistrationRequest({
-            challenge_from_server: sessionChallenge.payload.challenge,
-            size_to_acquire: DEFAULT_DEVICE_SIZE_QUOTA,
-            proof_of_delegated_identity: proofOfDelegatedIdentity.payload,
-        });
+        const registrationRequestResult = await deps
+            .getTrezorConnect()
+            .evoluSignRegistrationRequest({
+                challenge_from_server: sessionChallenge.payload.challenge,
+                size_to_acquire: DEFAULT_DEVICE_SIZE_QUOTA,
+                proof_of_delegated_identity: proofOfDelegatedIdentity.payload,
+            });
 
         if (!registrationRequestResult.success) {
             return err(DeviceError(registrationRequestResult.error.message));

--- a/suite-common/suite-sync/package.json
+++ b/suite-common/suite-sync/package.json
@@ -34,6 +34,7 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/analytics-uploader": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -28,7 +28,7 @@ import {
 } from '@suite-common/suite-sync-types';
 import { type AccountsRootState, selectAccounts } from '@suite-common/wallet-core';
 import { type Analytics } from '@trezor/analytics-uploader';
-import type TrezorConnect from '@trezor/connect';
+import { type GetTrezorConnectDep } from '@trezor/connect-common';
 
 import { createEnsureSuiteSyncKeys } from './createEnsureSuiteSyncKeys';
 import { createSuiteSyncInternalErrorHandler } from './createSuiteSyncInternalErrorHandler';
@@ -83,8 +83,8 @@ type CreateSuiteSyncCompositionRootDeps = {
         SuiteSyncDataRootState;
     dispatch: Dispatch;
     subscribeError: SubscribeSuiteSyncInternalErrorHandler;
-    trezorConnect: Pick<typeof TrezorConnect, 'evoluGetNode' | 'evoluSignRegistrationRequest'>;
-} & OnStorageEnsuredDep &
+} & GetTrezorConnectDep<'evoluGetNode' | 'evoluSignRegistrationRequest'> &
+    OnStorageEnsuredDep &
     SuiteSyncAnalyticsDep &
     EnsureDelegatedIdentityKeyDep &
     CreateSuiteStorageDep &
@@ -113,7 +113,7 @@ export const createSuiteSyncCompositionRoot = (
             platformEncryption: deps.platformEncryption,
         }),
         retrieveSuiteSyncOwner: createRetrieveSuiteSyncOwner({
-            trezorConnect: deps.trezorConnect,
+            getTrezorConnect: deps.getTrezorConnect,
             createSuiteSyncOwner: deps.createSuiteSyncOwner,
         }),
         loadSuiteSyncOwnerFromState,
@@ -138,12 +138,14 @@ export const createSuiteSyncCompositionRoot = (
             getDeviceForStaticSessionId,
             getIsUsingTrezorRelay: () => isUsingTrezorServer(getRelayUrl()),
             getIsTorEnabled: deps.getIsTorEnabled,
-            trezorConnect: deps.trezorConnect,
+            getTrezorConnect: deps.getTrezorConnect,
             fetch: deps.fetch,
         });
 
     const suiteSyncInternalErrorHandler = createSuiteSyncInternalErrorHandler({
         getSelectedDevice: toGetter(deps.getState, selectSelectedDevice),
+        getRelayUrl,
+        suiteSyncStorageRepository,
         allocateOwnerQuota,
         ensureDelegatedIdentityKey: deps.ensureDelegatedIdentityKey,
         suiteSyncUncontrolledErrorHandler: deps.suiteSyncUncontrolledErrorHandler,

--- a/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts
@@ -2,6 +2,7 @@ import { createMockDeps } from '@suite-common/dependency-injection';
 import { DeviceError } from '@suite-common/device';
 import { type AllocateOwnerQuotaErr } from '@suite-common/suite-sync-quota-manager';
 import { asSuiteSyncOwnerId } from '@suite-common/suite-sync-storage';
+import { mockSuiteSyncStorage } from '@suite-common/suite-sync-storage/mocks';
 import {
     type DeviceErrorType,
     type TrezorDevice,
@@ -33,6 +34,8 @@ const createDevice = (overrides: Partial<TrezorDevice> = {}): TrezorDevice =>
 describe(createSuiteSyncInternalErrorHandler.name, () => {
     it('propagates a device error when no selected device is available', async () => {
         const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
+            getRelayUrl: null,
+            suiteSyncStorageRepository: { get: null, set: null, delete: null },
             allocateOwnerQuota: null,
             ensureDelegatedIdentityKey: null,
             suiteSyncUncontrolledErrorHandler: () => undefined,
@@ -51,14 +54,22 @@ describe(createSuiteSyncInternalErrorHandler.name, () => {
         expect(deps.allocateOwnerQuota).not.toHaveBeenCalled();
     });
 
-    it('retrieves delegated key and allocates additional owner quota for RelayQuotaExceeded', async () => {
+    it('resumes syncing after allocating additional owner quota for RelayQuotaExceeded', async () => {
         const device = createDevice();
+        const updateRelayUrl = jest.fn(() => Promise.resolve());
+        const storage = mockSuiteSyncStorage({ updateRelayUrl });
         const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
             allocateOwnerQuota: () => Promise.resolve(ok()),
             ensureDelegatedIdentityKey: () =>
                 Promise.resolve(ok(asDelegatedIdentityKey('delegated-key'))),
             suiteSyncUncontrolledErrorHandler: () => undefined,
             getSelectedDevice: () => device,
+            getRelayUrl: () => 'https://relay.example.com',
+            suiteSyncStorageRepository: {
+                get: () => storage,
+                set: null,
+                delete: null,
+            },
         });
 
         const handleError = createSuiteSyncInternalErrorHandler(deps);
@@ -74,12 +85,32 @@ describe(createSuiteSyncInternalErrorHandler.name, () => {
             isWriteMode: true,
         });
         expect(deps.suiteSyncUncontrolledErrorHandler).not.toHaveBeenCalled();
+        expect(deps.suiteSyncStorageRepository.get).toHaveBeenCalledWith(walletDescriptor);
+        expect(updateRelayUrl).toHaveBeenCalledWith('https://relay.example.com');
+    });
+
+    it('does not reconnect when wallet storage was removed during the top-up', async () => {
+        const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
+            allocateOwnerQuota: () => Promise.resolve(ok()),
+            ensureDelegatedIdentityKey: () =>
+                Promise.resolve(ok(asDelegatedIdentityKey('delegated-key'))),
+            suiteSyncUncontrolledErrorHandler: null,
+            getSelectedDevice: () => createDevice(),
+            getRelayUrl: null,
+            suiteSyncStorageRepository: { get: () => null, set: null, delete: null },
+        });
+
+        await createSuiteSyncInternalErrorHandler(deps)({ type: 'RelayQuotaExceeded', ownerId });
+
+        expect(deps.getRelayUrl).not.toHaveBeenCalled();
     });
 
     it('propagates delegated key retrieval failures', async () => {
         const device = createDevice();
         const deviceError: DeviceErrorType = DeviceError('Delegated key failed');
         const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
+            getRelayUrl: null,
+            suiteSyncStorageRepository: { get: null, set: null, delete: null },
             allocateOwnerQuota: null,
             ensureDelegatedIdentityKey: () => Promise.resolve(err(deviceError)),
             suiteSyncUncontrolledErrorHandler: () => undefined,
@@ -105,6 +136,8 @@ describe(createSuiteSyncInternalErrorHandler.name, () => {
         };
 
         const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
+            getRelayUrl: null,
+            suiteSyncStorageRepository: { get: null, set: null, delete: null },
             allocateOwnerQuota: () => Promise.resolve(err(allocationError)),
             ensureDelegatedIdentityKey: () =>
                 Promise.resolve(ok(asDelegatedIdentityKey('delegated-key'))),
@@ -127,6 +160,8 @@ describe(createSuiteSyncInternalErrorHandler.name, () => {
         const relayError = { type: 'RelayOther', message: 'relay failed' } as const;
 
         const deps = createMockDeps<SuiteSyncInternalErrorHandlerDeps>({
+            getRelayUrl: null,
+            suiteSyncStorageRepository: { get: null, set: null, delete: null },
             allocateOwnerQuota: null,
             ensureDelegatedIdentityKey: null,
             suiteSyncUncontrolledErrorHandler: () => undefined,

--- a/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.ts
@@ -1,20 +1,26 @@
 import { type EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-key-types';
 import { DeviceError, isTrezorDeviceWithState } from '@suite-common/device';
 import { type AllocateOwnerQuotaDep } from '@suite-common/suite-sync-quota-manager';
-import { type Errors, type SuiteSyncInternalErrorHandler } from '@suite-common/suite-sync-types';
+import {
+    type Errors,
+    type SuiteSyncInternalErrorHandler,
+    type SuiteSyncStorageRepositoryDep,
+} from '@suite-common/suite-sync-types';
 import { type TrezorDevice, asDelegatedIdentityKey } from '@suite-common/suite-types';
 import { parseStaticSessionId } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
 
+import { createStorageIdFromDeviceStaticSessionId } from './storage/createStorageIdFromDeviceStaticSessionId';
 import { type SuiteSyncUncontrolledErrorHandlerDep } from './suiteSyncUncontrolledErrorHandler';
 
 type GetSelectedDevice = () => TrezorDevice | undefined;
 
 export type SuiteSyncInternalErrorHandlerDeps = AllocateOwnerQuotaDep &
     EnsureDelegatedIdentityKeyDep &
+    SuiteSyncStorageRepositoryDep &
     SuiteSyncUncontrolledErrorHandlerDep &
     // Todo: temporary, see: https://github.com/trezor/trezor-suite/issues/27049
-    { getSelectedDevice: GetSelectedDevice };
+    { getSelectedDevice: GetSelectedDevice; getRelayUrl: () => string };
 
 /**
  * Responsibility of this service is to map errors from Storage to the SuiteSync
@@ -64,7 +70,17 @@ export const createSuiteSyncInternalErrorHandler =
 
                 if (!result.success) {
                     deps.suiteSyncUncontrolledErrorHandler({ error: result.error, device });
+
+                    return;
                 }
+
+                const storageId = createStorageIdFromDeviceStaticSessionId(
+                    device.state.staticSessionId,
+                );
+                const storage = deps.suiteSyncStorageRepository.get(storageId);
+
+                // The relay rejected the write; reconnect to sync pending labels after the top-up.
+                await storage?.updateRelayUrl(deps.getRelayUrl());
 
                 return;
             }

--- a/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.test.ts
+++ b/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.test.ts
@@ -6,10 +6,10 @@ import {
 } from '@suite-common/suite-sync-storage';
 import { asDelegatedIdentityKey } from '@suite-common/suite-types';
 import { asDeviceUniquePath } from '@trezor/connect';
+import { type GetTrezorConnect } from '@trezor/connect-common';
 import { ok } from '@trezor/type-utils';
 
 import {
-    type RetrieveSuiteSyncOwnerDeps,
     type RetrieveSuiteSyncOwnerParams,
     createRetrieveSuiteSyncOwner,
 } from './createRetrieveSuiteSyncOwner';
@@ -29,19 +29,19 @@ const owner1: SuiteSyncOwner = {
     ownerSecret: asSuiteSyncOwnerSecretHex('owner1secretHex'),
 };
 
-const trezorConnect: RetrieveSuiteSyncOwnerDeps['trezorConnect'] = {
+const mockGetTrezorConnect: GetTrezorConnect<'evoluGetNode'> = () => ({
     evoluGetNode: () =>
         Promise.resolve({
             payload: { data: 'evoluNodeData' },
             success: true,
         }),
-};
+});
 
 describe(createRetrieveSuiteSyncOwner.name, () => {
     it('succeeds for valid delegated key', async () => {
         const ensureSuiteSyncOwner = createRetrieveSuiteSyncOwner({
             createSuiteSyncOwner: () => ok(owner1),
-            trezorConnect,
+            getTrezorConnect: mockGetTrezorConnect,
         });
 
         const result = await ensureSuiteSyncOwner({ device, delegatedKey: DELEGATED_IDENTITY_KEY });
@@ -53,7 +53,7 @@ describe(createRetrieveSuiteSyncOwner.name, () => {
     it('fails for invalid DelegatedIdentityKey', async () => {
         const ensureSuiteSyncOwner = createRetrieveSuiteSyncOwner({
             createSuiteSyncOwner: () => ok(owner1),
-            trezorConnect,
+            getTrezorConnect: mockGetTrezorConnect,
         });
 
         const delegatedKey = asDelegatedIdentityKey('delegated-broke-key');
@@ -65,10 +65,10 @@ describe(createRetrieveSuiteSyncOwner.name, () => {
     });
 
     it('returns DeviceNotConnectedError without calling Connect when device is not connected', async () => {
-        const evoluGetNode = jest.fn();
+        const getTrezorConnect = jest.fn();
         const ensureSuiteSyncOwner = createRetrieveSuiteSyncOwner({
             createSuiteSyncOwner: () => ok(owner1),
-            trezorConnect: { evoluGetNode },
+            getTrezorConnect,
         });
 
         const result = await ensureSuiteSyncOwner({
@@ -78,6 +78,6 @@ describe(createRetrieveSuiteSyncOwner.name, () => {
 
         expect(result.success).toBe(false);
         expect(!result.success && result.error.type).toBe('DeviceNotConnectedError');
-        expect(evoluGetNode).not.toHaveBeenCalled();
+        expect(getTrezorConnect).not.toHaveBeenCalled();
     });
 });

--- a/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts
@@ -12,7 +12,7 @@ import {
     type DeviceNotConnectedErrorType,
     type TrezorDeviceWithState,
 } from '@suite-common/suite-types';
-import type TrezorConnect from '@trezor/connect';
+import { type GetTrezorConnectDep } from '@trezor/connect-common';
 import { type Result, err } from '@trezor/type-utils';
 
 const PROOF_OF_DELEGATED_IDENTITY_HEADER = 'EvoluGetNode';
@@ -27,8 +27,7 @@ export type RetrieveSuiteSyncOwnerParams = {
 
 export type RetrieveSuiteSyncOwnerDeps = {
     createSuiteSyncOwner: CreateSuiteSyncOwner;
-    trezorConnect: Pick<typeof TrezorConnect, 'evoluGetNode'>;
-};
+} & GetTrezorConnectDep<'evoluGetNode'>;
 
 export type RetrieveSuiteSyncOwner = (
     params: RetrieveSuiteSyncOwnerParams,
@@ -66,7 +65,7 @@ export const createRetrieveSuiteSyncOwner =
             return proofOfDelegatedIdentity;
         }
 
-        const result = await deps.trezorConnect.evoluGetNode({
+        const result = await deps.getTrezorConnect().evoluGetNode({
             device: {
                 path: device.path,
                 state: device.state,

--- a/suite-common/suite-sync/tsconfig.json
+++ b/suite-common/suite-sync/tsconfig.json
@@ -27,6 +27,9 @@
             "path": "../../packages/analytics-uploader"
         },
         { "path": "../../packages/connect" },
+        {
+            "path": "../../packages/connect-common"
+        },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/type-utils" },

--- a/suite-native/app/src/createSuiteNativeCompositionRoot.ts
+++ b/suite-native/app/src/createSuiteNativeCompositionRoot.ts
@@ -10,6 +10,7 @@ import {
     prepareRootReducers,
 } from '@suite-native/state';
 import { createEnsureEncryptionKey, createMMKVStorage } from '@suite-native/storage';
+import TrezorConnect from '@trezor/connect';
 
 import { type NativeApp, createNativeApp } from './createNativeApp';
 
@@ -38,6 +39,7 @@ export const createSuiteNativeCompositionRoot = (
         getState: store.getState,
         ensureEncryptionKey,
         mmkvStorage,
+        getTrezorConnect: () => TrezorConnect,
     });
     const storePersistor = createStorePersistor({ store });
     const hydrateReduxStore = createHydrateReduxStore({ storePersistor });

--- a/suite-native/state/src/createNativeServicesCompositionRoot.ts
+++ b/suite-native/state/src/createNativeServicesCompositionRoot.ts
@@ -31,7 +31,7 @@ import type {
 } from '@suite-native/storage';
 import { createSuiteSyncNativeCompositionRoot } from '@suite-native/suite-sync';
 import { selectTradedAccountKeys, selectTradingEnvironment } from '@suite-native/trading-state';
-import TrezorConnect, { type ConnectSettings, initLog } from '@trezor/connect';
+import { type ConnectSettings, type GetTrezorConnectPrivilegedDep, initLog } from '@trezor/connect';
 import { resolveConnectPath } from '@trezor/env-utils';
 import { BridgeTransport } from '@trezor/transport-common';
 import { NativeBluetoothTransport } from '@trezor/transport-native-bluetooth';
@@ -57,7 +57,8 @@ const transports = transportsPerDeviceType[deviceType];
 
 type NativeAppDeps = Pick<NativeReduxStore, 'getState' | 'dispatch'> &
     EnsureEncryptionKeyDep &
-    NativeStorageDep;
+    NativeStorageDep &
+    GetTrezorConnectPrivilegedDep;
 
 export const createNativeServicesCompositionRoot = (deps: NativeAppDeps): NativeServices => {
     const platformEncryption = createNativePlatformEncryption({
@@ -67,14 +68,14 @@ export const createNativeServicesCompositionRoot = (deps: NativeAppDeps): Native
         dispatch: deps.dispatch,
         getState: deps.getState,
         platformEncryption,
-        trezorConnect: TrezorConnect,
+        getTrezorConnect: deps.getTrezorConnect,
     });
 
     const suiteSync = createSuiteSyncNativeCompositionRoot({
         dispatch: deps.dispatch,
         getState: deps.getState,
         platformEncryption,
-        trezorConnect: TrezorConnect,
+        getTrezorConnect: deps.getTrezorConnect,
         ensureDelegatedIdentityKey,
         analytics,
         fetch: globalThis.fetch.bind(globalThis),
@@ -88,7 +89,9 @@ export const createNativeServicesCompositionRoot = (deps: NativeAppDeps): Native
         updateAddressLabel: suiteSync.labeling.updateAddressLabel,
         updateOutputLabel: suiteSync.labeling.updateOutputLabel,
     });
-    const networkModules = createNetworksCompositionRoot({ getTrezorConnect: () => TrezorConnect });
+    const networkModules = createNetworksCompositionRoot({
+        getTrezorConnect: deps.getTrezorConnect,
+    });
     const networkModuleRepository = createNetworkModuleRepository({ networkModules });
     const getNetworkConfig = createGetNetworkConfig({ networkModuleRepository });
     const findNetworkSymbolForProtocol = createFindNetworkSymbolForProtocol({

--- a/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
+++ b/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
@@ -17,13 +17,13 @@ import {
 } from '@suite-common/suite-sync-evolu';
 import { type FetchDep } from '@suite-common/suite-sync-quota-manager';
 import { type SuiteSync } from '@suite-common/suite-sync-types';
-import { type TrezorConnectPrivilegedAPI } from '@trezor/connect';
+import { type GetTrezorConnectPrivilegedDep } from '@trezor/connect';
 
 type SuiteSyncNativeCompositionRootDeps = {
     getState: () => any;
     dispatch: Dispatch;
-    trezorConnect: TrezorConnectPrivilegedAPI;
-} & SuiteSyncAnalyticsDep &
+} & GetTrezorConnectPrivilegedDep &
+    SuiteSyncAnalyticsDep &
     PlatformEncryptionDep &
     EnsureDelegatedIdentityKeyDep &
     FetchDep;

--- a/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
+++ b/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
@@ -12,7 +12,7 @@ import {
 import { evoluCreateSuiteSyncOwner } from '@suite-common/suite-sync-evolu';
 import { type FetchDep } from '@suite-common/suite-sync-quota-manager';
 import { type OnStorageEnsured, type SuiteSync } from '@suite-common/suite-sync-types';
-import { type TrezorConnectPrivilegedAPI } from '@trezor/connect';
+import { type GetTrezorConnectPrivilegedDep } from '@trezor/connect';
 
 import { createEvoluDeps } from './evolu/createEvoluDeps';
 import { suiteSyncErrorHandler } from './suiteSyncErrorHandler';
@@ -21,9 +21,9 @@ import { createTurnOnDesktopSuiteSync } from './turnOnDesktopSuiteSync';
 type SuiteSyncDesktopCompositionRootDeps = {
     getState: () => any;
     dispatch: Dispatch;
-    trezorConnect: TrezorConnectPrivilegedAPI;
     onStorageEnsured: OnStorageEnsured;
-} & PlatformEncryptionDep &
+} & GetTrezorConnectPrivilegedDep &
+    PlatformEncryptionDep &
     EnsureDelegatedIdentityKeyDep &
     DesktopAnalyticsDep &
     FetchDep;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10739,6 +10739,7 @@ __metadata:
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
   languageName: unknown
@@ -11394,6 +11395,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/analytics-uploader": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
@@ -17321,6 +17323,7 @@ __metadata:
     "@noble/hashes": "npm:^2.0.1"
     "@suite-common/calldata": "workspace:*"
     "@suite-common/dependency-injection": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/network-ethereum": "workspace:*"
     "@trezor/network-module-suite-common-types": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
## Description

Follow up on #32362 by injecting Connect from web, desktop, and native app roots through getTrezorConnect into network modules and Suite Sync services. Connect-common owns the getter contracts: composition roots use the full privileged API, while individual services declare the methods they need. Resume syncing pending labels after successful quota top-ups to fix the pre-existing web and desktop E2E failure.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in two functional areas: (1) Suite Sync initialization, delegated identity key retrieval, and quota management, and (2) Ethereum ENS named-address resolution. The broad composition-root files are global wiring, but the co-changed Suite Sync-specific composition roots indicate the main runtime risk is in the sync flow. Recommend running the focused Suite Sync and ENS tests rather than the full 142-test set mapped to the global roots. Type-only and native/desktop-specific files have no web E2E coverage.

<details><summary><b>Changed files (32)</b></summary>

- `networks/ethereum/network-ethereum-suite-common/package.json`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/createCallEnsUniversalResolver.ts`
- `networks/ethereum/network-ethereum-suite-common/src/namedAddress/createResolveNamedAddressViaBlockbook.ts`
- `networks/ethereum/network-ethereum-suite-common/tsconfig.json`
- `networks/ethereum/network-ethereum-suite-common/tsconfig.lib.json`
- `networks/network-module/network-module-suite-common-types/mocks/mockGetTrezorConnect.ts`
- `networks/network-module/network-module-suite-common-types/src/NetworkSuiteCommonModuleApi.ts`
- `networks/network-module/network-module-suite-common-types/src/index.ts`
- `packages/connect-common/src/types/getTrezorConnect.ts`
- `packages/connect-common/src/types/index.ts`
- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`
- `packages/suite-web/src/createSuiteWebCompositionRoot.ts`
- `packages/suite/src/support/createSuiteCompositionRoot.ts`
- `suite-common/delegated-identity-key/package.json`
- `suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts`
- `suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.test.ts`
- `suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.ts`
- `suite-common/delegated-identity-key/tsconfig.json`
- `suite-common/suite-sync-quota-manager/src/createSuiteSyncQuotaManagerCompositionRoot.ts`
- `suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.test.ts`
- `suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.ts`
- `suite-common/suite-sync/package.json`
- `suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts`
- `suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts`
- `suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.ts`
- `suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.test.ts`
- `suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.ts`
- `suite-common/suite-sync/tsconfig.json`
- `suite-native/app/src/createSuiteNativeCompositionRoot.ts`
- `suite-native/state/src/createNativeServicesCompositionRoot.ts`
- `suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts`
- `suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Directly exercises the Suite Sync write path (account/wallet/address/output labels) and Evolu relay sync, which depends on the suite-sync composition root, delegated identity key retrieval, and owner retrieval changed files.
- `suite/e2e/tests/metadata/suite-sync/quota-manager.test.ts` — Directly tests the suite-sync-quota-manager device registration and quota top-up logic, including DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA and device unspent storage tracking changed in createRegisterDevice and the quota manager composition root.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Validates the full Suite Sync setup flow including device confirmation for key derivation, quota manager seeding, and label sync from the Evolu relay, touching the delegated identity key, sync composition root, and owner retrieval changes.
- `suite/e2e/tests/wallet/send-ens.test.ts` — Directly tests the changed Ethereum ENS named-address resolution logic, including forward resolution via the Universal Resolver and Blockbook fallback path implemented in createCallEnsUniversalResolver and createResolveNamedAddressViaBlockbook.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Tests migrating legacy labels into Suite Sync and enabling Suite Sync afterwards, which exercises the sync composition root, owner retrieval, and delegated identity key setup paths.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Covers Suite Sync with multiple passphrase wallets and banner state transitions, which relies on the sync composition root and delegated identity key retrieval from the device.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — Verifies Suite Sync setup behavior and banner persistence on unsupported devices, which depends on the sync composition root and internal error handling changes.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Exercises Suite Sync label mutations and relay synchronization for account, wallet, address, and output labels, relying on the sync composition root and owner retrieval logic.

</details>

⚠️ **Changes with no test coverage (21)**
- `networks/ethereum/network-ethereum-suite-common/package.json`
- `networks/ethereum/network-ethereum-suite-common/tsconfig.json`
- `networks/ethereum/network-ethereum-suite-common/tsconfig.lib.json`
- `networks/network-module/network-module-suite-common-types/mocks/mockGetTrezorConnect.ts`
- `networks/network-module/network-module-suite-common-types/src/NetworkSuiteCommonModuleApi.ts`
- `networks/network-module/network-module-suite-common-types/src/index.ts`
- `packages/connect-common/src/types/getTrezorConnect.ts`
- `packages/connect-common/src/types/index.ts`
- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`
- `suite-common/delegated-identity-key/package.json`
- `suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.test.ts`
- `suite-common/delegated-identity-key/tsconfig.json`
- `suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.test.ts`
- `suite-common/suite-sync/package.json`
- `suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts`
- `suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.test.ts`
- `suite-common/suite-sync/tsconfig.json`
- `suite-native/app/src/createSuiteNativeCompositionRoot.ts`
- `suite-native/state/src/createNativeServicesCompositionRoot.ts`
- `suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts`
- `suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts`

_Updated: 2026-09-11T11:34:37.508Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/suite-connect-dependency/web/](https://dev.suite.sldev.cz/suite-web/refactor/suite-connect-dependency/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-connect-dependency&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-connect-dependency&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T11:37:45.563Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T11:36:47.817Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->