### PR TITLE
fix(suite-common): add fake pending tx after tron send

### DIFF
--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -110,6 +110,7 @@ import { type TransactionsRootState } from '../transactions/transactionsReducerT
 import {
     addFakePendingCardanoTxThunk,
     addFakePendingEvmTxThunk,
+    addFakePendingTronSendTxThunk,
     addFakePendingTxThunk,
 } from '../transactions/transactionsThunks';
 import {
@@ -348,57 +349,83 @@ export const synchronizeSentTransactionThunk = createThunk<
                 );
                 dispatch(accountsActions.updateAccount(pendingAccount));
             }
-        } else if (selectedAccount.networkType === 'bitcoin') {
-            dispatch(
-                addFakePendingTxThunk({
-                    precomposedTransaction,
-                    account: selectedAccount,
-                }),
-            );
-        } else if (selectedAccount.networkType === 'ethereum') {
-            // manually add fake pending tx as we don't have the data about mempool txs
-            dispatch(
-                addFakePendingEvmTxThunk({
-                    precomposedTransaction,
-                    precomposedForm,
-                    txid,
-                    account: selectedAccount,
-                    ethereumNonce,
-                }),
-            );
-            dispatch(accountsActions.updateAccount(selectedAccount));
 
-            // EVM cancel/bump: when the precomposed tx replaces a prior pending tx (identified by
-            // prevTxid), evict the old tx from the store immediately. The backend notification is
-            // delayed, and keeping the replaced tx visible would show the user a stale pending entry.
-            // blockchainGetTransactions is called to confirm the old tx is truly gone from the
-            // mempool before the local removal takes effect; its response is not awaited because we
-            // dispatch removeTransaction optimistically and the backend will correct any discrepancy
-            // on the next account sync.
-            if ('prevTxid' in precomposedTransaction && precomposedTransaction.prevTxid) {
-                const { prevTxid } = precomposedTransaction;
-                void TrezorConnect.blockchainGetTransactions({
-                    txs: [prevTxid],
-                    coin: asCoinSymbol(selectedAccount.symbol),
-                });
+            return;
+        }
+
+        const { networkType } = selectedAccount;
+
+        switch (networkType) {
+            case 'bitcoin':
                 dispatch(
-                    transactionsActions.removeTransaction({
+                    addFakePendingTxThunk({
+                        precomposedTransaction,
                         account: selectedAccount,
-                        txs: [{ txid: prevTxid }],
                     }),
                 );
-            }
+                break;
+            case 'ethereum':
+                // manually add fake pending tx as we don't have the data about mempool txs
+                dispatch(
+                    addFakePendingEvmTxThunk({
+                        precomposedTransaction,
+                        precomposedForm,
+                        txid,
+                        account: selectedAccount,
+                        ethereumNonce,
+                    }),
+                );
+                dispatch(accountsActions.updateAccount(selectedAccount));
 
-            // Kick the periodic sync chain: external-backend EVM networks get no block-driven
-            // syncs and the confirmation notification can be missed, so the self-re-arming
-            // per-symbol sync is the guaranteed path from pending to confirmed — make sure it
-            // is running now that a pending tx exists. The fake pending tx added above carries
-            // a deadline, so the immediate fetch keeps it until the backend picks up the real tx.
-            dispatch(syncAccountsWithBlockchainThunk(selectedAccount.symbol));
-        } else {
-            // there is no point in fetching account data right after tx submit
-            //  as the account will update only after the tx is confirmed
-            dispatch(syncAccountsWithBlockchainThunk(selectedAccount.symbol));
+                // EVM cancel/bump: when the precomposed tx replaces a prior pending tx (identified by
+                // prevTxid), evict the old tx from the store immediately. The backend notification is
+                // delayed, and keeping the replaced tx visible would show the user a stale pending entry.
+                // blockchainGetTransactions is called to confirm the old tx is truly gone from the
+                // mempool before the local removal takes effect; its response is not awaited because we
+                // dispatch removeTransaction optimistically and the backend will correct any discrepancy
+                // on the next account sync.
+                if ('prevTxid' in precomposedTransaction && precomposedTransaction.prevTxid) {
+                    const { prevTxid } = precomposedTransaction;
+                    void TrezorConnect.blockchainGetTransactions({
+                        txs: [prevTxid],
+                        coin: asCoinSymbol(selectedAccount.symbol),
+                    });
+                    dispatch(
+                        transactionsActions.removeTransaction({
+                            account: selectedAccount,
+                            txs: [{ txid: prevTxid }],
+                        }),
+                    );
+                }
+
+                // Kick the periodic sync chain: external-backend EVM networks get no block-driven
+                // syncs and the confirmation notification can be missed, so the self-re-arming
+                // per-symbol sync is the guaranteed path from pending to confirmed — make sure it
+                // is running now that a pending tx exists. The fake pending tx added above carries
+                // a deadline, so the immediate fetch keeps it until the backend picks up the real tx.
+                dispatch(syncAccountsWithBlockchainThunk(selectedAccount.symbol));
+                break;
+            case 'tron':
+                dispatch(
+                    addFakePendingTronSendTxThunk({
+                        precomposedTransaction,
+                        txid,
+                        account: selectedAccount,
+                    }),
+                );
+
+                dispatch(syncAccountsWithBlockchainThunk(selectedAccount.symbol));
+                break;
+            case 'cardano':
+            case 'ripple':
+            case 'solana':
+            case 'stellar':
+                // there is no point in fetching account data right after tx submit
+                //  as the account will update only after the tx is confirmed
+                dispatch(syncAccountsWithBlockchainThunk(selectedAccount.symbol));
+                break;
+            default:
+                exhaustive(networkType);
         }
     },
 );

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -11,6 +11,7 @@ import {
     type WalletAccountTransaction,
 } from '@suite-common/wallet-types';
 import {
+    calculateTronFeeBreakdown,
     enhanceTransaction,
     ensureHexPrefix,
     findAccountsByAddress,
@@ -19,6 +20,7 @@ import {
     getEvmTransactionTextSignature,
     getPendingAccount,
     getRbfParams,
+    getTronResources,
     isEip1559,
     isEvmYieldTxByTextSignature,
     isRbfBumpFeeTransaction,
@@ -506,6 +508,7 @@ interface AddFakePendingTronTxThunkParams {
     fee: string;
     type: WalletAccountTransaction['type'];
     target?: { addresses: string[]; amount: string };
+    tokens?: WalletAccountTransaction['tokens'];
     tronSpecific?: WalletAccountTransaction['tronSpecific'];
 }
 
@@ -517,7 +520,10 @@ export const addFakePendingTronTxThunk = createThunk<
     { state: AddFakePendingTronTxThunkState }
 >(
     `${TRANSACTIONS_MODULE_PREFIX}/addFakePendingTransaction`,
-    ({ txid, account, amount, fee, type, target, tronSpecific }, { dispatch, getState }) => {
+    (
+        { txid, account, amount, fee, type, target, tokens, tronSpecific },
+        { dispatch, getState },
+    ) => {
         if (account.networkType !== 'tron') return;
 
         const blockTime = selectRawNetworkFeeInfo(getState(), account.symbol)?.blockTime ?? 0;
@@ -535,21 +541,19 @@ export const addFakePendingTronTxThunk = createThunk<
             targets: target
                 ? [{ n: 0, addresses: target.addresses, isAddress: true, amount: target.amount }]
                 : [],
-            tokens: [],
+            tokens: tokens ?? [],
             internalTransfers: [],
             tronSpecific,
             details: {
-                vin: target
-                    ? [
-                          {
-                              n: 0,
-                              addresses: target.addresses,
-                              isAddress: true,
-                              isOwn: true,
-                              isAccountOwned: true,
-                          },
-                      ]
-                    : [],
+                vin: [
+                    {
+                        n: 0,
+                        addresses: [account.descriptor],
+                        isAddress: true,
+                        isOwn: true,
+                        isAccountOwned: true,
+                    },
+                ],
                 vout: target
                     ? [{ value: target.amount, n: 0, addresses: target.addresses, isAddress: true }]
                     : [],
@@ -560,6 +564,69 @@ export const addFakePendingTronTxThunk = createThunk<
             deadline,
         };
         dispatch(transactionsActions.addTransaction({ transactions: [fakeTx], account }));
+    },
+);
+
+interface AddFakePendingTronSendTxThunkParams {
+    precomposedTransaction: PrecomposedTransactionFinal;
+    txid: string;
+    account: Account;
+}
+
+type AddFakePendingTronSendTxThunkState = AddFakePendingTronTxThunkState;
+
+export const addFakePendingTronSendTxThunk = createThunk<
+    void,
+    AddFakePendingTronSendTxThunkParams,
+    { state: AddFakePendingTronSendTxThunkState }
+>(
+    `${TRANSACTIONS_MODULE_PREFIX}/addFakePendingTransaction`,
+    ({ precomposedTransaction, txid, account }, { dispatch }) => {
+        const [output] = precomposedTransaction.outputs;
+        const { token } = precomposedTransaction;
+        const recipient = output?.address;
+        const outputAmount = output?.amount?.toString() ?? '0';
+        const feeBreakdown = calculateTronFeeBreakdown(
+            precomposedTransaction,
+            getTronResources(account),
+            account.symbol,
+        );
+
+        const tokenTransfer: TokenTransfer | undefined =
+            token && recipient
+                ? {
+                      type: 'sent',
+                      standard: token.standard,
+                      amount: outputAmount,
+                      from: account.descriptor,
+                      to: recipient,
+                      contract: token.contract,
+                      name: token.name,
+                      symbol: token.symbol,
+                      decimals: token.decimals,
+                  }
+                : undefined;
+
+        dispatch(
+            addFakePendingTronTxThunk({
+                account,
+                txid,
+                amount: token ? '0' : outputAmount,
+                fee: precomposedTransaction.fee,
+                type: 'sent',
+                target:
+                    recipient && !token
+                        ? { addresses: [recipient], amount: outputAmount }
+                        : undefined,
+                tokens: tokenTransfer ? [tokenTransfer] : [],
+                tronSpecific: {
+                    contractType: token ? 'TriggerSmartContract' : 'TransferContract',
+                    bandwidthUsage: feeBreakdown
+                        ? feeBreakdown.coveredBandwidth.toString()
+                        : undefined,
+                },
+            }),
+        );
     },
 );
 


### PR DESCRIPTION
## Description

Sending TRX produced no pending transaction. TRON fell through to the generic branch in `synchronizeSentTransactionThunk`, which only syncs the account. On mobile the send flow waits for the tx in the store, so it hung on "Confirm on Trezor" until confirmation.

Adds `addFakePendingTronSendTxThunk`, mirroring the EVM/Cardano ones.

## Notes for QA

## Related Issue

Resolve #32326

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-send-pending-tx/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-send-pending-tx/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files are broad, global thunk dependencies (142 static references each), so the strategy focuses narrowly on tests that directly send transactions or manage transaction data. The highest risk is in the core send form flows (BTC, ETH, SOL, DOGE, LTC, ENS, CSV import) and transaction listing/export. Trading sell/swap tests are included at medium priority because they ultimately invoke the same send/transaction paths. No changed files lack coverage entirely.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/send/sendFormThunks.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — Directly exercises the send form for DOGE, including amount validation, fee display, and device confirmation paths that are handled by sendFormThunks. A regression in transaction composition or signing would be immediately visible here.
- `suite/e2e/tests/wallet/send-ens.test.ts` — Tests ENS name resolution inside the send form's address input. sendFormThunks manages send form state and address handling, so changes to it could break forward/reverse ENS resolution behavior.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly fills and submits an Ethereum send transaction with custom gas fees, then verifies device prompt values derived from composed transaction data. This is a core sendFormThunks code path.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests the LTC send form with broadcast mode and spending MimbleWimble peg-out outputs, covering transaction input selection and send form submission handled by sendFormThunks.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Directly manipulates the Bitcoin send form: adding/removing outputs, locktime, OP_RETURN, and satoshi unit switching. These are precisely the kind of send form state and transaction composition paths owned by sendFormThunks.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Exercises the Solana send form including 'Send Max' balance/fee/reserve calculation and transaction submission. Changes to sendFormThunks could affect the computed max amount or composed transaction.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Imports a CSV file directly into the send form to populate multiple outputs and metadata labels. This relies on sendFormThunks to process and load external send form state.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Directly exercises transaction listing/export functionality across multiple coins, which is the primary domain of transactionsThunks. A regression in transaction state management would be visible here.
- `suite/e2e/tests/wallet/transactions.test.ts` — Tests transaction search and graph range filtering on a BTC account. This directly depends on transactionsThunks for fetching and presenting transaction data.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/wallet/without-device.test.ts` — Covers the send flow when the device is disconnected mid-flow and the connection modal behavior. sendFormThunks handles the signing initiation, so a regression could affect the reconnection experience.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Concludes a BTC sell flow by constructing and broadcasting a send transaction to the provider. sendFormThunks or related transaction composition logic is exercised during the final send step.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Finalizes an ETH sell by sending crypto to a provider address after hardware confirmation. The send transaction path is shared with sendFormThunks infrastructure.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Sends an ERC-20 token (USDC) to a provider as part of the sell flow. Token send transaction composition is handled by the same thunk layer as standard sends.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Broadcasts a Solana sell transaction and verifies status updates. Changes to Solana transaction composition in sendFormThunks or transaction tracking in transactionsThunks could affect this flow.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Signs and broadcasts an ETH swap transaction, then watches status updates. The send and transaction-update paths are relevant to both changed thunk files.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Signs and broadcasts a Solana swap transaction and verifies toast/transaction detail updates. Relevant to send composition and transaction state management.

</details>

_Updated: 2026-09-11T09:38:22.111Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-send-pending-tx&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-send-pending-tx&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-send-pending-tx&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH to SOL | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T09:40:43.277Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap ETH to SOL | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T09:40:24.983Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->