### PR TITLE
test(connect-common): document widened event factory returns

### DIFF
--- a/packages/connect-common/src/events/messageFactory.type-test.ts
+++ b/packages/connect-common/src/events/messageFactory.type-test.ts
@@ -1,0 +1,107 @@
+import type { TRANSPORT } from '@trezor/transport-common';
+
+import { BLOCKCHAIN, type BlockchainEvent, createBlockchainMessage } from './blockchain';
+import { DEVICE, type DeviceEvent, createDeviceMessage } from './device';
+import { type TransportEvent, createTransportMessage } from './transport';
+import { UI_EVENTS, type UiEvent, createUiEventMessage } from './ui-event';
+import { UI_REQUESTS, type UiRequestEvent, createUiRequestMessage } from './ui-request';
+
+/* BLOCKCHAIN MESSAGES */
+declare const blockchainError: Extract<
+    BlockchainEvent,
+    { type: typeof BLOCKCHAIN.ERROR }
+>['payload'];
+const blockchainMessage = createBlockchainMessage(BLOCKCHAIN.ERROR, blockchainError);
+void (blockchainMessage.type satisfies typeof BLOCKCHAIN.ERROR);
+void (blockchainMessage.payload satisfies typeof blockchainError);
+
+declare const blockchainNotification: Extract<
+    BlockchainEvent,
+    { type: typeof BLOCKCHAIN.NOTIFICATION }
+>['payload'];
+const blockchainMessage2 = createBlockchainMessage(BLOCKCHAIN.NOTIFICATION, blockchainNotification);
+void (blockchainMessage2.type satisfies typeof BLOCKCHAIN.NOTIFICATION);
+void (blockchainMessage2.payload satisfies typeof blockchainNotification);
+
+// @ts-expect-error Payload is required for blockchain error messages.
+createBlockchainMessage(BLOCKCHAIN.ERROR);
+
+/* DEVICE MESSAGES */
+declare const deviceButtonRequest: Extract<DeviceEvent, { type: typeof DEVICE.BUTTON }>['payload'];
+const deviceMessage = createDeviceMessage(DEVICE.BUTTON, deviceButtonRequest);
+void (deviceMessage.type satisfies typeof DEVICE.BUTTON);
+void (deviceMessage.payload satisfies typeof deviceButtonRequest);
+
+declare const deviceConnect: Extract<DeviceEvent, { type: typeof DEVICE.CONNECT }>['payload'];
+const deviceMessage2 = createDeviceMessage(DEVICE.CONNECT, deviceConnect);
+// @ts-expect-error TODO
+void (deviceMessage2.type satisfies typeof DEVICE.CONNECT);
+// @ts-expect-error TODO
+void (deviceMessage2.payload satisfies typeof deviceConnect);
+
+// @ts-expect-error Device button payload is not compatible with blockchain error type.
+createDeviceMessage(BLOCKCHAIN.ERROR, deviceButtonRequest);
+// @ts-expect-error Device message type is not compatible with the payload.
+createDeviceMessage(DEVICE.CONNECT, deviceButtonRequest);
+
+/* TRANSPORT MESSAGES */
+declare const transportError: Extract<TransportEvent, { type: typeof TRANSPORT.ERROR }>['payload'];
+declare const transportErrorType: typeof TRANSPORT.ERROR;
+
+const transportMessage = createTransportMessage(transportErrorType, transportError);
+void (transportMessage.type satisfies typeof TRANSPORT.ERROR);
+void (transportMessage.payload satisfies typeof transportError);
+
+// @ts-expect-error
+void (transportMessage.payload satisfies typeof blockchainError);
+
+declare const transportStartType: typeof TRANSPORT.START;
+declare const transportStart: Extract<TransportEvent, { type: typeof TRANSPORT.START }>['payload'];
+const transportMessage1 = createTransportMessage(transportStartType, transportStart);
+void (transportMessage1.type satisfies typeof TRANSPORT.START);
+void (transportMessage1.payload satisfies typeof transportStart);
+
+declare const transportRequestDevice: typeof TRANSPORT.REQUEST_DEVICE;
+// @ts-expect-error Transport request-device is not a transport event message.
+createTransportMessage(transportRequestDevice, undefined);
+
+// @ts-expect-error Transport error messages require an error payload.
+createTransportMessage(transportError, undefined);
+
+/* UI EVENT MESSAGES */
+declare const uiEventPayload: Extract<
+    UiEvent,
+    { type: typeof UI_EVENTS.BUNDLE_PROGRESS }
+>['payload'];
+
+const uiEventMessage = createUiEventMessage(UI_EVENTS.TRANSPORT_MISSING);
+void (uiEventMessage.type satisfies typeof UI_EVENTS.TRANSPORT_MISSING);
+void (uiEventMessage.payload satisfies undefined);
+
+const uiEventMessage2 = createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS, uiEventPayload);
+void (uiEventMessage2.type satisfies typeof UI_EVENTS.BUNDLE_PROGRESS);
+void (uiEventMessage2.payload satisfies typeof uiEventPayload);
+
+// TODO: ts-expect-error Transport missing UI event does not accept a payload.
+createUiEventMessage(UI_EVENTS.TRANSPORT_MISSING, undefined);
+
+// @ts-expect-error Bundle progress UI event requires a payload.
+createUiEventMessage(UI_EVENTS.BUNDLE_PROGRESS);
+
+/* UI REQUEST MESSAGES */
+declare const uiRequestPayload: Extract<
+    UiRequestEvent,
+    { type: typeof UI_REQUESTS.REQUEST_PIN }
+>['payload'];
+
+const uiRequestMessage = createUiRequestMessage(UI_REQUESTS.REQUEST_PIN, uiRequestPayload, {
+    requestId: 'request-id',
+});
+void (uiRequestMessage.type satisfies typeof UI_REQUESTS.REQUEST_PIN);
+void (uiRequestMessage.payload satisfies typeof uiRequestPayload);
+
+// TODO: ts-expect-error UI request messages require request options.
+// createUiRequestMessage(UI_REQUESTS.REQUEST_PIN, uiRequestPayload);
+
+// TODO: ts-expect-error UI request options require requestId.
+createUiRequestMessage(UI_REQUESTS.REQUEST_PIN, uiRequestPayload, {});


### PR DESCRIPTION
## Goal

Establish the expected event factory return types as a baseline on `develop` before merging #32242.

Intended merge order:

1. Merge this test-only PR into `develop`.
2. Update and merge #32242 only after it satisfies the new baseline.

## Problem

The event message factories changed in #32242 still validate each payload against the selected event type, but their return values are asserted to the complete message union. Callers therefore lose the concrete `type` selected at the call site.

This test captures the expected literal return type for all five affected factories: blockchain, device, transport, UI event, and UI request.

## Regression proof against #32242

Before changing this PR's base to `develop`, CI evaluated the test against `fix/connect-ui_event-followup`, the branch reviewed in #32242. The [Type Checking job failed](https://github.com/trezor/trezor-suite/actions/runs/34573194275/job/103181146677) on the five new literal-type assertions, demonstrating the regression.

## Validation on develop

- `yarn workspace @trezor/connect-common type-check`
- `yarn prettier --check packages/connect-common/src/events/messageFactory.type-test.ts`
- `yarn eslint packages/connect-common/src/events/messageFactory.type-test.ts`

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a TypeScript type-test for connect-common event messageFactory, which underpins TrezorConnect request/response and popup event messaging. Since no static coverage mapping was available, I inferred a small set of TrezorConnect E2E tests that exercise the event-driven flows most likely to be affected. These tests should catch regressions in Connect popup behavior, permissions, address export, and transaction signing without running the entire suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-common/src/events/messageFactory.type-test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the full TrezorConnect popup lifecycle (permissions, address export, cancellation, popup management) which directly relies on the connect-common event message types for communication between Suite and the Connect popup. Since no static mapping exists, this is inferred as the highest-confidence coverage for messageFactory event changes.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Tests Bitcoin address export via TrezorConnect.getAddress, including permissions modal, on-device verification, and bundle exports. These flows are driven by connect-common message events, so type or behavior changes in messageFactory could surface here.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Covers TrezorConnect permission grants/remembrance, which are event-driven interactions between Suite and Connect. A change in messageFactory event typing could affect how permission events are dispatched or interpreted.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Validates the end-to-end BTC transaction signing flow through TrezorConnect, including permissions and multi-step device prompts. This path relies on the connect-common event layer for request/response messaging.

</details>

_Updated: 2026-09-11T12:37:09.734Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-event-factory-return-types/web/](https://dev.suite.sldev.cz/suite-web/test/connect-event-factory-return-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-event-factory-return-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-event-factory-return-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T12:40:57.248Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T12:39:29.730Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->