### PR TITLE
feat(trading): add trade history CSV export

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.test.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.test.ts
@@ -5,6 +5,7 @@ import {
     getTradingFormRoute,
     getTradingHeaderTitle,
     isTradingTopLevelRoute,
+    isTradingTransactionsRoute,
 } from './tradingPageHeaderUtils';
 
 describe('tradingPageHeaderUtils', () => {
@@ -36,6 +37,21 @@ describe('tradingPageHeaderUtils', () => {
             undefined,
         ] as const)('returns false for %s', route => {
             expect(isTradingTopLevelRoute(route)).toBe(false);
+        });
+    });
+
+    describe('isTradingTransactionsRoute', () => {
+        it('returns true for the transactions route', () => {
+            expect(isTradingTransactionsRoute('wallet-trading-transactions')).toBe(true);
+        });
+
+        it.each([
+            'wallet-trading-buy',
+            'wallet-trading-exchange-detail',
+            'suite-index',
+            undefined,
+        ] as const)('returns false for %s', route => {
+            expect(isTradingTransactionsRoute(route)).toBe(false);
         });
     });
 

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.ts
@@ -43,6 +43,9 @@ const isDetailRoute = (route?: TradingRoute): boolean =>
 export const isTradingTopLevelRoute = (route?: TradingRoute): route is TradingRoute =>
     route !== undefined && topLevelRoutes.includes(route);
 
+export const isTradingTransactionsRoute = (route?: TradingRoute): boolean =>
+    route === TRANSACTIONS_ROUTE;
+
 const getSectionFormRoute = (route?: TradingRoute): TradingRoute =>
     sections.find(s => s.detail === route || s.confirm === route)?.form ?? 'suite-index';
 

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/useTradingPageHeader.tsx
@@ -9,11 +9,13 @@ import { CaretLeftIcon } from '@trezor/icons';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { BasicName } from 'src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName';
 import { useLayout, useSelector } from 'src/hooks/suite';
+import { TradingTransactionsExportButton } from 'src/views/wallet/trading/common/TradingTransactions/TradingTransactionsExportButton';
 
 import {
     getBackRoute,
     getTradingHeaderTitle,
     isTradingTopLevelRoute,
+    isTradingTransactionsRoute,
 } from './tradingPageHeaderUtils';
 
 type TradingPageHeaderProps = {
@@ -27,6 +29,7 @@ const TradingPageHeader = ({ title }: TradingPageHeaderProps) => {
     const activeSection = useSelector(selectTradingActiveSection);
 
     const isTopLevelRoute = isTradingTopLevelRoute(currentRouteName);
+    const isTransactionsRoute = isTradingTransactionsRoute(currentRouteName);
 
     const goToRoute = (route: Route['name']) => () => {
         dispatch(gotoThunk({ routeName: route, preserveParams: true }));
@@ -62,6 +65,11 @@ const TradingPageHeader = ({ title }: TradingPageHeaderProps) => {
                         >
                             <Translation id="TR_TRADING_LAST_TRANSACTIONS" />
                         </Button>
+                    </Box>
+                )}
+                {isTransactionsRoute && (
+                    <Box margin={{ left: 'auto' }}>
+                        <TradingTransactionsExportButton />
                     </Box>
                 )}
             </Row>

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsExportButton.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsExportButton.tsx
@@ -1,0 +1,32 @@
+import { useSelector } from 'react-redux';
+
+import { Translation } from '@suite/intl';
+import { selectDeviceHasTradingTrades } from '@suite-common/trading';
+import { Button, Tooltip } from '@trezor/components';
+import { DownloadSimpleIcon } from '@trezor/icons';
+
+import { useTradingHistoryExport } from './useTradingHistoryExport';
+
+export const TradingTransactionsExportButton = () => {
+    const hasTrades = useSelector(selectDeviceHasTradingTrades);
+
+    const exportTradeHistory = useTradingHistoryExport();
+
+    if (!hasTrades) {
+        return null;
+    }
+
+    return (
+        <Tooltip content={<Translation id="TR_TRADING_TRADE_HISTORY_EXPORT_TOOLTIP" />}>
+            <Button
+                intent="neutral"
+                priority="secondary"
+                iconLeft={DownloadSimpleIcon}
+                onClick={exportTradeHistory}
+                data-testid="@trading/transactions/export-button"
+            >
+                <Translation id="TR_TRADING_TRADE_HISTORY_EXPORT_BUTTON" />
+            </Button>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/useTradingHistoryExport.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/useTradingHistoryExport.test.tsx
@@ -1,0 +1,203 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { type Coins, type CryptoId, type ExchangeProviderInfo } from 'invity-api';
+
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { triggerWebDownloadFile } from '@suite-common/suite-utils';
+import { createTestCompositionRoot } from '@suite-common/test-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    type TradingTransactionExchange,
+    initialState as tradingInitialState,
+} from '@suite-common/trading';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type StaticSessionId } from '@trezor/device-utils';
+
+import { type AppState } from 'src/reducers/store';
+import { renderHookWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { useTradingHistoryExport } from './useTradingHistoryExport';
+import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
+
+jest.mock('@suite-common/suite-utils', () => ({
+    ...jest.requireActual('@suite-common/suite-utils'),
+    triggerWebDownloadFile: jest.fn(),
+}));
+
+const triggerWebDownloadFileMock = jest.mocked(triggerWebDownloadFile);
+
+const BITCOIN = 'bitcoin' as CryptoId;
+const ETHEREUM = 'ethereum' as CryptoId;
+const DEVICE_STATIC_SESSION_ID = 'descriptor@deviceId:0' as StaticSessionId;
+
+const EXPECTED_HEADER =
+    'Trade ID,Date and time,Type,Spent amount,Spend ticker,Spend network,Spend transaction ID,Receive amount,Receive ticker,Receive network,Provider,Status,Receive transaction ID,Payment ID';
+const EXPECTED_ROW =
+    'exchange-order,2026-01-03T00:00:00Z,swap,0.5,ETH,Ethereum,,0.02,BTC,Bitcoin,Changelly,SUCCESS,,';
+
+const coins = {
+    bitcoin: {
+        symbol: 'btc',
+        name: 'Bitcoin',
+        coingeckoId: 'bitcoin',
+        services: { buy: true, sell: true, exchange: true },
+    },
+    ethereum: {
+        symbol: 'eth',
+        name: 'Ethereum',
+        coingeckoId: 'ethereum',
+        services: { buy: true, sell: true, exchange: true },
+    },
+} satisfies Coins;
+
+const changellyProvider: ExchangeProviderInfo = {
+    name: 'changelly',
+    companyName: 'Changelly',
+    logo: 'changelly.svg',
+    isActive: true,
+    isFixedRate: false,
+    isDex: false,
+    buyTickers: [],
+    sellTickers: [],
+    addressFormats: {},
+    statusUrl: 'https://changelly.com/status',
+    supportUrl: 'https://changelly.com/support',
+    kycUrl: 'https://changelly.com/kyc',
+    kycPolicy: 'No KYC required',
+    kycPolicyType: 'noKYC',
+};
+
+const selectedDevice = mockSuiteDevice({
+    connected: true,
+    available: true,
+    state: { staticSessionId: DEVICE_STATIC_SESSION_ID },
+});
+
+const ethAccount = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('ethDescriptor'),
+    deviceState: DEVICE_STATIC_SESSION_ID,
+});
+
+const exchange: TradingTransactionExchange = {
+    tradeType: 'exchange',
+    key: 'exchange-key',
+    date: '2026-01-03T00:00:00Z',
+    data: {
+        orderId: 'exchange-order',
+        status: 'SUCCESS',
+        exchange: 'changelly',
+        sendStringAmount: '0.5',
+        send: ETHEREUM,
+        receiveStringAmount: '0.02',
+        receive: BITCOIN,
+    },
+    sendAccountKey: ethAccount.key,
+    receiveAccountKey: ethAccount.key,
+};
+
+const buildState = (): AppState => ({
+    ...mockInitialAppState,
+    device: { ...mockInitialAppState.device, selectedDevice },
+    wallet: {
+        ...mockInitialAppState.wallet,
+        accounts: [ethAccount],
+        trading: {
+            ...tradingInitialState,
+            info: { ...tradingInitialState.info, coins },
+            exchange: {
+                ...tradingInitialState.exchange,
+                exchangeInfo: {
+                    providerInfos: { changelly: changellyProvider },
+                    buyCryptoIds: [],
+                    sellCryptoIds: [],
+                },
+            },
+            trades: [exchange],
+        },
+    },
+});
+
+const renderExport = () => {
+    const root = createTestCompositionRoot({
+        extra: { services: {} },
+        preloadedState: buildState(),
+    });
+    const { result } = renderHookWithProviders(root, () => useTradingHistoryExport());
+
+    return {
+        exportTradeHistory: () => result.current(),
+        getActions: () => root.services.getActions(),
+    };
+};
+
+const getDownloadedFile = () => {
+    const call = triggerWebDownloadFileMock.mock.calls.at(0);
+
+    if (!call) {
+        throw new Error('Nothing was downloaded.');
+    }
+
+    const [blob, fileName] = call;
+
+    if (!(blob instanceof Blob)) {
+        throw new Error('The downloaded file is not a Blob.');
+    }
+
+    return { blob, fileName };
+};
+
+// `readAsText` strips the CSV's leading BOM, which is asserted in `tradeHistoryExportUtils.test.ts`.
+const readBlobText = (blob: Blob) =>
+    new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+
+        reader.onload = () => resolve(String(reader.result));
+        reader.onerror = () => reject(reader.error);
+        reader.readAsText(blob);
+    });
+
+describe('useTradingHistoryExport', () => {
+    beforeEach(() => {
+        triggerWebDownloadFileMock.mockClear();
+        triggerWebDownloadFileMock.mockImplementation(() => {});
+    });
+
+    it('builds a CSV with translated column labels and a row per trade', async () => {
+        const { exportTradeHistory } = renderExport();
+
+        exportTradeHistory();
+
+        const csvContent = await readBlobText(getDownloadedFile().blob);
+
+        expect(csvContent).toBe(`${EXPECTED_HEADER}\n${EXPECTED_ROW}`);
+    });
+
+    it('downloads the CSV under a file name stamped with the export time', () => {
+        const { exportTradeHistory } = renderExport();
+
+        exportTradeHistory();
+
+        const { blob, fileName } = getDownloadedFile();
+
+        expect(blob.type).toBe('text/csv;charset=utf-8');
+        expect(fileName).toMatch(/^trade_history_\d{8}T\d{6}\.csv$/);
+    });
+
+    it('shows an error toast when the download fails', () => {
+        triggerWebDownloadFileMock.mockImplementation(() => {
+            throw new Error('download failed');
+        });
+        const { exportTradeHistory, getActions } = renderExport();
+
+        exportTradeHistory();
+
+        expect(getActions()).toContainEqual(
+            expect.objectContaining({
+                type: notificationsActions.addToast.type,
+                payload: expect.objectContaining({ type: 'error', error: 'Export failed' }),
+            }),
+        );
+    });
+});

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/useTradingHistoryExport.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/useTradingHistoryExport.ts
@@ -1,0 +1,70 @@
+import { useStore } from 'react-redux';
+
+import { type TranslationFunction, useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectDispatch } from '@suite-common/redux-utils';
+import { triggerWebDownloadFile } from '@suite-common/suite-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    type TradingHistoryCsvColumnLabels,
+    type TradingRootStateWithDeviceAndAccounts,
+    prepareTradingHistoryCsv,
+    selectDeviceTradingTradesOrderedByDate,
+} from '@suite-common/trading';
+
+import { getExportedFileName } from 'src/utils/wallet/exportTransactionsUtils';
+
+const CSV_MIME_TYPE = 'text/csv;charset=utf-8';
+const CSV_FILE_NAME = 'trade_history';
+
+const getCsvColumnLabels = (
+    translationString: TranslationFunction,
+): TradingHistoryCsvColumnLabels => ({
+    orderId: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_ORDER_ID'),
+    date: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_DATE'),
+    type: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_TYPE'),
+    spentAmount: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPENT_AMOUNT'),
+    spendTicker: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_TICKER'),
+    spendNetwork: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_NETWORK'),
+    spendTransactionId: translationString(
+        'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_TRANSACTION_ID',
+    ),
+    receiveAmount: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_AMOUNT'),
+    receiveTicker: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_TICKER'),
+    receiveNetwork: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_NETWORK'),
+    provider: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_PROVIDER'),
+    status: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_STATUS'),
+    receiveTransactionId: translationString(
+        'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_TRANSACTION_ID',
+    ),
+    paymentId: translationString('TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_PAYMENT_ID'),
+});
+
+export const useTradingHistoryExport = () => {
+    const store = useStore<TradingRootStateWithDeviceAndAccounts>();
+    const { dispatch } = useServices(selectDispatch);
+    const { translationString } = useTranslation();
+
+    return () => {
+        try {
+            const state = store.getState();
+            const trades = selectDeviceTradingTradesOrderedByDate(state);
+            const csvContent = prepareTradingHistoryCsv(getCsvColumnLabels(translationString))(
+                state,
+                trades,
+            );
+
+            triggerWebDownloadFile(
+                new Blob([csvContent], { type: CSV_MIME_TYPE }),
+                getExportedFileName(CSV_FILE_NAME, 'csv'),
+            );
+        } catch {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: translationString('TR_EXPORT_FAIL'),
+                }),
+            );
+        }
+    };
+};

--- a/suite/e2e/support/pageObjects/trading/transactionsSection.ts
+++ b/suite/e2e/support/pageObjects/trading/transactionsSection.ts
@@ -1,6 +1,8 @@
 import { Locator, Page } from '@playwright/test';
+import { readFileSync } from 'fs';
 
 import { TradingTransactionRow } from './transactionRow';
+import { step } from '../../common';
 
 type TradingTransactionsTab = 'all' | 'exchange' | 'buy' | 'sell';
 
@@ -14,6 +16,7 @@ export class TradingTransactionsSection {
     readonly backToTradeFormButton: Locator;
     readonly typeEmptyState: Locator;
     readonly showAllTradesButton: Locator;
+    readonly exportButton: Locator;
     readonly tab: (tradeType: TradingTransactionsTab) => Locator;
 
     constructor(private page: Page) {
@@ -28,10 +31,20 @@ export class TradingTransactionsSection {
         );
         this.typeEmptyState = page.getByTestId('@trading/transactions/type-empty-state');
         this.showAllTradesButton = page.getByTestId('@trading/transactions/show-all-trades');
+        this.exportButton = page.getByTestId('@trading/transactions/export-button');
         this.tab = tradeType => page.getByTestId(`@trading/transactions/tab/${tradeType}`);
     }
 
     transactionRow(orderId: string): TradingTransactionRow {
         return new TradingTransactionRow(this.page, orderId);
+    }
+
+    @step()
+    async downloadExportedCsv(): Promise<string> {
+        const downloadPromise = this.page.waitForEvent('download');
+        await this.exportButton.click();
+        const download = await downloadPromise;
+
+        return readFileSync(await download.path(), 'utf-8');
     }
 }

--- a/suite/e2e/tests/trading/swap-history.test.ts
+++ b/suite/e2e/tests/trading/swap-history.test.ts
@@ -15,6 +15,14 @@ const listStatusTranslationKeys = {
     CONFIRMING: 'TR_EXCHANGE_STATUS_CONFIRMING',
 } as const;
 
+const CSV_BOM = '\uFEFF';
+
+const parseCsvRows = (csvContent: string): string[][] =>
+    csvContent
+        .replace(CSV_BOM, '')
+        .split('\n')
+        .map(line => line.split(','));
+
 const formatTradeDate = (date: string) =>
     new Intl.DateTimeFormat('en-US', {
         year: 'numeric',
@@ -195,6 +203,35 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
                 await expect(tradingPage.transactionDetailHeader).toHaveTranslation(
                     'TR_TRADING_HEADER_PROCESSING_TITLE',
                     { values: { type: 'swap' } },
+                );
+            });
+        },
+    );
+
+    test(
+        'User can export trade history as CSV',
+        { annotation: createTestAnnotation({ stream: TestStream.Trade }) },
+        async ({ walletPage, tradingPage }) => {
+            await test.step('Navigate to swap/exchange trading section', async () => {
+                await walletPage.openSwapTrading({ symbol: 'btc' });
+            });
+
+            await test.step('Open trading transactions history', async () => {
+                await tradingPage.transactions.menuButton.click();
+                await expect(tradingPage.transactions.heading).toHaveTranslation(
+                    'TR_TRADING_LAST_TRANSACTIONS',
+                );
+                await expect(tradingPage.transactions.rows).toHaveCount(SEEDED_TRADES.length);
+            });
+
+            const csvContent = await test.step('Export the trade history', () =>
+                tradingPage.transactions.downloadExportedCsv());
+
+            await test.step('Verify the exported file holds the seeded trades', () => {
+                const [, ...tradeRows] = parseCsvRows(csvContent);
+
+                expect(tradeRows.map(([orderId]) => orderId).sort()).toEqual(
+                    SEEDED_TRADES.map(trade => trade.orderId).sort(),
                 );
             });
         },

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1366,6 +1366,70 @@ export const messages = defineMessages({
         defaultMessage: 'Show all trades',
         id: 'TR_TRADING_TRADE_HISTORY_SHOW_ALL',
     },
+    TR_TRADING_TRADE_HISTORY_EXPORT_BUTTON: {
+        defaultMessage: 'Export trades',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_BUTTON',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_TOOLTIP: {
+        defaultMessage: 'Downloads a CSV file with all your trades',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_TOOLTIP',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_ORDER_ID: {
+        defaultMessage: 'Trade ID',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_ORDER_ID',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_DATE: {
+        defaultMessage: 'Date and time',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_DATE',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_TYPE: {
+        defaultMessage: 'Type',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_TYPE',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPENT_AMOUNT: {
+        defaultMessage: 'Spent amount',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPENT_AMOUNT',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_TICKER: {
+        defaultMessage: 'Spend ticker',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_TICKER',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_NETWORK: {
+        defaultMessage: 'Spend network',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_NETWORK',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_TRANSACTION_ID: {
+        defaultMessage: 'Spend transaction ID',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_SPEND_TRANSACTION_ID',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_AMOUNT: {
+        defaultMessage: 'Receive amount',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_AMOUNT',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_TICKER: {
+        defaultMessage: 'Receive ticker',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_TICKER',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_NETWORK: {
+        defaultMessage: 'Receive network',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_NETWORK',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_PROVIDER: {
+        defaultMessage: 'Provider',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_PROVIDER',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_STATUS: {
+        defaultMessage: 'Status',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_STATUS',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_TRANSACTION_ID: {
+        defaultMessage: 'Receive transaction ID',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_RECEIVE_TRANSACTION_ID',
+    },
+    TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_PAYMENT_ID: {
+        defaultMessage: 'Payment ID',
+        id: 'TR_TRADING_TRADE_HISTORY_EXPORT_COLUMN_PAYMENT_ID',
+    },
     TR_TRADING_ENTER_AMOUNT_IN: {
         defaultMessage: 'Enter in {currency}',
         id: 'TR_TRADING_ENTER_AMOUNT_IN',


### PR DESCRIPTION
## Description

- Adds an **Export trades** button to the trade history page header; clicking it downloads all trades of the connected device as a CSV.
- The CSV is built by the shared `prepareTradingHistoryCsv` from `@suite-common/trading`, already used by the mobile app, so both platforms export the same structure.
- The button is hidden when the device has no trades; a failed download shows an error toast.

## Notes for QA

- Web & desktop, Trading → Trade history. File is named `trade_history_<date>T<time>.csv`.

## Related Issue

Resolve #29956

## Screenshots:
<img width="1145" height="485" alt="image" src="https://github.com/user-attachments/assets/56cf2449-cbd7-42bf-9f47-ce33f7948adf" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/29956-trading-history-export/web/](https://dev.suite.sldev.cz/suite-web/feat/29956-trading-history-export/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/29956-trading-history-export&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/29956-trading-history-export&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T13:11:43.721Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T13:11:23.109Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->