### PR TITLE
refactor(suite): rename platform init factories to app factories

### DIFF
--- a/packages/suite-desktop-ui/src/createDesktopApp.tsx
+++ b/packages/suite-desktop-ui/src/createDesktopApp.tsx
@@ -21,16 +21,16 @@ import { MainDesktop } from './MainDesktop';
 import { initSentry } from './sentry';
 import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
 
-type DesktopInitDeps = {
+type DesktopAppDeps = {
     services: SuiteServices & SuiteReduxStoreDep & HydrateReduxStoreDep;
 };
 
-export type DesktopInit = (container: HTMLElement) => Promise<void>;
+export type DesktopApp = (container: HTMLElement) => Promise<void>;
 
-export type DesktopInitDep = { desktopInit: DesktopInit };
+export type DesktopAppDep = { desktopApp: DesktopApp };
 
-export const createDesktopInit =
-    (deps: DesktopInitDeps): DesktopInit =>
+export const createDesktopApp =
+    (deps: DesktopAppDeps): DesktopApp =>
     async container => {
         initSentry();
 

--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -10,9 +10,9 @@ import { rootReducer } from 'src/reducers/store';
 import { createSuiteServicesCompositionRoot } from 'src/support/createSuiteCompositionRoot';
 import { extraDependencies } from 'src/support/extraDependencies';
 
-import { type DesktopInit, createDesktopInit } from './createDesktopInit';
+import { type DesktopApp, createDesktopApp } from './createDesktopApp';
 
-type SuiteDesktopCompositionRoot = { init: DesktopInit };
+type SuiteDesktopCompositionRoot = { app: DesktopApp };
 
 export const createSuiteDesktopCompositionRoot = (): SuiteDesktopCompositionRoot => {
     const history = createMemoryHistory();
@@ -47,8 +47,8 @@ export const createSuiteDesktopCompositionRoot = (): SuiteDesktopCompositionRoot
     const hydrateReduxStore = createHydrateReduxStore({ store, reducer: rootReducer });
     const services = { ...suiteServices, store, hydrateReduxStore };
     // Services need the store's dispatch/getState, while Redux thunks need those services in extra.
-    // Inject them after construction to break the cycle, before init can dispatch any actions.
+    // Inject them after construction to break the cycle, before the app can dispatch any actions.
     injectServicesIntoReduxExtra(services);
 
-    return { init: createDesktopInit({ services }) };
+    return { app: createDesktopApp({ services }) };
 };

--- a/packages/suite-desktop-ui/src/index.tsx
+++ b/packages/suite-desktop-ui/src/index.tsx
@@ -2,11 +2,11 @@ import { createSuiteDesktopCompositionRoot } from './createSuiteDesktopCompositi
 
 __webpack_nonce__ = window.cspNonce;
 
-const { init } = createSuiteDesktopCompositionRoot();
+const { app } = createSuiteDesktopCompositionRoot();
 
 window.onload = () => {
     const appElement = document.getElementById('app');
     if (appElement) {
-        init(appElement);
+        app(appElement);
     }
 };

--- a/packages/suite-web/src/createSuiteWebCompositionRoot.ts
+++ b/packages/suite-web/src/createSuiteWebCompositionRoot.ts
@@ -14,10 +14,10 @@ import { createConnectLoggerFactory } from 'src/support/createConnectLoggerFacto
 import { createSuiteServicesCompositionRoot } from 'src/support/createSuiteCompositionRoot';
 import { extraDependencies } from 'src/support/extraDependencies';
 
-import { type WebInit, createWebInit } from './createWebInit';
+import { type WebApp, createWebApp } from './createWebApp';
 import { getWebThpHostName } from './support/getWebThpHostName';
 
-type SuiteWebCompositionRoot = { init: WebInit };
+type SuiteWebCompositionRoot = { app: WebApp };
 
 export const createSuiteWebCompositionRoot = (): SuiteWebCompositionRoot => {
     const history = createBrowserHistory();
@@ -62,8 +62,8 @@ export const createSuiteWebCompositionRoot = (): SuiteWebCompositionRoot => {
     const hydrateReduxStore = createHydrateReduxStore({ store, reducer: rootReducer });
     const services = { ...suiteServices, store, hydrateReduxStore };
     // Services need the store's dispatch/getState, while Redux thunks need those services in extra.
-    // Inject them after construction to break the cycle, before init can dispatch any actions.
+    // Inject them after construction to break the cycle, before the app can dispatch any actions.
     injectServicesIntoReduxExtra(services);
 
-    return { init: createWebInit({ services }) };
+    return { app: createWebApp({ services }) };
 };

--- a/packages/suite-web/src/createWebApp.tsx
+++ b/packages/suite-web/src/createWebApp.tsx
@@ -14,16 +14,16 @@ import { MainWeb } from './MainWeb';
 import { initSentry } from './sentry';
 import { logXssWarning } from './support/xssWarning';
 
-type WebInitDeps = {
+type WebAppDeps = {
     services: SuiteServices & SuiteReduxStoreDep & HydrateReduxStoreDep;
 };
 
-export type WebInit = (container: HTMLElement) => Promise<void>;
+export type WebApp = (container: HTMLElement) => Promise<void>;
 
-export type WebInitDep = { webInit: WebInit };
+export type WebAppDep = { webApp: WebApp };
 
-export const createWebInit =
-    (deps: WebInitDeps): WebInit =>
+export const createWebApp =
+    (deps: WebAppDeps): WebApp =>
     async container => {
         logXssWarning();
 

--- a/packages/suite-web/src/index.ts
+++ b/packages/suite-web/src/index.ts
@@ -11,9 +11,9 @@ const observer = new MutationObserver(() => {
 
         import(/* webpackChunkName: "app" */ './createSuiteWebCompositionRoot')
             .then(({ createSuiteWebCompositionRoot }) => {
-                const { init } = createSuiteWebCompositionRoot();
+                const { app } = createSuiteWebCompositionRoot();
 
-                return init(appElement);
+                return app(appElement);
             })
             .catch(err => console.error(err)); // Fatal error
     }

--- a/packages/suite-web/src/static/vite-index.ts
+++ b/packages/suite-web/src/static/vite-index.ts
@@ -9,9 +9,9 @@ const observer = new MutationObserver(() => {
 
         import('../createSuiteWebCompositionRoot')
             .then(({ createSuiteWebCompositionRoot }) => {
-                const { init } = createSuiteWebCompositionRoot();
+                const { app } = createSuiteWebCompositionRoot();
 
-                return init(appElement);
+                return app(appElement);
             })
             .catch(err => console.error(err)); // Fatal error
     }

--- a/suite-native/app/index.js
+++ b/suite-native/app/index.js
@@ -13,8 +13,8 @@ import { createSuiteNativeCompositionRoot } from './src/createSuiteNativeComposi
 
 markStartupJsBundleEvaluated();
 
-const { init } = createSuiteNativeCompositionRoot();
-const App = init();
+const { app } = createSuiteNativeCompositionRoot();
+const App = app();
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/suite-native/app/src/createNativeApp.tsx
+++ b/suite-native/app/src/createNativeApp.tsx
@@ -15,15 +15,15 @@ import {
 import { PureApp } from './App';
 import { disableRTL } from './rtl';
 
-type NativeInitDeps = {
+type NativeAppDeps = {
     services: NativeServices & HydrateReduxStoreDep & NativeReduxStoreDep & StorePersistorDep;
 };
 
-export type NativeInit = () => ComponentType;
+export type NativeApp = () => ComponentType;
 
-export type NativeInitDep = { nativeInit: NativeInit };
+export type NativeAppDep = { nativeApp: NativeApp };
 
-export const createNativeInit = (deps: NativeInitDeps): NativeInit => {
+export const createNativeApp = (deps: NativeAppDeps): NativeApp => {
     let App: ComponentType | null = null;
 
     const initialize = async () => {

--- a/suite-native/app/src/createSuiteNativeCompositionRoot.ts
+++ b/suite-native/app/src/createSuiteNativeCompositionRoot.ts
@@ -11,10 +11,10 @@ import {
 } from '@suite-native/state';
 import { createEnsureEncryptionKey, createMMKVStorage } from '@suite-native/storage';
 
-import { type NativeInit, createNativeInit } from './createNativeInit';
+import { type NativeApp, createNativeApp } from './createNativeApp';
 
 type SuiteNativeCompositionRoot = {
-    init: NativeInit;
+    app: NativeApp;
 };
 
 export const createSuiteNativeCompositionRoot = (
@@ -44,8 +44,8 @@ export const createSuiteNativeCompositionRoot = (
     const services = { ...nativeServices, store, storePersistor, hydrateReduxStore };
 
     // Services need the store's dispatch/getState, while Redux thunks need those services in extra.
-    // Inject them after construction to break the cycle, before init starts persistence.
+    // Inject them after construction to break the cycle, before the app starts persistence.
     injectServicesIntoReduxExtra(services);
 
-    return { init: createNativeInit({ services }) };
+    return { app: createNativeApp({ services }) };
 };


### PR DESCRIPTION
## Description

Rename createDesktopInit, createWebInit, and createNativeInit to createDesktopApp, createWebApp, and createNativeApp, including their files and related types. Expose app instead of init from all three composition roots and update the desktop, web, Vite, and native entry points.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/platform-app-factories&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/platform-app-factories&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/platform-app-factories&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/platform-app-factories/web/](https://dev.suite.sldev.cz/suite-web/refactor/platform-app-factories/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH to SOL | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T07:45:58.131Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap ETH to SOL | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T07:44:52.395Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set refactors application composition roots and entry points across web, desktop, and native platforms. The highest risk is a broken bootstrap path that prevents the app from loading at all. Prioritize tests that exercise the earliest app-launch code paths: browser compatibility gates, desktop launch/bridge spawn, and first-run onboarding persistence. A secondary set covers reload, migration, and multi-session scenarios that re-initialize the app with existing state. Native entry files have no E2E coverage in this suite.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite-desktop-ui/src/createDesktopApp.tsx`
- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`
- `packages/suite-desktop-ui/src/index.tsx`
- `packages/suite-web/src/createSuiteWebCompositionRoot.ts`
- `packages/suite-web/src/createWebApp.tsx`
- `packages/suite-web/src/index.ts`
- `packages/suite-web/src/static/vite-index.ts`
- `suite-native/app/index.js`
- `suite-native/app/src/createNativeApp.tsx`
- `suite-native/app/src/createSuiteNativeCompositionRoot.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — Verifies the web application loads successfully in Firefox without hitting unsupported-browser gating. Changes to the web composition root or app initialization path could break this entry-point behavior.
- `suite/e2e/tests/browser/ios.test.ts` — Tests the iOS unsupported-platform landing page, which is rendered at the earliest stage of web app bootstrap. A refactor of the web entry point could change how this gate is evaluated.
- `suite/e2e/tests/browser/safari.test.ts` — Exercises Safari's unsupported-browser page and the bypass flow, both of which depend on the web app's initial mount and routing setup.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Launches the full desktop application and validates that it initializes, spawns the bundled bridge, and survives a renderer reload. This directly exercises the desktop composition-root and app-launch path.
- `suite/e2e/tests/suite/initial-run.test.ts` — Validates the first-run onboarding flow and its persistence across page reloads, which depends on the composition root correctly wiring Redux, storage, and onboarding state.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Tests the desktop app launched in daemon (without-UI) mode and a subsequent UI instance. This exercises an alternative desktop bootstrap configuration that may be affected by composition-root changes.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Navigating directly to /accounts on first load must surface the analytics consent dialog. This flow relies on the composition root initializing analytics and onboarding guards correctly.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — Covers the transition from completed onboarding into the dashboard's post-onboarding state and asset discovery, which depends on the composition root completing onboarding state transitions.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Loads an old Suite version, completes onboarding, then loads a new version and verifies persisted locale settings. This exercises app re-initialization with existing storage state.
- `suite/e2e/tests/suite/db-migration.test.ts` — Verifies IndexedDB settings migrate correctly when the app is reloaded across Suite versions, touching store rehydration and initialization in the composition root.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests page reloads and opening Suite in a new tab, scenarios that re-run the app bootstrap and session initialization paths.
- `suite/e2e/tests/suite/version-page.test.ts` — Validates that the hidden /version route renders build metadata, providing a lightweight check that the app shell and routing initialize correctly.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite-web/src/static/vite-index.ts`
- `suite-native/app/index.js`
- `suite-native/app/src/createNativeApp.tsx`
- `suite-native/app/src/createSuiteNativeCompositionRoot.ts`

_Updated: 2026-09-11T07:45:57.211Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->