### PR TITLE
test(e2e-utils): raise the LLM test selector's PR size gate to 3000 l…

### DIFF
--- a/.github/actions/check-pr-size/action.yml
+++ b/.github/actions/check-pr-size/action.yml
@@ -2,7 +2,7 @@
 name: "Check PR Size"
 description: >
   Determines whether a PR is small enough for LLM test selection.
-  Small PR = max 1000 total lines changed.
+  Small PR = max 3000 total lines changed.
 inputs:
   additions:
     description: "Number of line additions (github.event.pull_request.additions)"
@@ -25,7 +25,7 @@ runs:
         DELETIONS: ${{ inputs.deletions }}
       run: |
         TOTAL_CHANGES=$(( ADDITIONS + DELETIONS ))
-        if [ "$TOTAL_CHANGES" -le 1000 ]; then
+        if [ "$TOTAL_CHANGES" -le 3000 ]; then
           echo "is_small_pr=true" >> "$GITHUB_OUTPUT"
           echo "Small PR: $TOTAL_CHANGES lines changed"
         else

--- a/packages/e2e-utils/src/llmTestSelector/index.ts
+++ b/packages/e2e-utils/src/llmTestSelector/index.ts
@@ -51,10 +51,12 @@ interface OpenRouterCompletion {
     id?: string;
     choices?: {
         finish_reason?: string;
+        native_finish_reason?: string;
         message?: {
             tool_calls?: { function?: { name?: string; arguments?: string } }[];
         };
     }[];
+    usage?: { completion_tokens?: number };
 }
 
 // ---------------------------------------------------------------------------
@@ -71,7 +73,7 @@ const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
 const OPENROUTER_MODEL = 'moonshotai/kimi-k2.7-code';
 // Pinned to the cheaper (int4) tag of the model author's own endpoint — the only provider this account's OpenRouter privacy settings currently allow for this model.
 const OPENROUTER_PROVIDER_ORDER = ['moonshotai/int4'];
-const OPENROUTER_MAX_TOKENS = 32768;
+const OPENROUTER_MAX_TOKENS = 49152;
 
 const ALLOWED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.css', '.json']);
 
@@ -675,7 +677,12 @@ const selectTestsViaApi = async (
 
     const choice = completion.choices?.[0];
 
-    if (choice?.finish_reason === 'length') {
+    const isTruncated =
+        choice?.finish_reason === 'length' ||
+        choice?.native_finish_reason === 'length' ||
+        (completion.usage?.completion_tokens ?? 0) >= OPENROUTER_MAX_TOKENS;
+
+    if (isTruncated) {
         throw new Error(
             `OpenRouter response was truncated at max_tokens (${OPENROUTER_MAX_TOKENS}) — the recommendation set was too large to fit. Increase OPENROUTER_MAX_TOKENS or narrow the candidate tests.`,
         );


### PR DESCRIPTION
…ines

<!--- Provide a general summary of your changes in the Title above -->

## Description

The model cost is low and that opens us another possibility to run it on even bigger PRs and save both CI run and Currency cost

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/optimize-LLM-selector-limit/web/](https://dev.suite.sldev.cz/suite-web/optimize-LLM-selector-limit/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=optimize-LLM-selector-limit&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=optimize-LLM-selector-limit&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T10:59:21.401Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T10:59:02.806Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->