### PR TITLE
refactor(suite): inject desktop API into desktop app

### DIFF
--- a/packages/suite-desktop-ui/src/createDesktopApp.tsx
+++ b/packages/suite-desktop-ui/src/createDesktopApp.tsx
@@ -4,7 +4,7 @@ import { createRoot } from 'react-dom/client';
 
 import { ServicesProvider } from '@suite-common/dependency-injection';
 import TrezorConnect from '@trezor/connect-electron';
-import { desktopApi } from '@trezor/suite-desktop-api';
+import { type DesktopApi } from '@trezor/suite-desktop-api';
 
 import { initBluetoothThunk } from 'src/actions/bluetooth/initBluetoothThunk';
 import * as STORAGE from 'src/actions/suite/constants/storageConstants';
@@ -22,6 +22,7 @@ import { initSentry } from './sentry';
 import { TorLoadingScreen } from './support/screens/TorLoadingScreen';
 
 type DesktopAppDeps = {
+    desktopApi: DesktopApi;
     services: SuiteServices & SuiteReduxStoreDep & HydrateReduxStoreDep;
 };
 
@@ -39,7 +40,7 @@ export const createDesktopApp =
         root.render(<LoadingScreen />);
 
         const preloadAction = await preloadStore();
-        const { statePatch } = await desktopApi.handshake();
+        const { statePatch } = await deps.desktopApi.handshake();
 
         deps.services.hydrateReduxStore(preloadAction, statePatch);
 
@@ -50,14 +51,14 @@ export const createDesktopApp =
 
         // start logging to file if Debug menu is active
         if (preloadAction?.type === STORAGE.LOAD && preloadAction.payload.debug?.showDebugMenu) {
-            desktopApi.configLogger({
+            deps.desktopApi.configLogger({
                 level: 'debug',
                 writeToDisk: true,
             });
         }
 
         // Loading Tor as separate module, before the rest of the modules.
-        const { shouldRunTor } = await desktopApi.loadTorModule();
+        const { shouldRunTor } = await deps.desktopApi.loadTorModule();
 
         // When we run this first time `shouldRunTor` will tell if Tor should run according to previous settings,
         // when it runs because of renderer (e.g. Ctrl+R) it will always be false.
@@ -72,11 +73,11 @@ export const createDesktopApp =
                         </ReduxProvider>
                     </ServicesProvider>,
                 );
-                desktopApi.toggleTor(true);
+                deps.desktopApi.toggleTor(true);
             });
         }
 
-        const loadModules = await desktopApi.loadModules({
+        const loadModules = await deps.desktopApi.loadModules({
             legacyBioAuthEnabled: deps.services.store.getState()?.bioAuth?.bioAuthEnabled,
         });
         if (!loadModules.success) {

--- a/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
+++ b/packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts
@@ -50,5 +50,5 @@ export const createSuiteDesktopCompositionRoot = (): SuiteDesktopCompositionRoot
     // Inject them after construction to break the cycle, before the app can dispatch any actions.
     injectServicesIntoReduxExtra(services);
 
-    return { app: createDesktopApp({ services }) };
+    return { app: createDesktopApp({ desktopApi, services }) };
 };


### PR DESCRIPTION
## Description

Pass desktopApi from the desktop composition root into createDesktopApp so startup uses an explicit dependency. This is a minimal preparatory step toward #32378, keeping the broader package and API refactoring for follow-up work.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are foundational desktop-only bootstrap and composition-root code. No static test mapping exists, so recommendations are inferred from tests that explicitly launch or depend on the desktop app. The bridge-daemon test is the highest-value single test because it verifies the app launches and initializes correctly. A subset of TrezorConnect desktop tests provides additional coverage of connect bridge exposure and desktop-specific IPC/state wiring without over-broadening the suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-ui/src/createDesktopApp.tsx`
- `packages/suite-desktop-ui/src/createSuiteDesktopCompositionRoot.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test directly launches the Trezor Suite desktop app in both daemon/without-UI and standard UI modes, and verifies the window initializes and the title contains 'Trezor Suite'. Since the changed files are the desktop app creation and composition root, this is the most direct regression test for the bootstrap path.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This desktop-only test completes onboarding and then relies on the desktop composition root exposing the TrezorConnect bridge (coreMode: 'suite-desktop'). A regression in the composition root could break connect initialization or permissions modal rendering.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests the Connect settings page and remembered permissions in the desktop app. Changes to the desktop composition root could affect how connect-related state and UI are wired, especially the Connect apps settings tab.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test specifically exercises the desktop composition's exposeConnectWs path, app/focus IPC, and connectPopup Redux wiring. It is a good canary for whether connect integration and desktop-specific IPC still function after composition-root changes.

</details>

_Updated: 2026-09-11T12:29:17.144Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/desktop-app-api-dependency/web/](https://dev.suite.sldev.cz/suite-web/refactor/desktop-app-api-dependency/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/desktop-app-api-dependency&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/desktop-app-api-dependency&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T12:32:34.297Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |

</details>

_Updated: 2026-09-11T12:31:57.619Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->