### PR TITLE
fix(solana): validate serialized DEX transactions

### DIFF
--- a/networks/solana/network-solana/src/runtime/exports.ts
+++ b/networks/solana/network-solana/src/runtime/exports.ts
@@ -4,4 +4,5 @@ export * from './fees';
 export * from './signing';
 export * from './staking';
 export * from './shim';
+export * from './transactionInfo';
 export * from './utils';

--- a/networks/solana/network-solana/src/runtime/fees.test.ts
+++ b/networks/solana/network-solana/src/runtime/fees.test.ts
@@ -1,0 +1,154 @@
+import { address, createNoopSigner } from '@solana/kit';
+import * as splToken from '@solana-program/token';
+import * as splToken2022 from '@solana-program/token-2022';
+
+import { getAccountCreationFee } from './fees';
+import { type SolanaAPI } from '../types';
+
+const payer = createNoopSigner(address('ANctUhC7YZPueiv4T8bkDcHYEAJ7Hwoxhvgnr2QkF8uR'));
+const owner = address('5Q9c3XoBef8BYA5RzSmogWnRrQas6HPwYuo4AYPafpom');
+const mint = address('HBoNJ5v8g71s2boRivrHnfSB5MVPLDHHyVjruPfhGkvL');
+const tokenAccount = address('73rsTqUoMd34Y3YwXtu4An2LkncLF9SeDY6TGUFfksfe');
+const token2022Account = address('3nn86A71hFhoqYgPqLWSXdoxUwtfJNWoevBQUouAjSEg');
+
+const createApi = ({
+    accounts = [],
+    rents = [100n],
+}: {
+    accounts?: unknown[];
+    rents?: bigint[];
+} = {}) => {
+    const rentResponses = rents.map(rent => jest.fn().mockResolvedValue(rent));
+    const getMinimumBalanceForRentExemption = jest.fn(() => ({
+        send: rentResponses.shift() ?? jest.fn().mockResolvedValue(BigInt(0)),
+    }));
+
+    return {
+        api: {
+            rpc: {
+                getMinimumBalanceForRentExemption,
+                getMultipleAccounts: jest.fn(() => ({
+                    send: jest.fn().mockResolvedValue({ value: accounts }),
+                })),
+            },
+        } as unknown as SolanaAPI,
+        getMinimumBalanceForRentExemption,
+    };
+};
+
+describe('getAccountCreationFee', () => {
+    it('sums rent for every token account created by the transaction', async () => {
+        const { api, getMinimumBalanceForRentExemption } = createApi({
+            rents: [100n, 200n],
+        });
+        const instructions = [
+            splToken.getCreateAssociatedTokenInstruction({
+                ata: tokenAccount,
+                mint,
+                owner,
+                payer,
+            }),
+            splToken2022.getCreateAssociatedTokenInstruction({
+                ata: token2022Account,
+                mint,
+                owner,
+                payer,
+            }),
+        ];
+
+        const fee = await getAccountCreationFee({
+            api,
+            feePayer: payer.address,
+            instructions,
+            newAccountProgramName: undefined,
+        });
+
+        expect(fee).toBe(300n);
+        expect(getMinimumBalanceForRentExemption).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not reserve rent when an idempotently-created account already exists', async () => {
+        const { api, getMinimumBalanceForRentExemption } = createApi({
+            accounts: [{ data: ['', 'base64'] }],
+        });
+        const instruction = splToken.getCreateAssociatedTokenIdempotentInstruction({
+            ata: tokenAccount,
+            mint,
+            owner,
+            payer,
+        });
+
+        const fee = await getAccountCreationFee({
+            api,
+            feePayer: payer.address,
+            instructions: [instruction],
+            newAccountProgramName: undefined,
+        });
+
+        expect(fee).toBe(0n);
+        expect(getMinimumBalanceForRentExemption).not.toHaveBeenCalled();
+    });
+
+    it('reserves rent when an idempotently-created account does not exist', async () => {
+        const { api, getMinimumBalanceForRentExemption } = createApi({
+            accounts: [null],
+            rents: [100n],
+        });
+        const instruction = splToken.getCreateAssociatedTokenIdempotentInstruction({
+            ata: tokenAccount,
+            mint,
+            owner,
+            payer,
+        });
+
+        const fee = await getAccountCreationFee({
+            api,
+            feePayer: payer.address,
+            instructions: [instruction],
+            newAccountProgramName: undefined,
+        });
+
+        expect(fee).toBe(100n);
+        expect(getMinimumBalanceForRentExemption).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reserve rent paid by another account', async () => {
+        const { api, getMinimumBalanceForRentExemption } = createApi();
+        const instruction = splToken.getCreateAssociatedTokenInstruction({
+            ata: tokenAccount,
+            mint,
+            owner,
+            payer: createNoopSigner(owner),
+        });
+
+        const fee = await getAccountCreationFee({
+            api,
+            feePayer: payer.address,
+            instructions: [instruction],
+            newAccountProgramName: undefined,
+        });
+
+        expect(fee).toBe(0n);
+        expect(getMinimumBalanceForRentExemption).not.toHaveBeenCalled();
+    });
+
+    it('uses the legacy account program hint only when it was not detected in the transaction', async () => {
+        const { api, getMinimumBalanceForRentExemption } = createApi({ rents: [100n] });
+        const instruction = splToken.getCreateAssociatedTokenInstruction({
+            ata: tokenAccount,
+            mint,
+            owner,
+            payer,
+        });
+
+        const fee = await getAccountCreationFee({
+            api,
+            feePayer: payer.address,
+            instructions: [instruction],
+            newAccountProgramName: 'spl-token',
+        });
+
+        expect(fee).toBe(100n);
+        expect(getMinimumBalanceForRentExemption).toHaveBeenCalledTimes(1);
+    });
+});

--- a/networks/solana/network-solana/src/runtime/fees.ts
+++ b/networks/solana/network-solana/src/runtime/fees.ts
@@ -1,4 +1,5 @@
 import {
+    type Instruction,
     decompileTransactionMessageFetchingLookupTables,
     getBase16Encoder,
     getBase64Decoder,
@@ -8,6 +9,7 @@ import {
     getTransactionEncoder,
     isWritableRole,
     pipe,
+    address as solanaAddress,
 } from '@solana/kit';
 import {
     MAX_COMPUTE_UNIT_LIMIT,
@@ -38,6 +40,7 @@ import type {
     TransactionMessageWithFeePayer,
     V0CompiledTransactionMessage,
 } from '../types';
+import { getCreatedTokenAccounts } from './transactionInfo';
 
 const DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS = BigInt(300_000); // micro-lamports, value taken from other wallets
 
@@ -179,6 +182,77 @@ const getAccountProgramSize = (programName: AccountProgramName) =>
         'spl-token-2022': _getToken2022Size(),
     })[programName];
 
+type GetAccountCreationFeeParams = {
+    api: SolanaAPI;
+    feePayer: string;
+    instructions: readonly Instruction[];
+    newAccountProgramName: AccountProgramName | undefined;
+};
+
+export const getAccountCreationFee = async ({
+    api,
+    feePayer,
+    instructions,
+    newAccountProgramName,
+}: GetAccountCreationFeeParams): Promise<bigint> => {
+    const createdTokenAccounts = Array.from(
+        new Map(
+            getCreatedTokenAccounts(instructions)
+                .filter(accountInfo => accountInfo.payer === feePayer)
+                .map(accountInfo => [accountInfo.address, accountInfo]),
+        ).values(),
+    );
+    const idempotentTokenAccounts = createdTokenAccounts.filter(account => account.isIdempotent);
+    const { value: existingIdempotentAccounts } =
+        idempotentTokenAccounts.length > 0
+            ? await api.rpc
+                  .getMultipleAccounts(
+                      idempotentTokenAccounts.map(accountInfo =>
+                          solanaAddress(accountInfo.address),
+                      ),
+                      { encoding: 'base64' },
+                  )
+                  .send()
+            : { value: [] };
+    const existingIdempotentAccountAddresses = new Set(
+        idempotentTokenAccounts.flatMap((accountInfo, index) =>
+            existingIdempotentAccounts[index] ? [accountInfo.address] : [],
+        ),
+    );
+    const tokenAccountProgramsToCreate = createdTokenAccounts.flatMap(accountInfo =>
+        accountInfo.isIdempotent && existingIdempotentAccountAddresses.has(accountInfo.address)
+            ? []
+            : [accountInfo.tokenProgramName],
+    );
+    const detectedTokenAccountPrograms = new Set(
+        createdTokenAccounts.map(accountInfo => accountInfo.tokenProgramName),
+    );
+    const accountProgramsToCreate: AccountProgramName[] = [
+        ...tokenAccountProgramsToCreate,
+        ...(newAccountProgramName &&
+        (newAccountProgramName === 'staking' ||
+            !detectedTokenAccountPrograms.has(newAccountProgramName))
+            ? [newAccountProgramName]
+            : []),
+    ];
+    const accountProgramCounts = accountProgramsToCreate.reduce(
+        (counts, programName) =>
+            counts.set(programName, (counts.get(programName) ?? BigInt(0)) + BigInt(1)),
+        new Map<AccountProgramName, bigint>(),
+    );
+    const rents = await Promise.all(
+        Array.from(accountProgramCounts, async ([programName, count]) => {
+            const rent = await api.rpc
+                .getMinimumBalanceForRentExemption(BigInt(getAccountProgramSize(programName)))
+                .send();
+
+            return rent * count;
+        }),
+    );
+
+    return rents.reduce((total, rent) => total + rent, BigInt(0));
+};
+
 export const getFees = async (
     messageHex: string,
     newAccountProgramName: AccountProgramName | undefined,
@@ -204,13 +278,12 @@ export const getFees = async (
 
     const baseFee = await getBaseFee(api.rpc, message);
 
-    const accountCreationFee = newAccountProgramName
-        ? await api.rpc
-              .getMinimumBalanceForRentExemption(
-                  BigInt(getAccountProgramSize(newAccountProgramName)),
-              )
-              .send()
-        : BigInt(0);
+    const accountCreationFee = await getAccountCreationFee({
+        api,
+        feePayer: decompiledTransactionMessage.feePayer.address,
+        instructions: decompiledTransactionMessage.instructions,
+        newAccountProgramName,
+    });
 
     return { baseFee, priorityFee, accountCreationFee, decompiledTransactionMessage };
 };

--- a/networks/solana/network-solana/src/runtime/signing.ts
+++ b/networks/solana/network-solana/src/runtime/signing.ts
@@ -23,14 +23,10 @@ import {
     parseCreateAccountInstruction,
     parseTransferSolInstruction,
 } from '@solana-program/system';
-import {
-    TOKEN_PROGRAM_ADDRESS,
-    TokenInstruction,
-    identifyTokenInstruction,
-    parseTransferCheckedInstruction,
-} from '@solana-program/token';
 
 import { BigNumber } from '@trezor/utils';
+
+import { parseTokenTransferInstruction } from './transactionInfo';
 
 const parseInstruction = (instruction: Instruction) => {
     // Fee decoding
@@ -80,22 +76,13 @@ const parseInstruction = (instruction: Instruction) => {
     }
 
     // Tokens
-    if (
-        instruction.programAddress === TOKEN_PROGRAM_ADDRESS &&
-        instruction.data &&
-        instruction.accounts
-    ) {
-        const instructionSafe = {
-            ...instruction,
-            data: instruction.data as Uint8Array,
-            accounts: instruction.accounts,
-        };
-        const type = identifyTokenInstruction(instructionSafe);
-        if (type === TokenInstruction.TransferChecked) {
-            const parsed = parseTransferCheckedInstruction(instructionSafe);
-
-            return { type: 'transfer-checked', parsed } as const;
-        }
+    const tokenTransferInstruction = parseTokenTransferInstruction(instruction);
+    if (tokenTransferInstruction) {
+        return {
+            type: 'transfer-checked',
+            parsed: tokenTransferInstruction.parsed,
+            tokenProgramName: tokenTransferInstruction.tokenProgramName,
+        } as const;
     }
 
     return { type: 'other' } as const;

--- a/networks/solana/network-solana/src/runtime/transactionInfo.test.ts
+++ b/networks/solana/network-solana/src/runtime/transactionInfo.test.ts
@@ -1,0 +1,120 @@
+import { type Address, address, createNoopSigner } from '@solana/kit';
+import * as splToken from '@solana-program/token';
+import * as splToken2022 from '@solana-program/token-2022';
+
+import {
+    getCreatedTokenAccounts,
+    getSolanaTokenAccountInfos,
+    parseTokenTransferInstruction,
+} from './transactionInfo';
+
+const baseAddress = address('5Q9c3XoBef8BYA5RzSmogWnRrQas6HPwYuo4AYPafpom');
+const authority = createNoopSigner(address('ANctUhC7YZPueiv4T8bkDcHYEAJ7Hwoxhvgnr2QkF8uR'));
+const mint = address('HBoNJ5v8g71s2boRivrHnfSB5MVPLDHHyVjruPfhGkvL');
+const otherMint = address('So11111111111111111111111111111111111111112');
+const source = address('6EjZ73R3oEUHQL4zczkx3pRD3acysP3ug7hwMAdzdtNQ');
+const destination = address('73rsTqUoMd34Y3YwXtu4An2LkncLF9SeDY6TGUFfksfe');
+const otherDestination = address('3nn86A71hFhoqYgPqLWSXdoxUwtfJNWoevBQUouAjSEg');
+
+const getTransferInstruction = (
+    tokenLibrary: typeof splToken | typeof splToken2022,
+    tokenMint: Address = mint,
+    tokenDestination: Address = destination,
+) =>
+    tokenLibrary.getTransferCheckedInstruction({
+        amount: 1n,
+        authority,
+        decimals: 6,
+        destination: tokenDestination,
+        mint: tokenMint,
+        source,
+    });
+
+describe('Solana transaction info', () => {
+    it.each([
+        ['SPL Token', splToken, 'spl-token'],
+        ['Token-2022', splToken2022, 'spl-token-2022'],
+    ] as const)('parses %s transfer-checked instructions', (_, tokenLibrary, expectedProgram) => {
+        const parsedInstruction = parseTokenTransferInstruction(
+            getTransferInstruction(tokenLibrary),
+        );
+
+        expect(parsedInstruction?.tokenProgramName).toBe(expectedProgram);
+        expect(parsedInstruction?.parsed.accounts.mint.address).toBe(mint);
+        expect(parsedInstruction?.parsed.accounts.destination.address).toBe(destination);
+    });
+
+    it.each([
+        ['SPL Token', splToken, splToken.TOKEN_PROGRAM_ADDRESS],
+        ['Token-2022', splToken2022, splToken2022.TOKEN_2022_PROGRAM_ADDRESS],
+    ] as const)(
+        'returns only the %s transfer targeting the base address ATA',
+        async (_, tokenLibrary, tokenProgram) => {
+            const [expectedTokenAccount] = await tokenLibrary.findAssociatedTokenPda({
+                mint,
+                owner: baseAddress,
+                tokenProgram,
+            });
+            const tokenAccountInfos = await getSolanaTokenAccountInfos({
+                baseAddress,
+                instructions: [
+                    getTransferInstruction(tokenLibrary, mint, otherDestination),
+                    getTransferInstruction(tokenLibrary, otherMint, otherDestination),
+                    getTransferInstruction(tokenLibrary, mint, expectedTokenAccount),
+                ],
+                tokenMint: mint,
+            });
+
+            expect(tokenAccountInfos).toEqual([
+                {
+                    baseAddress,
+                    tokenAccount: expectedTokenAccount,
+                    tokenMint: mint,
+                    tokenProgram,
+                },
+            ]);
+        },
+    );
+
+    it.each([
+        ['SPL Token', splToken, 'spl-token'],
+        ['Token-2022', splToken2022, 'spl-token-2022'],
+    ] as const)(
+        'finds %s associated-token-account creation',
+        (_, tokenLibrary, expectedProgram) => {
+            const instruction = tokenLibrary.getCreateAssociatedTokenInstruction({
+                ata: destination,
+                mint,
+                owner: baseAddress,
+                payer: authority,
+            });
+
+            expect(getCreatedTokenAccounts([instruction])).toEqual([
+                {
+                    address: destination,
+                    isIdempotent: false,
+                    payer: authority.address,
+                    tokenProgramName: expectedProgram,
+                },
+            ]);
+        },
+    );
+
+    it('marks idempotent associated-token-account creation', () => {
+        const instruction = splToken.getCreateAssociatedTokenIdempotentInstruction({
+            ata: destination,
+            mint,
+            owner: baseAddress,
+            payer: authority,
+        });
+
+        expect(getCreatedTokenAccounts([instruction])).toEqual([
+            {
+                address: destination,
+                isIdempotent: true,
+                payer: authority.address,
+                tokenProgramName: 'spl-token',
+            },
+        ]);
+    });
+});

--- a/networks/solana/network-solana/src/runtime/transactionInfo.ts
+++ b/networks/solana/network-solana/src/runtime/transactionInfo.ts
@@ -1,0 +1,153 @@
+import { type Instruction, address } from '@solana/kit';
+import * as splToken from '@solana-program/token';
+import * as splToken2022 from '@solana-program/token-2022';
+
+import { type TokenProgramName } from '../types';
+
+export type SolanaTxTokenAccountInfo = {
+    baseAddress: string;
+    tokenProgram: string;
+    tokenMint: string;
+    tokenAccount: string;
+};
+
+export type CreatedTokenAccount = {
+    address: string;
+    payer: string;
+    tokenProgramName: TokenProgramName;
+    isIdempotent: boolean;
+};
+
+export const parseTokenTransferInstruction = (instruction: Instruction) => {
+    if (!instruction.data || !instruction.accounts) {
+        return undefined;
+    }
+
+    const instructionSafe = {
+        ...instruction,
+        data: instruction.data as Uint8Array,
+        accounts: instruction.accounts,
+    };
+
+    if (instruction.programAddress === splToken.TOKEN_PROGRAM_ADDRESS) {
+        const instructionType = splToken.identifyTokenInstruction(instructionSafe);
+
+        if (instructionType !== splToken.TokenInstruction.TransferChecked) {
+            return undefined;
+        }
+
+        return {
+            parsed: splToken.parseTransferCheckedInstruction(instructionSafe),
+            tokenProgramName: 'spl-token',
+        } as const;
+    }
+
+    if (instruction.programAddress === splToken2022.TOKEN_2022_PROGRAM_ADDRESS) {
+        const instructionType = splToken2022.identifyToken2022Instruction(instructionSafe);
+
+        if (instructionType !== splToken2022.Token2022Instruction.TransferChecked) {
+            return undefined;
+        }
+
+        return {
+            parsed: splToken2022.parseTransferCheckedInstruction(instructionSafe),
+            tokenProgramName: 'spl-token-2022',
+        } as const;
+    }
+
+    return undefined;
+};
+
+type GetSolanaTokenAccountInfosParams = {
+    baseAddress: string;
+    instructions: readonly Instruction[];
+    tokenMint: string;
+};
+
+export const getSolanaTokenAccountInfos = async ({
+    baseAddress,
+    instructions,
+    tokenMint,
+}: GetSolanaTokenAccountInfosParams): Promise<SolanaTxTokenAccountInfo[]> => {
+    const resolvedTokenAccountInfos = await Promise.all(
+        instructions.map(async instruction => {
+            const transferInstruction = parseTokenTransferInstruction(instruction);
+
+            if (transferInstruction?.parsed.accounts.mint.address !== tokenMint) {
+                return;
+            }
+
+            const tokenLibrary =
+                transferInstruction.tokenProgramName === 'spl-token' ? splToken : splToken2022;
+            const tokenProgram =
+                transferInstruction.tokenProgramName === 'spl-token'
+                    ? splToken.TOKEN_PROGRAM_ADDRESS
+                    : splToken2022.TOKEN_2022_PROGRAM_ADDRESS;
+            const [expectedTokenAccount] = await tokenLibrary.findAssociatedTokenPda({
+                mint: address(tokenMint),
+                owner: address(baseAddress),
+                tokenProgram: address(tokenProgram),
+            });
+            const tokenAccount = transferInstruction.parsed.accounts.destination.address;
+
+            if (tokenAccount !== expectedTokenAccount) {
+                return;
+            }
+
+            return {
+                baseAddress,
+                tokenAccount,
+                tokenMint,
+                tokenProgram,
+            };
+        }),
+    );
+    const uniqueTokenAccountInfos = new Map<string, SolanaTxTokenAccountInfo>();
+    resolvedTokenAccountInfos.forEach(tokenAccountInfo => {
+        if (tokenAccountInfo) {
+            uniqueTokenAccountInfos.set(tokenAccountInfo.tokenAccount, tokenAccountInfo);
+        }
+    });
+
+    return Array.from(uniqueTokenAccountInfos.values());
+};
+
+export const getCreatedTokenAccounts = (
+    instructions: readonly Instruction[],
+): CreatedTokenAccount[] =>
+    instructions.flatMap(instruction => {
+        if (
+            instruction.programAddress !== splToken.ASSOCIATED_TOKEN_PROGRAM_ADDRESS ||
+            !instruction.accounts
+        ) {
+            return [];
+        }
+
+        const discriminator = instruction.data?.[0] ?? 0;
+        if (discriminator !== 0 && discriminator !== 1) {
+            return [];
+        }
+
+        const payer = instruction.accounts[0]?.address;
+        const tokenAccount = instruction.accounts[1]?.address;
+        const tokenProgramAccount = instruction.accounts.find(
+            account =>
+                account.address === splToken.TOKEN_PROGRAM_ADDRESS ||
+                account.address === splToken2022.TOKEN_2022_PROGRAM_ADDRESS,
+        );
+        if (!payer || !tokenAccount || !tokenProgramAccount) {
+            return [];
+        }
+
+        return [
+            {
+                address: tokenAccount,
+                isIdempotent: discriminator === 1,
+                payer,
+                tokenProgramName:
+                    tokenProgramAccount.address === splToken.TOKEN_PROGRAM_ADDRESS
+                        ? ('spl-token' as const)
+                        : ('spl-token-2022' as const),
+            },
+        ];
+    });

--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -27,6 +27,11 @@ export interface PrivatePendingParams {
     txids?: string[]; // EVM: their tx hashes; blockbook fetch-backs each to cache+serve the body
 }
 
+export type SolanaTokenMetadata = {
+    baseAddress: string;
+    mint: string;
+};
+
 export interface EstimateFeeParams {
     blocks?: number[];
     specific?: {
@@ -37,6 +42,7 @@ export interface EstimateFeeParams {
         data?: string; // eth tx data, sol tx message
         value?: string; // eth tx amount
         newAccountProgramName?: 'staking' | 'spl-token' | 'spl-token-2022'; // program name of the Solana account that is being created, default: 'spl-token'
+        solanaToken?: SolanaTokenMetadata;
         privatePending?: PrivatePendingParams; // blockbook only (EVM), wallet's in-flight (locally pending) txs
     };
 }

--- a/packages/blockchain-link-types/src/responses.ts
+++ b/packages/blockchain-link-types/src/responses.ts
@@ -93,6 +93,13 @@ export interface GetFiatRatesTickersList {
     };
 }
 
+type SolanaTokenAccountInfo = {
+    baseAddress: string;
+    tokenProgram: string;
+    tokenMint: string;
+    tokenAccount: string;
+};
+
 export interface EstimateFee {
     type: typeof RESPONSES.ESTIMATE_FEE;
     payload: {
@@ -101,6 +108,7 @@ export interface EstimateFee {
         feePayer?: string;
         feeLimit?: string;
         eip1559?: Eip1559Fees;
+        solanaTokenAccountInfos?: SolanaTokenAccountInfo[];
     }[];
 }
 

--- a/packages/blockchain-link/src/workers/solana/handlers/estimateFee.test.ts
+++ b/packages/blockchain-link/src/workers/solana/handlers/estimateFee.test.ts
@@ -1,0 +1,62 @@
+import { type MessageTypes } from '@trezor/blockchain-link-types';
+import solana from '@trezor/network-solana/runtime';
+
+import { estimateFee } from './estimateFee';
+import { type Request } from '../types';
+
+jest.mock('@trezor/network-solana/runtime', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+describe('Solana estimateFee', () => {
+    it('returns token-account mappings resolved from the decompiled transaction', async () => {
+        const instructions = [{ programAddress: 'token-program' }];
+        const solanaTokenAccountInfos = [
+            {
+                baseAddress: 'recipient',
+                tokenAccount: 'token-account',
+                tokenMint: 'token-mint',
+                tokenProgram: 'token-program',
+            },
+        ];
+        const getSolanaTokenAccountInfos = jest.fn(() => solanaTokenAccountInfos);
+        jest.mocked(solana).mockResolvedValue({
+            getFees: jest.fn().mockResolvedValue({
+                accountCreationFee: BigInt(100),
+                baseFee: BigInt(5000),
+                decompiledTransactionMessage: {
+                    feePayer: { address: 'fee-payer' },
+                    instructions,
+                },
+                priorityFee: {
+                    computeUnitLimit: '200000',
+                    computeUnitPrice: '300000',
+                    fee: '60000',
+                },
+            }),
+            getSolanaTokenAccountInfos,
+        } as unknown as Awaited<ReturnType<typeof solana>>);
+        const request = {
+            connect: jest.fn().mockResolvedValue({}),
+            payload: {
+                specific: {
+                    data: 'serialized-transaction',
+                    solanaToken: {
+                        baseAddress: 'recipient',
+                        mint: 'token-mint',
+                    },
+                },
+            },
+        } as unknown as Request<MessageTypes.EstimateFee>;
+
+        const result = await estimateFee(request);
+
+        expect(getSolanaTokenAccountInfos).toHaveBeenCalledWith({
+            baseAddress: 'recipient',
+            instructions,
+            tokenMint: 'token-mint',
+        });
+        expect(result.payload[0]?.solanaTokenAccountInfos).toEqual(solanaTokenAccountInfos);
+    });
+});

--- a/packages/blockchain-link/src/workers/solana/handlers/estimateFee.ts
+++ b/packages/blockchain-link/src/workers/solana/handlers/estimateFee.ts
@@ -1,15 +1,17 @@
-import type { MessageTypes } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes } from '@trezor/blockchain-link-types';
 import { RESPONSES } from '@trezor/blockchain-link-types';
 import solana from '@trezor/network-solana/runtime';
 import { BigNumber } from '@trezor/utils';
 
 import type { Request } from '../types';
 
-export const estimateFee = async (request: Request<MessageTypes.EstimateFee>) => {
+export const estimateFee = async (
+    request: Request<MessageTypes.EstimateFee>,
+): Promise<ResponseTypes.EstimateFee> => {
     const api = await request.connect();
-    const { getFees } = await solana();
+    const { getFees, getSolanaTokenAccountInfos } = await solana();
 
-    const { data: messageHex, newAccountProgramName } = request.payload.specific ?? {};
+    const { data: messageHex, newAccountProgramName, solanaToken } = request.payload.specific ?? {};
 
     if (messageHex == null) {
         throw new Error('Could not estimate fee for transaction.');
@@ -17,6 +19,15 @@ export const estimateFee = async (request: Request<MessageTypes.EstimateFee>) =>
 
     const { baseFee, priorityFee, accountCreationFee, decompiledTransactionMessage } =
         await getFees(messageHex, newAccountProgramName, api);
+    const resolvedTokenAccountInfos = solanaToken
+        ? await getSolanaTokenAccountInfos({
+              baseAddress: solanaToken.baseAddress,
+              instructions: decompiledTransactionMessage.instructions,
+              tokenMint: solanaToken.mint,
+          })
+        : [];
+    const solanaTokenAccountInfos =
+        resolvedTokenAccountInfos.length > 0 ? resolvedTokenAccountInfos : undefined;
 
     const payload = [
         {
@@ -27,6 +38,7 @@ export const estimateFee = async (request: Request<MessageTypes.EstimateFee>) =>
             feePerUnit: priorityFee.computeUnitPrice,
             feeLimit: priorityFee.computeUnitLimit,
             feePayer: decompiledTransactionMessage.feePayer.address,
+            solanaTokenAccountInfos,
         },
     ];
 

--- a/packages/connect-common/src/types/api/blockchain.type-test.ts
+++ b/packages/connect-common/src/types/api/blockchain.type-test.ts
@@ -67,6 +67,27 @@ export const blockchainEstimateFee = async (api: TrezorConnect) => {
             feeLevels: 'preloaded',
         },
     });
+
+    const solana = await api.blockchainEstimateFee({
+        coin: 'sol',
+        request: {
+            specific: {
+                data: 'serialized-transaction',
+                solanaToken: {
+                    baseAddress: 'recipient',
+                    mint: 'token-mint',
+                },
+            },
+        },
+    });
+    if (solana.success) {
+        solana.payload.levels[0]?.solanaTokenAccountInfos?.forEach(tokenAccountInfo => {
+            tokenAccountInfo.baseAddress.toLowerCase();
+            tokenAccountInfo.tokenAccount.toLowerCase();
+            tokenAccountInfo.tokenMint.toLowerCase();
+            tokenAccountInfo.tokenProgram.toLowerCase();
+        });
+    }
 };
 
 export const blockchainGetTransactions = async (api: TrezorConnect) => {

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -47,6 +47,7 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
                     { name: 'to', type: 'string' },
                     { name: 'txsize', type: 'number' },
                     { name: 'newAccountProgramName', type: 'string' },
+                    { name: 'solanaToken', type: 'object' },
                     { name: 'privatePending', type: 'object' },
                 ]);
             }

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.test.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.test.ts
@@ -34,7 +34,7 @@ const VALID_PAYLOAD = {
     serializedTx: '00aa',
     toAddress: 'recipient-base-address',
     token: {
-        mint: 'fallback-token-mint',
+        mint: 'payload-token-mint',
         program: 'spl-token',
         decimals: 6,
         accounts: [
@@ -60,59 +60,50 @@ describe('solanaComposeTransaction', () => {
         jest.clearAllMocks();
     });
 
-    it('uses transfer-checked instruction data when serializedTx can be decompiled', async () => {
+    it('uses verified token-account data when serializedTx can be decompiled', async () => {
+        const instructions = [{ programAddress: 'token-program' }];
+        const tokenAccountInfo = {
+            baseAddress: 'recipient-base-address',
+            tokenProgram: tokenProgramsInfo['spl-token'].publicKey,
+            tokenMint: 'payload-token-mint',
+            tokenAccount: 'matching-destination-account',
+        };
+        const getSolanaTokenAccountInfos = jest.fn().mockResolvedValue([tokenAccountInfo]);
         jest.mocked(solana).mockResolvedValue({
             getDecompiledMessage: jest.fn().mockReturnValue({
-                instructions: [
-                    {
-                        type: 'transfer-checked',
-                        parsed: {
-                            accounts: {
-                                mint: { address: 'instruction-token-mint' },
-                                destination: { address: 'instruction-destination-account' },
-                            },
-                        },
-                    },
-                ],
+                message: { instructions },
             }),
+            getSolanaTokenAccountInfos,
         } as any);
 
         expect(await createMethod().run({ sendCoreMessage: undefined } as any)).toEqual({
             serializedTx: VALID_PAYLOAD.serializedTx,
             additionalInfo: {
-                newAccountProgramName: 'spl-token',
-                tokenAccountInfo: {
-                    baseAddress: 'recipient-base-address',
-                    tokenProgram: tokenProgramsInfo['spl-token'].publicKey,
-                    tokenMint: 'instruction-token-mint',
-                    tokenAccount: 'instruction-destination-account',
-                },
+                tokenAccountInfo,
             },
+        });
+        expect(getSolanaTokenAccountInfos).toHaveBeenCalledWith({
+            baseAddress: 'recipient-base-address',
+            instructions,
+            tokenMint: 'payload-token-mint',
         });
     });
 
-    it('falls back to payload token data when transfer-checked instruction is missing', async () => {
+    it('omits token metadata when no verified token account is found', async () => {
         jest.mocked(solana).mockResolvedValue({
             getDecompiledMessage: jest.fn().mockReturnValue({
-                instructions: [{ type: 'memo' }],
+                message: { instructions: [{ programAddress: 'memo-program' }] },
             }),
+            getSolanaTokenAccountInfos: jest.fn().mockResolvedValue([]),
         } as any);
 
         expect(await createMethod().run({ sendCoreMessage: undefined } as any)).toEqual({
             serializedTx: VALID_PAYLOAD.serializedTx,
-            additionalInfo: {
-                newAccountProgramName: 'spl-token',
-                tokenAccountInfo: {
-                    baseAddress: 'recipient-base-address',
-                    tokenProgram: tokenProgramsInfo['spl-token'].publicKey,
-                    tokenMint: 'fallback-token-mint',
-                    tokenAccount: 'recipient-base-address',
-                },
-            },
+            additionalInfo: {},
         });
     });
 
-    it('falls back to payload token data when decompilation throws', async () => {
+    it('omits token metadata when decompilation throws', async () => {
         jest.mocked(solana).mockResolvedValue({
             getDecompiledMessage: jest.fn(() => {
                 throw new Error('decode failed');
@@ -121,15 +112,7 @@ describe('solanaComposeTransaction', () => {
 
         expect(await createMethod().run({ sendCoreMessage: undefined } as any)).toEqual({
             serializedTx: VALID_PAYLOAD.serializedTx,
-            additionalInfo: {
-                newAccountProgramName: 'spl-token',
-                tokenAccountInfo: {
-                    baseAddress: 'recipient-base-address',
-                    tokenProgram: tokenProgramsInfo['spl-token'].publicKey,
-                    tokenMint: 'fallback-token-mint',
-                    tokenAccount: 'recipient-base-address',
-                },
-            },
+            additionalInfo: {},
         });
     });
 });

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -1,12 +1,12 @@
 import type { CoinInfo, PermissionRequest } from '@trezor/connect-common';
 import { SolanaComposeTransaction as SolanaComposeTransactionSchema } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { SYSTEM_PROGRAM_PUBLIC_KEY, tokenProgramsInfo } from '@trezor/network-solana/constants';
+import { SYSTEM_PROGRAM_PUBLIC_KEY } from '@trezor/network-solana/constants';
 import solana from '@trezor/network-solana/runtime';
 import { Assert } from '@trezor/schema-utils';
 
 import { assertBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
-import type { MethodContext, MethodMessage } from '../../../core/AbstractMethod';
+import type { MethodContext, MethodMessage, MethodReturnType } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getCoinInfoOrThrow } from '../../../data/coinInfo';
 
@@ -43,7 +43,9 @@ export default class SolanaComposeTransaction extends AbstractMethod<
         return 'Compose Solana transaction';
     }
 
-    async run({ sendCoreMessage }: MethodContext) {
+    async run({
+        sendCoreMessage,
+    }: MethodContext): Promise<MethodReturnType<'solanaComposeTransaction'>> {
         const backend = await initBlockchain(
             this.params.coinInfo,
             sendCoreMessage,
@@ -54,45 +56,28 @@ export default class SolanaComposeTransaction extends AbstractMethod<
         // firmware can resolve known SPL tokens instead of displaying a raw address.
         if (this.params.serializedTx) {
             const { token, toAddress } = this.params;
-            let newAccountProgramName;
             let tokenAccountInfo;
 
             if (token && toAddress) {
-                newAccountProgramName = token.program;
-                const fallbackTokenAccountInfo = {
-                    baseAddress: toAddress,
-                    tokenProgram: tokenProgramsInfo[token.program].publicKey,
-                    tokenMint: token.mint,
-                    tokenAccount: toAddress,
-                };
-
                 try {
-                    const { getDecompiledMessage } = await solana();
+                    const { getDecompiledMessage, getSolanaTokenAccountInfos } = await solana();
                     const decompiledMessage = getDecompiledMessage(this.params.serializedTx, true);
-                    const tokenTransferInstruction = decompiledMessage?.instructions.find(
-                        instruction => instruction.type === 'transfer-checked',
-                    );
 
-                    tokenAccountInfo = tokenTransferInstruction
-                        ? {
-                              baseAddress: toAddress,
-                              tokenProgram: tokenProgramsInfo[token.program].publicKey,
-                              tokenMint: tokenTransferInstruction.parsed.accounts.mint.address,
-                              tokenAccount:
-                                  tokenTransferInstruction.parsed.accounts.destination.address,
-                          }
-                        : fallbackTokenAccountInfo;
+                    if (decompiledMessage) {
+                        [tokenAccountInfo] = await getSolanaTokenAccountInfos({
+                            baseAddress: toAddress,
+                            instructions: decompiledMessage.message.instructions,
+                            tokenMint: token.mint,
+                        });
+                    }
                 } catch {
-                    tokenAccountInfo = fallbackTokenAccountInfo;
+                    // Transaction metadata is optional and may require address lookup tables.
                 }
             }
 
             return {
                 serializedTx: this.params.serializedTx,
-                additionalInfo: {
-                    newAccountProgramName,
-                    tokenAccountInfo,
-                },
+                additionalInfo: tokenAccountInfo ? { tokenAccountInfo } : {},
             };
         }
 

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.test.ts
@@ -226,6 +226,76 @@ describe('sendDexTransactionThunk', () => {
         expect(confirmTradeThunkArgs.nextStep).toBe(nextStep);
     });
 
+    it.each([undefined, '', '   '])(
+        'should reject Solana dex transaction when dexTx.data is %p',
+        async data => {
+            const quote = getQuote();
+            const { store, returnUrl } = getMocks({
+                selectedQuote: {
+                    ...quote,
+                    dexTx: { ...quote.dexTx, data },
+                } as TradingExchangeState['selectedQuote'],
+            });
+            const solanaAccount = { ...accountBtc, networkType: 'solana' } as Account;
+
+            const result = await store.dispatch(
+                exchangeThunks.sendDexTransactionThunk({
+                    account: solanaAccount,
+                    returnUrl,
+                    nextStep: jest.fn(),
+                    triggerAnalyticsTradeConfirmation: jest.fn(),
+                    processResponseData: jest.fn(),
+                    signAndPushSendFormTransaction: jest.fn(),
+                }),
+            );
+
+            expect(result.meta.requestStatus).toEqual('rejected');
+            expect(result.payload).toEqual({
+                type: 'error',
+                error: { id: 'TR_TRADING_INCORRECT_SERIALIZED_DATA' },
+            });
+            expect(tradingThunks.recomposeAndSignTxThunk).not.toHaveBeenCalled();
+        },
+    );
+
+    it('allows an EVM DEX transaction without calldata', async () => {
+        const quote = getQuote();
+        const { store, returnUrl } = getMocks({
+            selectedQuote: {
+                ...quote,
+                dexTx: { ...quote.dexTx, data: '' },
+            } as TradingExchangeState['selectedQuote'],
+        });
+        const ethereumAccount = { ...accountBtc, networkType: 'ethereum' } as Account;
+        (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock) = jest
+            .fn()
+            .mockImplementation(
+                createThunk('@trading/thunk/recomposeAndSignTx', (_, { fulfillWithValue }) =>
+                    fulfillWithValue({ success: true, payload: { txid: 'txid' } }),
+                ),
+            );
+        (confirmExchangeTradeThunk as unknown as jest.Mock).mockImplementation(
+            createThunk('@trading-exchange/thunk/confirmTrade', () => undefined),
+        );
+
+        const result = await store.dispatch(
+            exchangeThunks.sendDexTransactionThunk({
+                account: ethereumAccount,
+                returnUrl,
+                nextStep: jest.fn(),
+                triggerAnalyticsTradeConfirmation: jest.fn(),
+                processResponseData: jest.fn(),
+                signAndPushSendFormTransaction: jest.fn(),
+            }),
+        );
+
+        expect(result.meta.requestStatus).toEqual('fulfilled');
+        expect(
+            (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock).mock.calls[0][0]
+                .transactionData,
+        ).toBeUndefined();
+    });
+
     it('should base64→hex convert dexTx.data when account.networkType is solana', async () => {
         const base64Data = Buffer.from('hello', 'utf8').toString('base64');
         const expectedHex = Buffer.from(base64Data, 'base64').toString('hex');

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -74,6 +74,15 @@ export const sendDexTransactionThunk = createThunk<
             });
         }
 
+        if (account.networkType === 'solana' && !selectedQuote.dexTx.data?.trim()) {
+            console.error('Failed to send Solana DEX transaction - missing serialized data');
+
+            return rejectWithValue({
+                type: 'error',
+                error: { id: 'TR_TRADING_INCORRECT_SERIALIZED_DATA' },
+            });
+        }
+
         const tradingFormState = getTradingFormState({
             activeSection: 'exchange',
             providers,

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.test.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.test.ts
@@ -1,0 +1,93 @@
+import { createTestStore } from '@suite-common/test-utils';
+import {
+    type Account,
+    AddressDisplayOptions,
+    type FormState,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
+import TrezorConnect from '@trezor/connect';
+
+import { signSolanaSendFormTransactionThunk } from './sendFormSolanaThunks';
+
+const tokenAccountInfo = {
+    baseAddress: 'recipient',
+    tokenAccount: 'recipient-token-account',
+    tokenMint: 'token-mint',
+    tokenProgram: 'token-program',
+};
+const account = {
+    descriptor: 'account',
+    networkType: 'solana',
+    path: "m/44'/501'/0'/0'",
+    symbol: 'sol',
+} as unknown as Account;
+const device = {
+    instance: 0,
+    path: 'device-path',
+    state: 'device-state',
+    useEmptyPassphrase: true,
+};
+const formState = {
+    destinationTag: undefined,
+    outputs: [{ address: 'recipient', amount: '1', type: 'payment' }],
+    transactionData: 'serialized-transaction',
+} as FormState;
+const precomposedTransaction = {
+    feeLimit: '200000',
+    feePerByte: '300000',
+    solanaTokenAccountInfos: [tokenAccountInfo],
+    type: 'final',
+} as PrecomposedTransactionFinal;
+
+describe(signSolanaSendFormTransactionThunk.name, () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('passes backend-resolved token-account mappings to the device', async () => {
+        jest.spyOn(TrezorConnect, 'blockchainGetInfo').mockResolvedValue({
+            success: true,
+            payload: { blockHash: 'block-hash', blockHeight: 1 },
+        } as any);
+        jest.spyOn(TrezorConnect, 'solanaComposeTransaction').mockResolvedValue({
+            success: true,
+            payload: {
+                additionalInfo: {},
+                serializedTx: 'serialized-transaction',
+            },
+        } as any);
+        const signTransaction = jest
+            .spyOn(TrezorConnect, 'solanaSignTransaction')
+            .mockResolvedValue({
+                success: true,
+                payload: { serializedTx: 'signed-transaction' },
+            } as any);
+        const store = createTestStore({
+            extra: undefined,
+            preloadedState: {
+                wallet: {
+                    settings: { addressDisplayType: AddressDisplayOptions.ORIGINAL },
+                },
+            },
+        });
+
+        await store
+            .dispatch(
+                signSolanaSendFormTransactionThunk({
+                    device: device as any,
+                    formState,
+                    precomposedTransaction,
+                    selectedAccount: account,
+                }),
+            )
+            .unwrap();
+
+        expect(signTransaction).toHaveBeenCalledWith(
+            expect.objectContaining({
+                additionalInfo: {
+                    tokenAccountsInfos: [tokenAccountInfo],
+                },
+            }),
+        );
+    });
+});

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -23,7 +23,7 @@ import {
 } from '@suite-common/wallet-utils';
 import type { TokenInfo } from '@trezor/blockchain-link-types';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
-import TrezorConnect, { type FeeLevel } from '@trezor/connect';
+import TrezorConnect, { type FeeLevel, type SolanaTxTokenAccountInfo } from '@trezor/connect';
 import { asCoinSymbol } from '@trezor/connect-common';
 import { SOL_COMPUTE_UNIT_LIMIT } from '@trezor/network-solana/constants';
 import { BigNumber } from '@trezor/utils';
@@ -259,6 +259,12 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
                 specific: {
                     data: transaction.payload.serializedTx,
                     newAccountProgramName: transaction.payload.additionalInfo.newAccountProgramName,
+                    solanaToken: tokenInfo
+                        ? {
+                              baseAddress: firstOutput.address,
+                              mint: tokenInfo.contract,
+                          }
+                        : undefined,
                 },
             },
         });
@@ -266,6 +272,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
         let fetchedFee: string | undefined;
         let fetchedFeePerUnit: string | undefined;
         let fetchedFeeLimit: string | undefined;
+        let solanaTokenAccountInfos: SolanaTxTokenAccountInfo[] | undefined;
         if (estimatedFee.success) {
             // We access the array directly like this because the fee response from the solana worker always returns an array of size 1
             const { levels: estimatedFeeLevels } = estimatedFee.payload;
@@ -274,6 +281,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
             fetchedFee = feeLevel.feePerTx;
             fetchedFeePerUnit = feeLevel.feePerUnit;
             fetchedFeeLimit = feeLevel.feeLimit;
+            solanaTokenAccountInfos = feeLevel.solanaTokenAccountInfos;
         } else {
             // Error fetching fee, fall back on default values defined in `/packages/connect/src/data/defaultFeeLevels.ts`
             console.warn('Error fetching fee, using default values.', estimatedFee.error.message);
@@ -293,8 +301,8 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
 
         const resultLevels: PrecomposedLevels = {};
 
-        const response = predefinedLevels.map(level =>
-            calculate(
+        const response = predefinedLevels.map(level => {
+            const calculatedTransaction = calculate(
                 account.availableBalance,
                 output,
                 level,
@@ -303,8 +311,12 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
                 tokenInfo,
                 composeContext,
                 isNetworkReserveEnabled,
-            ),
-        );
+            );
+
+            return calculatedTransaction.type === 'error'
+                ? calculatedTransaction
+                : { ...calculatedTransaction, solanaTokenAccountInfos };
+        });
         response.forEach((tx, index) => {
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const predefinedLevel: (typeof predefinedLevels)[number] = predefinedLevels[index];
@@ -415,6 +427,11 @@ export const signSolanaSendFormTransactionThunk = createThunk<
         }
 
         const payment_req = paymentRequests?.[0];
+        const tokenAccountInfos =
+            precomposedTransaction.solanaTokenAccountInfos ??
+            (transaction.payload.additionalInfo.tokenAccountInfo
+                ? [transaction.payload.additionalInfo.tokenAccountInfo]
+                : undefined);
 
         const response = await TrezorConnect.solanaSignTransaction({
             device: {
@@ -427,9 +444,9 @@ export const signSolanaSendFormTransactionThunk = createThunk<
             serializedTx: transaction.payload.serializedTx,
             payment_req,
             serialize: true,
-            additionalInfo: transaction.payload.additionalInfo.tokenAccountInfo
+            additionalInfo: tokenAccountInfos?.length
                 ? {
-                      tokenAccountsInfos: [transaction.payload.additionalInfo.tokenAccountInfo],
+                      tokenAccountsInfos: tokenAccountInfos,
                   }
                 : undefined,
             chunkify: selectAddressDisplayType(getState()) === AddressDisplayOptions.CHUNKED,

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -13,6 +13,7 @@ import type {
     PrecomposeResultError as PrecomposedTransactionConnectResponseError,
     PrecomposeResultFinal as PrecomposedTransactionConnectResponseFinal,
     PrecomposeResultNonFinal as PrecomposedTransactionConnectResponseNonFinal,
+    SolanaTxTokenAccountInfo,
     StaticSessionId,
     TokenInfo,
 } from '@trezor/connect';
@@ -159,6 +160,7 @@ type PrecomposedTransactionNonFinal = PrecomposedTransactionConnectResponseNonFi
     accountActivationFee?: string;
     memoFee?: string;
     solanaTxMeta?: SolanaTxMeta;
+    solanaTokenAccountInfos?: SolanaTxTokenAccountInfo[];
     isDeviceReviewOnly?: boolean;
 };
 
@@ -179,6 +181,7 @@ type PrecomposedTransactionBase = PrecomposedTransactionConnectResponseFinal & {
     maxFeePerGas?: string;
     maxPriorityFeePerGas?: string;
     solanaTxMeta?: SolanaTxMeta;
+    solanaTokenAccountInfos?: SolanaTxTokenAccountInfo[];
     isDeviceReviewOnly?: boolean;
 };
 


### PR DESCRIPTION
## Description

- reject Solana DEX quotes without serialized transaction data before recomposition
- derive rent from actual fee-payer-funded associated-token-account creation instructions
- resolve address lookup tables before extracting token metadata
- accept metadata only when mint, token program, and derived recipient ATA match
- support SPL Token and Token-2022 transfer-checked instructions
- preserve empty EVM calldata behavior

## Notes for QA

Focus on Solana token DEX trades using versioned transactions/address lookup tables. Verify device token recognition and fee estimates with existing, newly created, and idempotently created recipient ATAs.

Missing Solana serialized data must stop before signing. Native EVM DEX transfers without calldata remain valid.

## Related Issue

Follow-up to https://github.com/trezor/trezor-suite/pull/31982

## Screenshots:

N/A

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-dex-transaction-safety/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-dex-transaction-safety/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-dex-transaction-safety&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-dex-transaction-safety&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/solana-dex-transaction-safety&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH USDC token to SOL USDT token | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T15:17:55.025Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-11T15:17:43.958Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set focuses on Solana transaction runtime (fees, signing, transactionInfo), Solana fee estimation in blockchain-link, Solana transaction composition in Connect, Solana send-form thunks, and the DEX swap transaction thunk. The highest regression risk lies in Solana send/swap/stake flows and DEX swap execution. Run the focused high-priority Solana end-to-end tests plus the two DEX LIFI tests; the additional 'stake more' test covers a closely related staking path. Type-only blockchain-link type files have no direct e2e coverage and should be validated by unit/type checks.

<details><summary><b>Changed files (19)</b></summary>

- `networks/solana/network-solana/src/runtime/exports.ts`
- `networks/solana/network-solana/src/runtime/fees.test.ts`
- `networks/solana/network-solana/src/runtime/fees.ts`
- `networks/solana/network-solana/src/runtime/signing.ts`
- `networks/solana/network-solana/src/runtime/transactionInfo.test.ts`
- `networks/solana/network-solana/src/runtime/transactionInfo.ts`
- `packages/blockchain-link-types/src/params.ts`
- `packages/blockchain-link-types/src/responses.ts`
- `packages/blockchain-link/src/workers/solana/handlers/estimateFee.test.ts`
- `packages/blockchain-link/src/workers/solana/handlers/estimateFee.ts`
- `packages/connect-common/src/types/api/blockchain.type-test.ts`
- `packages/connect/src/api/blockchainEstimateFee.ts`
- `packages/connect/src/api/solana/api/solanaComposeTransaction.test.ts`
- `packages/connect/src/api/solana/api/solanaComposeTransaction.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/wallet-core/src/send/sendFormSolanaThunks.test.ts`
- `suite-common/wallet-core/src/send/sendFormSolanaThunks.ts`
- `suite-common/wallet-types/src/transaction.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Creates the first Solana stake and signs a staking transaction on device, directly exercising the changed Solana runtime fee/signing/transactionInfo, Solana fee estimation, and Solana compose-transaction code paths.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Unstaking and claiming SOL signs multiple Solana staking transactions; any regression in Solana transaction composition, signing, or fee handling will surface here.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live SOL-to-USDC swap broadcasts a native SOL transaction to a provider, providing end-to-end coverage of Solana fee estimation and transaction composition under real quotes.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live SPL-token-to-SOL swap exercises the SPL-token send path, which relies on the changed Solana runtime transactionInfo/signing and fee estimation logic.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Sells SOL by composing and broadcasting a Solana transaction from the trading sell flow, directly using solanaComposeTransaction and Solana fee estimation.
- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — Token approval step for a LI.FI DEX swap directly invokes the changed sendDexTransactionThunk and related transaction-type handling.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Executes a full LI.FI DEX swap, covering the DEX transaction dispatch path changed in sendDexTransactionThunk.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Swaps native SOL and signs/broadcasts the Solana-side transaction, making it a strong regression guard for Solana compose and fee estimation changes.
- `suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts` — Cross-chain swap from a Solana SPL token to ETH exercises token-account-aware Solana transaction composition and fee handling.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Directly sends SOL from a hidden wallet and verifies amounts and fees on the device prompt; this is the most end-to-end coverage of the changed Solana runtime, fee estimation, compose-transaction, and send-form thunk code.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Adds to an existing Solana stake using a distinct 'stake more' flow that reuses the same Solana transaction composition and signing infrastructure as initial-stake.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/blockchain-link-types/src/params.ts`
- `packages/blockchain-link-types/src/responses.ts`

_Updated: 2026-09-11T15:18:11.527Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->