### PR TITLE
fix(activity-center): handle exchange notifications

### DIFF
--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -320,6 +320,7 @@ export type TransactionNotificationType =
     | 'tx-claimed'
     | 'tx-revoked'
     | 'tx-approved'
+    | 'tx-exchange'
     | 'tx-wrap'
     | 'tx-unwrap'
     | 'raw-tx-sent'

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -4978,6 +4978,7 @@ export const messages = {
             txApproved: 'Approved in {account}',
             txWrap: 'Wrapped in {account}',
             txUnwrap: 'Unwrapped in {account}',
+            txExchange: 'Traded in {account}',
         },
     },
     biometricsButton: 'Unlock with biometrics',

--- a/suite-native/intl/translations/en-US.json
+++ b/suite-native/intl/translations/en-US.json
@@ -2740,6 +2740,7 @@
     "moduleActivityCenter.notifications.txApproved": "Approved in {account}",
     "moduleActivityCenter.notifications.txWrap": "Wrapped in {account}",
     "moduleActivityCenter.notifications.txUnwrap": "Unwrapped in {account}",
+    "moduleActivityCenter.notifications.txExchange": "Traded in {account}",
     "biometricsButton": "Unlock with biometrics",
     "search.noResults": "No results"
 }

--- a/suite-native/module-activity-center/src/components/notifications/TransactionNotificationItem.test.tsx
+++ b/suite-native/module-activity-center/src/components/notifications/TransactionNotificationItem.test.tsx
@@ -1,0 +1,40 @@
+import type { ComponentProps } from 'react';
+
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
+
+import { TransactionNotificationItem } from './TransactionNotificationItem';
+
+type TransactionNotificationItemProps = ComponentProps<typeof TransactionNotificationItem>;
+
+describe('TransactionNotificationItem', () => {
+    it('renders tx-exchange notification without crashing', async () => {
+        const exchangeNotification = {
+            id: 1234567890,
+            context: 'toast',
+            type: 'tx-exchange',
+            descriptor: '0x1234567890abcdef',
+            symbol: 'btc',
+            txid: '0xtxid123',
+            formattedAmount: '0.1 BTC',
+            metadata: {},
+        } as unknown as TransactionNotificationItemProps['notification'];
+
+        const { getByText } = await renderWithStoreProvider(
+            <TransactionNotificationItem
+                notification={exchangeNotification}
+                seen={false}
+                index={0}
+            />,
+            {
+                preloadedState: {
+                    device: {
+                        selectedDevice: undefined,
+                        devices: [],
+                    } as any,
+                },
+            },
+        );
+
+        expect(getByText(/Traded in/i)).toBeTruthy();
+    });
+});

--- a/suite-native/module-activity-center/src/components/notifications/TransactionNotificationItem.tsx
+++ b/suite-native/module-activity-center/src/components/notifications/TransactionNotificationItem.tsx
@@ -39,6 +39,7 @@ const txTypeIconMap = {
     'tx-approved': 'arrowUp',
     'tx-wrap': 'arrowUp',
     'tx-unwrap': 'arrowDown',
+    'tx-exchange': 'swap',
 } as const satisfies Record<TransactionNotificationType, IconName>;
 
 const translationIdMap = {
@@ -56,6 +57,7 @@ const translationIdMap = {
     'tx-approved': 'moduleActivityCenter.notifications.txApproved',
     'tx-wrap': 'moduleActivityCenter.notifications.txWrap',
     'tx-unwrap': 'moduleActivityCenter.notifications.txUnwrap',
+    'tx-exchange': 'moduleActivityCenter.notifications.txExchange',
 } as const satisfies Record<TransactionNotificationType, string>;
 
 const fullWidthDividerStyle = prepareNativeStyle(utils => ({


### PR DESCRIPTION
fix(activity-center): prevent crash on exchange notifications

## Description

Opening the Activity Center after completing a CEX trade or DEX swap can crash the mobile app when the resulting `tx-exchange` notification is rendered.

The notification type already exists in the toast notification payload, but it was missing from `TransactionNotificationType`. The type assertion in `getTxNotificationFields` allowed this mismatch to bypass the `satisfies Record<TransactionNotificationType, ...>` checks, resulting in missing icon/translation mappings at runtime.

This PR:
- Adds `tx-exchange` to `TransactionNotificationType`
- Maps `tx-exchange` to the `swap` icon
- Adds the `Traded in {account}` notification translation
- Adds a regression test covering `tx-exchange` rendering

Issue #30754's acceptance criteria required all transaction notification types — including `tx-exchange` — to render with the correct icon and text. The PR that closed it (#31066) states in its commit message that it "expand[s] the type to include `tx-exchange` and `successful-claim` variants," but the merged code never actually added either to `TransactionNotificationType`. This PR completes that intended change for `tx-exchange`, matching the currently reported crash.

## Related finding (not fixed here)

While tracing this, I found `successful-claim` has the identical gap — it's dispatched from `TriggerActivityNotification.tsx` and `ClaimCard.tsx` on staking claims, and is also missing from `TransactionNotificationType` on current `develop`. This appears capable of triggering the same crash. Kept this PR scoped to the reported issue; happy to open a follow-up for `successful-claim` if useful.

## Notes for QA

Please verify on mobile that:

1. Complete a CEX trade or DEX swap.
2. Return to the dashboard.
3. Open the Activity Center using the notification bell.
4. Confirm that the exchange notification is displayed without crashing and shows the expected swap icon and "Traded in {account}" text.

Automated validation completed:
- Module lint
- Module type-check
- Targeted `TransactionNotificationItem` Jest test
- `git diff --check`
- Pre-commit ESLint, Stylelint, Prettier, and translation structure checks

The full native unit test suite and manual device/emulator reproduction were not performed.

## Related Issue

Resolve #32405