### PR TITLE
Normalize Cardano DRep ids to CIP-129

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.test.ts
@@ -155,6 +155,8 @@ const prepare = (action: CardanoAction, votingDelegation?: AccountVotingDelegati
 
 const CUSTOM_DREP_BECH32 = 'drep14w46h2at4w46h2at4w46h2at4w46h2at4w46h2at4w46kxzm6ac';
 const CUSTOM_DREP_HEX = 'abababababababababababababababababababababababababababab';
+const DREP_HASH = '429b12461640cefd3a4a192f7c531d8f6c6d33610b727f481eb22d39';
+const DREP_UNSUPPORTED_HEADER = 'drep1qfpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgzsugcp';
 
 describe('prepareTxPlan', () => {
     beforeEach(() => {
@@ -276,7 +278,7 @@ describe('prepareTxPlan', () => {
     });
 
     describe.each(['delegate', 'voteDelegate'] as const)('%s', action => {
-        it.each(['not-a-drep', '', CARDANO_EVERSTAKE_DREP.hex])(
+        it.each(['not-a-drep', '', CARDANO_EVERSTAKE_DREP.hex, DREP_UNSUPPORTED_HEADER])(
             'returns null without composing when the custom drepId %p is invalid',
             async drepId => {
                 await expect(
@@ -300,6 +302,44 @@ describe('prepareTxPlan', () => {
                 keyHash: CUSTOM_DREP_HEX,
                 scriptHash: undefined,
             });
+        });
+
+        it.each([
+            [
+                'an amended CIP-105 key hash',
+                'drep_vkh1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjat06vr',
+                { type: PROTO.CardanoDRepType.KEY_HASH, keyHash: DREP_HASH, scriptHash: undefined },
+            ],
+            [
+                'a CIP-129 key hash',
+                'drep1yfpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsqdglp',
+                { type: PROTO.CardanoDRepType.KEY_HASH, keyHash: DREP_HASH, scriptHash: undefined },
+            ],
+            [
+                'a CIP-105 script hash',
+                'drep_script1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknj5wf0ec',
+                {
+                    type: PROTO.CardanoDRepType.SCRIPT_HASH,
+                    keyHash: undefined,
+                    scriptHash: DREP_HASH,
+                },
+            ],
+            [
+                'a CIP-129 script hash',
+                'drep1ydpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsjaelx',
+                {
+                    type: PROTO.CardanoDRepType.SCRIPT_HASH,
+                    keyHash: undefined,
+                    scriptHash: DREP_HASH,
+                },
+            ],
+        ])('delegates the vote to a custom DRep given as %s', async (_, drepId, dRep) => {
+            await prepare(action, {
+                accountKey: STAKE_READY_ACCOUNT_KEY,
+                option: { type: 'another_drep', drepId },
+            });
+
+            expect(getVoteDelegationCertificate()?.dRep).toEqual(dRep);
         });
 
         it.each([

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -20,14 +20,13 @@ import {
     type StakeRootState,
     calculateStakeFormTransaction,
     composeStakingTransaction,
+    decodeCardanoDrepId,
     getCardanoAccountPoolId,
     hasCardanoLiveVoteDelegation,
     isCardanoStakedWithEverstake,
-    parseDrepBech32,
     selectBestCardanoPool,
     selectCardanoPoolsInfo,
     selectStakeVotingDelegation,
-    validateCardanoDrep,
 } from '@suite-common/wallet-core';
 import {
     type Account,
@@ -173,17 +172,17 @@ export const prepareTxPlan = async ({
         confirmedOption?.type === 'current' && hasCardanoLiveVoteDelegation(account);
 
     if ((action === 'delegate' || action === 'voteDelegate') && !isKeepingCurrentVote) {
-        const isVotingToAnotherDrep = confirmedOption?.type === 'another_drep';
+        const drepBech32 =
+            confirmedOption?.type === 'another_drep'
+                ? confirmedOption.drepId
+                : CARDANO_EVERSTAKE_DREP.bech32;
 
-        if (isVotingToAnotherDrep && !validateCardanoDrep(confirmedOption.drepId)) {
+        const dRep = decodeCardanoDrepId(drepBech32);
+
+        if (dRep === null) {
             return null;
         }
 
-        const drepBech32 = isVotingToAnotherDrep
-            ? confirmedOption.drepId
-            : CARDANO_EVERSTAKE_DREP.bech32;
-
-        const dRep = parseDrepBech32(drepBech32);
         certificates.push(...getVotingCertificates(stakingPath, dRep));
     }
 

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegations.test.tsx
@@ -15,7 +15,7 @@ import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
 import { VotingDelegations } from './VotingDelegations';
 import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
 
-const CUSTOM_DREP_ID = 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs';
+const CUSTOM_DREP_ID = 'drep1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjmv589e';
 const PREDEFINED_DREP_ID = 'drep_always_abstain';
 const ACCOUNT_KEY = 'ada-account-key' as AccountKey;
 

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.test.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.test.tsx
@@ -1,0 +1,105 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { type UnknownAction } from '@reduxjs/toolkit';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { createTestCompositionRoot } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { stakeInitialState } from '@suite-common/wallet-core';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
+
+import { stakeReducer } from 'src/reducers/wallet';
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { VotingDelegationsOptions } from './VotingDelegationsOptions';
+import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+const DREP_CIP105_SCRIPT_HASH = 'drep_script1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknj5wf0ec';
+const DREP_VKH_KEY_HASH = 'drep_vkh1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjat06vr';
+const DREP_CIP129_SCRIPT_HASH = 'drep1ydpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsjaelx';
+const DREP_CIP129_KEY_HASH = 'drep1yfpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsqdglp';
+const ACCOUNT_KEY = 'ada-account-key' as AccountKey;
+
+const cardanoAccount = {
+    key: ACCOUNT_KEY,
+    index: 0,
+    symbol: asNetworkSymbol('ada'),
+    networkType: 'cardano',
+} as unknown as Account;
+
+const renderDrepIdInput = () => {
+    const preloadedState = {
+        ...mockInitialAppState,
+        wallet: {
+            ...mockInitialAppState.wallet,
+            stake: {
+                ...stakeInitialState,
+                votingDelegation: {
+                    accountKey: ACCOUNT_KEY,
+                    option: { type: 'another_drep', drepId: '' },
+                },
+            },
+        },
+    };
+
+    const root = createTestCompositionRoot({
+        extra: { services: {} },
+        preloadedState,
+        reducer: (state = preloadedState, action: UnknownAction) => ({
+            ...state,
+            wallet: { ...state.wallet, stake: stakeReducer(state.wallet.stake, action) },
+        }),
+        serializableCheck: { ignoredActions: [] },
+    });
+
+    renderWithProviders(root, <VotingDelegationsOptions account={cardanoAccount} />);
+
+    return screen.getByRole('textbox');
+};
+
+describe('VotingDelegationsOptions', () => {
+    it.each([
+        ['a CIP-105 script hash', DREP_CIP105_SCRIPT_HASH, DREP_CIP129_SCRIPT_HASH],
+        ['an amended CIP-105 key hash', DREP_VKH_KEY_HASH, DREP_CIP129_KEY_HASH],
+    ])('converts %s to CIP-129 and says so', (_, drepId, convertedDrepId) => {
+        const input = renderDrepIdInput();
+
+        fireEvent.change(input, { target: { value: drepId } });
+
+        expect(input).toHaveValue(convertedDrepId);
+        expect(screen.getByText('TR_STAKING_DREP_ID_CONVERTED')).toBeInTheDocument();
+    });
+
+    it('keeps a CIP-129 id as it is and shows no notice', () => {
+        const input = renderDrepIdInput();
+
+        fireEvent.change(input, { target: { value: DREP_CIP129_SCRIPT_HASH } });
+
+        expect(input).toHaveValue(DREP_CIP129_SCRIPT_HASH);
+        expect(screen.queryByText('TR_STAKING_DREP_ID_CONVERTED')).not.toBeInTheDocument();
+    });
+
+    it('drops the notice once the converted id is edited into an invalid one', () => {
+        const input = renderDrepIdInput();
+
+        fireEvent.change(input, { target: { value: DREP_CIP105_SCRIPT_HASH } });
+        fireEvent.change(input, { target: { value: `${DREP_CIP129_SCRIPT_HASH}x` } });
+
+        expect(screen.queryByText('TR_STAKING_DREP_ID_CONVERTED')).not.toBeInTheDocument();
+        expect(screen.getByText('TR_STAKING_INVALID_DREP_ID')).toBeInTheDocument();
+    });
+
+    it('keeps a value that is not a DRep id and reports it as invalid', () => {
+        const input = renderDrepIdInput();
+
+        fireEvent.change(input, { target: { value: 'not-a-drep' } });
+
+        expect(input).toHaveValue('not-a-drep');
+        expect(screen.getByText('TR_STAKING_INVALID_DREP_ID')).toBeInTheDocument();
+    });
+});

--- a/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
+++ b/packages/suite/src/components/earn/modals/shared/VotingDelegations/VotingDelegationsOptions.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectDispatch } from '@suite-common/redux-utils';
 import {
     type VotingDelegationOption,
+    normalizeCardanoDrepId,
     selectVotingDelegationOption,
     stakeActions,
     validateCardanoDrep,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { Column, Input, Radio, Text } from '@trezor/components';
+import { Column, Icon, Input, Radio, Text } from '@trezor/components';
+import { CheckIcon } from '@trezor/icons';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -35,6 +37,7 @@ export const VotingDelegationsOptions = ({
     hasTitle = false,
     hasKeepCurrentOption = false,
 }: VotingDelegationsOptionsProps) => {
+    const [hasDrepIdConverted, setHasDrepIdConverted] = useState(false);
     const { dispatch } = useServices(selectDispatch);
     const { translationString } = useTranslation();
     const selectedVotingDelegation = useSelector(state =>
@@ -50,7 +53,14 @@ export const VotingDelegationsOptions = ({
         selectedVotingDelegation.drepId !== '' &&
         !validateCardanoDrep(selectedVotingDelegation.drepId);
 
+    const isDrepIdConverted =
+        hasDrepIdConverted &&
+        selectedVotingDelegation.type === 'another_drep' &&
+        selectedVotingDelegation.drepId !== '';
+
     const handleOptionSelect = (type: VotingDelegationOption['type']) => {
+        setHasDrepIdConverted(false);
+
         switch (type) {
             case 'everstake':
                 dispatch(
@@ -82,12 +92,28 @@ export const VotingDelegationsOptions = ({
     };
 
     const handleDrepIdChange = (value: string) => {
+        const normalizedDrepId = normalizeCardanoDrepId(value);
+
+        setHasDrepIdConverted(normalizedDrepId !== null && normalizedDrepId !== value);
+
         dispatch(
             stakeActions.setAccountVotingDelegation({
                 accountKey: account.key,
-                option: { type: 'another_drep', drepId: value },
+                option: { type: 'another_drep', drepId: normalizedDrepId ?? value },
             }),
         );
+    };
+
+    const getDrepIdBottomText = () => {
+        if (hasError) {
+            return <Translation id="TR_STAKING_INVALID_DREP_ID" />;
+        }
+
+        if (isDrepIdConverted) {
+            return <Translation id="TR_STAKING_DREP_ID_CONVERTED" />;
+        }
+
+        return null;
     };
 
     const optionKeys = hasKeepCurrentOption ? VOTING_OPTION_KEYS_WITH_CURRENT : VOTING_OPTION_KEYS;
@@ -115,10 +141,11 @@ export const VotingDelegationsOptions = ({
                                     value={selectedVotingDelegation.drepId}
                                     inputMode="text"
                                     hasError={hasError}
-                                    bottomText={
-                                        hasError ? (
-                                            <Translation id="TR_STAKING_INVALID_DREP_ID" />
-                                        ) : null
+                                    bottomText={getDrepIdBottomText()}
+                                    bottomTextIconComponent={
+                                        isDrepIdConverted ? (
+                                            <Icon as={CheckIcon} size={16} isDisabled={true} />
+                                        ) : undefined
                                     }
                                     onChange={e => handleDrepIdChange(e.target.value)}
                                 />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/CurrentDelegate.test.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/CurrentDelegate.test.tsx
@@ -1,0 +1,68 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { screen } from '@testing-library/react';
+
+import { createTestCompositionRoot } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { CurrentDelegate } from './CurrentDelegate';
+import { mockInitialAppState } from '../../../../../../../mocks/mockInitialAppState';
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+const EVERSTAKE_DREP_CIP105 = 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs';
+const DREP_CIP105_KEY_HASH = 'drep1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjmv589e';
+const DREP_CIP129_KEY_HASH = 'drep1yfpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsqdglp';
+const PREDEFINED_DREP_ID = 'drep_always_abstain';
+
+const createCardanoAccount = (drepId: string): Account =>
+    ({
+        key: 'ada-account-key',
+        index: 0,
+        symbol: asNetworkSymbol('ada'),
+        networkType: 'cardano',
+        misc: { staking: { isActive: true, drep: { drep_id: drepId } } },
+    }) as unknown as Account;
+
+const renderCurrentDelegate = (drepId: string) => {
+    const root = createTestCompositionRoot({
+        extra: { services: {} },
+        preloadedState: mockInitialAppState,
+        serializableCheck: { ignoredActions: [] },
+    });
+
+    renderWithProviders(root, <CurrentDelegate account={createCardanoAccount(drepId)} />);
+};
+
+describe('CurrentDelegate', () => {
+    it.each([
+        ['CIP-129', CARDANO_EVERSTAKE_DREP.bech32],
+        ['legacy', EVERSTAKE_DREP_CIP105],
+    ])('names Everstake behind its DRep reported in the %s spelling', (_, drepId) => {
+        renderCurrentDelegate(drepId);
+
+        expect(screen.getByText('Everstake')).toBeInTheDocument();
+        expect(screen.getByText(CARDANO_EVERSTAKE_DREP.bech32)).toBeInTheDocument();
+    });
+
+    it('shows another DRep reported in the legacy spelling as CIP-129', () => {
+        renderCurrentDelegate(DREP_CIP105_KEY_HASH);
+
+        expect(screen.getByText('TR_STAKE_PROVIDER_UNKNOWN')).toBeInTheDocument();
+        expect(screen.getByText(DREP_CIP129_KEY_HASH)).toBeInTheDocument();
+        expect(screen.queryByText(DREP_CIP105_KEY_HASH)).not.toBeInTheDocument();
+    });
+
+    it('passes a predefined DRep through unchanged', () => {
+        renderCurrentDelegate(PREDEFINED_DREP_ID);
+
+        expect(screen.getByText(PREDEFINED_DREP_ID)).toBeInTheDocument();
+    });
+});

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/CurrentDelegate.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/CurrentDelegate.tsx
@@ -1,5 +1,9 @@
 import { Translation } from '@suite/intl';
-import { CARDANO_EVERSTAKE_DREP, getCardanoAccountDrepId } from '@suite-common/wallet-core';
+import {
+    CARDANO_EVERSTAKE_DREP,
+    areCardanoDrepIdsEqual,
+    getCardanoAccountDrepId,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, Paragraph, Text } from '@trezor/components';
 
@@ -12,7 +16,9 @@ export const CurrentDelegate = ({ account }: CurrentDelegateProps) => {
     const currentDelegateDrepId = getCardanoAccountDrepId(account);
 
     const getStakeProviderLabel = () => {
-        if (CARDANO_EVERSTAKE_DREP.bech32 === currentDelegateDrepId) return 'Everstake';
+        if (areCardanoDrepIdsEqual(CARDANO_EVERSTAKE_DREP.bech32, currentDelegateDrepId)) {
+            return 'Everstake';
+        }
 
         return <Translation id="TR_STAKE_PROVIDER_UNKNOWN" />;
     };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.test.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.test.tsx
@@ -1,0 +1,127 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { type UnknownAction } from '@reduxjs/toolkit';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { createTestCompositionRoot } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { CARDANO_EVERSTAKE_DREP, stakeInitialState } from '@suite-common/wallet-core';
+import {
+    type Account,
+    type AccountKey,
+    type SelectedAccountLoaded,
+} from '@suite-common/wallet-types';
+
+import { stakeReducer } from 'src/reducers/wallet';
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { StakeChangeDelegateModalLoaded } from './StakeChangeDelegateModal';
+import { mockInitialAppState } from '../../../../../../../mocks/mockInitialAppState';
+
+global.ResizeObserver = class MockedResizeObserver {
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn();
+};
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+jest.mock('src/hooks/wallet/useChangeDelegateForm', () => {
+    const { useForm } = jest.requireActual('react-hook-form');
+
+    return {
+        ...jest.requireActual('src/hooks/wallet/useChangeDelegateForm'),
+        useChangeDelegateForm: () => {
+            const methods = useForm();
+
+            return {
+                methods,
+                handleSubmit: methods.handleSubmit,
+                signTx: jest.fn(),
+                changeFeeLevel: jest.fn(),
+            };
+        },
+    };
+});
+
+jest.mock('src/components/wallet/Fees/Fees', () => ({ Fees: () => null }));
+
+jest.mock('src/hooks/suite/useMessageSystemStaking', () => ({
+    useMessageSystemStaking: () => ({ isVotingDisabled: false }),
+}));
+
+const DREP_CIP105_KEY_HASH = 'drep1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjmv589e';
+const DREP_VKH_KEY_HASH = 'drep_vkh1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjat06vr';
+const DREP_CIP129_KEY_HASH = 'drep1yfpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsqdglp';
+const ACCOUNT_KEY = 'ada-account-key' as AccountKey;
+
+const cardanoAccount = {
+    key: ACCOUNT_KEY,
+    index: 0,
+    symbol: asNetworkSymbol('ada'),
+    networkType: 'cardano',
+    misc: { staking: { isActive: true, drep: { drep_id: DREP_CIP105_KEY_HASH } } },
+} as unknown as Account;
+
+const selectedAccount = {
+    status: 'loaded',
+    account: cardanoAccount,
+} as unknown as SelectedAccountLoaded;
+
+const renderModal = () => {
+    const preloadedState = {
+        ...mockInitialAppState,
+        wallet: {
+            ...mockInitialAppState.wallet,
+            stake: {
+                ...stakeInitialState,
+                votingDelegation: {
+                    accountKey: ACCOUNT_KEY,
+                    option: { type: 'another_drep', drepId: '' },
+                },
+            },
+        },
+    };
+
+    const root = createTestCompositionRoot({
+        extra: { services: {} },
+        preloadedState,
+        reducer: (state = preloadedState, action: UnknownAction) => ({
+            ...state,
+            wallet: { ...state.wallet, stake: stakeReducer(state.wallet.stake, action) },
+        }),
+        serializableCheck: { ignoredActions: [] },
+    });
+
+    renderWithProviders(root, <StakeChangeDelegateModalLoaded selectedAccount={selectedAccount} />);
+};
+
+const enterDrepId = (drepId: string) =>
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: drepId } });
+
+const getContinueButton = () => screen.getByRole('button', { name: 'TR_CONTINUE' });
+
+describe('StakeChangeDelegateModal', () => {
+    it.each([
+        ['CIP-129', DREP_CIP129_KEY_HASH],
+        ['legacy', DREP_CIP105_KEY_HASH],
+        ['amended CIP-105', DREP_VKH_KEY_HASH],
+    ])('blocks re-delegating to the current DRep entered in its %s spelling', (_, drepId) => {
+        renderModal();
+
+        enterDrepId(drepId);
+
+        expect(getContinueButton()).toBeDisabled();
+    });
+
+    it('allows delegating to a different DRep', () => {
+        renderModal();
+
+        enterDrepId(CARDANO_EVERSTAKE_DREP.bech32);
+
+        expect(getContinueButton()).toBeEnabled();
+    });
+});

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -9,6 +9,7 @@ import { selectDispatch } from '@suite-common/redux-utils';
 import {
     CARDANO_EVERSTAKE_DREP,
     DEFAULT_VOTING_OPTION,
+    areCardanoDrepIdsEqual,
     getCardanoAccountDrepId,
     selectVotingDelegationOption,
     stakeActions,
@@ -53,7 +54,7 @@ export const StakeChangeDelegateModalLoaded = ({
         changeDelegateContextValues;
 
     const currentDrepId = getCardanoAccountDrepId(account);
-    const isEverstake = currentDrepId === CARDANO_EVERSTAKE_DREP.bech32;
+    const isEverstake = areCardanoDrepIdsEqual(currentDrepId, CARDANO_EVERSTAKE_DREP.bech32);
 
     // we don't want to show current delegation option in this modal
     // if it was pre-selected, select the default option instead
@@ -113,7 +114,7 @@ export const StakeChangeDelegateModalLoaded = ({
             case 'another_drep': {
                 const { drepId } = selectedVotingDelegation;
 
-                if (drepId === currentDrepId) {
+                if (areCardanoDrepIdsEqual(drepId, currentDrepId)) {
                     return { isDisabled: true, errorType: 'current_delegate' as const };
                 }
 

--- a/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts
+++ b/packages/suite/src/hooks/earn/useCardanoAccountVotingDelegation.test.ts
@@ -20,7 +20,8 @@ import {
 } from './useCardanoAccountVotingDelegation';
 import { mockInitialAppState } from '../../../mocks/mockInitialAppState';
 
-const CUSTOM_DREP_ID = 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs';
+// Not the Everstake DRep: its legacy spelling normalises to CARDANO_EVERSTAKE_DREP.
+const CUSTOM_DREP_ID = 'drep1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjmv589e';
 const PREDEFINED_DREP_ID = 'drep_always_abstain';
 const ACCOUNT_KEY = 'ada-account-key' as AccountKey;
 const OTHER_ACCOUNT_KEY = 'other-ada-account-key' as AccountKey;

--- a/suite-common/wallet-core/src/staking/cardano/__fixtures__/cardanoStakingUtils.ts
+++ b/suite-common/wallet-core/src/staking/cardano/__fixtures__/cardanoStakingUtils.ts
@@ -2,6 +2,7 @@ import { bech32 } from '@scure/base';
 
 import { type AdaPools } from '@suite-common/earn-staking-api';
 import { EVERSTAKE_POOLS, FIVE_BINARIES_POOLS } from '@suite-common/wallet-config';
+import { PROTO } from '@trezor/connect';
 
 import { CARDANO_EVERSTAKE_DREP, CARDANO_EVERSTAKE_STAKING_POOL } from '../cardanoStakingConstants';
 
@@ -202,15 +203,314 @@ export const isCardanoStakedWithFiveBinaries = [
     },
 ];
 
-const cardanoAccountWithDrep = (drep: { drep_id: string } | null, isActive = true) => ({
+const DREP_HASH = '429b12461640cefd3a4a192f7c531d8f6c6d33610b727f481eb22d39';
+const DREP_CIP105_KEY_HASH = 'drep1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjmv589e';
+const DREP_VKH_KEY_HASH = 'drep_vkh1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknjat06vr';
+const DREP_CIP105_SCRIPT_HASH = 'drep_script1g2d3y3skgr806wj2ryhhc5ca3akx6vmppde87jq7kgknj5wf0ec';
+const DREP_CIP129_KEY_HASH = 'drep1yfpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsqdglp';
+const DREP_CIP129_SCRIPT_HASH = 'drep1ydpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsjaelx';
+
+const DREP_CC_HOT_HEADER = 'drep1qfpfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgzsugcp';
+const DREP_RESERVED_HEADER = 'drep1y9pfkyjxzeqvalf6fgvj7lznrk8kcmfnvy9hyl6gr6ez6wgsl5jlg';
+
+const EVERSTAKE_DREP_CIP105 = 'drep1ectemlv45xsnvenfgkhwsxncfvxev4qllj7x5w6vlfc7kmd9zcs';
+
+const PREDEFINED_DREP_ID = 'drep_always_abstain';
+
+const drepHashBytes = Buffer.from(DREP_HASH, 'hex');
+const encodeDrepId = (prefix: string, payload: Uint8Array) =>
+    bech32.encode(prefix, bech32.toWords(payload));
+
+const DREP_SCRIPT_WITH_CIP129_PAYLOAD = encodeDrepId(
+    'drep_script',
+    Uint8Array.from([0x23, ...drepHashBytes]),
+);
+const DREP_VKH_WITH_CIP129_PAYLOAD = encodeDrepId(
+    'drep_vkh',
+    Uint8Array.from([0x22, ...drepHashBytes]),
+);
+const DREP_TRUNCATED_HASH = encodeDrepId('drep', drepHashBytes.subarray(1));
+const POOL_ID = encodeDrepId('pool', drepHashBytes);
+
+const DREP_BROKEN_CHECKSUM = DREP_CIP129_KEY_HASH.replace(/.$/, character =>
+    character === 'q' ? 'p' : 'q',
+);
+const DREP_UPPERCASE = DREP_CIP129_KEY_HASH.toUpperCase();
+const DREP_MIXED_CASE = `${DREP_CIP129_KEY_HASH.slice(0, 10).toUpperCase()}${DREP_CIP129_KEY_HASH.slice(10)}`;
+
+export const validateCardanoDrep = [
+    { description: 'CIP-129 key hash', drepId: DREP_CIP129_KEY_HASH, result: true },
+    { description: 'CIP-129 script hash', drepId: DREP_CIP129_SCRIPT_HASH, result: true },
+    { description: 'legacy CIP-105 key hash', drepId: DREP_CIP105_KEY_HASH, result: true },
+    { description: 'amended CIP-105 key hash', drepId: DREP_VKH_KEY_HASH, result: true },
+    { description: 'CIP-105 script hash', drepId: DREP_CIP105_SCRIPT_HASH, result: true },
+    { description: 'the Everstake DRep', drepId: CARDANO_EVERSTAKE_DREP.bech32, result: true },
+    { description: 'an all-uppercase id', drepId: DREP_UPPERCASE, result: true },
+    {
+        description: 'CIP-129 payload headed by a CC hot credential',
+        drepId: DREP_CC_HOT_HEADER,
+        result: false,
+    },
+    {
+        description: 'CIP-129 payload with an undefined credential type',
+        drepId: DREP_RESERVED_HEADER,
+        result: false,
+    },
+    {
+        description: 'CIP-129 payload spelled `drep_script`',
+        drepId: DREP_SCRIPT_WITH_CIP129_PAYLOAD,
+        result: false,
+    },
+    {
+        description: 'CIP-129 payload spelled `drep_vkh`',
+        drepId: DREP_VKH_WITH_CIP129_PAYLOAD,
+        result: false,
+    },
+    { description: 'a hash one byte short', drepId: DREP_TRUNCATED_HASH, result: false },
+    { description: 'a pool id', drepId: POOL_ID, result: false },
+    { description: 'a broken checksum', drepId: DREP_BROKEN_CHECKSUM, result: false },
+    { description: 'a mixed-case id', drepId: DREP_MIXED_CASE, result: false },
+    { description: 'the always-abstain id', drepId: PREDEFINED_DREP_ID, result: false },
+    { description: 'the no-confidence id', drepId: 'drep_always_no_confidence', result: false },
+    { description: 'an empty string', drepId: '', result: false },
+    { description: 'arbitrary text', drepId: 'not-a-drep', result: false },
+    { description: 'a bare hex hash', drepId: CARDANO_EVERSTAKE_DREP.hex, result: false },
+];
+
+const keyHashCredential = { type: PROTO.CardanoDRepType.KEY_HASH, hex: DREP_HASH };
+const scriptHashCredential = { type: PROTO.CardanoDRepType.SCRIPT_HASH, hex: DREP_HASH };
+
+export const decodeCardanoDrepId = [
+    {
+        description: 'legacy CIP-105 key hash',
+        drepId: DREP_CIP105_KEY_HASH,
+        result: keyHashCredential,
+    },
+    {
+        description: 'amended CIP-105 key hash',
+        drepId: DREP_VKH_KEY_HASH,
+        result: keyHashCredential,
+    },
+    { description: 'CIP-129 key hash', drepId: DREP_CIP129_KEY_HASH, result: keyHashCredential },
+    {
+        description: 'CIP-105 script hash',
+        drepId: DREP_CIP105_SCRIPT_HASH,
+        result: scriptHashCredential,
+    },
+    {
+        description: 'CIP-129 script hash',
+        drepId: DREP_CIP129_SCRIPT_HASH,
+        result: scriptHashCredential,
+    },
+    {
+        description: 'the Everstake DRep, pinned to the hash the device is sent',
+        drepId: CARDANO_EVERSTAKE_DREP.bech32,
+        result: { type: PROTO.CardanoDRepType.KEY_HASH, hex: CARDANO_EVERSTAKE_DREP.hex },
+    },
+    { description: 'an unsupported header byte', drepId: DREP_CC_HOT_HEADER, result: null },
+    { description: 'the always-abstain id', drepId: PREDEFINED_DREP_ID, result: null },
+    { description: 'an empty string', drepId: '', result: null },
+];
+
+export const normalizeCardanoDrepId = [
+    {
+        description: 'legacy CIP-105 key hash',
+        drepId: DREP_CIP105_KEY_HASH,
+        result: DREP_CIP129_KEY_HASH,
+    },
+    {
+        description: 'amended CIP-105 key hash',
+        drepId: DREP_VKH_KEY_HASH,
+        result: DREP_CIP129_KEY_HASH,
+    },
+    {
+        description: 'CIP-105 script hash',
+        drepId: DREP_CIP105_SCRIPT_HASH,
+        result: DREP_CIP129_SCRIPT_HASH,
+    },
+    {
+        description: 'a canonical key hash is returned unchanged',
+        drepId: DREP_CIP129_KEY_HASH,
+        result: DREP_CIP129_KEY_HASH,
+    },
+    {
+        description: 'a canonical script hash is returned unchanged',
+        drepId: DREP_CIP129_SCRIPT_HASH,
+        result: DREP_CIP129_SCRIPT_HASH,
+    },
+    {
+        description: 'an all-uppercase id is lowercased',
+        drepId: DREP_UPPERCASE,
+        result: DREP_CIP129_KEY_HASH,
+    },
+    {
+        description: 'the Everstake DRep in the legacy spelling',
+        drepId: EVERSTAKE_DREP_CIP105,
+        result: CARDANO_EVERSTAKE_DREP.bech32,
+    },
+    {
+        description: 'the Everstake DRep constant',
+        drepId: CARDANO_EVERSTAKE_DREP.bech32,
+        result: CARDANO_EVERSTAKE_DREP.bech32,
+    },
+    { description: 'an unsupported header byte', drepId: DREP_CC_HOT_HEADER, result: null },
+    { description: 'the always-abstain id', drepId: PREDEFINED_DREP_ID, result: null },
+    { description: 'an empty string', drepId: '', result: null },
+    { description: 'arbitrary text', drepId: 'not-a-drep', result: null },
+];
+
+export const areCardanoDrepIdsEqual = [
+    {
+        description: 'legacy and canonical key hash',
+        drepIdA: DREP_CIP105_KEY_HASH,
+        drepIdB: DREP_CIP129_KEY_HASH,
+        result: true,
+    },
+    {
+        description: 'amended CIP-105 and canonical key hash',
+        drepIdA: DREP_VKH_KEY_HASH,
+        drepIdB: DREP_CIP129_KEY_HASH,
+        result: true,
+    },
+    {
+        description: 'CIP-105 and canonical script hash',
+        drepIdA: DREP_CIP105_SCRIPT_HASH,
+        drepIdB: DREP_CIP129_SCRIPT_HASH,
+        result: true,
+    },
+    {
+        description: 'the Everstake DRep in both spellings',
+        drepIdA: EVERSTAKE_DREP_CIP105,
+        drepIdB: CARDANO_EVERSTAKE_DREP.bech32,
+        result: true,
+    },
+    {
+        description: 'the always-abstain id against itself',
+        drepIdA: PREDEFINED_DREP_ID,
+        drepIdB: PREDEFINED_DREP_ID,
+        result: true,
+    },
+    {
+        description: 'a script hash and a key hash sharing one hash',
+        drepIdA: DREP_CIP105_SCRIPT_HASH,
+        drepIdB: DREP_CIP105_KEY_HASH,
+        result: false,
+    },
+    {
+        description: 'both canonical spellings of one hash',
+        drepIdA: DREP_CIP129_SCRIPT_HASH,
+        drepIdB: DREP_CIP129_KEY_HASH,
+        result: false,
+    },
+    {
+        description: 'two different DReps',
+        drepIdA: DREP_CIP129_KEY_HASH,
+        drepIdB: CARDANO_EVERSTAKE_DREP.bech32,
+        result: false,
+    },
+    {
+        description: 'the two predefined ids',
+        drepIdA: PREDEFINED_DREP_ID,
+        drepIdB: 'drep_always_no_confidence',
+        result: false,
+    },
+    {
+        description: 'the always-abstain id against a real DRep',
+        drepIdA: PREDEFINED_DREP_ID,
+        drepIdB: DREP_CIP129_KEY_HASH,
+        result: false,
+    },
+    { description: 'two accounts with no delegation', drepIdA: null, drepIdB: null, result: false },
+    { description: 'two empty strings', drepIdA: '', drepIdB: '', result: false },
+    {
+        description: 'a DRep against no delegation',
+        drepIdA: DREP_CIP129_KEY_HASH,
+        drepIdB: undefined,
+        result: false,
+    },
+];
+
+const cardanoAccountWithDrep = (
+    drep: { drep_id: string; hex?: string } | null,
+    isActive = true,
+) => ({
     networkType: 'cardano',
     misc: { staking: { poolId: everstakePool, drep, isActive } },
 });
+
+export const getCardanoAccountDrepId = [
+    {
+        description: 'legacy drep_id with the canonical payload in hex',
+        account: cardanoAccountWithDrep({
+            drep_id: EVERSTAKE_DREP_CIP105,
+            hex: `22${CARDANO_EVERSTAKE_DREP.hex}`,
+        }),
+        result: CARDANO_EVERSTAKE_DREP.bech32,
+    },
+    {
+        description: 'hex says script hash where the drep_id spelling cannot',
+        account: cardanoAccountWithDrep({
+            drep_id: DREP_CIP105_KEY_HASH,
+            hex: `23${DREP_HASH}`,
+        }),
+        result: DREP_CIP129_SCRIPT_HASH,
+    },
+    {
+        description: 'empty hex falls back to converting drep_id',
+        account: cardanoAccountWithDrep({ drep_id: EVERSTAKE_DREP_CIP105, hex: '' }),
+        result: CARDANO_EVERSTAKE_DREP.bech32,
+    },
+    {
+        description: 'missing hex falls back to converting a script drep_id',
+        account: cardanoAccountWithDrep({ drep_id: DREP_CIP105_SCRIPT_HASH }),
+        result: DREP_CIP129_SCRIPT_HASH,
+    },
+    {
+        description: 'unusable hex falls back to converting drep_id',
+        account: cardanoAccountWithDrep({ drep_id: DREP_CIP105_KEY_HASH, hex: 'zz' }),
+        result: DREP_CIP129_KEY_HASH,
+    },
+    {
+        description: 'an already canonical drep_id',
+        account: cardanoAccountWithDrep({ drep_id: DREP_CIP129_SCRIPT_HASH }),
+        result: DREP_CIP129_SCRIPT_HASH,
+    },
+    {
+        description: 'a predefined drep_id passes through unchanged',
+        account: cardanoAccountWithDrep({ drep_id: PREDEFINED_DREP_ID, hex: '' }),
+        result: PREDEFINED_DREP_ID,
+    },
+    {
+        description: 'account without delegation',
+        account: cardanoAccountWithDrep(null),
+        result: null,
+    },
+    {
+        description: 'account whose backend drep_id is empty',
+        account: cardanoAccountWithDrep({ drep_id: '' }),
+        result: null,
+    },
+    {
+        description: 'non-cardano account',
+        account: { networkType: 'ethereum' },
+        result: null,
+    },
+];
 
 export const hasCardanoLiveVoteDelegation = [
     {
         description: 'registered account voting for a DRep',
         account: cardanoAccountWithDrep({ drep_id: CARDANO_EVERSTAKE_DREP.bech32 }),
+        result: true,
+    },
+    {
+        description: 'registered account voting for a DRep reported in the legacy spelling',
+        account: cardanoAccountWithDrep({ drep_id: EVERSTAKE_DREP_CIP105 }),
+        result: true,
+    },
+    {
+        description: 'registered account voting to always abstain',
+        account: cardanoAccountWithDrep({ drep_id: PREDEFINED_DREP_ID, hex: '' }),
         result: true,
     },
     {

--- a/suite-common/wallet-core/src/staking/cardano/cardanoStakingUtils.test.ts
+++ b/suite-common/wallet-core/src/staking/cardano/cardanoStakingUtils.test.ts
@@ -4,12 +4,17 @@ import { type Account } from '@suite-common/wallet-types';
 import * as fixtures from './__fixtures__/cardanoStakingUtils';
 import { CARDANO_EVERSTAKE_STAKING_POOL } from './cardanoStakingConstants';
 import {
+    areCardanoDrepIdsEqual,
+    decodeCardanoDrepId,
+    getCardanoAccountDrepId,
     hasCardanoLiveVoteDelegation,
     isCardanoStakedOutsideEverstake,
     isCardanoStakedWithEverstake,
     isCardanoStakedWithFiveBinaries,
+    normalizeCardanoDrepId,
     poolBech32ToHex,
     selectBestCardanoPool,
+    validateCardanoDrep,
 } from './cardanoStakingUtils';
 
 describe('cardano staking utils', () => {
@@ -57,6 +62,47 @@ describe('cardano staking utils', () => {
     fixtures.hasCardanoLiveVoteDelegation.forEach(f => {
         it(`hasCardanoLiveVoteDelegation: ${f.description}`, () => {
             expect(hasCardanoLiveVoteDelegation(f.account as Account)).toBe(f.result);
+        });
+    });
+
+    fixtures.validateCardanoDrep.forEach(f => {
+        it(`validateCardanoDrep: ${f.description}`, () => {
+            expect(validateCardanoDrep(f.drepId)).toBe(f.result);
+        });
+    });
+
+    fixtures.decodeCardanoDrepId.forEach(f => {
+        it(`decodeCardanoDrepId: ${f.description}`, () => {
+            expect(decodeCardanoDrepId(f.drepId)).toEqual(f.result);
+        });
+    });
+
+    fixtures.normalizeCardanoDrepId.forEach(f => {
+        it(`normalizeCardanoDrepId: ${f.description}`, () => {
+            expect(normalizeCardanoDrepId(f.drepId)).toBe(f.result);
+        });
+    });
+
+    it('normalizeCardanoDrepId: normalizing a canonical id changes nothing', () => {
+        fixtures.normalizeCardanoDrepId.forEach(f => {
+            const normalizedDrepId = normalizeCardanoDrepId(f.drepId);
+
+            if (normalizedDrepId === null) return;
+
+            expect(normalizeCardanoDrepId(normalizedDrepId)).toBe(normalizedDrepId);
+        });
+    });
+
+    fixtures.areCardanoDrepIdsEqual.forEach(f => {
+        it(`areCardanoDrepIdsEqual: ${f.description}`, () => {
+            expect(areCardanoDrepIdsEqual(f.drepIdA, f.drepIdB)).toBe(f.result);
+            expect(areCardanoDrepIdsEqual(f.drepIdB, f.drepIdA)).toBe(f.result);
+        });
+    });
+
+    fixtures.getCardanoAccountDrepId.forEach(f => {
+        it(`getCardanoAccountDrepId: ${f.description}`, () => {
+            expect(getCardanoAccountDrepId(f.account as Account)).toBe(f.result);
         });
     });
 });

--- a/suite-common/wallet-core/src/staking/cardano/cardanoStakingUtils.ts
+++ b/suite-common/wallet-core/src/staking/cardano/cardanoStakingUtils.ts
@@ -14,6 +14,7 @@ import {
     supportedCardanoNetworkSymbols,
 } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
+import { exhaustive } from '@trezor/type-utils';
 import { isArrayMember } from '@trezor/utils';
 
 import { CARDANO_EVERSTAKE_STAKING_POOL } from './cardanoStakingConstants';
@@ -40,12 +41,124 @@ export const getCardanoAccountPoolId = (account?: Account) => {
     return poolId || null;
 };
 
-export const getCardanoAccountDrepId = (account?: Account) => {
+const DREP_HASH_LENGTH = 28;
+const DREP_CIP129_PAYLOAD_LENGTH = DREP_HASH_LENGTH + 1;
+
+// https://cips.cardano.org/cip/CIP-0129
+const DREP_CIP129_KEY_HASH_HEADER = 0x22;
+const DREP_CIP129_SCRIPT_HASH_HEADER = 0x23;
+
+export type CardanoDrepCredential = {
+    type: PROTO.CardanoDRepType.KEY_HASH | PROTO.CardanoDRepType.SCRIPT_HASH;
+    hex: string;
+};
+
+// https://cips.cardano.org/cip/CIP-0129
+const decodeDrepCip129Payload = (bytes: Uint8Array): CardanoDrepCredential | null => {
+    if (bytes.length !== DREP_CIP129_PAYLOAD_LENGTH) return null;
+
+    const hex = Buffer.from(bytes.slice(1)).toString('hex');
+
+    switch (bytes[0]) {
+        case DREP_CIP129_KEY_HASH_HEADER:
+            return { type: PROTO.CardanoDRepType.KEY_HASH, hex };
+        case DREP_CIP129_SCRIPT_HASH_HEADER:
+            return { type: PROTO.CardanoDRepType.SCRIPT_HASH, hex };
+        default:
+            return null;
+    }
+};
+
+// https://cips.cardano.org/cip/CIP-0105#drep-keys-1
+const decodeDrepCip105Payload = (
+    bytes: Uint8Array,
+    prefix: string,
+): CardanoDrepCredential | null => {
+    if (bytes.length !== DREP_HASH_LENGTH) return null;
+
+    const hex = Buffer.from(bytes).toString('hex');
+
+    switch (prefix) {
+        case 'drep':
+        case 'drep_vkh':
+            return { type: PROTO.CardanoDRepType.KEY_HASH, hex };
+        case 'drep_script':
+            return { type: PROTO.CardanoDRepType.SCRIPT_HASH, hex };
+        default:
+            return null;
+    }
+};
+
+export const decodeCardanoDrepId = (drepId: string): CardanoDrepCredential | null => {
+    try {
+        const { prefix, bytes } = bech32.decodeToBytes(drepId);
+
+        return prefix === 'drep' && bytes.length === DREP_CIP129_PAYLOAD_LENGTH
+            ? decodeDrepCip129Payload(bytes)
+            : decodeDrepCip105Payload(bytes, prefix);
+    } catch {
+        return null;
+    }
+};
+
+export const validateCardanoDrep = (drepId: string): boolean =>
+    decodeCardanoDrepId(drepId) !== null;
+
+const getDrepCip129Header = (type: CardanoDrepCredential['type']): number => {
+    switch (type) {
+        case PROTO.CardanoDRepType.KEY_HASH:
+            return DREP_CIP129_KEY_HASH_HEADER;
+        case PROTO.CardanoDRepType.SCRIPT_HASH:
+            return DREP_CIP129_SCRIPT_HASH_HEADER;
+        default:
+            return exhaustive(type);
+    }
+};
+
+const encodeCardanoDrepIdCip129 = (credential: CardanoDrepCredential): string => {
+    const payload = Uint8Array.from([
+        getDrepCip129Header(credential.type),
+        ...Buffer.from(credential.hex, 'hex'),
+    ]);
+
+    return bech32.encode('drep', bech32.toWords(payload));
+};
+
+export const normalizeCardanoDrepId = (drepId: string): string | null => {
+    const credential = decodeCardanoDrepId(drepId);
+
+    return credential === null ? null : encodeCardanoDrepIdCip129(credential);
+};
+
+export const areCardanoDrepIdsEqual = (
+    drepIdA?: string | null,
+    drepIdB?: string | null,
+): boolean => {
+    if (!drepIdA || !drepIdB) return false;
+
+    if (drepIdA === drepIdB) return true;
+
+    const normalizedDrepIdA = normalizeCardanoDrepId(drepIdA);
+
+    return normalizedDrepIdA !== null && normalizedDrepIdA === normalizeCardanoDrepId(drepIdB);
+};
+
+const normalizeAccountDrepId = (drep: { drep_id: string; hex?: string }): string => {
+    const credentialFromHex = decodeDrepCip129Payload(
+        Uint8Array.from(Buffer.from(drep.hex ?? '', 'hex')),
+    );
+
+    if (credentialFromHex !== null) return encodeCardanoDrepIdCip129(credentialFromHex);
+
+    return normalizeCardanoDrepId(drep.drep_id) ?? drep.drep_id;
+};
+
+export const getCardanoAccountDrepId = (account?: Account): string | null => {
     if (account?.networkType !== 'cardano') return null;
 
-    const drepId = account.misc?.staking?.drep?.drep_id;
+    const drep = account.misc?.staking?.drep;
 
-    return drepId || null;
+    return drep?.drep_id ? normalizeAccountDrepId(drep) : null;
 };
 
 export const hasCardanoLiveVoteDelegation = (account?: Account) =>
@@ -113,69 +226,6 @@ export const selectBestCardanoPool = (pools?: AdaPools['pools'], currentPoolId?:
         hex: poolBech32ToHex(bestPool.id),
         bech32: bestPool.id,
     };
-};
-
-export const validateCardanoDrep = (drepId: string): boolean => {
-    try {
-        const { prefix, words } = bech32.decode(drepId as `${string}1${string}`);
-        if (prefix !== 'drep' && prefix !== 'drep_script') return false;
-
-        const bytes = bech32.fromWords(words);
-        if (bytes.length !== 28 && bytes.length !== 29) return false;
-
-        if (prefix === 'drep_script' && bytes.length !== 28) return false;
-
-        return true;
-    } catch {
-        return false;
-    }
-};
-
-// https://cips.cardano.org/cip/CIP-0129
-const parseDrepCip129 = (bytes: number[]) => {
-    const header = bytes[0];
-    const hex = Buffer.from(bytes.slice(1)).toString('hex');
-
-    switch (header) {
-        case 0x22:
-            return { type: PROTO.CardanoDRepType.KEY_HASH, hex };
-        case 0x23:
-            return { type: PROTO.CardanoDRepType.SCRIPT_HASH, hex };
-        default:
-            throw new Error(`Unsupported DRep id CIP-129 header: ${header}`);
-    }
-};
-
-// https://cips.cardano.org/cip/CIP-0105#drep-keys-1
-// Legacy
-const parseDrepCip105 = (bytes: number[], prefix: string) => {
-    const hex = Buffer.from(bytes).toString('hex');
-
-    switch (prefix) {
-        case 'drep':
-            return { type: PROTO.CardanoDRepType.KEY_HASH, hex };
-        case 'drep_script':
-            return { type: PROTO.CardanoDRepType.SCRIPT_HASH, hex };
-        default:
-            throw new Error(`Unsupported DRep id CIP-105 prefix: ${prefix}`);
-    }
-};
-
-export const parseDrepBech32 = (drepId: string): { type: PROTO.CardanoDRepType; hex: string } => {
-    if (!validateCardanoDrep(drepId)) throw new Error('Not a DRep bech32');
-
-    const { words, prefix } = bech32.decode(drepId as `${string}1${string}`);
-    const bytes = Array.from(bech32.fromWords(words));
-
-    if (bytes.length === 28) {
-        return parseDrepCip105(bytes, prefix);
-    }
-
-    if (bytes.length === 29) {
-        return parseDrepCip129(bytes);
-    }
-
-    throw new Error(`Unsupported DRep payload length: ${bytes.length}`);
 };
 
 type CardanoSpecific = NonNullable<WalletAccountTransaction['cardanoSpecific']>;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10851,6 +10851,10 @@ export const messages = defineMessages({
         id: 'TR_STAKING_DREP_ID',
         defaultMessage: 'DRep ID',
     },
+    TR_STAKING_DREP_ID_CONVERTED: {
+        id: 'TR_STAKING_DREP_ID_CONVERTED',
+        defaultMessage: 'Converted to the new DRep ID format',
+    },
     TR_STAKING_CARD_TEXT_FUNDS_STAY: {
         id: 'TR_STAKING_CARD_TEXT_FUNDS_STAY',
         defaultMessage:


### PR DESCRIPTION
## Description

DRep IDs are auto-converted to CIP-129 on input and in the current delegation, and compared by credential instead of bech32 string. Until trezor/trezor-firmware#6192 lands, the device still shows the legacy format.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24040

## Screenshots:
<img width="590" height="449" alt="Screenshot 2026-09-12 at 03 16 22" src="https://github.com/user-attachments/assets/48b08840-1a12-4f57-9061-809d6326ff7d" />
<img width="647" height="534" alt="Screenshot 2026-09-11 at 20 26 07" src="https://github.com/user-attachments/assets/35c1404d-09be-42a1-8a36-b70824e99afc" />