### PR TITLE
Keep Cardano staking data when an account sync omits it

### DIFF
--- a/packages/blockchain-link-types/src/blockfrost.ts
+++ b/packages/blockchain-link-types/src/blockfrost.ts
@@ -169,7 +169,8 @@ export interface BlockfrostAccountInfo {
         total: number;
         index: number;
     };
-    misc: {
+    // The stake-address lookup is separate and can fail, so this may be absent.
+    misc?: {
         staking: {
             address: string;
             isActive: boolean;

--- a/packages/blockchain-link-utils/src/__fixtures__/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/__fixtures__/blockfrost.ts
@@ -625,6 +625,79 @@ export default {
                 },
             },
         },
+        {
+            description: 'Drops a null staking block',
+            data: {
+                descriptor: 'descriptor',
+                empty: false,
+                balance: '27429803',
+                availableBalance: '27256514',
+                history: { total: 0, unconfirmed: 0 },
+                misc: { staking: null },
+            },
+            result: {
+                descriptor: 'descriptor',
+                empty: false,
+                balance: '27429803',
+                availableBalance: '27256514',
+                history: { total: 0, unconfirmed: 0, transactions: [] },
+                misc: {},
+            },
+        },
+        {
+            description: 'Drops a partially filled staking block (failed stake-address lookup)',
+            data: {
+                descriptor: 'descriptor',
+                empty: false,
+                balance: '27429803',
+                availableBalance: '27256514',
+                history: { total: 0, unconfirmed: 0 },
+                misc: { staking: { isActive: true, rewards: '173289' } },
+            },
+            result: {
+                descriptor: 'descriptor',
+                empty: false,
+                balance: '27429803',
+                availableBalance: '27256514',
+                history: { total: 0, unconfirmed: 0, transactions: [] },
+                misc: {},
+            },
+        },
+        {
+            description: 'Forwards a complete staking block unchanged',
+            data: {
+                descriptor: 'descriptor',
+                empty: false,
+                balance: '27429803',
+                availableBalance: '27256514',
+                history: { total: 0, unconfirmed: 0 },
+                misc: {
+                    staking: {
+                        address: 'stake1uxzutrtmxwv2rf2j3hdpps66ch0jydmkr58vwgnetddcdwg32u4rc',
+                        isActive: true,
+                        rewards: '173289',
+                        poolId: 'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy',
+                        drep: null,
+                    },
+                },
+            },
+            result: {
+                descriptor: 'descriptor',
+                empty: false,
+                balance: '27429803',
+                availableBalance: '27256514',
+                history: { total: 0, unconfirmed: 0, transactions: [] },
+                misc: {
+                    staking: {
+                        address: 'stake1uxzutrtmxwv2rf2j3hdpps66ch0jydmkr58vwgnetddcdwg32u4rc',
+                        isActive: true,
+                        rewards: '173289',
+                        poolId: 'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy',
+                        drep: null,
+                    },
+                },
+            },
+        },
     ],
 
     transformTransaction: [

--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -343,11 +343,26 @@ export const transformTransaction = (
     };
 };
 
+// A half-filled block reads as "not delegated"; nothing validates the response shape.
+const isStakingComplete = (staking: unknown) =>
+    typeof staking === 'object' &&
+    staking !== null &&
+    'address' in staking &&
+    typeof staking.address === 'string' &&
+    'isActive' in staking &&
+    typeof staking.isActive === 'boolean' &&
+    'rewards' in staking &&
+    typeof staking.rewards === 'string' &&
+    // `drep` is not required: backends that predate it still report the delegation.
+    'poolId' in staking;
+
 export const transformAccountInfo = (info: BlockfrostAccountInfo): AccountInfo => {
     const blockfrostTxs = info.history.transactions;
+    const { staking } = info.misc ?? {};
 
     const result = {
         ...info,
+        misc: staking === undefined || isStakingComplete(staking) ? info.misc : {},
         tokens: transformTokenInfo(info.tokens),
         history: {
             ...info.history,

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -51,6 +51,8 @@ export type CreateAccountActionProps = Pick<
     | 'visible'
 > & {
     accountInfo: AccountInfo;
+    // Carries the last known-good values, so a field the payload does not report is not erased.
+    previousAccount?: Account;
 } & AccountBackendSpecific &
     AccountFailureSpecific;
 
@@ -61,6 +63,7 @@ const createAccount = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/createAccount`,
     ({
         accountInfo,
+        previousAccount,
         ...account
     }: CreateAccountActionProps): {
         payload: { account: Account; supportedNetworks: readonly NetworkSymbol[] };
@@ -101,7 +104,7 @@ const createAccount = createAction(
                 }),
                 utxo: enhanceUtxo(utxo, networkType, index),
                 metadata: { key: metadataKey },
-                ...getAccountSpecific(accountInfo, networkType),
+                ...getAccountSpecific({ accountInfo, networkType, previousAccount }),
             };
 
             return {
@@ -154,7 +157,11 @@ const updateAccount = createAction(
                         utxo: enhanceUtxo(accountInfo.utxo, account.networkType, account.index),
                         addresses: enhanceAddresses(accountInfo, account),
                         tokens: enhanceTokens(accountInfo.tokens),
-                        ...getAccountSpecific(accountInfo, account.networkType),
+                        ...getAccountSpecific({
+                            accountInfo,
+                            networkType: account.networkType,
+                            previousAccount: account,
+                        }),
                     },
                 },
             };

--- a/suite-common/wallet-core/src/accounts/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.test.ts
@@ -4,7 +4,11 @@ import { mockActionType, mockReducer } from '@suite-common/redux-utils/mocks';
 import { createTestStore } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import {
+    mockAccountToken,
+    mockWalletAccount,
+    networkSpecificDefaultCardano,
+} from '@suite-common/wallet-types/mocks';
 import { type AccountInfo } from '@trezor/connect';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
@@ -156,6 +160,100 @@ describe('Account Reducer', () => {
         spyWarn.mockRestore();
 
         expect(store.getState().wallet.accounts.length).toEqual(0);
+    });
+
+    describe('cardano staking', () => {
+        const delegatedStaking: NonNullable<NonNullable<AccountInfo['misc']>['staking']> = {
+            address: 'stake1uxzutrtmxwv2rf2j3hdpps66ch0jydmkr58vwgnetddcdwg32u4rc',
+            isActive: true,
+            rewards: '173289',
+            poolId: 'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy',
+            drep: null,
+        };
+
+        // `mockWalletAccount`'s cardano defaults type `poolId` as the literal `null`.
+        const cardanoAccount: Account = {
+            ...mockWalletAccount(
+                { symbol: asNetworkSymbol('ada'), deviceState: '1stTestnetAddress@device_id:0' },
+                networkSpecificDefaultCardano,
+            ),
+            networkType: 'cardano',
+            marker: undefined,
+            stellarCursor: undefined,
+            page: undefined,
+            misc: { staking: delegatedStaking },
+        };
+
+        it('keeps the delegation when a refresh reports the account without staking data', () => {
+            const store = initStore({
+                preloadedState: { wallet: { accounts: [cardanoAccount] } },
+            });
+
+            store.dispatch(
+                accountsActions.updateAccount(cardanoAccount, {
+                    descriptor: cardanoAccount.descriptor,
+                    balance: '1000',
+                    availableBalance: '1000',
+                    empty: false,
+                    history: { total: 1, unconfirmed: 0, transactions: [] },
+                }),
+            );
+
+            expect(store.getState().wallet.accounts[0]?.misc).toEqual({
+                staking: delegatedStaking,
+            });
+        });
+
+        it('honors a de-delegation that the payload actually reports', () => {
+            const store = initStore({
+                preloadedState: { wallet: { accounts: [cardanoAccount] } },
+            });
+
+            store.dispatch(
+                accountsActions.updateAccount(cardanoAccount, {
+                    descriptor: cardanoAccount.descriptor,
+                    balance: '1000',
+                    availableBalance: '1000',
+                    empty: false,
+                    history: { total: 1, unconfirmed: 0, transactions: [] },
+                    misc: { staking: { ...delegatedStaking, isActive: false, poolId: null } },
+                }),
+            );
+
+            expect(store.getState().wallet.accounts[0]?.misc).toEqual({
+                staking: { ...delegatedStaking, isActive: false, poolId: null },
+            });
+        });
+
+        it('keeps the delegation when discovery re-creates an account it already knows', () => {
+            const store = initStore({
+                preloadedState: { wallet: { accounts: [cardanoAccount] } },
+            });
+
+            store.dispatch(
+                accountsActions.createAccount({
+                    deviceState: cardanoAccount.deviceState,
+                    index: cardanoAccount.index,
+                    path: cardanoAccount.path,
+                    accountType: cardanoAccount.accountType,
+                    symbol: cardanoAccount.symbol,
+                    visible: true,
+                    accountInfo: {
+                        descriptor: cardanoAccount.descriptor,
+                        balance: '1000',
+                        availableBalance: '1000',
+                        empty: false,
+                        history: { total: 1, unconfirmed: 0, transactions: [] },
+                    },
+                    previousAccount: cardanoAccount,
+                }),
+            );
+
+            expect(store.getState().wallet.accounts.length).toEqual(1);
+            expect(store.getState().wallet.accounts[0]?.misc).toEqual({
+                staking: delegatedStaking,
+            });
+        });
     });
 
     describe('locally tracked tokens', () => {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -26,7 +26,11 @@ import {
 import { getNewInstanceNumber } from '@suite-common/suite-utils';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import { type TrezorConnectBackendType } from '@suite-common/wallet-config';
-import { type DiscoveryStatus, type GetTradedAccountKeysDep } from '@suite-common/wallet-types';
+import {
+    type Account,
+    type DiscoveryStatus,
+    type GetTradedAccountKeysDep,
+} from '@suite-common/wallet-types';
 import TrezorConnect, {
     type AccountInfo,
     type DeviceState,
@@ -186,6 +190,18 @@ export const applyDeviceStatesThunk = createThunk<
         }
     },
 );
+
+// Discovery re-emits known accounts, and `createAccount` replaces the stored one wholesale.
+const findPreviousAccount = (
+    accounts: readonly Account[],
+    accountPayload: CreateAccountActionProps,
+) =>
+    accounts.find(
+        account =>
+            account.symbol === accountPayload.symbol &&
+            account.accountType === accountPayload.accountType &&
+            account.index === accountPayload.index,
+    );
 
 const transformProgressEventData = (
     { response, progress, total }: ProgressEvent,
@@ -445,6 +461,17 @@ export const runDiscoveryThunk = createThunk<
 
             // we do not create empty accounts right away, but store the progress events for later
             const accountQueue: CreateAccountActionProps[] = [];
+            const dispatchCreateAccount = (accountPayload: CreateAccountActionProps) =>
+                dispatch(
+                    accountsActions.createAccount({
+                        ...accountPayload,
+                        previousAccount: findPreviousAccount(
+                            selectAccountsByDeviceState(getState(), deviceState.staticSessionId),
+                            accountPayload,
+                        ),
+                    }),
+                );
+
             const onBundleProgress = (event: ProgressEvent) => {
                 const currentDiscovery = selectDiscoveryByDevicePath(getState(), device.path);
                 if (!currentDiscovery) {
@@ -473,12 +500,10 @@ export const runDiscoveryThunk = createThunk<
                             );
                         }
 
-                        accountQueue.forEach(account =>
-                            dispatch(accountsActions.createAccount(account)),
-                        );
+                        accountQueue.forEach(dispatchCreateAccount);
                         accountQueue.splice(0, accountQueue.length);
                     }
-                    dispatch(accountsActions.createAccount(accountPayload));
+                    dispatchCreateAccount(accountPayload);
                 }
 
                 dispatch(discoveryActions.updateDiscovery(discoveryPayload, device.path));
@@ -751,7 +776,15 @@ export const runAdditionalDiscoveryThunk = createThunk<
                 discovery,
             );
 
-            dispatch(accountsActions.createAccount(accountPayload));
+            dispatch(
+                accountsActions.createAccount({
+                    ...accountPayload,
+                    previousAccount: findPreviousAccount(
+                        selectAccountsByDeviceState(getState(), staticSessionId),
+                        accountPayload,
+                    ),
+                }),
+            );
             dispatch(discoveryActions.updateDiscovery(discoveryPayload, device.path));
         };
 

--- a/suite-common/wallet-utils/src/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/accountUtils.test.ts
@@ -6,7 +6,12 @@ import {
     asAccountDescriptor,
     createAccountKey,
 } from '@suite-common/wallet-types';
-import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import {
+    mockAccountToken,
+    mockWalletAccount,
+    networkSpecificDefaultCardano,
+} from '@suite-common/wallet-types/mocks';
+import { type AccountInfo } from '@trezor/connect';
 
 import * as fixtures from './__fixtures__/accountUtils';
 import {
@@ -16,11 +21,13 @@ import {
     findAccountsByAddress,
     findTransactionSenderAccount,
     getAccountIdentifier,
+    getAccountSpecific,
     getBip43Type,
     getNetworkAccountFeatures,
     getUtxoFromSignedTransaction,
     getUtxoOutpoint,
     hasNetworkFeatures,
+    isAccountOutdated,
     isTestnet,
     sortByBIP44AddressIndex,
     sortByCoin,
@@ -37,6 +44,114 @@ const btcSymbol = asNetworkSymbol('btc');
 const xrpSymbol = asNetworkSymbol('xrp');
 const ethSymbol = asNetworkSymbol('eth');
 const ltcSymbol = asNetworkSymbol('ltc');
+
+type CardanoStaking = NonNullable<NonNullable<AccountInfo['misc']>['staking']>;
+
+describe('cardano staking data from an incomplete payload', () => {
+    const delegatedStaking: CardanoStaking = {
+        address: 'stake1uxzutrtmxwv2rf2j3hdpps66ch0jydmkr58vwgnetddcdwg32u4rc',
+        isActive: true,
+        rewards: '173289',
+        poolId: 'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy',
+        drep: null,
+    };
+
+    // `mockWalletAccount`'s cardano defaults type `poolId` as the literal `null`.
+    const delegatedAccount: Account = {
+        ...mockWalletAccount({ symbol: asNetworkSymbol('ada') }, networkSpecificDefaultCardano),
+        networkType: 'cardano',
+        marker: undefined,
+        stellarCursor: undefined,
+        page: undefined,
+        misc: { staking: delegatedStaking },
+    };
+
+    const adaAccountInfo = (misc?: AccountInfo['misc']): AccountInfo => ({
+        descriptor: delegatedAccount.descriptor,
+        balance: '27429803',
+        availableBalance: '27256514',
+        empty: false,
+        history: { total: 13, unconfirmed: 0 },
+        misc,
+    });
+
+    describe('getAccountSpecific', () => {
+        it('keeps the known delegation when the payload carries no staking data', () => {
+            const result = getAccountSpecific({
+                accountInfo: adaAccountInfo(),
+                networkType: 'cardano',
+                previousAccount: delegatedAccount,
+            });
+
+            expect(result.misc).toEqual({ staking: delegatedStaking });
+        });
+
+        it('fills in only the fields that a partial payload omits', () => {
+            // The declared type cannot express a partially populated block.
+            const partialStaking = { isActive: true, rewards: '200000' } as CardanoStaking;
+
+            const result = getAccountSpecific({
+                accountInfo: adaAccountInfo({ staking: partialStaking }),
+                networkType: 'cardano',
+                previousAccount: delegatedAccount,
+            });
+
+            expect(result.misc).toEqual({
+                staking: { ...delegatedStaking, rewards: '200000' },
+            });
+        });
+
+        it('respects an explicit null poolId as a de-delegation instead of restoring the pool', () => {
+            const result = getAccountSpecific({
+                accountInfo: adaAccountInfo({
+                    staking: { ...delegatedStaking, isActive: false, poolId: null },
+                }),
+                networkType: 'cardano',
+                previousAccount: delegatedAccount,
+            });
+
+            expect(result.misc).toEqual({
+                staking: { ...delegatedStaking, isActive: false, poolId: null },
+            });
+        });
+
+        it('uses empty defaults when there is no previous account', () => {
+            const result = getAccountSpecific({
+                accountInfo: adaAccountInfo(),
+                networkType: 'cardano',
+            });
+
+            expect(result.misc).toEqual({
+                staking: { address: '', isActive: false, rewards: '0', poolId: null, drep: null },
+            });
+        });
+    });
+
+    describe('isAccountOutdated', () => {
+        it('does not report the account outdated when the payload carries no staking data', () => {
+            expect(isAccountOutdated(delegatedAccount, adaAccountInfo())).toBe(false);
+        });
+
+        it('still reports the account outdated when the stake pool changes', () => {
+            expect(
+                isAccountOutdated(
+                    delegatedAccount,
+                    adaAccountInfo({
+                        staking: { ...delegatedStaking, poolId: 'pool1changed' },
+                    }),
+                ),
+            ).toBe(true);
+        });
+
+        it('does not report the account outdated when the payload omits only some staking fields', () => {
+            const partialStaking = { isActive: true, rewards: '173289' } as CardanoStaking;
+
+            expect(
+                isAccountOutdated(delegatedAccount, adaAccountInfo({ staking: partialStaking })),
+            ).toBe(false);
+        });
+    });
+});
 
 describe('account utils', () => {
     fixtures.getUtxoFromSignedTransaction.forEach(f => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -659,6 +659,10 @@ export const getTotalFiatBalance = ({
 
 export const isTestnet = (symbol: NetworkSymbol) => getNetwork(symbol).testnet;
 
+// An unreported field means "not reported", never "changed".
+const isReportedAndDifferent = <T>(freshValue: T | undefined, storedValue: T) =>
+    freshValue !== undefined && freshValue !== storedValue;
+
 export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
     if (
         // if backend/coin supports addrTxCount, compare it instead of total
@@ -678,35 +682,42 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
         case 'ripple':
             // different sequence or balance
             return (
-                freshInfo.misc!.sequence !== account.misc.sequence ||
+                isReportedAndDifferent(freshInfo.misc?.sequence, account.misc.sequence) ||
                 freshInfo.balance !== account.balance ||
-                freshInfo.misc!.reserve !== account.misc.reserve
+                isReportedAndDifferent(freshInfo.misc?.reserve, account.misc.reserve)
             );
         case 'stellar':
             // different sequence or balance
             return (
-                freshInfo.misc!.stellarSequence !== account.misc.stellarSequence ||
+                isReportedAndDifferent(
+                    freshInfo.misc?.stellarSequence,
+                    account.misc.stellarSequence,
+                ) ||
                 freshInfo.balance !== account.balance ||
-                freshInfo.misc!.reserve !== account.misc.reserve ||
+                isReportedAndDifferent(freshInfo.misc?.reserve, account.misc.reserve) ||
                 // compare token balances (detect token balance changes)
                 JSON.stringify(freshInfo.tokens) !== JSON.stringify(account.tokens)
             );
         case 'ethereum':
             return (
-                freshInfo.misc!.nonce !== account.misc.nonce ||
+                isReportedAndDifferent(freshInfo.misc?.nonce, account.misc.nonce) ||
                 freshInfo.balance !== account.balance || // balance can change because of beacon chain/internal txs
+                // An absent `stakingPools` is authoritative: the backend maps an empty list to it.
                 JSON.stringify(freshInfo?.misc?.stakingPools) !==
                     JSON.stringify(account?.misc?.stakingPools)
             );
-        case 'cardano':
+        case 'cardano': {
+            const freshStaking = freshInfo.misc?.staking;
+
             return (
                 // stake address (de)registration
-                freshInfo.misc!.staking?.isActive !== account.misc.staking.isActive ||
+                isReportedAndDifferent(freshStaking?.isActive, account.misc.staking.isActive) ||
                 // changed rewards amount (rewards are distributed every epoch (5 days))
-                freshInfo.misc!.staking?.rewards !== account.misc.staking.rewards ||
+                isReportedAndDifferent(freshStaking?.rewards, account.misc.staking.rewards) ||
                 // changed stake pool
-                freshInfo.misc!.staking?.poolId !== account.misc.staking.poolId
+                isReportedAndDifferent(freshStaking?.poolId, account.misc.staking.poolId)
             );
+        }
         case 'solana':
             return (
                 // compare last transaction signature since the total number of txs may not be fetched fully
@@ -727,8 +738,18 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
     }
 };
 
+type GetAccountSpecificParams = {
+    accountInfo: Partial<AccountInfo>;
+    networkType: NetworkType;
+    previousAccount?: Account;
+};
+
 // Used in accountActions and failed accounts
-export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkType: NetworkType) => {
+export const getAccountSpecific = ({
+    accountInfo,
+    networkType,
+    previousAccount,
+}: GetAccountSpecificParams) => {
     const { misc } = accountInfo;
     if (networkType === 'ripple') {
         return {
@@ -757,15 +778,26 @@ export const getAccountSpecific = (accountInfo: Partial<AccountInfo>, networkTyp
     }
 
     if (networkType === 'cardano') {
+        const previousStaking =
+            previousAccount?.networkType === 'cardano' ? previousAccount.misc.staking : undefined;
+        const freshStaking = misc?.staking;
+
         return {
             networkType,
             misc: {
                 staking: {
-                    rewards: misc?.staking?.rewards ?? '0',
-                    isActive: misc?.staking?.isActive ?? false,
-                    address: misc?.staking?.address ?? '',
-                    poolId: misc?.staking?.poolId ?? null,
-                    drep: misc?.staking?.drep ?? null,
+                    rewards: freshStaking?.rewards ?? previousStaking?.rewards ?? '0',
+                    isActive: freshStaking?.isActive ?? previousStaking?.isActive ?? false,
+                    address: freshStaking?.address ?? previousStaking?.address ?? '',
+                    // `null` is authoritative, so only an absent field falls back.
+                    poolId:
+                        freshStaking?.poolId !== undefined
+                            ? freshStaking.poolId
+                            : (previousStaking?.poolId ?? null),
+                    drep:
+                        freshStaking?.drep !== undefined
+                            ? freshStaking.drep
+                            : (previousStaking?.drep ?? null),
                 },
             },
             marker: undefined,


### PR DESCRIPTION
## Description

A Blockfrost response that omits or half-fills `misc.staking` reset a delegated Cardano account to undelegated, re-registering the stake key and silently re-delegating to another pool. Staking is now merged per field against the last known-good values, with an incomplete block dropped at the backend boundary.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30047